### PR TITLE
Stale-while-revalidate for the workflow detail fetch

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 
+@Suppress("TooManyFunctions")
 internal class WorkflowManager(
     private val backend: Backend,
     private val workflowDetailResolver: WorkflowDetailResolver,
@@ -68,6 +69,27 @@ internal class WorkflowManager(
             onSuccess(cached)
             return
         }
+        fetchAndCacheWorkflow(
+            appUserID = appUserID,
+            workflowId = workflowId,
+            appInBackground = appInBackground,
+            callbackDispatcher = callbackDispatcher,
+            persistEnvelopeOnResolve = persistEnvelopeOnResolve,
+            onSuccess = onSuccess,
+            onError = onError,
+        )
+    }
+
+    @Suppress("LongParameterList")
+    private fun fetchAndCacheWorkflow(
+        appUserID: String,
+        workflowId: String,
+        appInBackground: Boolean,
+        callbackDispatcher: Dispatcher?,
+        persistEnvelopeOnResolve: Boolean,
+        onSuccess: (WorkflowDataResult) -> Unit,
+        onError: (PurchasesError) -> Unit,
+    ) {
         val onSuccessHandler: (WorkflowDetailResponse) -> Unit = { response ->
             scope.launch {
                 // resolve() can fail in several ways (missing inline data, CDN fetch/parse failures,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -43,9 +43,16 @@ internal class WorkflowManager(
     }
 
     /**
-     * Fetches and resolves a single workflow, serving a fresh in-memory cache hit when one exists
-     * and otherwise fetching from the backend.
+     * Fetches and resolves a single workflow using stale-while-revalidate, mirroring
+     * [com.revenuecat.purchases.common.offerings.OfferingsManager]'s offerings serving:
+     * a fresh cache hit is served directly; a stale-but-present hit is served immediately and the
+     * cache is refreshed in the background (no callbacks, failures logged); a miss fetches from the
+     * backend and delivers the outcome through [onSuccess]/[onError].
      *
+     * @param staleWhileRevalidate when true (the default, used by the on-demand render path), a
+     * stale-but-present cached workflow is served immediately with a background refresh. When false
+     * (the prefetch path), a stale workflow blocks on a full refetch instead — so prefetch keeps
+     * forcing a fresh fetch and persisting its envelope rather than serving a stale value.
      * @param persistEnvelopeOnResolve when true, also persists the raw detail envelope to disk after
      * a successful resolve, so it survives an app restart and can be re-resolved while the backend is
      * down (see [getWorkflowsList]'s recovery path). Only the prefetch path sets this: prefetched
@@ -63,21 +70,48 @@ internal class WorkflowManager(
         onError: (PurchasesError) -> Unit,
         callbackDispatcher: Dispatcher? = null,
         persistEnvelopeOnResolve: Boolean = false,
+        staleWhileRevalidate: Boolean = true,
     ) {
         val cached = workflowsCache.cachedWorkflow(workflowId)
-        if (cached != null && !workflowsCache.isWorkflowCacheStale(workflowId, appInBackground)) {
-            onSuccess(cached)
-            return
+        when {
+            cached != null && !workflowsCache.isWorkflowCacheStale(workflowId, appInBackground) -> {
+                onSuccess(cached)
+            }
+            cached != null && staleWhileRevalidate -> {
+                // Serve the stale value immediately, then refresh the cache in the background.
+                // The caller already has a usable value, so the refresh delivers no callbacks: a
+                // success only updates the cache, and a failure is logged and swallowed. Mirrors
+                // OfferingsManager.vendCachedOfferingsAndMaybeRefresh. Concurrent stale callers can
+                // each fire a refresh; this is not deduplicated, matching the offerings stale path.
+                onSuccess(cached)
+                fetchAndCacheWorkflow(
+                    appUserID = appUserID,
+                    workflowId = workflowId,
+                    appInBackground = appInBackground,
+                    callbackDispatcher = callbackDispatcher,
+                    persistEnvelopeOnResolve = persistEnvelopeOnResolve,
+                    onSuccess = {},
+                    onError = { error ->
+                        errorLog {
+                            "Background workflow refresh failed for $workflowId: " +
+                                error.underlyingErrorMessage
+                        }
+                    },
+                )
+            }
+            else -> {
+                // Miss, or stale with SWR disabled (the prefetch path): block on the fetch.
+                fetchAndCacheWorkflow(
+                    appUserID = appUserID,
+                    workflowId = workflowId,
+                    appInBackground = appInBackground,
+                    callbackDispatcher = callbackDispatcher,
+                    persistEnvelopeOnResolve = persistEnvelopeOnResolve,
+                    onSuccess = onSuccess,
+                    onError = onError,
+                )
+            }
         }
-        fetchAndCacheWorkflow(
-            appUserID = appUserID,
-            workflowId = workflowId,
-            appInBackground = appInBackground,
-            callbackDispatcher = callbackDispatcher,
-            persistEnvelopeOnResolve = persistEnvelopeOnResolve,
-            onSuccess = onSuccess,
-            onError = onError,
-        )
     }
 
     @Suppress("LongParameterList")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -271,6 +271,7 @@ internal class WorkflowManager(
                 appInBackground = appInBackground,
                 callbackDispatcher = prefetchDispatcher,
                 persistEnvelopeOnResolve = true,
+                staleWhileRevalidate = false,
                 onSuccess = { continuation.safeResume(Unit) },
                 onError = { error ->
                     errorLog { "Failed to prefetch workflow $workflowId: ${error.underlyingErrorMessage}" }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -165,11 +165,11 @@ internal class WorkflowsCache(
         }
 
     /**
-     * Drops persisted envelopes whose workflowId is no longer in the latest list. This is the
-     * keyed-map equivalent of how [com.revenuecat.purchases.common.offerings.OfferingsCache] stays
-     * bounded by wholesale-replacing its single response blob: the persisted set always equals what
-     * the latest backend response says exists, so workflows the backend stopped sending don't
-     * linger on disk.
+     * Drops persisted envelopes whose workflowId is no longer in the latest list. Because only
+     * successfully-prefetched workflows are ever written here (see [cacheWorkflowDetailEnvelope]),
+     * this prune removes stale prefetch envelopes for workflows the backend has stopped sending.
+     * It is the keyed-map equivalent of how [com.revenuecat.purchases.common.offerings.OfferingsCache]
+     * stays bounded by wholesale-replacing its single response blob.
      */
     @Synchronized
     private fun pruneWorkflowDetailEnvelopesToList(workflowIds: Set<String>) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -482,6 +482,59 @@ class WorkflowManagerTest {
         }
     }
 
+    @Test
+    fun `getWorkflow stale hit does not surface a failing background refresh to the caller`() {
+        val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        coEvery { mockResolver.resolve(response) } returns staleResult
+
+        // First backend call succeeds (populates the cache); the second fails (background refresh).
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        var call = 0
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            call++
+            if (call == 1) {
+                successSlot.captured(response)
+            } else {
+                errorSlot.captured(PurchasesError(PurchasesErrorCode.NetworkError, "boom"))
+            }
+        }
+
+        // First call at t=0 populates the cache.
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Stale call whose background refresh fails: caller still gets the stale value, no error.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        var served: WorkflowDataResult? = null
+        var erroredWith: PurchasesError? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { served = it },
+            onError = { erroredWith = it },
+        )
+
+        assertThat(served).isSameAs(staleResult)
+        assertThat(erroredWith).isNull()
+    }
+
     // endregion getWorkflow cache
 
     // region getWorkflowsList

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -581,6 +581,8 @@ class WorkflowManagerTest {
         )
 
         assertThat(served).isSameAs(refreshedResult)
+        // The blocking fetch also wrote the refreshed value through to the cache.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(refreshedResult)
     }
 
     // endregion getWorkflow cache

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -535,6 +535,50 @@ class WorkflowManagerTest {
         assertThat(erroredWith).isNull()
     }
 
+    @Test
+    fun `getWorkflow with staleWhileRevalidate false blocks on the refetch instead of serving stale`() {
+        val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        val refreshedResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers { successSlot.captured(response) }
+
+        // First call at t=0 populates the cache.
+        every { mockDateProvider.now } returns Date(0)
+        coEvery { mockResolver.resolve(response) } returns staleResult
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Stale call with SWR disabled: must deliver the freshly-fetched value, not the stale one.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        coEvery { mockResolver.resolve(response) } returns refreshedResult
+        var served: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { served = it },
+            onError = { fail("unexpected error $it") },
+            staleWhileRevalidate = false,
+        )
+
+        assertThat(served).isSameAs(refreshedResult)
+    }
+
     // endregion getWorkflow cache
 
     // region getWorkflowsList

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -378,10 +378,10 @@ class WorkflowManagerTest {
     }
 
     @Test
-    fun `getWorkflow re-fetches when cache is stale`() {
+    fun `getWorkflow refreshes in the background and still re-fetches when cache is stale`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
-        val expectedResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
-        coEvery { mockResolver.resolve(response) } returns expectedResult
+        val firstResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        val secondResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -396,6 +396,7 @@ class WorkflowManagerTest {
 
         // First call at t=0 populates the cache.
         every { mockDateProvider.now } returns Date(0)
+        coEvery { mockResolver.resolve(response) } returns firstResult
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowId = "wf_1",
@@ -404,17 +405,20 @@ class WorkflowManagerTest {
             onError = { fail("unexpected error $it") },
         )
 
-        // Second call past the 5-minute foreground TTL should re-fetch.
-        val sixMinutesMs = 6L * 60 * 1000
-        every { mockDateProvider.now } returns Date(sixMinutesMs)
+        // Second call past the 5-minute foreground TTL serves the stale value and refetches.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        coEvery { mockResolver.resolve(response) } returns secondResult
+        var served: WorkflowDataResult? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowId = "wf_1",
             appInBackground = false,
-            onSuccess = {},
+            onSuccess = { served = it },
             onError = { fail("unexpected error $it") },
         )
 
+        // SWR: the caller gets the stale value, and the background refresh still hits the backend.
+        assertThat(served).isSameAs(firstResult)
         verify(exactly = 2) {
             mockBackend.getWorkflow(
                 appUserID = "user_1",
@@ -1260,6 +1264,65 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
         // WorkflowsCache.cacheWorkflowDetailEnvelope -> DeviceCache.cacheWorkflowDetailEnvelopes (the mocked layer)
+        val persistedSlot = slot<String>()
+        verify(exactly = 1) { mockDeviceCache.cacheWorkflowDetailEnvelopes(capture(persistedSlot)) }
+        assertThat(persistedSlot.captured).contains("wf_1")
+    }
+
+    @Test
+    fun `prefetch persists the envelope even when the workflow is already cached but stale`() {
+        // Seed the detail cache at t=0 so the workflow is present but will be stale at prefetch time.
+        every { mockDateProvider.now } returns Date(0)
+        workflowsCache.cacheWorkflow("wf_1", WorkflowDataResult(workflow = mockk(), enrolledVariants = null))
+
+        // Advance past the 5-minute TTL: the prefetch now sees a stale-but-present cache entry.
+        // With SWR disabled on the prefetch path it must still do a real fetch and persist, not serve stale.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+
+        val envelope = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn/wf_1.json",
+            hash = "h",
+        )
+        coEvery { mockResolver.resolve(envelope) } returns
+            WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+
+        val listResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "A", offeringId = "default", prefetch = true),
+            ),
+        )
+        val listSuccess = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccess), onError = any())
+        } answers { listSuccess.captured(listResponse) }
+
+        val detailSuccess = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                any(),
+                onSuccess = capture(detailSuccess),
+                onError = any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        } answers { detailSuccess.captured(envelope) }
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // A real prefetch fetch happened (the prefetch overload with the prefetch dispatcher)...
+        verify(exactly = 1) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                any(),
+                onSuccess = any(),
+                onError = any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        }
+        // ...and the envelope was persisted, proving the stale prefetch took the blocking fetch path.
         val persistedSlot = slot<String>()
         verify(exactly = 1) { mockDeviceCache.cacheWorkflowDetailEnvelopes(capture(persistedSlot)) }
         assertThat(persistedSlot.captured).contains("wf_1")

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -426,6 +426,62 @@ class WorkflowManagerTest {
         }
     }
 
+    @Test
+    fun `getWorkflow stale hit serves the cached value and refreshes the cache in the background`() {
+        val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        val refreshedResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers { successSlot.captured(response) }
+
+        // First call at t=0 populates the cache with the stale result.
+        every { mockDateProvider.now } returns Date(0)
+        coEvery { mockResolver.resolve(response) } returns staleResult
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Move past the 5-minute foreground TTL and make the next resolve produce a different result.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        coEvery { mockResolver.resolve(response) } returns refreshedResult
+
+        var served: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { served = it },
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Caller receives the stale cached value, not the background-refreshed one.
+        assertThat(served).isSameAs(staleResult)
+        // The background refresh ran and updated the cache to the fresh value.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(refreshedResult)
+        verify(exactly = 2) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+            )
+        }
+    }
+
     // endregion getWorkflow cache
 
     // region getWorkflowsList


### PR DESCRIPTION
Linear https://linear.app/revenuecat/issue/WFL-281/stale-while-revalidate-for-the-workflow-detail-fetch

Stacked on #3537.

I noticed that in `OfferingsManager` we do stale-while-revalidate serving (`vendCachedOfferingsAndMaybeRefresh`). Meaning that we serve stale data while fetching in the background more fresh offerings. We were not doing that for workflows, so there was a change in behavior. Before this PR a "stale" cache was a "miss" that blocked the paywall on a full backend round-trip.

To understand it better, I've generated these diagrams:

## How offerings already behaves

When a cached value exists it is always served right away; staleness only decides whether a background refresh is also kicked off. The caller never waits on the network when the cache has something to give.

<img width="969" height="732" alt="Captura de pantalla 2026-06-05 a las 8 14 17" src="https://github.com/user-attachments/assets/53051c78-69b4-436b-9f25-0a61dbc0e8bc" />

## Workflows before this PR

`getWorkflow` only short-circuited on a fresh hit. A cached-but-stale workflow fell through to the same path as a cache miss and blocked the render on a full refetch, even though a perfectly usable workflow was sitting in the cache.

<img width="979" height="698" alt="Captura de pantalla 2026-06-05 a las 8 15 25" src="https://github.com/user-attachments/assets/458b4fbd-9cfe-44e3-a611-e3a26f8e3c4c" />

## Workflows after this PR

Now `getWorkflow` serves the cached value immediately, then fire a background refresh that delivers no callbacks (a success just updates the cache, a failure is logged and swallowed).

<img width="975" height="653" alt="Captura de pantalla 2026-06-05 a las 8 16 53" src="https://github.com/user-attachments/assets/5c76b084-fec5-4941-9b29-48f35bf4d35b" />

<details>
<summary>📋 Design context (for reviewers and AI agents)</summary>

### Why

This is follow-up #3 from the workflow-detail-envelope-persistence decision. It is a **different layer** from the backend-down recovery work in #3537 underneath it: this is about *normal* in-memory serving, not disk fallback. The goal is parity with `OfferingsManager`, which has always done stale-while-revalidate. The parity question applies to any SDK that caches workflow details (iOS once it has the cache layer — it is a stage behind; no iOS action here).

### The change

`getWorkflow` is rewritten from a two-way (fresh → serve, everything-else → block-and-fetch) into a three-way branch mirroring `vendCachedOfferingsAndMaybeRefresh`:

| Cache state | Behavior | Changed? |
|---|---|---|
| **Fresh hit** | serve cached, no network | unchanged |
| **Stale hit** | serve cached immediately via `onSuccess`, **then** fire a background refresh that updates the cache only — no caller `onSuccess`/`onError`; a failed refresh is logged and swallowed | **this PR** |
| **Miss** | fetch from backend, deliver via `onSuccess`/`onError` | unchanged |

Mechanically: the fetch + resolve + cache + callback block was extracted into a private `fetchAndCacheWorkflow(...)` (pure extraction, no behavior change), and `getWorkflow` now dispatches into it from the three branches.

### Prefetch carve-out — the one deliberate exception

The split is expressed as a single parameter: `getWorkflow(..., staleWhileRevalidate: Boolean = true)`. Fresh and miss are identical across callers, so one boolean captures the difference cleanly (it only affects the stale-present case).

- **Render / on-demand path** (`PurchasesOrchestrator.getWorkflow`): `staleWhileRevalidate = true` (default).
- **Prefetch path** (`prefetchWorkflow`): `staleWhileRevalidate = false`.

Prefetch must NOT adopt SWR. Its job is to force a real refresh and **persist the detail envelope** (the #3537 backend-down-recovery feature). If prefetch served stale + background-refreshed, its stale case would stop blocking-and-persisting and weaken that guarantee. So prefetch keeps today's blocking-fetch-and-persist behavior on a stale workflow.

The background refresh inherits the caller's `persistEnvelopeOnResolve`. On the render path that is `false`, so the SWR background refresh does **not** persist — keeping this work cleanly out of the scope of the on-demand-persistence follow-up (#1).

### No new dedup

Two concurrent stale render calls can each fire a background refresh. This matches offerings — `fetchAndCacheOfferings` on the stale path isn't deduped either — so it is parity-acceptable. Documented in a code comment rather than guarded.

### Test coverage

- stale hit serves the cached value *before* the background refresh resolves
- stale hit fires exactly one background refresh that updates the cache
- stale hit does **not** surface a failing background refresh to the caller
- prefetch path blocks and persists on a stale workflow (no SWR)
- the existing "re-fetches when cache is stale" test stays green (backend still called), with intent/assertions updated to reflect that the stale value is now served first

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall load timing when workflow cache is stale (immediate render vs blocking fetch); prefetch path is explicitly preserved but behavior diverges by caller.
> 
> **Overview**
> **`getWorkflow`** now matches offerings-style **stale-while-revalidate**: a **fresh** hit is unchanged; a **stale** in-memory hit returns the cached workflow immediately and kicks off a **background** refetch that only updates the cache (failures are logged, not delivered to the caller); a **miss** still blocks on the network.
> 
> The fetch/resolve/cache path is factored into **`fetchAndCacheWorkflow`**. A new **`staleWhileRevalidate`** flag (default **`true`** for on-demand paywall loads) controls the stale branch; **`prefetchWorkflow`** passes **`false`** so prefetch still **blocks**, refetches, and **persists detail envelopes** when the cache is stale.
> 
> Tests cover immediate stale serving, background cache updates, swallowed background errors, blocking behavior when SWR is off, and stale prefetch persistence. **`WorkflowsCache`** prune docs are clarified only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8509e19f7bd64f672b6eeaef7caef0099d29d98e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->