### PR TITLE
Drop stale cache write-backs from a fetch that began before an identity change

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
@@ -26,15 +26,26 @@ internal class OfferingsCache(
 
     private var cachedLanguageTags: String? = null
 
+    // See WorkflowsCache: bumped on identity-transition clears so an in-flight fetch can't repopulate
+    // the cleared cache after the user changed. cacheOfferings drops a write whose captured generation
+    // no longer matches; the check and this increment share the intrinsic @Synchronized lock, so the
+    // clear-then-write ordering is atomic.
+    private var cacheGeneration: Int = 0
+
+    @Synchronized
+    fun currentGeneration(): Int = cacheGeneration
+
     @Synchronized
     fun clearCache() {
+        cacheGeneration++
         offeringsCachedObject.clearCache()
         deviceCache.clearOfferingsResponseCache()
         cachedLanguageTags = null
     }
 
     @Synchronized
-    fun cacheOfferings(offerings: Offerings, offeringsResponse: JSONObject) {
+    fun cacheOfferings(offerings: Offerings, offeringsResponse: JSONObject, expectedGeneration: Int) {
+        if (expectedGeneration != cacheGeneration) return
         val finalJsonToCache = offeringsResponse.copy(deep = false).apply {
             put(ORIGINAL_SOURCE_KEY, offerings.originalSource)
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -195,6 +195,7 @@ internal class OfferingsManager(
             return
         }
         log(LogIntent.RC_SUCCESS) { OfferingStrings.OFFERINGS_START_UPDATE_FROM_NETWORK }
+        val generation = offeringsCache.currentGeneration()
         backend.getOfferings(
             appUserID,
             appInBackground,
@@ -205,6 +206,7 @@ internal class OfferingsManager(
                     offeringsJSON = body,
                     originalDataSource = originalDataSource,
                     loadedFromDiskCache = false,
+                    expectedGeneration = generation,
                     onError,
                     onSuccess,
                 )
@@ -233,6 +235,7 @@ internal class OfferingsManager(
                                 offeringsJSON = cachedOfferingsResponse,
                                 originalDataSource = originalDataSource,
                                 loadedFromDiskCache = true,
+                                expectedGeneration = generation,
                                 onError,
                                 onSuccess,
                             )
@@ -252,6 +255,7 @@ internal class OfferingsManager(
         offeringsJSON: JSONObject,
         originalDataSource: HTTPResponseOriginalSource,
         loadedFromDiskCache: Boolean,
+        expectedGeneration: Int,
         onError: ((PurchasesError) -> Unit)? = null,
         onSuccess: ((OfferingsResultData) -> Unit)? = null,
     ) {
@@ -270,7 +274,7 @@ internal class OfferingsManager(
                 offeringsCache.cacheOfferings(
                     offeringsResultData.offerings,
                     offeringsJSON,
-                    offeringsCache.currentGeneration(),
+                    expectedGeneration,
                 )
                 val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
                 if (!loadedFromDiskCache) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -267,7 +267,11 @@ internal class OfferingsManager(
                     offeringImagePreDownloader.preDownloadOfferingImages(it)
                 }
                 offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
-                offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
+                offeringsCache.cacheOfferings(
+                    offeringsResultData.offerings,
+                    offeringsJSON,
+                    offeringsCache.currentGeneration(),
+                )
                 val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
                 if (!loadedFromDiskCache) {
                     workflowManager?.forceWorkflowsListCacheStale()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -71,8 +71,14 @@ internal class WorkflowManager(
         callbackDispatcher: Dispatcher? = null,
         persistEnvelopeOnResolve: Boolean = false,
         staleWhileRevalidate: Boolean = true,
-        expectedGeneration: Int = workflowsCache.currentGeneration(),
+        expectedGeneration: Int? = null,
     ) {
+        // On-demand callers omit expectedGeneration and capture the current epoch here, at entry;
+        // the prefetch path threads in the list fetch's epoch instead. The default stays a constant
+        // (null) rather than reading the cache here so the synthesized `getWorkflow$default` never
+        // touches `workflowsCache` — that field is null on a mocked WorkflowManager, and an `every {}`
+        // recording that omits this arg would otherwise NPE.
+        val resolvedGeneration = expectedGeneration ?: workflowsCache.currentGeneration()
         val cached = workflowsCache.cachedWorkflow(workflowId)
         when {
             cached != null && !workflowsCache.isWorkflowCacheStale(workflowId, appInBackground) -> {
@@ -91,7 +97,7 @@ internal class WorkflowManager(
                     appInBackground = appInBackground,
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
-                    expectedGeneration = expectedGeneration,
+                    expectedGeneration = resolvedGeneration,
                     onSuccess = {},
                     onError = { error ->
                         errorLog {
@@ -109,7 +115,7 @@ internal class WorkflowManager(
                     appInBackground = appInBackground,
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
-                    expectedGeneration = expectedGeneration,
+                    expectedGeneration = resolvedGeneration,
                     onSuccess = onSuccess,
                     onError = onError,
                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -137,9 +137,15 @@ internal class WorkflowManager(
                     onError(e.toPurchasesError())
                     return@launch
                 }
-                workflowsCache.cacheWorkflow(workflowId, result)
+                workflowsCache.cacheWorkflow(workflowId, result, workflowsCache.currentGeneration())
                 if (persistEnvelopeOnResolve) {
-                    runCatching { workflowsCache.cacheWorkflowDetailEnvelope(workflowId, response) }
+                    runCatching {
+                        workflowsCache.cacheWorkflowDetailEnvelope(
+                            workflowId,
+                            response,
+                            workflowsCache.currentGeneration(),
+                        )
+                    }
                         .onFailure { errorLog(it) { "Failed to persist workflow detail envelope for $workflowId" } }
                 }
                 scope.launch {
@@ -182,6 +188,7 @@ internal class WorkflowManager(
      * pending callbacks for that user fire together when the in-flight sequence finishes. A call
      * for a different user starts its own fetch rather than joining the in-flight one.
      */
+    @Suppress("LongMethod")
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
         // Decide under the lock, act outside it so onComplete never fires while holding it.
         val startFetch = synchronized(callbackLock) {
@@ -211,7 +218,11 @@ internal class WorkflowManager(
                     // Drop workflows without an offeringId: they can't be reached via
                     // workflowIdForOfferingId, so caching or prefetching them is wasted work.
                     val filtered = response.onlyWorkflowsWithOfferingId()
-                    workflowsCache.cacheWorkflowsList(filtered, buildOfferingIdMap(filtered.workflows))
+                    workflowsCache.cacheWorkflowsList(
+                        filtered,
+                        buildOfferingIdMap(filtered.workflows),
+                        workflowsCache.currentGeneration(),
+                    )
 
                     val prefetchWorkflows = filtered.workflows.filter { it.prefetch }
                     scope.launch {
@@ -235,7 +246,11 @@ internal class WorkflowManager(
                     // this payload.
                     workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
                         val filtered = response.onlyWorkflowsWithOfferingId()
-                        workflowsCache.cacheWorkflowsListInMemory(filtered, buildOfferingIdMap(filtered.workflows))
+                        workflowsCache.cacheWorkflowsListInMemory(
+                            filtered,
+                            buildOfferingIdMap(filtered.workflows),
+                            workflowsCache.currentGeneration(),
+                        )
                     }
                     val envelopes = workflowsCache.cachedWorkflowDetailEnvelopesFromDisk().orEmpty()
                     if (envelopes.isEmpty()) {
@@ -297,7 +312,7 @@ internal class WorkflowManager(
             errorLog(e) { "Failed to restore workflow $workflowId from disk cache" }
             return
         }
-        workflowsCache.cacheWorkflow(workflowId, result)
+        workflowsCache.cacheWorkflow(workflowId, result, workflowsCache.currentGeneration())
     }
 
     fun workflowIdForOfferingId(offeringId: String): String? =

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -71,6 +71,7 @@ internal class WorkflowManager(
         callbackDispatcher: Dispatcher? = null,
         persistEnvelopeOnResolve: Boolean = false,
         staleWhileRevalidate: Boolean = true,
+        expectedGeneration: Int = workflowsCache.currentGeneration(),
     ) {
         val cached = workflowsCache.cachedWorkflow(workflowId)
         when {
@@ -90,6 +91,7 @@ internal class WorkflowManager(
                     appInBackground = appInBackground,
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
+                    expectedGeneration = expectedGeneration,
                     onSuccess = {},
                     onError = { error ->
                         errorLog {
@@ -107,6 +109,7 @@ internal class WorkflowManager(
                     appInBackground = appInBackground,
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
+                    expectedGeneration = expectedGeneration,
                     onSuccess = onSuccess,
                     onError = onError,
                 )
@@ -121,6 +124,7 @@ internal class WorkflowManager(
         appInBackground: Boolean,
         callbackDispatcher: Dispatcher?,
         persistEnvelopeOnResolve: Boolean,
+        expectedGeneration: Int,
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -137,13 +141,13 @@ internal class WorkflowManager(
                     onError(e.toPurchasesError())
                     return@launch
                 }
-                workflowsCache.cacheWorkflow(workflowId, result, workflowsCache.currentGeneration())
+                workflowsCache.cacheWorkflow(workflowId, result, expectedGeneration)
                 if (persistEnvelopeOnResolve) {
                     runCatching {
                         workflowsCache.cacheWorkflowDetailEnvelope(
                             workflowId,
                             response,
-                            workflowsCache.currentGeneration(),
+                            expectedGeneration,
                         )
                     }
                         .onFailure { errorLog(it) { "Failed to persist workflow detail envelope for $workflowId" } }
@@ -210,6 +214,7 @@ internal class WorkflowManager(
         if (!startFetch) {
             completePendingCallbacks(appUserID)
         } else {
+            val generation = workflowsCache.currentGeneration()
             backend.getWorkflows(
                 appUserID = appUserID,
                 appInBackground = appInBackground,
@@ -221,7 +226,7 @@ internal class WorkflowManager(
                     workflowsCache.cacheWorkflowsList(
                         filtered,
                         buildOfferingIdMap(filtered.workflows),
-                        workflowsCache.currentGeneration(),
+                        generation,
                     )
 
                     val prefetchWorkflows = filtered.workflows.filter { it.prefetch }
@@ -233,7 +238,7 @@ internal class WorkflowManager(
                         coroutineScope {
                             prefetchWorkflows.forEach { summary ->
                                 launch {
-                                    prefetchWorkflow(appUserID, summary.id, appInBackground)
+                                    prefetchWorkflow(appUserID, summary.id, appInBackground, generation)
                                 }
                             }
                         }
@@ -249,7 +254,7 @@ internal class WorkflowManager(
                         workflowsCache.cacheWorkflowsListInMemory(
                             filtered,
                             buildOfferingIdMap(filtered.workflows),
-                            workflowsCache.currentGeneration(),
+                            generation,
                         )
                     }
                     val envelopes = workflowsCache.cachedWorkflowDetailEnvelopesFromDisk().orEmpty()
@@ -262,7 +267,7 @@ internal class WorkflowManager(
                             // fail its siblings. completePendingCallbacks still fires exactly once.
                             coroutineScope {
                                 envelopes.forEach { (workflowId, envelope) ->
-                                    launch { restoreWorkflowFromEnvelope(workflowId, envelope) }
+                                    launch { restoreWorkflowFromEnvelope(workflowId, envelope, generation) }
                                 }
                             }
                             completePendingCallbacks(appUserID)
@@ -277,8 +282,16 @@ internal class WorkflowManager(
      * Suspends until [getWorkflow] for [workflowId] resolves. Prefetch is best-effort, so a failure
      * is logged and the coroutine resumes normally instead of throwing, keeping one failed prefetch
      * from cancelling its siblings in the surrounding [coroutineScope].
+     *
+     * [expectedGeneration] anchors detail fetches to the list's cache epoch: if the cache was
+     * cleared between the list fetch and the detail write, the write is dropped.
      */
-    private suspend fun prefetchWorkflow(appUserID: String, workflowId: String, appInBackground: Boolean) {
+    private suspend fun prefetchWorkflow(
+        appUserID: String,
+        workflowId: String,
+        appInBackground: Boolean,
+        expectedGeneration: Int,
+    ) {
         suspendCancellableCoroutine { continuation ->
             getWorkflow(
                 appUserID = appUserID,
@@ -287,6 +300,7 @@ internal class WorkflowManager(
                 callbackDispatcher = prefetchDispatcher,
                 persistEnvelopeOnResolve = true,
                 staleWhileRevalidate = false,
+                expectedGeneration = expectedGeneration,
                 onSuccess = { continuation.safeResume(Unit) },
                 onError = { error ->
                     errorLog { "Failed to prefetch workflow $workflowId: ${error.underlyingErrorMessage}" }
@@ -302,8 +316,15 @@ internal class WorkflowManager(
      * pre-downloaded during the original prefetch) re-resolution needs no network. If that file was
      * evicted, resolution may need the CDN and can fail while the backend is down; the failure is
      * logged and swallowed so one bad envelope doesn't fail its siblings in the surrounding [coroutineScope].
+     *
+     * [expectedGeneration] is the generation captured when [getWorkflowsList] started its fetch, so
+     * a restore that lands after a cache clear is dropped rather than repopulating the stale cache.
      */
-    private suspend fun restoreWorkflowFromEnvelope(workflowId: String, envelope: WorkflowDetailResponse) {
+    private suspend fun restoreWorkflowFromEnvelope(
+        workflowId: String,
+        envelope: WorkflowDetailResponse,
+        expectedGeneration: Int,
+    ) {
         val result = try {
             workflowDetailResolver.resolve(envelope)
         } catch (e: CancellationException) {
@@ -312,7 +333,7 @@ internal class WorkflowManager(
             errorLog(e) { "Failed to restore workflow $workflowId from disk cache" }
             return
         }
-        workflowsCache.cacheWorkflow(workflowId, result, workflowsCache.currentGeneration())
+        workflowsCache.cacheWorkflow(workflowId, result, expectedGeneration)
     }
 
     fun workflowIdForOfferingId(offeringId: String): String? =

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -45,6 +45,14 @@ internal class WorkflowsCache(
     @Volatile
     private var offeringIdToWorkflowIdMap: Map<String, String> = emptyMap()
 
+    // Bumped on every clearCache() (identity transitions). A fetch captures the generation at its
+    // start and passes it back on write; a write whose captured generation no longer matches is
+    // dropped, so a fetch that began before an identity transition can't repopulate the cleared cache.
+    private var cacheGeneration: Int = 0
+
+    @Synchronized
+    fun currentGeneration(): Int = cacheGeneration
+
     // region Workflow detail cache
 
     @Synchronized
@@ -56,7 +64,8 @@ internal class WorkflowsCache(
         cachedWorkflows[workflowId]?.lastUpdatedAt?.isCacheStale(appInBackground, dateProvider) ?: true
 
     @Synchronized
-    fun cacheWorkflow(workflowId: String, result: WorkflowDataResult) {
+    fun cacheWorkflow(workflowId: String, result: WorkflowDataResult, expectedGeneration: Int) {
+        if (expectedGeneration != cacheGeneration) return
         val cached = cachedWorkflows.getOrPut(workflowId) { InMemoryCachedObject(dateProvider = dateProvider) }
         cached.cacheInstance(result)
     }
@@ -85,15 +94,24 @@ internal class WorkflowsCache(
      * Caches the workflows list in memory and persists it to disk, the same way
      * [com.revenuecat.purchases.common.offerings.OfferingsCache.cacheOfferings] caches offerings.
      *
-     * This means workflows share the same accepted appUserID limitation as offerings: a fetch that
-     * is in flight during an identity transition can complete *after* [clearCache] and repopulate
-     * the cleared cache with the previous user's list (last-write-wins). It is not guarded here, so
-     * it self-heals on the next fetch, exactly as the offerings cache does. If we ever decide to
-     * close that window, it should be done consistently for both caches rather than only here.
+     * Guarded by [expectedGeneration]: a fetch captures [currentGeneration] at its start and passes
+     * it back here. If an identity transition called [clearCache] in between (bumping the generation),
+     * the captured value no longer matches and the write is dropped, so an in-flight fetch from the
+     * previous user can't repopulate the cleared cache. The guard and the [clearCache] increment share
+     * this object's intrinsic lock, so the check-then-write is atomic.
+     * [com.revenuecat.purchases.common.offerings.OfferingsCache.cacheOfferings] carries the same guard
+     * so both caches stay consistent across an identity change.
      */
     @Synchronized
-    fun cacheWorkflowsList(response: WorkflowsListResponse, offeringIdMap: Map<String, String>) {
-        cacheWorkflowsListInMemory(response, offeringIdMap)
+    fun cacheWorkflowsList(
+        response: WorkflowsListResponse,
+        offeringIdMap: Map<String, String>,
+        expectedGeneration: Int,
+    ) {
+        if (expectedGeneration != cacheGeneration) return
+        // Re-checked under the same lock by cacheWorkflowsListInMemory; redundant on this path (the
+        // lock is held throughout) but keeps the guard uniform for its direct callers.
+        cacheWorkflowsListInMemory(response, offeringIdMap, expectedGeneration)
         deviceCache.cacheWorkflowsListResponse(
             JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
         )
@@ -106,7 +124,12 @@ internal class WorkflowsCache(
      * holds this exact payload so rewriting it would be wasted work.
      */
     @Synchronized
-    fun cacheWorkflowsListInMemory(response: WorkflowsListResponse, offeringIdMap: Map<String, String>) {
+    fun cacheWorkflowsListInMemory(
+        response: WorkflowsListResponse,
+        offeringIdMap: Map<String, String>,
+        expectedGeneration: Int,
+    ) {
+        if (expectedGeneration != cacheGeneration) return
         workflowsListCachedObject.cacheInstance(response)
         offeringIdToWorkflowIdMap = offeringIdMap
     }
@@ -146,7 +169,8 @@ internal class WorkflowsCache(
      * replaced rather than preserved.
      */
     @Synchronized
-    fun cacheWorkflowDetailEnvelope(workflowId: String, envelope: WorkflowDetailResponse) {
+    fun cacheWorkflowDetailEnvelope(workflowId: String, envelope: WorkflowDetailResponse, expectedGeneration: Int) {
+        if (expectedGeneration != cacheGeneration) return
         val current = cachedWorkflowDetailEnvelopesFromDisk().orEmpty().toMutableMap()
         current[workflowId] = envelope
         persistWorkflowDetailEnvelopes(current)
@@ -190,6 +214,7 @@ internal class WorkflowsCache(
 
     @Synchronized
     fun clearCache() {
+        cacheGeneration++
         cachedWorkflows.clear()
         workflowsListCachedObject.clearCache()
         offeringIdToWorkflowIdMap = emptyMap()

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsSourceTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsSourceTest.kt
@@ -121,7 +121,7 @@ class OfferingsSourceTest {
 
         // Cache the offerings
         every { deviceCache.cacheOfferingsResponse(any()) } returns Unit
-        offeringsCache.cacheOfferings(originalOfferings, offeringsJson)
+        offeringsCache.cacheOfferings(originalOfferings, offeringsJson, offeringsCache.currentGeneration())
 
         // Verify originalSource was stored in JSON
         io.mockk.verify(exactly = 1) {
@@ -153,7 +153,7 @@ class OfferingsSourceTest {
             put(OfferingsCache.ORIGINAL_SOURCE_KEY, HTTPResponseOriginalSource.FALLBACK.name)
         }
         every { deviceCache.getOfferingsResponseCache() } returns cachedJsonWithSource
-        offeringsCache.cacheOfferings(originalOfferings, offeringsJson)
+        offeringsCache.cacheOfferings(originalOfferings, offeringsJson, offeringsCache.currentGeneration())
 
         // Retrieve from cache - originalSource should be preserved
         val cachedOfferings = offeringsCache.cachedOfferings
@@ -192,7 +192,7 @@ class OfferingsSourceTest {
         every { deviceCache.cacheOfferingsResponse(any()) } returns Unit
         // Mock cached response without originalSource field (old cache format)
         every { deviceCache.getOfferingsResponseCache() } returns JSONObject(ONE_OFFERINGS_RESPONSE)
-        offeringsCache.cacheOfferings(originalOfferings, offeringsJson)
+        offeringsCache.cacheOfferings(originalOfferings, offeringsJson, offeringsCache.currentGeneration())
 
         // Retrieve from cache - should use cached instance's originalSource
         val cachedOfferings = offeringsCache.cachedOfferings

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
@@ -55,7 +55,7 @@ class OfferingsCacheTest {
         every { deviceCache.cacheOfferingsResponse(any()) } just Runs
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, offeringsResponse)
+        }, offeringsResponse, offeringsCache.currentGeneration())
         assertThat(offeringsCache.cachedOfferings).isNotNull
         offeringsCache.clearCache()
         assertThat(offeringsCache.cachedOfferings).isNull()
@@ -72,7 +72,7 @@ class OfferingsCacheTest {
         val offeringsResponse = JSONObject()
         every { deviceCache.cacheOfferingsResponse(any()) } just Runs
         assertThat(offeringsCache.cachedOfferings).isNull()
-        offeringsCache.cacheOfferings(offerings, offeringsResponse)
+        offeringsCache.cacheOfferings(offerings, offeringsResponse, offeringsCache.currentGeneration())
         assertThat(offeringsCache.cachedOfferings).isEqualTo(offerings)
         verify(exactly = 1) {
             deviceCache.cacheOfferingsResponse(
@@ -101,7 +101,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isFalse
     }
 
@@ -110,7 +110,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
         currentDate = currentDate.add(6.minutes)
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isTrue
     }
@@ -120,7 +120,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
         offeringsCache.forceCacheStale()
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isTrue
     }
@@ -130,7 +130,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
         assertThat(offeringsCache.cachedOfferings).isNotNull
         offeringsCache.clearInMemoryOfferingsCache()
         assertThat(offeringsCache.cachedOfferings).isNull()
@@ -141,7 +141,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isFalse
         offeringsCache.clearInMemoryOfferingsCache()
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isTrue
@@ -153,7 +153,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
         offeringsCache.clearInMemoryOfferingsCache()
         verify(exactly = 0) { deviceCache.clearOfferingsResponseCache() }
     }
@@ -165,7 +165,7 @@ class OfferingsCacheTest {
         every { deviceCache.getOfferingsResponseCache() } returns offeringsResponse
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, offeringsResponse)
+        }, offeringsResponse, offeringsCache.currentGeneration())
 
         offeringsCache.clearInMemoryOfferingsCache()
 
@@ -174,6 +174,43 @@ class OfferingsCacheTest {
     }
 
     // endregion offerings cache
+
+    // region generation guard tests
+
+    @Test
+    fun `currentGeneration increments on clearCache`() {
+        every { deviceCache.clearOfferingsResponseCache() } just Runs
+        val before = offeringsCache.currentGeneration()
+        offeringsCache.clearCache()
+        assertThat(offeringsCache.currentGeneration()).isEqualTo(before + 1)
+    }
+
+    @Test
+    fun `cacheOfferings is a no-op when the generation is stale`() {
+        every { deviceCache.clearOfferingsResponseCache() } just Runs
+        val staleGeneration = offeringsCache.currentGeneration()
+        offeringsCache.clearCache()
+
+        offeringsCache.cacheOfferings(mockk<Offerings>().apply {
+            every { originalSource } returns HTTPResponseOriginalSource.MAIN
+        }, JSONObject(), staleGeneration)
+
+        assertThat(offeringsCache.cachedOfferings).isNull()
+        verify(exactly = 0) { deviceCache.cacheOfferingsResponse(any()) }
+    }
+
+    @Test
+    fun `cacheOfferings writes when the generation is current`() {
+        mockDeviceCacheOfferingResponse()
+        offeringsCache.cacheOfferings(mockk<Offerings>().apply {
+            every { originalSource } returns HTTPResponseOriginalSource.MAIN
+        }, JSONObject(), offeringsCache.currentGeneration())
+
+        assertThat(offeringsCache.cachedOfferings).isNotNull()
+        verify(exactly = 1) { deviceCache.cacheOfferingsResponse(any()) }
+    }
+
+    // endregion generation guard tests
 
     // region locale cache tests
 
@@ -187,7 +224,7 @@ class OfferingsCacheTest {
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
 
         // Assert
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isFalse
@@ -203,7 +240,7 @@ class OfferingsCacheTest {
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
         localeProvider.languageTags = listOf("fr-FR", "de-DE")
 
         // Assert
@@ -221,7 +258,7 @@ class OfferingsCacheTest {
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
         localeProvider.languageTags = listOf("fr-FR")
 
         // Assert
@@ -239,7 +276,7 @@ class OfferingsCacheTest {
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
         localeProvider.languageTags = listOf("es-ES", "en-US")
 
         // Assert
@@ -258,7 +295,7 @@ class OfferingsCacheTest {
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, JSONObject(), offeringsCache.currentGeneration())
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isFalse
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isFalse
         offeringsCache.clearCache()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
@@ -210,6 +210,20 @@ class OfferingsCacheTest {
         verify(exactly = 1) { deviceCache.cacheOfferingsResponse(any()) }
     }
 
+    @Test
+    fun `clearInMemoryOfferingsCache does not bump the generation`() {
+        val before = offeringsCache.currentGeneration()
+        offeringsCache.clearInMemoryOfferingsCache()
+        assertThat(offeringsCache.currentGeneration()).isEqualTo(before)
+    }
+
+    @Test
+    fun `forceCacheStale does not bump the generation`() {
+        val before = offeringsCache.currentGeneration()
+        offeringsCache.forceCacheStale()
+        assertThat(offeringsCache.currentGeneration()).isEqualTo(before)
+    }
+
     // endregion generation guard tests
 
     // region locale cache tests

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -6,8 +6,10 @@ import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.FakeLocaleProvider
 import com.revenuecat.purchases.common.GetOfferingsErrorHandlingBehavior
 import com.revenuecat.purchases.common.HTTPResponseOriginalSource
+import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
@@ -54,6 +56,7 @@ class OfferingsManagerTest {
     @Before
     fun setUp() {
         cache = mockk()
+        every { cache.currentGeneration() } returns 0
         backend = mockk()
         offeringsFactory = mockk()
         offeringImagePreDownloader = mockk<OfferingImagePreDownloader>().apply {
@@ -1167,4 +1170,45 @@ class OfferingsManagerTest {
     }
 
     // endregion workflowManager onComplete integration
+
+    // region cache generation race guard
+
+    @Test
+    fun `fetchAndCacheOfferings does not repopulate the cache when cleared mid-fetch`() {
+        val mockDeviceCache = mockk<DeviceCache>().apply {
+            every { clearOfferingsResponseCache() } just Runs
+            every { cacheOfferingsResponse(any()) } just Runs
+            every { getOfferingsResponseCache() } returns null
+        }
+        val realOfferingsCache = OfferingsCache(
+            deviceCache = mockDeviceCache,
+            localeProvider = FakeLocaleProvider("en-US"),
+        )
+
+        val managerWithRealCache = OfferingsManager(
+            offeringsCache = realOfferingsCache,
+            backend = backend,
+            offeringsFactory = offeringsFactory,
+            offeringImagePreDownloader = offeringImagePreDownloader,
+            diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
+            offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            workflowManager = mockWorkflowManager,
+        )
+
+        val onSuccessSlot = slot<(JSONObject, HTTPResponseOriginalSource) -> Unit>()
+        every {
+            backend.getOfferings(any(), any(), onSuccess = capture(onSuccessSlot), onError = any())
+        } just Runs
+
+        mockOfferingsFactory()
+
+        // Fetch starts (captures the generation), identity transition clears, then the response lands.
+        managerWithRealCache.fetchAndCacheOfferings(appUserID = "user_1", appInBackground = false)
+        realOfferingsCache.clearCache()
+        onSuccessSlot.captured(JSONObject(ONE_OFFERINGS_RESPONSE), HTTPResponseOriginalSource.MAIN)
+
+        assertThat(realOfferingsCache.cachedOfferings).isNull()
+    }
+
+    // endregion cache generation race guard
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -188,7 +188,7 @@ class OfferingsManagerTest {
             cache.cachedOfferings
         } returns null
         every {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         } just Runs
 
         mockDeviceCache()
@@ -207,7 +207,7 @@ class OfferingsManagerTest {
             backend.getOfferings(appUserId, appInBackground = false, onSuccess = any(), onError = any())
         }
         verify(exactly = 1) {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         }
     }
 
@@ -220,7 +220,7 @@ class OfferingsManagerTest {
             cache.cachedOfferings
         } returns null
         every {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         } just Runs
 
         var receivedOfferings: Offerings? = null
@@ -237,7 +237,7 @@ class OfferingsManagerTest {
             backend.getOfferings(appUserId, appInBackground = true, onSuccess = any(), onError = any())
         }
         verify(exactly = 1) {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         }
     }
 
@@ -249,7 +249,7 @@ class OfferingsManagerTest {
             cache.cachedOfferings
         } returns null
         every {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         } just Runs
 
         mockDeviceCache()
@@ -323,7 +323,7 @@ class OfferingsManagerTest {
             cache.cachedOfferings
         } returns null
         every {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         } just Runs
         mockDeviceCache()
         val (_, offerings) = stubOfferings(productId)
@@ -340,7 +340,7 @@ class OfferingsManagerTest {
         assertThat(receivedOfferings).isNotNull
         assertThat(receivedOfferings).isEqualTo(offerings)
         verify {
-            cache.cacheOfferings(offerings, any())
+            cache.cacheOfferings(offerings, any(), any())
         }
     }
 
@@ -350,7 +350,7 @@ class OfferingsManagerTest {
             cache.cachedOfferings
         } returns null
         every {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         } just Runs
 
         mockBackendResponseError()
@@ -377,7 +377,7 @@ class OfferingsManagerTest {
             cache.cachedOfferings
         } returns null
         every {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         } just Runs
 
         mockBackendResponseError()
@@ -396,7 +396,7 @@ class OfferingsManagerTest {
 
         assertThat(receivedOfferings).isEqualTo(testOfferings)
 
-        verify(exactly = 1) { cache.cacheOfferings(testOfferings, backendResponse) }
+        verify(exactly = 1) { cache.cacheOfferings(testOfferings, backendResponse, any()) }
         verify(exactly = 1) {
             offeringsFactory.createOfferings(
                 offeringsJSON = backendResponse,
@@ -414,7 +414,7 @@ class OfferingsManagerTest {
             cache.cachedOfferings
         } returns null
         every {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         } just Runs
 
         val expectedError = PurchasesError(PurchasesErrorCode.NetworkError)
@@ -473,7 +473,7 @@ class OfferingsManagerTest {
             cache.cachedOfferings
         } returns null
         every {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         } just Runs
 
         mockBackendResponseError()
@@ -542,7 +542,7 @@ class OfferingsManagerTest {
             cache.cachedOfferings
         } returns null
         every {
-            cache.cacheOfferings(any(), any())
+            cache.cacheOfferings(any(), any(), any())
         } just Runs
 
         mockBackendResponseError()
@@ -587,7 +587,7 @@ class OfferingsManagerTest {
     @Test
     fun `getOfferings does not force workflows list stale on disk-cache fallback`() {
         every { cache.cachedOfferings } returns null
-        every { cache.cacheOfferings(any(), any()) } just Runs
+        every { cache.cacheOfferings(any(), any(), any()) } just Runs
         mockBackendResponseError()
         every { cache.cachedOfferingsResponse } returns JSONObject(ONE_OFFERINGS_RESPONSE)
         mockDeviceCache(wasSuccessful = false)
@@ -1024,7 +1024,7 @@ class OfferingsManagerTest {
 
     private fun mockDeviceCache(wasSuccessful: Boolean = true) {
         if (wasSuccessful) {
-            every { cache.cacheOfferings(any(), any()) } just Runs
+            every { cache.cacheOfferings(any(), any(), any()) } just Runs
         } else {
             every { cache.forceCacheStale() } just Runs
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -1275,7 +1275,7 @@ class WorkflowManagerTest {
     fun `prefetch persists the envelope even when the workflow is already cached but stale`() {
         // Seed the detail cache at t=0 so the workflow is present but will be stale at prefetch time.
         every { mockDateProvider.now } returns Date(0)
-        workflowsCache.cacheWorkflow("wf_1", WorkflowDataResult(workflow = mockk(), enrolledVariants = null))
+        workflowsCache.cacheWorkflow("wf_1", WorkflowDataResult(workflow = mockk(), enrolledVariants = null), workflowsCache.currentGeneration())
 
         // Advance past the 5-minute TTL: the prefetch now sees a stale-but-present cache entry.
         // With SWR disabled on the prefetch path it must still do a real fetch and persist, not serve stale.

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -994,6 +994,29 @@ class WorkflowManagerTest {
         }
     }
 
+    @Test
+    fun `getWorkflowsList does not repopulate the cache when cleared mid-fetch`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
+        } just Runs
+
+        // Fetch starts (captures the generation), then an identity transition clears the cache...
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+        workflowsCache.clearCache()
+        // ...and only now does the in-flight response land.
+        successSlot.captured(response)
+
+        // The stale write is dropped: the cleared cache stays empty, disk is not rewritten.
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isNull()
+        verify(exactly = 0) { mockDeviceCache.cacheWorkflowsListResponse(any()) }
+    }
+
     // endregion issue fixes
 
     // region onComplete callback

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -403,4 +403,27 @@ class WorkflowsCacheTest {
 
         verify(exactly = 0) { deviceCache.cacheWorkflowDetailEnvelopes(any()) }
     }
+
+    @Test
+    fun `cacheWorkflowsListInMemory is a no-op when the generation is stale`() {
+        val staleGeneration = workflowsCache.currentGeneration()
+        workflowsCache.clearCache()
+
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        workflowsCache.cacheWorkflowsListInMemory(response, mapOf("default" to "wf_1"), staleGeneration)
+
+        assertThat(workflowsCache.workflowIdForOfferingId("default")).isNull()
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
+    }
+
+    @Test
+    fun `forceWorkflowsListCacheStale does not bump the generation`() {
+        val before = workflowsCache.currentGeneration()
+        workflowsCache.forceWorkflowsListCacheStale()
+        assertThat(workflowsCache.currentGeneration()).isEqualTo(before)
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -51,7 +51,7 @@ class WorkflowsCacheTest {
     @Test
     fun `cachedWorkflow returns cached value after cacheWorkflow`() {
         val result = mockk<WorkflowDataResult>()
-        workflowsCache.cacheWorkflow("wf_1", result)
+        workflowsCache.cacheWorkflow("wf_1", result, workflowsCache.currentGeneration())
         assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(result)
     }
 
@@ -63,35 +63,35 @@ class WorkflowsCacheTest {
 
     @Test
     fun `isWorkflowCacheStale is false right after caching in foreground`() {
-        workflowsCache.cacheWorkflow("wf_1", mockk())
+        workflowsCache.cacheWorkflow("wf_1", mockk(), workflowsCache.currentGeneration())
         assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isFalse
     }
 
     @Test
     fun `isWorkflowCacheStale is true after foreground TTL expires`() {
-        workflowsCache.cacheWorkflow("wf_1", mockk())
+        workflowsCache.cacheWorkflow("wf_1", mockk(), workflowsCache.currentGeneration())
         currentDate = currentDate.add(6.minutes)
         assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
     }
 
     @Test
     fun `isWorkflowCacheStale is false after foreground TTL expires when in background`() {
-        workflowsCache.cacheWorkflow("wf_1", mockk())
+        workflowsCache.cacheWorkflow("wf_1", mockk(), workflowsCache.currentGeneration())
         currentDate = currentDate.add(6.minutes)
         assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = true)).isFalse
     }
 
     @Test
     fun `isWorkflowCacheStale is true after background TTL expires`() {
-        workflowsCache.cacheWorkflow("wf_1", mockk())
+        workflowsCache.cacheWorkflow("wf_1", mockk(), workflowsCache.currentGeneration())
         currentDate = currentDate.add(26.hours)
         assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = true)).isTrue
     }
 
     @Test
     fun `clearCache removes all cached workflows`() {
-        workflowsCache.cacheWorkflow("wf_1", mockk())
-        workflowsCache.cacheWorkflow("wf_2", mockk())
+        workflowsCache.cacheWorkflow("wf_1", mockk(), workflowsCache.currentGeneration())
+        workflowsCache.cacheWorkflow("wf_2", mockk(), workflowsCache.currentGeneration())
         workflowsCache.clearCache()
         assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
         assertThat(workflowsCache.cachedWorkflow("wf_2")).isNull()
@@ -102,13 +102,13 @@ class WorkflowsCacheTest {
     @Test
     fun `isWorkflowsListCacheStale is true initially and false after caching`() {
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
-        workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap())
+        workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap(), workflowsCache.currentGeneration())
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isFalse
     }
 
     @Test
     fun `isWorkflowsListCacheStale is true after foreground TTL expires`() {
-        workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap())
+        workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap(), workflowsCache.currentGeneration())
         currentDate = currentDate.add(6.minutes)
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
     }
@@ -118,6 +118,7 @@ class WorkflowsCacheTest {
         workflowsCache.cacheWorkflowsList(
             WorkflowsListResponse(workflows = emptyList()),
             mapOf("default" to "wf_1"),
+            workflowsCache.currentGeneration(),
         )
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isFalse
 
@@ -133,6 +134,7 @@ class WorkflowsCacheTest {
         workflowsCache.cacheWorkflowsList(
             WorkflowsListResponse(workflows = emptyList()),
             mapOf("default" to "wf_1"),
+            workflowsCache.currentGeneration(),
         )
         assertThat(workflowsCache.workflowIdForOfferingId("default")).isEqualTo("wf_1")
         assertThat(workflowsCache.workflowIdForOfferingId("premium")).isNull()
@@ -143,6 +145,7 @@ class WorkflowsCacheTest {
         workflowsCache.cacheWorkflowsList(
             WorkflowsListResponse(workflows = emptyList()),
             mapOf("default" to "wf_1"),
+            workflowsCache.currentGeneration(),
         )
         workflowsCache.clearCache()
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
@@ -158,6 +161,7 @@ class WorkflowsCacheTest {
                 ),
             ),
             mapOf("default" to "wf_1"),
+            workflowsCache.currentGeneration(),
         )
         verify(exactly = 1) { deviceCache.cacheWorkflowsListResponse(any()) }
     }
@@ -171,6 +175,7 @@ class WorkflowsCacheTest {
                 ),
             ),
             mapOf("default" to "wf_1"),
+            workflowsCache.currentGeneration(),
         )
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isFalse
         assertThat(workflowsCache.workflowIdForOfferingId("default")).isEqualTo("wf_1")
@@ -224,7 +229,7 @@ class WorkflowsCacheTest {
         val payloadSlot = slot<String>()
         every { deviceCache.cacheWorkflowDetailEnvelopes(capture(payloadSlot)) } just Runs
 
-        workflowsCache.cacheWorkflowDetailEnvelope("wf_1", cdnEnvelope("https://cdn/wf_1.json"))
+        workflowsCache.cacheWorkflowDetailEnvelope("wf_1", cdnEnvelope("https://cdn/wf_1.json"), workflowsCache.currentGeneration())
 
         assertThat(payloadSlot.captured).contains("wf_1")
         assertThat(payloadSlot.captured).contains("https://cdn/wf_1.json")
@@ -237,7 +242,7 @@ class WorkflowsCacheTest {
         val payloadSlot = slot<String>()
         every { deviceCache.cacheWorkflowDetailEnvelopes(capture(payloadSlot)) } just Runs
 
-        workflowsCache.cacheWorkflowDetailEnvelope("wf_new", cdnEnvelope("https://cdn/wf_new.json"))
+        workflowsCache.cacheWorkflowDetailEnvelope("wf_new", cdnEnvelope("https://cdn/wf_new.json"), workflowsCache.currentGeneration())
 
         val persisted = WorkflowJsonParser.parseWorkflowDetailEnvelopes(payloadSlot.captured)
         assertThat(persisted.keys).containsExactlyInAnyOrder("wf_existing", "wf_new")
@@ -301,6 +306,7 @@ class WorkflowsCacheTest {
                 ),
             ),
             mapOf("default" to "wf_keep"),
+            workflowsCache.currentGeneration(),
         )
 
         assertThat(payloadSlot.captured).contains("wf_keep")
@@ -319,6 +325,7 @@ class WorkflowsCacheTest {
                 ),
             ),
             mapOf("default" to "wf_keep"),
+            workflowsCache.currentGeneration(),
         )
 
         verify(exactly = 0) { deviceCache.cacheWorkflowDetailEnvelopes(any()) }
@@ -328,9 +335,9 @@ class WorkflowsCacheTest {
     fun `different workflowIds are cached independently`() {
         val first = mockk<WorkflowDataResult>()
         val second = mockk<WorkflowDataResult>()
-        workflowsCache.cacheWorkflow("wf_1", first)
+        workflowsCache.cacheWorkflow("wf_1", first, workflowsCache.currentGeneration())
         currentDate = currentDate.add(6.minutes)
-        workflowsCache.cacheWorkflow("wf_2", second)
+        workflowsCache.cacheWorkflow("wf_2", second, workflowsCache.currentGeneration())
 
         // Both values remain retrievable.
         assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(first)
@@ -339,5 +346,61 @@ class WorkflowsCacheTest {
         // wf_1 was cached 6 minutes ago so it is stale in foreground; wf_2 is fresh.
         assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
         assertThat(workflowsCache.isWorkflowCacheStale("wf_2", appInBackground = false)).isFalse
+    }
+
+    @Test
+    fun `currentGeneration increments on clearCache`() {
+        val before = workflowsCache.currentGeneration()
+        workflowsCache.clearCache()
+        assertThat(workflowsCache.currentGeneration()).isEqualTo(before + 1)
+    }
+
+    @Test
+    fun `cacheWorkflowsList is a no-op when the generation is stale`() {
+        val staleGeneration = workflowsCache.currentGeneration()
+        workflowsCache.clearCache() // advances the generation past staleGeneration
+
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        workflowsCache.cacheWorkflowsList(response, mapOf("default" to "wf_1"), staleGeneration)
+
+        assertThat(workflowsCache.workflowIdForOfferingId("default")).isNull()
+        verify(exactly = 0) { deviceCache.cacheWorkflowsListResponse(any()) }
+    }
+
+    @Test
+    fun `cacheWorkflowsList writes when the generation is current`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        workflowsCache.cacheWorkflowsList(response, mapOf("default" to "wf_1"), workflowsCache.currentGeneration())
+
+        assertThat(workflowsCache.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+        verify(exactly = 1) { deviceCache.cacheWorkflowsListResponse(any()) }
+    }
+
+    @Test
+    fun `cacheWorkflow is a no-op when the generation is stale`() {
+        val staleGeneration = workflowsCache.currentGeneration()
+        workflowsCache.clearCache()
+
+        workflowsCache.cacheWorkflow("wf_1", mockk(relaxed = true), staleGeneration)
+
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
+    }
+
+    @Test
+    fun `cacheWorkflowDetailEnvelope is a no-op when the generation is stale`() {
+        val staleGeneration = workflowsCache.currentGeneration()
+        workflowsCache.clearCache()
+
+        workflowsCache.cacheWorkflowDetailEnvelope("wf_1", cdnEnvelope("https://cdn/wf_1.json"), staleGeneration)
+
+        verify(exactly = 0) { deviceCache.cacheWorkflowDetailEnvelopes(any()) }
     }
 }


### PR DESCRIPTION
## Summary

`WorkflowsCache` and `OfferingsCache` are user-agnostic — an identity transition wipes them with `clearCache()`. But an in-flight backend fetch can write back *after* the clear, repopulating the just-cleared cache with the previous user's data, which is then served until the next fetch self-heals it:

```
T0  fetch(userA) → backend request in flight
T1  identity change → clearCache()        // wipes in-memory + disk
T2  userA's onSuccess lands → cache write  // repopulates with userA data
```

`@Synchronized` couldn't close this: it serializes individual mutations but can't order a `clear()` against a write-back that crosses the async backend boundary.

This adds a **clear-generation token** to both caches. Each owns a monotonic `cacheGeneration: Int`, bumped inside its `@Synchronized clearCache()`. A fetch captures `currentGeneration()` at its start and threads that value through the whole async sequence; every write commits only if the captured generation still matches — checked under the same lock the increment uses, so clear-then-write is atomic. A write from any prior epoch is dropped, and the cleared cache stays empty until the next fetch repopulates it for the current user.

Both caches are covered together: a workflows-only guard would leave offerings (the thing workflows are keyed to) still racy. Chosen over an appUserID compare because a monotonic counter is correct under fast A→B→A login churn, where the id matches again but the epoch differs.

## What changed

| Area | Change |
|------|--------|
| `WorkflowsCache` | `cacheGeneration` + `currentGeneration()`; bump in `clearCache()`; `expectedGeneration` guard on `cacheWorkflow`, `cacheWorkflowsList`, `cacheWorkflowsListInMemory`, `cacheWorkflowDetailEnvelope` |
| `WorkflowManager` | capture in `getWorkflowsList` (threaded through the success write, prefetch loop, and error-restore paths) and `getWorkflow` (captured at entry; prefetch passes the list's epoch) |
| `OfferingsCache` | `cacheGeneration` + `currentGeneration()`; bump in `clearCache()`; `expectedGeneration` guard on `cacheOfferings` |
| `OfferingsManager` | capture in `fetchAndCacheOfferings`, threaded through `createAndCacheOfferings` (network-success and disk-fallback paths) |

Out of scope by design: `clearInMemoryOfferingsCache()` / `forceCacheStale()` / `forceWorkflowsListCacheStale()` do not bump the generation (locale-override and forced-staleness have separate semantics). No `appUserID` is introduced into either cache. All new symbols are `internal` — no public API change.

## Test plan

- [x] `WorkflowsCacheTest` / `OfferingsCacheTest`: `currentGeneration()` increments on `clearCache()`; each gated write is a no-op on a stale generation and commits on the current one; the non-identity-transition clear methods leave the generation unchanged.
- [x] `WorkflowManagerTest` / `OfferingsManagerTest`: the real race against a real cache — capture the success callback, `clearCache()`, then fire the callback; assert the cleared cache stays empty and disk is not rewritten.
- [x] Full `:purchases` unit suite (3223 tests), `detektAll`, `api-check` — all green, no public API diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)