### PR TITLE
Look for embedded paywall fonts in public/assets

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/OfferingFontPreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/OfferingFontPreDownloader.kt
@@ -19,7 +19,7 @@ internal class OfferingFontPreDownloader(
 ) {
 
     // Directories within the app's assets where embedded fonts may be bundled, searched in order.
-    // "public/assets" is where Capacitor apps that use our paywalls SDK place their fonts.
+    // "public/assets" is a likely location for Capacitor apps that use our paywalls SDK to place their fonts.
     private val assetsFontsDirs = listOf("fonts", "public/assets")
 
     // GenericFontFamily names as defined by Compose. Restated here because we don't include any Compose dependencies.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/OfferingFontPreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/OfferingFontPreDownloader.kt
@@ -18,7 +18,9 @@ internal class OfferingFontPreDownloader(
     private val fontLoader: FontLoader,
 ) {
 
-    private val assetsFontsDir = "fonts"
+    // Directories within the app's assets where embedded fonts may be bundled, searched in order.
+    // "public/assets" is where Capacitor apps that use our paywalls SDK place their fonts.
+    private val assetsFontsDirs = listOf("fonts", "public/assets")
 
     // GenericFontFamily names as defined by Compose. Restated here because we don't include any Compose dependencies.
     private val genericFonts = setOf(
@@ -79,8 +81,10 @@ internal class OfferingFontPreDownloader(
     private fun Context.getAssetFontPath(name: String): String? {
         val nameWithExtension = if (name.endsWith(".ttf")) name else "$name.ttf"
 
-        return resources.assets.list(assetsFontsDir)
-            ?.find { it == nameWithExtension }
-            ?.let { "$assetsFontsDir/$it" }
+        return assetsFontsDirs.firstNotNullOfOrNull { dir ->
+            resources.assets.list(dir)
+                ?.find { it == nameWithExtension }
+                ?.let { "$dir/$it" }
+        }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/OfferingFontPreDownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/OfferingFontPreDownloaderTest.kt
@@ -258,4 +258,43 @@ class OfferingFontPreDownloaderTest {
             fontLoader.getCachedFontFamilyOrStartDownload(downloadableFont.android as FontInfo.Name)
         }
     }
-} 
+
+    @Test
+    fun `preDownloadOfferingFontsIfNeeded skips fonts bundled in public assets dir`() {
+        every { context.resources.assets.list("fonts") } returns emptyArray()
+        every { context.resources.assets.list("public/assets") } returns arrayOf("capacitorFont.ttf")
+
+        val capacitorFont = FontsConfig(
+            android = FontInfo.Name(
+                value = "capacitorFont",
+                family = "test-family",
+                weight = 400,
+                style = FontStyle.NORMAL,
+                url = "https://example.com/shouldnotdownloadfont.ttf",
+                hash = "hash123",
+            ),
+        )
+
+        val offering = Offering(
+            identifier = "offering-id",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = emptyList(),
+            paywallComponents = Offering.PaywallComponents(
+                uiConfig = UiConfig(
+                    app = AppConfig(
+                        fonts = mapOf(
+                            FontAlias("capacitorFont") to capacitorFont,
+                        )
+                    )
+                ),
+                data = mockk(),
+            ),
+        )
+        preDownloader.preDownloadOfferingFontsIfNeeded(Offerings(null, mapOf("offering" to offering)))
+
+        verify(exactly = 0) {
+            fontLoader.getCachedFontFamilyOrStartDownload(any())
+        }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -497,7 +497,7 @@ internal class MockResourceProvider(
     override fun getAssetFontPaths(names: List<String>): Map<String, String>? {
         val foundPaths = names.associateWith { name ->
             val nameWithExtension = if (name.endsWith(".ttf")) name else "$name.ttf"
-            "${ResourceProvider.ASSETS_FONTS_DIR}/$nameWithExtension"
+            "${ResourceProvider.ASSETS_FONTS_DIRS.first()}/$nameWithExtension"
         }
 
         return foundPaths.filter { assetPaths.contains(it.value) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -497,7 +497,7 @@ internal class MockResourceProvider(
     override fun getAssetFontPaths(names: List<String>): Map<String, String>? {
         val foundPaths = names.associateWith { name ->
             val nameWithExtension = if (name.endsWith(".ttf")) name else "$name.ttf"
-            "${ResourceProvider.ASSETS_FONTS_DIRS.first()}/$nameWithExtension"
+            "fonts/$nameWithExtension"
         }
 
         return foundPaths.filter { assetPaths.contains(it.value) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallResourceProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallResourceProvider.kt
@@ -18,7 +18,7 @@ import java.util.Locale
 internal interface ResourceProvider {
     companion object {
         // Directories within the app's assets where embedded fonts may be bundled, searched in order.
-        // "public/assets" is where Capacitor apps that use our paywalls SDK place their fonts.
+        // "public/assets" is a likely location for Capacitor apps that use our paywalls SDK to place their fonts.
         val ASSETS_FONTS_DIRS = listOf("fonts", "public/assets")
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallResourceProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallResourceProvider.kt
@@ -17,7 +17,9 @@ import java.util.Locale
  */
 internal interface ResourceProvider {
     companion object {
-        const val ASSETS_FONTS_DIR = "fonts"
+        // Directories within the app's assets where embedded fonts may be bundled, searched in order.
+        // "public/assets" is where Capacitor apps that use our paywalls SDK place their fonts.
+        val ASSETS_FONTS_DIRS = listOf("fonts", "public/assets")
     }
 
     fun getApplicationName(): String
@@ -82,13 +84,17 @@ internal class PaywallResourceProvider(
     }
 
     override fun getAssetFontPaths(names: List<String>): Map<String, String>? {
-        val assetsList = resources.assets.list(ResourceProvider.ASSETS_FONTS_DIR)
+        val assetsListByDir = ResourceProvider.ASSETS_FONTS_DIRS.associateWith { dir ->
+            resources.assets.list(dir)
+        }
 
         return names
             .mapNotNull { name ->
                 val nameWithExtension = if (name.endsWith(".ttf")) name else "$name.ttf"
-                val path = assetsList?.find { it == nameWithExtension }
-                    ?.let { "${ResourceProvider.ASSETS_FONTS_DIR}/$it" }
+                val path = ResourceProvider.ASSETS_FONTS_DIRS.firstNotNullOfOrNull { dir ->
+                    assetsListByDir[dir]?.find { it == nameWithExtension }
+                        ?.let { "$dir/$it" }
+                }
                 if (path != null) {
                     name to path
                 } else {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallResourceProviderTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallResourceProviderTest.kt
@@ -1,0 +1,72 @@
+package com.revenuecat.purchases.ui.revenuecatui.helpers
+
+import android.content.res.Resources
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class PaywallResourceProviderTest {
+
+    private fun resourceProviderWith(
+        assetsByDir: Map<String, Array<String>>,
+    ): PaywallResourceProvider {
+        val resources = mockk<Resources> {
+            every { assets.list(any()) } returns emptyArray()
+            assetsByDir.forEach { (dir, files) ->
+                every { assets.list(dir) } returns files
+            }
+        }
+        return PaywallResourceProvider(
+            applicationName = "TestApp",
+            packageName = "com.test.app",
+            resources = resources,
+        )
+    }
+
+    @Test
+    fun `getAssetFontPaths resolves fonts in the fonts dir`() {
+        val provider = resourceProviderWith(mapOf("fonts" to arrayOf("myFont.ttf")))
+
+        val paths = provider.getAssetFontPaths(listOf("myFont"))
+
+        assertThat(paths).isEqualTo(mapOf("myFont" to "fonts/myFont.ttf"))
+    }
+
+    @Test
+    fun `getAssetFontPaths resolves fonts in the public assets dir`() {
+        val provider = resourceProviderWith(mapOf("public/assets" to arrayOf("capacitorFont.ttf")))
+
+        val paths = provider.getAssetFontPaths(listOf("capacitorFont"))
+
+        assertThat(paths).isEqualTo(mapOf("capacitorFont" to "public/assets/capacitorFont.ttf"))
+    }
+
+    @Test
+    fun `getAssetFontPaths prefers fonts dir over public assets dir`() {
+        val provider = resourceProviderWith(
+            mapOf(
+                "fonts" to arrayOf("sharedFont.ttf"),
+                "public/assets" to arrayOf("sharedFont.ttf"),
+            ),
+        )
+
+        val paths = provider.getAssetFontPaths(listOf("sharedFont"))
+
+        assertThat(paths).isEqualTo(mapOf("sharedFont" to "fonts/sharedFont.ttf"))
+    }
+
+    @Test
+    fun `getAssetFontPaths returns null when no font is found in any dir`() {
+        val provider = resourceProviderWith(emptyMap())
+
+        val paths = provider.getAssetFontPaths(listOf("missingFont"))
+
+        assertThat(paths).isNull()
+    }
+}


### PR DESCRIPTION
### Why

Capacitor apps that use our paywalls SDK under the hood bundle their fonts into `src/main/assets/public/assets/` (which maps to the AssetManager path `public/assets/` at runtime). The SDK only ever looked in `assets/fonts/`, so these locally bundled fonts were never found and the SDK fell through to downloading them over the network instead of using the local copy.

### What

Search `public/assets/` in addition to `fonts/` when resolving embedded fonts, in both places that look up bundled fonts:
- `OfferingFontPreDownloader` — the pre-download "is this font bundled?" check that decides whether to skip the download.
- `PaywallResourceProvider.getAssetFontPaths` — the render-time asset font resolution.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to asset font path resolution with ordered fallback and tests; no auth, billing, or network contract changes beyond skipping unnecessary font downloads when assets are found.
> 
> **Overview**
> Embedded paywall fonts are now resolved from **`public/assets/`** in addition to **`fonts/`**, so Capacitor apps that bundle fonts under `public/assets` are treated as local copies instead of triggering network downloads.
> 
> **`OfferingFontPreDownloader`** walks an ordered list of asset directories when deciding if a font is bundled (skipping pre-download). **`PaywallResourceProvider.getAssetFontPaths`** uses the same ordered search at render time, with **`fonts/`** winning when the same `.ttf` exists in both places.
> 
> Tests cover Capacitor-style fonts in `public/assets`, precedence, and missing fonts; **`MockResourceProvider`** test data was aligned with the `fonts/` path shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36173ed766e556149a47fe6511fe17d70ef6ca82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->