### PR TITLE
fix(test-store): don’t mention Play Store in error logs when the Test Store is used

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
@@ -40,6 +41,7 @@ internal abstract class OfferingParser {
         productsById: Map<String, List<StoreProduct>>,
         originalSource: HTTPResponseOriginalSource = HTTPResponseOriginalSource.MAIN,
         loadedFromDiskCache: Boolean = false,
+        configuredStore: Store = Store.PLAY_STORE,
     ): Offerings {
         log(LogIntent.DEBUG) { OfferingStrings.BUILDING_OFFERINGS.format(productsById.size) }
 
@@ -65,7 +67,7 @@ internal abstract class OfferingParser {
                 offerings[it.identifier] = it
 
                 if (it.availablePackages.isEmpty()) {
-                    warnLog { OfferingStrings.OFFERING_EMPTY.format(it.identifier) }
+                    warnLog { offeringEmptyMessage(it.identifier, configuredStore) }
                 }
             }
         }
@@ -103,6 +105,15 @@ internal abstract class OfferingParser {
             originalSource = originalSource,
             loadedFromDiskCache = loadedFromDiskCache,
         )
+    }
+
+    private fun offeringEmptyMessage(offeringIdentifier: String, configuredStore: Store): String {
+        val template = if (configuredStore == Store.TEST_STORE) {
+            OfferingStrings.OFFERING_EMPTY_TEST_STORE
+        } else {
+            OfferingStrings.OFFERING_EMPTY
+        }
+        return template.format(offeringIdentifier)
     }
 
     @OptIn(InternalRevenueCatAPI::class)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.Dispatcher
@@ -57,9 +58,13 @@ internal class OfferingsFactory(
                             notFoundProductIds
                                 .takeIf { it.isNotEmpty() }
                                 ?.let { missingProducts ->
+                                    val isTestStore = appConfig.store == Store.TEST_STORE
                                     log(LogIntent.GOOGLE_WARNING) {
-                                        OfferingStrings.CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR
-                                            .format(missingProducts.joinToString(", "))
+                                        if (isTestStore) {
+                                            OfferingStrings.CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR_TEST_STORE
+                                        } else {
+                                            OfferingStrings.CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR
+                                        }.format(missingProducts.joinToString(", "))
                                     }
                                 }
 
@@ -68,12 +73,17 @@ internal class OfferingsFactory(
                                 productsById,
                                 originalDataSource,
                                 loadedFromDiskCache,
+                                appConfig.store,
                             )
                             if (offerings.all.isEmpty()) {
                                 onError(
                                     PurchasesError(
                                         PurchasesErrorCode.ConfigurationError,
-                                        OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND,
+                                        if (appConfig.store == Store.TEST_STORE) {
+                                            OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND_TEST_STORE
+                                        } else {
+                                            OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND
+                                        },
                                     ),
                                 )
                             } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -8,6 +8,9 @@ internal object OfferingStrings {
     const val CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR = "Could not find ProductDetails for %s " +
         "\nThere is a problem with your configuration in Play Store Developer Console. " +
         "More info here: https://errors.rev.cat/configuring-products"
+    const val CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR_TEST_STORE = "Could not find ProductDetails for %s " +
+        "\nThere is a problem with your configuration in the RevenueCat dashboard. " +
+        "More info here: https://errors.rev.cat/configuring-products"
     const val FETCHING_OFFERINGS_ERROR = "Error fetching offerings - %s"
     const val FETCHING_PRODUCTS = "Requesting products from the store with identifiers: %s"
     const val FETCHING_PRODUCTS_FINISHED = "Products request finished for %s"
@@ -52,9 +55,16 @@ internal object OfferingStrings {
     const val CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND = "There's a problem with your configuration. " +
         "None of the products registered in the RevenueCat dashboard could be fetched from the Play Store.\n" +
         "More information: https://rev.cat/why-are-offerings-empty"
+    const val CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND_TEST_STORE = "There's a problem with your configuration. " +
+        "None of the products registered in the RevenueCat dashboard could be found.\n" +
+        "More information: https://rev.cat/why-are-offerings-empty"
     const val OFFERING_EMPTY = "There's a problem with your configuration. No packages could be found for offering " +
         "with identifier %s. This could be due to Products not being configured correctly in " +
         "the RevenueCat dashboard or Play Store.\nTo configure products, follow the instructions in " +
+        "https://rev.cat/how-to-configure-offerings.\nMore information: https://rev.cat/why-are-offerings-empty"
+    const val OFFERING_EMPTY_TEST_STORE = "There's a problem with your configuration. No packages could be found " +
+        "for offering with identifier %s. This could be due to Products not being configured correctly in " +
+        "the RevenueCat dashboard.\nTo configure products, follow the instructions in " +
         "https://rev.cat/how-to-configure-offerings.\nMore information: https://rev.cat/why-are-offerings-empty"
     const val ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE = "Error fetching offerings. Using disk cache."
     const val TARGETING_ERROR = "Error while parsing targeting - skipping"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
@@ -391,6 +391,30 @@ class OfferingsFactoryTest {
     }
 
     @Test
+    fun `Test Store cannot-find-product string references the RevenueCat dashboard, not the Play Store`() {
+        assertThat(OfferingStrings.CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR_TEST_STORE)
+            .contains("RevenueCat dashboard")
+            .doesNotContain("Play Store")
+    }
+
+    @Test
+    fun `Play Store cannot-find-product string references the Play Store`() {
+        assertThat(OfferingStrings.CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR).contains("Play Store")
+    }
+
+    @Test
+    fun `Test Store offering-empty string references the RevenueCat dashboard, not the Play Store`() {
+        assertThat(OfferingStrings.OFFERING_EMPTY_TEST_STORE)
+            .contains("RevenueCat dashboard")
+            .doesNotContain("Play Store")
+    }
+
+    @Test
+    fun `Play Store offering-empty string references the Play Store`() {
+        assertThat(OfferingStrings.OFFERING_EMPTY).contains("Play Store")
+    }
+
+    @Test
     fun `createOfferings returns error if json with wrong format`() {
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
@@ -421,9 +445,33 @@ class OfferingsFactoryTest {
 
         assertThat(purchasesError).isNotNull
         assertThat(purchasesError!!.code).isEqualTo(PurchasesErrorCode.ConfigurationError)
-        assertThat(purchasesError!!.underlyingErrorMessage).contains(
-            OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND
+        assertThat(purchasesError!!.underlyingErrorMessage)
+            .isEqualTo(OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND)
+    }
+
+    @Test
+    fun `configuration error when products are not set up uses Test Store wording for Test Store`() {
+        every { appConfig.apiKeyValidationResult } returns APIKeyValidator.ValidationResult.SIMULATED_STORE
+        every { appConfig.store } returns Store.TEST_STORE
+
+        val productIds = listOf(productId)
+        mockStoreProduct(productIds, listOf(), ProductType.SUBS)
+        mockStoreProduct(productIds, listOf(), ProductType.INAPP)
+
+        var purchasesError: PurchasesError? = null
+        offeringsFactory.createOfferings(
+            offeringsJSON = oneOfferingResponse,
+            originalDataSource = HTTPResponseOriginalSource.MAIN,
+            loadedFromDiskCache = false,
+            onError = { purchasesError = it },
+            onSuccess = { fail("Expected error") }
         )
+
+        assertThat(purchasesError).isNotNull
+        assertThat(purchasesError!!.code).isEqualTo(PurchasesErrorCode.ConfigurationError)
+        assertThat(purchasesError!!.underlyingErrorMessage)
+            .isEqualTo(OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND_TEST_STORE)
+        assertThat(purchasesError!!.underlyingErrorMessage).doesNotContain("Play Store")
     }
 
     @Test


### PR DESCRIPTION
Android counterpart for https://github.com/RevenueCat/purchases-ios/pull/6906, making offering product loading errors test-store aware. This prevents these errors from pointing developers to the Play Store when Test Store is used.

These errors should rarely happen (if at all) but figured it was good to add for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only branching on configured store for logs and configuration errors; behavior unchanged aside from messaging, with unit test coverage.
> 
> **Overview**
> When the SDK is configured for **Test Store**, offering/product configuration errors no longer tell developers to fix things in the **Play Store**. The change threads `appConfig.store` into offerings building and picks **Test Store–specific** copy from `OfferingStrings` instead of the Play Store templates.
> 
> **`OfferingsFactory`** now uses Test Store strings for missing-product warnings and for the configuration error when no dashboard products resolve. **`OfferingParser.createOfferings`** gains a `configuredStore` parameter (default Play Store) and routes empty-offering warnings through a small helper that selects the right template. New constants cover cannot-find-product, products-not-found, and empty-offering cases for Test Store (RevenueCat dashboard wording). Tests assert string content and that Test Store flows return the Test Store configuration error without mentioning Play Store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a1b9c31ae72484f65f5b9dd7eb269d200d6f77c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->