### PR TITLE
Removes stale paywall template screenshots if necessary

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -917,7 +917,6 @@ DESC
         end
       end
 
-      # Remove Android screenshots for paywalls we no longer render, so stale or renamed entries don't linger.
       remove_stale_android_template_screenshots(
         target_repository_path: target_repository_path,
         produced_offering_ids: produced_offering_ids
@@ -939,14 +938,12 @@ DESC
     end
   end
 
-  # Removes android.png screenshots (and now-empty directories) for paywalls that were not rendered in this run, so
-  # stale or renamed entries don't linger in the target repository. Only touches android.png, so it never deletes
-  # screenshots owned by other platforms (e.g. ios.png, mac-*.png).
+  # Removes android.png screenshots (and now-empty directories) for paywalls that were not rendered in this run, Only
+  # touches android.png, so it never deletes screenshots owned by other platforms (e.g. ios.png, mac-*.png).
   private_lane :remove_stale_android_template_screenshots do |options|
     target_repository_path = options[:target_repository_path] || UI.user_error!("No target_repository_path provided")
     produced_offering_ids = options[:produced_offering_ids] || UI.user_error!("No produced_offering_ids provided")
 
-    # Safety: never prune if we produced nothing (e.g. a failed render), to avoid wiping all screenshots.
     UI.user_error!("No Android screenshots were produced; refusing to prune stale screenshots.") if produced_offering_ids.empty?
 
     templates_dir = "#{target_repository_path}/screenshots/templates"
@@ -957,7 +954,7 @@ DESC
       File.delete(existing)
     end
 
-    # Remove any template directories that no longer contain any files (e.g. once every platform dropped a paywall).
+    # Remove any empty directories.
     Dir.glob("#{templates_dir}/*").each do |dir|
       next unless File.directory?(dir)
       Dir.rmdir(dir) if Dir.empty?(dir)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -904,9 +904,11 @@ DESC
     begin
       record_paparazzi_screenshots(gradle_module: ":ui:revenuecatui", tests: "PaywallComponentsTemplatePreviewRecorder", output_dir: tmp_dir)
       # Loop over all PNG files in the tmp_dir, parse the offering ID from the file names, and move them into the target repository.
+      produced_offering_ids = []
       sh("find #{tmp_dir} -name '*.png'").split("\n").each do |file_path|
         if file_path =~ /___([0-9A-Za-z%.-]+)___/
           offering_id = CGI.unescape($1).force_encoding("UTF-8")
+          produced_offering_ids << offering_id
           target_dir = "#{target_repository_path}/screenshots/templates/#{offering_id}"
           sh("mkdir -p \"#{target_dir}\"")
           sh("mv \"#{file_path}\" \"#{target_dir}/android.png\"")
@@ -914,6 +916,12 @@ DESC
           UI.user_error!("No offering ID found in file: #{File.basename(file_path)}")
         end
       end
+
+      # Remove Android screenshots for paywalls we no longer render, so stale or renamed entries don't linger.
+      remove_stale_android_template_screenshots(
+        target_repository_path: target_repository_path,
+        produced_offering_ids: produced_offering_ids
+      )
     ensure
       sh("rm -rf #{tmp_dir}")
     end
@@ -928,6 +936,31 @@ DESC
         body: "This is an automatic update of the Android template screenshots.",
         team_reviewers: ["coresdk", "monetization", "bab-s"]
       )
+    end
+  end
+
+  # Removes android.png screenshots (and now-empty directories) for paywalls that were not rendered in this run, so
+  # stale or renamed entries don't linger in the target repository. Only touches android.png, so it never deletes
+  # screenshots owned by other platforms (e.g. ios.png, mac-*.png).
+  private_lane :remove_stale_android_template_screenshots do |options|
+    target_repository_path = options[:target_repository_path] || UI.user_error!("No target_repository_path provided")
+    produced_offering_ids = options[:produced_offering_ids] || UI.user_error!("No produced_offering_ids provided")
+
+    # Safety: never prune if we produced nothing (e.g. a failed render), to avoid wiping all screenshots.
+    UI.user_error!("No Android screenshots were produced; refusing to prune stale screenshots.") if produced_offering_ids.empty?
+
+    templates_dir = "#{target_repository_path}/screenshots/templates"
+    Dir.glob("#{templates_dir}/*/android.png").each do |existing|
+      offering_id = File.basename(File.dirname(existing)).force_encoding("UTF-8")
+      next if produced_offering_ids.include?(offering_id)
+      UI.message("Removing stale Android screenshot: #{existing}")
+      File.delete(existing)
+    end
+
+    # Remove any template directories that no longer contain any files (e.g. once every platform dropped a paywall).
+    Dir.glob("#{templates_dir}/*").each do |dir|
+      next unless File.directory?(dir)
+      Dir.rmdir(dir) if Dir.empty?(dir)
     end
   end
 


### PR DESCRIPTION
## Description
We would only ever add new paywall screenshots to paywall-rendering-validation, never remove ones that we deleted from paywall-preview-resources. This PR implements just that.

iOS equivalent: https://github.com/RevenueCat/purchases-ios/pull/6984
  
<div><a href="https://cursor.com/agents/bc-916e35d0-71c1-49cb-ab37-f644d0757727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-916e35d0-71c1-49cb-ab37-f644d0757727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automated deletion in an external repo could remove valid screenshots if offering IDs fail to parse or the recorder returns an incomplete set; the empty-list guard mitigates total wipe on zero output.
> 
> **Overview**
> The automated **paywall template screenshot** flow now **removes stale Android assets** from the validation repo when templates disappear from preview resources, matching the iOS behavior.
> 
> While moving Paparazzi PNGs into `screenshots/templates/{offering_id}/`, the lane collects **`produced_offering_ids`** and then runs **`remove_stale_android_template_screenshots`**, which deletes **`android.png`** (only) for offering folders not in that set and drops empty directories. If the run produces **no** screenshots, pruning is **skipped** so a failed recording cannot wipe the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a47a2fbf037656ed10e6b0501c248c694a0720ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->