### PR TITLE
refactor(remote-config): manifest persistence, request body handling

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -28,6 +28,7 @@ import com.revenuecat.purchases.common.networking.RewardVerificationResponse
 import com.revenuecat.purchases.common.networking.WebBillingProductsResponse
 import com.revenuecat.purchases.common.networking.buildPostReceiptResponse
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.workflows.WorkflowDetailResponse
 import com.revenuecat.purchases.common.workflows.WorkflowJsonParser
@@ -1308,6 +1309,7 @@ internal class Backend(
 
     fun getRemoteConfig(
         appInBackground: Boolean,
+        manifest: RemoteConfiguration.Manifest,
         onSuccess: (RCContainer?, VerificationResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -1320,13 +1322,25 @@ internal class Backend(
             ?.let { runCatching { URL(it) }.getOrNull() }
         val baseURL = overrideURL ?: appConfig.baseURL
         val fallbackBaseURLs = if (overrideURL != null) emptyList() else appConfig.fallbackBaseURLs
+        val manifestMap = JsonProvider.defaultJson
+            .encodeToJsonElement(RemoteConfiguration.Manifest.serializer(), manifest).asMap()
+        if (manifestMap == null) {
+            onError(
+                PurchasesError(
+                    PurchasesErrorCode.UnknownError,
+                    "Error encoding remote config manifest.",
+                ).also { errorLog(it) },
+            )
+            return
+        }
+        val body = mapOf("manifest" to manifestMap)
 
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
                     baseURL,
                     endpoint,
-                    body = null,
+                    body = body,
                     postFieldsToSign = null,
                     backendHelper.authenticationHeaders,
                     fallbackBaseURLs = fallbackBaseURLs,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -28,7 +28,6 @@ import com.revenuecat.purchases.common.networking.RewardVerificationResponse
 import com.revenuecat.purchases.common.networking.WebBillingProductsResponse
 import com.revenuecat.purchases.common.networking.buildPostReceiptResponse
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
-import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.workflows.WorkflowDetailResponse
 import com.revenuecat.purchases.common.workflows.WorkflowJsonParser
@@ -1307,9 +1306,12 @@ internal class Backend(
         }
     }
 
+    @Suppress("LongParameterList")
     fun getRemoteConfig(
         appInBackground: Boolean,
-        manifest: RemoteConfiguration.Manifest,
+        domain: String,
+        manifest: String?,
+        prefetchedBlobs: List<String>,
         onSuccess: (RCContainer?, VerificationResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -1322,18 +1324,12 @@ internal class Backend(
             ?.let { runCatching { URL(it) }.getOrNull() }
         val baseURL = overrideURL ?: appConfig.baseURL
         val fallbackBaseURLs = if (overrideURL != null) emptyList() else appConfig.fallbackBaseURLs
-        val manifestMap = JsonProvider.defaultJson
-            .encodeToJsonElement(RemoteConfiguration.Manifest.serializer(), manifest).asMap()
-        if (manifestMap == null) {
-            onError(
-                PurchasesError(
-                    PurchasesErrorCode.UnknownError,
-                    "Error encoding remote config manifest.",
-                ).also { errorLog(it) },
-            )
-            return
+        // The manifest is an opaque token replayed verbatim; omitted on the first run when there is none.
+        val body = buildMap<String, Any?> {
+            put("domain", domain)
+            manifest?.let { put("manifest", it) }
+            put("prefetched_blobs", prefetchedBlobs)
         }
-        val body = mapOf("manifest" to manifestMap)
 
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -23,7 +23,7 @@ import java.io.IOException
  * an empty list for inline-only topics.
  */
 @Serializable
-internal data class PersistedRemoteConfig(
+internal data class PersistedRemoteConfigurationState(
     val domain: String,
     val manifest: String,
     val activeTopics: List<String> = emptyList(),
@@ -33,22 +33,22 @@ internal data class PersistedRemoteConfig(
 )
 
 /**
- * Persists [PersistedRemoteConfig] to `noBackupFilesDir/RevenueCat/remote_config/` (excluded from backups as a
- * regenerable cache). Writes are atomic and crash-safe via [AtomicFile]; a missing or corrupt file reads back as
- * `null`.
+ * Persists [PersistedRemoteConfigurationState] to `noBackupFilesDir/RevenueCat/remote_config/`
+ * (excluded from backups as a regenerable cache). Writes are atomic and crash-safe via [AtomicFile];
+ * a missing or corrupt file reads back as `null`.
  */
 internal class RemoteConfigDiskCache(
     private val applicationContext: Context,
 ) {
     private val json = JsonProvider.defaultJson
 
-    fun read(): PersistedRemoteConfig? {
+    fun read(): PersistedRemoteConfigurationState? {
         val target = targetFile()
         if (!target.exists()) return null
         val atomicFile = AtomicFile(target)
         return try {
             json.decodeFromString(
-                PersistedRemoteConfig.serializer(),
+                PersistedRemoteConfigurationState.serializer(),
                 atomicFile.readFully().toString(Charsets.UTF_8),
             )
         } catch (e: IOException) {
@@ -60,7 +60,7 @@ internal class RemoteConfigDiskCache(
         }
     }
 
-    fun write(config: PersistedRemoteConfig) {
+    fun write(config: PersistedRemoteConfigurationState) {
         try {
             val target = targetFile()
             target.parentFile?.let { parent ->
@@ -69,7 +69,7 @@ internal class RemoteConfigDiskCache(
                 }
             }
             val content = json.encodeToString(
-                PersistedRemoteConfig.serializer(),
+                PersistedRemoteConfigurationState.serializer(),
                 config,
             )
             val atomicFile = AtomicFile(target)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -1,0 +1,74 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import android.content.Context
+import com.revenuecat.purchases.common.JsonProvider
+import com.revenuecat.purchases.common.errorLog
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import java.io.File
+import java.io.IOException
+
+/** The last server [manifest] plus the resolved topic bodies the SDK currently has cached. */
+@Serializable
+internal data class PersistedRemoteConfig(
+    val manifest: RemoteConfiguration.Manifest,
+    val topics: Map<String, ConfigTopic> = emptyMap(),
+)
+
+/**
+ * Persists [PersistedRemoteConfig] to `noBackupFilesDir/RevenueCat/` (excluded from backups as a regenerable
+ * cache). Writes are atomic (temp file + rename); a missing or corrupt file reads back as `null`.
+ */
+internal class RemoteConfigDiskCache(
+    private val applicationContext: Context,
+) {
+    private val json = JsonProvider.defaultJson
+
+    fun read(): PersistedRemoteConfig? {
+        val target = File(File(applicationContext.noBackupFilesDir, REMOTE_CONFIG_ROOT), REMOTE_CONFIG_FILE_NAME)
+        if (!target.exists()) return null
+        return try {
+            json.decodeFromString(PersistedRemoteConfig.serializer(), target.readText())
+        } catch (e: IOException) {
+            errorLog(e) { "Failed to read remote config from disk." }
+            null
+        } catch (e: SerializationException) {
+            errorLog(e) { "Failed to deserialize remote config from disk." }
+            null
+        }
+    }
+
+    fun write(manifest: RemoteConfiguration.Manifest, resolvedTopics: Map<String, ConfigTopic>) {
+        val parent = File(applicationContext.noBackupFilesDir, REMOTE_CONFIG_ROOT)
+        try {
+            if (!parent.exists()) {
+                parent.mkdirs()
+            }
+            val content = json.encodeToString(
+                PersistedRemoteConfig.serializer(),
+                PersistedRemoteConfig(manifest, resolvedTopics),
+            )
+            val target = File(parent, REMOTE_CONFIG_FILE_NAME)
+            val tempFile = File.createTempFile("rc_remote_config_", ".tmp", parent)
+            try {
+                tempFile.writeText(content)
+                if (!tempFile.renameTo(target)) {
+                    tempFile.copyTo(target, overwrite = true)
+                }
+            } finally {
+                if (tempFile.exists()) {
+                    tempFile.delete()
+                }
+            }
+        } catch (e: IOException) {
+            errorLog(e) { "Failed to persist remote config to disk." }
+        } catch (e: SerializationException) {
+            errorLog(e) { "Failed to serialize remote config for disk persistence." }
+        }
+    }
+
+    private companion object {
+        private const val REMOTE_CONFIG_ROOT = "RevenueCat"
+        private const val REMOTE_CONFIG_FILE_NAME = "remote_config.json"
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -8,11 +8,27 @@ import kotlinx.serialization.SerializationException
 import java.io.File
 import java.io.IOException
 
-/** The last server [manifest] plus the resolved topic bodies the SDK currently has cached. */
+/**
+ * The sync bookkeeping the SDK persists between `/v2/config` calls.
+ *
+ * [manifest] is the **opaque** server token, stored verbatim and replayed on the next request; the SDK never
+ * parses it. [activeTopics] is the last response's full active-topic-name set (used to detect removed topics).
+ * [prefetchBlobs] is the last response's prefetch set (retention input + which blobs to fetch). [lastRefreshAt]
+ * is the SDK's own wall-clock of the last sync attempt, used only for refresh cadence.
+ *
+ * The full topic bodies are intentionally **not** persisted: an item's payload lives either in the blob store
+ * (addressed by its blob ref) or is projected into a purpose-built cache by its topic handler, so the only
+ * topic state the sync needs to keep is which blobs each topic keeps alive for retention. [topicBlobRefs] holds
+ * an empty list for inline-only topics.
+ */
 @Serializable
 internal data class PersistedRemoteConfig(
-    val manifest: RemoteConfiguration.Manifest,
-    val topics: Map<String, ConfigTopic> = emptyMap(),
+    val domain: String,
+    val manifest: String,
+    val activeTopics: List<String> = emptyList(),
+    val prefetchBlobs: List<String> = emptyList(),
+    val topicBlobRefs: Map<String, List<String>> = emptyMap(),
+    val lastRefreshAt: Long = 0,
 )
 
 /**
@@ -38,7 +54,7 @@ internal class RemoteConfigDiskCache(
         }
     }
 
-    fun write(manifest: RemoteConfiguration.Manifest, resolvedTopics: Map<String, ConfigTopic>) {
+    fun write(config: PersistedRemoteConfig) {
         val parent = File(applicationContext.noBackupFilesDir, REMOTE_CONFIG_ROOT)
         try {
             if (!parent.exists()) {
@@ -46,7 +62,7 @@ internal class RemoteConfigDiskCache(
             }
             val content = json.encodeToString(
                 PersistedRemoteConfig.serializer(),
-                PersistedRemoteConfig(manifest, resolvedTopics),
+                config,
             )
             val target = File(parent, REMOTE_CONFIG_FILE_NAME)
             val tempFile = File.createTempFile("rc_remote_config_", ".tmp", parent)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.remoteconfig
 
 import android.content.Context
+import androidx.core.util.AtomicFile
 import com.revenuecat.purchases.common.JsonProvider
 import com.revenuecat.purchases.common.errorLog
 import kotlinx.serialization.Serializable
@@ -32,8 +33,9 @@ internal data class PersistedRemoteConfig(
 )
 
 /**
- * Persists [PersistedRemoteConfig] to `noBackupFilesDir/RevenueCat/` (excluded from backups as a regenerable
- * cache). Writes are atomic (temp file + rename); a missing or corrupt file reads back as `null`.
+ * Persists [PersistedRemoteConfig] to `noBackupFilesDir/RevenueCat/remote_config/` (excluded from backups as a
+ * regenerable cache). Writes are atomic and crash-safe via [AtomicFile]; a missing or corrupt file reads back as
+ * `null`.
  */
 internal class RemoteConfigDiskCache(
     private val applicationContext: Context,
@@ -41,10 +43,14 @@ internal class RemoteConfigDiskCache(
     private val json = JsonProvider.defaultJson
 
     fun read(): PersistedRemoteConfig? {
-        val target = File(File(applicationContext.noBackupFilesDir, REMOTE_CONFIG_ROOT), REMOTE_CONFIG_FILE_NAME)
+        val target = targetFile()
         if (!target.exists()) return null
+        val atomicFile = AtomicFile(target)
         return try {
-            json.decodeFromString(PersistedRemoteConfig.serializer(), target.readText())
+            json.decodeFromString(
+                PersistedRemoteConfig.serializer(),
+                atomicFile.readFully().toString(Charsets.UTF_8),
+            )
         } catch (e: IOException) {
             errorLog(e) { "Failed to read remote config from disk." }
             null
@@ -55,26 +61,25 @@ internal class RemoteConfigDiskCache(
     }
 
     fun write(config: PersistedRemoteConfig) {
-        val parent = File(applicationContext.noBackupFilesDir, REMOTE_CONFIG_ROOT)
         try {
-            if (!parent.exists()) {
-                parent.mkdirs()
+            val target = targetFile()
+            target.parentFile?.let { parent ->
+                if (!parent.exists()) {
+                    parent.mkdirs()
+                }
             }
             val content = json.encodeToString(
                 PersistedRemoteConfig.serializer(),
                 config,
             )
-            val target = File(parent, REMOTE_CONFIG_FILE_NAME)
-            val tempFile = File.createTempFile("rc_remote_config_", ".tmp", parent)
+            val atomicFile = AtomicFile(target)
+            val out = atomicFile.startWrite()
             try {
-                tempFile.writeText(content)
-                if (!tempFile.renameTo(target)) {
-                    tempFile.copyTo(target, overwrite = true)
-                }
-            } finally {
-                if (tempFile.exists()) {
-                    tempFile.delete()
-                }
+                out.write(content.toByteArray())
+                atomicFile.finishWrite(out)
+            } catch (e: IOException) {
+                atomicFile.failWrite(out)
+                throw e
             }
         } catch (e: IOException) {
             errorLog(e) { "Failed to persist remote config to disk." }
@@ -83,8 +88,15 @@ internal class RemoteConfigDiskCache(
         }
     }
 
+    private fun targetFile(): File =
+        File(
+            File(File(applicationContext.noBackupFilesDir, REMOTE_CONFIG_ROOT), REMOTE_CONFIG_SUBDIR),
+            REMOTE_CONFIG_FILE_NAME,
+        )
+
     private companion object {
         private const val REMOTE_CONFIG_ROOT = "RevenueCat"
+        private const val REMOTE_CONFIG_SUBDIR = "remote_config"
         private const val REMOTE_CONFIG_FILE_NAME = "remote_config.json"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -1,26 +1,36 @@
 package com.revenuecat.purchases.common.remoteconfig
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.errorLog
 import kotlinx.serialization.SerializationException
 
 /**
- * Orchestrates a single `/v2/config` sync: replays the persisted [RemoteConfiguration.Manifest], then on `204`
- * keeps the cache untouched and on `200` persists the fresh server manifest plus the resolved topic bodies.
+ * Orchestrates a single `/v2/config` sync: replays the persisted opaque manifest, then on `204` keeps the cache
+ * untouched and on `200` persists the fresh server manifest plus the resolved per-topic blob refs.
  *
- * Blob extraction (Phase 3), topic-handler dispatch (Phase 4) and lifecycle wiring (Phase 7) are not done here
- * yet; this manager currently only owns manifest replay and persistence.
+ * The manifest is opaque (stored and replayed verbatim); the active-topic set and removed-topic detection come
+ * from the response's [RemoteConfiguration.activeTopics]. Blob extraction (Phase 3), topic-handler dispatch
+ * (Phase 4) and lifecycle wiring (Phase 7) are not done here yet; this manager currently only owns manifest
+ * replay and persistence.
  */
+@OptIn(InternalRevenueCatAPI::class)
 internal class RemoteConfigManager(
     private val backend: Backend,
     private val diskCache: RemoteConfigDiskCache,
+    private val dateProvider: DateProvider = DefaultDateProvider(),
 ) {
     fun refreshRemoteConfig(appInBackground: Boolean) {
         val persisted = diskCache.read()
-        val requestManifest = persisted?.manifest ?: RemoteConfiguration.Manifest(domain = DEFAULT_DOMAIN)
         backend.getRemoteConfig(
             appInBackground = appInBackground,
-            manifest = requestManifest,
+            domain = persisted?.domain ?: DEFAULT_DOMAIN,
+            // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
+            manifest = persisted?.manifest,
+            // No blob store yet (Phase 3 reports the refs actually cached); the SDK holds nothing here.
+            prefetchedBlobs = emptyList(),
             onSuccess = { container, _ ->
                 if (container == null) {
                     // 204: nothing changed, keep the cache.
@@ -40,14 +50,27 @@ internal class RemoteConfigManager(
     }
 
     private fun persist(previous: PersistedRemoteConfig?, response: RemoteConfiguration) {
-        val previousTopics = previous?.topics ?: emptyMap()
-        // Changed bodies overwrite previous ones; topics dropped from the new manifest are pruned.
-        val mergedTopics = (previousTopics + response.topics)
-            .filterKeys { it in response.manifest.topics.keys }
-        diskCache.write(response.manifest, mergedTopics)
+        val previousBlobRefs = previous?.topicBlobRefs ?: emptyMap()
+        // Changed topics overwrite their refs; topics no longer active are pruned.
+        val mergedBlobRefs = (previousBlobRefs + response.topics.toTopicBlobRefs())
+            .filterKeys { it in response.activeTopics }
+        diskCache.write(
+            PersistedRemoteConfig(
+                domain = response.domain,
+                manifest = response.manifest,
+                activeTopics = response.activeTopics,
+                prefetchBlobs = response.prefetchBlobs,
+                topicBlobRefs = mergedBlobRefs,
+                lastRefreshAt = dateProvider.now.time,
+            ),
+        )
     }
 
     private companion object {
         private const val DEFAULT_DOMAIN = "app"
     }
 }
+
+/** The blob refs each topic's items reference, keyed by topic name (empty list for inline-only topics). */
+internal fun Map<String, ConfigTopic>.toTopicBlobRefs(): Map<String, List<String>> =
+    mapValues { (_, topic) -> topic.values.mapNotNull { it.blobRef } }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -1,0 +1,53 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.errorLog
+import kotlinx.serialization.SerializationException
+
+/**
+ * Orchestrates a single `/v2/config` sync: replays the persisted [RemoteConfiguration.Manifest], then on `204` keeps the
+ * cache untouched and on `200` persists the fresh server manifest plus the resolved topic bodies.
+ *
+ * Blob extraction (Phase 3), topic-handler dispatch (Phase 4) and lifecycle wiring (Phase 7) are not done here
+ * yet; this manager currently only owns manifest replay and persistence.
+ */
+internal class RemoteConfigManager(
+    private val backend: Backend,
+    private val diskCache: RemoteConfigDiskCache,
+) {
+    fun refreshRemoteConfig(appInBackground: Boolean) {
+        val persisted = diskCache.read()
+        val requestManifest = persisted?.manifest ?: RemoteConfiguration.Manifest(domain = DEFAULT_DOMAIN)
+        backend.getRemoteConfig(
+            appInBackground = appInBackground,
+            manifest = requestManifest,
+            onSuccess = { container, _ ->
+                if (container == null) {
+                    // 204: nothing changed, keep the cache.
+                    return@getRemoteConfig
+                }
+                try {
+                    val response = RemoteConfiguration.parse(container.config.data)
+                    persist(previous = persisted, response = response)
+                } catch (e: SerializationException) {
+                    errorLog(e) { "Failed to parse remote config response. Keeping the cached configuration." }
+                }
+            },
+            onError = { error ->
+                errorLog(error)
+            },
+        )
+    }
+
+    private fun persist(previous: PersistedRemoteConfig?, response: RemoteConfiguration) {
+        val previousTopics = previous?.topics ?: emptyMap()
+        // Changed bodies overwrite previous ones; topics dropped from the new manifest are pruned.
+        val mergedTopics = (previousTopics + response.topics)
+            .filterKeys { it in response.manifest.topics.keys }
+        diskCache.write(response.manifest, mergedTopics)
+    }
+
+    private companion object {
+        private const val DEFAULT_DOMAIN = "app"
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -49,13 +49,13 @@ internal class RemoteConfigManager(
         )
     }
 
-    private fun persist(previous: PersistedRemoteConfig?, response: RemoteConfiguration) {
+    private fun persist(previous: PersistedRemoteConfigurationState?, response: RemoteConfiguration) {
         val previousBlobRefs = previous?.topicBlobRefs ?: emptyMap()
         // Changed topics overwrite their refs; topics no longer active are pruned.
         val mergedBlobRefs = (previousBlobRefs + response.topics.toTopicBlobRefs())
             .filterKeys { it in response.activeTopics }
         diskCache.write(
-            PersistedRemoteConfig(
+            PersistedRemoteConfigurationState(
                 domain = response.domain,
                 manifest = response.manifest,
                 activeTopics = response.activeTopics,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -5,8 +5,8 @@ import com.revenuecat.purchases.common.errorLog
 import kotlinx.serialization.SerializationException
 
 /**
- * Orchestrates a single `/v2/config` sync: replays the persisted [RemoteConfiguration.Manifest], then on `204` keeps the
- * cache untouched and on `200` persists the fresh server manifest plus the resolved topic bodies.
+ * Orchestrates a single `/v2/config` sync: replays the persisted [RemoteConfiguration.Manifest], then on `204`
+ * keeps the cache untouched and on `200` persists the fresh server manifest plus the resolved topic bodies.
  *
  * Blob extraction (Phase 3), topic-handler dispatch (Phase 4) and lifecycle wiring (Phase 7) are not done here
  * yet; this manager currently only owns manifest replay and persistence.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonObject
+import java.nio.ByteBuffer
 
 /**
  * The `/v2/config` configuration response. This is the JSON payload carried in element 0 (the config
@@ -75,6 +76,14 @@ internal data class RemoteConfiguration(
     companion object {
         fun parse(bytes: ByteArray): RemoteConfiguration =
             JsonProvider.defaultJson.decodeFromString(serializer(), bytes.decodeToString())
+
+        /** Duplicates [buffer] so the caller's read-only, zero-copy `RCElement.data` view is left untouched. */
+        fun parse(buffer: ByteBuffer): RemoteConfiguration {
+            val view = buffer.duplicate()
+            val bytes = ByteArray(view.remaining())
+            view.get(bytes)
+            return parse(bytes)
+        }
     }
 }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -34,6 +35,14 @@ import kotlin.time.Duration.Companion.seconds
 class BackendGetRemoteConfigTest {
 
     private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
+
+    private val testManifest = RemoteConfiguration.Manifest(
+        domain = "app",
+        topics = mapOf("sources" to "etag1"),
+        prefetchBlobs = listOf("blobRefServer"),
+        prefetchedBlobs = listOf("blobRefA"),
+        lastRefreshAt = 1710000100L,
+    )
 
     private lateinit var appConfig: AppConfig
     private lateinit var httpClient: HTTPClient
@@ -86,6 +95,7 @@ class BackendGetRemoteConfigTest {
         var verification: VerificationResult? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            manifest = testManifest,
             onSuccess = { result, verificationResult ->
                 container = result
                 verification = verificationResult
@@ -102,35 +112,13 @@ class BackendGetRemoteConfigTest {
     }
 
     @Test
-    fun `getRemoteConfig surfaces a 204 No Content response as a null container`() {
-        mockHttpResult(
-            responseCode = RCHTTPStatusCodes.NO_CONTENT,
-            payload = HTTPResult.Payload.RCFormat(ByteArray(0)),
-        )
-        var callbackCount = 0
-        var container: RCContainer? = mockk()
-        var verification: VerificationResult? = null
-        backend.getRemoteConfig(
-            appInBackground = false,
-            onSuccess = { result, verificationResult ->
-                callbackCount++
-                container = result
-                verification = verificationResult
-            },
-            onError = { error -> fail("Expected success. Got error: $error") },
-        )
-        assertThat(callbackCount).isEqualTo(1)
-        assertThat(container).isNull()
-        assertThat(verification).isEqualTo(VerificationResult.NOT_REQUESTED)
-    }
-
-    @Test
     fun `getRemoteConfig surfaces malformed RC Format payload as PurchasesError`() {
         mockHttpResult(payload = HTTPResult.Payload.RCFormat("not a container".toByteArray()))
 
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            manifest = testManifest,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error -> obtainedError = error },
         )
@@ -144,10 +132,85 @@ class BackendGetRemoteConfigTest {
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            manifest = testManifest,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error -> obtainedError = error },
         )
         assertThat(obtainedError).isNotNull
+    }
+
+    @Test
+    fun `getRemoteConfig surfaces a 204 No Content response as a null container`() {
+        var callbackCount = 0
+        var container: RCContainer? = mockk()
+        mockHttpResult(
+            responseCode = RCHTTPStatusCodes.NO_CONTENT,
+            payload = HTTPResult.Payload.RCFormat(ByteArray(0)),
+            verificationResult = VerificationResult.VERIFIED,
+        )
+
+        var verification: VerificationResult? = null
+        backend.getRemoteConfig(
+            appInBackground = false,
+            manifest = testManifest,
+            onSuccess = { result, verificationResult ->
+                callbackCount++
+                container = result
+                verification = verificationResult
+            },
+            onError = { error -> fail("Expected success. Got error: $error") },
+        )
+
+        assertThat(callbackCount).isEqualTo(1)
+        assertThat(container).isNull()
+        assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
+    }
+
+    @Test
+    fun `getRemoteConfig replays the full manifest as the request body`() {
+        val bodySlot = mutableListOf<Map<String, Any?>?>()
+        every {
+            httpClient.performRequest(
+                any(),
+                any(),
+                body = captureNullable(bodySlot),
+                postFieldsToSign = any(),
+                requestHeaders = any(),
+                fallbackBaseURLs = any(),
+            )
+        } returns HTTPResult(
+            RCHTTPStatusCodes.NO_CONTENT,
+            HTTPResult.Payload.RCFormat(ByteArray(0)),
+            HTTPResult.Origin.BACKEND,
+            requestDate = null,
+            VerificationResult.NOT_REQUESTED,
+            isLoadShedderResponse = false,
+            isFallbackURL = false,
+        )
+
+        backend.getRemoteConfig(
+            appInBackground = false,
+            manifest = testManifest,
+            onSuccess = { _, _ -> },
+            onError = { error -> fail("Expected success. Got error: $error") },
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val manifestBody = bodySlot.firstOrNull()?.get("manifest") as? Map<String, Any?>
+        assertThat(manifestBody).isNotNull
+        // The whole manifest is echoed back (every key present), not a subset.
+        assertThat(manifestBody?.keys).containsExactlyInAnyOrder(
+            "domain",
+            "topics",
+            "prefetch_blobs",
+            "prefetched_blobs",
+            "last_refresh_at",
+        )
+        assertThat(manifestBody?.get("domain")).isEqualTo("app")
+        assertThat(manifestBody?.get("topics")).isEqualTo(mapOf("sources" to "etag1"))
+        assertThat(manifestBody?.get("prefetch_blobs")).isEqualTo(listOf("blobRefServer"))
+        assertThat(manifestBody?.get("prefetched_blobs")).isEqualTo(listOf("blobRefA"))
+        assertThat((manifestBody?.get("last_refresh_at") as? Number)?.toLong()).isEqualTo(1710000100L)
     }
 
     @Test
@@ -159,6 +222,7 @@ class BackendGetRemoteConfigTest {
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            manifest = testManifest,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error -> obtainedError = error },
         )
@@ -171,11 +235,13 @@ class BackendGetRemoteConfigTest {
         val lock = CountDownLatch(2)
         asyncBackend.getRemoteConfig(
             appInBackground = false,
+            manifest = testManifest,
             onSuccess = { _, _ -> lock.countDown() },
             onError = { fail("Expected success. Got error: $it") },
         )
         asyncBackend.getRemoteConfig(
             appInBackground = false,
+            manifest = testManifest,
             onSuccess = { _, _ -> lock.countDown() },
             onError = { fail("Expected success. Got error: $it") },
         )
@@ -185,7 +251,7 @@ class BackendGetRemoteConfigTest {
             httpClient.performRequest(
                 mockBaseURL,
                 Endpoint.GetRemoteConfig,
-                body = null,
+                body = any(),
                 postFieldsToSign = null,
                 requestHeaders = any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -13,7 +13,6 @@ import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
-import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -36,13 +35,9 @@ class BackendGetRemoteConfigTest {
 
     private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
 
-    private val testManifest = RemoteConfiguration.Manifest(
-        domain = "app",
-        topics = mapOf("sources" to "etag1"),
-        prefetchBlobs = listOf("blobRefServer"),
-        prefetchedBlobs = listOf("blobRefA"),
-        lastRefreshAt = 1710000100L,
-    )
+    private val testDomain = "app"
+    private val testManifest = "v1.1710000100.sources:etag1"
+    private val testPrefetchedBlobs = listOf("blobRefA")
 
     private lateinit var appConfig: AppConfig
     private lateinit var httpClient: HTTPClient
@@ -95,7 +90,9 @@ class BackendGetRemoteConfigTest {
         var verification: VerificationResult? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            domain = testDomain,
             manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { result, verificationResult ->
                 container = result
                 verification = verificationResult
@@ -118,7 +115,9 @@ class BackendGetRemoteConfigTest {
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            domain = testDomain,
             manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error -> obtainedError = error },
         )
@@ -132,7 +131,9 @@ class BackendGetRemoteConfigTest {
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            domain = testDomain,
             manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error -> obtainedError = error },
         )
@@ -152,7 +153,9 @@ class BackendGetRemoteConfigTest {
         var verification: VerificationResult? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            domain = testDomain,
             manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { result, verificationResult ->
                 callbackCount++
                 container = result
@@ -167,8 +170,99 @@ class BackendGetRemoteConfigTest {
     }
 
     @Test
-    fun `getRemoteConfig replays the full manifest as the request body`() {
+    fun `getRemoteConfig sends domain, opaque manifest and prefetched_blobs as the request body`() {
         val bodySlot = mutableListOf<Map<String, Any?>?>()
+        mockNoContentRequest(bodySlot)
+
+        backend.getRemoteConfig(
+            appInBackground = false,
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> },
+            onError = { error -> fail("Expected success. Got error: $error") },
+        )
+
+        val body = bodySlot.firstOrNull()
+        assertThat(body).isNotNull
+        assertThat(body?.keys).containsExactlyInAnyOrder("domain", "manifest", "prefetched_blobs")
+        assertThat(body?.get("domain")).isEqualTo("app")
+        // The manifest is replayed verbatim as the opaque string the SDK received.
+        assertThat(body?.get("manifest")).isEqualTo(testManifest)
+        assertThat(body?.get("prefetched_blobs")).isEqualTo(listOf("blobRefA"))
+    }
+
+    @Test
+    fun `getRemoteConfig omits the manifest on the first run`() {
+        val bodySlot = mutableListOf<Map<String, Any?>?>()
+        mockNoContentRequest(bodySlot)
+
+        backend.getRemoteConfig(
+            appInBackground = false,
+            domain = testDomain,
+            manifest = null,
+            prefetchedBlobs = emptyList(),
+            onSuccess = { _, _ -> },
+            onError = { error -> fail("Expected success. Got error: $error") },
+        )
+
+        val body = bodySlot.firstOrNull()
+        assertThat(body?.keys).containsExactlyInAnyOrder("domain", "prefetched_blobs")
+        assertThat(body).doesNotContainKey("manifest")
+    }
+
+    @Test
+    fun `getRemoteConfig propagates HTTP errors`() {
+        mockHttpResult(
+            responseCode = RCHTTPStatusCodes.ERROR,
+            payload = HTTPResult.Payload.Text("""{"code": 7000, "message": "internal error"}"""),
+        )
+        var obtainedError: PurchasesError? = null
+        backend.getRemoteConfig(
+            appInBackground = false,
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> fail("Expected error. Got success") },
+            onError = { error -> obtainedError = error },
+        )
+        assertThat(obtainedError).isNotNull
+    }
+
+    @Test
+    fun `getRemoteConfig dedups concurrent calls`() {
+        mockHttpResult(payload = HTTPResult.Payload.RCFormat(buildContainer()), delayMs = 200)
+        val lock = CountDownLatch(2)
+        asyncBackend.getRemoteConfig(
+            appInBackground = false,
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> lock.countDown() },
+            onError = { fail("Expected success. Got error: $it") },
+        )
+        asyncBackend.getRemoteConfig(
+            appInBackground = false,
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> lock.countDown() },
+            onError = { fail("Expected success. Got error: $it") },
+        )
+        lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
+        assertThat(lock.count).isEqualTo(0)
+        verify(exactly = 1) {
+            httpClient.performRequest(
+                mockBaseURL,
+                Endpoint.GetRemoteConfig,
+                body = any(),
+                postFieldsToSign = null,
+                requestHeaders = any(),
+            )
+        }
+    }
+
+    private fun mockNoContentRequest(bodySlot: MutableList<Map<String, Any?>?>) {
         every {
             httpClient.performRequest(
                 any(),
@@ -187,75 +281,6 @@ class BackendGetRemoteConfigTest {
             isLoadShedderResponse = false,
             isFallbackURL = false,
         )
-
-        backend.getRemoteConfig(
-            appInBackground = false,
-            manifest = testManifest,
-            onSuccess = { _, _ -> },
-            onError = { error -> fail("Expected success. Got error: $error") },
-        )
-
-        @Suppress("UNCHECKED_CAST")
-        val manifestBody = bodySlot.firstOrNull()?.get("manifest") as? Map<String, Any?>
-        assertThat(manifestBody).isNotNull
-        // The whole manifest is echoed back (every key present), not a subset.
-        assertThat(manifestBody?.keys).containsExactlyInAnyOrder(
-            "domain",
-            "topics",
-            "prefetch_blobs",
-            "prefetched_blobs",
-            "last_refresh_at",
-        )
-        assertThat(manifestBody?.get("domain")).isEqualTo("app")
-        assertThat(manifestBody?.get("topics")).isEqualTo(mapOf("sources" to "etag1"))
-        assertThat(manifestBody?.get("prefetch_blobs")).isEqualTo(listOf("blobRefServer"))
-        assertThat(manifestBody?.get("prefetched_blobs")).isEqualTo(listOf("blobRefA"))
-        assertThat((manifestBody?.get("last_refresh_at") as? Number)?.toLong()).isEqualTo(1710000100L)
-    }
-
-    @Test
-    fun `getRemoteConfig propagates HTTP errors`() {
-        mockHttpResult(
-            responseCode = RCHTTPStatusCodes.ERROR,
-            payload = HTTPResult.Payload.Text("""{"code": 7000, "message": "internal error"}"""),
-        )
-        var obtainedError: PurchasesError? = null
-        backend.getRemoteConfig(
-            appInBackground = false,
-            manifest = testManifest,
-            onSuccess = { _, _ -> fail("Expected error. Got success") },
-            onError = { error -> obtainedError = error },
-        )
-        assertThat(obtainedError).isNotNull
-    }
-
-    @Test
-    fun `getRemoteConfig dedups concurrent calls`() {
-        mockHttpResult(payload = HTTPResult.Payload.RCFormat(buildContainer()), delayMs = 200)
-        val lock = CountDownLatch(2)
-        asyncBackend.getRemoteConfig(
-            appInBackground = false,
-            manifest = testManifest,
-            onSuccess = { _, _ -> lock.countDown() },
-            onError = { fail("Expected success. Got error: $it") },
-        )
-        asyncBackend.getRemoteConfig(
-            appInBackground = false,
-            manifest = testManifest,
-            onSuccess = { _, _ -> lock.countDown() },
-            onError = { fail("Expected success. Got error: $it") },
-        )
-        lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
-        assertThat(lock.count).isEqualTo(0)
-        verify(exactly = 1) {
-            httpClient.performRequest(
-                mockBaseURL,
-                Endpoint.GetRemoteConfig,
-                body = any(),
-                postFieldsToSign = null,
-                requestHeaders = any(),
-            )
-        }
     }
 
     private fun mockHttpResult(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
@@ -83,7 +83,7 @@ class RemoteConfigDiskCacheTest {
     fun `read returns null for an incompatible old-format file`() {
         // The previous format stored "manifest" as an object; it is now an opaque string. An old file no longer
         // deserializes, so read returns null gracefully and the next sync rebuilds from scratch.
-        val parent = File(testFolder, "RevenueCat").apply { mkdirs() }
+        val parent = File(File(testFolder, "RevenueCat"), "remote_config").apply { mkdirs() }
         File(parent, "remote_config.json").writeText(
             """{"manifest":{"domain":"app","topics":{"sources":"etag1"}},"topicBlobRefs":{}}""",
         )
@@ -92,10 +92,12 @@ class RemoteConfigDiskCacheTest {
     }
 
     @Test
-    fun `write creates the RevenueCat directory when absent`() {
+    fun `write creates the remote_config directory when absent`() {
         diskCache.write(PersistedRemoteConfig(domain = "app", manifest = "v1.0."))
 
-        assertThat(File(File(testFolder, "RevenueCat"), "remote_config.json").exists()).isTrue
+        assertThat(
+            File(File(File(testFolder, "RevenueCat"), "remote_config"), "remote_config.json").exists(),
+        ).isTrue
     }
 
     @Test
@@ -108,7 +110,7 @@ class RemoteConfigDiskCacheTest {
 
     @Test
     fun `read returns null when the persisted file is corrupt`() {
-        val parent = File(testFolder, "RevenueCat").apply { mkdirs() }
+        val parent = File(File(testFolder, "RevenueCat"), "remote_config").apply { mkdirs() }
         File(parent, "remote_config.json").writeText("{ this is not valid json")
 
         assertThat(diskCache.read()).isNull()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
@@ -1,0 +1,120 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class RemoteConfigDiskCacheTest {
+
+    private val testFolder = "temp_remote_config_test_folder"
+
+    private lateinit var applicationContext: Context
+    private lateinit var diskCache: RemoteConfigDiskCache
+
+    @Before
+    fun setup() {
+        val tempTestFolder = File(testFolder)
+        if (tempTestFolder.exists()) {
+            error("Temp test folder should not exist before starting tests")
+        }
+        tempTestFolder.mkdirs()
+
+        applicationContext = mockk()
+        every { applicationContext.noBackupFilesDir } returns tempTestFolder
+
+        diskCache = RemoteConfigDiskCache(applicationContext)
+    }
+
+    @After
+    fun tearDown() {
+        File(testFolder).deleteRecursively()
+    }
+
+    @Test
+    fun `read returns null when nothing has been persisted`() {
+        assertThat(diskCache.read()).isNull()
+    }
+
+    @Test
+    fun `write then read round-trips the manifest and resolved topics`() {
+        val manifest = RemoteConfiguration.Manifest(
+            domain = "app",
+            topics = mapOf("sources" to "etag1", "product_entitlement_mapping" to "etag2"),
+            prefetchBlobs = listOf("blobRefA"),
+            prefetchedBlobs = listOf("blobRefA"),
+            lastRefreshAt = 1710000100L,
+        )
+        val topics = mapOf(
+            "sources" to mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = "blobRefA", prefetch = true)),
+        )
+
+        diskCache.write(manifest, topics)
+        val read = diskCache.read()
+
+        assertThat(read).isNotNull
+        assertThat(read?.manifest).isEqualTo(manifest)
+        assertThat(read?.topics).isEqualTo(topics)
+    }
+
+    @Test
+    fun `write then read round-trips inline item content`() {
+        val manifest = RemoteConfiguration.Manifest(domain = "app", topics = mapOf("sources" to "etag1"))
+        val inlineItem = RemoteConfiguration.ConfigItem(
+            content = buildJsonObject {
+                put("id", "primary")
+                put("url", "https://api.revenuecat.com")
+                put("priority", 100)
+                put("weight", 100)
+            },
+        )
+        val topics = mapOf("sources" to mapOf("api" to inlineItem))
+
+        diskCache.write(manifest, topics)
+        val read = diskCache.read()
+
+        val readItem = read?.topics?.getValue("sources")?.getValue("api")
+        assertThat(readItem).isEqualTo(inlineItem)
+        assertThat(readItem?.blobRef).isNull()
+        assertThat(readItem?.content?.get("id")?.jsonPrimitive?.content).isEqualTo("primary")
+        assertThat(readItem?.content?.get("priority")?.jsonPrimitive?.int).isEqualTo(100)
+    }
+
+    @Test
+    fun `write creates the RevenueCat directory when absent`() {
+        val manifest = RemoteConfiguration.Manifest(domain = "app")
+
+        diskCache.write(manifest, emptyMap())
+
+        assertThat(File(File(testFolder, "RevenueCat"), "remote_config.json").exists()).isTrue
+    }
+
+    @Test
+    fun `write overwrites a previous snapshot`() {
+        diskCache.write(RemoteConfiguration.Manifest(domain = "app", topics = mapOf("sources" to "old")), emptyMap())
+        diskCache.write(RemoteConfiguration.Manifest(domain = "app", topics = mapOf("sources" to "new")), emptyMap())
+
+        assertThat(diskCache.read()?.manifest?.topics).containsExactlyEntriesOf(mapOf("sources" to "new"))
+    }
+
+    @Test
+    fun `read returns null when the persisted file is corrupt`() {
+        val parent = File(testFolder, "RevenueCat").apply { mkdirs() }
+        File(parent, "remote_config.json").writeText("{ this is not valid json")
+
+        assertThat(diskCache.read()).isNull()
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
@@ -4,10 +4,6 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.int
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -50,64 +46,64 @@ class RemoteConfigDiskCacheTest {
     }
 
     @Test
-    fun `write then read round-trips the manifest and resolved topics`() {
-        val manifest = RemoteConfiguration.Manifest(
+    fun `write then read round-trips the full persisted config`() {
+        val config = PersistedRemoteConfig(
             domain = "app",
-            topics = mapOf("sources" to "etag1", "product_entitlement_mapping" to "etag2"),
+            manifest = "v1.1710000100.sources:etag1,product_entitlement_mapping:etag2",
+            activeTopics = listOf("sources", "product_entitlement_mapping"),
             prefetchBlobs = listOf("blobRefA"),
-            prefetchedBlobs = listOf("blobRefA"),
+            topicBlobRefs = mapOf(
+                "sources" to listOf("blobRefA"),
+                "product_entitlement_mapping" to listOf("pemBlob"),
+            ),
             lastRefreshAt = 1710000100L,
         )
-        val topics = mapOf(
-            "sources" to mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = "blobRefA", prefetch = true)),
-        )
 
-        diskCache.write(manifest, topics)
+        diskCache.write(config)
         val read = diskCache.read()
 
-        assertThat(read).isNotNull
-        assertThat(read?.manifest).isEqualTo(manifest)
-        assertThat(read?.topics).isEqualTo(topics)
+        assertThat(read).isEqualTo(config)
     }
 
     @Test
-    fun `write then read round-trips inline item content`() {
-        val manifest = RemoteConfiguration.Manifest(domain = "app", topics = mapOf("sources" to "etag1"))
-        val inlineItem = RemoteConfiguration.ConfigItem(
-            content = buildJsonObject {
-                put("id", "primary")
-                put("url", "https://api.revenuecat.com")
-                put("priority", 100)
-                put("weight", 100)
-            },
+    fun `inline-only topics persist with an empty blob ref list`() {
+        val config = PersistedRemoteConfig(
+            domain = "app",
+            manifest = "v1.1.sources:etag1",
+            activeTopics = listOf("sources"),
+            topicBlobRefs = mapOf("sources" to emptyList()),
         )
-        val topics = mapOf("sources" to mapOf("api" to inlineItem))
 
-        diskCache.write(manifest, topics)
-        val read = diskCache.read()
+        diskCache.write(config)
 
-        val readItem = read?.topics?.getValue("sources")?.getValue("api")
-        assertThat(readItem).isEqualTo(inlineItem)
-        assertThat(readItem?.blobRef).isNull()
-        assertThat(readItem?.content?.get("id")?.jsonPrimitive?.content).isEqualTo("primary")
-        assertThat(readItem?.content?.get("priority")?.jsonPrimitive?.int).isEqualTo(100)
+        assertThat(diskCache.read()?.topicBlobRefs).isEqualTo(mapOf("sources" to emptyList<String>()))
+    }
+
+    @Test
+    fun `read returns null for an incompatible old-format file`() {
+        // The previous format stored "manifest" as an object; it is now an opaque string. An old file no longer
+        // deserializes, so read returns null gracefully and the next sync rebuilds from scratch.
+        val parent = File(testFolder, "RevenueCat").apply { mkdirs() }
+        File(parent, "remote_config.json").writeText(
+            """{"manifest":{"domain":"app","topics":{"sources":"etag1"}},"topicBlobRefs":{}}""",
+        )
+
+        assertThat(diskCache.read()).isNull()
     }
 
     @Test
     fun `write creates the RevenueCat directory when absent`() {
-        val manifest = RemoteConfiguration.Manifest(domain = "app")
-
-        diskCache.write(manifest, emptyMap())
+        diskCache.write(PersistedRemoteConfig(domain = "app", manifest = "v1.0."))
 
         assertThat(File(File(testFolder, "RevenueCat"), "remote_config.json").exists()).isTrue
     }
 
     @Test
     fun `write overwrites a previous snapshot`() {
-        diskCache.write(RemoteConfiguration.Manifest(domain = "app", topics = mapOf("sources" to "old")), emptyMap())
-        diskCache.write(RemoteConfiguration.Manifest(domain = "app", topics = mapOf("sources" to "new")), emptyMap())
+        diskCache.write(PersistedRemoteConfig(domain = "app", manifest = "v1.1.sources:old"))
+        diskCache.write(PersistedRemoteConfig(domain = "app", manifest = "v1.2.sources:new"))
 
-        assertThat(diskCache.read()?.manifest?.topics).containsExactlyEntriesOf(mapOf("sources" to "new"))
+        assertThat(diskCache.read()?.manifest).isEqualTo("v1.2.sources:new")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
@@ -47,7 +47,7 @@ class RemoteConfigDiskCacheTest {
 
     @Test
     fun `write then read round-trips the full persisted config`() {
-        val config = PersistedRemoteConfig(
+        val config = PersistedRemoteConfigurationState(
             domain = "app",
             manifest = "v1.1710000100.sources:etag1,product_entitlement_mapping:etag2",
             activeTopics = listOf("sources", "product_entitlement_mapping"),
@@ -67,7 +67,7 @@ class RemoteConfigDiskCacheTest {
 
     @Test
     fun `inline-only topics persist with an empty blob ref list`() {
-        val config = PersistedRemoteConfig(
+        val config = PersistedRemoteConfigurationState(
             domain = "app",
             manifest = "v1.1.sources:etag1",
             activeTopics = listOf("sources"),
@@ -93,7 +93,7 @@ class RemoteConfigDiskCacheTest {
 
     @Test
     fun `write creates the remote_config directory when absent`() {
-        diskCache.write(PersistedRemoteConfig(domain = "app", manifest = "v1.0."))
+        diskCache.write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.0."))
 
         assertThat(
             File(File(File(testFolder, "RevenueCat"), "remote_config"), "remote_config.json").exists(),
@@ -102,8 +102,8 @@ class RemoteConfigDiskCacheTest {
 
     @Test
     fun `write overwrites a previous snapshot`() {
-        diskCache.write(PersistedRemoteConfig(domain = "app", manifest = "v1.1.sources:old"))
-        diskCache.write(PersistedRemoteConfig(domain = "app", manifest = "v1.2.sources:new"))
+        diskCache.write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.1.sources:old"))
+        diskCache.write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.2.sources:new"))
 
         assertThat(diskCache.read()?.manifest).isEqualTo("v1.2.sources:new")
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -90,7 +90,7 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
-        val written = slot<PersistedRemoteConfig>()
+        val written = slot<PersistedRemoteConfigurationState>()
         verify(exactly = 1) { diskCache.write(capture(written)) }
         assertThat(written.captured.manifest).isEqualTo("v1.200.sources:etag2")
         assertThat(written.captured.activeTopics).containsExactly("sources")
@@ -121,7 +121,7 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
-        val written = slot<PersistedRemoteConfig>()
+        val written = slot<PersistedRemoteConfigurationState>()
         verify(exactly = 1) { diskCache.write(capture(written)) }
         assertThat(written.captured.topicBlobRefs)
             .containsExactlyEntriesOf(mapOf("sources" to listOf("newSources")))
@@ -142,7 +142,7 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
-        val written = slot<PersistedRemoteConfig>()
+        val written = slot<PersistedRemoteConfigurationState>()
         verify(exactly = 1) { diskCache.write(capture(written)) }
         assertThat(written.captured.topicBlobRefs).containsExactlyEntriesOf(mapOf("sources" to emptyList()))
     }
@@ -181,7 +181,7 @@ class RemoteConfigManagerTest {
         manifest: String,
         domain: String = "app",
         topicBlobRefs: Map<String, List<String>> = emptyMap(),
-    ) = PersistedRemoteConfig(
+    ) = PersistedRemoteConfigurationState(
         domain = domain,
         manifest = manifest,
         topicBlobRefs = topicBlobRefs,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -1,0 +1,159 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.networking.RCContainer
+import com.revenuecat.purchases.common.networking.RCElement
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.nio.ByteBuffer
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class RemoteConfigManagerTest {
+
+    private lateinit var backend: Backend
+    private lateinit var diskCache: RemoteConfigDiskCache
+    private lateinit var manager: RemoteConfigManager
+
+    private val manifestSlot = slot<RemoteConfiguration.Manifest>()
+    private val onSuccessSlot = slot<(RCContainer?, VerificationResult) -> Unit>()
+    private val onErrorSlot = slot<(PurchasesError) -> Unit>()
+
+    @Before
+    fun setup() {
+        backend = mockk()
+        diskCache = mockk(relaxed = true)
+        manager = RemoteConfigManager(backend, diskCache)
+
+        every {
+            backend.getRemoteConfig(
+                appInBackground = any(),
+                manifest = capture(manifestSlot),
+                onSuccess = capture(onSuccessSlot),
+                onError = capture(onErrorSlot),
+            )
+        } just Runs
+    }
+
+    @Test
+    fun `first run sends an empty app-domain manifest`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false)
+
+        assertThat(manifestSlot.captured).isEqualTo(RemoteConfiguration.Manifest(domain = "app"))
+    }
+
+    @Test
+    fun `replays the persisted manifest on subsequent runs`() {
+        val persistedManifest = RemoteConfiguration.Manifest(domain = "app", topics = mapOf("sources" to "etag1"))
+        every { diskCache.read() } returns PersistedRemoteConfig(persistedManifest, emptyMap())
+
+        manager.refreshRemoteConfig(appInBackground = false)
+
+        assertThat(manifestSlot.captured).isEqualTo(persistedManifest)
+    }
+
+    @Test
+    fun `a 200 response persists the server manifest and changed topic bodies`() {
+        every { diskCache.read() } returns null
+        val response = """
+            {
+              "domain": "app",
+              "manifest": { "domain": "app", "topics": { "sources": "etag2" } },
+              "topics": { "sources": { "default": { "blob_ref": "newBlob" } } }
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(appInBackground = false)
+        onSuccessSlot.captured.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        val manifestWritten = slot<RemoteConfiguration.Manifest>()
+        val topicsWritten = slot<Map<String, ConfigTopic>>()
+        verify(exactly = 1) { diskCache.write(capture(manifestWritten), capture(topicsWritten)) }
+        assertThat(manifestWritten.captured.topics).containsExactlyEntriesOf(mapOf("sources" to "etag2"))
+        assertThat(topicsWritten.captured.getValue("sources").getValue("default").blobRef).isEqualTo("newBlob")
+    }
+
+    @Test
+    fun `a 200 response merges unchanged topics and prunes topics dropped from the manifest`() {
+        val previous = PersistedRemoteConfig(
+            manifest = RemoteConfiguration.Manifest(
+                domain = "app",
+                topics = mapOf("sources" to "etag1", "product_entitlement_mapping" to "pemEtag1"),
+            ),
+            topics = mapOf(
+                "sources" to mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = "oldSources")),
+                "product_entitlement_mapping" to mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = "pemBlob")),
+            ),
+        )
+        every { diskCache.read() } returns previous
+        // sources changed; product_entitlement_mapping dropped from the manifest entirely.
+        val response = """
+            {
+              "domain": "app",
+              "manifest": { "domain": "app", "topics": { "sources": "etag2" } },
+              "topics": { "sources": { "default": { "blob_ref": "newSources" } } }
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(appInBackground = false)
+        onSuccessSlot.captured.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        val topicsWritten = slot<Map<String, ConfigTopic>>()
+        verify(exactly = 1) { diskCache.write(any(), capture(topicsWritten)) }
+        assertThat(topicsWritten.captured.keys).containsExactly("sources")
+        assertThat(topicsWritten.captured.getValue("sources").getValue("default").blobRef).isEqualTo("newSources")
+    }
+
+    @Test
+    fun `a 204 response leaves the cache untouched`() {
+        every { diskCache.read() } returns PersistedRemoteConfig(RemoteConfiguration.Manifest(domain = "app"), emptyMap())
+
+        manager.refreshRemoteConfig(appInBackground = false)
+        onSuccessSlot.captured.invoke(null, VerificationResult.VERIFIED)
+
+        verify(exactly = 0) { diskCache.write(any(), any()) }
+    }
+
+    @Test
+    fun `an error leaves the cache untouched`() {
+        every { diskCache.read() } returns PersistedRemoteConfig(RemoteConfiguration.Manifest(domain = "app"), emptyMap())
+
+        manager.refreshRemoteConfig(appInBackground = false)
+        onErrorSlot.captured.invoke(PurchasesError(PurchasesErrorCode.UnknownError, "boom"))
+
+        verify(exactly = 0) { diskCache.write(any(), any()) }
+    }
+
+    @Test
+    fun `a malformed config payload leaves the cache untouched`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false)
+        onSuccessSlot.captured.invoke(containerWithConfig("{ not valid json"), VerificationResult.VERIFIED)
+
+        verify(exactly = 0) { diskCache.write(any(), any()) }
+    }
+
+    private fun containerWithConfig(json: String): RCContainer {
+        val element = mockk<RCElement>()
+        every { element.data } returns ByteBuffer.wrap(json.toByteArray())
+        val container = mockk<RCContainer>()
+        every { container.config } returns element
+        return container
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -1,15 +1,15 @@
 package com.revenuecat.purchases.common.remoteconfig
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCElement
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -19,7 +19,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.nio.ByteBuffer
+import java.util.Date
 
+@OptIn(InternalRevenueCatAPI::class)
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class RemoteConfigManagerTest {
@@ -28,115 +30,141 @@ class RemoteConfigManagerTest {
     private lateinit var diskCache: RemoteConfigDiskCache
     private lateinit var manager: RemoteConfigManager
 
-    private val manifestSlot = slot<RemoteConfiguration.Manifest>()
-    private val onSuccessSlot = slot<(RCContainer?, VerificationResult) -> Unit>()
-    private val onErrorSlot = slot<(PurchasesError) -> Unit>()
+    private var capturedDomain: String? = null
+    private var capturedManifest: String? = null
+    private var capturedPrefetchedBlobs: List<String>? = null
+    private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
+    private lateinit var onError: (PurchasesError) -> Unit
 
     @Before
     fun setup() {
         backend = mockk()
         diskCache = mockk(relaxed = true)
-        manager = RemoteConfigManager(backend, diskCache)
+        manager = RemoteConfigManager(backend, diskCache, dateProvider = FixedDateProvider)
 
         every {
-            backend.getRemoteConfig(
-                appInBackground = any(),
-                manifest = capture(manifestSlot),
-                onSuccess = capture(onSuccessSlot),
-                onError = capture(onErrorSlot),
-            )
-        } just Runs
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any())
+        } answers {
+            capturedDomain = arg(1)
+            capturedManifest = arg(2)
+            capturedPrefetchedBlobs = arg(3)
+            onSuccess = arg(4)
+            onError = arg(5)
+        }
     }
 
     @Test
-    fun `first run sends an empty app-domain manifest`() {
+    fun `first run sends the app domain with no manifest`() {
         every { diskCache.read() } returns null
 
         manager.refreshRemoteConfig(appInBackground = false)
 
-        assertThat(manifestSlot.captured).isEqualTo(RemoteConfiguration.Manifest(domain = "app"))
+        assertThat(capturedDomain).isEqualTo("app")
+        assertThat(capturedManifest).isNull()
+        assertThat(capturedPrefetchedBlobs).isEmpty()
     }
 
     @Test
-    fun `replays the persisted manifest on subsequent runs`() {
-        val persistedManifest = RemoteConfiguration.Manifest(domain = "app", topics = mapOf("sources" to "etag1"))
-        every { diskCache.read() } returns PersistedRemoteConfig(persistedManifest, emptyMap())
+    fun `replays the persisted opaque manifest on subsequent runs`() {
+        every { diskCache.read() } returns persisted(manifest = "v1.123.sources:etag1", domain = "app")
 
         manager.refreshRemoteConfig(appInBackground = false)
 
-        assertThat(manifestSlot.captured).isEqualTo(persistedManifest)
+        assertThat(capturedDomain).isEqualTo("app")
+        assertThat(capturedManifest).isEqualTo("v1.123.sources:etag1")
     }
 
     @Test
-    fun `a 200 response persists the server manifest and changed topic bodies`() {
+    fun `a 200 response persists the server manifest, active topics and changed topic blob refs`() {
         every { diskCache.read() } returns null
         val response = """
             {
               "domain": "app",
-              "manifest": { "domain": "app", "topics": { "sources": "etag2" } },
+              "manifest": "v1.200.sources:etag2",
+              "active_topics": ["sources"],
+              "prefetch_blobs": ["newBlob"],
               "topics": { "sources": { "default": { "blob_ref": "newBlob" } } }
             }
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false)
-        onSuccessSlot.captured.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
-        val manifestWritten = slot<RemoteConfiguration.Manifest>()
-        val topicsWritten = slot<Map<String, ConfigTopic>>()
-        verify(exactly = 1) { diskCache.write(capture(manifestWritten), capture(topicsWritten)) }
-        assertThat(manifestWritten.captured.topics).containsExactlyEntriesOf(mapOf("sources" to "etag2"))
-        assertThat(topicsWritten.captured.getValue("sources").getValue("default").blobRef).isEqualTo("newBlob")
+        val written = slot<PersistedRemoteConfig>()
+        verify(exactly = 1) { diskCache.write(capture(written)) }
+        assertThat(written.captured.manifest).isEqualTo("v1.200.sources:etag2")
+        assertThat(written.captured.activeTopics).containsExactly("sources")
+        assertThat(written.captured.prefetchBlobs).containsExactly("newBlob")
+        assertThat(written.captured.topicBlobRefs).containsExactlyEntriesOf(mapOf("sources" to listOf("newBlob")))
+        assertThat(written.captured.lastRefreshAt).isEqualTo(FIXED_MILLIS)
     }
 
     @Test
-    fun `a 200 response merges unchanged topics and prunes topics dropped from the manifest`() {
-        val previous = PersistedRemoteConfig(
-            manifest = RemoteConfiguration.Manifest(
-                domain = "app",
-                topics = mapOf("sources" to "etag1", "product_entitlement_mapping" to "pemEtag1"),
-            ),
-            topics = mapOf(
-                "sources" to mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = "oldSources")),
-                "product_entitlement_mapping" to mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = "pemBlob")),
+    fun `a 200 response merges unchanged topics and prunes topics no longer active`() {
+        every { diskCache.read() } returns persisted(
+            manifest = "v1.1.sources:etag1,product_entitlement_mapping:pemEtag1",
+            topicBlobRefs = mapOf(
+                "sources" to listOf("oldSources"),
+                "product_entitlement_mapping" to listOf("pemBlob"),
             ),
         )
-        every { diskCache.read() } returns previous
-        // sources changed; product_entitlement_mapping dropped from the manifest entirely.
+        // sources changed; product_entitlement_mapping no longer active.
         val response = """
             {
               "domain": "app",
-              "manifest": { "domain": "app", "topics": { "sources": "etag2" } },
+              "manifest": "v1.2.sources:etag2",
+              "active_topics": ["sources"],
               "topics": { "sources": { "default": { "blob_ref": "newSources" } } }
             }
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false)
-        onSuccessSlot.captured.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
-        val topicsWritten = slot<Map<String, ConfigTopic>>()
-        verify(exactly = 1) { diskCache.write(any(), capture(topicsWritten)) }
-        assertThat(topicsWritten.captured.keys).containsExactly("sources")
-        assertThat(topicsWritten.captured.getValue("sources").getValue("default").blobRef).isEqualTo("newSources")
+        val written = slot<PersistedRemoteConfig>()
+        verify(exactly = 1) { diskCache.write(capture(written)) }
+        assertThat(written.captured.topicBlobRefs)
+            .containsExactlyEntriesOf(mapOf("sources" to listOf("newSources")))
+    }
+
+    @Test
+    fun `a 200 response persists an empty blob ref list for inline-only topics`() {
+        every { diskCache.read() } returns null
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.sources:etag2",
+              "active_topics": ["sources"],
+              "topics": { "sources": { "api": { "url": "https://api.revenuecat.com", "priority": 100 } } }
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(appInBackground = false)
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        val written = slot<PersistedRemoteConfig>()
+        verify(exactly = 1) { diskCache.write(capture(written)) }
+        assertThat(written.captured.topicBlobRefs).containsExactlyEntriesOf(mapOf("sources" to emptyList()))
     }
 
     @Test
     fun `a 204 response leaves the cache untouched`() {
-        every { diskCache.read() } returns PersistedRemoteConfig(RemoteConfiguration.Manifest(domain = "app"), emptyMap())
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
         manager.refreshRemoteConfig(appInBackground = false)
-        onSuccessSlot.captured.invoke(null, VerificationResult.VERIFIED)
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
 
-        verify(exactly = 0) { diskCache.write(any(), any()) }
+        verify(exactly = 0) { diskCache.write(any()) }
     }
 
     @Test
     fun `an error leaves the cache untouched`() {
-        every { diskCache.read() } returns PersistedRemoteConfig(RemoteConfiguration.Manifest(domain = "app"), emptyMap())
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
         manager.refreshRemoteConfig(appInBackground = false)
-        onErrorSlot.captured.invoke(PurchasesError(PurchasesErrorCode.UnknownError, "boom"))
+        onError.invoke(PurchasesError(PurchasesErrorCode.UnknownError, "boom"))
 
-        verify(exactly = 0) { diskCache.write(any(), any()) }
+        verify(exactly = 0) { diskCache.write(any()) }
     }
 
     @Test
@@ -144,10 +172,20 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         manager.refreshRemoteConfig(appInBackground = false)
-        onSuccessSlot.captured.invoke(containerWithConfig("{ not valid json"), VerificationResult.VERIFIED)
+        onSuccess.invoke(containerWithConfig("{ not valid json"), VerificationResult.VERIFIED)
 
-        verify(exactly = 0) { diskCache.write(any(), any()) }
+        verify(exactly = 0) { diskCache.write(any()) }
     }
+
+    private fun persisted(
+        manifest: String,
+        domain: String = "app",
+        topicBlobRefs: Map<String, List<String>> = emptyMap(),
+    ) = PersistedRemoteConfig(
+        domain = domain,
+        manifest = manifest,
+        topicBlobRefs = topicBlobRefs,
+    )
 
     private fun containerWithConfig(json: String): RCContainer {
         val element = mockk<RCElement>()
@@ -155,5 +193,12 @@ class RemoteConfigManagerTest {
         val container = mockk<RCContainer>()
         every { container.config } returns element
         return container
+    }
+
+    private companion object {
+        private const val FIXED_MILLIS = 1_710_000_000_000L
+        private val FixedDateProvider = object : DateProvider {
+            override val now: Date get() = Date(FIXED_MILLIS)
+        }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigurationTest.kt
@@ -266,7 +266,8 @@ class RemoteConfigurationTest {
         val payload = """
             {
               "domain": "app",
-              "manifest": { "domain": "app", "topics": { "sources": "etag1" } }
+              "manifest": "v1.1710001000.sources:etag1",
+              "active_topics": ["sources"]
             }
         """.trimIndent()
         val buffer = ByteBuffer.wrap(payload.toByteArray())
@@ -274,7 +275,8 @@ class RemoteConfigurationTest {
         val response = RemoteConfiguration.parse(buffer)
 
         assertThat(response.domain).isEqualTo("app")
-        assertThat(response.manifest.topics).containsExactlyEntriesOf(mapOf("sources" to "etag1"))
+        assertThat(response.manifest).isEqualTo("v1.1710001000.sources:etag1")
+        assertThat(response.activeTopics).containsExactly("sources")
         // The overload duplicates the buffer, so the caller's position is untouched.
         assertThat(buffer.position()).isEqualTo(0)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigurationTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import java.nio.ByteBuffer
 
 class RemoteConfigurationTest {
 
@@ -258,5 +259,23 @@ class RemoteConfigurationTest {
 
         assertThatThrownBy { RemoteConfiguration.parse(payload.trimIndent().toByteArray()) }
             .isInstanceOf(SerializationException::class.java)
+    }
+
+    @Test
+    fun `parses from a ByteBuffer without consuming the caller's buffer`() {
+        val payload = """
+            {
+              "domain": "app",
+              "manifest": { "domain": "app", "topics": { "sources": "etag1" } }
+            }
+        """.trimIndent()
+        val buffer = ByteBuffer.wrap(payload.toByteArray())
+
+        val response = RemoteConfiguration.parse(buffer)
+
+        assertThat(response.domain).isEqualTo("app")
+        assertThat(response.manifest.topics).containsExactlyEntriesOf(mapOf("sources" to "etag1"))
+        // The overload duplicates the buffer, so the caller's position is untouched.
+        assertThat(buffer.position()).isEqualTo(0)
     }
 }


### PR DESCRIPTION
### Description
This PR is part of the stack to support the new Remote configuration endpoint.

In this PR, we add support to cache the Manifest in the remote config response, and then post it back in the request so the backend can decide what needs updating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the remote-config network contract and introduces on-disk state that affects what the server is told on each sync; behavior is mostly internal with safe fallbacks on parse/read failures, but incorrect persistence could cause extra full fetches or stale topic bookkeeping until later phases wire blob handling.
> 
> **Overview**
> Adds **incremental `/v2/config` sync** by persisting an opaque server **manifest** and replaying it on the next request so the backend can return **204** when nothing changed.
> 
> `Backend.getRemoteConfig` now POSTs **`domain`**, optional **`manifest`** (omitted on first sync), and **`prefetched_blobs`** instead of an empty body. **`RemoteConfigDiskCache`** atomically stores sync bookkeeping (manifest, active topics, prefetch list, per-topic blob refs) under `noBackupFilesDir`; corrupt or legacy on-disk format reads as `null` and forces a fresh sync. **`RemoteConfigManager`** loads that state, drives the backend call, leaves the cache alone on **204**/errors/bad payloads, and on **200** merges changed topic blob refs while pruning inactive topics. **`RemoteConfiguration.parse(ByteBuffer)`** duplicates the buffer so RC container views stay untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4d12cbb78456e0398d696ec64364363e257fd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->