### PR TITLE
fix(workflows): evict workflow detail cache on 4xx so a retracted workflow is not re-served

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -160,10 +160,11 @@ internal class WorkflowManager(
             { error, behavior ->
                 if (behavior == GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK) {
                     // 4xx: the server intentionally changed/removed this workflow, so don't serve the
-                    // saved copy. Invalidate the in-memory entry so the next call retries rather than
-                    // serving a still-cached value — mirrors the list's invalidateWorkflowsListTimestamp
-                    // and OfferingsManager's forceCacheStale on 4xx.
-                    workflowsCache.invalidateWorkflowTimestamp(workflowId)
+                    // saved copy. Evict the in-memory entry entirely (value included) rather than only
+                    // clearing its timestamp: on the stale-while-revalidate render path the entry would
+                    // otherwise stay as a stale-but-present hit and keep being served on every
+                    // subsequent render. Removing it forces the next call to miss and surface the error.
+                    workflowsCache.clearWorkflow(workflowId)
                     onError(error)
                 } else {
                     // Transport error / 5xx / malformed body: the backend is unavailable, not refusing.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -73,16 +73,28 @@ internal class WorkflowsCache(
     }
 
     /**
-     * Clears the cached timestamp for [workflowId]'s in-memory detail entry, forcing the next
-     * [isWorkflowCacheStale] check to report it stale so a subsequent fetch retries rather than
-     * serving the still-cached value. The per-workflow analogue of [invalidateWorkflowsListTimestamp]
-     * (and of [com.revenuecat.purchases.common.offerings.OfferingsCache.forceCacheStale]); the detail
-     * fetch calls it on a terminal error that produced no fresh value, matching how the list and
-     * offerings invalidate their cache on the same failures. No-op when nothing is cached.
+     * Clears the cached timestamp for [workflowId]'s in-memory detail entry while keeping the
+     * resolved value, forcing the next [isWorkflowCacheStale] check to report it stale so a
+     * subsequent fetch retries. The value is intentionally retained: this is used on transient
+     * failures (transport / 5xx with no disk envelope to recover), where stale-while-revalidate
+     * should keep serving the saved copy and just retry in the background. For a 4xx, where the
+     * saved copy must no longer be served, use [clearWorkflow] instead. No-op when nothing is cached.
      */
     @Synchronized
     fun invalidateWorkflowTimestamp(workflowId: String) {
         cachedWorkflows[workflowId]?.clearCacheTimestamp()
+    }
+
+    /**
+     * Removes [workflowId]'s in-memory detail entry entirely (value and timestamp), so it is neither
+     * served as a fresh hit nor as a stale-but-present stale-while-revalidate hit. Used on a 4xx,
+     * where the server has authoritatively removed or refused the workflow and the saved copy must
+     * not be shown again. Contrast with [invalidateWorkflowTimestamp], which keeps the value so it
+     * can keep being served while a transient failure is retried. No-op when nothing is cached.
+     */
+    @Synchronized
+    fun clearWorkflow(workflowId: String) {
+        cachedWorkflows.remove(workflowId)
     }
 
     // endregion Workflow detail cache

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -382,9 +382,79 @@ class WorkflowManagerTest {
         assertThat(receivedError).isEqualTo(expectedError)
         coVerify(exactly = 0) { mockResolver.resolve(any()) }
         verify(exactly = 0) { mockDeviceCache.getWorkflowDetailEnvelopesCache() }
-        // Invalidate the in-memory entry so the next call retries rather than serving a cached value,
+        // Evict the in-memory entry so the next call retries rather than serving a cached value,
         // mirroring the list/offerings 4xx policy.
-        verify { workflowsCache.invalidateWorkflowTimestamp("wf_1") }
+        verify { workflowsCache.clearWorkflow("wf_1") }
+    }
+
+    @Test
+    fun `getWorkflow 4xx on the background refresh evicts the workflow so it is not served again`() {
+        // A workflow is cached, then the server removes it (4xx). SWR serves the stale value on the
+        // render that triggers the refresh (unavoidable), but the retracted workflow must not be
+        // served on any subsequent render. A 4xx therefore has to evict the cached value entirely,
+        // not just clear its timestamp (which would leave it as a stale-but-present SWR hit).
+        val inlineResponse = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val staleResult = WorkflowDataResult(workflow = inlineResponse.data!!, enrolledVariants = null)
+        coEvery { mockResolver.resolve(inlineResponse) } returns staleResult
+
+        val notFound = PurchasesError(PurchasesErrorCode.UnknownBackendError, "not found")
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        val errorSlot = slot<(PurchasesError, GetWorkflowsErrorHandlingBehavior) -> Unit>()
+        var call = 0
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            call++
+            if (call == 1) {
+                successSlot.captured(inlineResponse)
+            } else {
+                errorSlot.captured(notFound, GetWorkflowsErrorHandlingBehavior.SHOULD_NOT_FALLBACK)
+            }
+        }
+
+        // Populate at t=0.
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Stale render at t=6min: serves the stale value, the background refresh then 4xxes.
+        every { mockDateProvider.now } returns Date(6L * 60 * 1000)
+        var served: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { served = it },
+            onError = { fail("unexpected error $it") },
+        )
+        assertThat(served).isSameAs(staleResult)
+
+        // The 4xx must have evicted the cached value entirely, not just cleared its timestamp.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
+
+        // Consequence: the next render does not re-serve the retracted workflow; it surfaces the error.
+        var servedAgain: WorkflowDataResult? = null
+        var errorAgain: PurchasesError? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { servedAgain = it },
+            onError = { errorAgain = it },
+        )
+        assertThat(servedAgain).isNull()
+        assertThat(errorAgain).isEqualTo(notFound)
     }
 
     @Test


### PR DESCRIPTION
Stacked on #3567.

## Problem

On a 4xx for a workflow detail fetch, the fallback handler called `invalidateWorkflowTimestamp`, which only nulls the in-memory entry's timestamp and **keeps its resolved value**. On the stale-while-revalidate render path (the default, used by `PurchasesOrchestrator.getWorkflow`), this leaves a stale-but-present entry:

1. Render serves the stale value, fires a background refresh.
2. Backend returns 4xx (`SHOULD_NOT_FALLBACK`) → timestamp invalidated, value retained.
3. Next render hits `cached != null && staleWhileRevalidate` → serves the retracted workflow **again**, refreshes, 4xxes again, loops.

So the 4xx branch's stated intent ("don't serve the saved copy") was only honored on the miss path (where there is no value to serve). A workflow the server has removed/refused keeps rendering until a force-refresh (`clearWorkflowDetailCaches`) or identity-clear.

## Fix

Add `WorkflowsCache.clearWorkflow(workflowId)`, which removes the entry entirely (value and timestamp), and call it from the 4xx branch. `invalidateWorkflowTimestamp` is kept for the transient fallback paths in `resolveDiskFallback` (no disk envelope / resolve throws), where SWR *should* keep serving the saved copy and just retry. The two methods now have distinct, documented semantics.

The render that triggered the refresh still serves the stale value once (inherent to SWR, unavoidable); the fix ensures no *subsequent* render does.

## Proof

New test `getWorkflow 4xx on the background refresh evicts the workflow so it is not served again`:
- **Before the fix:** fails at the cache-empty assertion (`expected: null but was: WorkflowDataResult(...)`) — the retracted workflow stays cached and is re-served.
- **After the fix:** `WorkflowManagerTest` + `WorkflowsCacheTest` = 63 tests, 0 failures. `./gradlew detektAll` BUILD SUCCESSFUL.

## Known residual (intentionally out of scope here)

A 4xx evicts the in-memory value but does not prune that workflow's **disk envelope**. If it was a prefetched workflow, a later offline list-fetch fallback (`restoreWorkflowDetailsFromDisk`) could re-resolve and re-serve it. Disk envelopes are pruned only when the *list* drops the workflow (`pruneWorkflowDetailEnvelopesToList`). A detail-4xx-while-still-listed is contradictory backend state and rare. Flag if you want the 4xx branch to also drop the disk envelope.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: stacked on #3567 (this PR number assigned on creation)
- Branch: `review/3567-4xx-evict` (base: `cesar/workflow-feature-task`)
- Author / human owner: facumenzella
- Agent(s): Claude Code (Fable 5 / claude-fable-5)
- Session source: current conversation
- Generated: 2026-06-10
- Context document version: 1

## Goal

Review purchases-android #3567 (workflow detail 4xx fallback), validate it against iOS, then address a concrete defect found in review and prove it with a test.

## Initial Prompt

"Let's review #3567. What's missing? Validate against iOS." Follow-up narrowed to: ignore iOS, do a harsh review of #3567; then "how do we address [finding] 1? Can we prove the problem with a test?"; then "push this, and open a draft PR stacked on this one".

## Important Follow-up Prompts

- "ignore ios for now" — refocus from cross-platform validation to a standalone critical review of the Android PR.
- "how do we address 1? Can we prove the problem with a test?" — fix the 4xx-keeps-serving defect with a red→green test.

## Agent Contribution

- Traced the SWR/4xx interaction through `WorkflowManager.getWorkflow` → `fetchAndCacheWorkflow` → `onErrorWithFallback`, `WorkflowsCache.invalidateWorkflowTimestamp`, `InMemoryCachedObject.clearCacheTimestamp` (nulls timestamp, keeps value), and the render caller `PurchasesOrchestrator.getWorkflow` (default `staleWhileRevalidate = true`).
- Wrote a failing test reproducing the re-serve; implemented `WorkflowsCache.clearWorkflow`; switched the 4xx branch to evict; updated the existing 4xx miss test and KDoc/comments.

## Human Decisions

- Directed the review to ignore iOS and to fix finding #1.
- Approved pushing and opening this as a draft PR stacked on #3567.
- Deferred the disk-envelope-on-4xx pruning (kept out of scope).

## Key Implementation Decisions

- Decision: evict the value on 4xx via a new `clearWorkflow`, keep `invalidateWorkflowTimestamp` for transient paths.
  - Rationale: a 4xx is authoritative (`SHOULD_NOT_FALLBACK`); the saved copy must not be re-served. Transient errors should keep serving stale and retry.
  - Rejected: changing `invalidateWorkflowTimestamp` to also drop the value (would break the transient `resolveDiskFallback` paths that intentionally keep the stale value).

## Files / Symbols Touched

- `purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt`
  - Symbols: new `clearWorkflow(workflowId)`; clarified `invalidateWorkflowTimestamp` KDoc.
  - Review relevance: `clearWorkflow` removes the map entry; confirm `@Synchronized` and no other caller depends on value-retention.
- `purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt`
  - Symbols: `fetchAndCacheWorkflow` → `onErrorWithFallback` 4xx branch.
  - Review relevance: 4xx now calls `clearWorkflow`; transient branch still uses `resolveDiskFallback` (which uses `invalidateWorkflowTimestamp`).
- `purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt`
  - Symbols: new SWR-4xx eviction test; updated `getWorkflow does not fall back to disk envelope on 4xx` to verify `clearWorkflow`.

## Dependencies / Config / Migrations

- None.

## Validation

- Commands run:
  - `./gradlew :purchases:testDefaultsBc8DebugUnitTest --tests "...WorkflowManagerTest" --tests "...WorkflowsCacheTest"`: 63 tests, 0 failures (new test red before the production change, green after).
  - `./gradlew detektAll`: BUILD SUCCESSFUL.
- Manual verification: Not run (covered by automated test).
- CI: Not captured (will run on PR).

## Validation Gaps

- Bc7 variant not run locally (`testDefaultsBc7DebugUnitTest`).
- Disk-envelope re-serve after a detail 4xx is not covered (out of scope; see residual note).

## Review Focus

- Is evicting on 4xx (vs keeping-stale) the desired product behavior for a retracted workflow?
- Should the 4xx branch also prune the persisted disk envelope to prevent offline re-serve via `restoreWorkflowDetailsFromDisk`?

## Risks / Reviewer Notes

- Risk: a 4xx that is actually transient/auth-scoped now drops the cached workflow.
  - Evidence: 4xx is defined as `SHOULD_NOT_FALLBACK` (authoritative) in this codebase.
  - Mitigation: next call refetches; transient (5xx/transport) errors are unaffected (still keep-stale + retry).

## Non-goals / Out of Scope

- Pruning disk envelopes on detail 4xx.
- Any iOS change (a matching per-detail fallback is planned separately on iOS).

## Omitted Context

- Raw transcript, iOS cross-validation details, repetitive attempts, and chain-of-thought were omitted.

</details>
