### PR TITLE
Surface actionable error when product change hits a pending deferred replacement

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -113,6 +113,13 @@ internal class BillingWrapper(
          * The maximum number of pending requests we report to diagnostics.
          */
         private const val MAX_PENDING_REQUEST_COUNT_REPORTED = 100
+
+        /**
+         * Fragment of the Google Play Billing debug message returned (alongside a DEVELOPER_ERROR response code)
+         * when attempting a product change on a subscription that already has a pending deferred replacement.
+         * The full message is "There is an existing deferred replacement for the old product".
+         */
+        private const val DEFERRED_REPLACEMENT_DEBUG_MESSAGE_FRAGMENT = "deferred replacement"
     }
 
     @get:Synchronized
@@ -655,6 +662,15 @@ internal class BillingWrapper(
                 // we get the transaction for the previous product.
                 message = "Error: onPurchasesUpdated received an OK BillingResult with a Null purchases list."
                 responseCode = BillingClient.BillingResponseCode.ERROR
+            }
+
+            if (billingResult.responseCode == BillingClient.BillingResponseCode.DEVELOPER_ERROR &&
+                billingResult.debugMessage.contains(DEFERRED_REPLACEMENT_DEBUG_MESSAGE_FRAGMENT, ignoreCase = true)
+            ) {
+                // Google rejects a product change when the subscription being replaced already has a pending
+                // deferred replacement queued. Append an actionable explanation since the raw DEVELOPER_ERROR
+                // ("There is an existing deferred replacement for the old product") is not self-explanatory.
+                message += " ${BillingStrings.BILLING_WRAPPER_DEFERRED_REPLACEMENT_PENDING}"
             }
 
             val purchasesError = responseCode.billingResponseToPurchasesError(message).also { errorLog(it) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -14,6 +14,11 @@ internal object BillingStrings {
         "account configured in Play Store. Reopen the Play Store or clean its caches if this keeps happening. " +
         "Original error message: %s"
     const val BILLING_WRAPPER_PURCHASES_ERROR = "BillingWrapper purchases failed to update: %s"
+    const val BILLING_WRAPPER_DEFERRED_REPLACEMENT_PENDING = "This product change failed because the subscription " +
+        "being replaced already has a pending deferred replacement (for example, a previously scheduled downgrade " +
+        "that has not taken effect yet). Google Play does not allow queuing another replacement on a subscription " +
+        "that already has a deferred change pending. The previous change will take effect at the end of the current " +
+        "billing period. Wait until then before attempting another product change for this subscription."
     const val BILLING_WRAPPER_PURCHASES_UPDATED = "BillingWrapper purchases updated: %s"
     const val BILLING_PURCHASE_HISTORY_RECORD_MORE_THAN_ONE_SKU = "There's more than one sku in the " +
         "PurchaseHistoryRecord, but only one will be used."

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1269,6 +1269,45 @@ class BillingWrapperTest {
     }
 
     @Test
+    fun `purchaseUpdate failure includes a helpful hint when there is a pending deferred replacement`() {
+        val slot = slot<PurchasesError>()
+        every {
+            mockPurchasesListener.onPurchasesFailedToUpdate(capture(slot))
+        } just Runs
+
+        val billingResult = BillingResult.newBuilder()
+            .setResponseCode(BillingClient.BillingResponseCode.DEVELOPER_ERROR)
+            .setDebugMessage("There is an existing deferred replacement for the old product")
+            .build()
+
+        purchasesUpdatedListener!!.onPurchasesUpdated(billingResult, null)
+
+        assertThat(slot.isCaptured).isTrue
+        assertThat(slot.captured.code).isEqualTo(PurchasesErrorCode.PurchaseInvalidError)
+        assertThat(slot.captured.underlyingErrorMessage)
+            .contains(BillingStrings.BILLING_WRAPPER_DEFERRED_REPLACEMENT_PENDING)
+    }
+
+    @Test
+    fun `purchaseUpdate failure does not add deferred replacement hint for unrelated developer errors`() {
+        val slot = slot<PurchasesError>()
+        every {
+            mockPurchasesListener.onPurchasesFailedToUpdate(capture(slot))
+        } just Runs
+
+        val billingResult = BillingResult.newBuilder()
+            .setResponseCode(BillingClient.BillingResponseCode.DEVELOPER_ERROR)
+            .setDebugMessage("Some unrelated developer error")
+            .build()
+
+        purchasesUpdatedListener!!.onPurchasesUpdated(billingResult, null)
+
+        assertThat(slot.isCaptured).isTrue
+        assertThat(slot.captured.underlyingErrorMessage)
+            .doesNotContain(BillingStrings.BILLING_WRAPPER_DEFERRED_REPLACEMENT_PENDING)
+    }
+
+    @Test
     fun `calling billing close() sets purchasesUpdatedListener to null and disconnects from BillingClient`() {
         every {
             mockClient.endConnection()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

A developer reported that a second subscription product change fails when the subscription being replaced already has a **pending DEFERRED replacement** (for example, a previously scheduled downgrade A → B that has not taken effect yet). When the user reopens the paywall, Plan A is still active (DEFERRED keeps the old plan running until the end of the billing period), so the paywall treats A as the active subscription and attempts a new change A → C. Google Play rejects this:

```
BillingWrapper purchases failed to update: DebugMessage: There is an existing deferred
replacement for the old product. ErrorCode: DEVELOPER_ERROR. ...
PurchasesError(code=PurchaseInvalidError, ... message='One or more of the arguments provided are invalid.')
```

The resulting `PurchaseInvalidError` / "One or more of the arguments provided are invalid" gives developers no hint about the real cause.

### Description

When Google Play returns a `DEVELOPER_ERROR` whose debug message indicates an existing deferred replacement, `BillingWrapper.onPurchasesUpdated` now appends a clear, actionable explanation to the surfaced `PurchasesError.underlyingErrorMessage` describing that the subscription already has a pending deferred change which must take effect (at the end of the billing period) before another product change can be made. The error code is unchanged (still `PurchaseInvalidError`), so this is purely additive and does not affect the public API.

Changes:
- `BillingStrings.BILLING_WRAPPER_DEFERRED_REPLACEMENT_PENDING`: new explanatory message.
- `BillingWrapper`: detect the deferred-replacement debug message (matched defensively, case-insensitive) and append the hint.
- `BillingWrapperTest`: two new tests verifying the hint is added for the deferred-replacement case and not for unrelated `DEVELOPER_ERROR`s.

**Note / follow-up:** This improves the failure UX but does not fully prevent the failed attempt. The SDK currently has no way to know that a subscription has a pending deferred change — neither `CustomerInfo`/`SubscriptionInfo` (the backend `subscriptions` payload exposes no pending-change field) nor the Google Play `Purchase`/`queryPurchasesAsync` client API expose it. Fully detecting this state (so the paywall can avoid offering an invalid downgrade target, or pick the correct base product) requires backend support to surface the pending/scheduled product change in the subscriber response. A follow-up should track exposing that data (and corresponding `purchases-ios`/hybrid follow-ups).

Tested via `./gradlew :purchases:testDefaultsBc8DebugUnitTest --tests "com.revenuecat.purchases.google.BillingWrapperTest"` (passing) and `./gradlew detektAll` (passing).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fc5cd1a-7066-4c57-bc46-6b51b290d0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fc5cd1a-7066-4c57-bc46-6b51b290d0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

