### PR TITLE
Persist workflow detail envelopes for recovery when backend is down

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -136,6 +136,8 @@ public open class DeviceCache(
 
     private val workflowsListResponseCacheKey: String by lazy { "$apiKeyPrefix.workflowsListResponse" }
 
+    private val workflowDetailEnvelopesCacheKey: String by lazy { "$apiKeyPrefix.workflowDetailEnvelopes" }
+
     internal fun startEditing(): SharedPreferences.Editor {
         return preferences.edit()
     }
@@ -628,6 +630,27 @@ public open class DeviceCache(
     @Synchronized
     internal fun clearWorkflowsListResponseCache() {
         preferences.edit().remove(workflowsListResponseCacheKey).apply()
+    }
+
+    // endregion
+
+    // region workflow detail envelopes
+
+    @Synchronized
+    internal fun getWorkflowDetailEnvelopesCache(): String? {
+        return preferences.getString(workflowDetailEnvelopesCacheKey, null)
+    }
+
+    @Synchronized
+    internal fun cacheWorkflowDetailEnvelopes(payload: String) {
+        preferences.edit()
+            .putString(workflowDetailEnvelopesCacheKey, payload)
+            .apply()
+    }
+
+    @Synchronized
+    internal fun clearWorkflowDetailEnvelopesCache() {
+        preferences.edit().remove(workflowDetailEnvelopesCacheKey).apply()
     }
 
     // endregion

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowJsonParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowJsonParser.kt
@@ -15,4 +15,7 @@ internal object WorkflowJsonParser {
 
     fun parseWorkflowsListResponse(payload: String): WorkflowsListResponse =
         JsonTools.json.decodeFromString<WorkflowsListResponse>(payload)
+
+    fun parseWorkflowDetailEnvelopes(payload: String): Map<String, WorkflowDetailResponse> =
+        JsonTools.json.decodeFromString<Map<String, WorkflowDetailResponse>>(payload)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -49,6 +49,7 @@ internal class WorkflowManager(
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
         callbackDispatcher: Dispatcher? = null,
+        persistEnvelopeOnResolve: Boolean = false,
     ) {
         val cached = workflowsCache.cachedWorkflow(workflowId)
         if (cached != null && !workflowsCache.isWorkflowCacheStale(workflowId, appInBackground)) {
@@ -69,6 +70,10 @@ internal class WorkflowManager(
                     return@launch
                 }
                 workflowsCache.cacheWorkflow(workflowId, result)
+                if (persistEnvelopeOnResolve) {
+                    runCatching { workflowsCache.cacheWorkflowDetailEnvelope(workflowId, response) }
+                        .onFailure { errorLog(it) { "Failed to persist workflow detail envelope for $workflowId" } }
+                }
                 scope.launch {
                     runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result.workflow) }
                         .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
@@ -182,6 +187,7 @@ internal class WorkflowManager(
                 workflowId = workflowId,
                 appInBackground = appInBackground,
                 callbackDispatcher = prefetchDispatcher,
+                persistEnvelopeOnResolve = true,
                 onSuccess = { continuation.safeResume(Unit) },
                 onError = { error ->
                     errorLog { "Failed to prefetch workflow $workflowId: ${error.underlyingErrorMessage}" }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -41,6 +41,18 @@ internal class WorkflowManager(
         prefetchDispatcher.close()
     }
 
+    /**
+     * Fetches and resolves a single workflow, serving a fresh in-memory cache hit when one exists
+     * and otherwise fetching from the backend.
+     *
+     * @param persistEnvelopeOnResolve when true, also persists the raw detail envelope to disk after
+     * a successful resolve, so it survives an app restart and can be re-resolved while the backend is
+     * down (see [getWorkflowsList]'s recovery path). Only the prefetch path sets this: prefetched
+     * workflows are the curated, bounded set the backend marked as mattering, so persisting all of
+     * them is safe. On-demand fetches leave it false to avoid unbounded disk growth (a user can open
+     * many distinct paywalls in a session), so persisting those behind an LRU cap is a planned
+     * follow-up rather than part of this path.
+     */
     @Suppress("LongParameterList")
     fun getWorkflow(
         appUserID: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -214,8 +214,10 @@ internal class WorkflowManager(
 
     /**
      * Re-resolves a persisted [envelope] into the in-memory cache during backend-down recovery. For
-     * USE_CDN this is a local file read (the CDN file is already cached). A failure is logged and
-     * swallowed so one bad envelope doesn't fail its siblings in the surrounding [coroutineScope].
+     * USE_CDN this avoids a backend call: when the CDN file is still cached locally (it was
+     * pre-downloaded during the original prefetch) re-resolution needs no network. If that file was
+     * evicted, resolution may need the CDN and can fail while the backend is down; the failure is
+     * logged and swallowed so one bad envelope doesn't fail its siblings in the surrounding [coroutineScope].
      */
     private suspend fun restoreWorkflowFromEnvelope(workflowId: String, envelope: WorkflowDetailResponse) {
         val result = try {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -169,7 +169,22 @@ internal class WorkflowManager(
                         val filtered = response.onlyWorkflowsWithOfferingId()
                         workflowsCache.cacheWorkflowsListInMemory(filtered, buildOfferingIdMap(filtered.workflows))
                     }
-                    completePendingCallbacks(appUserID)
+                    val envelopes = workflowsCache.cachedWorkflowDetailEnvelopesFromDisk().orEmpty()
+                    if (envelopes.isEmpty()) {
+                        completePendingCallbacks(appUserID)
+                    } else {
+                        scope.launch {
+                            // Re-resolve persisted envelopes into the in-memory cache, mirroring the
+                            // success-path prefetch loop. A failed re-resolve is logged and does not
+                            // fail its siblings. completePendingCallbacks still fires exactly once.
+                            coroutineScope {
+                                envelopes.forEach { (workflowId, envelope) ->
+                                    launch { restoreWorkflowFromEnvelope(workflowId, envelope) }
+                                }
+                            }
+                            completePendingCallbacks(appUserID)
+                        }
+                    }
                 },
             )
         }
@@ -195,6 +210,23 @@ internal class WorkflowManager(
                 },
             )
         }
+    }
+
+    /**
+     * Re-resolves a persisted [envelope] into the in-memory cache during backend-down recovery. For
+     * USE_CDN this is a local file read (the CDN file is already cached). A failure is logged and
+     * swallowed so one bad envelope doesn't fail its siblings in the surrounding [coroutineScope].
+     */
+    private suspend fun restoreWorkflowFromEnvelope(workflowId: String, envelope: WorkflowDetailResponse) {
+        val result = try {
+            workflowDetailResolver.resolve(envelope)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            errorLog(e) { "Failed to restore workflow $workflowId from disk cache" }
+            return
+        }
+        workflowsCache.cacheWorkflow(workflowId, result)
     }
 
     fun workflowIdForOfferingId(offeringId: String): String? =

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -29,8 +29,9 @@ import kotlinx.serialization.builtins.serializer
  * failure, and [clearCache] wipes it on identity transitions.
  *
  * It additionally persists per-workflow detail envelopes to disk: [cacheWorkflowDetailEnvelope]
- * writes a single envelope (merging with any already-stored ones), and
- * [cachedWorkflowDetailEnvelopesFromDisk] restores the full map after a backend failure.
+ * writes a single envelope (merging with any already-stored ones),
+ * [cachedWorkflowDetailEnvelopesFromDisk] restores the full map after a backend failure, and
+ * [clearCache] wipes the envelope store on identity transitions (alongside the list disk cache).
  */
 // Coherent owner of all workflow cache state; splitting would obscure the single clearCache semantics
 @Suppress("TooManyFunctions")
@@ -190,5 +191,6 @@ internal class WorkflowsCache(
         workflowsListCachedObject.clearCache()
         offeringIdToWorkflowIdMap = emptyMap()
         deviceCache.clearWorkflowsListResponseCache()
+        deviceCache.clearWorkflowDetailEnvelopesCache()
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -97,6 +97,7 @@ internal class WorkflowsCache(
         deviceCache.cacheWorkflowsListResponse(
             JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
         )
+        pruneWorkflowDetailEnvelopesToList(response.workflows.map { it.id }.toSet())
     }
 
     /**
@@ -158,6 +159,22 @@ internal class WorkflowsCache(
                 .onFailure { errorLog(it) { "Failed to restore workflow detail envelopes from disk cache" } }
                 .getOrNull()
         }
+
+    /**
+     * Drops persisted envelopes whose workflowId is no longer in the latest list. This is the
+     * keyed-map equivalent of how [com.revenuecat.purchases.common.offerings.OfferingsCache] stays
+     * bounded by wholesale-replacing its single response blob: the persisted set always equals what
+     * the latest backend response says exists, so workflows the backend stopped sending don't
+     * linger on disk.
+     */
+    @Synchronized
+    private fun pruneWorkflowDetailEnvelopesToList(workflowIds: Set<String>) {
+        val current = cachedWorkflowDetailEnvelopesFromDisk() ?: return
+        val pruned = current.filterKeys { it in workflowIds }
+        if (pruned.size != current.size) {
+            persistWorkflowDetailEnvelopes(pruned)
+        }
+    }
 
     private fun persistWorkflowDetailEnvelopes(envelopes: Map<String, WorkflowDetailResponse>) {
         deviceCache.cacheWorkflowDetailEnvelopes(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -141,6 +141,10 @@ internal class WorkflowsCache(
      * already there. Called only from the prefetch path after a successful resolve, so a persisted
      * envelope is always one we could render offline. Mirrors how [cacheWorkflowsList] writes the
      * list to disk.
+     *
+     * Reads, merges, and rewrites the whole on-disk map; the prefetch set is small so this is cheap.
+     * If the existing payload can't be parsed it is treated as empty, so an unreadable map is
+     * replaced rather than preserved.
      */
     @Synchronized
     fun cacheWorkflowDetailEnvelope(workflowId: String, envelope: WorkflowDetailResponse) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -33,7 +33,6 @@ import kotlinx.serialization.builtins.serializer
  * [cachedWorkflowDetailEnvelopesFromDisk] restores the full map after a backend failure, and
  * [clearCache] wipes the envelope store on identity transitions (alongside the list disk cache).
  */
-// Coherent owner of all workflow cache state; splitting would obscure the single clearCache semantics
 @Suppress("TooManyFunctions")
 @OptIn(InternalRevenueCatAPI::class)
 internal class WorkflowsCache(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -8,6 +8,8 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.caching.InMemoryCachedObject
 import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.errorLog
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 
 /**
  * In-memory cache for all workflow data: the resolved per-workflow [WorkflowDataResult]s and the
@@ -25,7 +27,13 @@ import com.revenuecat.purchases.common.errorLog
  * [com.revenuecat.purchases.common.offerings.OfferingsCache] owns the offerings response on disk:
  * [cacheWorkflowsList] persists it, [cachedWorkflowsListResponseFromDisk] restores it on backend
  * failure, and [clearCache] wipes it on identity transitions.
+ *
+ * It additionally persists per-workflow detail envelopes to disk: [cacheWorkflowDetailEnvelope]
+ * writes a single envelope (merging with any already-stored ones), and
+ * [cachedWorkflowDetailEnvelopesFromDisk] restores the full map after a backend failure.
  */
+// Coherent owner of all workflow cache state; splitting would obscure the single clearCache semantics
+@Suppress("TooManyFunctions")
 @OptIn(InternalRevenueCatAPI::class)
 internal class WorkflowsCache(
     private val deviceCache: DeviceCache,
@@ -119,6 +127,45 @@ internal class WorkflowsCache(
         offeringIdToWorkflowIdMap[offeringId]
 
     // endregion Workflows list cache
+
+    private companion object {
+        private val envelopesSerializer = MapSerializer(String.serializer(), WorkflowDetailResponse.serializer())
+    }
+
+    // region Workflow detail envelopes disk cache
+
+    /**
+     * Persists [envelope] under [workflowId] in the on-disk envelope map, merging with whatever is
+     * already there. Called only from the prefetch path after a successful resolve, so a persisted
+     * envelope is always one we could render offline. Mirrors how [cacheWorkflowsList] writes the
+     * list to disk.
+     */
+    @Synchronized
+    fun cacheWorkflowDetailEnvelope(workflowId: String, envelope: WorkflowDetailResponse) {
+        val current = cachedWorkflowDetailEnvelopesFromDisk().orEmpty().toMutableMap()
+        current[workflowId] = envelope
+        persistWorkflowDetailEnvelopes(current)
+    }
+
+    /**
+     * Reads the persisted envelope map, or null when nothing is cached or the payload can't be
+     * parsed (the parse failure is logged). Used to recover envelopes after a backend failure,
+     * mirroring [cachedWorkflowsListResponseFromDisk].
+     */
+    fun cachedWorkflowDetailEnvelopesFromDisk(): Map<String, WorkflowDetailResponse>? =
+        deviceCache.getWorkflowDetailEnvelopesCache()?.let { cached ->
+            runCatching { WorkflowJsonParser.parseWorkflowDetailEnvelopes(cached) }
+                .onFailure { errorLog(it) { "Failed to restore workflow detail envelopes from disk cache" } }
+                .getOrNull()
+        }
+
+    private fun persistWorkflowDetailEnvelopes(envelopes: Map<String, WorkflowDetailResponse>) {
+        deviceCache.cacheWorkflowDetailEnvelopes(
+            JsonTools.json.encodeToString(envelopesSerializer, envelopes),
+        )
+    }
+
+    // endregion Workflow detail envelopes disk cache
 
     @Synchronized
     fun clearCache() {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -66,6 +66,7 @@ class DeviceCacheTest {
     private val productEntitlementMappingCacheKey = "com.revenuecat.purchases.api_key.productEntitlementMapping"
     private val offeringsResponseCacheKey = "com.revenuecat.purchases.api_key.offeringsResponse"
     private val workflowsListResponseCacheKey = "com.revenuecat.purchases.api_key.workflowsListResponse"
+    private val workflowDetailEnvelopesCacheKey = "com.revenuecat.purchases.api_key.workflowDetailEnvelopes"
 
     private val slotForPutLong = slot<Long>()
 
@@ -748,6 +749,35 @@ class DeviceCacheTest {
     }
 
     // endregion workflows list response
+
+    // region workflow detail envelopes
+
+    @Test
+    fun `getWorkflowDetailEnvelopesCache returns null when nothing is cached`() {
+        every { mockPrefs.getString(workflowDetailEnvelopesCacheKey, null) } returns null
+        assertThat(cache.getWorkflowDetailEnvelopesCache()).isNull()
+    }
+
+    @Test
+    fun `cacheWorkflowDetailEnvelopes stores string in preferences`() {
+        val payload = """{"wf_1":{"action":"use_cdn","url":"https://cdn/x.json","hash":"h"}}"""
+        cache.cacheWorkflowDetailEnvelopes(payload)
+        verifyAll {
+            mockEditor.putString(workflowDetailEnvelopesCacheKey, payload)
+            mockEditor.apply()
+        }
+    }
+
+    @Test
+    fun `clearWorkflowDetailEnvelopesCache removes key from preferences`() {
+        cache.clearWorkflowDetailEnvelopesCache()
+        verifyAll {
+            mockEditor.remove(workflowDetailEnvelopesCacheKey)
+            mockEditor.apply()
+        }
+    }
+
+    // endregion workflow detail envelopes
 
     // region storefront
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -1068,4 +1068,153 @@ class WorkflowManagerTest {
     }
 
     // endregion onComplete callback
+
+    // region envelope persistence
+
+    @Test
+    fun `prefetch persists the workflow detail envelope`() {
+        val envelope = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn/wf_1.json",
+            hash = "h",
+        )
+        coEvery { mockResolver.resolve(envelope) } returns
+            WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+
+        val listResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "A", offeringId = "default", prefetch = true),
+            ),
+        )
+        val listSuccess = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccess), onError = any())
+        } answers { listSuccess.captured(listResponse) }
+
+        val detailSuccess = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                any(),
+                onSuccess = capture(detailSuccess),
+                onError = any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        } answers { detailSuccess.captured(envelope) }
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // WorkflowsCache.cacheWorkflowDetailEnvelope -> DeviceCache.cacheWorkflowDetailEnvelopes (the mocked layer)
+        verify(exactly = 1) { mockDeviceCache.cacheWorkflowDetailEnvelopes(any()) }
+    }
+
+    @Test
+    fun `on-demand getWorkflow does not persist the envelope`() {
+        val envelope = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        coEvery { mockResolver.resolve(envelope) } returns
+            WorkflowDataResult(workflow = envelope.data!!, enrolledVariants = null)
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers { successSlot.captured(envelope) }
+
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        verify(exactly = 0) { mockDeviceCache.cacheWorkflowDetailEnvelopes(any()) }
+    }
+
+    @Test
+    fun `prefetch does not persist the envelope when resolve fails`() {
+        val envelope = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn/wf_1.json",
+            hash = "h",
+        )
+        coEvery { mockResolver.resolve(envelope) } throws IllegalStateException("boom")
+
+        val listResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "A", offeringId = "default", prefetch = true),
+            ),
+        )
+        val listSuccess = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccess), onError = any())
+        } answers { listSuccess.captured(listResponse) }
+
+        val detailSuccess = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                any(),
+                onSuccess = capture(detailSuccess),
+                onError = any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        } answers { detailSuccess.captured(envelope) }
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        verify(exactly = 0) { mockDeviceCache.cacheWorkflowDetailEnvelopes(any()) }
+    }
+
+    @Test
+    fun `prefetch still completes when persisting the envelope throws`() {
+        val envelope = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn/wf_1.json",
+            hash = "h",
+        )
+        val resolved = WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+        coEvery { mockResolver.resolve(envelope) } returns resolved
+        // Persisting blows up at the DeviceCache layer.
+        every { mockDeviceCache.cacheWorkflowDetailEnvelopes(any()) } throws IOException("disk full")
+
+        val listResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "A", offeringId = "default", prefetch = true),
+            ),
+        )
+        val listSuccess = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccess), onError = any())
+        } answers { listSuccess.captured(listResponse) }
+
+        val detailSuccess = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                any(),
+                onSuccess = capture(detailSuccess),
+                onError = any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        } answers { detailSuccess.captured(envelope) }
+
+        var completeCount = 0
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completeCount++ }
+
+        // Persistence failure must not hang the prefetch: onComplete still fires exactly once...
+        assertThat(completeCount).isEqualTo(1)
+        // ...and the resolved workflow is still cached in memory (cacheWorkflow ran before the failed persist).
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(resolved)
+    }
+
+    // endregion envelope persistence
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -1217,4 +1217,72 @@ class WorkflowManagerTest {
     }
 
     // endregion envelope persistence
+
+    // region onError envelope restore
+
+    @Test
+    fun `list onError re-resolves persisted envelopes so getWorkflow is a cache hit`() {
+        // The resolver is mocked, so INLINE vs USE_CDN is indistinguishable here — the manager just
+        // hands the envelope to the resolver. This proves restore -> re-resolve -> cache-hit.
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns
+            """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":true}]}"""
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
+
+        val restored = WorkflowDataResult(workflow = mockk(), enrolledVariants = mapOf("e" to "v"))
+        coEvery {
+            mockResolver.resolve(
+                WorkflowDetailResponse(action = WorkflowResponseAction.USE_CDN, url = "https://cdn/wf_1.json", hash = "h"),
+            )
+        } returns restored
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+        var result: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { result = it },
+            onError = { fail("expected cache hit, got $it") },
+        )
+        assertThat(result).isSameAs(restored)
+        verify(exactly = 0) { mockBackend.getWorkflow(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `list onError completes once and isolates a failing envelope re-resolve`() {
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns
+            """{"workflows":[{"id":"wf_ok","display_name":"OK","offering_id":"a","prefetch":true},{"id":"wf_bad","display_name":"BAD","offering_id":"b","prefetch":true}]}"""
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_ok":{"action":"use_cdn","url":"u_ok","hash":"h"},"wf_bad":{"action":"use_cdn","url":"u_bad","hash":"h"}}"""
+
+        val okResult = WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+        coEvery {
+            mockResolver.resolve(WorkflowDetailResponse(action = WorkflowResponseAction.USE_CDN, url = "u_ok", hash = "h"))
+        } returns okResult
+        coEvery {
+            mockResolver.resolve(WorkflowDetailResponse(action = WorkflowResponseAction.USE_CDN, url = "u_bad", hash = "h"))
+        } throws IllegalStateException("cdn read failed")
+
+        var completeCount = 0
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completeCount++ }
+
+        assertThat(completeCount).isEqualTo(1)
+        assertThat(workflowsCache.cachedWorkflow("wf_ok")).isSameAs(okResult)
+        assertThat(workflowsCache.cachedWorkflow("wf_bad")).isNull()
+    }
+
+    // endregion onError envelope restore
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -1106,7 +1107,9 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
         // WorkflowsCache.cacheWorkflowDetailEnvelope -> DeviceCache.cacheWorkflowDetailEnvelopes (the mocked layer)
-        verify(exactly = 1) { mockDeviceCache.cacheWorkflowDetailEnvelopes(any()) }
+        val persistedSlot = slot<String>()
+        verify(exactly = 1) { mockDeviceCache.cacheWorkflowDetailEnvelopes(capture(persistedSlot)) }
+        assertThat(persistedSlot.captured).contains("wf_1")
     }
 
     @Test
@@ -1282,6 +1285,37 @@ class WorkflowManagerTest {
         assertThat(completeCount).isEqualTo(1)
         assertThat(workflowsCache.cachedWorkflow("wf_ok")).isSameAs(okResult)
         assertThat(workflowsCache.cachedWorkflow("wf_bad")).isNull()
+    }
+
+    @Test
+    fun `list onError completes immediately when no envelopes are persisted`() {
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns null
+
+        var completeCount = 0
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completeCount++ }
+
+        assertThat(completeCount).isEqualTo(1)
+        coVerify(exactly = 0) { mockResolver.resolve(any()) }
+    }
+
+    @Test
+    fun `list onError completes once when the persisted envelope payload is corrupt`() {
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns "not valid json"
+
+        var completeCount = 0
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completeCount++ }
+
+        assertThat(completeCount).isEqualTo(1)
     }
 
     // endregion onError envelope restore

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -184,6 +184,12 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `clearCache clears the persisted workflow detail envelopes`() {
+        workflowsCache.clearCache()
+        verify(exactly = 1) { deviceCache.clearWorkflowDetailEnvelopesCache() }
+    }
+
+    @Test
     fun `cachedWorkflowsListResponseFromDisk parses the persisted response`() {
         val cachedJson =
             """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -5,8 +5,11 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.utils.add
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -199,6 +202,83 @@ class WorkflowsCacheTest {
     fun `cachedWorkflowsListResponseFromDisk returns null when the payload is corrupt`() {
         every { deviceCache.getWorkflowsListResponseCache() } returns "not valid json"
         assertThat(workflowsCache.cachedWorkflowsListResponseFromDisk()).isNull()
+    }
+
+    private fun cdnEnvelope(url: String, hash: String = "h"): WorkflowDetailResponse =
+        WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = url,
+            hash = hash,
+            enrolledVariants = mapOf("exp" to "variant_a"),
+        )
+
+    @Test
+    fun `cacheWorkflowDetailEnvelope persists the envelope keyed by workflowId`() {
+        every { deviceCache.getWorkflowDetailEnvelopesCache() } returns null
+        val payloadSlot = slot<String>()
+        every { deviceCache.cacheWorkflowDetailEnvelopes(capture(payloadSlot)) } just Runs
+
+        workflowsCache.cacheWorkflowDetailEnvelope("wf_1", cdnEnvelope("https://cdn/wf_1.json"))
+
+        assertThat(payloadSlot.captured).contains("wf_1")
+        assertThat(payloadSlot.captured).contains("https://cdn/wf_1.json")
+    }
+
+    @Test
+    fun `cacheWorkflowDetailEnvelope merges into existing persisted envelopes`() {
+        every { deviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_existing":{"action":"use_cdn","url":"u0","hash":"h0"}}"""
+        val payloadSlot = slot<String>()
+        every { deviceCache.cacheWorkflowDetailEnvelopes(capture(payloadSlot)) } just Runs
+
+        workflowsCache.cacheWorkflowDetailEnvelope("wf_new", cdnEnvelope("https://cdn/wf_new.json"))
+
+        val persisted = WorkflowJsonParser.parseWorkflowDetailEnvelopes(payloadSlot.captured)
+        assertThat(persisted.keys).containsExactlyInAnyOrder("wf_existing", "wf_new")
+        assertThat(persisted.getValue("wf_existing").url).isEqualTo("u0")
+        assertThat(persisted.getValue("wf_new").url).isEqualTo("https://cdn/wf_new.json")
+    }
+
+    @Test
+    fun `cachedWorkflowDetailEnvelopesFromDisk parses persisted envelopes`() {
+        every { deviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/x.json","hash":"h","enrolled_variants":{"e":"v"}}}"""
+
+        val envelopes = workflowsCache.cachedWorkflowDetailEnvelopesFromDisk()
+
+        assertThat(envelopes).containsKey("wf_1")
+        assertThat(envelopes!!.getValue("wf_1").url).isEqualTo("https://cdn/x.json")
+        assertThat(envelopes.getValue("wf_1").enrolledVariants).isEqualTo(mapOf("e" to "v"))
+    }
+
+    @Test
+    fun `cachedWorkflowDetailEnvelopesFromDisk round-trips an INLINE envelope with its workflow data`() {
+        val inlineJson = """
+            {"wf_inline":{"action":"inline","data":{
+              "id":"wf_inline","display_name":"Test","initial_step_id":"step_1",
+              "steps":{"step_1":{"id":"step_1","type":"screen"}},
+              "screens":{},
+              "ui_config":{"app":{"colors":{},"fonts":{}},"localizations":{},"variable_config":{}}
+            }}}
+        """.trimIndent()
+        every { deviceCache.getWorkflowDetailEnvelopesCache() } returns inlineJson
+
+        val envelopes = workflowsCache.cachedWorkflowDetailEnvelopesFromDisk()
+
+        assertThat(envelopes!!.getValue("wf_inline").action).isEqualTo(WorkflowResponseAction.INLINE)
+        assertThat(envelopes.getValue("wf_inline").data?.id).isEqualTo("wf_inline")
+    }
+
+    @Test
+    fun `cachedWorkflowDetailEnvelopesFromDisk returns null when nothing is cached`() {
+        every { deviceCache.getWorkflowDetailEnvelopesCache() } returns null
+        assertThat(workflowsCache.cachedWorkflowDetailEnvelopesFromDisk()).isNull()
+    }
+
+    @Test
+    fun `cachedWorkflowDetailEnvelopesFromDisk returns null when the payload is corrupt`() {
+        every { deviceCache.getWorkflowDetailEnvelopesCache() } returns "not valid json"
+        assertThat(workflowsCache.cachedWorkflowDetailEnvelopesFromDisk()).isNull()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -282,6 +282,43 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `cacheWorkflowsList prunes persisted envelopes not in the new list`() {
+        every { deviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_old":{"action":"use_cdn","url":"u1","hash":"h1"},"wf_keep":{"action":"use_cdn","url":"u2","hash":"h2"}}"""
+        val payloadSlot = slot<String>()
+        every { deviceCache.cacheWorkflowDetailEnvelopes(capture(payloadSlot)) } just Runs
+
+        workflowsCache.cacheWorkflowsList(
+            WorkflowsListResponse(
+                workflows = listOf(
+                    WorkflowSummary(id = "wf_keep", displayName = "Keep", offeringId = "default", prefetch = true),
+                ),
+            ),
+            mapOf("default" to "wf_keep"),
+        )
+
+        assertThat(payloadSlot.captured).contains("wf_keep")
+        assertThat(payloadSlot.captured).doesNotContain("wf_old")
+    }
+
+    @Test
+    fun `cacheWorkflowsList does not rewrite envelopes when nothing is pruned`() {
+        every { deviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_keep":{"action":"use_cdn","url":"u","hash":"h"}}"""
+
+        workflowsCache.cacheWorkflowsList(
+            WorkflowsListResponse(
+                workflows = listOf(
+                    WorkflowSummary(id = "wf_keep", displayName = "Keep", offeringId = "default", prefetch = true),
+                ),
+            ),
+            mapOf("default" to "wf_keep"),
+        )
+
+        verify(exactly = 0) { deviceCache.cacheWorkflowDetailEnvelopes(any()) }
+    }
+
+    @Test
     fun `different workflowIds are cached independently`() {
         val first = mockk<WorkflowDataResult>()
         val second = mockk<WorkflowDataResult>()


### PR DESCRIPTION
This PR persists the detail envelopes to disk, mirroring what we do with `OfferingsCache`, so a cold start with the backend down renders the prefetched workflows. We are already saving to disk the list of workflows, and we were missing this part.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall/workflow delivery and disk cache behavior on network failure and cold start; scope is bounded (prefetch + prune) but incorrect recovery could affect paywall rendering.
> 
> **Overview**
> Adds **disk persistence of workflow detail envelopes** (alongside the existing workflows list cache) so prefetched paywalls can be **re-resolved offline** after restart or when the backend is unreachable.
> 
> **Prefetch-only writes:** `getWorkflow` gains `persistEnvelopeOnResolve` (default `false`). Only the workflows-list **prefetch** path sets it `true` after a successful resolve, storing the raw `WorkflowDetailResponse` in `DeviceCache` via `WorkflowsCache` (merge-by-workflow-id map). On-demand fetches do **not** persist, to avoid unbounded disk use.
> 
> **Backend-down recovery:** When `getWorkflowsList` fails, the manager still restores the list from disk; if persisted envelopes exist, it **re-resolves** them in parallel into the in-memory workflow cache (`restoreWorkflowFromEnvelope`), so subsequent `getWorkflow` can be a cache hit without calling the backend. Failures per envelope are logged and isolated; `onComplete` still runs once.
> 
> **Cache hygiene:** `cacheWorkflowsList` **prunes** stored envelopes to IDs in the latest list; `clearCache` clears the envelope store on identity transitions. `WorkflowJsonParser` adds parsing for the envelope map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc39f941c43d3b10185966d370714e3b9f865bef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->