### PR TITLE
feat(workflows): drive paywall-event gating by step screen_type

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -16,8 +16,10 @@ import com.revenuecat.purchases.utils.serializers.URLSerializer
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import java.net.URL
 
 @InternalRevenueCatAPI
@@ -59,6 +61,22 @@ public data class WorkflowTrigger(
     @SerialName("component_id") val componentId: String,
 )
 
+/**
+ * Step `screen_type` classification values and the metadata key they are returned under.
+ *
+ * The backend tags each step with its screen classification inside `metadata` (`metadata.screen_type`),
+ * e.g. `["paywall"]`. The SDK uses this to decide which workflow steps report paywall events.
+ */
+@InternalRevenueCatAPI
+public object WorkflowScreenType {
+
+    /** The key the classification list is stored under inside a step's `metadata`. */
+    public const val METADATA_KEY: String = "screen_type"
+
+    /** A step whose screen is a paywall; it should report paywall impression/close events. */
+    public const val PAYWALL: String = "paywall"
+}
+
 @InternalRevenueCatAPI
 @Serializable
 public data class WorkflowStep(
@@ -70,7 +88,30 @@ public data class WorkflowStep(
     val outputs: Map<String, JsonElement> = emptyMap(),
     @SerialName("trigger_actions") val triggerActions: Map<String, WorkflowTriggerAction> = emptyMap(),
     val metadata: JsonElement? = null,
-)
+) {
+    /**
+     * The step's screen classification, as reported by the backend under `metadata.screen_type`.
+     *
+     * Returns `null` when the step was not tagged (older workflows, or workflows served before the
+     * screen-analytics rollout) and an empty list when it was tagged with no known type. The
+     * null-vs-empty distinction matters for paywall-event gating: an untagged step preserves the prior
+     * always-report behavior, while a step explicitly tagged without `paywall` suppresses paywall
+     * events. See `tracksPaywallEvents` in the UI layer.
+     */
+    @InternalRevenueCatAPI
+    public val stepScreenType: List<String>?
+        get() {
+            // A present-but-non-array `screen_type` (null, scalar, object) is treated the same as an
+            // absent key: untagged (returns null), so events keep reporting. This matches the iOS
+            // contract and is the conservative default; the backend only ever ships `screen_type` as a
+            // JSON array, so suppressing on a malformed shape would risk muting real events.
+            val metadataObject = metadata as? JsonObject ?: return null
+            val screenType = metadataObject[WorkflowScreenType.METADATA_KEY] as? JsonArray ?: return null
+            return screenType.mapNotNull { element ->
+                (element as? JsonPrimitive)?.takeIf { it.isString }?.content
+            }
+        }
+}
 
 @InternalRevenueCatAPI
 @Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -94,9 +94,9 @@ public data class WorkflowStep(
      *
      * Returns `null` when the step was not tagged (older workflows, or workflows served before the
      * screen-analytics rollout) and an empty list when it was tagged with no known type. The
-     * null-vs-empty distinction matters for paywall-event gating: an untagged step preserves the prior
-     * always-report behavior, while a step explicitly tagged without `paywall` suppresses paywall
-     * events. See `tracksPaywallEvents` in the UI layer.
+     * null-vs-empty distinction matters for paywall-event gating: an untagged step falls back to the
+     * prior structural inference (`id == singleStepFallbackId`), while a step explicitly tagged without
+     * `paywall` suppresses paywall events. See `tracksPaywallEvents` in the UI layer.
      */
     @InternalRevenueCatAPI
     public val stepScreenType: List<String>?

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -103,4 +103,82 @@ internal class WorkflowModelsDeserializationTest {
         val decoded = WorkflowJsonParser.parseWorkflowsListResponse(encoded)
         assertThat(decoded).isEqualTo(original)
     }
+
+    @Test
+    fun `WorkflowStep stepScreenType reads paywall from metadata`() {
+        val json = """
+            {"id": "step_1", "type": "screen", "metadata": {"screen_type": ["paywall"]}}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.stepScreenType).containsExactly("paywall")
+    }
+
+    @Test
+    fun `WorkflowStep stepScreenType is empty when tagged with empty array`() {
+        // A step the backend tagged with no known type. Empty (not null) means "explicitly not a
+        // paywall", which suppresses paywall events.
+        val json = """
+            {"id": "step_1", "type": "screen", "metadata": {"screen_type": []}}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.stepScreenType).isEmpty()
+    }
+
+    @Test
+    fun `WorkflowStep stepScreenType is null when screen_type key absent`() {
+        // Older workflows omit screen_type. Null (not empty) preserves the always-report behavior.
+        val json = """
+            {"id": "step_1", "type": "screen", "metadata": {"other_key": "value"}}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.stepScreenType).isNull()
+    }
+
+    @Test
+    fun `WorkflowStep stepScreenType is null when metadata is null`() {
+        val json = """
+            {"id": "step_1", "type": "screen", "metadata": null}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.stepScreenType).isNull()
+    }
+
+    @Test
+    fun `WorkflowStep stepScreenType is null when metadata is absent`() {
+        val json = """
+            {"id": "step_1", "type": "screen"}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.stepScreenType).isNull()
+    }
+
+    @Test
+    fun `WorkflowStep stepScreenType ignores non-string entries`() {
+        val json = """
+            {"id": "step_1", "type": "screen", "metadata": {"screen_type": ["paywall", 1, null]}}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.stepScreenType).containsExactly("paywall")
+    }
+
+    // A present-but-non-array `screen_type` is treated as untagged (null), matching iOS. The backend
+    // only ships `screen_type` as a JSON array; these pin the conservative fallback for malformed shapes.
+
+    @Test
+    fun `WorkflowStep stepScreenType is null when screen_type is a scalar`() {
+        val json = """
+            {"id": "step_1", "type": "screen", "metadata": {"screen_type": "paywall"}}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.stepScreenType).isNull()
+    }
+
+    @Test
+    fun `WorkflowStep stepScreenType is null when screen_type is an object`() {
+        val json = """
+            {"id": "step_1", "type": "screen", "metadata": {"screen_type": {"value": "paywall"}}}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.stepScreenType).isNull()
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -24,6 +24,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.WorkflowScreenType
 import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
@@ -1021,7 +1022,7 @@ internal class PaywallViewModelImpl(
         }
         if (!shouldApplyState) return
         currentWorkflowStepTracksPaywallEvents = newState is PaywallState.Loaded.Components &&
-            step.tracksPaywallEvents(workflow)
+            step.tracksPaywallEvents()
         val pendingTransition = if (fromStepId != null && navigationDirection != null) {
             WorkflowPendingTransition(
                 fromStepId = fromStepId,
@@ -1281,8 +1282,22 @@ internal class PaywallViewModelImpl(
         return null
     }
 
-    private fun WorkflowStep.tracksPaywallEvents(workflow: PublishedWorkflow): Boolean =
-        id == workflow.singleStepFallbackId
+    /**
+     * Whether this workflow step reports paywall events (`paywall_impression` / `paywall_close`),
+     * driven by the backend `screen_type` tag (khepri #21429), matching purchases-ios #7021:
+     * - tagged with `paywall` → reports;
+     * - tagged without `paywall` (including an empty list) → suppressed;
+     * - untagged (null `screen_type`, e.g. a pre-rollout/legacy payload) → reports, preserving the
+     *   prior always-report behavior rather than muting events during rollout.
+     *
+     * This replaces the previous structural inference (`id == singleStepFallbackId`); the backend tags
+     * exactly the fallback step as `["paywall"]`, so the tagged behavior is equivalent while the
+     * explicit signal lets the backend classify steps independently of `single_step_fallback_id`.
+     */
+    private fun WorkflowStep.tracksPaywallEvents(): Boolean {
+        val screenType = stepScreenType ?: return true
+        return screenType.contains(WorkflowScreenType.PAYWALL)
+    }
 
     private fun getCurrentLocaleList(): LocaleListCompat {
         val preferredLocale = purchases.preferredUILocaleOverride ?: return LocaleListCompat.getDefault()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -1022,7 +1022,7 @@ internal class PaywallViewModelImpl(
         }
         if (!shouldApplyState) return
         currentWorkflowStepTracksPaywallEvents = newState is PaywallState.Loaded.Components &&
-            step.tracksPaywallEvents()
+            step.tracksPaywallEvents(workflow)
         val pendingTransition = if (fromStepId != null && navigationDirection != null) {
             WorkflowPendingTransition(
                 fromStepId = fromStepId,
@@ -1284,18 +1284,20 @@ internal class PaywallViewModelImpl(
 
     /**
      * Whether this workflow step reports paywall events (`paywall_impression` / `paywall_close`),
-     * driven by the backend `screen_type` tag (khepri #21429), matching purchases-ios #7021:
+     * driven by the backend `screen_type` tag (khepri #21429):
      * - tagged with `paywall` → reports;
      * - tagged without `paywall` (including an empty list) → suppressed;
-     * - untagged (null `screen_type`, e.g. a pre-rollout/legacy payload) → reports, preserving the
-     *   prior always-report behavior rather than muting events during rollout.
+     * - untagged (null `screen_type`, e.g. a pre-rollout/legacy payload) → falls back to the prior
+     *   structural inference `id == singleStepFallbackId`, so untagged workflows behave exactly as
+     *   before the `screen_type` rollout (only the fallback step reports) rather than over-reporting
+     *   on every step.
      *
-     * This replaces the previous structural inference (`id == singleStepFallbackId`); the backend tags
-     * exactly the fallback step as `["paywall"]`, so the tagged behavior is equivalent while the
-     * explicit signal lets the backend classify steps independently of `single_step_fallback_id`.
+     * Once the backend republishes a workflow it tags exactly the fallback step as `["paywall"]`, so
+     * tagged behavior is equivalent to the fallback while the explicit signal lets the backend classify
+     * steps independently of `single_step_fallback_id`.
      */
-    private fun WorkflowStep.tracksPaywallEvents(): Boolean {
-        val screenType = stepScreenType ?: return true
+    private fun WorkflowStep.tracksPaywallEvents(workflow: PublishedWorkflow): Boolean {
+        val screenType = stepScreenType ?: return id == workflow.singleStepFallbackId
         return screenType.contains(WorkflowScreenType.PAYWALL)
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -23,6 +23,7 @@ import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowDataResult
 import com.revenuecat.purchases.common.workflows.WorkflowScreen
+import com.revenuecat.purchases.common.workflows.WorkflowScreenType
 import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.common.workflows.WorkflowTrigger
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
@@ -69,6 +70,9 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -191,6 +195,9 @@ class PaywallViewModelWorkflowTest {
         return WorkflowDataResult(workflow = wfl, enrolledVariants = null) to offerings
     }
 
+    private fun screenTypeMetadata(vararg types: String): JsonObject =
+        JsonObject(mapOf(WorkflowScreenType.METADATA_KEY to JsonArray(types.map { JsonPrimitive(it) })))
+
     private fun makeContextPackageWorkflow(): Pair<WorkflowDataResult, Offerings> {
         val earlyScreen = makeScreen(screenId1).copy(componentsConfig = noPackagesComponentsConfig)
         val terminalScreen = makeScreen(screenId2).copy(componentsConfig = twoPackageComponentsConfig)
@@ -209,6 +216,8 @@ class PaywallViewModelWorkflowTest {
             ),
             triggerActions = mapOf("action-next" to WorkflowTriggerAction.Step(stepId = "step-2")),
             paramValues = emptyMap(),
+            // Context (non-paywall) step: tagged with an empty screen_type so it suppresses paywall events.
+            metadata = screenTypeMetadata(),
         )
         val terminalStep = WorkflowStep(
             id = "step-2",
@@ -217,6 +226,8 @@ class PaywallViewModelWorkflowTest {
             triggers = emptyList(),
             triggerActions = emptyMap(),
             paramValues = emptyMap(),
+            // Paywall step: tagged so it reports paywall events.
+            metadata = screenTypeMetadata(WorkflowScreenType.PAYWALL),
         )
         val wfl = workflow.copy(
             steps = mapOf("step-1" to earlyStep, "step-2" to terminalStep),
@@ -1623,4 +1634,106 @@ class PaywallViewModelWorkflowTest {
     }
 
     // endregion purchase/restore callbacks
+
+    // region screen_type paywall-event gating
+
+    private fun singleStepScreenTypeWorkflow(metadata: JsonObject?): WorkflowDataResult {
+        val step = WorkflowStep(
+            id = "step-only",
+            type = "screen",
+            screenId = screenId1,
+            triggers = emptyList(),
+            triggerActions = emptyMap(),
+            metadata = metadata,
+        )
+        return WorkflowDataResult(
+            workflow = workflow.copy(
+                initialStepId = "step-only",
+                steps = mapOf("step-only" to step),
+                screens = mapOf(screenId1 to makeScreen(screenId1)),
+                singleStepFallbackId = "step-only",
+            ),
+            enrolledVariants = null,
+        )
+    }
+
+    private fun List<FeatureEvent>.paywallEventsOfType(type: PaywallEventType) =
+        filterIsInstance<PaywallEvent>().filter { it.type == type }
+
+    @Test
+    fun `step tagged paywall reports impression and close`() = runTest {
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        vm.startWorkflowPresentationFromResult(
+            singleStepScreenTypeWorkflow(screenTypeMetadata(WorkflowScreenType.PAYWALL)),
+            testOfferings,
+            null,
+        )
+        vm.trackPaywallImpressionIfNeeded()
+        assertThat(captured.paywallEventsOfType(PaywallEventType.IMPRESSION)).hasSize(1)
+
+        vm.closePaywall(result = null)
+        assertThat(captured.paywallEventsOfType(PaywallEventType.CLOSE)).hasSize(1)
+    }
+
+    @Test
+    fun `step tagged non-paywall suppresses impression and close`() = runTest {
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        // Empty screen_type means "explicitly not a paywall".
+        vm.startWorkflowPresentationFromResult(
+            singleStepScreenTypeWorkflow(screenTypeMetadata()),
+            testOfferings,
+            null,
+        )
+        vm.trackPaywallImpressionIfNeeded()
+        vm.closePaywall(result = null)
+
+        assertThat(captured.filterIsInstance<PaywallEvent>()).isEmpty()
+    }
+
+    @Test
+    fun `untagged step reports impression to preserve behavior`() = runTest {
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        // No metadata → stepScreenType is null (untagged / pre-rollout) → reports.
+        vm.startWorkflowPresentationFromResult(
+            singleStepScreenTypeWorkflow(metadata = null),
+            testOfferings,
+            null,
+        )
+        vm.trackPaywallImpressionIfNeeded()
+
+        assertThat(captured.paywallEventsOfType(PaywallEventType.IMPRESSION)).hasSize(1)
+    }
+
+    @Test
+    fun `untagged multi-step workflow reports from a non-fallback step`() = runTest {
+        // Deliberate, owner-approved divergence from the prior singleStepFallbackId-only behavior:
+        // when no step carries screen_type (pre-rollout / legacy backend), every workflow step reports
+        // paywall events, not just the fallback step. step1 (initial) is NOT the fallback here, yet it
+        // reports. This pins the untagged=report semantics ported from purchases-ios #7021.
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        // Base workflow steps carry no screen_type; point the fallback at step-2 so step-1 is a
+        // non-fallback initial step.
+        val untaggedMultiStep = WorkflowDataResult(
+            workflow = workflow.copy(singleStepFallbackId = "step-2"),
+            enrolledVariants = null,
+        )
+        vm.startWorkflowPresentationFromResult(untaggedMultiStep, testOfferings, null)
+        vm.trackPaywallImpressionIfNeeded()
+
+        assertThat(captured.paywallEventsOfType(PaywallEventType.IMPRESSION)).hasSize(1)
+    }
+
+    // endregion
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -1697,12 +1697,13 @@ class PaywallViewModelWorkflowTest {
     }
 
     @Test
-    fun `untagged step reports impression to preserve behavior`() = runTest {
+    fun `untagged fallback step reports impression to preserve behavior`() = runTest {
         val captured = mutableListOf<FeatureEvent>()
         every { purchases.track(any()) } answers { captured.add(firstArg()) }
 
         val vm = createVm()
-        // No metadata → stepScreenType is null (untagged / pre-rollout) → reports.
+        // No metadata → stepScreenType is null (untagged / pre-rollout) → falls back to the structural
+        // inference `id == singleStepFallbackId`. Here the only step is the fallback, so it reports.
         vm.startWorkflowPresentationFromResult(
             singleStepScreenTypeWorkflow(metadata = null),
             testOfferings,
@@ -1714,11 +1715,11 @@ class PaywallViewModelWorkflowTest {
     }
 
     @Test
-    fun `untagged multi-step workflow reports from a non-fallback step`() = runTest {
-        // Deliberate, owner-approved divergence from the prior singleStepFallbackId-only behavior:
-        // when no step carries screen_type (pre-rollout / legacy backend), every workflow step reports
-        // paywall events, not just the fallback step. step1 (initial) is NOT the fallback here, yet it
-        // reports. This pins the untagged=report semantics ported from purchases-ios #7021.
+    fun `untagged non-fallback step suppresses impression matching pre-rollout behavior`() = runTest {
+        // When no step carries screen_type (pre-rollout / legacy backend), gating falls back to the
+        // prior structural inference: only the singleStepFallbackId step reports. step-1 (initial) is
+        // NOT the fallback here (step-2 is), so it suppresses — matching the behavior on main before the
+        // screen_type rollout, rather than over-reporting on every step.
         val captured = mutableListOf<FeatureEvent>()
         every { purchases.track(any()) } answers { captured.add(firstArg()) }
 
@@ -1732,7 +1733,7 @@ class PaywallViewModelWorkflowTest {
         vm.startWorkflowPresentationFromResult(untaggedMultiStep, testOfferings, null)
         vm.trackPaywallImpressionIfNeeded()
 
-        assertThat(captured.paywallEventsOfType(PaywallEventType.IMPRESSION)).hasSize(1)
+        assertThat(captured.paywallEventsOfType(PaywallEventType.IMPRESSION)).isEmpty()
     }
 
     // endregion


### PR DESCRIPTION
Implements per-step paywall impression gating on Android, driven by the backend's `screen_type` tag. iOS shipped an earlier variant of this feature; it will be updated to match the behavior in this PR (on non-paywall steps, track only workflow events rather than leaving purchases unattributed).

## Motivation

Workflows need the SDK to identify which steps are paywalls so paywall events are tracked per step (WFL-334). The backend (khepri #21429) tags each step's `metadata.screen_type`: `["paywall"]` for the step whose id equals the workflow's `single_step_fallback_id`, and `[]` for every other step.

## What changed

- **Parse** (`WorkflowModels.kt`): adds `WorkflowScreenType` (`screen_type` / `paywall` constants) and `WorkflowStep.stepScreenType: List<String>?`, reading `metadata.screen_type`. `null` = untagged, `[]` = tagged non-paywall. A present-but-non-array value (`null`, scalar, object) is treated as untagged, matching iOS.
- **Gate** (`PaywallViewModel.kt`): `WorkflowStep.tracksPaywallEvents()` now reads `screen_type`. A step reports paywall events when its `screen_type` contains `paywall`, and is suppressed when tagged without `paywall` (including `[]`). When `screen_type` is absent (untagged / pre-rollout / legacy payload) it falls back to the prior structural inference `id == singleStepFallbackId`, so untagged workflows behave exactly as on `main` (only the fallback step reports) until the backend republishes them.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata
- PR: #3620, branch `port/7021-workflows-screen-type-impressions`
- Author / human owner: facumenzella
- Agent: Claude Code (Opus 4.8, 1M context)
- Related: backend khepri #21429. iOS shipped an earlier variant (purchases-ios #7021); it will be updated to match this PR's non-paywall-step behavior (track workflow events only).
- Reviewers: Codex `/codex:review` + `/codex:adversarial-review` (review-fix loop, converged on this final diff)

## Goal
Consume the backend's per-step `screen_type` on Android and use it to gate which workflow steps report paywall events.

## Key decisions (human-owned)
- **Reconcile approach**: re-port onto `main`'s existing `tracksPaywallEvents` scaffold (swap the signal to `screen_type`), rather than keeping a parallel mechanism or abandoning the port. `main` had concurrently shipped the feature via `id == singleStepFallbackId`.
- **Untagged behavior**: untagged steps fall back to `main`'s structural inference (`id == singleStepFallbackId`), so untagged workflows behave exactly as before the rollout (only the fallback step reports). An earlier revision had untagged steps always report (literal iOS semantics); that was reversed after review (vegaro) showed every step of an un-republished workflow would over-report a `paywall_impression`, which is worse than `main` on the very metric this feature exists to fix.

## Agent contribution
- Parsing: `stepScreenType` reads `metadata.screen_type` via cast-to-`JsonArray` then `mapNotNull` of string primitives; non-array shapes return `null` (faithful to iOS `case .array` guard).
- Gate: `tracksPaywallEvents(workflow)` reads `screen_type` (contains `paywall` → report; tagged without `paywall` → suppress; untagged → fall back to `id == workflow.singleStepFallbackId`).
- Tagged the `makeContextPackageWorkflow` test fixture so existing suppression tests hold under the new signal.

## Decision log / course corrections
- Initial implementation built a **parallel** gate (`shouldReportPaywallImpression`, `paywallPresentationReportsImpression`, two-part fingerprint, an `InternalPaywall` `LaunchedEffect` key) before discovering `main` already had `tracksPaywallEvents`. Codex review + adversarial-review on that approach surfaced (and the agent fixed) a same-screen-navigation stale-gate bug. That entire approach was **discarded** after the rebase revealed `main`'s mechanism; the same-screen concern is moot because `main` sets the gate per step at state-build time.
- A rebase onto `origin/main` (22 commits ahead) exposed the conflict; the branch was reset to `origin/main` and re-implemented as the smaller Option A diff.

## Files
- `purchases/.../common/workflows/WorkflowModels.kt` — `WorkflowScreenType`, `WorkflowStep.stepScreenType`.
- `ui/revenuecatui/.../data/PaywallViewModel.kt` — `tracksPaywallEvents()` reads `screen_type`.
- Tests: `WorkflowModelsDeserializationTest`, `PaywallViewModelWorkflowTest`.

## Validation
- `./gradlew detektAll`: green (also runs as the pre-commit hook).
- `:purchases:testDefaultsBc8DebugUnitTest --tests WorkflowModelsDeserializationTest`: 18 pass (8 new).
- `:ui:revenuecatui:testDefaultsBc8DebugUnitTest --tests PaywallViewModelWorkflowTest --tests PaywallViewModelTest`: pass, 0 failures (PaywallViewModelWorkflowTest 57).

## Review focus
- Confirm building on `main`'s `tracksPaywallEvents` flag (vs. iOS's per-view threading) is the right altitude on Android.

## Validation gaps
- Untagged steps fall back to `id == singleStepFallbackId`. When `singleStepFallbackId` itself is `null` this reports on no step (faithful to `main`); a `?: true` "report everything" fallback was considered and not adopted to keep zero divergence from `main`.
- No on-device test of navigating to a `[]`-tagged step and purchasing there (covered at unit level via the per-step flag and `trackComponentInteraction` path on `main`).
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which workflow steps emit paywall analytics; incorrect null vs empty handling could over- or under-report impressions, though tests and conservative malformed-json behavior mitigate this.
> 
> **Overview**
> Workflow paywall **impression/close** gating now uses the backend **`metadata.screen_type`** tag instead of only inferring from **`single_step_fallback_id`**.
> 
> **Parsing:** `WorkflowScreenType` and **`WorkflowStep.stepScreenType`** read `screen_type` as a string array; **null** means untagged, **[]** means explicitly non-paywall; malformed non-array values are treated as untagged (iOS-aligned).
> 
> **Gating:** `tracksPaywallEvents` reports when the tag includes **`paywall`**, suppresses when tagged without it, and for untagged steps still falls back to **`id == singleStepFallbackId`** so legacy workflows match pre-rollout behavior. Multi-step test fixtures now set **`screen_type`** on context vs paywall steps; new unit tests cover parsing and gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f352b933491035f544ade542f717a998db6180b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->