### PR TITLE
feat: stale-while-revalidate for the workflows list fetch

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -234,8 +234,11 @@ internal class WorkflowManager(
         when (action) {
             ListFetchAction.COMPLETE_NOW -> completePendingCallbacks(appUserID)
             ListFetchAction.STALE_WHILE_REVALIDATE -> {
-                onComplete()
-                fetchWorkflowsList(appUserID, appInBackground, forceRefresh = false)
+                try {
+                    onComplete()
+                } finally {
+                    fetchWorkflowsList(appUserID, appInBackground, forceRefresh = false)
+                }
             }
             ListFetchAction.BLOCKING_FETCH -> fetchWorkflowsList(appUserID, appInBackground, forceRefresh)
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -217,52 +217,56 @@ internal class WorkflowManager(
         if (!startFetch) {
             completePendingCallbacks(appUserID)
         } else {
-            backend.getWorkflows(
-                appUserID = appUserID,
-                appInBackground = appInBackground,
-                type = "paywall",
-                onSuccess = { response ->
-                    // Drop workflows without an offeringId: they can't be reached via
-                    // workflowIdForOfferingId, so caching or prefetching them is wasted work.
-                    val filtered = response.onlyWorkflowsWithOfferingId()
-                    // Clear detail caches after a successful fetch so the prefetch loop below is a
-                    // guaranteed cache miss and always populates fresh data. Cleared here rather than
-                    // before the network call so a failed fetch leaves in-memory details intact.
-                    if (forceRefresh) workflowsCache.clearWorkflowDetailCaches()
-                    workflowsCache.cacheWorkflowsList(filtered, buildOfferingIdMap(filtered.workflows))
+            fetchWorkflowsList(appUserID, appInBackground, forceRefresh)
+        }
+    }
 
-                    val prefetchWorkflows = filtered.workflows.filter { it.prefetch }
-                    scope.launch {
-                        // Wait for all prefetches before completing so onComplete fires once the whole
-                        // sequence settles. A failed prefetch is logged and does not fail the others.
-                        // Concurrency is bounded downstream, not here: detail fetches by prefetchDispatcher's
-                        // thread pool, CDN downloads by the workflows FileRepository's limited scope.
-                        coroutineScope {
-                            prefetchWorkflows.forEach { summary ->
-                                launch {
-                                    prefetchWorkflow(appUserID, summary.id, appInBackground)
-                                }
+    private fun fetchWorkflowsList(appUserID: String, appInBackground: Boolean, forceRefresh: Boolean) {
+        backend.getWorkflows(
+            appUserID = appUserID,
+            appInBackground = appInBackground,
+            type = "paywall",
+            onSuccess = { response ->
+                // Drop workflows without an offeringId: they can't be reached via
+                // workflowIdForOfferingId, so caching or prefetching them is wasted work.
+                val filtered = response.onlyWorkflowsWithOfferingId()
+                // Clear detail caches after a successful fetch so the prefetch loop below is a
+                // guaranteed cache miss and always populates fresh data. Cleared here rather than
+                // before the network call so a failed fetch leaves in-memory details intact.
+                if (forceRefresh) workflowsCache.clearWorkflowDetailCaches()
+                workflowsCache.cacheWorkflowsList(filtered, buildOfferingIdMap(filtered.workflows))
+
+                val prefetchWorkflows = filtered.workflows.filter { it.prefetch }
+                scope.launch {
+                    // Wait for all prefetches before completing so onComplete fires once the whole
+                    // sequence settles. A failed prefetch is logged and does not fail the others.
+                    // Concurrency is bounded downstream, not here: detail fetches by prefetchDispatcher's
+                    // thread pool, CDN downloads by the workflows FileRepository's limited scope.
+                    coroutineScope {
+                        prefetchWorkflows.forEach { summary ->
+                            launch {
+                                prefetchWorkflow(appUserID, summary.id, appInBackground)
                             }
                         }
-                        completePendingCallbacks(appUserID)
                     }
-                },
-                onError = { error, behavior ->
-                    errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
-                    if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
-                        // A 4xx means the server intentionally changed/removed these workflows. Don't
-                        // resurrect a stale list from disk; just settle the callbacks so offerings
-                        // delivery isn't stranded. Invalidate the timestamp so the next non-forced call
-                        // retries rather than serving a still-fresh in-memory list — mirrors
-                        // OfferingsManager.handleErrorFetchingOfferings calling forceCacheStale().
-                        workflowsCache.invalidateWorkflowsListTimestamp()
-                        completePendingCallbacks(appUserID)
-                    } else {
-                        restoreWorkflowsListFromDisk(appUserID)
-                    }
-                },
-            )
-        }
+                    completePendingCallbacks(appUserID)
+                }
+            },
+            onError = { error, behavior ->
+                errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
+                if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
+                    // A 4xx means the server intentionally changed/removed these workflows. Don't
+                    // resurrect a stale list from disk; just settle the callbacks so offerings
+                    // delivery isn't stranded. Invalidate the timestamp so the next non-forced call
+                    // retries rather than serving a still-fresh in-memory list — mirrors
+                    // OfferingsManager.handleErrorFetchingOfferings calling forceCacheStale().
+                    workflowsCache.invalidateWorkflowsListTimestamp()
+                    completePendingCallbacks(appUserID)
+                } else {
+                    restoreWorkflowsListFromDisk(appUserID)
+                }
+            },
+        )
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -170,6 +170,8 @@ internal class WorkflowManager(
         }
     }
 
+    private enum class ListFetchAction { COMPLETE_NOW, STALE_WHILE_REVALIDATE, BLOCKING_FETCH }
+
     /**
      * Fetches the workflows list, then prefetches all entries marked `prefetch = true`.
      *
@@ -189,6 +191,12 @@ internal class WorkflowManager(
      * ignores [forceRefresh]: an in-flight batch is not interrupted, so a forced refresh that arrives
      * while a batch is running joins it instead of starting a new fetch. That window self-heals on the
      * next fetch.
+     *
+     * When the cached list is stale but present and the call is not forced, it is served
+     * stale-while-revalidate: [onComplete] fires immediately with the cached offeringId → workflowId
+     * map and the list is refreshed in the background, mirroring
+     * [com.revenuecat.purchases.common.offerings.OfferingsManager.vendCachedOfferingsAndMaybeRefresh].
+     * A forced refresh or a cold miss still blocks until the fetch settles.
      */
     fun getWorkflowsList(
         appUserID: String,
@@ -197,27 +205,39 @@ internal class WorkflowManager(
         onComplete: () -> Unit = {},
     ) {
         // Decide under the lock, act outside it so onComplete never fires while holding it.
-        val startFetch = synchronized(callbackLock) {
+        val action = synchronized(callbackLock) {
             val inFlight = pendingCompletionCallbacks[appUserID]
             if (inFlight != null) {
-                // Already fetching for this user: queue onto it. Joining ignores cache freshness and
-                // forceRefresh on purpose — the list response stamps the cache fresh mid-sequence,
-                // before its prefetch finishes, so a freshness check would let this caller complete
-                // early, and an in-flight batch is never interrupted.
                 inFlight.add(onComplete)
                 return
             }
-            // Nothing in flight: open a batch and fetch when forced or when the cached list is stale.
-            pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
-            forceRefresh || workflowsCache.isWorkflowsListCacheStale(appInBackground)
+            val stale = workflowsCache.isWorkflowsListCacheStale(appInBackground)
+            when {
+                // Fresh, nothing in flight: complete now.
+                !forceRefresh && !stale -> {
+                    pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
+                    ListFetchAction.COMPLETE_NOW
+                }
+                // Stale-but-present, not forced: serve the cached map now and refresh in the background.
+                !forceRefresh && workflowsCache.hasCachedWorkflowsList() -> {
+                    pendingCompletionCallbacks[appUserID] = mutableListOf()
+                    ListFetchAction.STALE_WHILE_REVALIDATE
+                }
+                // Forced, or cold miss: fetch and block.
+                else -> {
+                    pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
+                    ListFetchAction.BLOCKING_FETCH
+                }
+            }
         }
 
-        // Fresh cache and nothing in flight: complete now. Otherwise the request's onSuccess/onError
-        // fire the queued callbacks when it settles.
-        if (!startFetch) {
-            completePendingCallbacks(appUserID)
-        } else {
-            fetchWorkflowsList(appUserID, appInBackground, forceRefresh)
+        when (action) {
+            ListFetchAction.COMPLETE_NOW -> completePendingCallbacks(appUserID)
+            ListFetchAction.STALE_WHILE_REVALIDATE -> {
+                onComplete()
+                fetchWorkflowsList(appUserID, appInBackground, forceRefresh = false)
+            }
+            ListFetchAction.BLOCKING_FETCH -> fetchWorkflowsList(appUserID, appInBackground, forceRefresh)
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -77,6 +77,9 @@ internal class WorkflowsCache(
     // region Workflows list cache
 
     @Synchronized
+    fun hasCachedWorkflowsList(): Boolean = workflowsListCachedObject.cachedInstance != null
+
+    @Synchronized
     fun isWorkflowsListCacheStale(appInBackground: Boolean): Boolean =
         workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -969,6 +969,117 @@ class WorkflowManagerTest {
         assertThat(workflowManager.workflowIdForOfferingId("default")).isNull()
     }
 
+    @Test
+    fun `getWorkflowsList serves immediately when stale-but-present and not forced`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        // Populate the cache at t=0 (auto-resolve the first fetch).
+        val firstSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(firstSlot), onError = any())
+        } answers { firstSlot.captured(response) }
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Advance past the TTL: stale-but-present. Capture the background fetch WITHOUT resolving it.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        val pendingSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(pendingSlot), onError = any())
+        } answers { }
+
+        var completed = false
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completed = true }
+
+        // SWR: onComplete fired immediately, before the background refresh resolved...
+        assertThat(completed).isTrue
+        // ...and a background refresh was still issued (2 total: initial populate + SWR refresh).
+        verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+    }
+
+    @Test
+    fun `getWorkflowsList blocks until the fetch settles on a cold cache`() {
+        val response = WorkflowsListResponse(workflows = emptyList())
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
+        } answers { } // do not resolve yet
+        every { mockDateProvider.now } returns Date(0)
+
+        var completed = false
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completed = true }
+
+        // Cold miss: nothing cached, so onComplete must wait for the fetch.
+        assertThat(completed).isFalse
+        successSlot.captured(response)
+        assertThat(completed).isTrue
+    }
+
+    @Test
+    fun `getWorkflowsList with forceRefresh blocks even when the cache is stale-but-present`() {
+        val response = WorkflowsListResponse(workflows = emptyList())
+        val firstSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(firstSlot), onError = any())
+        } answers { firstSlot.captured(response) }
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Stale-but-present, but force a refresh and DON'T resolve the backend.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        val pendingSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(pendingSlot), onError = any())
+        } answers { }
+
+        var completed = false
+        workflowManager.getWorkflowsList(
+            appUserID = "user_1", appInBackground = false, forceRefresh = true,
+        ) { completed = true }
+
+        // forceRefresh keeps blocking: onComplete waits for the fetch.
+        assertThat(completed).isFalse
+        pendingSlot.captured(response)
+        assertThat(completed).isTrue
+    }
+
+    @Test
+    fun `concurrent caller during an SWR background refresh joins it and fires once`() {
+        val response = WorkflowsListResponse(workflows = emptyList())
+        val firstSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(firstSlot), onError = any())
+        } answers { firstSlot.captured(response) }
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Stale. Keep the SWR background refresh unresolved so a second caller can arrive mid-flight.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        val pendingSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(pendingSlot), onError = any())
+        } answers { }
+
+        var firstCompleted = false
+        var secondCompleted = false
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { firstCompleted = true }
+        assertThat(firstCompleted).isTrue // vended immediately
+
+        // Second caller while the background refresh is in flight: joins, fires no new fetch.
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { secondCompleted = true }
+        assertThat(secondCompleted).isFalse
+
+        // Settle the background refresh; the joined caller fires exactly once.
+        pendingSlot.captured(response)
+        assertThat(secondCompleted).isTrue
+
+        // Initial populate + one background refresh = 2 fetches; the joined caller added none.
+        verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+    }
+
     // endregion getWorkflowsList
 
     // region workflowIdForOfferingId

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -117,6 +117,13 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `hasCachedWorkflowsList is false after clearCache`() {
+        workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap())
+        workflowsCache.clearCache()
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isFalse
+    }
+
+    @Test
     fun `isWorkflowsListCacheStale is true initially and false after caching`() {
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
         workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap())

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -100,6 +100,23 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `hasCachedWorkflowsList is false before any list is cached`() {
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isFalse
+    }
+
+    @Test
+    fun `hasCachedWorkflowsList is true after caching a list`() {
+        workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap())
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isTrue
+    }
+
+    @Test
+    fun `hasCachedWorkflowsList is true after an in-memory-only restore`() {
+        workflowsCache.cacheWorkflowsListInMemory(WorkflowsListResponse(workflows = emptyList()), emptyMap())
+        assertThat(workflowsCache.hasCachedWorkflowsList()).isTrue
+    }
+
+    @Test
     fun `isWorkflowsListCacheStale is true initially and false after caching`() {
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
         workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap())


### PR DESCRIPTION
## Summary

- `WorkflowManager.getWorkflowsList` now serves a stale-but-present cached list immediately and refreshes in the background (SWR), instead of blocking the cached-offerings vend on a full refetch + prefetch loop
- A three-way `ListFetchAction` dispatch replaces the old two-way `forceRefresh || isStale` branch: fresh → complete now, stale-but-present & not forced → SWR, forced or cold miss → blocking fetch
- Mirrors `OfferingsManager.vendCachedOfferingsAndMaybeRefresh` and the detail-fetch SWR added in #3540

## Motivation

`getWorkflowsList` was the last of the three cache paths that still blocked on a stale cache. The cached-offerings vend gates `onSuccess(cachedOfferings)` on `getWorkflowsList` completing, so a stale workflow list delayed offerings delivery even when offerings itself had a fresh cache — partially defeating offerings' own SWR one line earlier.

## Changes

| Path | Before | After |
|---|---|---|
| Fresh (not forced, not stale) | Complete now | Complete now (unchanged) |
| Stale-but-present, not forced | Fetch & block | **SWR: vend now + background refresh** |
| Forced or cold miss | Fetch & block | Fetch & block (unchanged) |

`forceRefresh = true` keeps blocking — it's passed only after a fresh offerings network response to realign the `offeringId → workflowId` map, where serving a stale map against just-changed offerings could briefly vend a mismatched mapping.

The SWR branch registers an empty batch in `pendingCompletionCallbacks` before releasing the lock, so a concurrent stale caller joins the in-flight background refresh rather than starting a second fetch + prefetch loop. The `STALE_WHILE_REVALIDATE` dispatch wraps `onComplete()` in `try/finally` to guarantee `fetchWorkflowsList` always runs (and cleans up the map entry) even if the callback throws.

## Test plan

- `WorkflowsCacheTest`: 3 tests covering `hasCachedWorkflowsList` (false before cache, true after `cacheWorkflowsList`, true after `cacheWorkflowsListInMemory`, false after `clearCache`)
- `WorkflowManagerTest`: 4 new tests covering SWR vends immediately before background resolves, cold miss blocks, `forceRefresh` blocks even when stale-but-present, concurrent caller joins the in-flight refresh and fires exactly once on settle
- `OfferingsManager` suite and full `:purchases:testDefaultsBc8DebugUnitTest` pass