### PR TITLE
Remove workflow details fallback on 4xx errors

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -104,7 +104,10 @@ internal typealias WebBillingProductsCallback = Pair<(WebBillingProductsResponse
 internal typealias RemoteConfigCallback = Pair<(RemoteConfigResponse) -> Unit, (PurchasesError) -> Unit>
 
 @OptIn(InternalRevenueCatAPI::class)
-internal typealias WorkflowDetailCallback = Pair<(WorkflowDetailResponse) -> Unit, (PurchasesError) -> Unit>
+internal typealias WorkflowDetailCallback = Pair<
+    (WorkflowDetailResponse) -> Unit,
+    (PurchasesError, errorHandlingBehavior: GetWorkflowsErrorHandlingBehavior) -> Unit,
+    >
 
 internal typealias WorkflowsListCallback = Pair<
     (WorkflowsListResponse) -> Unit,
@@ -1013,7 +1016,7 @@ internal class Backend(
         workflowId: String,
         appInBackground: Boolean,
         onSuccess: (WorkflowDetailResponse) -> Unit,
-        onError: (PurchasesError) -> Unit,
+        onError: (PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit,
         callbackDispatcher: Dispatcher = dispatcher,
     ) {
         val endpoint = Endpoint.GetWorkflow(appUserID, workflowId)
@@ -1035,7 +1038,7 @@ internal class Backend(
                 synchronized(this@Backend) {
                     workflowDetailCallbacks.remove(cacheKey)
                 }?.forEach { (_, onErrorHandler) ->
-                    onErrorHandler(error)
+                    onErrorHandler(error, GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS)
                 }
             }
 
@@ -1049,12 +1052,23 @@ internal class Backend(
                                 WorkflowJsonParser.parseWorkflowDetailResponse(result.payload),
                             )
                         } catch (e: SerializationException) {
-                            onErrorHandler(e.toPurchasesError().also { errorLog(it) })
+                            onErrorHandler(
+                                e.toPurchasesError().also { errorLog(it) },
+                                GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+                            )
                         } catch (e: IllegalArgumentException) {
-                            onErrorHandler(e.toPurchasesError().also { errorLog(it) })
+                            onErrorHandler(
+                                e.toPurchasesError().also { errorLog(it) },
+                                GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+                            )
                         }
                     } else {
-                        onErrorHandler(result.toPurchasesError().also { errorLog(it) })
+                        val errorBehavior = if (RCHTTPStatusCodes.isServerError(result.responseCode)) {
+                            GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS
+                        } else {
+                            GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK
+                        }
+                        onErrorHandler(result.toPurchasesError().also { errorLog(it) }, errorBehavior)
                     }
                 }
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -150,6 +150,14 @@ internal class WorkflowManager(
                 onSuccess(result)
             }
         }
+        val onErrorWithFallback: (PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit =
+            { error, behavior ->
+                if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
+                    onError(error)
+                } else {
+                    scope.launch { resolveDiskFallback(workflowId, error, onSuccess, onError) }
+                }
+            }
         if (callbackDispatcher != null) {
             backend.getWorkflow(
                 appUserID = appUserID,
@@ -157,7 +165,7 @@ internal class WorkflowManager(
                 appInBackground = appInBackground,
                 callbackDispatcher = callbackDispatcher,
                 onSuccess = onSuccessHandler,
-                onError = { error, _ -> onError(error) },
+                onError = onErrorWithFallback,
             )
         } else {
             backend.getWorkflow(
@@ -165,9 +173,39 @@ internal class WorkflowManager(
                 workflowId = workflowId,
                 appInBackground = appInBackground,
                 onSuccess = onSuccessHandler,
-                onError = { error, _ -> onError(error) },
+                onError = onErrorWithFallback,
             )
         }
+    }
+
+    /**
+     * Attempts to re-resolve the persisted disk envelope for [workflowId] after a
+     * fallback-eligible backend error. If no envelope is present, or if re-resolution fails,
+     * the original [networkError] is forwarded through [onError] so the caller is never left
+     * without a response. On success the result is cached in memory and delivered via [onSuccess].
+     */
+    private suspend fun resolveDiskFallback(
+        workflowId: String,
+        networkError: PurchasesError,
+        onSuccess: (WorkflowDataResult) -> Unit,
+        onError: (PurchasesError) -> Unit,
+    ) {
+        val envelope = workflowsCache.cachedWorkflowDetailEnvelopeFromDisk(workflowId)
+        if (envelope == null) {
+            onError(networkError)
+            return
+        }
+        val result = try {
+            workflowDetailResolver.resolve(envelope)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            errorLog(e) { "Failed to re-resolve disk envelope for $workflowId during fallback" }
+            onError(networkError)
+            return
+        }
+        workflowsCache.cacheWorkflow(workflowId, result)
+        onSuccess(result)
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -81,16 +81,15 @@ internal class WorkflowManager(
             cached != null && staleWhileRevalidate -> {
                 // Serve the stale value immediately, then refresh the cache in the background.
                 // The caller already has a usable value, so the refresh delivers no callbacks: a
-                // success only updates the cache, and a failure is logged and swallowed — the entry
-                // stays stale and the next render retries. Mirrors
-                // OfferingsManager.vendCachedOfferingsAndMaybeRefresh. We pass
-                // alreadyServedStaleValue = true so a failed refresh skips disk recovery: the caller
-                // already has the stale value, so re-pinning from the persisted envelope would buy
-                // nothing and could overwrite a newer on-demand-fetched in-memory value with an older
-                // prefetched one, suppressing the retry for a full TTL. Disk recovery is only for
-                // callers that have nothing to serve (the foreground miss and the prefetch recovery
-                // path below). Concurrent stale callers can each fire a refresh; this is not
-                // deduplicated, matching the offerings stale path.
+                // success updates the cache, and a failure goes through the same disk fallback as any
+                // other fetch (see fetchAndCacheWorkflow) — on a backend-down error with a persisted
+                // envelope it re-pins from disk and re-stamps fresh, matching OfferingsManager.
+                // Known gap vs offerings: offerings persists every fetch, so its disk copy is always
+                // the latest; the detail path persists prefetched workflows only, so a background
+                // refresh can re-pin an older prefetched envelope over a newer on-demand value and
+                // suppress the retry for a TTL. Bounded and self-healing; the on-demand envelope
+                // persistence + LRU follow-up closes it. Concurrent stale callers can each fire a
+                // refresh; this is not deduplicated, matching the offerings stale path.
                 onSuccess(cached)
                 fetchAndCacheWorkflow(
                     appUserID = appUserID,
@@ -98,7 +97,6 @@ internal class WorkflowManager(
                     appInBackground = appInBackground,
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
-                    alreadyServedStaleValue = true,
                     onSuccess = {},
                     onError = { error ->
                         errorLog {
@@ -109,15 +107,13 @@ internal class WorkflowManager(
                 )
             }
             else -> {
-                // Miss, or stale with SWR disabled (the prefetch path): block on the fetch. These
-                // callers have nothing to serve yet, so disk recovery applies on a fallback-eligible error.
+                // Miss, or stale with SWR disabled (the prefetch path): block on the fetch.
                 fetchAndCacheWorkflow(
                     appUserID = appUserID,
                     workflowId = workflowId,
                     appInBackground = appInBackground,
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
-                    alreadyServedStaleValue = false,
                     onSuccess = onSuccess,
                     onError = onError,
                 )
@@ -132,10 +128,6 @@ internal class WorkflowManager(
         appInBackground: Boolean,
         callbackDispatcher: Dispatcher?,
         persistEnvelopeOnResolve: Boolean,
-        // True only for the SWR background refresh, whose caller already received the stale value.
-        // Such a refresh skips disk recovery on error (see onErrorWithFallback): there is nothing to
-        // recover for, so it stays stale and retries next render rather than re-pinning from disk.
-        alreadyServedStaleValue: Boolean,
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -166,25 +158,18 @@ internal class WorkflowManager(
         }
         val onErrorWithFallback: (PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit =
             { error, behavior ->
-                // Two independent axes decide the error handling: whether the caller already has a
-                // value (alreadyServedStaleValue), and what the backend said (behavior).
-                when {
-                    // Caller already served the stale value (SWR background refresh): nothing to
-                    // recover, regardless of the backend status. Leave the entry stale so the next
-                    // render retries; don't read disk or touch the cache. (Invalidating would be a
-                    // no-op anyway — this path is only reached for an already-stale entry.)
-                    alreadyServedStaleValue -> onError(error)
+                if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
                     // 4xx: the server intentionally changed/removed this workflow, so don't serve the
                     // saved copy. Invalidate the in-memory entry so the next call retries rather than
                     // serving a still-cached value — mirrors the list's invalidateWorkflowsListTimestamp
                     // and OfferingsManager's forceCacheStale on 4xx.
-                    behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK -> {
-                        workflowsCache.invalidateWorkflowTimestamp(workflowId)
-                        onError(error)
-                    }
+                    workflowsCache.invalidateWorkflowTimestamp(workflowId)
+                    onError(error)
+                } else {
                     // Transport error / 5xx / malformed body: the backend is unavailable, not refusing.
-                    // Recover from the persisted envelope if we have one.
-                    else -> scope.launch { resolveDiskFallback(workflowId, error, onSuccess, onError) }
+                    // Recover from the persisted envelope if we have one, matching OfferingsManager's
+                    // disk fallback. Applies to every caller, including the SWR background refresh.
+                    scope.launch { resolveDiskFallback(workflowId, error, onSuccess, onError) }
                 }
             }
         if (callbackDispatcher != null) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -153,6 +153,11 @@ internal class WorkflowManager(
         val onErrorWithFallback: (PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit =
             { error, behavior ->
                 if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
+                    // A 4xx means the server intentionally changed/removed this workflow. Don't serve
+                    // the saved copy; invalidate the in-memory entry so the next call retries rather
+                    // than serving a still-cached value — mirrors the list's
+                    // invalidateWorkflowsListTimestamp and OfferingsManager's forceCacheStale on 4xx.
+                    workflowsCache.invalidateWorkflowTimestamp(workflowId)
                     onError(error)
                 } else {
                     scope.launch { resolveDiskFallback(workflowId, error, onSuccess, onError) }
@@ -181,8 +186,11 @@ internal class WorkflowManager(
     /**
      * Attempts to re-resolve the persisted disk envelope for [workflowId] after a
      * fallback-eligible backend error. If no envelope is present, or if re-resolution fails,
-     * the original [networkError] is forwarded through [onError] so the caller is never left
-     * without a response. On success the result is cached in memory and delivered via [onSuccess].
+     * the in-memory entry is invalidated and the original [networkError] is forwarded through
+     * [onError] so the caller is never left without a response and the next call retries instead of
+     * serving a stale value — mirroring how the list and offerings invalidate when a fallback
+     * yields nothing fresh. On success the result is cached in memory (which re-stamps it fresh) and
+     * delivered via [onSuccess].
      */
     private suspend fun resolveDiskFallback(
         workflowId: String,
@@ -192,6 +200,7 @@ internal class WorkflowManager(
     ) {
         val envelope = workflowsCache.cachedWorkflowDetailEnvelopeFromDisk(workflowId)
         if (envelope == null) {
+            workflowsCache.invalidateWorkflowTimestamp(workflowId)
             onError(networkError)
             return
         }
@@ -201,6 +210,7 @@ internal class WorkflowManager(
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             errorLog(e) { "Failed to re-resolve disk envelope for $workflowId during fallback" }
+            workflowsCache.invalidateWorkflowTimestamp(workflowId)
             onError(networkError)
             return
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -83,13 +83,14 @@ internal class WorkflowManager(
                 // The caller already has a usable value, so the refresh delivers no callbacks: a
                 // success only updates the cache, and a failure is logged and swallowed — the entry
                 // stays stale and the next render retries. Mirrors
-                // OfferingsManager.vendCachedOfferingsAndMaybeRefresh. The disk fallback is disabled
-                // here on purpose (allowDiskFallback = false): the caller already has the stale value,
-                // so re-pinning from the persisted envelope would buy nothing and could overwrite a
-                // newer on-demand-fetched in-memory value with an older prefetched one, suppressing the
-                // retry for a full TTL. Disk fallback is only for callers that have nothing to serve
-                // (the foreground miss and the prefetch recovery path below). Concurrent stale callers
-                // can each fire a refresh; this is not deduplicated, matching the offerings stale path.
+                // OfferingsManager.vendCachedOfferingsAndMaybeRefresh. We pass
+                // alreadyServedStaleValue = true so a failed refresh skips disk recovery: the caller
+                // already has the stale value, so re-pinning from the persisted envelope would buy
+                // nothing and could overwrite a newer on-demand-fetched in-memory value with an older
+                // prefetched one, suppressing the retry for a full TTL. Disk recovery is only for
+                // callers that have nothing to serve (the foreground miss and the prefetch recovery
+                // path below). Concurrent stale callers can each fire a refresh; this is not
+                // deduplicated, matching the offerings stale path.
                 onSuccess(cached)
                 fetchAndCacheWorkflow(
                     appUserID = appUserID,
@@ -97,7 +98,7 @@ internal class WorkflowManager(
                     appInBackground = appInBackground,
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
-                    allowDiskFallback = false,
+                    alreadyServedStaleValue = true,
                     onSuccess = {},
                     onError = { error ->
                         errorLog {
@@ -109,14 +110,14 @@ internal class WorkflowManager(
             }
             else -> {
                 // Miss, or stale with SWR disabled (the prefetch path): block on the fetch. These
-                // callers have nothing to serve yet, so the disk fallback applies.
+                // callers have nothing to serve yet, so disk recovery applies on a fallback-eligible error.
                 fetchAndCacheWorkflow(
                     appUserID = appUserID,
                     workflowId = workflowId,
                     appInBackground = appInBackground,
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
-                    allowDiskFallback = true,
+                    alreadyServedStaleValue = false,
                     onSuccess = onSuccess,
                     onError = onError,
                 )
@@ -131,7 +132,10 @@ internal class WorkflowManager(
         appInBackground: Boolean,
         callbackDispatcher: Dispatcher?,
         persistEnvelopeOnResolve: Boolean,
-        allowDiskFallback: Boolean,
+        // True only for the SWR background refresh, whose caller already received the stale value.
+        // Such a refresh skips disk recovery on error (see onErrorWithFallback): there is nothing to
+        // recover for, so it stays stale and retries next render rather than re-pinning from disk.
+        alreadyServedStaleValue: Boolean,
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -162,20 +166,24 @@ internal class WorkflowManager(
         }
         val onErrorWithFallback: (PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit =
             { error, behavior ->
+                // Two independent axes decide the error handling: whether the caller already has a
+                // value (alreadyServedStaleValue), and what the backend said (behavior).
                 when {
-                    // SWR background refresh: the caller already has the stale value. Don't touch the
-                    // cache — leave the entry stale so the next render retries, and don't re-pin from
-                    // disk. (Invalidating would be a no-op here: this path is only reached for an
-                    // already-stale entry.)
-                    !allowDiskFallback -> onError(error)
-                    // A 4xx means the server intentionally changed/removed this workflow. Don't serve
-                    // the saved copy; invalidate the in-memory entry so the next call retries rather
-                    // than serving a still-cached value — mirrors the list's
-                    // invalidateWorkflowsListTimestamp and OfferingsManager's forceCacheStale on 4xx.
+                    // Caller already served the stale value (SWR background refresh): nothing to
+                    // recover, regardless of the backend status. Leave the entry stale so the next
+                    // render retries; don't read disk or touch the cache. (Invalidating would be a
+                    // no-op anyway — this path is only reached for an already-stale entry.)
+                    alreadyServedStaleValue -> onError(error)
+                    // 4xx: the server intentionally changed/removed this workflow, so don't serve the
+                    // saved copy. Invalidate the in-memory entry so the next call retries rather than
+                    // serving a still-cached value — mirrors the list's invalidateWorkflowsListTimestamp
+                    // and OfferingsManager's forceCacheStale on 4xx.
                     behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK -> {
                         workflowsCache.invalidateWorkflowTimestamp(workflowId)
                         onError(error)
                     }
+                    // Transport error / 5xx / malformed body: the backend is unavailable, not refusing.
+                    // Recover from the persisted envelope if we have one.
                     else -> scope.launch { resolveDiskFallback(workflowId, error, onSuccess, onError) }
                 }
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -81,9 +81,15 @@ internal class WorkflowManager(
             cached != null && staleWhileRevalidate -> {
                 // Serve the stale value immediately, then refresh the cache in the background.
                 // The caller already has a usable value, so the refresh delivers no callbacks: a
-                // success only updates the cache, and a failure is logged and swallowed. Mirrors
-                // OfferingsManager.vendCachedOfferingsAndMaybeRefresh. Concurrent stale callers can
-                // each fire a refresh; this is not deduplicated, matching the offerings stale path.
+                // success only updates the cache, and a failure is logged and swallowed — the entry
+                // stays stale and the next render retries. Mirrors
+                // OfferingsManager.vendCachedOfferingsAndMaybeRefresh. The disk fallback is disabled
+                // here on purpose (allowDiskFallback = false): the caller already has the stale value,
+                // so re-pinning from the persisted envelope would buy nothing and could overwrite a
+                // newer on-demand-fetched in-memory value with an older prefetched one, suppressing the
+                // retry for a full TTL. Disk fallback is only for callers that have nothing to serve
+                // (the foreground miss and the prefetch recovery path below). Concurrent stale callers
+                // can each fire a refresh; this is not deduplicated, matching the offerings stale path.
                 onSuccess(cached)
                 fetchAndCacheWorkflow(
                     appUserID = appUserID,
@@ -91,6 +97,7 @@ internal class WorkflowManager(
                     appInBackground = appInBackground,
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
+                    allowDiskFallback = false,
                     onSuccess = {},
                     onError = { error ->
                         errorLog {
@@ -101,13 +108,15 @@ internal class WorkflowManager(
                 )
             }
             else -> {
-                // Miss, or stale with SWR disabled (the prefetch path): block on the fetch.
+                // Miss, or stale with SWR disabled (the prefetch path): block on the fetch. These
+                // callers have nothing to serve yet, so the disk fallback applies.
                 fetchAndCacheWorkflow(
                     appUserID = appUserID,
                     workflowId = workflowId,
                     appInBackground = appInBackground,
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
+                    allowDiskFallback = true,
                     onSuccess = onSuccess,
                     onError = onError,
                 )
@@ -122,6 +131,7 @@ internal class WorkflowManager(
         appInBackground: Boolean,
         callbackDispatcher: Dispatcher?,
         persistEnvelopeOnResolve: Boolean,
+        allowDiskFallback: Boolean,
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -152,15 +162,21 @@ internal class WorkflowManager(
         }
         val onErrorWithFallback: (PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit =
             { error, behavior ->
-                if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
+                when {
+                    // SWR background refresh: the caller already has the stale value. Don't touch the
+                    // cache — leave the entry stale so the next render retries, and don't re-pin from
+                    // disk. (Invalidating would be a no-op here: this path is only reached for an
+                    // already-stale entry.)
+                    !allowDiskFallback -> onError(error)
                     // A 4xx means the server intentionally changed/removed this workflow. Don't serve
                     // the saved copy; invalidate the in-memory entry so the next call retries rather
                     // than serving a still-cached value — mirrors the list's
                     // invalidateWorkflowsListTimestamp and OfferingsManager's forceCacheStale on 4xx.
-                    workflowsCache.invalidateWorkflowTimestamp(workflowId)
-                    onError(error)
-                } else {
-                    scope.launch { resolveDiskFallback(workflowId, error, onSuccess, onError) }
+                    behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK -> {
+                        workflowsCache.invalidateWorkflowTimestamp(workflowId)
+                        onError(error)
+                    }
+                    else -> scope.launch { resolveDiskFallback(workflowId, error, onSuccess, onError) }
                 }
             }
         if (callbackDispatcher != null) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -157,7 +157,7 @@ internal class WorkflowManager(
                 appInBackground = appInBackground,
                 callbackDispatcher = callbackDispatcher,
                 onSuccess = onSuccessHandler,
-                onError = onError,
+                onError = { error, _ -> onError(error) },
             )
         } else {
             backend.getWorkflow(
@@ -165,7 +165,7 @@ internal class WorkflowManager(
                 workflowId = workflowId,
                 appInBackground = appInBackground,
                 onSuccess = onSuccessHandler,
-                onError = onError,
+                onError = { error, _ -> onError(error) },
             )
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -72,6 +72,19 @@ internal class WorkflowsCache(
         cachedWorkflows.clear()
     }
 
+    /**
+     * Clears the cached timestamp for [workflowId]'s in-memory detail entry, forcing the next
+     * [isWorkflowCacheStale] check to report it stale so a subsequent fetch retries rather than
+     * serving the still-cached value. The per-workflow analogue of [invalidateWorkflowsListTimestamp]
+     * (and of [com.revenuecat.purchases.common.offerings.OfferingsCache.forceCacheStale]); the detail
+     * fetch calls it on a terminal error that produced no fresh value, matching how the list and
+     * offerings invalidate their cache on the same failures. No-op when nothing is cached.
+     */
+    @Synchronized
+    fun invalidateWorkflowTimestamp(workflowId: String) {
+        cachedWorkflows[workflowId]?.clearCacheTimestamp()
+    }
+
     // endregion Workflow detail cache
 
     // region Workflows list cache

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -169,6 +169,13 @@ internal class WorkflowsCache(
         }
 
     /**
+     * Returns the persisted envelope for [workflowId], or null when the key is absent or
+     * the on-disk map can't be read. Convenience wrapper over [cachedWorkflowDetailEnvelopesFromDisk].
+     */
+    fun cachedWorkflowDetailEnvelopeFromDisk(workflowId: String): WorkflowDetailResponse? =
+        cachedWorkflowDetailEnvelopesFromDisk()?.get(workflowId)
+
+    /**
      * Drops persisted envelopes whose workflowId is no longer in the latest list. Because only
      * successfully-prefetched workflows are ever written here (see [cacheWorkflowDetailEnvelope]),
      * this prune removes stale prefetch envelopes for workflows the backend has stopped sending.

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
@@ -128,7 +128,7 @@ class BackendWorkflowsTest {
                 assertThat(response.enrolledVariants).isNull()
                 success = true
             },
-            onError = { fail("unexpected error $it") },
+            onError = { e, _ -> fail("unexpected error $e") },
         )
         assertThat(success).isTrue()
     }
@@ -167,7 +167,7 @@ class BackendWorkflowsTest {
                 assertThat(response.data).isNull()
                 success = true
             },
-            onError = { fail("unexpected error $it") },
+            onError = { e, _ -> fail("unexpected error $e") },
         )
         assertThat(success).isTrue()
     }
@@ -191,9 +191,105 @@ class BackendWorkflowsTest {
             workflowId = "wf_missing",
             appInBackground = false,
             onSuccess = { fail("expected error") },
-            onError = { errorCode = it.code },
+            onError = { error, _ -> errorCode = error.code },
         )
         assertThat(errorCode).isNotNull
+    }
+
+    @Test
+    fun `getWorkflow passes SHOULD_NOT_FALLBACK on 4xx`() {
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflow(appUserId, "wf_1"),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.NOT_FOUND, """{"error":"not found"}""")
+
+        var behavior: GetWorkflowsErrorHandlingBehavior? = null
+        backend.getWorkflow(
+            appUserID = appUserId,
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = { _, b -> behavior = b },
+        )
+        assertThat(behavior).isEqualTo(GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK)
+    }
+
+    @Test
+    fun `getWorkflow passes SHOULD_FALLBACK_TO_CACHED_WORKFLOWS on 5xx`() {
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflow(appUserId, "wf_1"),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.ERROR, """{"error":"server error"}""")
+
+        var behavior: GetWorkflowsErrorHandlingBehavior? = null
+        backend.getWorkflow(
+            appUserID = appUserId,
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = { _, b -> behavior = b },
+        )
+        assertThat(behavior).isEqualTo(GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS)
+    }
+
+    @Test
+    fun `getWorkflow passes SHOULD_FALLBACK_TO_CACHED_WORKFLOWS on transport error`() {
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflow(appUserId, "wf_1"),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } throws IOException("network failure")
+
+        var behavior: GetWorkflowsErrorHandlingBehavior? = null
+        backend.getWorkflow(
+            appUserID = appUserId,
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = { _, b -> behavior = b },
+        )
+        assertThat(behavior).isEqualTo(GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS)
+    }
+
+    @Test
+    fun `getWorkflow passes SHOULD_FALLBACK_TO_CACHED_WORKFLOWS on malformed 2xx body`() {
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflow(appUserId, "wf_1"),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.SUCCESS, """not valid json""")
+
+        var behavior: GetWorkflowsErrorHandlingBehavior? = null
+        backend.getWorkflow(
+            appUserID = appUserId,
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = { _, b -> behavior = b },
+        )
+        assertThat(behavior).isEqualTo(GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS)
     }
 
     @Test
@@ -363,7 +459,7 @@ class BackendWorkflowsTest {
             workflowId = "wf_1",
             appInBackground = false,
             onSuccess = {},
-            onError = {},
+            onError = { _, _ -> },
             callbackDispatcher = overrideDispatcher,
         )
 
@@ -398,7 +494,7 @@ class BackendWorkflowsTest {
             workflowId = "wf_1",
             appInBackground = false,
             onSuccess = {},
-            onError = {},
+            onError = { _, _ -> },
         )
 
         assertThat(mainDispatcher.enqueueCount).isEqualTo(1)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -300,6 +300,125 @@ class WorkflowManagerTest {
         assertThat(error!!.code).isEqualTo(PurchasesErrorCode.NetworkError)
     }
 
+    // region detail fetch status-based fallback
+
+    @Test
+    fun `getWorkflow falls back to disk envelope on 5xx and delivers success`() {
+        val envelope = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn/wf_1.json",
+            hash = "h",
+        )
+        val expectedResult = WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+        coEvery { mockResolver.resolve(envelope) } returns expectedResult
+
+        // Disk holds one envelope for wf_1
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
+
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            errorSlot.captured(
+                PurchasesError(PurchasesErrorCode.NetworkError, "server error"),
+                GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+            )
+        }
+
+        var successResult: WorkflowDataResult? = null
+        var errorCalled = false
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { successResult = it },
+            onError = { errorCalled = true },
+        )
+
+        assertThat(successResult).isEqualTo(expectedResult)
+        assertThat(errorCalled).isFalse()
+        // Result was cached in memory after re-resolution
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isEqualTo(expectedResult)
+    }
+
+    @Test
+    fun `getWorkflow does not fall back to disk envelope on 4xx`() {
+        val expectedError = PurchasesError(PurchasesErrorCode.UnknownBackendError, "not found")
+
+        // Disk holds an envelope, but we must not serve it on 4xx
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
+
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            errorSlot.captured(expectedError, GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK)
+        }
+
+        var receivedError: PurchasesError? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { fail("unexpected success") },
+            onError = { receivedError = it },
+        )
+
+        assertThat(receivedError).isEqualTo(expectedError)
+        coVerify(exactly = 0) { mockResolver.resolve(any()) }
+    }
+
+    @Test
+    fun `getWorkflow surfaces error when fallback eligible but no envelope on disk`() {
+        val expectedError = PurchasesError(PurchasesErrorCode.NetworkError, "transport error")
+
+        // No envelope on disk
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns null
+
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            errorSlot.captured(
+                expectedError,
+                GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+            )
+        }
+
+        var receivedError: PurchasesError? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { fail("unexpected success") },
+            onError = { receivedError = it },
+        )
+
+        assertThat(receivedError).isEqualTo(expectedError)
+    }
+
+    // endregion detail fetch status-based fallback
+
     // region getWorkflow cache
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -18,6 +18,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -48,7 +49,7 @@ class WorkflowManagerTest {
         originalLogHandler = currentLogHandler
         currentLogHandler = NoOpLogHandler
         every { mockDateProvider.now } returns Date(0) // ensures cache is always stale by default
-        workflowsCache = WorkflowsCache(deviceCache = mockDeviceCache, dateProvider = mockDateProvider)
+        workflowsCache = spyk(WorkflowsCache(deviceCache = mockDeviceCache, dateProvider = mockDateProvider))
         workflowManager = WorkflowManager(
             backend = mockBackend,
             workflowDetailResolver = mockResolver,
@@ -381,6 +382,9 @@ class WorkflowManagerTest {
         assertThat(receivedError).isEqualTo(expectedError)
         coVerify(exactly = 0) { mockResolver.resolve(any()) }
         verify(exactly = 0) { mockDeviceCache.getWorkflowDetailEnvelopesCache() }
+        // Invalidate the in-memory entry so the next call retries rather than serving a cached value,
+        // mirroring the list/offerings 4xx policy.
+        verify { workflowsCache.invalidateWorkflowTimestamp("wf_1") }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -711,14 +711,23 @@ class WorkflowManagerTest {
     }
 
     @Test
-    fun `getWorkflow stale hit does not re-pin from disk when the background refresh fails`() {
-        val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
-        val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
-        coEvery { mockResolver.resolve(response) } returns staleResult
+    fun `getWorkflow stale hit re-pins from the persisted envelope when the background refresh fails`() {
+        // Matches OfferingsManager: a fallback-eligible background-refresh failure recovers the
+        // persisted envelope and re-stamps the cache fresh. Known gap vs offerings (re-pinning an
+        // older prefetched envelope over a newer on-demand value) is bounded and self-healing, closed
+        // by the on-demand envelope persistence + LRU follow-up.
+        val inlineResponse = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val staleResult = WorkflowDataResult(workflow = inlineResponse.data!!, enrolledVariants = null)
+        coEvery { mockResolver.resolve(inlineResponse) } returns staleResult
 
-        // A persisted envelope exists on disk — the SWR background refresh must NOT serve it. The
-        // caller already has the stale value, so re-pinning from disk would only suppress the retry
-        // (and could overwrite a newer in-memory value with an older prefetched one).
+        // A distinct value persisted on disk, which the failed refresh should recover and re-pin.
+        val diskEnvelope = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn/wf_1.json",
+            hash = "h",
+        )
+        val diskResult = WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+        coEvery { mockResolver.resolve(diskEnvelope) } returns diskResult
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
 
@@ -737,7 +746,7 @@ class WorkflowManagerTest {
         } answers {
             call++
             if (call == 1) {
-                successSlot.captured(response)
+                successSlot.captured(inlineResponse)
             } else {
                 errorSlot.captured(
                     PurchasesError(PurchasesErrorCode.NetworkError, "boom"),
@@ -746,7 +755,7 @@ class WorkflowManagerTest {
             }
         }
 
-        // Populate at t=0.
+        // Populate at t=0 with the in-memory (INLINE) value.
         every { mockDateProvider.now } returns Date(0)
         workflowManager.getWorkflow(
             appUserID = "user_1",
@@ -756,7 +765,7 @@ class WorkflowManagerTest {
             onError = { fail("unexpected error $it") },
         )
 
-        // Stale call at t=6min: serves stale, the background refresh fails.
+        // Stale call at t=6min: serves stale immediately, the background refresh then fails.
         every { mockDateProvider.now } returns Date(6L * 60 * 1000)
         var served: WorkflowDataResult? = null
         workflowManager.getWorkflow(
@@ -767,13 +776,31 @@ class WorkflowManagerTest {
             onError = { fail("unexpected error $it") },
         )
 
-        // Caller got the stale value...
+        // Caller got the stale in-memory value immediately...
         assertThat(served).isSameAs(staleResult)
-        // ...the disk envelope was never consulted on the background refresh...
-        verify(exactly = 0) { mockDeviceCache.getWorkflowDetailEnvelopesCache() }
-        // ...and the entry stays stale with its original value, not re-pinned fresh from disk.
-        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(staleResult)
-        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+        // ...and the failed refresh recovered the disk envelope, re-pinned it, and re-stamped fresh.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(diskResult)
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isFalse
+
+        // Consequence: the next render serves the recovered disk value with no further backend call.
+        var servedAgain: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { servedAgain = it },
+            onError = { fail("unexpected error $it") },
+        )
+        assertThat(servedAgain).isSameAs(diskResult)
+        verify(exactly = 2) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+            )
+        }
     }
 
     @Test
@@ -1833,6 +1860,61 @@ class WorkflowManagerTest {
         assertThat(completeCount).isEqualTo(1)
         // ...and the resolved workflow is still cached in memory (cacheWorkflow ran before the failed persist).
         assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(resolved)
+    }
+
+    @Test
+    fun `prefetch detail fetch falls back to the persisted envelope on a fallback-eligible error`() {
+        // The disk fallback applies to every caller, including prefetch: this is the intended
+        // backend-down recovery (consistent with restoreWorkflowFromEnvelope). The persisted envelope
+        // is re-resolved, cached, and re-stamped fresh.
+        val listResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "W", offeringId = "off_1", prefetch = true),
+            ),
+        )
+        val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccessSlot), onError = any())
+        } answers { listSuccessSlot.captured(listResponse) }
+
+        // The persisted envelope on disk and the value it resolves to.
+        val diskEnvelope = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn/wf_1.json",
+            hash = "h",
+        )
+        val diskResult = WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+        coEvery { mockResolver.resolve(diskEnvelope) } returns diskResult
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
+
+        // The prefetch detail fetch fails fallback-eligibly (5xx) on the prefetch dispatcher.
+        val detailErrorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = capture(detailErrorSlot),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        } answers {
+            detailErrorSlot.captured(
+                PurchasesError(PurchasesErrorCode.NetworkError, "server boom"),
+                GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+            )
+        }
+
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // The prefetch recovered the persisted envelope and cached it in memory.
+        coVerify(exactly = 1) { mockResolver.resolve(diskEnvelope) }
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(diskResult)
+        // cacheWorkflow re-stamped it fresh, so an on-demand render serves this recovered value
+        // without re-hitting the backend until it goes stale again.
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isFalse
     }
 
     // endregion envelope persistence

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -711,6 +711,72 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflow stale hit does not re-pin from disk when the background refresh fails`() {
+        val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        coEvery { mockResolver.resolve(response) } returns staleResult
+
+        // A persisted envelope exists on disk — the SWR background refresh must NOT serve it. The
+        // caller already has the stale value, so re-pinning from disk would only suppress the retry
+        // (and could overwrite a newer in-memory value with an older prefetched one).
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
+
+        // First backend call succeeds (populates the cache); the second fails fallback-eligibly.
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        var call = 0
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            call++
+            if (call == 1) {
+                successSlot.captured(response)
+            } else {
+                errorSlot.captured(
+                    PurchasesError(PurchasesErrorCode.NetworkError, "boom"),
+                    GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+                )
+            }
+        }
+
+        // Populate at t=0.
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Stale call at t=6min: serves stale, the background refresh fails.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        var served: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { served = it },
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Caller got the stale value...
+        assertThat(served).isSameAs(staleResult)
+        // ...the disk envelope was never consulted on the background refresh...
+        verify(exactly = 0) { mockDeviceCache.getWorkflowDetailEnvelopesCache() }
+        // ...and the entry stays stale with its original value, not re-pinned fresh from disk.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(staleResult)
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+    }
+
+    @Test
     fun `getWorkflow with staleWhileRevalidate false blocks on the refetch instead of serving stale`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
         val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -104,7 +104,7 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow propagates backend errors`() {
         val expectedError = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflow(
                 appUserID = "user_1",
@@ -114,7 +114,7 @@ class WorkflowManagerTest {
                 onError = capture(errorSlot),
             )
         } answers {
-            errorSlot.captured(expectedError)
+            errorSlot.captured(expectedError, GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK)
         }
 
         var error: PurchasesError? = null
@@ -495,7 +495,7 @@ class WorkflowManagerTest {
 
         // First backend call succeeds (populates the cache); the second fails (background refresh).
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
-        val errorSlot = slot<(PurchasesError) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         var call = 0
         every {
             mockBackend.getWorkflow(
@@ -510,7 +510,10 @@ class WorkflowManagerTest {
             if (call == 1) {
                 successSlot.captured(response)
             } else {
-                errorSlot.captured(PurchasesError(PurchasesErrorCode.NetworkError, "boom"))
+                errorSlot.captured(
+                    PurchasesError(PurchasesErrorCode.NetworkError, "boom"),
+                    GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+                )
             }
         }
 
@@ -1270,7 +1273,7 @@ class WorkflowManagerTest {
         } answers { listSuccessSlot.captured(response) }
 
         val detailSuccessA = slot<(WorkflowDetailResponse) -> Unit>()
-        val detailErrorB = slot<(PurchasesError) -> Unit>()
+        val detailErrorB = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
         every {
             mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccessA), any(), any())
         } just Runs
@@ -1287,7 +1290,10 @@ class WorkflowManagerTest {
         detailSuccessA.captured(WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk()))
         assertThat(completed).isFalse()
 
-        detailErrorB.captured(PurchasesError(PurchasesErrorCode.NetworkError, "fail"))
+        detailErrorB.captured(
+            PurchasesError(PurchasesErrorCode.NetworkError, "fail"),
+            GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+        )
         assertThat(completed).isTrue()
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -380,6 +380,7 @@ class WorkflowManagerTest {
 
         assertThat(receivedError).isEqualTo(expectedError)
         coVerify(exactly = 0) { mockResolver.resolve(any()) }
+        verify(exactly = 0) { mockDeviceCache.getWorkflowDetailEnvelopesCache() }
     }
 
     @Test
@@ -415,6 +416,49 @@ class WorkflowManagerTest {
         )
 
         assertThat(receivedError).isEqualTo(expectedError)
+    }
+
+    @Test
+    fun `getWorkflow surfaces original error when fallback resolve throws`() {
+        val originalError = PurchasesError(PurchasesErrorCode.NetworkError, "server error")
+        val envelope = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn/wf_1.json",
+            hash = "h",
+        )
+        coEvery { mockResolver.resolve(envelope) } throws IllegalStateException("cdn unavailable")
+
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
+
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            errorSlot.captured(
+                originalError,
+                GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+            )
+        }
+
+        var receivedError: PurchasesError? = null
+        var successCalled = false
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { successCalled = true },
+            onError = { receivedError = it },
+        )
+
+        assertThat(receivedError).isEqualTo(originalError)
+        assertThat(successCalled).isFalse()
     }
 
     // endregion detail fetch status-based fallback

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -89,6 +89,24 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `invalidateWorkflowTimestamp makes a fresh entry stale`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isFalse
+
+        workflowsCache.invalidateWorkflowTimestamp("wf_1")
+
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+        // The value itself is retained; only its freshness is cleared.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNotNull
+    }
+
+    @Test
+    fun `invalidateWorkflowTimestamp is a no-op when nothing is cached`() {
+        workflowsCache.invalidateWorkflowTimestamp("wf_missing")
+        assertThat(workflowsCache.cachedWorkflow("wf_missing")).isNull()
+    }
+
+    @Test
     fun `clearCache removes all cached workflows`() {
         workflowsCache.cacheWorkflow("wf_1", mockk())
         workflowsCache.cacheWorkflow("wf_2", mockk())

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -273,6 +273,25 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `cachedWorkflowDetailEnvelopeFromDisk returns the matching envelope`() {
+        every { deviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/x.json","hash":"h"},"wf_2":{"action":"use_cdn","url":"u2","hash":"h2"}}"""
+
+        val envelope = workflowsCache.cachedWorkflowDetailEnvelopeFromDisk("wf_1")
+
+        assertThat(envelope).isNotNull
+        assertThat(envelope!!.url).isEqualTo("https://cdn/x.json")
+    }
+
+    @Test
+    fun `cachedWorkflowDetailEnvelopeFromDisk returns null for an absent key`() {
+        every { deviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/x.json","hash":"h"}}"""
+
+        assertThat(workflowsCache.cachedWorkflowDetailEnvelopeFromDisk("wf_missing")).isNull()
+    }
+
+    @Test
     fun `cacheWorkflowsList prunes persisted envelopes not in the new list`() {
         every { deviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"wf_old":{"action":"use_cdn","url":"u1","hash":"h1"},"wf_keep":{"action":"use_cdn","url":"u2","hash":"h2"}}"""


### PR DESCRIPTION
The workflow detail fetch had no fallback on failure, unlike offerings and the workflow list fetch. On transport errors, 5xx responses, or malformed bodies, the error was surfaced immediately even when a persisted envelope was available on disk.

Mirrors #3562 but in the workflow detail path. The fallback applies to every caller (foreground miss, prefetch, and the SWR background refresh), matching `OfferingsManager`:

```mermaid
flowchart TD
    A([Backend detail fetch fails]) --> B{Error-handling<br/>behavior}

    B -->|"4xx<br/>(SHOULD_NOT_FALLBACK)"| INV
    B -->|"transport · 5xx · malformed<br/>(SHOULD_FALLBACK)"| C{Disk envelope<br/>for workflowId?}

    C -->|absent| INV
    C -->|present| D[Re-resolve envelope]

    D -->|resolve fails| INV
    D -->|resolve ok| E[cacheWorkflow<br/>re-stamps fresh]
    E --> OK

    INV[Invalidate in-memory<br/>timestamp] --> ERR

    OK(["onSuccess<br/>resolved result"]):::ok
    ERR(["onError<br/>original backend error"]):::err

    classDef ok fill:#d4edda,stroke:#28a745,color:#155724
    classDef err fill:#f8d7da,stroke:#dc3545,color:#721c24
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall/workflow loading when the backend is down or returns errors; behavior is aligned with existing offerings fallbacks but affects what users see offline and after 4xx responses.
> 
> **Overview**
> Workflow detail fetches now carry **`GetWorkflowsErrorHandlingBehavior`** from `Backend.getWorkflow`, matching offerings and the workflows list: **4xx** → `SHOULD_NOT_FALLBACK`, **transport / 5xx / malformed body** → `SHOULD_FALLBACK_TO_CACHED_WORKFLOWS`.
> 
> **`WorkflowManager`** uses that signal on foreground misses and prefetch (not on stale-while-revalidate background refreshes, via `alreadyServedStaleValue`). On fallback-eligible failures it **re-resolves a persisted detail envelope from disk** and succeeds when possible; on **4xx** or when disk recovery fails it **invalidates the in-memory workflow timestamp** so the next call retries instead of serving a stale cached value. SWR background refresh failures stay logged-only and do not touch disk or re-pin from envelope.
> 
> **`WorkflowsCache`** adds `invalidateWorkflowTimestamp` and `cachedWorkflowDetailEnvelopeFromDisk` to support that policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d33a376ffcac4a2f0d01d3889389793ef0c19b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


