### PR TITLE
WFL-303 | Add fallback URL for workflows

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -47,8 +47,11 @@ internal sealed class Endpoint(
         fallbackPath = "/workflows/v1/workflows",
     ) {
         override fun getPath(useFallback: Boolean): String {
-            if (useFallback && fallbackPath != null) return fallbackPath
-            val base = pathTemplate.format(Uri.encode(userId))
+            val base = if (useFallback && fallbackPath != null) {
+                fallbackPath
+            } else {
+                pathTemplate.format(Uri.encode(userId))
+            }
             return if (type != null) "$base?type=${Uri.encode(type)}" else base
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -31,15 +31,23 @@ internal sealed class Endpoint(
     data class GetWorkflow(val userId: String, val workflowId: String) : Endpoint(
         "/v1/subscribers/%s/workflows/%s",
         "get_workflow",
+        fallbackPath = "/workflows/v1/workflows/%s",
     ) {
-        override fun getPath(useFallback: Boolean) =
-            pathTemplate.format(Uri.encode(userId), Uri.encode(workflowId))
+        override fun getPath(useFallback: Boolean): String {
+            return if (useFallback && fallbackPath != null) {
+                fallbackPath.format(Uri.encode(workflowId))
+            } else {
+                pathTemplate.format(Uri.encode(userId), Uri.encode(workflowId))
+            }
+        }
     }
     data class GetWorkflows(val userId: String, val type: String? = null) : Endpoint(
         "/v1/subscribers/%s/workflows",
         "get_workflows",
+        fallbackPath = "/workflows/v1/workflows",
     ) {
         override fun getPath(useFallback: Boolean): String {
+            if (useFallback && fallbackPath != null) return fallbackPath
             val base = pathTemplate.format(Uri.encode(userId))
             return if (type != null) "$base?type=${Uri.encode(type)}" else base
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -81,6 +81,13 @@ class EndpointTest {
     @Test
     fun `GetWorkflows fallback path is correct`() {
         val endpoint = Endpoint.GetWorkflows("test user-id", type = "paywall")
+        val expectedPath = "/workflows/v1/workflows?type=paywall"
+        assertThat(endpoint.getPath(useFallback = true)).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `GetWorkflows fallback path without type is correct`() {
+        val endpoint = Endpoint.GetWorkflows("test user-id")
         val expectedPath = "/workflows/v1/workflows"
         assertThat(endpoint.getPath(useFallback = true)).isEqualTo(expectedPath)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -72,6 +72,20 @@ class EndpointTest {
     }
 
     @Test
+    fun `GetWorkflow fallback path is correct`() {
+        val endpoint = Endpoint.GetWorkflow("test user-id", "wf abc")
+        val expectedPath = "/workflows/v1/workflows/wf%20abc"
+        assertThat(endpoint.getPath(useFallback = true)).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `GetWorkflows fallback path is correct`() {
+        val endpoint = Endpoint.GetWorkflows("test user-id", type = "paywall")
+        val expectedPath = "/workflows/v1/workflows"
+        assertThat(endpoint.getPath(useFallback = true)).isEqualTo(expectedPath)
+    }
+
+    @Test
     fun `LogIn has correct path`() {
         val endpoint = Endpoint.LogIn
         val expectedPath = "/v1/subscribers/identify"


### PR DESCRIPTION
### Motivation

Add Fortress fallback URLs for Workflow endpoints 

iOS counterpart: https://github.com/RevenueCat/purchases-ios/pull/7008

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized networking path logic with tests; failover only affects workflow API calls when fallback base URLs are configured.
> 
> **Overview**
> Adds **Fortress fallback path** support for `GetWorkflow` and `GetWorkflows`, matching the existing pattern used by offerings.
> 
> When `getPath(useFallback = true)` is used (e.g. on HTTP client retry to alternate base URLs), **single-workflow** requests go to `/workflows/v1/workflows/{workflowId}` instead of the subscriber-scoped path, and **list** requests use `/workflows/v1/workflows`, still appending `?type=` when a type filter is set. Primary paths are unchanged.
> 
> Unit tests cover fallback paths with and without the type query parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a5503308bb12a5fc4d6a8f7de41df556865a1f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->