### PR TITLE
Add Slovenian support for paywalls

### DIFF
--- a/ui/revenuecatui/src/main/res/values-sl/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-sl/strings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="OK">V redu</string>
+    <string name="all_plans">Vse naročnine</string>
+    <string name="privacy">Zasebnost</string>
+    <string name="privacy_policy">Pravilnik o zasebnosti</string>
+    <string name="restore">Obnovi</string>
+    <string name="restore_purchases">Obnovi nakupe</string>
+    <string name="terms">Pogoji</string>
+    <string name="terms_and_conditions">Pogoji in določila</string>
+    <string name="annual">Letno</string>
+    <string name="semester">6 mesecev</string>
+    <string name="quarter">3 meseci</string>
+    <string name="bimonthly">2 meseca</string>
+    <string name="monthly">Mesečno</string>
+    <string name="weekly">Tedensko</string>
+    <string name="lifetime">Doživljenjsko</string>
+    <string name="package_discount">%1$d%% popusta</string>
+    <string name="continue_cta">Nadaljuj</string>
+    <string name="default_offer_details_with_intro_offer">Začnite {{ sub_offer_duration }} preizkusno obdobje, nato {{ total_price_and_per_month }}.</string>
+    <string name="no_browser_cannot_open_link">Ni nameščenega brskalnika. Povezave ni mogoče odpreti.</string>
+    <string name="cannot_open_link">Neveljavna povezava. Ni mogoče odpreti.</string>
+    <string name="revenuecatui_purchase">Kupi</string>
+    <string name="revenuecatui_restore_purchases">@string/restore_purchases</string>
+</resources>


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Customer request ([PWENG-115](https://linear.app/revenuecat/issue/PWENG-115/add-slovene-locale-support-in-paywalls)) to support Slovenian in paywalls. The existing workaround of substituting Slovenian for English only works for single-locale projects and breaks for customers with multiple locales.

### Description
Adds Slovenian (`sl`) paywall string resources to the RevenueCatUI Android SDK.

- Added `ui/revenuecatui/src/main/res/values-sl/strings.xml` with the Slovenian translations of the paywall UI strings (actions, subscription period labels, offer/discount templates, and link-error messages).

The key set matches the existing locale resource files exactly (e.g. `values-sk`), so no strings are missing or extra.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Resource-only localization with no runtime or business-logic changes.
> 
> **Overview**
> Adds ** Slovenian (`sl`)** localization for RevenueCatUI paywalls by introducing `values-sl/strings.xml`.
> 
> The new file mirrors the existing locale bundles (same keys as e.g. `values-sk`) and covers paywall copy for CTAs, plan periods, privacy/terms/restore actions, discount and intro-offer templates, and browser/link error messages. Android will pick these strings when the device locale is Slovenian, instead of falling back to English in multi-locale apps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e7195b43932395475c9ad9b4b72e69e4ce29a00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->