### PR TITLE
URL-encode offering IDs in `PaywallComponentsTemplatePreviewRecorder`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -902,9 +902,6 @@ DESC
       record_paparazzi_screenshots(gradle_module: ":ui:revenuecatui", tests: "PaywallComponentsTemplatePreviewRecorder", output_dir: tmp_dir)
       # Loop over all PNG files in the tmp_dir, parse the offering ID from the file names, and move them into the target repository.
       sh("find #{tmp_dir} -name '*.png'").split("\n").each do |file_path|
-        # The recorder percent-encodes the offering ID and places it between triple underscores in the snapshot file
-        # name. We percent-decode it to recover the exact offering ID, including any characters Paparazzi would
-        # otherwise rewrite in the file name (e.g. spaces). See PaywallComponentsTemplatePreviewRecorder.
         if file_path =~ /___([0-9A-Za-z%.-]+)___/
           offering_id = CGI.unescape($1).force_encoding("UTF-8")
           target_dir = "#{target_repository_path}/screenshots/templates/#{offering_id}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,9 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
+# Used to percent-decode offering IDs parsed from Paparazzi snapshot file names.
+require "cgi"
+
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
@@ -899,11 +902,11 @@ DESC
       record_paparazzi_screenshots(gradle_module: ":ui:revenuecatui", tests: "PaywallComponentsTemplatePreviewRecorder", output_dir: tmp_dir)
       # Loop over all PNG files in the tmp_dir, parse the offering ID from the file names, and move them into the target repository.
       sh("find #{tmp_dir} -name '*.png'").split("\n").each do |file_path|
-        # The recorder hex-encodes the offering ID and places it between triple underscores in the snapshot file name.
-        # We hex-decode it to recover the exact offering ID, including any characters Paparazzi would otherwise rewrite
-        # in the file name (e.g. spaces). See PaywallComponentsTemplatePreviewRecorder.
-        if file_path =~ /___([0-9a-f]+)___/
-          offering_id = [$1].pack("H*").force_encoding("UTF-8")
+        # The recorder percent-encodes the offering ID and places it between triple underscores in the snapshot file
+        # name. We percent-decode it to recover the exact offering ID, including any characters Paparazzi would
+        # otherwise rewrite in the file name (e.g. spaces). See PaywallComponentsTemplatePreviewRecorder.
+        if file_path =~ /___([0-9A-Za-z%.-]+)___/
+          offering_id = CGI.unescape($1).force_encoding("UTF-8")
           target_dir = "#{target_repository_path}/screenshots/templates/#{offering_id}"
           sh("mkdir -p \"#{target_dir}\"")
           sh("mv \"#{file_path}\" \"#{target_dir}/android.png\"")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -899,8 +899,11 @@ DESC
       record_paparazzi_screenshots(gradle_module: ":ui:revenuecatui", tests: "PaywallComponentsTemplatePreviewRecorder", output_dir: tmp_dir)
       # Loop over all PNG files in the tmp_dir, parse the offering ID from the file names, and move them into the target repository.
       sh("find #{tmp_dir} -name '*.png'").split("\n").each do |file_path|
-        if file_path =~ /\_\_\_(.*?)\_\_\_/
-          offering_id = $1
+        # The recorder hex-encodes the offering ID and places it between triple underscores in the snapshot file name.
+        # We hex-decode it to recover the exact offering ID, including any characters Paparazzi would otherwise rewrite
+        # in the file name (e.g. spaces). See PaywallComponentsTemplatePreviewRecorder.
+        if file_path =~ /___([0-9a-f]+)___/
+          offering_id = [$1].pack("H*").force_encoding("UTF-8")
           target_dir = "#{target_repository_path}/screenshots/templates/#{offering_id}"
           sh("mkdir -p \"#{target_dir}\"")
           sh("mv \"#{file_path}\" \"#{target_dir}/android.png\"")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,7 +10,6 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
-# Used to percent-decode offering IDs parsed from Paparazzi snapshot file names.
 require "cgi"
 
 # Uncomment the line if you want fastlane to automatically update itself

--- a/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
+++ b/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
@@ -57,12 +57,14 @@ class PaywallComponentsTemplatePreviewRecorder internal constructor(
         const val SCALE = 3
 
         @JvmStatic
-        // We hex-encode the offering ID and place it between triple underscores so we can easily and unambiguously
+        // We percent-encode the offering ID and place it between triple underscores so we can easily and unambiguously
         // parse it later. We can't use the raw offering ID, because Paparazzi rewrites characters that are not safe in
         // file names (e.g. spaces become underscores) when generating the snapshot file name. Since some offering IDs
-        // contain real underscores (e.g. "wide_badge_style"), we can't reliably reverse that sanitization. Hex encoding
-        // only produces characters that Paparazzi leaves untouched, so the screenshot upload lane can recover the exact
-        // offering ID by hex-decoding it.
+        // contain real underscores (e.g. "wide_badge_style"), we can't reliably reverse that sanitization. Our
+        // percent-encoding only emits characters that Paparazzi leaves untouched, and never emits an underscore, so the
+        // triple-underscore delimiters stay unambiguous and the screenshot upload lane can recover the exact offering ID
+        // by percent-decoding it. We use percent-encoding rather than e.g. hex to keep these names (which also show up
+        // on Emerge) somewhat human-readable.
         @Parameters(name = "___{0}___")
         fun data(): List<Array<Any>> {
             // The PaywallResourcesProvider uses an OfferingParser under the hood, which logs.
@@ -71,14 +73,21 @@ class PaywallComponentsTemplatePreviewRecorder internal constructor(
             Purchases.logHandler = PrintLnLogHandler
             return PaywallResourcesProvider()
                 .values
-                .map { paywall -> arrayOf(paywall.offering.identifier.encodeToHexString(), paywall) }
+                .map { paywall -> arrayOf(paywall.offering.identifier.percentEncodeForSnapshotName(), paywall) }
                 .toList()
         }
 
-        private fun String.encodeToHexString(): String =
-            toByteArray(Charsets.UTF_8).joinToString(separator = "") { byte ->
-                "%02x".format(byte.toUByte().toInt())
+        // Percent-encodes the receiver, keeping only ASCII letters, digits, '.' and '-' literal (all of which Paparazzi
+        // preserves in snapshot file names). Every other byte - including spaces and underscores - becomes %XX, so the
+        // result stays readable yet never collides with the triple-underscore delimiters nor Paparazzi's sanitization.
+        private fun String.percentEncodeForSnapshotName(): String {
+            val unreserved = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.-"
+            return toByteArray(Charsets.UTF_8).joinToString(separator = "") { byte ->
+                val code = byte.toUByte().toInt()
+                val char = code.toChar()
+                if (char in unreserved) char.toString() else "%%%02X".format(code)
             }
+        }
 
         @JvmStatic
         @BeforeClass

--- a/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
+++ b/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
@@ -57,14 +57,7 @@ class PaywallComponentsTemplatePreviewRecorder internal constructor(
         const val SCALE = 3
 
         @JvmStatic
-        // We percent-encode the offering ID and place it between triple underscores so we can easily and unambiguously
-        // parse it later. We can't use the raw offering ID, because Paparazzi rewrites characters that are not safe in
-        // file names (e.g. spaces become underscores) when generating the snapshot file name. Since some offering IDs
-        // contain real underscores (e.g. "wide_badge_style"), we can't reliably reverse that sanitization. Our
-        // percent-encoding only emits characters that Paparazzi leaves untouched, and never emits an underscore, so the
-        // triple-underscore delimiters stay unambiguous and the screenshot upload lane can recover the exact offering ID
-        // by percent-decoding it. We use percent-encoding rather than e.g. hex to keep these names (which also show up
-        // on Emerge) somewhat human-readable.
+        // Placing the offering ID between triple underscores and percent-encoding it so we can easily parse it later.
         @Parameters(name = "___{0}___")
         fun data(): List<Array<Any>> {
             // The PaywallResourcesProvider uses an OfferingParser under the hood, which logs.
@@ -73,14 +66,13 @@ class PaywallComponentsTemplatePreviewRecorder internal constructor(
             Purchases.logHandler = PrintLnLogHandler
             return PaywallResourcesProvider()
                 .values
-                .map { paywall -> arrayOf(paywall.offering.identifier.percentEncodeForSnapshotName(), paywall) }
+                .map { paywall -> arrayOf(paywall.offering.identifier.percentEncoded(), paywall) }
                 .toList()
         }
 
-        // Percent-encodes the receiver, keeping only ASCII letters, digits, '.' and '-' literal (all of which Paparazzi
-        // preserves in snapshot file names). Every other byte - including spaces and underscores - becomes %XX, so the
-        // result stays readable yet never collides with the triple-underscore delimiters nor Paparazzi's sanitization.
-        private fun String.percentEncodeForSnapshotName(): String {
+        // Percent-encodes this String, keeping only ASCII letters, digits, '.' and '-' literal (all of which Paparazzi
+        // preserves in snapshot file names).
+        private fun String.percentEncoded(): String {
             val unreserved = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.-"
             return toByteArray(Charsets.UTF_8).joinToString(separator = "") { byte ->
                 val code = byte.toUByte().toInt()

--- a/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
+++ b/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
@@ -57,7 +57,12 @@ class PaywallComponentsTemplatePreviewRecorder internal constructor(
         const val SCALE = 3
 
         @JvmStatic
-        // Placing the offering ID between triple underscores so we can easily parse it later.
+        // We hex-encode the offering ID and place it between triple underscores so we can easily and unambiguously
+        // parse it later. We can't use the raw offering ID, because Paparazzi rewrites characters that are not safe in
+        // file names (e.g. spaces become underscores) when generating the snapshot file name. Since some offering IDs
+        // contain real underscores (e.g. "wide_badge_style"), we can't reliably reverse that sanitization. Hex encoding
+        // only produces characters that Paparazzi leaves untouched, so the screenshot upload lane can recover the exact
+        // offering ID by hex-decoding it.
         @Parameters(name = "___{0}___")
         fun data(): List<Array<Any>> {
             // The PaywallResourcesProvider uses an OfferingParser under the hood, which logs.
@@ -66,9 +71,14 @@ class PaywallComponentsTemplatePreviewRecorder internal constructor(
             Purchases.logHandler = PrintLnLogHandler
             return PaywallResourcesProvider()
                 .values
-                .map { paywall -> arrayOf(paywall.offering.identifier, paywall) }
+                .map { paywall -> arrayOf(paywall.offering.identifier.encodeToHexString(), paywall) }
                 .toList()
         }
+
+        private fun String.encodeToHexString(): String =
+            toByteArray(Charsets.UTF_8).joinToString(separator = "") { byte ->
+                "%02x".format(byte.toUByte().toInt())
+            }
 
         @JvmStatic
         @BeforeClass


### PR DESCRIPTION
## Description
Paparazzi replaces any spaces in test names with underscores. This is a problem in [paywall-rendering-validation](https://github.com/RevenueCat/paywall-rendering-validation). An offering ID with a space, such as "Virtual currencies 1", would cause Android's screenshot to show up under "Virtual_currencies_1". Other platforms don't have this limitation.

## Fix
The fix is to URL encode the offering IDs in Paparazzi tests, and decode them before they're uploaded to [paywall-rendering-validation](https://github.com/RevenueCat/paywall-rendering-validation).

<div><a href="https://cursor.com/agents/bc-916e35d0-71c1-49cb-ab37-f644d0757727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-916e35d0-71c1-49cb-ab37-f644d0757727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Paparazzi snapshot naming and the Fastlane screenshot upload path; no runtime SDK or purchase behavior changes.
> 
> **Overview**
> Fixes Android paywall template screenshots landing under wrong folder names in **paywall-rendering-validation** when offering IDs contain spaces (Paparazzi turns spaces into underscores in test/snapshot names).
> 
> **`PaywallComponentsTemplatePreviewRecorder`** now puts a **percent-encoded** offering ID in the parameterized test name (`___…___`), using a small UTF-8 encoder that only leaves letters, digits, `.`, and `-` unescaped so filenames stay stable.
> 
> The **`record_and_push_paywall_template_screenshots`** Fastlane lane parses those encoded segments with a stricter regex and **`CGI.unescape`**s them back to the real offering ID before writing `screenshots/templates/{offering_id}/android.png`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e97b89f33ee6fb5a695157be612e4507142238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->