### PR TITLE
Make PaywallViewModel dispatcher injectable to fix flaky tests

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -66,6 +66,7 @@ import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorSt
 import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowNavigator
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowScreenMapper
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -161,6 +162,7 @@ internal class PaywallViewModelImpl(
     preview: Boolean = false,
     private val productChangeCalculator: ProductChangeCalculator = ProductChangeCalculator(purchases),
     private val useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT,
+    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel(), PaywallViewModel {
     private val variableDataProvider = VariableDataProvider(resourceProvider, preview)
 
@@ -1015,7 +1017,7 @@ internal class PaywallViewModelImpl(
         preWarmJob = viewModelScope.launch {
             for ((stepId, step) in workflow.steps) {
                 if (stepId in workflowStepStateCache) continue
-                val computed = withContext(Dispatchers.Default) {
+                val computed = withContext(backgroundDispatcher) {
                     computeStateForStep(step, workflow, offerings, presentedOfferingContext)
                 }
                 if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -358,6 +358,9 @@ class PaywallViewModelWorkflowTest {
             colorScheme = TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
+            // Run the step-state pre-warm on the test scheduler so advanceUntilIdle() awaits it
+            // instead of it escaping to Dispatchers.Default and resuming after resetMain().
+            backgroundDispatcher = testDispatcher,
         )
     }
 
@@ -488,6 +491,9 @@ class PaywallViewModelWorkflowTest {
             colorScheme = TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
+            // Run the step-state pre-warm on the test scheduler so advanceUntilIdle() awaits it
+            // instead of it escaping to Dispatchers.Default and resuming after resetMain().
+            backgroundDispatcher = testDispatcher,
         )
         vmWithVars.updateStateFromWorkflow(fetchResult, testOfferings, null)
 


### PR DESCRIPTION
`PaywallViewModelWorkflowTest` looks flaky on CI

I believe the reason is that `preWarmWorkflowStepCache()` launches on `viewModelScope` (the test Main dispatcher) but hops to `withContext(Dispatchers.Default)` for the heavy `computeStateForStep` work.

Making the dispatcher injectable and injecting the test dispatcher in the workflow test's VM construction so the pre-warm runs on the test scheduler should fix it.

Example failure: 

https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/22653/workflows/97ebb0de-5850-4621-ae49-725e31304259/jobs/223710/tests

Failure in `PaywallViewModelWorkflowTest`

```
java.lang.IllegalStateException: Dispatchers.Main is used concurrently with setting it
	at kotlinx.coroutines.test.internal.TestMainDispatcher$NonConcurrentlyModifiable.concurrentRW(TestMainDispatcher.kt:72)
	at kotlinx.coroutines.test.internal.TestMainDispatcher$NonConcurrentlyModifiable.setValue(TestMainDispatcher.kt:90)
	at kotlinx.coroutines.test.internal.TestMainDispatcher.resetDispatcher(TestMainDispatcher.kt:41)
	at kotlinx.coroutines.test.TestDispatchers.resetMain(TestDispatchers.kt:34)
	at com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelWorkflowTest.tearDown(PaywallViewModelWorkflowTest.kt:345)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.RunAfters.invokeMethod(RunAfters.java:46)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:524)
	at org.robolectric.internal.SandboxTestRunner.executeInSandbox(SandboxTestRunner.java:494)
	at org.robolectric.internal.SandboxTestRunner.access$900(SandboxTestRunner.java:67)
	at org.robolectric.internal.SandboxTestRunner$7.evaluate(SandboxTestRunner.java:442)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.robolectric.internal.SandboxTestRunner.access$600(SandboxTestRunner.java:67)
	at org.robolectric.internal.SandboxTestRunner$6.evaluate(SandboxTestRunner.java:333)
	at org.robolectric.internal.SandboxTestRunner$3.evaluate(SandboxTestRunner.java:233)
	at org.robolectric.internal.SandboxTestRunner$5.lambda$evaluate$0(SandboxTestRunner.java:317)
	at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:101)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	Suppressed: org.robolectric.android.internal.AndroidTestEnvironment$UnExecutedRunnablesException: Main looper has queued unexecuted runnables. This might be the cause of the test failure. You might need a shadowOf(Looper.getMainLooper()).idle() call.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production behavior is unchanged thanks to the default dispatcher; only test construction and an internal injectable hook for pre-warm offloading.
> 
> **Overview**
> Adds an optional **`backgroundDispatcher`** constructor parameter to **`PaywallViewModelImpl`** (default **`Dispatchers.Default`**) and uses it in **`preWarmWorkflowStepCache`** instead of a hardcoded **`Dispatchers.Default`** for **`computeStateForStep`**.
> 
> **`PaywallViewModelWorkflowTest`** passes the test **`StandardTestDispatcher`** so workflow step pre-warming stays on the test coroutine scheduler. That avoids work continuing on the real default pool after **`Dispatchers.resetMain()`**, which was causing flaky CI failures. Production wiring via **`PaywallViewModelFactory`** is unchanged and still uses the default dispatcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a99fef5a14c3a87bd193b4073359a00e18472f04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->