### PR TITLE
Add WebCheckoutOpened result & handling

### DIFF
--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -87,6 +87,7 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public default void onRestoreError(com.revenuecat.purchases.PurchasesError error);
     method public default void onRestoreInitiated(com.revenuecat.purchases.ui.revenuecatui.utils.Resumable resume);
     method public default void onRestoreStarted();
+    method public default void onWebCheckoutOpened();
   }
 
   @androidx.compose.runtime.Immutable @dev.drewhamilton.poko.Poko public final class PaywallOptions {
@@ -269,6 +270,10 @@ package com.revenuecat.purchases.ui.revenuecatui.activity {
     ctor public PaywallResult.Restored(com.revenuecat.purchases.CustomerInfo customerInfo);
     method public com.revenuecat.purchases.CustomerInfo getCustomerInfo();
     property public final com.revenuecat.purchases.CustomerInfo customerInfo;
+  }
+
+  @kotlinx.parcelize.Parcelize public static final class PaywallResult.WebCheckoutOpened extends com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult implements android.os.Parcelable {
+    field public static final com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult.WebCheckoutOpened INSTANCE;
   }
 
   public interface PaywallResultHandler extends androidx.activity.result.ActivityResultCallback<com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult> {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -68,6 +68,7 @@ import com.revenuecat.purchases.ui.revenuecatui.templates.Template3
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template4
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template5
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template7
+import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
 import com.revenuecat.purchases.ui.revenuecatui.utils.URLOpener
 import com.revenuecat.purchases.ui.revenuecatui.utils.URLOpeningMethod
 
@@ -395,9 +396,10 @@ private fun rememberPaywallActionHandler(viewModel: PaywallViewModel): suspend (
                     } else {
                         viewModel.invalidateCustomerInfoCache()
                         context.handleUrlDestination(url, action.openMethod)
+                        viewModel.notifyWebCheckoutOpened()
                         if (action.autoDismiss) {
                             Logger.d("Auto-dismissing paywall after launching web checkout.")
-                            viewModel.closePaywall()
+                            viewModel.closePaywall(PaywallResult.WebCheckoutOpened)
                         }
                     }
                 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -214,6 +214,10 @@ private class LoadingViewModel(
         return null
     }
 
+    override fun notifyWebCheckoutOpened() {
+        // no-op
+    }
+
     override fun invalidateCustomerInfoCache() {
         // no-op
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
@@ -39,4 +39,10 @@ public interface PaywallListener {
     public fun onRestoreStarted() {}
     public fun onRestoreCompleted(customerInfo: CustomerInfo) {}
     public fun onRestoreError(error: PurchasesError) {}
+
+    /**
+     * Called when the user tapped a web checkout CTA and the external payment URL was opened.
+     * This is distinct from cancellation — the user may still complete the purchase externally.
+     */
+    public fun onWebCheckoutOpened() {}
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -186,6 +186,10 @@ internal class PaywallActivity : ComponentActivity() {
                 userListener?.onRestoreError(error)
                 setResult(RESULT_OK, createResultIntent(PaywallResult.Error(error)))
             }
+
+            override fun onWebCheckoutOpened() {
+                userListener?.onWebCheckoutOpened()
+            }
         }
 
         val edgeToEdge = args?.edgeToEdge == true

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallResult.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallResult.kt
@@ -37,4 +37,11 @@ public sealed class PaywallResult : Parcelable {
     @Parcelize
     @Poko
     public class Restored(public val customerInfo: CustomerInfo) : PaywallResult(), Parcelable
+
+    /**
+     * User tapped web checkout and left the app to complete payment externally.
+     * This is not a cancellation — the purchase flow may still succeed in the background.
+     */
+    @Parcelize
+    public object WebCheckoutOpened : PaywallResult(), Parcelable
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -134,6 +134,7 @@ internal interface PaywallViewModel {
     fun onTransitionComplete(transitionId: Int)
 
     fun getWebCheckoutUrl(launchWebCheckout: PaywallAction.External.LaunchWebCheckout): String?
+    fun notifyWebCheckoutOpened()
     fun invalidateCustomerInfoCache()
 
     /**
@@ -365,6 +366,10 @@ internal class PaywallViewModelImpl(
             return null
         }
         return state.resolveWebCheckoutUrlForInteraction(launchWebCheckout)
+    }
+
+    override fun notifyWebCheckoutOpened() {
+        listener?.onWebCheckoutOpened()
     }
 
     override fun invalidateCustomerInfoCache() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -521,6 +521,7 @@ internal class MockViewModel(
     validationWarning: PaywallWarning? = null,
     private val allowsPurchases: Boolean = false,
     private val shouldErrorOnUnsupportedMethods: Boolean = true,
+    private val webCheckoutUrl: String? = null,
 ) : ViewModel(), PaywallViewModel {
     override val resourceProvider: ResourceProvider
         get() = MockResourceProvider()
@@ -608,8 +609,17 @@ internal class MockViewModel(
 
     var closePaywallCallCount = 0
         private set
+    var closePaywallResults = mutableListOf<PaywallResult?>()
+        private set
     override fun closePaywall(result: PaywallResult?) {
         closePaywallCallCount++
+        closePaywallResults.add(result)
+    }
+
+    var notifyWebCheckoutOpenedCallCount = 0
+        private set
+    override fun notifyWebCheckoutOpened() {
+        notifyWebCheckoutOpenedCallCount++
     }
 
     var getWebCheckoutUrlCallCount = 0
@@ -619,7 +629,7 @@ internal class MockViewModel(
     override fun getWebCheckoutUrl(launchWebCheckout: PaywallAction.External.LaunchWebCheckout): String? {
         getWebCheckoutUrlCallCount++
         getWebCheckoutUrlParams.add(launchWebCheckout)
-        return null
+        return webCheckoutUrl
     }
 
     var invalidateCustomerInfoCacheCallCount = 0

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
@@ -32,6 +32,7 @@ import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.R
+import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.helpers.UiConfig
@@ -271,6 +272,50 @@ class PaywallActionTests {
             availablePackages = listOf(TestData.Packages.monthly),
             paywallComponents = Offering.PaywallComponents(UiConfig(), data),
         )
+
+    @Test
+    fun `LaunchWebCheckout with autoDismiss closes paywall with WebCheckoutOpened result`(): Unit =
+        with(composeTestRule) {
+            // Arrange
+            val textColor = ColorScheme(ColorInfo.Hex(Color.Black.toArgb()))
+            val defaultLocale = LocaleId("en_US")
+            val localizationKey = LocalizationKey("web_checkout")
+            val localizationData = LocalizationData.Text("web checkout")
+            val localizations = nonEmptyMapOf(
+                defaultLocale to nonEmptyMapOf(localizationKey to localizationData),
+            )
+            val components = listOf(
+                PurchaseButtonComponent(
+                    stack = StackComponent(
+                        components = listOf(TextComponent(text = localizationKey, color = textColor)),
+                    ),
+                    method = PurchaseButtonComponent.Method.WebCheckout(),
+                ),
+            )
+            val offering = FakeOffering(components, localizations)
+            val viewModel = MockViewModel(
+                offering = offering,
+                allowsPurchases = true,
+                webCheckoutUrl = "https://checkout.example.com",
+            )
+            val options = PaywallOptions.Builder(dismissRequest = {}).setOffering(offering).build()
+
+            // Act
+            setContent { InternalPaywall(options, viewModel) }
+            // Buttons appear once in main content and once in sticky footer
+            onAllNodesWithText(localizationData.value)
+                .assertCountEquals(2)
+                .get(0)
+                .assertIsDisplayed()
+                .assertHasClickAction()
+                .performClick()
+            waitForIdle()
+
+            // Assert: listener notified and paywall closed with WebCheckoutOpened, not Cancelled
+            assertEquals(1, viewModel.notifyWebCheckoutOpenedCallCount)
+            assertEquals(1, viewModel.closePaywallCallCount)
+            assertEquals(PaywallResult.WebCheckoutOpened, viewModel.closePaywallResults.first())
+        }
 
     @Suppress("TestFunctionName")
     private fun FakeOffering(


### PR DESCRIPTION
Introduce WebCheckoutOpened to represent the user tapping a web checkout CTA and leaving the app. Add PaywallListener.onWebCheckoutOpened(), propagate a notifyWebCheckoutOpened() call through PaywallViewModel (impl calls listener), and have InternalPaywall call it and close the paywall with PaywallResult.WebCheckoutOpened when autoDismiss is true. Add a no-op override in LoadingViewModel, update MockViewModel to track calls/results, forward the event to user listeners in PaywallActivity, and add a test ensuring LaunchWebCheckout with autoDismiss closes with WebCheckoutOpened. Update api.txt to expose the new API surface.

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API and clearer dismiss semantics for web checkout; limited to RevenueCat UI paywall flows with tests.
> 
> **Overview**
> Adds a dedicated **web checkout** outcome so hosts can tell “user left for external payment” apart from **cancelled** or a completed in-app purchase.
> 
> **`PaywallResult.WebCheckoutOpened`** is a new parcelable activity result. **`PaywallListener.onWebCheckoutOpened()`** fires after the checkout URL opens. **`PaywallViewModel.notifyWebCheckoutOpened()`** routes that to the listener; on **`LaunchWebCheckout`** with **`autoDismiss`**, **`InternalPaywall`** now calls **`closePaywall(PaywallResult.WebCheckoutOpened)`** instead of a generic dismiss. **`PaywallActivity`** forwards the listener callback; loading/mock view models implement the new API; **`api.txt`** and a compose test cover auto-dismiss + result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b455289d2b5bdce83ea4e42515a7ca535c1bc13b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->