### PR TITLE
Danger: block manual edits to generated error codes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ aliases:
 version: 2.1
 orbs:
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@3.21.0
+  revenuecat: revenuecat/sdks-common-config@3.21.1
   codecov: codecov/codecov@3.2.4
 
 parameters:

--- a/Dangerfile
+++ b/Dangerfile
@@ -56,3 +56,5 @@ if total_changed > PROD_LINES_LIMIT
          "the `#{SKIP_SIZE_LABEL}` label to bypass.")
   end
 end
+
+fail_on_generated_edits(["purchases/src/main/kotlin/generated/"])


### PR DESCRIPTION
- Adds a Danger check to prevent modification of autogenerated files from [purchases-error-codes](https://github.com/RevenueCat/purchases-error-codes). Calls a function defined in [RevenueCat/Dangerfile](https://github.com/RevenueCat/Dangerfile/pull/16)
- Bumps the [shared orb](https://github.com/RevenueCat/sdks-circleci-orb/pull/68) to get the proper labels on the generated PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Danger policy only; no runtime SDK or app behavior changes.
> 
> **Overview**
> Adds a **Danger** guard so PRs that touch `purchases/src/main/kotlin/generated/` fail unless they come from the automated error-code update flow (`fail_on_generated_edits`, from the shared `RevenueCat/Dangerfile`).
> 
> Bumps the CircleCI **`revenuecat/sdks-common-config`** orb from **3.21.0** to **3.21.1** so generated error-code PRs get the right labels from the shared pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8fb6e3e06bde45979735ad3827d5de6d05f24b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->