### PR TITLE
AdMob reward verification doc & test fixes

### DIFF
--- a/feature/admob/README.md
+++ b/feature/admob/README.md
@@ -191,7 +191,7 @@ rewardedAd?.show(
     rewardVerificationStarted = {
         // Called when reward callback is received and verification polling begins.
     },
-    rewardVerificationResult = { result ->
+    rewardVerificationCompleted = { result ->
         rewardedAd = null
         if (result.verifiedReward != null) {
             // Verified reward.
@@ -285,7 +285,7 @@ rewardedInterstitialAd?.show(
     rewardVerificationStarted = {
         // Verification has started.
     },
-    rewardVerificationResult = { result ->
+    rewardVerificationCompleted = { result ->
         rewardedInterstitialAd = null
         if (result.verifiedReward != null) {
             // Verified reward.
@@ -296,7 +296,7 @@ rewardedInterstitialAd?.show(
 )
 ```
 
-When `rewardVerificationResult` returns a `verifiedReward` of type `VerifiedReward.VirtualCurrency`, the adapter
+When `rewardVerificationCompleted` returns a `verifiedReward` of type `VerifiedReward.VirtualCurrency`, the adapter
 automatically calls `Purchases.sharedInstance.invalidateVirtualCurrenciesCache()` (if Purchases is configured) before
 delivering the callback. You only need to refetch balances (`Purchases.sharedInstance.getVirtualCurrencies(...)`) when
 your UI needs fresh values.

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
@@ -97,11 +97,6 @@ internal class RewardVerificationManagerTest {
         assertEquals("test_api_key", payload.getString("api_key"))
         val attachedClientTransactionId = payload.getString("client_transaction_id")
         assertTrue(attachedClientTransactionId.isNotBlank())
-        // The serialized payload must match the format shared with the other SDKs hitting the same endpoint.
-        assertEquals(
-            "{\"api_key\":\"test_api_key\",\"client_transaction_id\":\"$attachedClientTransactionId\"}",
-            ssvOptions.captured.customData,
-        )
 
         var completedResult: RewardVerificationResult? = null
         val completed = CountDownLatch(1)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -212,10 +212,12 @@ public suspend fun Purchases.awaitCustomerCenterConfigData(): CustomerCenterConf
 /**
  * Fetches reward verification status for a single client transaction id.
  *
- * @throws [PurchasesException] with a [PurchasesError] if an error occurs while fetching the status.
+ * @throws [RewardVerificationException] (a [PurchasesException] subtype) with a [PurchasesError] if an error
+ * occurs while fetching the status. Inspect [RewardVerificationException.isServerError] to distinguish transient
+ * HTTP 5xx failures (retryable) from deterministic ones.
  */
 @JvmSynthetic
-@Throws(PurchasesException::class)
+@Throws(RewardVerificationException::class)
 @InternalRevenueCatAPI
 public suspend fun Purchases.awaitGetRewardVerificationResult(
     clientTransactionId: String,


### PR DESCRIPTION
## Description

Small follow-up fixes to the AdMob reward verification work.

1. Fix reward verification sample param name in AdMob README.
2. Document `RewardVerificationException` on `awaitGetRewardVerificationResult`.
3. Drop redundant assertion of reward verification SSV custom data JSON that was order-independent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no production logic changes beyond aligning @Throws with existing exception behavior.
> 
> **Overview**
> Small follow-up polish for AdMob reward verification docs and coroutine API docs, plus a test cleanup.
> 
> The **AdMob README** renames the sample callback from `rewardVerificationResult` to **`rewardVerificationCompleted`** for rewarded and rewarded-interstitial `show` examples, matching the public API.
> 
> **`awaitGetRewardVerificationResult`** KDoc and `@Throws` now document **`RewardVerificationException`** (including **`isServerError`** for retryable 5xx vs deterministic failures) instead of generic `PurchasesException`.
> 
> **`RewardVerificationManagerTest`** drops a brittle exact JSON string assertion on SSV `customData`; field-level checks remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d02df830f85c7b90d68b103cb4560a4b551f392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->