### PR TITLE
Add `contains` operator (case-insensitive substring)

### DIFF
--- a/rules-engine-internal/src/main/kotlin/com/revenuecat/purchases/rules/operators/Operators.kt
+++ b/rules-engine-internal/src/main/kotlin/com/revenuecat/purchases/rules/operators/Operators.kt
@@ -61,6 +61,7 @@ internal object Operators {
 
         // String and array
         "in" -> StringArrayOperators.opIn(args, vars)
+        "contains" -> StringArrayOperators.opContains(args, vars)
         "cat" -> StringArrayOperators.opCat(args, vars)
         "substr" -> StringArrayOperators.opSubstr(args, vars)
         "merge" -> StringArrayOperators.opMerge(args, vars)

--- a/rules-engine-internal/src/main/kotlin/com/revenuecat/purchases/rules/operators/StringArrayOperators.kt
+++ b/rules-engine-internal/src/main/kotlin/com/revenuecat/purchases/rules/operators/StringArrayOperators.kt
@@ -6,7 +6,7 @@ import com.revenuecat.purchases.rules.jsString
 import com.revenuecat.purchases.rules.strictEq
 
 /**
- * String + array operators: `in`, `cat`, `substr`, `merge`.
+ * String + array operators: `in`, `contains`, `cat`, `substr`, `merge`.
  *
  * Behavior follows the JSON Logic JS reference (`json-logic-js`).
  * `substr` slices by Unicode code points, not UTF-16 code units —
@@ -52,6 +52,39 @@ internal object StringArrayOperators {
                 }
             }
             is Value.ArrayValue -> haystack.items.any { strictEq(needle, it) }
+            else -> false
+        }
+        return Value.BoolValue(result)
+    }
+
+    /**
+     * `{"contains": [haystack, needle]}` — case-insensitive substring
+     * test (khepri-specific, not part of JSON Logic). The haystack must
+     * be a [Value.StringValue]; non-string haystacks return `false`. The
+     * needle is stringified via [jsString] and matched with
+     * locale-independent Unicode lowercasing (`String.lowercase()`).
+     * Unlike `in`, there is no json-logic falsy guard on the haystack —
+     * an empty needle matches any string haystack. Argument order is
+     * reversed from `in`: `function(haystack, needle)`. Extra operands
+     * beyond the second are ignored.
+     */
+    fun opContains(args: Value, vars: Value): Value {
+        val evaluated = Operators.evalArgs(args, vars)
+        val haystack = evaluated.firstOrNull() ?: Value.Null
+        val needle = if (evaluated.size >= BINARY_OPERAND_COUNT) {
+            evaluated[START_OPERAND_INDEX]
+        } else {
+            Value.Null
+        }
+        val result = when (haystack) {
+            is Value.StringValue -> {
+                val needleString = jsString(needle)
+                if (needleString.isEmpty()) {
+                    true
+                } else {
+                    haystack.value.lowercase().contains(needleString.lowercase())
+                }
+            }
             else -> false
         }
         return Value.BoolValue(result)

--- a/rules-engine-internal/src/test/kotlin/com/revenuecat/purchases/rules/PredicateFixtureLoaderTest.kt
+++ b/rules-engine-internal/src/test/kotlin/com/revenuecat/purchases/rules/PredicateFixtureLoaderTest.kt
@@ -21,7 +21,7 @@ internal class PredicateFixtureLoaderTest {
     fun `fixture count matches expected`() {
         // Bump this when adding or removing fixtures. Guards against a fixture
         // file silently failing to load and shrinking the suite.
-        val expectedCount = 347
+        val expectedCount = 367
         assertThat(PredicateConformanceFixtureLoader.allCases).hasSize(expectedCount)
     }
 }

--- a/rules-engine-internal/src/test/resources/predicate-fixtures/contains.json
+++ b/rules-engine-internal/src/test/resources/predicate-fixtures/contains.json
@@ -1,0 +1,130 @@
+{
+  "fixtures": [
+    {
+      "id": "contains_case_insensitive_substring_match",
+      "predicate": { "contains": ["FooBar", "oob"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_exact_case_substring_match",
+      "predicate": { "contains": ["foobar", "bar"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_no_match",
+      "predicate": { "contains": ["foobar", "baz"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_uppercase_needle_lowercase_haystack",
+      "predicate": { "contains": ["foobar", "BAR"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_lowercase_needle_uppercase_haystack",
+      "predicate": { "contains": ["FOOBAR", "bar"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_full_string_case_insensitive",
+      "predicate": { "contains": ["ABC", "abc"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_unicode_accented_case_folding",
+      "description": "locale-independent Unicode lowercasing folds accented letters",
+      "predicate": { "contains": ["CAFÉ", "café"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_empty_needle_matches_any_string",
+      "description": "every string contains the empty substring; no json-logic falsy guard (unlike in)",
+      "predicate": { "contains": ["abc", ""] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_empty_needle_matches_empty_haystack",
+      "predicate": { "contains": ["", ""] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_empty_haystack_nonempty_needle",
+      "predicate": { "contains": ["", "x"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_needle_longer_than_haystack",
+      "predicate": { "contains": ["ab", "abc"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_coerces_non_string_needle",
+      "description": "needle is stringified (mirrors in): 2 becomes \"2\"",
+      "predicate": { "contains": ["a1b2c3", 2] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_non_string_haystack_number",
+      "description": "case-insensitive substring is only defined on string haystacks; non-string returns false",
+      "predicate": { "contains": [12345, "234"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_non_string_haystack_null",
+      "predicate": { "contains": [null, "x"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_non_string_haystack_bool",
+      "predicate": { "contains": [true, "tru"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_non_string_haystack_array",
+      "predicate": { "contains": [["a", "b"], "a"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_non_string_haystack_object",
+      "predicate": { "contains": [{}, "x"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_zero_args",
+      "description": "contains is function(haystack, needle); a missing haystack is null, so non-string short-circuits to false",
+      "predicate": { "contains": [] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_one_arg_missing_needle",
+      "description": "a missing needle becomes null, stringified to \"null\", which is not a substring of the haystack",
+      "predicate": { "contains": ["only-one"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_ignores_args_beyond_second",
+      "predicate": { "contains": ["foobar", "foo", 999] },
+      "variables": {},
+      "expected": true
+    }
+  ]
+}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Adds the khepri-specific `contains` operator for case-insensitive substring checks in workflow predicates ([SDK-4348](https://linear.app/revenuecat/issue/SDK-4348)). Companion iOS PR: https://github.com/RevenueCat/purchases-ios/pull/6943

### Description
Implemented as `function(haystack, needle)` with locale-independent lowercasing; non-string haystacks return `false`, with no json-logic falsy guard on the haystack. Twenty shared predicate fixtures added (fixture count 347 → 367).