### PR TITLE
Fix `X ms is denormalized` crash in AmazonBillingTest

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -49,6 +49,7 @@ import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.Date
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -1337,10 +1338,10 @@ class AmazonBillingTest {
 
     private fun mockDiagnosticsTracker() {
         every {
-            mockDiagnosticsTracker.trackAmazonQueryPurchasesRequest(any(), any(), any())
+            mockDiagnosticsTracker.trackAmazonQueryPurchasesRequest(any<Duration>(), any(), any())
         } just Runs
         every {
-            mockDiagnosticsTracker.trackAmazonQueryProductDetailsRequest(any(), any(), any())
+            mockDiagnosticsTracker.trackAmazonQueryProductDetailsRequest(any<Duration>(), any(), any())
         } just Runs
     }
 }


### PR DESCRIPTION
The intermittent `AssertionError: X ms is denormalized` crash fixed in #3361 for `BaseBillingUseCaseTest.mockDiagnosticsTracker()` was also present in `AmazonBillingTest.mockDiagnosticsTracker()`.

https://app.circleci.com/pipelines/gh/RevenueCat/purchases-android/22731/workflows/7043b0b3-65ee-41b9-8171-7a72d5b8fd1f/jobs/226020/tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only MockK stub change; no production or billing behavior changes.
> 
> **Overview**
> Aligns **AmazonBillingTest** with the same MockK fix used in **BaseBillingUseCaseTest** (#3361): the first argument to `trackAmazonQueryPurchasesRequest` and `trackAmazonQueryProductDetailsRequest` in `mockDiagnosticsTracker()` is stubbed with **`any<Duration>()`** instead of untyped **`any()`**, and **`kotlin.time.Duration`** is imported.
> 
> That avoids intermittent **`X ms is denormalized`** failures when tests verify those calls with concrete **`Duration`** values (e.g. `123.milliseconds`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f70e616b70d6427bc0b88d6f73ea42b1390f272f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->