### PR TITLE
Log reward verification failure reason

### DIFF
--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Outcome.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Outcome.kt
@@ -4,17 +4,52 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.admob.RewardVerificationResult
 import com.revenuecat.purchases.admob.VerifiedReward
 
+// Internal poll result. The public [RewardVerificationResult] stays binary (verified/failed); these subtypes
+// capture *why* polling ended so the poller can log an actionable reason without adding public cases.
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal sealed interface Outcome {
     class Verified(val reward: VerifiedReward) : Outcome
 
-    object Failed : Outcome
+    sealed interface Failed : Outcome {
+        val logMessage: String
+
+        // True when [logMessage] should be logged at error level rather than warning.
+        val isError: Boolean
+
+        // Logs the backend-provided message verbatim.
+        class BackendRejected(private val backendMessage: String?) : Failed {
+            override val logMessage: String
+                get() = backendMessage?.takeIf { it.isNotBlank() }
+                    ?: RewardVerificationStrings.BACKEND_REJECTED_WITHOUT_MESSAGE
+            override val isError: Boolean get() = false
+        }
+
+        object ExhaustedWhilePending : Failed {
+            override val logMessage: String get() = RewardVerificationStrings.EXHAUSTED_WHILE_PENDING
+            override val isError: Boolean get() = false
+        }
+
+        object ExhaustedWhileTransientErroring : Failed {
+            override val logMessage: String get() = RewardVerificationStrings.EXHAUSTED_WHILE_TRANSIENT_ERRORING
+            override val isError: Boolean get() = false
+        }
+
+        object UnexpectedResponse : Failed {
+            override val logMessage: String get() = RewardVerificationStrings.UNEXPECTED_RESPONSE
+            override val isError: Boolean get() = true
+        }
+
+        class TerminalError(private val error: String) : Failed {
+            override val logMessage: String get() = RewardVerificationStrings.terminalError(error)
+            override val isError: Boolean get() = true
+        }
+    }
 }
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal fun Outcome.toResult(): RewardVerificationResult {
     return when (this) {
         is Outcome.Verified -> RewardVerificationResult.verified(reward)
-        Outcome.Failed -> RewardVerificationResult.failed
+        is Outcome.Failed -> RewardVerificationResult.failed
     }
 }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Outcome.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Outcome.kt
@@ -13,35 +13,34 @@ internal sealed interface Outcome {
     sealed interface Failed : Outcome {
         val logMessage: String
 
-        // True when [logMessage] should be logged at error level rather than warning.
-        val isError: Boolean
+        val isUnexpected: Boolean
 
         // Logs the backend-provided message verbatim.
         class BackendRejected(private val backendMessage: String?) : Failed {
             override val logMessage: String
                 get() = backendMessage?.takeIf { it.isNotBlank() }
                     ?: RewardVerificationStrings.BACKEND_REJECTED_WITHOUT_MESSAGE
-            override val isError: Boolean get() = false
+            override val isUnexpected: Boolean get() = false
         }
 
         object ExhaustedWhilePending : Failed {
             override val logMessage: String get() = RewardVerificationStrings.EXHAUSTED_WHILE_PENDING
-            override val isError: Boolean get() = false
+            override val isUnexpected: Boolean get() = false
         }
 
         object ExhaustedWhileTransientErroring : Failed {
             override val logMessage: String get() = RewardVerificationStrings.EXHAUSTED_WHILE_TRANSIENT_ERRORING
-            override val isError: Boolean get() = false
+            override val isUnexpected: Boolean get() = false
         }
 
         object UnexpectedResponse : Failed {
             override val logMessage: String get() = RewardVerificationStrings.UNEXPECTED_RESPONSE
-            override val isError: Boolean get() = true
+            override val isUnexpected: Boolean get() = true
         }
 
         class TerminalError(private val error: String) : Failed {
             override val logMessage: String get() = RewardVerificationStrings.terminalError(error)
-            override val isError: Boolean get() = true
+            override val isUnexpected: Boolean get() = true
         }
     }
 }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Outcome.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Outcome.kt
@@ -15,10 +15,16 @@ internal sealed interface Outcome {
 
         val isUnexpected: Boolean
 
-        // Logs the backend-provided message verbatim.
-        class BackendRejected(private val backendMessage: String?) : Failed {
+        // Logs the backend-provided message verbatim, falling back to the machine-readable failure
+        // reason when no message is present so the actionable signal isn't lost.
+        class BackendRejected(
+            private val backendMessage: String?,
+            private val failureReason: String? = null,
+        ) : Failed {
             override val logMessage: String
                 get() = backendMessage?.takeIf { it.isNotBlank() }
+                    ?: failureReason?.takeIf { it.isNotBlank() }
+                        ?.let { RewardVerificationStrings.backendRejectedWithReason(it) }
                     ?: RewardVerificationStrings.BACKEND_REJECTED_WITHOUT_MESSAGE
             override val isUnexpected: Boolean get() = false
         }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -59,7 +59,7 @@ internal object Poller {
             maxAttempts = maxAttempts,
         )
         if (outcome is Outcome.Failed) {
-            logFailure(outcome.logMessage, outcome.isError)
+            logFailure(outcome.logMessage, outcome.isUnexpected)
         }
         return outcome.toResult()
     }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -74,17 +74,17 @@ internal object Poller {
         Logger.d("Reward verification poll start transactionId=$clientTransactionId maxAttempts=$maxAttempts")
         var sawUnknownStatus = false
         var lastRetryWasTransientError = false
-        var terminal: Outcome? = null
+        var finalOutcome: Outcome? = null
         var attempt = 0
-        while (terminal == null && attempt < maxAttempts) {
+        while (finalOutcome == null && attempt < maxAttempts) {
             Logger.v(
                 "Reward verification poll attempt ${attempt + 1}/$maxAttempts transactionId=$clientTransactionId",
             )
             if (attempt > 0 && !awaitBackoff(sleepSeconds, jitterSeconds, clientTransactionId)) {
-                terminal = Outcome.Failed.TerminalError(BACKOFF_SCHEDULING_FAILED_DESCRIPTION)
+                finalOutcome = Outcome.Failed.TerminalError(BACKOFF_SCHEDULING_FAILED_DESCRIPTION)
             } else {
                 when (val step = fetchStep(clientTransactionId, fetcher)) {
-                    is Step.Terminal -> terminal = step.outcome
+                    is Step.Terminal -> finalOutcome = step.outcome
                     Step.RetryPending -> lastRetryWasTransientError = false
                     Step.RetryTransientError -> lastRetryWasTransientError = true
                     Step.RetryUnknown -> {
@@ -95,8 +95,8 @@ internal object Poller {
             }
             attempt++
         }
-        if (terminal != null) {
-            return terminal
+        if (finalOutcome != null) {
+            return finalOutcome
         }
         // Exhausted without a terminal status. An unknown status seen along the way is the most
         // actionable signal (likely version skew), so it takes precedence over the timeout buckets.

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -100,8 +100,6 @@ internal object Poller {
         }
         // Exhausted without a terminal status. An unknown status seen along the way is the most
         // actionable signal (likely version skew), so it takes precedence over the timeout buckets.
-        // Diagnostic only; the user-facing exhaustion message is logged once by poll().
-        Logger.v("Reward verification poll exhausted $maxAttempts attempts transactionId=$clientTransactionId")
         return when {
             sawUnknownStatus -> Outcome.Failed.UnexpectedResponse
             lastRetryWasTransientError -> Outcome.Failed.ExhaustedWhileTransientErroring
@@ -121,8 +119,6 @@ internal object Poller {
         } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {
-            // Diagnostic only; the user-facing terminal-error message is logged once by poll().
-            Logger.v("Reward verification poll backoff scheduling failed transactionId=$clientTransactionId")
             false
         }
     }
@@ -154,11 +150,9 @@ internal object Poller {
                 )
                 Step.RetryTransientError
             } else {
-                Logger.v("Reward verification poll terminal error: ${e.code} transactionId=$clientTransactionId")
                 Step.Terminal(Outcome.Failed.TerminalError(e.describeForLog()))
             }
         } catch (e: Exception) {
-            Logger.v("Reward verification poll unexpected error transactionId=$clientTransactionId")
             Step.Terminal(Outcome.Failed.TerminalError(e.describeForLog()))
         }
     }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -80,7 +80,7 @@ internal object Poller {
             Logger.v(
                 "Reward verification poll attempt ${attempt + 1}/$maxAttempts transactionId=$clientTransactionId",
             )
-            if (attempt > 0 && !awaitBackoff(sleepSeconds, jitterSeconds, clientTransactionId)) {
+            if (attempt > 0 && !awaitBackoff(sleepSeconds, jitterSeconds)) {
                 finalOutcome = Outcome.Failed.TerminalError(BACKOFF_SCHEDULING_FAILED_DESCRIPTION)
             } else {
                 when (val step = fetchStep(clientTransactionId, fetcher)) {
@@ -111,7 +111,6 @@ internal object Poller {
     private suspend fun awaitBackoff(
         sleepSeconds: suspend (Double) -> Unit,
         jitterSeconds: () -> Double,
-        clientTransactionId: String,
     ): Boolean {
         return try {
             sleepSeconds(jitterSeconds())

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -22,6 +22,17 @@ internal object Poller {
     private const val DEFAULT_JITTER_UPPER_BOUND_SECONDS: Double = 1.25
     private const val MILLIS_PER_SECOND: Double = 1_000.0
 
+    private const val BACKOFF_SCHEDULING_FAILED_DESCRIPTION: String =
+        "Failed to schedule the next reward verification poll attempt."
+
+    // The retry variants track why a read asked to retry, so an exhausted poll can report the most actionable reason.
+    private sealed interface Step {
+        class Terminal(val outcome: Outcome) : Step
+        object RetryPending : Step
+        object RetryTransientError : Step
+        object RetryUnknown : Step
+    }
+
     // Jittered ~1s per-attempt backoff so concurrent verifications don't align their polls.
     private val defaultJitterSeconds: () -> Double = {
         Random.nextDouble(
@@ -30,20 +41,27 @@ internal object Poller {
         )
     }
 
+    // sleepSeconds/jitterSeconds/maxAttempts/logFailure are injectable test seams; all default for production callers.
+    @Suppress("LongParameterList")
     suspend fun poll(
         clientTransactionId: String,
         fetcher: RewardVerificationFetcher = RewardVerificationFetcher.default,
         sleepSeconds: suspend (Double) -> Unit = { delay((it * MILLIS_PER_SECOND).toLong()) },
         jitterSeconds: () -> Double = defaultJitterSeconds,
         maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+        logFailure: (message: String, isError: Boolean) -> Unit = ::logFailureToLogcat,
     ): RewardVerificationResult {
-        return pollOutcome(
+        val outcome = pollOutcome(
             clientTransactionId = clientTransactionId,
             fetcher = fetcher,
             sleepSeconds = sleepSeconds,
             jitterSeconds = jitterSeconds,
             maxAttempts = maxAttempts,
-        ).toResult()
+        )
+        if (outcome is Outcome.Failed) {
+            logFailure(outcome.logMessage, outcome.isError)
+        }
+        return outcome.toResult()
     }
 
     private suspend fun pollOutcome(
@@ -54,26 +72,41 @@ internal object Poller {
         maxAttempts: Int,
     ): Outcome {
         Logger.d("Reward verification poll start transactionId=$clientTransactionId maxAttempts=$maxAttempts")
-        var outcome: Outcome? = null
+        var sawUnknownStatus = false
+        var lastRetryWasTransientError = false
+        var terminal: Outcome? = null
         var attempt = 0
-        while (outcome == null && attempt < maxAttempts) {
+        while (terminal == null && attempt < maxAttempts) {
             Logger.v(
                 "Reward verification poll attempt ${attempt + 1}/$maxAttempts transactionId=$clientTransactionId",
             )
-            outcome = if (attempt > 0 && !awaitBackoff(sleepSeconds, jitterSeconds, clientTransactionId)) {
-                Outcome.Failed
+            if (attempt > 0 && !awaitBackoff(sleepSeconds, jitterSeconds, clientTransactionId)) {
+                terminal = Outcome.Failed.TerminalError(BACKOFF_SCHEDULING_FAILED_DESCRIPTION)
             } else {
-                fetchOutcomeOrRetry(clientTransactionId, fetcher)
+                when (val step = fetchStep(clientTransactionId, fetcher)) {
+                    is Step.Terminal -> terminal = step.outcome
+                    Step.RetryPending -> lastRetryWasTransientError = false
+                    Step.RetryTransientError -> lastRetryWasTransientError = true
+                    Step.RetryUnknown -> {
+                        sawUnknownStatus = true
+                        lastRetryWasTransientError = false
+                    }
+                }
             }
             attempt++
         }
-        // Null outcome => every attempt exhausted without a terminal status.
-        if (outcome == null) {
-            Logger.w(
-                "Reward verification poll exhausted $maxAttempts attempts transactionId=$clientTransactionId",
-            )
+        if (terminal != null) {
+            return terminal
         }
-        return outcome ?: Outcome.Failed
+        // Exhausted without a terminal status. An unknown status seen along the way is the most
+        // actionable signal (likely version skew), so it takes precedence over the timeout buckets.
+        // Diagnostic only; the user-facing exhaustion message is logged once by poll().
+        Logger.v("Reward verification poll exhausted $maxAttempts attempts transactionId=$clientTransactionId")
+        return when {
+            sawUnknownStatus -> Outcome.Failed.UnexpectedResponse
+            lastRetryWasTransientError -> Outcome.Failed.ExhaustedWhileTransientErroring
+            else -> Outcome.Failed.ExhaustedWhilePending
+        }
     }
 
     // Returns false (fail deterministically) if scheduling the backoff fails, rather than spinning in a tight retry.
@@ -88,25 +121,28 @@ internal object Poller {
         } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {
-            Logger.e("Reward verification poll backoff scheduling failed transactionId=$clientTransactionId")
+            // Diagnostic only; the user-facing terminal-error message is logged once by poll().
+            Logger.v("Reward verification poll backoff scheduling failed transactionId=$clientTransactionId")
             false
         }
     }
 
-    // Returns a terminal Outcome, or null when polling should retry (pending/unknown or a transient error).
-    private suspend fun fetchOutcomeOrRetry(
+    // The broad Exception catch is the deliberate backstop that turns any unexpected failure into a terminal error.
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun fetchStep(
         clientTransactionId: String,
         fetcher: RewardVerificationFetcher,
-    ): Outcome? {
+    ): Step {
         return try {
             val result = fetcher.fetch(clientTransactionId)
             Logger.v("Reward verification poll result=${result.logDescription()} transactionId=$clientTransactionId")
             when (result) {
-                is CoreRewardVerificationResult.Verified -> Outcome.Verified(result.reward.toAdMobReward())
-                CoreRewardVerificationResult.FAILED -> Outcome.Failed
-                CoreRewardVerificationResult.PENDING,
-                CoreRewardVerificationResult.UNKNOWN,
-                -> null
+                is CoreRewardVerificationResult.Verified ->
+                    Step.Terminal(Outcome.Verified(result.reward.toAdMobReward()))
+                is CoreRewardVerificationResult.Failed ->
+                    Step.Terminal(Outcome.Failed.BackendRejected(result.message))
+                CoreRewardVerificationResult.PENDING -> Step.RetryPending
+                CoreRewardVerificationResult.UNKNOWN -> Step.RetryUnknown
             }
         } catch (e: CancellationException) {
             throw e
@@ -116,14 +152,14 @@ internal object Poller {
                     "Reward verification poll transient error, retrying: ${e.code} " +
                         "transactionId=$clientTransactionId",
                 )
-                null
+                Step.RetryTransientError
             } else {
-                Logger.e("Reward verification poll terminal error: ${e.code} transactionId=$clientTransactionId")
-                Outcome.Failed
+                Logger.v("Reward verification poll terminal error: ${e.code} transactionId=$clientTransactionId")
+                Step.Terminal(Outcome.Failed.TerminalError(e.describeForLog()))
             }
-        } catch (_: Exception) {
-            Logger.e("Reward verification poll unexpected error transactionId=$clientTransactionId")
-            Outcome.Failed
+        } catch (e: Exception) {
+            Logger.v("Reward verification poll unexpected error transactionId=$clientTransactionId")
+            Step.Terminal(Outcome.Failed.TerminalError(e.describeForLog()))
         }
     }
 
@@ -137,12 +173,25 @@ internal object Poller {
             (this is RewardVerificationException && isServerError)
     }
 
+    private fun PurchasesException.describeForLog(): String {
+        val underlying = underlyingErrorMessage?.takeIf { it.isNotBlank() }
+        return if (underlying != null) "$message ($underlying)" else message
+    }
+
+    private fun Exception.describeForLog(): String {
+        return message?.takeIf { it.isNotBlank() } ?: this::class.java.simpleName
+    }
+
+    private fun logFailureToLogcat(message: String, isError: Boolean) {
+        if (isError) Logger.e(message) else Logger.w(message)
+    }
+
     // Readable log form: object statuses log their name; Verified inlines the reward payload.
     private fun CoreRewardVerificationResult.logDescription(): String {
         return when (this) {
             is CoreRewardVerificationResult.Verified -> "verified(reward=$reward)"
             CoreRewardVerificationResult.PENDING -> "pending"
-            CoreRewardVerificationResult.FAILED -> "failed"
+            is CoreRewardVerificationResult.Failed -> "failed"
             CoreRewardVerificationResult.UNKNOWN -> "unknown"
         }
     }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -135,7 +135,7 @@ internal object Poller {
                 is CoreRewardVerificationResult.Verified ->
                     Step.Terminal(Outcome.Verified(result.reward.toAdMobReward()))
                 is CoreRewardVerificationResult.Failed ->
-                    Step.Terminal(Outcome.Failed.BackendRejected(result.message))
+                    Step.Terminal(Outcome.Failed.BackendRejected(result.message, result.failureReason))
                 CoreRewardVerificationResult.PENDING -> Step.RetryPending
                 CoreRewardVerificationResult.UNKNOWN -> Step.RetryUnknown
             }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntime.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntime.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.admob.Logger
 import com.revenuecat.purchases.admob.RewardVerificationResult
 import com.revenuecat.purchases.admob.VerifiedReward
 import com.revenuecat.purchases.admob.threading.runOnMainIfPresent
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -73,6 +74,11 @@ internal class RewardVerificationRuntime(
         verificationTask.invokeOnCompletion { cause ->
             removeClientTransactionId(adResponseId)
             if (cause != null) {
+                // poll() swallows every non-cancellation failure into a failed result, so a non-null cause
+                // here is the verification scope being cancelled (caller teardown / Purchases.close()).
+                if (cause is CancellationException) {
+                    Logger.w(RewardVerificationStrings.CANCELLED)
+                }
                 deliverOnce(RewardVerificationResult.failed)
             }
         }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationStrings.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationStrings.kt
@@ -1,0 +1,29 @@
+package com.revenuecat.purchases.admob.rewardverification
+
+internal object RewardVerificationStrings {
+
+    const val BACKEND_REJECTED_WITHOUT_MESSAGE: String =
+        "Reward verification was rejected by AdMob server-side verification."
+
+    const val EXHAUSTED_WHILE_PENDING: String =
+        "Reward verification timed out: the AdMob server-side verification (SSV) callback was not " +
+            "received in time. Possible causes: SSV is not enabled/configured for this ad unit in the " +
+            "AdMob Dashboard, the SSV callback URL is misconfigured in the AdMob Dashboard, AdMob delayed " +
+            "delivering the callback, or RevenueCat failed to process the SSV webhook."
+
+    const val EXHAUSTED_WHILE_TRANSIENT_ERRORING: String =
+        "Reward verification timed out after repeated transient errors while polling — typically " +
+            "unstable device network connectivity. The reward couldn't be verified."
+
+    const val UNEXPECTED_RESPONSE: String =
+        "Reward verification stopped after the server returned a status this SDK version doesn't " +
+            "recognize. Update to the latest SDK version; if you're already on the latest, contact " +
+            "RevenueCat support."
+
+    const val CANCELLED: String =
+        "Reward verification was cancelled before completion."
+
+    fun terminalError(error: String): String =
+        "Reward verification stopped after an unrecoverable error: $error. This is unexpected; if it " +
+            "persists, contact RevenueCat support with the error above."
+}

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationStrings.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationStrings.kt
@@ -5,6 +5,9 @@ internal object RewardVerificationStrings {
     const val BACKEND_REJECTED_WITHOUT_MESSAGE: String =
         "Reward verification was rejected by AdMob server-side verification."
 
+    fun backendRejectedWithReason(reason: String): String =
+        "Reward verification was rejected by AdMob server-side verification (reason: $reason)."
+
     const val EXHAUSTED_WHILE_PENDING: String =
         "Reward verification timed out: the AdMob server-side verification (SSV) callback was not " +
             "received in time. Possible causes: SSV is not enabled/configured for this ad unit in the " +

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntimeTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntimeTest.kt
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLog
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @RunWith(RobolectricTestRunner::class)
@@ -64,6 +65,8 @@ internal class RewardVerificationRuntimeTest {
         assertTrue(completionDelivered)
         assertNotNull(completedResult)
         assertTrue(completedResult!!.failed)
+        // Cancellation is logged so it isn't bucketed as a silent failure.
+        assertTrue(ShadowLog.getLogs().any { it.msg == RewardVerificationStrings.CANCELLED })
     }
 
     @Test

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/PollerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/PollerTest.kt
@@ -27,6 +27,14 @@ class PollerTest {
     private val noSleep: suspend (Double) -> Unit = { recordedSleeps.add(it) }
     private val fixedJitter: () -> Double = { 1.0 }
 
+    // Captures the user-facing failure message (and its severity) logged for a failed poll.
+    private val recordedFailures = mutableListOf<RecordedFailure>()
+    private val captureFailure: (String, Boolean) -> Unit = { message, isError ->
+        recordedFailures.add(RecordedFailure(message, isError))
+    }
+
+    private data class RecordedFailure(val message: String, val isError: Boolean)
+
     @Test
     fun `poll calls core status fetch with client transaction id`() = runBlocking {
         var receivedClientTransactionId: String? = null
@@ -70,20 +78,41 @@ class PollerTest {
     @Test
     fun `poll maps failed status to terminal failed outcome without retrying`() = runBlocking {
         var attempts = 0
+        val backendMessage = "AdMob server-side reward verification is not enabled for this app."
 
         val result = Poller.poll(
             clientTransactionId = "ct_1",
             fetcher = {
                 attempts++
-                CoreRewardVerificationResult.FAILED
+                CoreRewardVerificationResult.Failed(failureReason = "ssv_not_enabled", message = backendMessage)
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
+            logFailure = captureFailure,
         )
 
         assertEquals(1, attempts)
         assertTrue(result.failed)
         assertNull(result.verifiedReward)
+        // Backend-rejected: the backend message is logged verbatim, at warning level.
+        assertEquals(listOf(RecordedFailure(backendMessage, isError = false)), recordedFailures)
+    }
+
+    @Test
+    fun `poll logs a fallback message when the backend rejects without a message`() = runBlocking {
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = { CoreRewardVerificationResult.Failed() },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+            logFailure = captureFailure,
+        )
+
+        assertTrue(result.failed)
+        assertEquals(
+            listOf(RecordedFailure(RewardVerificationStrings.BACKEND_REJECTED_WITHOUT_MESSAGE, isError = false)),
+            recordedFailures,
+        )
     }
 
     @Test
@@ -124,12 +153,18 @@ class PollerTest {
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
             maxAttempts = 4,
+            logFailure = captureFailure,
         )
 
         assertEquals(4, attempts)
         assertEquals(3, recordedSleeps.size)
         assertTrue(result.failed)
         assertNull(result.verifiedReward)
+        // Exhausted while every read was still pending.
+        assertEquals(
+            listOf(RecordedFailure(RewardVerificationStrings.EXHAUSTED_WHILE_PENDING, isError = false)),
+            recordedFailures,
+        )
     }
 
     @Test
@@ -145,11 +180,72 @@ class PollerTest {
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
             maxAttempts = 3,
+            logFailure = captureFailure,
         )
 
         assertEquals(3, attempts)
         assertTrue(result.failed)
         assertNull(result.verifiedReward)
+        // An unknown status seen along the way is reported as unexpected_response (error level), not as a
+        // plain pending timeout.
+        assertEquals(
+            listOf(RecordedFailure(RewardVerificationStrings.UNEXPECTED_RESPONSE, isError = true)),
+            recordedFailures,
+        )
+    }
+
+    @Test
+    fun `poll prefers unexpected response over transient exhaustion when an unknown status was seen`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                // Unknown first, then transient errors until exhaustion: the unknown status wins.
+                if (attempts == 1) {
+                    CoreRewardVerificationResult.UNKNOWN
+                } else {
+                    throw RewardVerificationException(
+                        PurchasesError(PurchasesErrorCode.NetworkError),
+                        isServerError = false,
+                    )
+                }
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+            maxAttempts = 3,
+            logFailure = captureFailure,
+        )
+
+        assertTrue(result.failed)
+        assertEquals(
+            listOf(RecordedFailure(RewardVerificationStrings.UNEXPECTED_RESPONSE, isError = true)),
+            recordedFailures,
+        )
+    }
+
+    @Test
+    fun `poll reports transient exhaustion when polls keep failing with transient errors`() = runBlocking {
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                throw RewardVerificationException(
+                    PurchasesError(PurchasesErrorCode.NetworkError),
+                    isServerError = false,
+                )
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+            maxAttempts = 3,
+            logFailure = captureFailure,
+        )
+
+        assertTrue(result.failed)
+        assertEquals(
+            listOf(RecordedFailure(RewardVerificationStrings.EXHAUSTED_WHILE_TRANSIENT_ERRORING, isError = false)),
+            recordedFailures,
+        )
     }
 
     @Test
@@ -287,11 +383,22 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
+            logFailure = captureFailure,
         )
 
         assertEquals(1, attempts)
         assertTrue(result.failed)
         assertNull(result.verifiedReward)
+        // Terminal error: the failing error description is threaded into the terminal-error message at error level.
+        assertEquals(
+            listOf(
+                RecordedFailure(
+                    RewardVerificationStrings.terminalError(PurchasesErrorCode.InvalidCredentialsError.description),
+                    isError = true,
+                ),
+            ),
+            recordedFailures,
+        )
     }
 
     @Test
@@ -306,11 +413,16 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
+            logFailure = captureFailure,
         )
 
         assertEquals(1, attempts)
         assertTrue(result.failed)
         assertNull(result.verifiedReward)
+        assertEquals(
+            listOf(RecordedFailure(RewardVerificationStrings.terminalError("backend exploded"), isError = true)),
+            recordedFailures,
+        )
     }
 
     @Test
@@ -325,12 +437,17 @@ class PollerTest {
             },
             sleepSeconds = { throw IllegalStateException("scheduler down") },
             jitterSeconds = fixedJitter,
+            logFailure = captureFailure,
         )
 
         // First read returns pending, scheduling the backoff fails before the second read.
         assertEquals(1, attempts)
         assertTrue(result.failed)
         assertNull(result.verifiedReward)
+        // A backoff scheduling failure ends the poll as a terminal error at error level.
+        val failure = recordedFailures.single()
+        assertTrue(failure.isError)
+        assertTrue(failure.message.contains("unrecoverable error"))
     }
 
     @Test

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/PollerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/PollerTest.kt
@@ -116,6 +116,29 @@ class PollerTest {
     }
 
     @Test
+    fun `poll falls back to the failure reason when the backend rejects without a message`() = runBlocking {
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = { CoreRewardVerificationResult.Failed(failureReason = "no_reward_rule") },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+            logFailure = captureFailure,
+        )
+
+        assertTrue(result.failed)
+        // No human-readable message, but the machine-readable reason is still surfaced in the log.
+        assertEquals(
+            listOf(
+                RecordedFailure(
+                    RewardVerificationStrings.backendRejectedWithReason("no_reward_rule"),
+                    isError = false,
+                ),
+            ),
+            recordedFailures,
+        )
+    }
+
+    @Test
     fun `poll retries on pending until a terminal verified status is reached`() = runBlocking {
         var attempts = 0
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationResult.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationResult.kt
@@ -17,8 +17,14 @@ public sealed interface RewardVerificationResult {
 
     /**
      * Verification reached a terminal failure state.
+     *
+     * @param failureReason Machine-readable reason code from the backend, when provided.
+     * @param message Human-readable, actionable explanation from the backend, when provided.
      */
-    public object FAILED : RewardVerificationResult
+    public data class Failed(
+        val failureReason: String? = null,
+        val message: String? = null,
+    ) : RewardVerificationResult
 
     /**
      * The backend returned a status value that is not recognized by this SDK version.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RewardVerificationResponse.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RewardVerificationResponse.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.RewardVerificationResult
 import com.revenuecat.purchases.VerifiedReward
 import com.revenuecat.purchases.common.warnLog
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -16,13 +17,15 @@ import kotlinx.serialization.json.jsonPrimitive
 internal data class RewardVerificationResponse(
     val status: String,
     val reward: JsonElement? = null,
+    @SerialName("failure_reason") val failureReason: String? = null,
+    val message: String? = null,
 ) {
     @OptIn(InternalRevenueCatAPI::class)
     fun toRewardVerificationResult(): RewardVerificationResult {
         return when (status.lowercase()) {
             "pending" -> RewardVerificationResult.PENDING
             "verified" -> RewardVerificationResult.Verified(reward = reward.toVerifiedReward())
-            "failed" -> RewardVerificationResult.FAILED
+            "failed" -> RewardVerificationResult.Failed(failureReason = failureReason, message = message)
             else -> {
                 warnLog { "Unknown reward verification status: $status" }
                 RewardVerificationResult.UNKNOWN

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/RewardVerificationResponseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/RewardVerificationResponseTest.kt
@@ -35,12 +35,32 @@ class RewardVerificationResponseTest {
     }
 
     @Test
-    fun `maps failed status`() {
+    fun `maps failed status without reason or message`() {
         val response = JsonProvider.defaultJson.decodeFromString<RewardVerificationResponse>(
             """{"status":"failed"}""",
         )
 
-        assertThat(response.toRewardVerificationResult()).isEqualTo(RewardVerificationResult.FAILED)
+        assertThat(response.toRewardVerificationResult()).isEqualTo(RewardVerificationResult.Failed())
+    }
+
+    @Test
+    fun `maps failed status with failure reason and message`() {
+        val response = JsonProvider.defaultJson.decodeFromString<RewardVerificationResponse>(
+            """
+            {
+              "status":"failed",
+              "failure_reason":"ssv_not_enabled",
+              "message":"AdMob server-side reward verification is not enabled for this app."
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(response.toRewardVerificationResult()).isEqualTo(
+            RewardVerificationResult.Failed(
+                failureReason = "ssv_not_enabled",
+                message = "AdMob server-side reward verification is not enabled for this app.",
+            ),
+        )
     }
 
     @Test


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation

A failed to verify reward gave developers no actionable reason for the failure.

### Description

The poll response now parses `failure_reason`/`message`, and the poller logs *why* it ended- backend-rejected, exhausted (pending vs transient), unrecognized status, or terminal error.

The public result stays binary (verified/failed); cancellation still delivers `failed` and logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches reward-verification polling and core failed-status modeling; behavior for developers is mostly richer logs, but failure classification and internal API shape changed.
> 
> **Overview**
> Improves **actionable logging when AdMob reward verification fails**, while the **public callback result stays binary** (verified vs failed).
> 
> The core poll response now parses **`failure_reason` and `message`** on failed status (`RewardVerificationResult.Failed` replaces the old `FAILED` singleton). The AdMob **poller** classifies internal outcomes (backend rejection, timeout while pending, timeout after transient errors, unrecognized status, terminal errors) and emits **structured warning/error logs** via new `RewardVerificationStrings`, with severity driven by `isUnexpected`. Exhaustion logic **prioritizes unrecognized status** over generic timeout buckets when both occurred during the poll.
> 
> **Cancellation** during verification (e.g. `Purchases.close()`) still delivers `failed` but now logs an explicit cancelled message. Unit tests cover failure-message logging paths and response mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20180ca510362405d961110c92f457ea24db2603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->