### PR TITLE
Remove Samsung IAP SDK version warning log

### DIFF
--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
@@ -46,8 +46,6 @@ import com.revenuecat.purchases.strings.RestoreStrings
 import com.samsung.android.sdk.iap.lib.constants.HelperDefine
 import com.samsung.android.sdk.iap.lib.helper.IapHelper
 import com.samsung.android.sdk.iap.lib.vo.PurchaseVo
-import com.revenuecat.purchases.api.BuildConfig as PurchasesBuildConfig
-import com.samsung.android.sdk.iap.lib.BuildConfig as SamsungBuildConfig
 
 @OptIn(InternalRevenueCatAPI::class)
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -104,7 +102,6 @@ internal class GalaxyBillingWrapper(
 
     init {
         iapHelper.setOperationMode(mode = billingMode.toSamsungIAPOperationMode())
-        logWarningIfUnexpectedSamsungIAPVersionFound()
     }
 
     override fun startConnection(delayMilliseconds: Long) {
@@ -571,20 +568,5 @@ internal class GalaxyBillingWrapper(
 
     private fun onPurchaseError(error: PurchasesError) {
         purchasesUpdatedListener?.onPurchasesFailedToUpdate(error)
-    }
-
-    private fun logWarningIfUnexpectedSamsungIAPVersionFound() {
-        val expectedSamsungIAPSDKVersion = PurchasesBuildConfig.SAMSUNG_IAP_SDK_VERSION
-        val actualSamsungIAPSDKVersion = SamsungBuildConfig.VERSION_NAME
-
-        if (expectedSamsungIAPSDKVersion != actualSamsungIAPSDKVersion) {
-            log(intent = LogIntent.GALAXY_WARNING) {
-                "Unexpected Samsung IAP SDK version found. Expected " +
-                    "$expectedSamsungIAPSDKVersion, but found $actualSamsungIAPSDKVersion. Unexpected behavior " +
-                    "related to the Galaxy Store in-app purchases may occur. Please obtain and" +
-                    " include version $expectedSamsungIAPSDKVersion of the Samsung IAP SDK from the Samsung's" +
-                    " developer website."
-            }
-        }
     }
 }

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -76,12 +76,6 @@ android {
             value = "\"${(localProperties["REMOTE_CONFIG_BASE_URL"] as? String) ?: ""}\"",
         )
 
-        buildConfigField(
-            type = "String",
-            name = "SAMSUNG_IAP_SDK_VERSION",
-            value = "\"${libs.versions.samsungIap.get()}\"",
-        )
-
         packagingOptions.resources.excludes.addAll(
             listOf("META-INF/LICENSE.md", "META-INF/LICENSE-notice.md"),
         )


### PR DESCRIPTION
### Motivation
Before `purchases-android` SDK version 10.7.0, developers who wanted to use our integration with the Galaxy Store needed to obtain a copy of the Samsung IAP SDK `.aar` file from the Samsung Developer Portal and manually include it in their app builds. This meant that the RevenueCat SDK could not control which version of the Samsung IAP SDK was used at runtime. To help ensure that developers used a compatible IAP SDK version, we included a warning log if the IAP SDK version provided was not expected by that version of the `purchases-android` SDK.

The `purchases-android` SDK began including a copy of the Samsung IAP SDK transitively starting in version 10.7.0, as the Samsung IAP SDK started to be distributed via Maven beginning with version 6.5.2. Thus, this warning log is no longer required.

### Description
Removes the warning log that gets logged if the version of the Samsung IAP SDK does not match the version expected by the `purchases-android` SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and build-config cleanup only; no changes to purchase, restore, or billing flows.
> 
> **Overview**
> Removes the Galaxy Store startup check that compared the Samsung IAP SDK version at runtime against a value baked into `purchases-android` and logged a warning on mismatch.
> 
> That check and its supporting `BuildConfig.SAMSUNG_IAP_SDK_VERSION` field in `purchases/build.gradle.kts` are deleted, along with related imports in `GalaxyBillingWrapper`. Galaxy billing initialization still sets IAP operation mode; only the obsolete version-mismatch warning path is gone now that the SDK ships Samsung IAP transitively via Maven.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251bf522b4f009c45108df2cfa23a87786b38ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->