### PR TITLE
Revives update-paywall-templates workflow

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,12 +35,19 @@ default_platform(:android)
 
 # Hack to work around a Fastlane quirk where plugin actions are run from the parent of the current working directory.
 # We switch to the first subdirectory, then run the action. The action will run from the parent of the subdirectory, which is
-# our actual current working directory. The obvious limitation is that this doesn't work if the current working directory
-# does not have any subdirectories.
-# This is only needed when our current working directory is not the ./fastlane directory.
+# our actual current working directory.
+# This is only needed when our current working directory is not the ./fastlane directory. When it is the ./fastlane
+# directory, Fastlane already runs plugin actions from its parent (the repository root), which is what we want, so we
+# run the action directly. We also fall back to running directly when there are no subdirectories to switch into,
+# which otherwise raised "undefined method `chomp' for nil:NilClass".
 # https://docs.fastlane.tools/advanced/fastlane/#directory-behavior
 def run_plugin_action_in_current_directory(&block)
-  Dir.chdir(Dir["*/"].first.chomp("/"), &block)
+  first_subdirectory = Dir["*/"].first
+  if first_subdirectory.nil?
+    block.call
+  else
+    Dir.chdir(first_subdirectory.chomp("/"), &block)
+  end
 end
 
 platform :android do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,10 +36,7 @@ default_platform(:android)
 # Hack to work around a Fastlane quirk where plugin actions are run from the parent of the current working directory.
 # We switch to the first subdirectory, then run the action. The action will run from the parent of the subdirectory, which is
 # our actual current working directory.
-# This is only needed when our current working directory is not the ./fastlane directory. When it is the ./fastlane
-# directory, Fastlane already runs plugin actions from its parent (the repository root), which is what we want, so we
-# run the action directly. We also fall back to running directly when there are no subdirectories to switch into,
-# which otherwise raised "undefined method `chomp' for nil:NilClass".
+# This is only needed when our current working directory is not the ./fastlane directory.
 # https://docs.fastlane.tools/advanced/fastlane/#directory-behavior
 def run_plugin_action_in_current_directory(&block)
   first_subdirectory = Dir["*/"].first


### PR DESCRIPTION
## Description
The `update_paywall_preview_resources_submodule` lane has been failing since November, meaning the `paywall-preview-resources` submodule didn't get updated. [Here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/22893/workflows/52d5ef6a-8029-443c-8bf6-ac662ef9ae99/jobs/230849)'s the latest failure.

## Cause
```
Fastfile:43:in `run_plugin_action_in_current_directory': undefined method `chomp' for nil:NilClass (NoMethodError)
```

This broke in #2858 when I added `run_plugin_action_in_current_directory`. This crashes when the directory has no subdirectories.

## Fix
Make `run_plugin_action_in_current_directory` fall back to running the action directly when there are no subdirectories. 

<div><a href="https://cursor.com/agents/bc-916e35d0-71c1-49cb-ab37-f644d0757727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-916e35d0-71c1-49cb-ab37-f644d0757727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change to CI-only Fastlane directory workaround; no app or SDK runtime impact.
> 
> **Overview**
> Fixes **`run_plugin_action_in_current_directory`** in the Fastfile so automated lanes no longer crash when the current working directory has **no subdirectories**.
> 
> Previously the helper always called `Dir["*/"].first.chomp("/")`, which raised **`NoMethodError`** when `.first` was `nil`—breaking CI jobs such as **`update_paywall_preview_resources_submodule`** (and the update-paywall-templates workflow) since November.
> 
> The change stores the first subdirectory in a variable and, if it is missing, **invokes the block in place** instead of `chdir`ing; otherwise behavior is unchanged. A comment about the old limitation was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b2dfeaa389811a3c4e7ee305a06164ebea826c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->