### PR TITLE
Add update-error-codes workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1237,6 +1237,7 @@ workflows:
       - revenuecat/update-error-codes:
           platform: android
           output: purchases/src/main/kotlin/generated/com/revenuecat/purchases/PurchasesErrorCode.kt
+          commit_paths: "purchases/src/main/kotlin/generated/com/revenuecat/purchases/PurchasesErrorCode.kt,purchases/api-defaults-bc7.txt,purchases/api-defauts.txt,purchases/api-entitlement.txt"
           executor:
             name: android/android_docker
             tag: 2025.04.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,13 @@ aliases:
 version: 2.1
 orbs:
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@3.20.0
+  revenuecat: revenuecat/sdks-common-config@3.21.0
   codecov: codecov/codecov@3.2.4
 
 parameters:
   action:
     type: enum
-    enum: [default, bump, paywall_tester_release, rct_tester_release, deploy_snapshot_release, update_paywall_templates, update_golden_requests_backend_integration_tests]
+    enum: [default, bump, paywall_tester_release, rct_tester_release, deploy_snapshot_release, update_paywall_templates, update_golden_requests_backend_integration_tests, update_error_codes]
     default: default
   paywall_tester_track:
     type: enum
@@ -1229,3 +1229,29 @@ workflows:
       equal: [ update_golden_requests_backend_integration_tests, << pipeline.parameters.action >> ]
     jobs:
       - update-golden-requests-backend-integration-tests
+
+  update-error-codes:
+    when:
+      equal: [ update_error_codes, << pipeline.parameters.action >> ]
+    jobs:
+      - revenuecat/update-error-codes:
+          platform: android
+          output: purchases/src/main/kotlin/generated/com/revenuecat/purchases/PurchasesErrorCode.kt
+          executor:
+            name: android/android_docker
+            tag: 2025.04.1
+            resource_class: xlarge
+          update_api_steps:
+            - run:
+                name: Set Gradle env
+                command: |
+                  echo 'export JVM_OPTS=-Xmx6g' >> "$BASH_ENV"
+                  echo 'export GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2' >> "$BASH_ENV"
+            - install-sdkman
+            - revenuecat/install-gem-unix-dependencies:
+                cache-version: v1
+            - android/restore_gradle_cache
+            - run:
+                name: Update API
+                command: ./scripts/api-dump.sh
+            - android/save_gradle_cache

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: ce6a7efb479db6a99fe95e7bb6dd48cc1bf63b8e
+  revision: d911a06677d2926dd61beb80400b5b5e69fbc1df
   branch: main
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)


### PR DESCRIPTION
Adds the `update-error-codes` workflow (gated on `action=update_error_codes`) that runs `revenuecat/update-error-codes@3.21.0` on `android/android_docker`: copies the generated `PurchasesErrorCode.kt` from purchases-error-codes, runs `./scripts/api-dump.sh`, and opens/updates the PR. Bumps the orb to 3.21.0.

Merge after the orb is published and the plugin pin is bumped (`bundle update fastlane-plugin-revenuecat_internal`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and dependency pins only; no runtime SDK or app code changes in this diff.
> 
> **Overview**
> Adds a **manual CircleCI workflow** triggered with `action=update_error_codes` to sync Android purchase error codes from the shared source and refresh public API dumps in one PR.
> 
> The new **`update-error-codes`** workflow runs `revenuecat/update-error-codes` from **`sdks-common-config@3.21.0`** (orb bumped from 3.20.0). It writes generated `PurchasesErrorCode.kt`, then runs **`./scripts/api-dump.sh`** so Metalava API text files stay in sync; **`commit_paths`** limits the automation to those generated files. **`Gemfile.lock`** updates the **`fastlane-plugin-revenuecat_internal`** git pin to match the orb release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51418898efb1aa657eedd729d5b0fa97f8f9d0b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->