### PR TITLE
Replace workflows `forceStale` flag with a `forceRefresh` param

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -269,11 +269,13 @@ internal class OfferingsManager(
                 offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                 offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
                 val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
-                if (!loadedFromDiskCache) {
-                    workflowManager?.forceWorkflowsListCacheStale()
-                }
-                workflowManager?.getWorkflowsList(appUserID, appInBackground, onComplete = dispatchSuccess)
-                    ?: dispatchSuccess()
+                workflowManager?.getWorkflowsList(
+                    appUserID,
+                    appInBackground,
+                    // Refetch workflows only when these offerings are fresh from the network.
+                    forceRefresh = !loadedFromDiskCache,
+                    onComplete = dispatchSuccess,
+                ) ?: dispatchSuccess()
             },
         )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -246,9 +246,17 @@ internal class WorkflowManager(
                     errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
                     // Restore the in-memory cache from disk without rewriting it — disk already holds
                     // this payload.
-                    workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
+                    val restoredFromDisk = workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
                         val filtered = response.onlyWorkflowsWithOfferingId()
                         workflowsCache.cacheWorkflowsListInMemory(filtered, buildOfferingIdMap(filtered.workflows))
+                    } != null
+                    // Mirror OfferingsManager.handleErrorFetchingOfferings: when there is no disk
+                    // cache to fall back on, force the list stale so the next call retries. When a
+                    // disk restore did succeed, cacheWorkflowsListInMemory already stamped a fresh
+                    // timestamp, so we leave it alone — same as offerings leaving the cache fresh
+                    // after createAndCacheOfferings runs on the disk-fallback path.
+                    if (!restoredFromDisk) {
+                        workflowsCache.invalidateWorkflowsListTimestamp()
                     }
                     val envelopes = workflowsCache.cachedWorkflowDetailEnvelopesFromDisk().orEmpty()
                     if (envelopes.isEmpty()) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -172,30 +172,43 @@ internal class WorkflowManager(
     /**
      * Fetches the workflows list, then prefetches all entries marked `prefetch = true`.
      *
+     * [forceRefresh] fetches a fresh list even when the cached one is still within its TTL. It is set
+     * after a fresh offerings network response so the offeringId → workflowId map realigns with the
+     * offerings the caller just received, since the workflows list otherwise tracks only a time TTL.
+     *
      * Offerings delivery is gated on [onComplete] (see
      * [com.revenuecat.purchases.common.offerings.OfferingsManager]): it is invoked once the whole
      * sequence settles — list fetched, every prefetch finished or failed — so it must always fire
      * exactly once, otherwise offerings would never be delivered to the caller.
      *
-     * Concurrent callers for the same [appUserID] while a request is in-flight are deduplicated:
-     * the second call queues its [onComplete] and returns without a new network request, then all
-     * pending callbacks for that user fire together when the in-flight sequence finishes. A call
-     * for a different user starts its own fetch rather than joining the in-flight one.
+     * Concurrent callers for the same [appUserID] while a request is in-flight are deduplicated: the
+     * second call queues its [onComplete] and returns without a new network request, then all pending
+     * callbacks for that user fire together when the in-flight sequence finishes. A call for a
+     * different user starts its own fetch rather than joining the in-flight one. Note this join
+     * ignores [forceRefresh]: an in-flight batch is not interrupted, so a forced refresh that arrives
+     * while a batch is running joins it instead of starting a new fetch. That window self-heals on the
+     * next fetch.
      */
-    fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
+    fun getWorkflowsList(
+        appUserID: String,
+        appInBackground: Boolean,
+        forceRefresh: Boolean = false,
+        onComplete: () -> Unit = {},
+    ) {
         // Decide under the lock, act outside it so onComplete never fires while holding it.
         val startFetch = synchronized(callbackLock) {
             val inFlight = pendingCompletionCallbacks[appUserID]
             if (inFlight != null) {
-                // Already fetching for this user: queue onto it. Joining ignores cache freshness on
-                // purpose — the list response stamps the cache fresh mid-sequence, before its prefetch
-                // finishes, so a freshness check would let this caller complete early.
+                // Already fetching for this user: queue onto it. Joining ignores cache freshness and
+                // forceRefresh on purpose — the list response stamps the cache fresh mid-sequence,
+                // before its prefetch finishes, so a freshness check would let this caller complete
+                // early, and an in-flight batch is never interrupted.
                 inFlight.add(onComplete)
                 return
             }
-            // Nothing in flight: open a batch and fetch only if the cached list is stale.
+            // Nothing in flight: open a batch and fetch when forced or when the cached list is stale.
             pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
-            workflowsCache.isWorkflowsListCacheStale(appInBackground)
+            forceRefresh || workflowsCache.isWorkflowsListCacheStale(appInBackground)
         }
 
         // Fresh cache and nothing in flight: complete now. Otherwise the request's onSuccess/onError
@@ -302,15 +315,6 @@ internal class WorkflowManager(
 
     fun workflowIdForOfferingId(offeringId: String): String? =
         workflowsCache.workflowIdForOfferingId(offeringId)
-
-    /**
-     * Marks the workflows list stale so the next [getWorkflowsList] refetches it. Called when
-     * offerings are refetched off their normal TTL (forced/locale change) to keep the workflow map
-     * aligned with the offerings the caller just received.
-     */
-    fun forceWorkflowsListCacheStale() {
-        workflowsCache.forceWorkflowsListCacheStale()
-    }
 
     private fun completePendingCallbacks(appUserID: String) {
         val callbacks = synchronized(callbackLock) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -216,7 +216,6 @@ internal class WorkflowManager(
         if (!startFetch) {
             completePendingCallbacks(appUserID)
         } else {
-            if (forceRefresh) workflowsCache.clearWorkflowDetailCaches()
             backend.getWorkflows(
                 appUserID = appUserID,
                 appInBackground = appInBackground,
@@ -225,6 +224,10 @@ internal class WorkflowManager(
                     // Drop workflows without an offeringId: they can't be reached via
                     // workflowIdForOfferingId, so caching or prefetching them is wasted work.
                     val filtered = response.onlyWorkflowsWithOfferingId()
+                    // Clear detail caches after a successful fetch so the prefetch loop below is a
+                    // guaranteed cache miss and always populates fresh data. Cleared here rather than
+                    // before the network call so a failed fetch leaves in-memory details intact.
+                    if (forceRefresh) workflowsCache.clearWorkflowDetailCaches()
                     workflowsCache.cacheWorkflowsList(filtered, buildOfferingIdMap(filtered.workflows))
 
                     val prefetchWorkflows = filtered.workflows.filter { it.prefetch }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -216,6 +216,7 @@ internal class WorkflowManager(
         if (!startFetch) {
             completePendingCallbacks(appUserID)
         } else {
+            if (forceRefresh) workflowsCache.clearWorkflowDetailCaches()
             backend.getWorkflows(
                 appUserID = appUserID,
                 appInBackground = appInBackground,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -61,6 +61,17 @@ internal class WorkflowsCache(
         cached.cacheInstance(result)
     }
 
+    /**
+     * Clears all resolved workflow detail values from the in-memory cache. Used when a
+     * force-refresh is triggered (pull-to-refresh via offerings) so the subsequent prefetch is a
+     * guaranteed cache miss and always fetches fresh data from the backend, rather than serving
+     * a still-within-TTL cached value. The offeringId map is unaffected.
+     */
+    @Synchronized
+    fun clearWorkflowDetailCaches() {
+        cachedWorkflows.clear()
+    }
+
     // endregion Workflow detail cache
 
     // region Workflows list cache

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -70,18 +70,6 @@ internal class WorkflowsCache(
         workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
 
     /**
-     * Marks the in-memory list cache stale so the next fetch refreshes it, mirroring
-     * [com.revenuecat.purchases.common.offerings.OfferingsCache.forceCacheStale]. The current list and
-     * offeringId map are kept (so [workflowIdForOfferingId] still resolves during the refetch); only
-     * the freshness timestamp is dropped. Used to keep workflows aligned with offerings when offerings
-     * are refetched off-cycle (forced/locale change), since workflows otherwise track only a time TTL.
-     */
-    @Synchronized
-    fun forceWorkflowsListCacheStale() {
-        workflowsListCachedObject.clearCacheTimestamp()
-    }
-
-    /**
      * Caches the workflows list in memory and persists it to disk, the same way
      * [com.revenuecat.purchases.common.offerings.OfferingsCache.cacheOfferings] caches offerings.
      *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -69,6 +69,11 @@ internal class WorkflowsCache(
     fun isWorkflowsListCacheStale(appInBackground: Boolean): Boolean =
         workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
 
+    @Synchronized
+    fun invalidateWorkflowsListTimestamp() {
+        workflowsListCachedObject.clearCacheTimestamp()
+    }
+
     /**
      * Caches the workflows list in memory and persists it to disk, the same way
      * [com.revenuecat.purchases.common.offerings.OfferingsCache.cacheOfferings] caches offerings.

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -64,8 +64,8 @@ class OfferingsManagerTest {
             every { preDownloadOfferingFontsIfNeeded(any()) } just Runs
         }
         mockWorkflowManager = mockk(relaxed = true)
-        every { mockWorkflowManager.getWorkflowsList(any(), any(), any()) } answers {
-            thirdArg<() -> Unit>().invoke()
+        every { mockWorkflowManager.getWorkflowsList(any(), any(), any(), any()) } answers {
+            lastArg<() -> Unit>().invoke()
         }
 
         mockBackendResponseSuccess()
@@ -127,8 +127,14 @@ class OfferingsManagerTest {
         mockDeviceCache()
         mockOfferingsFactory()
         offeringsManager.onAppForeground(appUserID = "user_1")
+        // Foreground refresh is a network fetch, so it forces the workflows list to refetch.
         verify(exactly = 1) {
-            mockWorkflowManager.getWorkflowsList("user_1", appInBackground = false, onComplete = any())
+            mockWorkflowManager.getWorkflowsList(
+                "user_1",
+                appInBackground = false,
+                forceRefresh = true,
+                onComplete = any(),
+            )
         }
     }
 
@@ -576,16 +582,15 @@ class OfferingsManagerTest {
             onSuccess = {},
         )
 
+        // Offerings came fresh from the network, so the workflows list is forced to refetch (realigned)
+        // rather than skipped on its own TTL.
         verify(exactly = 1) {
-            mockWorkflowManager.getWorkflowsList(appUserId, false, onComplete = any())
+            mockWorkflowManager.getWorkflowsList(appUserId, false, forceRefresh = true, onComplete = any())
         }
-        // Offerings came fresh from the network, so the workflows list is realigned by being forced
-        // stale before the fetch, rather than skipped on its own TTL.
-        verify(exactly = 1) { mockWorkflowManager.forceWorkflowsListCacheStale() }
     }
 
     @Test
-    fun `getOfferings does not force workflows list stale on disk-cache fallback`() {
+    fun `getOfferings does not force workflows list refetch on disk-cache fallback`() {
         every { cache.cachedOfferings } returns null
         every { cache.cacheOfferings(any(), any()) } just Runs
         mockBackendResponseError()
@@ -600,9 +605,11 @@ class OfferingsManagerTest {
             onSuccess = {},
         )
 
-        // Offerings were restored from disk (no real change, backend likely down), so we must not
-        // force a workflows refetch here.
-        verify(exactly = 0) { mockWorkflowManager.forceWorkflowsListCacheStale() }
+        // Offerings were restored from disk (no real change, backend likely down), so the workflows
+        // list is not forced to refetch — it follows its own TTL.
+        verify(exactly = 1) {
+            mockWorkflowManager.getWorkflowsList(appUserId, false, forceRefresh = false, onComplete = any())
+        }
     }
 
     @Test
@@ -619,7 +626,7 @@ class OfferingsManagerTest {
         )
 
         verify(exactly = 1) {
-            mockWorkflowManager.getWorkflowsList(appUserId, true, onComplete = any())
+            mockWorkflowManager.getWorkflowsList(appUserId, true, forceRefresh = true, onComplete = any())
         }
     }
 
@@ -637,7 +644,7 @@ class OfferingsManagerTest {
         )
 
         verify(exactly = 1) {
-            mockWorkflowManager.getWorkflowsList(appUserId, false, onComplete = any())
+            mockWorkflowManager.getWorkflowsList(appUserId, false, forceRefresh = true, onComplete = any())
         }
     }
 
@@ -1058,12 +1065,12 @@ class OfferingsManagerTest {
     @Test
     fun `getOfferings does not call onSuccess until getWorkflowsList completes`() {
         val mockWorkflowManager = mockk<WorkflowManager>()
-        every { mockWorkflowManager.forceWorkflowsListCacheStale() } just Runs
         val onCompleteSlot = slot<() -> Unit>()
         every {
             mockWorkflowManager.getWorkflowsList(
                 appUserID = appUserId,
                 appInBackground = false,
+                forceRefresh = any(),
                 onComplete = capture(onCompleteSlot),
             )
         } just Runs
@@ -1132,6 +1139,7 @@ class OfferingsManagerTest {
             mockWorkflowManager.getWorkflowsList(
                 appUserID = appUserId,
                 appInBackground = false,
+                forceRefresh = any(),
                 onComplete = capture(onCompleteSlot),
             )
         } just Runs

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -705,56 +705,6 @@ class WorkflowManagerTest {
     }
 
     @Test
-    fun `getWorkflowsList retries after failed forceRefresh even when old list cache was fresh`() {
-        val initialResponse = WorkflowsListResponse(
-            workflows = listOf(
-                WorkflowSummary(id = "wf_old", displayName = "Old", offeringId = "default", prefetch = false),
-            ),
-        )
-        val refreshedResponse = WorkflowsListResponse(
-            workflows = listOf(
-                WorkflowSummary(id = "wf_new", displayName = "New", offeringId = "default", prefetch = false),
-            ),
-        )
-        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
-        val errorSlot = slot<(PurchasesError) -> Unit>()
-        var backendCalls = 0
-        every {
-            mockBackend.getWorkflows(
-                any(),
-                any(),
-                type = any(),
-                onSuccess = capture(successSlot),
-                onError = capture(errorSlot),
-            )
-        } answers {
-            backendCalls += 1
-            when (backendCalls) {
-                1 -> successSlot.captured(initialResponse)
-                2 -> errorSlot.captured(error)
-                else -> successSlot.captured(refreshedResponse)
-            }
-        }
-        every { mockDeviceCache.getWorkflowsListResponseCache() } returns null
-        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns null
-
-        every { mockDateProvider.now } returns Date(0)
-        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
-        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_old")
-
-        every { mockDateProvider.now } returns Date(1)
-        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false, forceRefresh = true)
-        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_old")
-
-        every { mockDateProvider.now } returns Date(2)
-        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
-
-        verify(exactly = 3) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
-        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_new")
-    }
-
-    @Test
     fun `getWorkflowsList with forceRefresh preserves in-memory detail caches when the fetch fails`() {
         val listResponse = WorkflowsListResponse(
             workflows = listOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -653,6 +653,58 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflowsList with forceRefresh re-fetches workflow details even when within TTL`() {
+        val listResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = true),
+            ),
+        )
+        val envelope = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        coEvery { mockResolver.resolve(envelope) } returns
+            WorkflowDataResult(workflow = envelope.data!!, enrolledVariants = null)
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any())
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            (args[3] as (WorkflowsListResponse) -> Unit).invoke(listResponse)
+        }
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            (args[3] as (WorkflowDetailResponse) -> Unit).invoke(envelope)
+        }
+
+        // Initial load at t=0: list + detail fetched and cached (detail is fresh within TTL).
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // forceRefresh at t=1ms: still within 5-min detail TTL, but forceRefresh clears detail
+        // caches so the prefetch is a guaranteed cache miss and goes to the backend.
+        every { mockDateProvider.now } returns Date(1)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false, forceRefresh = true)
+
+        verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+        verify(exactly = 2) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        }
+    }
+
+    @Test
     fun `getWorkflowsList retries after failed forceRefresh even when old list cache was fresh`() {
         val initialResponse = WorkflowsListResponse(
             workflows = listOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -653,6 +653,56 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflowsList retries after failed forceRefresh even when old list cache was fresh`() {
+        val initialResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_old", displayName = "Old", offeringId = "default", prefetch = false),
+            ),
+        )
+        val refreshedResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_new", displayName = "New", offeringId = "default", prefetch = false),
+            ),
+        )
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        var backendCalls = 0
+        every {
+            mockBackend.getWorkflows(
+                any(),
+                any(),
+                type = any(),
+                onSuccess = capture(successSlot),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            backendCalls += 1
+            when (backendCalls) {
+                1 -> successSlot.captured(initialResponse)
+                2 -> errorSlot.captured(error)
+                else -> successSlot.captured(refreshedResponse)
+            }
+        }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns null
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns null
+
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_old")
+
+        every { mockDateProvider.now } returns Date(1)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false, forceRefresh = true)
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_old")
+
+        every { mockDateProvider.now } returns Date(2)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        verify(exactly = 3) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_new")
+    }
+
+    @Test
     fun `getWorkflowsList triggers getWorkflow for each prefetch=true entry only`() {
         val response = WorkflowsListResponse(
             workflows = listOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -755,6 +755,91 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflowsList with forceRefresh preserves in-memory detail caches when the fetch fails`() {
+        val listResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = true),
+            ),
+        )
+        val envelope = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val expectedResult = WorkflowDataResult(workflow = envelope.data!!, enrolledVariants = null)
+        coEvery { mockResolver.resolve(envelope) } returns expectedResult
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            (args[3] as (WorkflowDetailResponse) -> Unit).invoke(envelope)
+        }
+
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        var listCalls = 0
+        every {
+            mockBackend.getWorkflows(
+                any(),
+                any(),
+                type = any(),
+                onSuccess = capture(successSlot),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            listCalls += 1
+            when (listCalls) {
+                1 -> successSlot.captured(listResponse)
+                else -> errorSlot.captured(PurchasesError(PurchasesErrorCode.NetworkError, "fail"))
+            }
+        }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns null
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns null
+
+        // Initial load at t=0: list + detail fetched and cached.
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // forceRefresh at t=1ms fails — detail cache must survive intact.
+        every { mockDateProvider.now } returns Date(1)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false, forceRefresh = true)
+
+        // getWorkflow should return the cached result without a new backend call.
+        var result: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { result = it },
+            onError = { fail("unexpected error: $it") },
+        )
+
+        assertThat(result).isEqualTo(expectedResult)
+        verify(exactly = 1) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        }
+        verify(exactly = 0) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+            )
+        }
+    }
+
+    @Test
     fun `getWorkflowsList triggers getWorkflow for each prefetch=true entry only`() {
         val response = WorkflowsListResponse(
             workflows = listOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -635,6 +635,24 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflowsList with forceRefresh fetches even when the in-memory cache is fresh`() {
+        val response = WorkflowsListResponse(workflows = emptyList())
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+        // First call at t=0 populates a fresh cache.
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Second call at t=1ms would normally be skipped as fresh, but forceRefresh overrides the TTL.
+        every { mockDateProvider.now } returns Date(1)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false, forceRefresh = true)
+
+        verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+    }
+
+    @Test
     fun `getWorkflowsList triggers getWorkflow for each prefetch=true entry only`() {
         val response = WorkflowsListResponse(
             workflows = listOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -114,21 +114,6 @@ class WorkflowsCacheTest {
     }
 
     @Test
-    fun `forceWorkflowsListCacheStale marks the list stale but keeps the offeringId map`() {
-        workflowsCache.cacheWorkflowsList(
-            WorkflowsListResponse(workflows = emptyList()),
-            mapOf("default" to "wf_1"),
-        )
-        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isFalse
-
-        workflowsCache.forceWorkflowsListCacheStale()
-
-        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
-        // The map is kept so workflowIdForOfferingId still resolves while the refetch is in flight.
-        assertThat(workflowsCache.workflowIdForOfferingId("default")).isEqualTo("wf_1")
-    }
-
-    @Test
     fun `workflowIdForOfferingId returns mapped id or null`() {
         workflowsCache.cacheWorkflowsList(
             WorkflowsListResponse(workflows = emptyList()),


### PR DESCRIPTION
Stacked on #3540.

`forceWorkflowsListCacheStale()` was a side effect I didn't like that cleared the list-cache timestamp, and the next `getWorkflowsList` checked it. That made it a bit coupled, hard to follow and not synchronized, so I replaced it with a `forceRefresh` parameter on `getWorkflowsList`. The behavior is preserved and a fresh offerings network response passes `forceRefresh = true` and a read from disk passes `false`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches offerings delivery gating and workflows caching/prefetch timing; behavior is intended to match the old force-stale path but adds new error-path invalidation and detail-cache clearing on successful force refresh.
> 
> **Overview**
> Replaces the **`forceWorkflowsListCacheStale()`** side effect with a **`forceRefresh`** argument on **`getWorkflowsList`**, so offerings can request a workflows refresh in one call instead of invalidating the list timestamp first.
> 
> **`OfferingsManager`** passes **`forceRefresh = !loadedFromDiskCache`**: network offerings trigger a workflows list refetch and realignment of the offeringId → workflowId map; disk fallback keeps the workflows list on its normal TTL.
> 
> On a successful forced list fetch, **`WorkflowManager`** clears in-memory workflow **detail** caches so prefetches always miss TTL and hit the backend. Detail caches are **not** cleared before the network call, so a failed forced fetch leaves cached details intact. List fetch errors without disk restore now call **`invalidateWorkflowsListTimestamp()`** (renamed from **`forceWorkflowsListCacheStale`**) so the next call retries, matching offerings error behavior.
> 
> Concurrent callers still dedupe; **`forceRefresh` is ignored when joining an in-flight batch** (documented). Tests updated and expanded for **`forceRefresh`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43f8a29b0d74889644b9c4bce5ea6bf88d011e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->