### PR TITLE
Add tests for workflow detail disk fallback on backend errors (#3567)

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -707,6 +707,105 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `REGRESSION a failing background refresh re-stamps the cache fresh from disk and suppresses the next refresh`() {
+        // In-memory stale value (resolved from an INLINE response on the first fetch).
+        val inlineResponse = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val staleResult = WorkflowDataResult(workflow = inlineResponse.data!!, enrolledVariants = null)
+        coEvery { mockResolver.resolve(inlineResponse) } returns staleResult
+
+        // A *different* value that lives on disk as a persisted envelope.
+        val diskEnvelope = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn/wf_1.json",
+            hash = "h",
+        )
+        val diskResult = WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+        coEvery { mockResolver.resolve(diskEnvelope) } returns diskResult
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
+
+        // Backend: first call succeeds (populates cache); every later call fails fallback-eligible.
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        var backendCalls = 0
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            backendCalls++
+            if (backendCalls == 1) {
+                successSlot.captured(inlineResponse)
+            } else {
+                errorSlot.captured(
+                    PurchasesError(PurchasesErrorCode.NetworkError, "server boom"),
+                    GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+                )
+            }
+        }
+
+        // t=0: populate the in-memory cache with the stale (INLINE) value.
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        // t=6min: entry is now stale, so SWR serves it and kicks off a background refresh.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        // Sanity: before the refresh runs, the cache is genuinely stale and holds the INLINE value.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(staleResult)
+
+        var served: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { served = it },
+            onError = { fail("unexpected error $it") },
+        )
+
+        // The caller correctly got the stale in-memory value immediately.
+        assertThat(served).isSameAs(staleResult)
+
+        // BUG: the failed background refresh fell back to disk and silently REPLACED the cached
+        // value with the disk-resolved one, and `cacheWorkflow` re-stamped lastUpdatedAt = now.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(diskResult)
+        // BUG: at the same instant the entry is no longer stale - the staleness clock was reset
+        // by disk data even though the backend never succeeded.
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isFalse()
+
+        // Consequence: a subsequent fetch at the same time serves the disk value with NO further
+        // backend call. The transient failure has suppressed refresh attempts for a full TTL.
+        var servedAgain: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { servedAgain = it },
+            onError = { fail("unexpected error $it") },
+        )
+        assertThat(servedAgain).isSameAs(diskResult)
+        // Only the populate (1) and the single background refresh (2) hit the backend.
+        verify(exactly = 2) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+            )
+        }
+    }
+
+    @Test
     fun `getWorkflow with staleWhileRevalidate false blocks on the refetch instead of serving stale`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
         val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -1172,6 +1172,61 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `prefetch detail fetch falling back on 5xx re-pins the stale disk envelope as fresh`() {
+        // A list with one prefetch=true workflow. The list fetch succeeds; the per-workflow detail
+        // fetch then 5xxs while a previously-persisted envelope for it still sits on disk.
+        val listResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "W", offeringId = "off_1", prefetch = true),
+            ),
+        )
+        val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccessSlot), onError = any())
+        } answers { listSuccessSlot.captured(listResponse) }
+
+        // The persisted (old) envelope on disk and the value it resolves to.
+        val diskEnvelope = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn/wf_1.json",
+            hash = "h",
+        )
+        val diskResult = WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+        coEvery { mockResolver.resolve(diskEnvelope) } returns diskResult
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
+            """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
+
+        // The prefetch detail fetch fails fallback-eligible (5xx) on the prefetch dispatcher.
+        val detailErrorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = capture(detailErrorSlot),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        } answers {
+            detailErrorSlot.captured(
+                PurchasesError(PurchasesErrorCode.NetworkError, "server boom"),
+                GetWorkflowsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
+            )
+        }
+
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // The prefetch, whose job is to refresh, instead re-resolved the OLD disk envelope and cached
+        // it. The detail backend was hit exactly once (no successful refresh).
+        coVerify(exactly = 1) { mockResolver.resolve(diskEnvelope) }
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(diskResult)
+        // And cacheWorkflow re-stamped it fresh, so the on-demand render path will serve this disk
+        // value without re-hitting the backend until the entry goes stale again.
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isFalse()
+    }
+
+    @Test
     fun `on-demand getWorkflow runs on the default dispatcher, not the prefetch one`() {
         every { mockBackend.getWorkflow(any(), any(), any(), any(), any(), any()) } answers { }
 


### PR DESCRIPTION
This came out of reviewing #3567.

The disk fallback you added in `fetchAndCacheWorkflow` gets hit by *every* caller of that method, not just the on-demand miss path the PR's tests cover. I wanted to nail down what happens on the other two callers, so here are two tests. They assert what the code does **today** (both green right now), so they're more "let's agree on what this does" than "here's a bug." If the behavior is what you intended, rename them and fold them in. If not, they're ready-made repros.

**Test 1 is the one I'd actually look at.**

When a workflow is stale-but-cached, `getWorkflow` serves the stale value and refreshes in the background. If that background refresh hits a 5xx (or transport error / bad body) and there's a disk envelope lying around, the new fallback re-resolves the disk envelope, overwrites the in-memory cache with it, and `cacheWorkflow` stamps it fresh. So a *failed* refresh ends up resetting the staleness clock from disk data, and the next render serves that disk value as "fresh" without retrying the backend for a full TTL.

What caught my eye: the KDoc on `getWorkflow` says the background-refresh failure is "logged and swallowed... mirrors OfferingsManager.vendCachedOfferingsAndMaybeRefresh", i.e. stay stale and retry next time. This quietly changes that. So the real question: did you mean the fallback to apply to the background refresh too, or only to the foreground miss?

**Test 2 is probably fine, I'm just writing it down.**

Same mechanism, but via the prefetch loop: list fetch succeeds, a `prefetch=true` detail fetch 5xxs, old envelope on disk, prefetch re-pins the old value as fresh. I think this one's intended since it lines up with `restoreWorkflowFromEnvelope`'s backend-down recovery, so don't read it as a complaint. It's here so the behavior is documented somewhere.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: review companion to #3567
- Branch: `cesar/workflow-feature-task-review` (base: `cesar/workflow-feature-task`)
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-06-09
- Context document version: 3

## Goal

Review #3567 for missing coverage, then prove the findings with executable tests.

## Initial Prompt

"Let's review https://github.com/RevenueCat/purchases-android/pull/3567. What's missing?" Then: "can we prove 1 with a test?", "what else?", "so we can also write a test for 1 right?" (the prefetch item).

## Agent Contribution

- Reviewed the PR diff and adjacent paths (`WorkflowManager.getWorkflow` / `fetchAndCacheWorkflow` / `resolveDiskFallback` / `prefetchWorkflow` / `restoreWorkflowFromEnvelope`, `WorkflowsCache`, `Backend.getWorkflow`, offerings/list fallback siblings).
- Authored two characterization tests in `WorkflowManagerTest.kt`.
- Self-corrected an invalid review finding (claimed list/detail 4xx divergence; was reading `main`, not the branch).
- Ran the module unit tests to confirm both pass.

## Human Decisions

- Chose to escalate findings into tests and a draft PR.
- Base-branch choice forced by a compile dependency on the stack's callback signature.

## Key Implementation Decisions

- Decision: assert current behavior (green today), Test 1 marked `// BUG:`, Test 2 neutral.
  - Rationale: characterize uncovered interactions; the author decides intent.
  - Rejected: red tests asserting desired behavior, premature while intent is unconfirmed.

## Files / Symbols Touched

- `purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt`, two new `@Test`s in `WorkflowManagerTest`.

## Validation

- `./gradlew :purchases:testDefaultsBc8DebugUnitTest --tests "com.revenuecat.purchases.common.workflows.WorkflowManagerTest"`: BUILD SUCCESSFUL, 62 cases, both new tests present and passing.
- Manual verification: Not run (test-only).
- CI: Not captured at time of writing.

## Validation Gaps

- Only `defaultsBc8` run locally; `bc7` and `customEntitlementComputation` not run.
- Cancellation path and thread-of-delivery differences not tested.

## Review Focus

- Test 1: should the SWR background-refresh disk fallback + re-stamp be removed (scope fallback to the foreground miss path only)?
- Test 2: confirm the prefetch re-pin is intended (consistency with `restoreWorkflowFromEnvelope`).

## Risks / Reviewer Notes

- Risk: a flaky backend pins a prefetched workflow to its on-disk envelope and suppresses refresh for a TTL. Evidence: Test 1. Mitigation: none yet, pending intent.

## Non-goals

- No production code changes; no fix applied.

## Omitted Context

- Raw transcript, unrelated exploration, and tool logs were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only PR with no production changes; it documents caching behavior for follow-up review of #3567.
> 
> **Overview**
> Adds two **characterization tests** in `WorkflowManagerTest` for workflow detail **disk fallback on fallback-eligible backend errors** (paths that share `fetchAndCacheWorkflow` / `resolveDiskFallback`).
> 
> The **REGRESSION** test covers **stale-while-revalidate**: after a stale in-memory hit, a failed background refresh with a persisted envelope replaces the cache with the disk-resolved workflow and **`cacheWorkflow` marks it fresh**, so a follow-up `getWorkflow` serves disk data without another backend call for a full TTL. Comments flag this as possibly unintended vs. “swallow failed background refresh and retry later.”
> 
> The second test covers **prefetch**: when list load succeeds but a `prefetch=true` detail fetch 5xxs, the same disk fallback **re-pins** the old envelope in memory as fresh. Both tests assert **current** behavior (green today), not a desired fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a59d95eee7d9a1f3c696c5c29c37e3364910ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->