### PR TITLE
Adds Cursor Cloud Agent environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,1 +1,6 @@
 FROM cimg/android:2025.04.1
+
+# The base image exposes the SDK via $ANDROID_HOME but only adds the tools to
+# PATH through its login profile, which isn't sourced in non-login agent shells.
+# Add them explicitly so sdkmanager/adb are directly callable in agent terminals.
+ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}"

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,1 @@
+FROM cimg/android:2025.04.1

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,2 +1,3 @@
+# Same version as in .circleci/config.yml.
 FROM cimg/android:2025.04.1
 ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}"

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,6 +1,2 @@
 FROM cimg/android:2025.04.1
-
-# The base image exposes the SDK via $ANDROID_HOME but only adds the tools to
-# PATH through its login profile, which isn't sourced in non-login agent shells.
-# Add them explicitly so sdkmanager/adb are directly callable in agent terminals.
 ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,6 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,9 @@ examples/paywall-tester/src/main/generated/baselineProfiles/
 .gradle/
 .gradletasknamecache
 build/
-.cursor/
+.cursor/*
+!.cursor/environment.json
+!.cursor/Dockerfile
 
 # Local configuration file (sdk path, etc)
 local.properties


### PR DESCRIPTION
## Description
Adds a [Cursor Cloud Agent environment](https://cursor.com/docs/cloud-agent/setup#manual-setup-with-dockerfile-advanced) so Cloud Agents can verify their own work and run Gradle and stuff. It's just the same image we use in CI. 

<div><a href="https://cursor.com/agents/bc-4dd17883-dcae-4892-95a5-a8ff9858729b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dd17883-dcae-4892-95a5-a8ff9858729b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-tooling and ignore rules only; no app, auth, or runtime behavior changes.
> 
> **Overview**
> Adds a **Cursor Cloud Agent** setup so agents can build and run Gradle in an environment aligned with CI.
> 
> A new `.cursor/Dockerfile` uses `cimg/android:2025.04.1` (same as `.circleci/config.yml`) and extends `PATH` for Android cmdline-tools and platform-tools. `.cursor/environment.json` points the agent build at that Dockerfile with repo root as context.
> 
> **`.gitignore`** no longer ignores the whole `.cursor/` directory; it ignores `.cursor/*` but **keeps** `.cursor/environment.json` and `.cursor/Dockerfile` tracked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c83663708fcbe40d42fac1f1a5d0e19deff249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->