### PR TITLE
refactor(remote-config): Trusted-entitlements signing for the binary remote config response

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -14,6 +14,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.RewardVerificationError
 import com.revenuecat.purchases.RewardVerificationResult
+import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.backendName
 import com.revenuecat.purchases.common.events.EventsRequest
@@ -109,7 +110,8 @@ internal typealias WebBillingProductsCallback = Pair<(WebBillingProductsResponse
 internal typealias RewardVerificationResultCallback =
     Pair<(RewardVerificationResult) -> Unit, (RewardVerificationError) -> Unit>
 
-internal typealias RemoteConfigCallback = Pair<(RCContainer?) -> Unit, (PurchasesError) -> Unit>
+internal typealias RemoteConfigCallback =
+    Pair<(RCContainer?, VerificationResult) -> Unit, (PurchasesError) -> Unit>
 
 @OptIn(InternalRevenueCatAPI::class)
 internal typealias WorkflowDetailCallback = Pair<
@@ -1306,7 +1308,7 @@ internal class Backend(
 
     fun getRemoteConfig(
         appInBackground: Boolean,
-        onSuccess: (RCContainer?) -> Unit,
+        onSuccess: (RCContainer?, VerificationResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
         val endpoint = Endpoint.GetRemoteConfig
@@ -1346,7 +1348,7 @@ internal class Backend(
                     if (result.isSuccessful()) {
                         if (result.responseCode == RCHTTPStatusCodes.NO_CONTENT) {
                             // 204: nothing changed, no container to parse.
-                            onSuccessHandler(null)
+                            onSuccessHandler(null, result.verificationResult)
                             return@forEach
                         }
                         val payload = result.payload
@@ -1360,7 +1362,7 @@ internal class Backend(
                             return@forEach
                         }
                         try {
-                            onSuccessHandler(RCContainer.parse(payload.bytes))
+                            onSuccessHandler(RCContainer.parse(payload.bytes), result.verificationResult)
                         } catch (e: RCContainerFormatException) {
                             onErrorHandler(e.toPurchasesError().also { errorLog(it) })
                         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -21,6 +21,8 @@ import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.HTTPTimeoutManager
 import com.revenuecat.purchases.common.networking.MapConverter
 import com.revenuecat.purchases.common.networking.NullPointerReadingErrorStreamException
+import com.revenuecat.purchases.common.networking.RCContainer
+import com.revenuecat.purchases.common.networking.RCContainerFormatException
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.common.verification.SignatureVerificationException
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
@@ -394,7 +396,11 @@ internal class HTTPClient(
         val verificationResult = if (shouldSignResponse &&
             RCHTTPStatusCodes.isSuccessful(responseCode)
         ) {
-            verifyResponse(path, connection, payloadText, nonce, postFieldsToSignHeader)
+            if (endpoint.expectsRCFormatResponse) {
+                verifyRCFormatResponse(path, connection, bodyBytes)
+            } else {
+                verifyResponse(path, connection, payloadText, nonce, postFieldsToSignHeader)
+            }
         } else {
             VerificationResult.NOT_REQUESTED
         }
@@ -576,11 +582,45 @@ internal class HTTPClient(
             urlPath = urlPath,
             signatureString = connection.getHeaderField(HTTPResult.SIGNATURE_HEADER_NAME),
             nonce = nonce,
-            body = payload,
+            bodyBytes = payload?.toByteArray(),
             requestTime = getRequestTimeHeader(connection),
             eTag = getETagHeader(connection),
             postFieldsToSignHeader = postFieldsToSignHeader,
         )
+    }
+
+    /**
+     * Verifies an RC Container Format response. The backend signs the config element's (element 0)
+     * 24-byte truncated SHA-256 checksum, so we verify the signature over that checksum and
+     * independently confirm the config bytes hash to it. Both checks are required: the signature ties
+     * the checksum to the backend, and [RCElement.isChecksumValid] ties the checksum to the data.
+     * This endpoint is not ETag-cached and sends no nonce / post params.
+     */
+    private fun verifyRCFormatResponse(
+        urlPath: String,
+        connection: URLConnection,
+        payloadBytes: ByteArray,
+    ): VerificationResult {
+        val config = try {
+            RCContainer.parse(payloadBytes).config
+        } catch (e: RCContainerFormatException) {
+            errorLog(e) { NetworkStrings.VERIFICATION_ERROR.format(urlPath) }
+            return VerificationResult.FAILED
+        }
+        return if (!config.isChecksumValid()) {
+            errorLog { NetworkStrings.VERIFICATION_ERROR.format(urlPath) }
+            VerificationResult.FAILED
+        } else {
+            signingManager.verifyResponse(
+                urlPath = urlPath,
+                signatureString = connection.getHeaderField(HTTPResult.SIGNATURE_HEADER_NAME),
+                nonce = null,
+                bodyBytes = config.checksumBytes(),
+                requestTime = getRequestTimeHeader(connection),
+                eTag = getETagHeader(connection),
+                postFieldsToSignHeader = null,
+            )
+        }
     }
 
     private fun getETagHeader(connection: URLConnection) = connection.getHeaderField(HTTPResult.ETAG_HEADER_NAME)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -397,7 +397,11 @@ internal class HTTPClient(
             RCHTTPStatusCodes.isSuccessful(responseCode)
         ) {
             if (endpoint.expectsRCFormatResponse) {
-                verifyRCFormatResponse(path, connection, bodyBytes)
+                if (responseCode == RCHTTPStatusCodes.NO_CONTENT && bodyBytes.isEmpty()) {
+                    VerificationResult.VERIFIED
+                } else {
+                    verifyRCFormatResponse(path, connection, bodyBytes)
+                }
             } else {
                 verifyResponse(path, connection, payloadText, nonce, postFieldsToSignHeader)
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -161,6 +161,7 @@ internal sealed class Endpoint(
             PostRedeemWebPurchase,
             is GetVirtualCurrencies,
             is GetRewardVerification,
+            GetRemoteConfig,
             ->
                 true
             is GetAmazonReceipt,
@@ -171,8 +172,6 @@ internal sealed class Endpoint(
             PostCreateSupportTicket,
             is WebBillingGetProducts,
             is AliasUsers,
-            // WIP: Move to true when we have the final endpoint for remote config, and we can remove the fallback
-            GetRemoteConfig,
             ->
                 false
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCElement.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCElement.kt
@@ -49,6 +49,14 @@ internal class RCElement(
         return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
     }
 
+    /** A copy of the stored [checksum] bytes (the truncated SHA-256 of [data]). */
+    fun checksumBytes(): ByteArray {
+        val view = checksum.duplicate()
+        val bytes = ByteArray(view.remaining())
+        view.get(bytes)
+        return bytes
+    }
+
     private companion object {
         private const val SHA_256_ALGORITHM = "SHA-256"
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -31,7 +31,7 @@ internal class SigningManager(
         val postParamsHashHeader: String?,
         val requestTime: String,
         val eTag: String?,
-        val body: String?,
+        val body: ByteArray?,
     ) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -46,7 +46,12 @@ internal class SigningManager(
             if (postParamsHashHeader != other.postParamsHashHeader) return false
             if (requestTime != other.requestTime) return false
             if (eTag != other.eTag) return false
-            if (body != other.body) return false
+            if (body != null) {
+                if (other.body == null) return false
+                if (!body.contentEquals(other.body)) return false
+            } else if (other.body != null) {
+                return false
+            }
 
             return true
         }
@@ -59,7 +64,7 @@ internal class SigningManager(
             result = 31 * result + (postParamsHashHeader?.hashCode() ?: 0)
             result = 31 * result + requestTime.hashCode()
             result = 31 * result + (eTag?.hashCode() ?: 0)
-            result = 31 * result + (body?.hashCode() ?: 0)
+            result = 31 * result + (body?.contentHashCode() ?: 0)
             return result
         }
 
@@ -71,7 +76,7 @@ internal class SigningManager(
                 (postParamsHashHeader?.toByteArray() ?: byteArrayOf()) +
                 requestTime.toByteArray() +
                 (eTag?.toByteArray() ?: byteArrayOf()) +
-                (body?.toByteArray() ?: byteArrayOf())
+                (body ?: byteArrayOf())
         }
     }
 
@@ -111,12 +116,16 @@ internal class SigningManager(
         }
     }
 
+    /**
+     * Verifies a response signature. [bodyBytes] is the signed payload: the UTF-8 bytes of a textual
+     * (JSON) body, or the config element's checksum for RC Container Format responses.
+     */
     @Suppress("LongParameterList", "ReturnCount", "CyclomaticComplexMethod", "LongMethod")
     fun verifyResponse(
         urlPath: String,
         signatureString: String?,
         nonce: String?,
-        body: String?,
+        bodyBytes: ByteArray?,
         requestTime: String?,
         eTag: String?,
         postFieldsToSignHeader: String?,
@@ -136,7 +145,7 @@ internal class SigningManager(
             errorLog { NetworkStrings.VERIFICATION_MISSING_REQUEST_TIME.format(urlPath) }
             return VerificationResult.FAILED
         }
-        if (body == null && eTag == null) {
+        if (bodyBytes == null && eTag == null) {
             errorLog { NetworkStrings.VERIFICATION_MISSING_BODY_OR_ETAG.format(urlPath) }
             return VerificationResult.FAILED
         }
@@ -169,7 +178,7 @@ internal class SigningManager(
                     postFieldsToSignHeader,
                     requestTime,
                     eTag,
-                    body,
+                    bodyBytes,
                 )
                 val verificationResult = intermediateKeyVerifier.verify(
                     signature.payload,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -12,12 +12,15 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import okhttp3.mockwebserver.MockResponse
+import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.io.ByteArrayOutputStream
+import java.security.MessageDigest
 import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
@@ -194,7 +197,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
                 urlPath = endpoint.getPath(),
                 "test-signature",
                 "test-nonce",
-                "{\"test-key\":\"test-value\"}",
+                match<ByteArray> { it.contentEquals("{\"test-key\":\"test-value\"}".toByteArray()) },
                 "1234567890",
                 "test-etag",
                 postFieldsToSignHeader = null
@@ -400,6 +403,110 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
         assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
     }
 
+    // region RC Container Format verification
+
+    @Test
+    fun `performRequest verifies an RC Container Format response over the config checksum`() {
+        val endpoint = Endpoint.GetRemoteConfig
+        val configBytes = "{\"config\":true}".toByteArray()
+        val container = buildContainer(configBytes)
+        val expectedChecksum = sha256Truncated(configBytes)
+
+        mockSigningResult(VerificationResult.VERIFIED)
+        enqueueRCFormat(container)
+
+        val result = client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            postFieldsToSign = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
+        assertThat(result.payload).isInstanceOf(HTTPResult.Payload.RCFormat::class.java)
+        verify(exactly = 1) {
+            mockSigningManager.verifyResponse(
+                urlPath = endpoint.getPath(),
+                "test-signature",
+                null,
+                match<ByteArray> { it.contentEquals(expectedChecksum) },
+                "1234567890",
+                "test-etag",
+                postFieldsToSignHeader = null
+            )
+        }
+    }
+
+    @Test
+    fun `performRequest fails RC Format verification when the config data does not match its checksum`() {
+        val endpoint = Endpoint.GetRemoteConfig
+        val configBytes = "{\"config\":true}".toByteArray()
+        // Store a checksum that does not match the config data.
+        val container = buildContainer(configBytes, configChecksum = ByteArray(24) { 0x7F })
+
+        mockSigningResult(VerificationResult.VERIFIED)
+        enqueueRCFormat(container)
+
+        val result = client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            postFieldsToSign = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.FAILED)
+        assertSigningNotPerformed()
+    }
+
+    @Test
+    fun `performRequest fails RC Format verification when the response is not a valid RC Container`() {
+        val endpoint = Endpoint.GetRemoteConfig
+
+        mockSigningResult(VerificationResult.VERIFIED)
+        enqueueRCFormat(byteArrayOf(1, 2, 3, 4))
+
+        val result = client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            postFieldsToSign = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.FAILED)
+        assertSigningNotPerformed()
+    }
+
+    @Test
+    fun `performRequest on enforced client throws when RC Format verification fails`() {
+        every { mockSigningManager.signatureVerificationMode } returns mockk<SignatureVerificationMode.Enforced>()
+        val endpoint = Endpoint.GetRemoteConfig
+        val container = buildContainer("{\"config\":true}".toByteArray())
+
+        mockSigningResult(VerificationResult.FAILED)
+        enqueueRCFormat(container)
+
+        assertThatExceptionOfType(SignatureVerificationException::class.java).isThrownBy {
+            client.performRequest(
+                baseURL,
+                endpoint,
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = emptyMap()
+            )
+        }
+    }
+
+    // endregion
+
     private fun mockSigningResult(result: VerificationResult) {
         every {
             mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
@@ -411,4 +518,48 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
         }
     }
+
+    private fun enqueueRCFormat(body: ByteArray) {
+        server.enqueue(
+            MockResponse()
+                .setBody(Buffer().write(body))
+                .setResponseCode(RCHTTPStatusCodes.SUCCESS)
+                .setHeader(HTTPResult.SIGNATURE_HEADER_NAME, "test-signature")
+                .setHeader(HTTPResult.REQUEST_TIME_HEADER_NAME, 1234567890L)
+                .setHeader(HTTPResult.ETAG_HEADER_NAME, "test-etag")
+        )
+    }
+
+    @Suppress("MagicNumber")
+    private fun buildContainer(
+        config: ByteArray,
+        configChecksum: ByteArray = sha256Truncated(config),
+    ): ByteArray {
+        val out = ByteArrayOutputStream()
+        out.write('R'.code)
+        out.write('C'.code)
+        out.write(1) // version
+        out.write(0) // flags
+        repeat(4) { out.write(0) } // header reserved
+        out.write(configChecksum)
+        out.writeUInt32LE(config.size)
+        out.writeUInt32LE(0) // element reserved
+        out.write(config)
+        while (out.size() % 8 != 0) {
+            out.write(0)
+        }
+        return out.toByteArray()
+    }
+
+    @Suppress("MagicNumber")
+    private fun ByteArrayOutputStream.writeUInt32LE(value: Int) {
+        write(value and 0xFF)
+        write((value ushr 8) and 0xFF)
+        write((value ushr 16) and 0xFF)
+        write((value ushr 24) and 0xFF)
+    }
+
+    @Suppress("MagicNumber")
+    private fun sha256Truncated(data: ByteArray): ByteArray =
+        MessageDigest.getInstance("SHA-256").digest(data).copyOf(24)
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -505,6 +505,28 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
         }
     }
 
+    @Test
+    fun `performRequest skips RC Format verification and returns VERIFIED for a 204 empty response`() {
+        val endpoint = Endpoint.GetRemoteConfig
+
+        mockSigningResult(VerificationResult.VERIFIED)
+        enqueueRCFormat(ByteArray(0), responseCode = RCHTTPStatusCodes.NO_CONTENT)
+
+        val result = client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            postFieldsToSign = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+
+        assertThat(result.responseCode).isEqualTo(RCHTTPStatusCodes.NO_CONTENT)
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
+        assertSigningNotPerformed()
+    }
+
     // endregion
 
     private fun mockSigningResult(result: VerificationResult) {
@@ -519,11 +541,11 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
         }
     }
 
-    private fun enqueueRCFormat(body: ByteArray) {
+    private fun enqueueRCFormat(body: ByteArray, responseCode: Int = RCHTTPStatusCodes.SUCCESS) {
         server.enqueue(
             MockResponse()
                 .setBody(Buffer().write(body))
-                .setResponseCode(RCHTTPStatusCodes.SUCCESS)
+                .setResponseCode(responseCode)
                 .setHeader(HTTPResult.SIGNATURE_HEADER_NAME, "test-signature")
                 .setHeader(HTTPResult.REQUEST_TIME_HEADER_NAME, 1234567890L)
                 .setHeader(HTTPResult.ETAG_HEADER_NAME, "test-etag")

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -77,12 +77,19 @@ class BackendGetRemoteConfigTest {
     fun `getRemoteConfig parses successful RC Format response into an RCContainer`() {
         val config = "{\"hello\":\"world\"}".toByteArray()
         val element = "blob-bytes".toByteArray()
-        mockHttpResult(payload = HTTPResult.Payload.RCFormat(buildContainer(config = config, elements = listOf(element))))
+        mockHttpResult(
+            payload = HTTPResult.Payload.RCFormat(buildContainer(config = config, elements = listOf(element))),
+            verificationResult = VerificationResult.VERIFIED,
+        )
 
         var container: RCContainer? = null
+        var verification: VerificationResult? = null
         backend.getRemoteConfig(
             appInBackground = false,
-            onSuccess = { container = it },
+            onSuccess = { result, verificationResult ->
+                container = result
+                verification = verificationResult
+            },
             onError = { error -> fail("Expected success. Got error: $error") },
         )
 
@@ -91,6 +98,7 @@ class BackendGetRemoteConfigTest {
         assertThat(parsed.config.data.let { buf -> ByteArray(buf.remaining()).also { buf.duplicate().get(it) } })
             .isEqualTo(config)
         assertThat(parsed.contentElements).hasSize(1)
+        assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
     }
 
     @Test
@@ -101,13 +109,19 @@ class BackendGetRemoteConfigTest {
         )
         var callbackCount = 0
         var container: RCContainer? = mockk()
+        var verification: VerificationResult? = null
         backend.getRemoteConfig(
             appInBackground = false,
-            onSuccess = { callbackCount++; container = it },
+            onSuccess = { result, verificationResult ->
+                callbackCount++
+                container = result
+                verification = verificationResult
+            },
             onError = { error -> fail("Expected success. Got error: $error") },
         )
         assertThat(callbackCount).isEqualTo(1)
         assertThat(container).isNull()
+        assertThat(verification).isEqualTo(VerificationResult.NOT_REQUESTED)
     }
 
     @Test
@@ -117,7 +131,7 @@ class BackendGetRemoteConfigTest {
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
-            onSuccess = { fail("Expected error. Got success") },
+            onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error -> obtainedError = error },
         )
         assertThat(obtainedError).isNotNull
@@ -130,7 +144,7 @@ class BackendGetRemoteConfigTest {
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
-            onSuccess = { fail("Expected error. Got success") },
+            onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error -> obtainedError = error },
         )
         assertThat(obtainedError).isNotNull
@@ -145,7 +159,7 @@ class BackendGetRemoteConfigTest {
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
-            onSuccess = { fail("Expected error. Got success") },
+            onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error -> obtainedError = error },
         )
         assertThat(obtainedError).isNotNull
@@ -157,12 +171,12 @@ class BackendGetRemoteConfigTest {
         val lock = CountDownLatch(2)
         asyncBackend.getRemoteConfig(
             appInBackground = false,
-            onSuccess = { lock.countDown() },
+            onSuccess = { _, _ -> lock.countDown() },
             onError = { fail("Expected success. Got error: $it") },
         )
         asyncBackend.getRemoteConfig(
             appInBackground = false,
-            onSuccess = { lock.countDown() },
+            onSuccess = { _, _ -> lock.countDown() },
             onError = { fail("Expected success. Got error: $it") },
         )
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
@@ -182,6 +196,7 @@ class BackendGetRemoteConfigTest {
         responseCode: Int = RCHTTPStatusCodes.SUCCESS,
         payload: HTTPResult.Payload,
         delayMs: Long? = null,
+        verificationResult: VerificationResult = VerificationResult.NOT_REQUESTED,
     ) {
         every {
             httpClient.performRequest(
@@ -201,7 +216,7 @@ class BackendGetRemoteConfigTest {
                 payload,
                 HTTPResult.Origin.BACKEND,
                 requestDate = null,
-                VerificationResult.NOT_REQUESTED,
+                verificationResult,
                 isLoadShedderResponse = false,
                 isFallbackURL = false,
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -215,6 +215,7 @@ class EndpointTest {
             Endpoint.PostRedeemWebPurchase,
             Endpoint.GetVirtualCurrencies(userId = "test-user-id"),
             Endpoint.GetRewardVerification("test-user-id", "client-transaction-id"),
+            Endpoint.GetRemoteConfig,
         )
         for (endpoint in expectedSupportsValidationEndpoints) {
             assertThat(endpoint.supportsSignatureVerification)
@@ -232,7 +233,6 @@ class EndpointTest {
             Endpoint.PostEvents,
             Endpoint.WebBillingGetProducts("test-user-id", setOf("product1", "product2")),
             Endpoint.AliasUsers("test-user-id"),
-            Endpoint.GetRemoteConfig,
         )
         for (endpoint in expectedNotSupportsValidationEndpoints) {
             assertThat(endpoint.supportsSignatureVerification)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -323,6 +323,56 @@ class SigningManagerTest {
         assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
     }
 
+    @Test
+    fun `verifyResponse verifies a binary body signed as raw bytes`() {
+        val signingManager = SigningManager(
+            SignatureVerificationMode.Informational(
+                IntermediateSignatureHelper(DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")),
+            ),
+            appConfig,
+            apiKey,
+        )
+        val salt = ByteArray(16).apply { SecureRandom().nextBytes(this) }
+        val configChecksum = ByteArray(24) { it.toByte() }
+        val signature = createFakeSignatureForBytes(bodyBytes = configChecksum, salt = salt)
+
+        val verified = signingManager.verifyResponse(
+            urlPath = "test-url-path",
+            signatureString = signature,
+            nonce = null,
+            bodyBytes = configChecksum,
+            requestTime = "1677005916012",
+            eTag = null,
+            postFieldsToSignHeader = null,
+        )
+        assertThat(verified).isEqualTo(VerificationResult.VERIFIED)
+    }
+
+    @Test
+    fun `verifyResponse fails for a binary body that does not match the signed bytes`() {
+        val signingManager = SigningManager(
+            SignatureVerificationMode.Informational(
+                IntermediateSignatureHelper(DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")),
+            ),
+            appConfig,
+            apiKey,
+        )
+        val salt = ByteArray(16).apply { SecureRandom().nextBytes(this) }
+        val configChecksum = ByteArray(24) { it.toByte() }
+        val signature = createFakeSignatureForBytes(bodyBytes = configChecksum, salt = salt)
+
+        val tampered = signingManager.verifyResponse(
+            urlPath = "test-url-path",
+            signatureString = signature,
+            nonce = null,
+            bodyBytes = ByteArray(24) { (it + 1).toByte() },
+            requestTime = "1677005916012",
+            eTag = null,
+            postFieldsToSignHeader = null,
+        )
+        assertThat(tampered).isEqualTo(VerificationResult.FAILED)
+    }
+
     // endregion
 
     // region Helpers
@@ -341,7 +391,7 @@ class SigningManagerTest {
         requestTime: String? = "1677005916012",
         eTag: String? = null,
         postParamsHeader: String? = null,
-    ) = signingManager.verifyResponse(requestPath, signature, nonce, body, requestTime, eTag, postParamsHeader)
+    ) = signingManager.verifyResponse(requestPath, signature, nonce, body?.toByteArray(), requestTime, eTag, postParamsHeader)
 
     // We can use this function to create new signatures if we need to change the test data
     @Suppress("Unused")
@@ -373,6 +423,35 @@ class SigningManagerTest {
             (eTag?.toByteArray() ?: byteArrayOf()) +
             (body?.toByteArray() ?: byteArrayOf())
         val signature =  intermediatePublicKey +
+            intermediateKeyExpirationDaysBytes +
+            intermediatePublicKeySignature +
+            salt +
+            intermediateSigner.sign(payloadToSign)
+        return Base64.encodeToString(signature, Base64.DEFAULT)
+    }
+
+    // Builds a signature over a raw-bytes body (no nonce / post params / eTag), mirroring the binary
+    // (RC Container) signing path.
+    private fun createFakeSignatureForBytes(
+        bodyBytes: ByteArray,
+        salt: ByteArray,
+        requestPath: String = "test-url-path",
+        requestTime: String = "1677005916012",
+        rootPrivateKeyEncoded: String = "YMHMQMpepBKamtSzO8KCN2M8Z3AUW5R1JXIFtxUWFUI",
+        intermediatePrivateKeyEncoded: String = "fPBoIjQ7DecE89ATW6PZsqLVQNyEs5fiX3sUyS3U4YI",
+        intermediatePublicKeyEncoded: String = "xoDYyUeHnIlSIAeOOzmvdNPOlbNSKK+xE0fE/ufS1fs=",
+        intermediateKeyExpirationDaysBytes: ByteArray = ByteBuffer.allocate(Int.SIZE_BYTES).putInt(50_000).order(ByteOrder.LITTLE_ENDIAN).array(),
+    ): String {
+        val rootSigner = Ed25519Sign(Base64.decode(rootPrivateKeyEncoded, Base64.DEFAULT))
+        val intermediatePublicKey = Base64.decode(intermediatePublicKeyEncoded, Base64.DEFAULT)
+        val intermediatePublicKeySignature = rootSigner.sign(intermediateKeyExpirationDaysBytes + intermediatePublicKey)
+        val intermediateSigner = Ed25519Sign(Base64.decode(intermediatePrivateKeyEncoded, Base64.DEFAULT))
+        val payloadToSign = salt +
+            apiKey.toByteArray() +
+            requestPath.toByteArray() +
+            requestTime.toByteArray() +
+            bodyBytes
+        val signature = intermediatePublicKey +
             intermediateKeyExpirationDaysBytes +
             intermediatePublicKeySignature +
             salt +


### PR DESCRIPTION
Stacked on #3607 (which adds the binary RC Container request/parsing).

Enables trusted-entitlements signature verification for the binary `GET /v2/config` response. This hasn't been tested against the actual endpoint yet, but this endpoint is currently unused so should be safe to merge.

## What
- `GetRemoteConfig.supportsSignatureVerification = true`. The response signature is verified over the config element's 24-byte truncated SHA-256 checksum (no nonce). Two independent checks are both required, else `FAILED`:
  1. `X-Signature` (Ed25519) covers the checksum -> backend authenticity.
  2. `RCElement.isChecksumValid()` ties the checksum to the actual config bytes.
- `SigningManager`: signed body is now `ByteArray?` (binary-safe).
- `HTTPClient.verifyBinaryResponse` parses the container, checks integrity, and verifies the signature over the config checksum.
- The resulting `VerificationResult` is surfaced through the `getRemoteConfig` callback.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signature verification and changes the getRemoteConfig callback shape, but scope is limited to the still-unused remote config endpoint with strong test coverage.
> 
> **Overview**
> Enables **trusted-entitlements signature verification** for `GET /v2/config` RC Container responses and threads the outcome to callers.
> 
> **`GetRemoteConfig`** is now in the set of endpoints that require response signing. Verification is **not** over the raw body: the client parses the container, requires **`RCElement.isChecksumValid()`** on the config element, then verifies **`X-Signature`** over that element’s **24-byte truncated SHA-256 checksum** (no nonce / post-params). Empty **204** responses are treated as **`VERIFIED`** without calling the signer.
> 
> **`SigningManager.verifyResponse`** now takes **`ByteArray?`** for the signed payload so JSON bodies and binary checksums use the same API. **`getRemoteConfig`** success callbacks are **`(RCContainer?, VerificationResult)`** instead of container-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de07e2bc82504b40b817198c0ddfc37a599a9c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->