### PR TITLE
Align paywall-rendering-validation density with iOS

### DIFF
--- a/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
+++ b/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
@@ -1,6 +1,10 @@
 package com.revenuecat.purchases.ui.revenuecatui.snapshottests
 
 import app.cash.paparazzi.DeviceConfig
+import com.android.resources.Density
+import com.android.resources.ScreenOrientation
+import com.android.resources.ScreenRatio
+import com.android.resources.ScreenSize
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallComponentsTemplate_Preview
@@ -31,8 +35,21 @@ class PaywallComponentsTemplatePreviewRecorder internal constructor(
     private val paywall: PaywallResources,
 ) : BasePaparazziTest(
     testConfig = TestConfig(
-        name = "pixel6",
-        deviceConfig = DeviceConfig.PIXEL_6,
+        name = "validation",
+        // Renders on a 450 x 1000 dp canvas at 3x density (480 dpi) to match the iOS paywall
+        // validation screenshots, which lay out at 450 x 1000 pt and capture at 3x. Paparazzi
+        // downscales the longest side to 1000px, so the output PNG ends up 450 x 1000 px on both
+        // platforms, keeping the layout canvas and supersampling density consistent.
+        deviceConfig = DeviceConfig(
+            screenWidth = 1350,
+            screenHeight = 3000,
+            xdpi = 480,
+            ydpi = 480,
+            orientation = ScreenOrientation.PORTRAIT,
+            density = Density.create(480),
+            ratio = ScreenRatio.LONG,
+            size = ScreenSize.NORMAL,
+        ),
     ),
 ) {
 

--- a/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
+++ b/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
@@ -36,17 +36,13 @@ class PaywallComponentsTemplatePreviewRecorder internal constructor(
 ) : BasePaparazziTest(
     testConfig = TestConfig(
         name = "validation",
-        // Renders on a 450 x 1000 dp canvas at 3x density (480 dpi) to match the iOS paywall
-        // validation screenshots, which lay out at 450 x 1000 pt and capture at 3x. Paparazzi
-        // downscales the longest side to 1000px, so the output PNG ends up 450 x 1000 px on both
-        // platforms, keeping the layout canvas and supersampling density consistent.
         deviceConfig = DeviceConfig(
             screenWidth = 1350,
             screenHeight = 3000,
             xdpi = 480,
             ydpi = 480,
             orientation = ScreenOrientation.PORTRAIT,
-            density = Density.create(480),
+            density = Density.create(SCALE * DENSITY_BASE),
             ratio = ScreenRatio.LONG,
             size = ScreenSize.NORMAL,
         ),
@@ -54,6 +50,12 @@ class PaywallComponentsTemplatePreviewRecorder internal constructor(
 ) {
 
     companion object {
+        // px = dp * (dpi / 160)
+        const val DENSITY_BASE = 160
+
+        // same scale as iOS uses
+        const val SCALE = 3
+
         @JvmStatic
         // Placing the offering ID between triple underscores so we can easily parse it later.
         @Parameters(name = "___{0}___")


### PR DESCRIPTION
## Description
The paywall-rendering-validation screenshots are being compared across platforms, but Android and iOS rendered at different pixel densities. This aligns Android with iOS (which is the path of least resistance).

On iOS we were using an iPhone 16 simulator's default scale of 3, which corresponds to a density on Android of 3x160=480.

Eyeballing the changes in Emerge and comparing them with what's currently in [paywall-rendering-validation](https://github.com/RevenueCat/paywall-rendering-validation) seems to confirm that this brings the difference between Android and iOS down by a lot. (It's not entirely gone though. Likely fonts and text rendering.)

Keep in mind that we'd still need to align the web SDK and the editor, but this is already an improvement.


<div><a href="https://cursor.com/agents/bc-d161bcee-534c-49e9-a7b5-cd740c336afe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d161bcee-534c-49e9-a7b5-cd740c336afe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes snapshot test device configuration in debug tests; no production paywall or runtime behavior.
> 
> **Overview**
> Updates **paywall-rendering-validation** Paparazzi recording in `PaywallComponentsTemplatePreviewRecorder` so Android screenshots use the same effective scale as iOS (3×, **480 dpi**) instead of `DeviceConfig.PIXEL_6`.
> 
> The test config is renamed from `"pixel6"` to `"validation"` and uses an explicit `DeviceConfig` (1350×3000 portrait, `xdpi`/`ydpi` 480, `Density.create(SCALE * DENSITY_BASE)` with documented `SCALE = 3` and `DENSITY_BASE = 160`). Re-recorded snapshots will differ from prior Android baselines but should compare more closely to iOS in the validation repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e197e9afd118d315c5b3c1b9a24fbd986a56dfab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->