### PR TITLE
Fix paywall crash when a downloaded font file fails to load

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FileTypefaceLoader.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FileTypefaceLoader.kt
@@ -6,8 +6,7 @@ import android.graphics.Typeface
 import java.io.File
 
 /**
- * Loads an [android.graphics.Typeface] from a local font [file]. Exposed as a seam so the platform's
- * file-based loaders can be substituted in tests.
+ * Loads an [android.graphics.Typeface] from a local font [file].
  */
 internal fun interface FileTypefaceLoader {
     fun load(file: File): Typeface?

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FileTypefaceLoader.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FileTypefaceLoader.kt
@@ -10,5 +10,5 @@ import java.io.File
  * file-based loaders can be substituted in tests.
  */
 internal fun interface FileTypefaceLoader {
-    fun load(file: File): Typeface
+    fun load(file: File): Typeface?
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FileTypefaceLoader.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FileTypefaceLoader.kt
@@ -1,0 +1,14 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.properties
+
+import android.graphics.Typeface
+import java.io.File
+
+/**
+ * Loads an [android.graphics.Typeface] from a local font [file]. Exposed as a seam so the platform's
+ * file-based loaders can be substituted in tests.
+ */
+internal fun interface FileTypefaceLoader {
+    fun load(file: File): Typeface
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FontSpec.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FontSpec.kt
@@ -208,15 +208,20 @@ internal fun FontSpec.resolve(
         FontSpec.Generic.Monospace -> FontFamily.Monospace
     }
 
-    is FontSpec.Downloaded -> FontFamily(
-        fonts = downloadedFontFamily.fonts.map { font ->
-            Font(
-                file = File(font.file.path),
-                weight = FontWeight(font.weight),
-                style = font.style.toComposeFontStyle(),
+    is FontSpec.Downloaded ->
+        if (downloadedFontFamily.fonts.isEmpty()) {
+            FontFamily.Default
+        } else {
+            FontFamily(
+                fonts = downloadedFontFamily.fonts.map { font ->
+                    localFileFont(
+                        file = File(font.file.path),
+                        weight = FontWeight(font.weight),
+                        style = font.style.toComposeFontStyle(),
+                    )
+                },
             )
-        },
-    )
+        }
 
     is FontSpec.System -> FontFamily(
         Font(familyName = DeviceFontFamilyName(name), weight = weight, style = style),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/LocalFileFont.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/LocalFileFont.kt
@@ -61,7 +61,7 @@ private object LocalFileFontTypefaceLoader : AndroidFont.TypefaceLoader {
     @Suppress("TooGenericExceptionCaught")
     override fun loadBlocking(context: Context, font: AndroidFont): Typeface {
         val localFont = (font as? LocalFileFont) ?: run {
-            Logger.w(
+            Logger.e(
                 "Expected font to be LocalFileFont, but was ${font::class.java.simpleName}. " +
                     "Falling back to default typeface.",
             )
@@ -76,7 +76,7 @@ private object LocalFileFontTypefaceLoader : AndroidFont.TypefaceLoader {
     }
 
     private fun fallbackTypeface(font: LocalFileFont, reason: String): Typeface {
-        Logger.w(
+        Logger.e(
             "Failed to load downloaded font from ${font.file.path} ($reason). " +
                 "Falling back to default typeface.",
         )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/LocalFileFont.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/LocalFileFont.kt
@@ -1,0 +1,92 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.properties
+
+import android.content.Context
+import android.graphics.Typeface
+import android.os.Build
+import androidx.compose.ui.text.font.AndroidFont
+import androidx.compose.ui.text.font.FontLoadingStrategy
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontVariation
+import androidx.compose.ui.text.font.FontWeight
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import java.io.File
+
+private val DefaultFileTypefaceLoader = FileTypefaceLoader { file ->
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        Typeface.Builder(file).build()
+    } else {
+        Typeface.createFromFile(file)
+    }
+}
+
+/**
+ * Creates a Compose [androidx.compose.ui.text.font.Font] backed by a local [file] (e.g. a downloaded font cached on
+ * disk) that NEVER throws when the file fails to load.
+ *
+ * Compose's built-in `Font(file = ...)` produces a [FontLoadingStrategy.Blocking] font whose loader rethrows any
+ * failure as `IllegalStateException("Unable to load font ...")` during text layout, crashing the app. This happens when
+ * the cached file was evicted by the OS after a prior existence check, is corrupt/truncated, or cannot be decoded by
+ * the platform. This font's loader catches every failure and returns a safe fallback [Typeface] (weight/style aware on
+ * API 28+, plain [Typeface.DEFAULT] below that), so a font-load failure degrades gracefully instead of crashing.
+ */
+@JvmSynthetic
+internal fun localFileFont(
+    file: File,
+    weight: FontWeight,
+    style: FontStyle,
+    fileTypefaceLoader: FileTypefaceLoader = DefaultFileTypefaceLoader,
+): AndroidFont = LocalFileFont(file, weight, style, fileTypefaceLoader)
+
+private class LocalFileFont(
+    val file: File,
+    override val weight: FontWeight,
+    override val style: FontStyle,
+    val fileTypefaceLoader: FileTypefaceLoader,
+) : AndroidFont(
+    loadingStrategy = FontLoadingStrategy.Blocking,
+    typefaceLoader = LocalFileFontTypefaceLoader,
+    variationSettings = FontVariation.Settings(weight, style),
+) {
+    override fun toString(): String = "LocalFileFont(file=$file, weight=$weight, style=$style)"
+}
+
+private object LocalFileFontTypefaceLoader : AndroidFont.TypefaceLoader {
+
+    // Not invoked for Blocking fonts, but required by the interface. Delegate to the blocking path.
+    override suspend fun awaitLoad(context: Context, font: AndroidFont): Typeface =
+        loadBlocking(context, font)
+
+    @Suppress("TooGenericExceptionCaught")
+    override fun loadBlocking(context: Context, font: AndroidFont): Typeface {
+        val localFont = (font as? LocalFileFont) ?: run {
+            Logger.w(
+                "Expected font to be LocalFileFont, but was ${font::class.java.simpleName}. " +
+                    "Falling back to default typeface.",
+            )
+            return fallbackTypeface(font)
+        }
+        return try {
+            localFont.fileTypefaceLoader.load(localFont.file)
+        } catch (e: Throwable) {
+            fallbackTypeface(localFont, reason = e.message ?: e.javaClass.simpleName)
+        }
+    }
+
+    private fun fallbackTypeface(font: LocalFileFont, reason: String): Typeface {
+        Logger.w(
+            "Failed to load downloaded font from ${font.file.path} ($reason). " +
+                "Falling back to default typeface.",
+        )
+        return fallbackTypeface(font)
+    }
+
+    private fun fallbackTypeface(font: AndroidFont): Typeface {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            Typeface.create(Typeface.DEFAULT, font.weight.weight, font.style == FontStyle.Italic)
+        } else {
+            Typeface.DEFAULT
+        }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/LocalFileFont.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/LocalFileFont.kt
@@ -69,6 +69,7 @@ private object LocalFileFontTypefaceLoader : AndroidFont.TypefaceLoader {
         }
         return try {
             localFont.fileTypefaceLoader.load(localFont.file)
+                ?: fallbackTypeface(localFont, reason = "loader returned null")
         } catch (e: Throwable) {
             fallbackTypeface(localFont, reason = e.message ?: e.javaClass.simpleName)
         }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FontSpecResolveTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FontSpecResolveTests.kt
@@ -1,0 +1,46 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.properties
+
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.DownloadedFont
+import com.revenuecat.purchases.paywalls.DownloadedFontFamily
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import com.revenuecat.purchases.paywalls.components.properties.FontStyle as RcFontStyle
+
+@OptIn(InternalRevenueCatAPI::class)
+@RunWith(AndroidJUnit4::class)
+class FontSpecResolveTests {
+
+    @Test
+    fun `resolve on empty downloaded family returns the default family`() {
+        val spec = FontSpec.Downloaded(DownloadedFontFamily(family = "MyFont", fonts = emptyList()))
+
+        val result = spec.resolve(weight = FontWeight.Normal, style = FontStyle.Normal)
+
+        assertThat(result).isEqualTo(FontFamily.Default)
+    }
+
+    @Test
+    fun `resolve on multi-weight downloaded family returns a non-default family`() {
+        val spec = FontSpec.Downloaded(
+            DownloadedFontFamily(
+                family = "MyFont",
+                fonts = listOf(
+                    DownloadedFont(weight = 400, style = RcFontStyle.NORMAL, file = File("regular.otf")),
+                    DownloadedFont(weight = 600, style = RcFontStyle.NORMAL, file = File("semibold.otf")),
+                    DownloadedFont(weight = 700, style = RcFontStyle.ITALIC, file = File("bolditalic.otf")),
+                ),
+            ),
+        )
+
+        val result = spec.resolve(weight = FontWeight.Normal, style = FontStyle.Normal)
+
+        assertThat(result).isNotEqualTo(FontFamily.Default)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/LocalFileFontTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/LocalFileFontTests.kt
@@ -57,6 +57,20 @@ class LocalFileFontTests {
     }
 
     @Test
+    fun `loadBlocking falls back without throwing when the loader returns null`() {
+        val font = localFileFont(
+            file = anyFile,
+            weight = FontWeight(600),
+            style = FontStyle.Normal,
+            fileTypefaceLoader = { null },
+        )
+
+        val result = font.loadBlocking()
+
+        assertThat(result).isNotNull
+    }
+
+    @Test
     @Config(sdk = [24])
     fun `loadBlocking fallback is Typeface DEFAULT below API 28`() {
         val font = localFileFont(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/LocalFileFontTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/LocalFileFontTests.kt
@@ -1,0 +1,91 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.properties
+
+import android.content.Context
+import android.graphics.Typeface
+import androidx.compose.ui.text.font.AndroidFont
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class LocalFileFontTests {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val anyFile = File("/data/user/0/com.example/cache/rc_paywall_fonts/font.otf")
+
+    @Test
+    fun `localFileFont preserves weight and style`() {
+        val font = localFileFont(file = anyFile, weight = FontWeight(600), style = FontStyle.Italic)
+
+        assertThat(font.weight).isEqualTo(FontWeight(600))
+        assertThat(font.style).isEqualTo(FontStyle.Italic)
+    }
+
+    @Test
+    fun `loadBlocking returns the loaded typeface on success`() {
+        val expected = Typeface.DEFAULT_BOLD
+        val font = localFileFont(
+            file = anyFile,
+            weight = FontWeight(400),
+            style = FontStyle.Normal,
+            fileTypefaceLoader = { expected },
+        )
+
+        val result = font.loadBlocking()
+
+        assertThat(result).isSameAs(expected)
+    }
+
+    @Test
+    fun `loadBlocking falls back without throwing when the loader throws`() {
+        val font = localFileFont(
+            file = anyFile,
+            weight = FontWeight(600),
+            style = FontStyle.Normal,
+            fileTypefaceLoader = { throw IllegalStateException("corrupt font") },
+        )
+
+        val result = font.loadBlocking()
+
+        assertThat(result).isNotNull
+    }
+
+    @Test
+    @Config(sdk = [24])
+    fun `loadBlocking fallback is Typeface DEFAULT below API 28`() {
+        val font = localFileFont(
+            file = anyFile,
+            weight = FontWeight(600),
+            style = FontStyle.Normal,
+            fileTypefaceLoader = { throw RuntimeException("boom") },
+        )
+
+        val result = font.loadBlocking()
+
+        assertThat(result).isSameAs(Typeface.DEFAULT)
+    }
+
+    @Test
+    @Config(sdk = [28])
+    fun `loadBlocking falls back without throwing on API 28 and up`() {
+        val font = localFileFont(
+            file = anyFile,
+            weight = FontWeight(600),
+            style = FontStyle.Italic,
+            fileTypefaceLoader = { throw RuntimeException("boom") },
+        )
+
+        val result = font.loadBlocking()
+
+        assertThat(result).isNotNull
+    }
+
+    private fun AndroidFont.loadBlocking(): Typeface =
+        typefaceLoader.loadBlocking(context, this)!!
+}


### PR DESCRIPTION
## Summary

We received reports of a crash in downloaded paywall fonts:

```
java.lang.IllegalStateException: Unable to load font
Font(file=/data/user/0/<pkg>/cache/rc_paywall_fonts/<hash>.otf, weight=FontWeight(weight=600), style=Normal)
```

### Root cause

When compose is resolving the fonts, this happened outside our currently controlled stack trace. This means that any issue loading the typeface (cache file evicted by the OS after the earlier `exists()` check, corrupt/truncated, or undecodable by the platform) could cause a crash. We should never crash due to fonts, so this changes how we load fonts to avoid any possible crashes by adding a fallback.

### Fix

Route downloaded fonts through a new `LocalFileFont` (custom `AndroidFont` + `TypefaceLoader`) whose `loadBlocking` catches load failures and returns a safe fallback `Typeface` (weight/style aware on API 28+, `Typeface.DEFAULT` below) instead of throwing. Empty families short-circuit to `FontFamily.Default`. Per-weight/style matching is preserved because each `DownloadedFont` remains a distinct `Font`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to paywall font resolution and rendering; behavior change is graceful fallback instead of crash, with tests covering failure paths.
> 
> **Overview**
> Fixes paywall crashes when cached downloaded font files fail during Compose text layout by **not** using Compose’s blocking `Font(file = …)` loader, which throws `IllegalStateException("Unable to load font …")` on missing, evicted, or corrupt cache files.
> 
> **Downloaded fonts** in `FontSpec.resolve` now build families via **`localFileFont`**, a custom `AndroidFont` whose `loadBlocking` catches load failures and returns a fallback `Typeface` (weight/style-aware on API 28+, `Typeface.DEFAULT` below). **`FileTypefaceLoader`** abstracts disk loading (`Typeface.Builder` on API 26+). Empty downloaded families resolve to **`FontFamily.Default`**.
> 
> Unit tests cover empty vs multi-face `FontSpec.Downloaded` resolution and fallback behavior on loader errors/null across API levels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa34209f3ce9254455dbe76e6a5883e139a390b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->