### PR TITLE
Fix legacy paywalls when workflows are enabled

### DIFF
--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -412,6 +412,10 @@ public class Purchases internal constructor(
         )
     }
 
+    @InternalRevenueCatAPI
+    public fun workflowIdForOfferingId(offeringId: String): String? =
+        purchasesOrchestrator.workflowIdForOfferingId(offeringId)
+
     /**
      * Gets the StoreProduct(s) for the given list of product ids for all product types.
      * @param [productIds] List of productIds

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -608,6 +608,9 @@ internal class PurchasesOrchestrator(
         )
     }
 
+    fun workflowIdForOfferingId(offeringId: String): String? =
+        workflowManager?.workflowIdForOfferingId(offeringId)
+
     fun getProducts(
         productIds: List<String>,
         type: ProductType? = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -64,4 +64,6 @@ internal class MockPurchasesType(
     override suspend fun awaitGetWorkflow(workflowId: String): WorkflowDataResult {
         throw NotImplementedError("Mock implementation for previews only")
     }
+
+    override fun workflowIdForOfferingId(offeringId: String): String? = null
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -729,13 +729,25 @@ internal class PaywallViewModelImpl(
     }
 
     private suspend fun updateStateFromOffering(offeringSelection: OfferingSelection) {
-        if (startWorkflowPresentationIfNeeded(offeringSelection)) {
+        // Injected workflow (e.g. mobile app preview): render locally, no /workflows fetch.
+        if (presentInjectedWorkflowIfNeeded(offeringSelection)) {
             return
         }
 
         val resolvedOfferingSelection = resolveOfferingSelection(offeringSelection)
-        val currentOffering = resolvedOfferingSelection.selectedOffering
-        val exitOfferingId = currentOffering?.paywallComponents?.data?.exitOffers?.dismiss?.offeringId
+        val selectedOffering = resolvedOfferingSelection.selectedOffering
+
+        // When workflows are enabled, every non-legacy paywall is served through the /workflows
+        // endpoint. `offering.paywall == null` is the durable marker of a non-legacy (workflow)
+        // paywall: a legacy v1 paywall always carries `offering.paywall`, and that field stays
+        // even after `paywallComponents` is removed and all V2 paywalls move to workflows. We
+        // deliberately do NOT gate on `paywallComponents`, which is going away.
+        if (useWorkflowsEndpoint && selectedOffering != null && selectedOffering.paywall == null) {
+            presentWorkflow(selectedOffering, resolvedOfferingSelection.offeringsForExitOfferLookup)
+            return
+        }
+
+        val exitOfferingId = selectedOffering?.paywallComponents?.data?.exitOffers?.dismiss?.offeringId
 
         val offerings = resolvedOfferingSelection.offeringsForExitOfferLookup
         updateExitOfferData(
@@ -748,52 +760,40 @@ internal class PaywallViewModelImpl(
                 ExitOfferData.Unavailable()
             },
         )
-        updatePaywallState(currentOffering)
+        updatePaywallState(selectedOffering)
     }
 
-    private suspend fun startWorkflowPresentationIfNeeded(offeringSelection: OfferingSelection): Boolean {
-        // Injected workflow (e.g. mobile app preview): render locally, no /workflows fetch.
-        val injectedWorkflow = options.injectedWorkflow
-        if (injectedWorkflow != null) {
-            val offering = offeringSelection.offering
-            if (offering == null) {
-                Logger.w(
-                    "Paywalls: injectedWorkflow set without a concrete Offering (use setOffering); " +
-                        "workflow screens may fail to resolve their packages.",
-                )
-            }
-            val offerings = Offerings(
-                current = offering,
-                all = offering?.let { mapOf(it.identifier to it) } ?: emptyMap(),
+    private fun presentInjectedWorkflowIfNeeded(offeringSelection: OfferingSelection): Boolean {
+        val injectedWorkflow = options.injectedWorkflow ?: return false
+        val offering = offeringSelection.offering
+        if (offering == null) {
+            Logger.w(
+                "Paywalls: injectedWorkflow set without a concrete Offering (use setOffering); " +
+                    "workflow screens may fail to resolve their packages.",
             )
-            startWorkflowPresentation(injectedWorkflow, offerings, offering?.presentedOfferingContext)
-            return true
         }
+        val offerings = Offerings(
+            current = offering,
+            all = offering?.let { mapOf(it.identifier to it) } ?: emptyMap(),
+        )
+        startWorkflowPresentation(injectedWorkflow, offerings, offering?.presentedOfferingContext)
+        return true
+    }
 
-        var updatedFromWorkflow = false
-        if (useWorkflowsEndpoint) {
-            val workflowParams = when (offeringSelection) {
-                is OfferingSelection.IdAndPresentedOfferingContext ->
-                    offeringSelection.offeringId to offeringSelection.presentedOfferingContext
-                is OfferingSelection.OfferingType ->
-                    offeringSelection.offeringType.identifier to offeringSelection.offeringType.presentedOfferingContext
-                is OfferingSelection.None -> null
-            }
-            if (workflowParams != null) {
-                val (offeringId, presentedOfferingContext) = workflowParams
-                coroutineScope {
-                    val fetchResultDeferred = async { purchases.awaitGetWorkflow(offeringId) }
-                    val offeringsDeferred = async { purchases.awaitOfferings() }
-                    startWorkflowPresentation(
-                        fetchResultDeferred.await(),
-                        offeringsDeferred.await(),
-                        presentedOfferingContext,
-                    )
-                }
-                updatedFromWorkflow = true
-            }
+    private suspend fun presentWorkflow(offering: Offering, preloadedOfferings: Offerings?) {
+        // Prefer the configured workflow id, which aligns with the prefetch cache key. Fall back to
+        // the offering id, which the backend lazily converts into a workflow for paywalls not yet
+        // converted to a workflow.
+        val workflowIdentifier = purchases.workflowIdForOfferingId(offering.identifier) ?: offering.identifier
+        coroutineScope {
+            val fetchResultDeferred = async { purchases.awaitGetWorkflow(workflowIdentifier) }
+            val offeringsDeferred = async { preloadedOfferings ?: purchases.awaitOfferings() }
+            startWorkflowPresentation(
+                fetchResultDeferred.await(),
+                offeringsDeferred.await(),
+                offering.presentedOfferingContext,
+            )
         }
-        return updatedFromWorkflow
     }
 
     private suspend fun resolveOfferingSelection(offeringSelection: OfferingSelection): ResolvedOfferingSelection =

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -69,6 +69,8 @@ internal interface PurchasesType {
     @Throws(PurchasesException::class)
     suspend fun awaitGetWorkflow(workflowId: String): WorkflowDataResult
 
+    fun workflowIdForOfferingId(offeringId: String): String?
+
     val useWorkflows: Boolean
 }
 
@@ -143,6 +145,10 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
     override suspend fun awaitGetWorkflow(workflowId: String): WorkflowDataResult {
         return purchases.awaitGetWorkflow(workflowId)
     }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    override fun workflowIdForOfferingId(offeringId: String): String? =
+        purchases.workflowIdForOfferingId(offeringId)
 
     @OptIn(InternalRevenueCatAPI::class)
     override val useWorkflows: Boolean

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -61,4 +61,6 @@ internal class MockPurchasesType(
     override suspend fun awaitGetWorkflow(workflowId: String): WorkflowDataResult {
         throw NotImplementedError("Mock implementation")
     }
+
+    override fun workflowIdForOfferingId(offeringId: String): String? = null
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -233,6 +233,7 @@ class PaywallViewModelTest {
         coEvery { purchases.awaitSyncPurchases() } returns customerInfo
         every { purchases.preferredUILocaleOverride } returns null
         every { purchases.useWorkflows } returns false
+        every { purchases.workflowIdForOfferingId(any()) } returns null
 
         every { listener.onPurchaseStarted(any()) } just runs
         every { listener.onPurchaseCompleted(any(), any()) } just runs
@@ -1425,14 +1426,15 @@ class PaywallViewModelTest {
             screens = mapOf("screen-1" to workflowScreen),
             uiConfig = UiConfig(),
         )
-        coEvery { purchases.awaitGetWorkflow(any()) } returns WorkflowDataResult(workflow, null)
+        every { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns "wfl-test"
+        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns WorkflowDataResult(workflow, null)
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
             purchases,
             PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
                 .setListener(listener)
-                .setOfferingSelection(OfferingSelection.IdAndPresentedOfferingContext("wfl-test", null))
+                .setOffering(offeringWithWPL)
                 .build(),
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
@@ -1483,14 +1485,15 @@ class PaywallViewModelTest {
             screens = mapOf("screen-1" to workflowScreen),
             uiConfig = UiConfig(),
         )
-        coEvery { purchases.awaitGetWorkflow(any()) } returns WorkflowDataResult(workflow, null)
+        every { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns "wfl-test"
+        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns WorkflowDataResult(workflow, null)
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
             purchases,
             PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
                 .setListener(listener)
-                .setOfferingSelection(OfferingSelection.IdAndPresentedOfferingContext("wfl-test", null))
+                .setOffering(offeringWithWPL)
                 .build(),
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
@@ -3085,6 +3088,143 @@ class PaywallViewModelTest {
         assertThat(model.workflowState.value?.currentStepId).isEqualTo("step-1")
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
         coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
+    }
+
+    @Test
+    fun `when useWorkflows is true and offering has a legacy paywall, does not fetch workflow`() {
+        // defaultOffering has a legacy paywall (offering.paywall != null), so it renders through
+        // the legacy path and never hits the workflows endpoint, even with workflows enabled.
+        PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(defaultOffering)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
+    }
+
+    @Test
+    fun `when useWorkflows is true and offering has a legacy paywall, renders legacy paywall`() {
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(defaultOffering)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Legacy::class.java)
+    }
+
+    @Test
+    fun `when useWorkflows is true and offering has no legacy paywall, fetches by workflow id from map`() {
+        // offeringWithWPL has no legacy paywall (offering.paywall == null), so it is served through
+        // the workflows endpoint. With a mapped workflow id, that id (not the offering id) is used.
+        val workflowId = "wfl-real-id"
+        every { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns workflowId
+        val workflowScreen = WorkflowScreen(
+            templateName = "template",
+            revision = 0,
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(components = listOf(TestData.Components.monthlyPackageComponent)),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    stickyFooter = null,
+                ),
+            ),
+            componentsLocalizations = localizations,
+            defaultLocaleIdentifier = defaultLocaleIdentifier,
+            offeringIdentifier = defaultOffering.identifier,
+        )
+        val stepOne = WorkflowStep(id = "step-1", type = "screen", screenId = "screen-1")
+        val workflow = PublishedWorkflow(
+            id = workflowId,
+            displayName = "Real Workflow",
+            initialStepId = "step-1",
+            steps = mapOf("step-1" to stepOne),
+            screens = mapOf("screen-1" to workflowScreen),
+            uiConfig = UiConfig(),
+        )
+        coEvery { purchases.awaitGetWorkflow(workflowId) } returns WorkflowDataResult(workflow, null)
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offeringWithWPL)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+        coVerify(exactly = 1) { purchases.awaitGetWorkflow(workflowId) }
+        coVerify(exactly = 0) { purchases.awaitGetWorkflow(offeringWithWPL.identifier) }
+    }
+
+    @Test
+    fun `when useWorkflows is true and offering has no legacy paywall but no mapped workflow, fetches by offering id`() {
+        // offeringWithWPL has no legacy paywall and no mapped workflow (not yet converted). It must
+        // still hit the workflows endpoint, passing the offering id so the backend lazily converts
+        // it — rather than falling back to a legacy paywall that does not exist.
+        every { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns null
+        val workflowScreen = WorkflowScreen(
+            templateName = "template",
+            revision = 0,
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(components = listOf(TestData.Components.monthlyPackageComponent)),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    stickyFooter = null,
+                ),
+            ),
+            componentsLocalizations = localizations,
+            defaultLocaleIdentifier = defaultLocaleIdentifier,
+            offeringIdentifier = defaultOffering.identifier,
+        )
+        val stepOne = WorkflowStep(id = "step-1", type = "screen", screenId = "screen-1")
+        val workflow = PublishedWorkflow(
+            id = "lazily-converted",
+            displayName = "Lazy Workflow",
+            initialStepId = "step-1",
+            steps = mapOf("step-1" to stepOne),
+            screens = mapOf("screen-1" to workflowScreen),
+            uiConfig = UiConfig(),
+        )
+        coEvery { purchases.awaitGetWorkflow(offeringWithWPL.identifier) } returns WorkflowDataResult(workflow, null)
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offeringWithWPL)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+        coVerify(exactly = 1) { purchases.awaitGetWorkflow(offeringWithWPL.identifier) }
     }
 
     private fun create(


### PR DESCRIPTION
Paywalls were served through the `/workflows` endpoint only when the offering was present in the prefetched offeringId→workflowId map. That map contains only paywalls converted to workflows, so a legacy v1 paywall errored on a 404 instead of rendering

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core paywall presentation routing when workflows are enabled; wrong branching could break legacy paywalls or workflow fetches, but scope is limited to PaywallViewModel and covered by new tests.
> 
> **Overview**
> Fixes paywall loading when **workflows** are enabled but an offering is still a **legacy v1** paywall (or otherwise not in the prefetch offering→workflow map). Previously everything could be forced through `/workflows`, which **404’d** for legacy offerings.
> 
> **PaywallViewModel** now branches on **`offering.paywall == null`** as the durable “non-legacy / workflow” signal: with workflows on, legacy offerings (**`paywall` present**) keep the existing legacy/components path and **never** call `/workflows`; non-legacy offerings fetch via **`presentWorkflow`**, using **`workflowIdForOfferingId`** when mapped (prefetch cache key) or **offering id** when not yet converted.
> 
> The SDK exposes **`Purchases.workflowIdForOfferingId`** (internal API) through **`PurchasesType`** for RevenueCat UI, with mocks/tests updated to cover legacy skip, mapped workflow id, and offering-id fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78142e139f191979f8ed4f3e28da022b9c282883. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->