### PR TITLE
Remove workflows fallback on 4xx errors

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -106,7 +106,10 @@ internal typealias RemoteConfigCallback = Pair<(RemoteConfigResponse) -> Unit, (
 @OptIn(InternalRevenueCatAPI::class)
 internal typealias WorkflowDetailCallback = Pair<(WorkflowDetailResponse) -> Unit, (PurchasesError) -> Unit>
 
-internal typealias WorkflowsListCallback = Pair<(WorkflowsListResponse) -> Unit, (PurchasesError) -> Unit>
+internal typealias WorkflowsListCallback = Pair<
+    (WorkflowsListResponse) -> Unit,
+    (PurchasesError, errorHandlingBehavior: GetWorkflowsErrorHandlingBehavior) -> Unit,
+    >
 
 internal enum class PostReceiptErrorHandlingBehavior {
     SHOULD_BE_MARKED_SYNCED,
@@ -116,6 +119,11 @@ internal enum class PostReceiptErrorHandlingBehavior {
 
 internal enum class GetOfferingsErrorHandlingBehavior {
     SHOULD_FALLBACK_TO_CACHED_OFFERINGS,
+    SHOULD_NOT_FALLBACK,
+}
+
+internal enum class GetWorkflowsErrorHandlingBehavior {
+    SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
     SHOULD_NOT_FALLBACK,
 }
 
@@ -1068,7 +1076,7 @@ internal class Backend(
         appInBackground: Boolean,
         type: String? = null,
         onSuccess: (WorkflowsListResponse) -> Unit,
-        onError: (PurchasesError) -> Unit,
+        onError: (PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit,
     ) {
         val endpoint = Endpoint.GetWorkflows(appUserID, type)
         val path = endpoint.getPath()
@@ -1089,7 +1097,7 @@ internal class Backend(
                 synchronized(this@Backend) {
                     workflowsListCallbacks.remove(cacheKey)
                 }?.forEach { (_, onErrorHandler) ->
-                    onErrorHandler(error)
+                    onErrorHandler(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS)
                 }
             }
 
@@ -1103,12 +1111,23 @@ internal class Backend(
                                 WorkflowJsonParser.parseWorkflowsListResponse(result.payload),
                             )
                         } catch (e: SerializationException) {
-                            onErrorHandler(e.toPurchasesError().also { errorLog(it) })
+                            onErrorHandler(
+                                e.toPurchasesError().also { errorLog(it) },
+                                GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+                            )
                         } catch (e: IllegalArgumentException) {
-                            onErrorHandler(e.toPurchasesError().also { errorLog(it) })
+                            onErrorHandler(
+                                e.toPurchasesError().also { errorLog(it) },
+                                GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+                            )
                         }
                     } else {
-                        onErrorHandler(result.toPurchasesError().also { errorLog(it) })
+                        val errorBehavior = if (RCHTTPStatusCodes.isServerError(result.responseCode)) {
+                            GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS
+                        } else {
+                            GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK
+                        }
+                        onErrorHandler(result.toPurchasesError().also { errorLog(it) }, errorBehavior)
                     }
                 }
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.GetWorkflowsErrorHandlingBehavior
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.toPurchasesError
@@ -246,40 +247,54 @@ internal class WorkflowManager(
                         completePendingCallbacks(appUserID)
                     }
                 },
-                onError = { error, _ ->
+                onError = { error, behavior ->
                     errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
-                    // Restore the in-memory cache from disk without rewriting it — disk already holds
-                    // this payload.
-                    val restoredFromDisk = workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
-                        val filtered = response.onlyWorkflowsWithOfferingId()
-                        workflowsCache.cacheWorkflowsListInMemory(filtered, buildOfferingIdMap(filtered.workflows))
-                    } != null
-                    // Mirror OfferingsManager.handleErrorFetchingOfferings: when there is no disk
-                    // cache to fall back on, force the list stale so the next call retries. When a
-                    // disk restore did succeed, cacheWorkflowsListInMemory already stamped a fresh
-                    // timestamp, so we leave it alone — same as offerings leaving the cache fresh
-                    // after createAndCacheOfferings runs on the disk-fallback path.
-                    if (!restoredFromDisk) {
-                        workflowsCache.invalidateWorkflowsListTimestamp()
-                    }
-                    val envelopes = workflowsCache.cachedWorkflowDetailEnvelopesFromDisk().orEmpty()
-                    if (envelopes.isEmpty()) {
+                    if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
+                        // A 4xx means the server intentionally changed/removed these workflows. Don't
+                        // resurrect a stale list from disk; just settle the callbacks so offerings
+                        // delivery isn't stranded. Caches are left as they are (no restore, no purge).
                         completePendingCallbacks(appUserID)
                     } else {
-                        scope.launch {
-                            // Re-resolve persisted envelopes into the in-memory cache, mirroring the
-                            // success-path prefetch loop. A failed re-resolve is logged and does not
-                            // fail its siblings. completePendingCallbacks still fires exactly once.
-                            coroutineScope {
-                                envelopes.forEach { (workflowId, envelope) ->
-                                    launch { restoreWorkflowFromEnvelope(workflowId, envelope) }
-                                }
-                            }
-                            completePendingCallbacks(appUserID)
-                        }
+                        restoreWorkflowsListFromDisk(appUserID)
                     }
                 },
             )
+        }
+    }
+
+    /**
+     * Restores the workflows list and persisted detail envelopes from disk after a fallback-eligible
+     * fetch failure (transport error, 5xx, or malformed body), then settles pending callbacks. The
+     * in-memory cache is rewritten from disk without re-persisting it — disk already holds this payload.
+     * [completePendingCallbacks] always fires exactly once.
+     */
+    private fun restoreWorkflowsListFromDisk(appUserID: String) {
+        val restoredFromDisk = workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
+            val filtered = response.onlyWorkflowsWithOfferingId()
+            workflowsCache.cacheWorkflowsListInMemory(filtered, buildOfferingIdMap(filtered.workflows))
+        } != null
+        // Mirror OfferingsManager.handleErrorFetchingOfferings: when there is no disk cache to fall
+        // back on, force the list stale so the next call retries. When a disk restore did succeed,
+        // cacheWorkflowsListInMemory already stamped a fresh timestamp, so we leave it alone — same as
+        // offerings leaving the cache fresh after createAndCacheOfferings runs on the disk-fallback path.
+        if (!restoredFromDisk) {
+            workflowsCache.invalidateWorkflowsListTimestamp()
+        }
+        val envelopes = workflowsCache.cachedWorkflowDetailEnvelopesFromDisk().orEmpty()
+        if (envelopes.isEmpty()) {
+            completePendingCallbacks(appUserID)
+        } else {
+            scope.launch {
+                // Re-resolve persisted envelopes into the in-memory cache, mirroring the success-path
+                // prefetch loop. A failed re-resolve is logged and does not fail its siblings.
+                // completePendingCallbacks still fires exactly once.
+                coroutineScope {
+                    envelopes.forEach { (workflowId, envelope) ->
+                        launch { restoreWorkflowFromEnvelope(workflowId, envelope) }
+                    }
+                }
+                completePendingCallbacks(appUserID)
+            }
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -252,7 +252,10 @@ internal class WorkflowManager(
                     if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
                         // A 4xx means the server intentionally changed/removed these workflows. Don't
                         // resurrect a stale list from disk; just settle the callbacks so offerings
-                        // delivery isn't stranded. Caches are left as they are (no restore, no purge).
+                        // delivery isn't stranded. Invalidate the timestamp so the next non-forced call
+                        // retries rather than serving a still-fresh in-memory list — mirrors
+                        // OfferingsManager.handleErrorFetchingOfferings calling forceCacheStale().
+                        workflowsCache.invalidateWorkflowsListTimestamp()
                         completePendingCallbacks(appUserID)
                     } else {
                         restoreWorkflowsListFromDisk(appUserID)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -246,7 +246,7 @@ internal class WorkflowManager(
                         completePendingCallbacks(appUserID)
                     }
                 },
-                onError = { error ->
+                onError = { error, _ ->
                     errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
                     // Restore the in-memory cache from disk without rewriting it — disk already holds
                     // this payload.

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.GetWorkflowsErrorHandlingBehavior
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.SyncDispatcher
 import com.revenuecat.purchases.common.networking.Endpoint
@@ -23,6 +24,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.io.IOException
 import java.net.URL
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
@@ -227,7 +229,7 @@ class BackendWorkflowsTest {
                 assertThat(response.workflows[1].offeringId).isNull()
                 success = true
             },
-            onError = { fail("unexpected error $it") },
+            onError = { e, _ -> fail("unexpected error $e") },
         )
         assertThat(success).isTrue()
     }
@@ -256,7 +258,7 @@ class BackendWorkflowsTest {
                 assertThat(response.workflows[0].id).isEqualTo("wf_1")
                 success = true
             },
-            onError = { fail("unexpected error $it") },
+            onError = { e, _ -> fail("unexpected error $e") },
         )
         assertThat(success).isTrue()
     }
@@ -279,7 +281,7 @@ class BackendWorkflowsTest {
             appUserID = appUserId,
             appInBackground = false,
             onSuccess = { fail("expected error") },
-            onError = { errorCode = it.code },
+            onError = { e, _ -> errorCode = e.code },
         )
         assertThat(errorCode).isNotNull
     }
@@ -309,7 +311,7 @@ class BackendWorkflowsTest {
             appUserID = appUserId,
             appInBackground = false,
             onSuccess = { resultLatch.countDown() },
-            onError = { fail("unexpected error $it") },
+            onError = { e, _ -> fail("unexpected error $e") },
         )
         assertThat(httpStarted.await(defaultTimeout, TimeUnit.MILLISECONDS)).isTrue()
         repeat(2) {
@@ -317,7 +319,7 @@ class BackendWorkflowsTest {
                 appUserID = appUserId,
                 appInBackground = false,
                 onSuccess = { resultLatch.countDown() },
-                onError = { fail("unexpected error $it") },
+                onError = { e, _ -> fail("unexpected error $e") },
             )
         }
         httpProceed.countDown()
@@ -411,6 +413,98 @@ class BackendWorkflowsTest {
         }
         override fun close() = Unit
         override fun isClosed() = false
+    }
+
+    @Test
+    fun `getWorkflows reports SHOULD_NOT_FALLBACK on 4xx`() {
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflows(appUserId),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.NOT_FOUND, """{"error": "not found"}""")
+
+        var behavior: GetWorkflowsErrorHandlingBehavior? = null
+        backend.getWorkflows(
+            appUserID = appUserId,
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = { _, b -> behavior = b },
+        )
+        assertThat(behavior).isEqualTo(GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK)
+    }
+
+    @Test
+    fun `getWorkflows reports SHOULD_FALLBACK on 5xx`() {
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflows(appUserId),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.ERROR, """{"error": "boom"}""")
+
+        var behavior: GetWorkflowsErrorHandlingBehavior? = null
+        backend.getWorkflows(
+            appUserID = appUserId,
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = { _, b -> behavior = b },
+        )
+        assertThat(behavior).isEqualTo(GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS)
+    }
+
+    @Test
+    fun `getWorkflows reports SHOULD_FALLBACK on malformed body`() {
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflows(appUserId),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.SUCCESS, "not valid json")
+
+        var behavior: GetWorkflowsErrorHandlingBehavior? = null
+        backend.getWorkflows(
+            appUserID = appUserId,
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = { _, b -> behavior = b },
+        )
+        assertThat(behavior).isEqualTo(GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS)
+    }
+
+    @Test
+    fun `getWorkflows reports SHOULD_FALLBACK on transport failure`() {
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflows(appUserId),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } throws IOException("network down")
+
+        var behavior: GetWorkflowsErrorHandlingBehavior? = null
+        backend.getWorkflows(
+            appUserID = appUserId,
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = { _, b -> behavior = b },
+        )
+        assertThat(behavior).isEqualTo(GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS)
     }
 
     private fun httpResult(responseCode: Int, payload: String) = HTTPResult(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -730,7 +730,7 @@ class WorkflowManagerTest {
         }
 
         val successSlot = slot<(WorkflowsListResponse) -> Unit>()
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         var listCalls = 0
         every {
             mockBackend.getWorkflows(
@@ -744,7 +744,10 @@ class WorkflowManagerTest {
             listCalls += 1
             when (listCalls) {
                 1 -> successSlot.captured(listResponse)
-                else -> errorSlot.captured(PurchasesError(PurchasesErrorCode.NetworkError, "fail"))
+                else -> errorSlot.captured(
+                    PurchasesError(PurchasesErrorCode.NetworkError, "fail"),
+                    GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+                )
             }
         }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns null
@@ -1690,6 +1693,60 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completeCount++ }
 
         assertThat(completeCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `getWorkflowsList does not restore from disk on a non-fallback (4xx) error`() {
+        val cachedJson = """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""
+        val error = PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "forbidden")
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns null
+
+        var completeCount = 0
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completeCount++ }
+
+        // No restore: the offeringId map stays empty, and the disk read is never consulted for restore.
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isNull()
+        verify(exactly = 0) { mockDeviceCache.getWorkflowsListResponseCache() }
+        verify(exactly = 0) { mockDeviceCache.getWorkflowDetailEnvelopesCache() }
+        // Offerings delivery is never stranded.
+        assertThat(completeCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `getWorkflowsList completes all concurrent callers exactly once on a non-fallback (4xx) error`() {
+        val cachedJson = """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""
+        val error = PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "forbidden")
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
+        } just Runs // hold the request in-flight so the second caller joins before it settles
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns null
+
+        var completeCount1 = 0
+        var completeCount2 = 0
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completeCount1++ }
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completeCount2++ }
+
+        // Both callers are pending; the backend was contacted exactly once (dedup).
+        assertThat(completeCount1).isEqualTo(0)
+        assertThat(completeCount2).isEqualTo(0)
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+
+        // Settle the single in-flight request with a SHOULD_NOT_FALLBACK error.
+        errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK)
+
+        // Every caller must complete exactly once — neither stranded nor double-fired.
+        assertThat(completeCount1).isEqualTo(1)
+        assertThat(completeCount2).isEqualTo(1)
+        // No disk restore should have been attempted.
+        verify(exactly = 0) { mockDeviceCache.getWorkflowsListResponseCache() }
+        verify(exactly = 0) { mockDeviceCache.getWorkflowDetailEnvelopesCache() }
     }
 
     // endregion onError envelope restore

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.GetWorkflowsErrorHandlingBehavior
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
@@ -922,10 +923,10 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflowsList silently logs error on backend failure`() {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
 
         // Should not throw
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
@@ -937,10 +938,10 @@ class WorkflowManagerTest {
     fun `getWorkflowsList restores offeringId map from disk cache on backend failure`() {
         val cachedJson = """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
 
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
@@ -953,10 +954,10 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflowsList silently ignores corrupt disk cache on backend failure`() {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns "not valid json"
 
         // Should not throw
@@ -1018,10 +1019,10 @@ class WorkflowManagerTest {
     fun `getWorkflowsList after disk-cache restore does not re-fetch before TTL expires`() {
         val cachedJson = """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
 
         // First call fails → restores from disk
@@ -1042,10 +1043,10 @@ class WorkflowManagerTest {
     fun `getWorkflowsList re-fetches after TTL expiry following disk-cache restore`() {
         val cachedJson = """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
 
         // First call at t=0 — fails, restores from disk, stamps in-memory cache at t=0
@@ -1105,10 +1106,10 @@ class WorkflowManagerTest {
             {"id":"wf_last","display_name":"Last","offering_id":"shared","prefetch":false}
         ]}"""
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
 
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
@@ -1315,10 +1316,10 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflowsList calls onComplete after network error`() {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "fail")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
 
         var completed = false
         workflowManager.getWorkflowsList("user_1", false) { completed = true }
@@ -1601,10 +1602,10 @@ class WorkflowManagerTest {
         // The resolver is mocked, so INLINE vs USE_CDN is indistinguishable here — the manager just
         // hands the envelope to the resolver. This proves restore -> re-resolve -> cache-hit.
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns
             """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":true}]}"""
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
@@ -1635,10 +1636,10 @@ class WorkflowManagerTest {
     @Test
     fun `list onError completes once and isolates a failing envelope re-resolve`() {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns
             """{"workflows":[{"id":"wf_ok","display_name":"OK","offering_id":"a","prefetch":true},{"id":"wf_bad","display_name":"BAD","offering_id":"b","prefetch":true}]}"""
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
@@ -1663,10 +1664,10 @@ class WorkflowManagerTest {
     @Test
     fun `list onError completes immediately when no envelopes are persisted`() {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns null
 
         var completeCount = 0
@@ -1679,10 +1680,10 @@ class WorkflowManagerTest {
     @Test
     fun `list onError completes once when the persisted envelope payload is corrupt`() {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
-        } answers { errorSlot.captured(error) }
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS) }
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns "not valid json"
 
         var completeCount = 0

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -1718,6 +1718,31 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflowsList invalidates list timestamp on a non-fallback (4xx) error`() {
+        // Stamp the in-memory cache as fresh so the cache does not look stale before the 4xx.
+        val recentDate = Date(1_000_000)
+        every { mockDateProvider.now } returns recentDate
+        workflowsCache.cacheWorkflowsListInMemory(
+            WorkflowsListResponse(workflows = emptyList()),
+            emptyMap(),
+        )
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isFalse()
+
+        val error = PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "forbidden")
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error, GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) }
+
+        // forceRefresh bypasses the freshness check, matching the real caller (createAndCacheOfferings).
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false, forceRefresh = true) {}
+
+        // Timestamp must be cleared so a subsequent non-forced call retries rather than serving a
+        // still-fresh in-memory list — mirrors OfferingsManager.handleErrorFetchingOfferings.
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue()
+    }
+
+    @Test
     fun `getWorkflowsList completes all concurrent callers exactly once on a non-fallback (4xx) error`() {
         val cachedJson = """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""
         val error = PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "forbidden")


### PR DESCRIPTION
## Summary

If the workflows list fetch fails, we restore the cache from disk on **any** error, including 4xx. So a 404 (workflow removed) or 403 (misconfigured key) made the SDK resurrect the previous list from disk and keep serving it.

This PR mirrors what we do for offerings policy. It does not require any backend change.

Fallback behavior (identical to offerings):

| Outcome | Behavior |
|---|---|
| Transport failure (no HTTP response) | fall back to cached workflows |
| HTTP 5xx | fall back to cached workflows |
| HTTP 4xx | do not fall back |
| Malformed 2xx body | fall back to cached workflows |

The disk copy is left untouched on 4xx (no purge).


Doing the same for the workflow detail endpoint will be done in a future PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offerings-gated workflows list caching on network errors; behavior is aligned with offerings and heavily tested but affects paywall/offering mapping when the API returns 4xx.
> 
> **Overview**
> Workflows list fetch failures now follow the same fallback rules as offerings, instead of always restoring from disk on any error.
> 
> `Backend.getWorkflows` reports a `GetWorkflowsErrorHandlingBehavior` with each error: **transport failures, 5xx, and malformed success bodies** still signal fallback to cached workflows; **HTTP 4xx** signals `SHOULD_NOT_FALLBACK`. `WorkflowManager` uses that signal on list errors—on 4xx it **does not** read the workflows list or detail envelopes from disk, **invalidates** the in-memory list freshness so the next call retries, and still **completes** pending `onComplete` callbacks so offerings delivery is not blocked. Fallback-eligible errors keep the existing disk restore path, now in `restoreWorkflowsListFromDisk`. Tests cover the new behavior mapping and the 4xx manager path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99321ba02ac533f9c4a2bb8fe9f538a00d3ec1c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->