### PR TITLE
Stale-while-revalidate for the workflows list fetch

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -415,10 +415,13 @@ internal class WorkflowManager(
                 if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
                     // A 4xx means the server intentionally changed/removed these workflows. Don't
                     // resurrect a stale list from disk; just settle the callbacks so offerings
-                    // delivery isn't stranded. Invalidate the timestamp so the next non-forced call
-                    // retries rather than serving a still-fresh in-memory list — mirrors
-                    // OfferingsManager.handleErrorFetchingOfferings calling forceCacheStale().
-                    workflowsCache.invalidateWorkflowsListTimestamp()
+                    // delivery isn't stranded. Drop the in-memory list and offeringId map entirely so
+                    // the stale-but-present SWR branch can't keep vending the server-rejected mappings
+                    // on every later call: clearing the instance (not just the timestamp) makes
+                    // hasCachedWorkflowsList() report a cold miss, so the next non-forced call blocks
+                    // on a fresh fetch. Mirrors OfferingsManager.handleErrorFetchingOfferings forcing
+                    // the cache stale on 4xx — adapted to the list's extra SWR presence check.
+                    workflowsCache.clearInMemoryWorkflowsList()
                     completePendingCallbacks(appUserID)
                 } else {
                     restoreWorkflowsListFromDisk(appUserID)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -354,8 +354,14 @@ internal class WorkflowManager(
             // OfferingsManager.vendCachedOfferingsAndMaybeRefresh. The background fetch's onSuccess/onError
             // fires any callers that joined the batch.
             ListFetchAction.STALE_WHILE_REVALIDATE -> {
-                onComplete()
-                fetchWorkflowsList(appUserID, appInBackground, forceRefresh = false)
+                try {
+                    onComplete()
+                } finally {
+                    // The refresh must start even if onComplete throws (it can run developer code
+                    // synchronously): the batch registered above is only ever settled by the fetch,
+                    // so skipping it would strand every later caller for this user on a dead batch.
+                    fetchWorkflowsList(appUserID, appInBackground, forceRefresh = false)
+                }
             }
             // Miss or forced: the request's onSuccess/onError fires the queued callbacks when it settles.
             ListFetchAction.BLOCKING_FETCH -> fetchWorkflowsList(appUserID, appInBackground, forceRefresh)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -205,6 +205,8 @@ internal class WorkflowManager(
         }
     }
 
+    private enum class ListFetchAction { COMPLETE_NOW, STALE_WHILE_REVALIDATE, BLOCKING_FETCH }
+
     /**
      * Caches [result] under the resolved workflow's own ID — the canonical key every later lookup
      * uses. On the lazy-conversion path the backend is called with an offering ID, so recording the
@@ -291,6 +293,12 @@ internal class WorkflowManager(
      * sequence settles — list fetched, every prefetch finished or failed — so it must always fire
      * exactly once, otherwise offerings would never be delivered to the caller.
      *
+     * When the cached list is stale but present and the call is not forced, it is served
+     * stale-while-revalidate: [onComplete] fires immediately with the cached offeringId → workflowId
+     * map and the list is refreshed in the background, mirroring
+     * [com.revenuecat.purchases.common.offerings.OfferingsManager.vendCachedOfferingsAndMaybeRefresh].
+     * A forced refresh or a cold miss still blocks until the fetch settles.
+     *
      * Concurrent callers for the same [appUserID] while a request is in-flight are deduplicated: the
      * second call queues its [onComplete] and returns without a new network request, then all pending
      * callbacks for that user fire together when the in-flight sequence finishes. A call for a
@@ -306,27 +314,51 @@ internal class WorkflowManager(
         onComplete: () -> Unit = {},
     ) {
         // Decide under the lock, act outside it so onComplete never fires while holding it.
-        val startFetch = synchronized(callbackLock) {
+        val action = synchronized(callbackLock) {
             val inFlight = pendingCompletionCallbacks[appUserID]
             if (inFlight != null) {
                 // Already fetching for this user: queue onto it. Joining ignores cache freshness and
-                // forceRefresh on purpose — the list response stamps the cache fresh mid-sequence,
-                // before its prefetch finishes, so a freshness check would let this caller complete
-                // early, and an in-flight batch is never interrupted.
+                // forceRefresh on purpose — the list response stamps the cache fresh mid-sequence, before
+                // its prefetch finishes, and an in-flight batch is never interrupted.
                 inFlight.add(onComplete)
                 return
             }
-            // Nothing in flight: open a batch and fetch when forced or when the cached list is stale.
-            pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
-            forceRefresh || workflowsCache.isWorkflowsListCacheStale(appInBackground)
+            val stale = workflowsCache.isWorkflowsListCacheStale(appInBackground)
+            when {
+                // Fresh, nothing in flight: complete now.
+                !forceRefresh && !stale -> {
+                    pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
+                    ListFetchAction.COMPLETE_NOW
+                }
+                // Stale-but-present, not forced: serve the cached map now and refresh in the background.
+                // Register an EMPTY batch so a concurrent caller joins this refresh instead of starting
+                // another (the list keeps the dedup offerings doesn't need, because the refresh fires a
+                // prefetch loop). onComplete is fired outside the lock, so it isn't in the batch and won't
+                // be double-fired when the refresh settles.
+                !forceRefresh && workflowsCache.hasCachedWorkflowsList() -> {
+                    pendingCompletionCallbacks[appUserID] = mutableListOf()
+                    ListFetchAction.STALE_WHILE_REVALIDATE
+                }
+                // Forced, or cold miss (no cached list): fetch and block.
+                else -> {
+                    pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
+                    ListFetchAction.BLOCKING_FETCH
+                }
+            }
         }
 
-        // Fresh cache and nothing in flight: complete now. Otherwise the request's onSuccess/onError
-        // fire the queued callbacks when it settles.
-        if (!startFetch) {
-            completePendingCallbacks(appUserID)
-        } else {
-            fetchWorkflowsList(appUserID, appInBackground, forceRefresh)
+        when (action) {
+            // Fresh cache and nothing in flight: complete now.
+            ListFetchAction.COMPLETE_NOW -> completePendingCallbacks(appUserID)
+            // Vend the cached map immediately, then refresh in the background, mirroring
+            // OfferingsManager.vendCachedOfferingsAndMaybeRefresh. The background fetch's onSuccess/onError
+            // fires any callers that joined the batch.
+            ListFetchAction.STALE_WHILE_REVALIDATE -> {
+                onComplete()
+                fetchWorkflowsList(appUserID, appInBackground, forceRefresh = false)
+            }
+            // Miss or forced: the request's onSuccess/onError fires the queued callbacks when it settles.
+            ListFetchAction.BLOCKING_FETCH -> fetchWorkflowsList(appUserID, appInBackground, forceRefresh)
         }
     }
 
@@ -336,9 +368,10 @@ internal class WorkflowManager(
      * from disk; on a 4xx it invalidates the timestamp and settles without restoring. Shared by the
      * blocking and stale-while-revalidate paths of [getWorkflowsList].
      *
-     * [forceRefresh] only controls whether the in-memory detail caches are cleared before the prefetch
-     * loop, so a forced refresh re-fetches every detail from the backend rather than serving still-fresh
-     * cached values.
+     * [forceRefresh] only controls whether the in-memory detail caches are cleared on a *successful*
+     * fetch (inside [onSuccess], not before the network call, so a failed fetch leaves cached details
+     * intact). A forced refresh then re-fetches every detail from the backend rather than serving
+     * still-fresh cached values.
      */
     private fun fetchWorkflowsList(appUserID: String, appInBackground: Boolean, forceRefresh: Boolean) {
         backend.getWorkflows(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -173,10 +173,12 @@ internal class WorkflowManager(
             { error, behavior ->
                 if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
                     // 4xx: the server intentionally changed/removed this workflow, so don't serve the
-                    // saved copy. Invalidate the in-memory entry so the next call retries rather than
-                    // serving a still-cached value — mirrors the list's invalidateWorkflowsListTimestamp
-                    // and OfferingsManager's forceCacheStale on 4xx.
-                    workflowsCache.invalidateWorkflowTimestamp(workflowId)
+                    // saved copy. Remove the in-memory entry entirely (not just its timestamp) so the
+                    // stale-while-revalidate branch in getWorkflow can't keep vending the rejected value
+                    // on every later render: the next call then misses and blocks on a fresh fetch.
+                    // Mirrors the list's clearInMemoryWorkflowsList and OfferingsManager's forceCacheStale
+                    // on 4xx.
+                    workflowsCache.removeCachedWorkflow(workflowId)
                     onError(error)
                 } else {
                     // Transport error / 5xx / malformed body: the backend is unavailable, not refusing.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -326,52 +326,66 @@ internal class WorkflowManager(
         if (!startFetch) {
             completePendingCallbacks(appUserID)
         } else {
-            backend.getWorkflows(
-                appUserID = appUserID,
-                appInBackground = appInBackground,
-                type = "paywall",
-                onSuccess = { response ->
-                    // Drop workflows without an offeringId: they can't be reached via
-                    // workflowIdForOfferingId, so caching or prefetching them is wasted work.
-                    val filtered = response.onlyWorkflowsWithOfferingId()
-                    // Clear detail caches after a successful fetch so the prefetch loop below is a
-                    // guaranteed cache miss and always populates fresh data. Cleared here rather than
-                    // before the network call so a failed fetch leaves in-memory details intact.
-                    if (forceRefresh) workflowsCache.clearWorkflowDetailCaches()
-                    workflowsCache.cacheWorkflowsList(filtered, buildOfferingIdMap(filtered.workflows))
+            fetchWorkflowsList(appUserID, appInBackground, forceRefresh)
+        }
+    }
 
-                    val prefetchWorkflows = filtered.workflows.filter { it.prefetch }
-                    scope.launch {
-                        // Wait for all prefetches before completing so onComplete fires once the whole
-                        // sequence settles. A failed prefetch is logged and does not fail the others.
-                        // Concurrency is bounded downstream, not here: detail fetches by prefetchDispatcher's
-                        // thread pool, CDN downloads by the workflows FileRepository's limited scope.
-                        coroutineScope {
-                            prefetchWorkflows.forEach { summary ->
-                                launch {
-                                    prefetchWorkflow(appUserID, summary.id, appInBackground)
-                                }
+    /**
+     * Fetches the workflows list from the backend, then prefetches all `prefetch = true` entries and
+     * settles pending callbacks. On a fallback-eligible failure (transport/5xx/malformed) it restores
+     * from disk; on a 4xx it invalidates the timestamp and settles without restoring. Shared by the
+     * blocking and stale-while-revalidate paths of [getWorkflowsList].
+     *
+     * [forceRefresh] only controls whether the in-memory detail caches are cleared before the prefetch
+     * loop, so a forced refresh re-fetches every detail from the backend rather than serving still-fresh
+     * cached values.
+     */
+    private fun fetchWorkflowsList(appUserID: String, appInBackground: Boolean, forceRefresh: Boolean) {
+        backend.getWorkflows(
+            appUserID = appUserID,
+            appInBackground = appInBackground,
+            type = "paywall",
+            onSuccess = { response ->
+                // Drop workflows without an offeringId: they can't be reached via
+                // workflowIdForOfferingId, so caching or prefetching them is wasted work.
+                val filtered = response.onlyWorkflowsWithOfferingId()
+                // Clear detail caches after a successful fetch so the prefetch loop below is a
+                // guaranteed cache miss and always populates fresh data. Cleared here rather than
+                // before the network call so a failed fetch leaves in-memory details intact.
+                if (forceRefresh) workflowsCache.clearWorkflowDetailCaches()
+                workflowsCache.cacheWorkflowsList(filtered, buildOfferingIdMap(filtered.workflows))
+
+                val prefetchWorkflows = filtered.workflows.filter { it.prefetch }
+                scope.launch {
+                    // Wait for all prefetches before completing so onComplete fires once the whole
+                    // sequence settles. A failed prefetch is logged and does not fail the others.
+                    // Concurrency is bounded downstream, not here: detail fetches by prefetchDispatcher's
+                    // thread pool, CDN downloads by the workflows FileRepository's limited scope.
+                    coroutineScope {
+                        prefetchWorkflows.forEach { summary ->
+                            launch {
+                                prefetchWorkflow(appUserID, summary.id, appInBackground)
                             }
                         }
-                        completePendingCallbacks(appUserID)
                     }
-                },
-                onError = { error, behavior ->
-                    errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
-                    if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
-                        // A 4xx means the server intentionally changed/removed these workflows. Don't
-                        // resurrect a stale list from disk; just settle the callbacks so offerings
-                        // delivery isn't stranded. Invalidate the timestamp so the next non-forced call
-                        // retries rather than serving a still-fresh in-memory list — mirrors
-                        // OfferingsManager.handleErrorFetchingOfferings calling forceCacheStale().
-                        workflowsCache.invalidateWorkflowsListTimestamp()
-                        completePendingCallbacks(appUserID)
-                    } else {
-                        restoreWorkflowsListFromDisk(appUserID)
-                    }
-                },
-            )
-        }
+                    completePendingCallbacks(appUserID)
+                }
+            },
+            onError = { error, behavior ->
+                errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
+                if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
+                    // A 4xx means the server intentionally changed/removed these workflows. Don't
+                    // resurrect a stale list from disk; just settle the callbacks so offerings
+                    // delivery isn't stranded. Invalidate the timestamp so the next non-forced call
+                    // retries rather than serving a still-fresh in-memory list — mirrors
+                    // OfferingsManager.handleErrorFetchingOfferings calling forceCacheStale().
+                    workflowsCache.invalidateWorkflowsListTimestamp()
+                    completePendingCallbacks(appUserID)
+                } else {
+                    restoreWorkflowsListFromDisk(appUserID)
+                }
+            },
+        )
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -93,6 +93,15 @@ internal class WorkflowsCache(
     fun isWorkflowsListCacheStale(appInBackground: Boolean): Boolean =
         workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
 
+    /**
+     * Whether a workflows list is currently held in memory. Distinct from [isWorkflowsListCacheStale],
+     * which returns true both when the list is stale and when it has never been cached (null timestamp);
+     * this tells the stale-but-present case apart from a cold miss so the SWR path in
+     * [com.revenuecat.purchases.common.workflows.WorkflowManager.getWorkflowsList] can vend a stale list.
+     */
+    @Synchronized
+    fun hasCachedWorkflowsList(): Boolean = workflowsListCachedObject.cachedInstance != null
+
     @Synchronized
     fun invalidateWorkflowsListTimestamp() {
         workflowsListCachedObject.clearCacheTimestamp()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -108,6 +108,24 @@ internal class WorkflowsCache(
     }
 
     /**
+     * Drops the in-memory workflows list and its derived offeringId → workflowId map, leaving the
+     * disk copy intact. Used on a 4xx (SHOULD_NOT_FALLBACK) list fetch: the server has intentionally
+     * removed/changed these workflows, so the stale-but-present SWR path in
+     * [com.revenuecat.purchases.common.workflows.WorkflowManager.getWorkflowsList] must not keep
+     * vending the rejected mappings on every later call. Clearing the instance (not just the
+     * timestamp, which [invalidateWorkflowsListTimestamp] does) makes [hasCachedWorkflowsList] report
+     * a cold miss, so the next non-forced call blocks on a fresh fetch rather than re-serving stale.
+     * The disk copy is preserved for the 5xx disk-fallback path, mirroring how
+     * [com.revenuecat.purchases.common.offerings.OfferingsManager] leaves its disk response untouched
+     * on a 4xx while forcing the cache stale.
+     */
+    @Synchronized
+    fun clearInMemoryWorkflowsList() {
+        workflowsListCachedObject.clearCache()
+        offeringIdToWorkflowIdMap = emptyMap()
+    }
+
+    /**
      * Caches the workflows list in memory and persists it to disk, the same way
      * [com.revenuecat.purchases.common.offerings.OfferingsCache.cacheOfferings] caches offerings.
      *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -85,6 +85,21 @@ internal class WorkflowsCache(
         cachedWorkflows[workflowId]?.clearCacheTimestamp()
     }
 
+    /**
+     * Removes [workflowId]'s in-memory detail entry entirely (value and timestamp), unlike
+     * [invalidateWorkflowTimestamp] which keeps the value and only clears its freshness. Used on a
+     * detail 4xx (SHOULD_NOT_FALLBACK): the server has intentionally removed/changed this workflow,
+     * so the stale-while-revalidate path in
+     * [com.revenuecat.purchases.common.workflows.WorkflowManager.getWorkflow] must not keep vending
+     * the rejected value on every later render. Dropping the entry makes the next [cachedWorkflow] a
+     * miss, so the call blocks on a fresh fetch. The per-workflow analogue of
+     * [clearInMemoryWorkflowsList]. No-op when nothing is cached.
+     */
+    @Synchronized
+    fun removeCachedWorkflow(workflowId: String) {
+        cachedWorkflows.remove(workflowId)
+    }
+
     // endregion Workflow detail cache
 
     // region Workflows list cache

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.serialization.SerializationException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.fail
 import org.junit.After
 import org.junit.Before
@@ -1724,6 +1725,41 @@ class WorkflowManagerTest {
 
         // Initial populate + one background refresh = 2 fetches; the joined caller added none.
         verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+    }
+
+    @Test
+    fun `SWR background refresh still starts when the vended onComplete throws`() {
+        val response = WorkflowsListResponse(workflows = emptyList())
+        val firstSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(firstSlot), onError = any())
+        } answers { firstSlot.captured(response) }
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Stale-but-present. Keep the SWR background refresh unresolved.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        val pendingSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(pendingSlot), onError = any())
+        } answers { }
+
+        // The vended callback throws (e.g. a listener dispatched synchronously on the main thread).
+        // The exception propagates to the caller, but the refresh must still start: otherwise the
+        // batch registered for the refresh is never settled and every later caller hangs on it.
+        assertThatThrownBy {
+            workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) {
+                throw IllegalStateException("listener failure")
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+        verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+
+        // The batch was not leaked: a joiner still completes when the refresh settles.
+        var joinerCompleted = false
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { joinerCompleted = true }
+        assertThat(joinerCompleted).isFalse
+        pendingSlot.captured(response)
+        assertThat(joinerCompleted).isTrue
     }
 
     // endregion getWorkflowsList

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -2569,15 +2569,20 @@ class WorkflowManagerTest {
     }
 
     @Test
-    fun `getWorkflowsList invalidates list timestamp on a non-fallback (4xx) error`() {
+    fun `getWorkflowsList drops the in-memory list and map on a non-fallback (4xx) error`() {
         // Stamp the in-memory cache as fresh so the cache does not look stale before the 4xx.
         val recentDate = Date(1_000_000)
         every { mockDateProvider.now } returns recentDate
         workflowsCache.cacheWorkflowsListInMemory(
-            WorkflowsListResponse(workflows = emptyList()),
-            emptyMap(),
+            WorkflowsListResponse(
+                workflows = listOf(
+                    WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+                ),
+            ),
+            mapOf("default" to "wf_1"),
         )
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isFalse()
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isTrue()
 
         val error = PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "forbidden")
         val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
@@ -2588,9 +2593,69 @@ class WorkflowManagerTest {
         // forceRefresh bypasses the freshness check, matching the real caller (createAndCacheOfferings).
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false, forceRefresh = true) {}
 
-        // Timestamp must be cleared so a subsequent non-forced call retries rather than serving a
-        // still-fresh in-memory list — mirrors OfferingsManager.handleErrorFetchingOfferings.
+        // The whole in-memory list must be dropped — not just marked stale — so the stale-but-present
+        // SWR path can't keep vending the server-rejected map. The next non-forced call then sees a
+        // cold miss and blocks on a fresh fetch. Mirrors OfferingsManager forcing the cache stale on 4xx.
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue()
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isFalse()
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isNull()
+    }
+
+    @Test
+    fun `getWorkflowsList stops SWR-serving the rejected map after a 4xx background refresh`() {
+        // Populate the cache at t=0 with a real mapping (auto-resolve the first fetch).
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        val firstSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(firstSlot), onError = any())
+        } answers { firstSlot.captured(response) }
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+
+        // Advance past the TTL: stale-but-present. The next call is served via SWR and fires a
+        // background refresh, which we settle synchronously with a 4xx SHOULD_NOT_FALLBACK error.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers {
+            errorSlot.captured(
+                PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "forbidden"),
+                GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK,
+            )
+        }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns null
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns null
+
+        var firstCompleted = false
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { firstCompleted = true }
+        // SWR vends immediately, even though the background refresh then 4xx'd.
+        assertThat(firstCompleted).isTrue()
+
+        // The 4xx must have dropped the in-memory list, so the rejected map is no longer served.
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isNull()
+
+        // A subsequent call is now a cold miss that blocks on a fresh fetch rather than SWR-serving
+        // the rejected map again. Resolve it with a recovered list.
+        val recovered = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_2", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        val recoverSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(recoverSlot), onError = any())
+        } answers { recoverSlot.captured(recovered) }
+
+        var secondCompleted = false
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { secondCompleted = true }
+        assertThat(secondCompleted).isTrue()
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_2")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -1601,6 +1601,98 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `joiner during an SWR background refresh fires exactly once when the refresh fails`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        // Populate the cache at t=0 (auto-resolve the first fetch).
+        val firstSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(firstSlot), onError = any())
+        } answers { firstSlot.captured(response) }
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Advance past the TTL: stale-but-present. Hold the SWR background refresh in flight by
+        // capturing both slots but resolving neither.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        val pendingSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        val pendingErrorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        every {
+            mockBackend.getWorkflows(
+                any(),
+                any(),
+                type = any(),
+                onSuccess = capture(pendingSuccessSlot),
+                onError = capture(pendingErrorSlot),
+            )
+        } answers { }
+
+        var firstCompleted = false
+        var secondCompleted = false
+
+        // First caller: SWR → vended immediately from stale cache.
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { firstCompleted = true }
+        assertThat(firstCompleted).isTrue()
+
+        // Second caller arrives while the background refresh is in flight: joins the batch.
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { secondCompleted = true }
+        assertThat(secondCompleted).isFalse()
+
+        // Settle the background refresh with a 4xx SHOULD_NOT_FALLBACK error (synchronous path).
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns null
+        every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns null
+        pendingErrorSlot.captured(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "forbidden"),
+            GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK,
+        )
+
+        // Joiner must fire exactly once even though the refresh failed.
+        assertThat(secondCompleted).isTrue()
+    }
+
+    @Test
+    fun `SWR background refresh updates the cached offeringId map on success`() {
+        // Populate cache at t=0 with wf_old mapped to offeringId "default".
+        val oldResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_old", displayName = "Old", offeringId = "default", prefetch = false),
+            ),
+        )
+        val firstSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(firstSlot), onError = any())
+        } answers { firstSlot.captured(oldResponse) }
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_old")
+
+        // Advance past the TTL. Capture the SWR background fetch without resolving it.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        val pendingSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(pendingSuccessSlot), onError = any())
+        } answers { }
+
+        // Trigger the SWR fetch; stale map still reads wf_old.
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_old")
+
+        // Resolve the background refresh with a new mapping wf_new.
+        val newResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_new", displayName = "New", offeringId = "default", prefetch = false),
+            ),
+        )
+        pendingSuccessSlot.captured(newResponse)
+
+        // The cached map must now reflect the refreshed value.
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_new")
+    }
+
+    @Test
     fun `concurrent caller during an SWR background refresh joins it and fires once`() {
         val response = WorkflowsListResponse(workflows = emptyList())
         val firstSlot = slot<(WorkflowsListResponse) -> Unit>()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -484,9 +484,79 @@ class WorkflowManagerTest {
         assertThat(receivedError).isEqualTo(expectedError)
         coVerify(exactly = 0) { mockResolver.resolve(any()) }
         verify(exactly = 0) { mockDeviceCache.getWorkflowDetailEnvelopesCache() }
-        // Invalidate the in-memory entry so the next call retries rather than serving a cached value,
-        // mirroring the list/offerings 4xx policy.
-        verify { workflowsCache.invalidateWorkflowTimestamp("wf_1") }
+        // Remove the in-memory entry so the next call retries rather than the SWR path serving a
+        // still-cached value, mirroring the list/offerings 4xx policy.
+        verify { workflowsCache.removeCachedWorkflow("wf_1") }
+    }
+
+    @Test
+    fun `getWorkflow stops SWR-serving a workflow after a 4xx background refresh`() {
+        val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
+        val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        coEvery { mockResolver.resolve(response) } returns staleResult
+
+        // First backend call succeeds (populates the cache); the second 4xx's (background refresh);
+        // the third succeeds (the retry the next call must make instead of SWR-serving the rejected value).
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        var call = 0
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            call++
+            if (call == 2) {
+                errorSlot.captured(
+                    PurchasesError(PurchasesErrorCode.UnknownBackendError, "not found"),
+                    GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK,
+                )
+            } else {
+                successSlot.captured(response)
+            }
+        }
+
+        // First call at t=0 populates the cache.
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowOrOfferingId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Stale-but-present: SWR serves the cached value immediately, then the background refresh 4xx's.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        var served: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowOrOfferingId = "wf_1",
+            appInBackground = false,
+            onSuccess = { served = it },
+            onError = { fail("unexpected error $it") },
+        )
+        assertThat(served).isSameAs(staleResult)
+
+        // The 4xx must have dropped the entry, so it is no longer served.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
+
+        // The next call is a cold miss that blocks on a fresh fetch rather than SWR-serving the
+        // rejected value again. It succeeds and re-populates the cache.
+        var reserved: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowOrOfferingId = "wf_1",
+            appInBackground = false,
+            onSuccess = { reserved = it },
+            onError = { fail("unexpected error $it") },
+        )
+        assertThat(reserved).isSameAs(staleResult)
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(staleResult)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -1523,6 +1523,117 @@ class WorkflowManagerTest {
         assertThat(workflowManager.workflowIdForOfferingId("default")).isNull()
     }
 
+    @Test
+    fun `getWorkflowsList serves immediately when stale-but-present and not forced`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        // Populate the cache at t=0 (auto-resolve the first fetch).
+        val firstSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(firstSlot), onError = any())
+        } answers { firstSlot.captured(response) }
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Advance past the TTL: stale-but-present. Capture the background fetch WITHOUT resolving it.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        val pendingSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(pendingSlot), onError = any())
+        } answers { }
+
+        var completed = false
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completed = true }
+
+        // SWR: onComplete fired immediately, before the background refresh resolved...
+        assertThat(completed).isTrue
+        // ...and a background refresh was still issued (2 total: initial populate + SWR refresh).
+        verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+    }
+
+    @Test
+    fun `getWorkflowsList blocks until the fetch settles on a cold cache`() {
+        val response = WorkflowsListResponse(workflows = emptyList())
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
+        } answers { } // do not resolve yet
+        every { mockDateProvider.now } returns Date(0)
+
+        var completed = false
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completed = true }
+
+        // Cold miss: nothing cached, so onComplete must wait for the fetch.
+        assertThat(completed).isFalse
+        successSlot.captured(response)
+        assertThat(completed).isTrue
+    }
+
+    @Test
+    fun `getWorkflowsList with forceRefresh blocks even when the cache is stale-but-present`() {
+        val response = WorkflowsListResponse(workflows = emptyList())
+        val firstSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(firstSlot), onError = any())
+        } answers { firstSlot.captured(response) }
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Stale-but-present, but force a refresh and DON'T resolve the backend.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        val pendingSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(pendingSlot), onError = any())
+        } answers { }
+
+        var completed = false
+        workflowManager.getWorkflowsList(
+            appUserID = "user_1", appInBackground = false, forceRefresh = true,
+        ) { completed = true }
+
+        // forceRefresh keeps blocking: onComplete waits for the fetch.
+        assertThat(completed).isFalse
+        pendingSlot.captured(response)
+        assertThat(completed).isTrue
+    }
+
+    @Test
+    fun `concurrent caller during an SWR background refresh joins it and fires once`() {
+        val response = WorkflowsListResponse(workflows = emptyList())
+        val firstSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(firstSlot), onError = any())
+        } answers { firstSlot.captured(response) }
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Stale. Keep the SWR background refresh unresolved so a second caller can arrive mid-flight.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        val pendingSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(pendingSlot), onError = any())
+        } answers { }
+
+        var firstCompleted = false
+        var secondCompleted = false
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { firstCompleted = true }
+        assertThat(firstCompleted).isTrue // vended immediately
+
+        // Second caller while the background refresh is in flight: joins, fires no new fetch.
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { secondCompleted = true }
+        assertThat(secondCompleted).isFalse
+
+        // Settle the background refresh; the joined caller fires exactly once.
+        pendingSlot.captured(response)
+        assertThat(secondCompleted).isTrue
+
+        // Initial populate + one background refresh = 2 fetches; the joined caller added none.
+        verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+    }
+
     // endregion getWorkflowsList
 
     // region workflowIdForOfferingId

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -107,6 +107,25 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `removeCachedWorkflow drops the value entirely, not just its freshness`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        workflowsCache.cacheWorkflow("wf_2", mockk())
+
+        workflowsCache.removeCachedWorkflow("wf_1")
+
+        // wf_1 is gone; wf_2 is untouched.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+        assertThat(workflowsCache.cachedWorkflow("wf_2")).isNotNull
+    }
+
+    @Test
+    fun `removeCachedWorkflow is a no-op when nothing is cached`() {
+        workflowsCache.removeCachedWorkflow("wf_missing")
+        assertThat(workflowsCache.cachedWorkflow("wf_missing")).isNull()
+    }
+
+    @Test
     fun `clearCache removes all cached workflows`() {
         workflowsCache.cacheWorkflow("wf_1", mockk())
         workflowsCache.cacheWorkflow("wf_2", mockk())

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -374,6 +374,23 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `hasCachedWorkflowsList is false before any list is cached`() {
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isFalse
+    }
+
+    @Test
+    fun `hasCachedWorkflowsList is true after caching a list`() {
+        workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap())
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isTrue
+    }
+
+    @Test
+    fun `hasCachedWorkflowsList is true after an in-memory-only restore`() {
+        workflowsCache.cacheWorkflowsListInMemory(WorkflowsListResponse(workflows = emptyList()), emptyMap())
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isTrue
+    }
+
+    @Test
     fun `different workflowIds are cached independently`() {
         val first = mockk<WorkflowDataResult>()
         val second = mockk<WorkflowDataResult>()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -208,6 +208,28 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `clearInMemoryWorkflowsList drops the in-memory list and map but leaves disk untouched`() {
+        workflowsCache.cacheWorkflowsListInMemory(
+            WorkflowsListResponse(
+                workflows = listOf(
+                    WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+                ),
+            ),
+            mapOf("default" to "wf_1"),
+        )
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isTrue
+        assertThat(workflowsCache.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+
+        workflowsCache.clearInMemoryWorkflowsList()
+
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isFalse
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
+        assertThat(workflowsCache.workflowIdForOfferingId("default")).isNull()
+        // The disk copy is preserved for the 5xx fallback path.
+        verify(exactly = 0) { deviceCache.clearWorkflowsListResponseCache() }
+    }
+
+    @Test
     fun `clearCache clears the disk cache`() {
         workflowsCache.clearCache()
         verify(exactly = 1) { deviceCache.clearWorkflowsListResponseCache() }


### PR DESCRIPTION
`WorkflowManager.getWorkflowsList` is the one workflow cache path that still blocked on a stale cache while both of `OfferingsManager` and `WorkflowManager.getWorkflow` already did stale-while-revalidate. 

A stale list cache delayed the offerings vend behind a full list refetch and a prefetch breaking offerings' own SWR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches offerings gating (`onComplete` timing), workflow/offering ID mapping, and cache semantics on 4xx; behavior is heavily tested but wrong SWR or eviction could affect paywall/offering delivery.
> 
> **Overview**
> **`getWorkflowsList`** now uses **stale-while-revalidate** when the in-memory list is past TTL but still present: **`onComplete`** runs immediately (so offerings are not blocked on a full list refetch + prefetch), while a background refresh dedupes concurrent callers. Fresh cache and **`forceRefresh`** / cold miss still complete only after the fetch settles. List fetch logic is centralized in **`fetchWorkflowsList`**.
> 
> On **4xx (SHOULD_NOT_FALLBACK)**, the PR stops only invalidating timestamps. **List** errors call **`clearInMemoryWorkflowsList()`**; **detail** errors call **`removeCachedWorkflow()`**, so SWR cannot keep vending rejected list mappings or workflow payloads. Disk copies stay for 5xx fallback.
> 
> **`WorkflowsCache`** adds **`hasCachedWorkflowsList()`**, **`clearInMemoryWorkflowsList()`**, and **`removeCachedWorkflow()`** to support those paths. Tests cover SWR timing, joiners, background 4xx, and **`onComplete`** throwing without stranding batches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6b285613b9281fc0f26d0bdaa40e6f1f5238b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->