### PR TITLE
Exclude rules-engine-internal from public sealed/data class detekt rules

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -29,7 +29,7 @@ complexity:
 libraries:
   active: true
   ForbiddenPublicDataClass:
-    excludes: [ '**/examples/**' ]
+    excludes: [ '**/examples/**', '**/rules-engine-internal/**' ]
     ignoreAnnotated: [ 'InternalRevenueCatAPI' ]
   LibraryEntitiesShouldNotBePublic:
     active: false
@@ -43,5 +43,5 @@ revenuecat:
   active: true
   ForbiddenPublicSealedClass:
     active: true
-    excludes: [ '**/examples/**' ]
+    excludes: [ '**/examples/**', '**/rules-engine-internal/**' ]
     ignoreAnnotated: [ 'InternalRevenueCatAPI' ]


### PR DESCRIPTION
### Motivation
`rules-engine-internal` is an internal module whose API is only consumed by other the RevenueCat SDK, so API-compatibility concerns behind `ForbiddenPublicSealedClass` and `ForbiddenPublicDataClass` don't apply. 

### Description
Adds `**/rules-engine-internal/**` to the `excludes` of both rules in `config/detekt/detekt.yml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static analysis config only; no runtime or public SDK API behavior changes.
> 
> **Overview**
> Detekt is updated so **`rules-engine-internal`** is treated like **`examples`**: paths under `**/rules-engine-internal/**` are excluded from **`ForbiddenPublicDataClass`** (libraries) and **`ForbiddenPublicSealedClass`** (revenuecat).
> 
> That lets the internal rules-engine module use public data/sealed types without the SDK’s public-API compatibility lint, since it is only consumed inside the SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9179f65fa8dce59c01dd024836594560eb04639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->