### PR TITLE
refactor(remote-config): user-scoped invalidation

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -8,20 +8,33 @@ import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerFormatException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Orchestrates a single `/v1/config` sync: replays the persisted opaque manifest, then on `204` keeps the cache
  * untouched and on `200` persists the fresh server manifest plus the full per-topic item index — the
- * configuration (incl. each item's inline content) is the source of truth, and persisting it is the entire
- * commit. Only then, gated on a successful persist, it writes the inlined blobs the resolved config still wants
- * and prunes the rest. It reports which prefetch blobs are now cached locally on the next request.
+ * configuration (incl. each item's inline content) is the source of truth, and persisting it is the **entire**
+ * sync commit, advancing the manifest unconditionally. Only then, gated on a successful persist, it writes the
+ * inlined blobs the resolved config still wants and prunes the rest; a missing or un-parseable blob is
+ * recoverable later (fetched on demand in a future phase) and never blocks the commit. It reports which prefetch
+ * blobs are now cached locally on the next request.
  *
  * The manifest is opaque (stored and replayed verbatim); the active-topic set and removed-topic detection come
- * from the response's [RemoteConfiguration.activeTopics]. Only blobs that arrive inlined in the response are
- * handled here; fetching missing prefetch blobs over the network (Phase 5, once blob sources are resolved),
- * topic-handler dispatch (Phase 4) and lifecycle wiring (Phase 7) are not done here yet.
+ * from the response's [RemoteConfiguration.activeTopics]. The manager is topic-agnostic: it never interprets item
+ * shapes or branches on topic name — consumer topics are read lazily by providers through the manager.
+ *
+ * The `200` path runs on [scope]: persistence is synchronous, but the launch lets [clearCache] cancel in-flight
+ * work and gives a later phase's network blob fetch a scope to run in. Identity changes call [clearCache], which
+ * bumps an epoch so a late `/v1/config` response (its HTTP request cannot be socket-cancelled) is dropped instead
+ * of persisting over the freshly wiped cache.
  *
  * Overlapping refreshes are deduped: only one [refreshRemoteConfig] runs at a time. A call made while one is
  * already in flight is skipped (the backend collapses concurrent requests but still fires every callback, which
@@ -33,13 +46,32 @@ internal class RemoteConfigManager(
     private val diskCache: RemoteConfigDiskCache,
     private val blobStore: RemoteConfigBlobStore,
     private val dateProvider: DateProvider = DefaultDateProvider(),
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
     private val isRefreshing = AtomicBoolean(false)
 
+    // Bumped by clearCache() on every identity change. A request captures the epoch when it starts; once it
+    // changes, the in-flight request's callbacks drop their result (the /v1/config request itself cannot be
+    // socket-cancelled), so an old user's response can never persist over the wiped cache.
+    private val epoch = AtomicInteger(0)
+
+    // Serializes a sync's "re-check epoch + persist" against clearCache()'s "bump epoch + wipe". persist() is
+    // synchronous, so cancellation can't interrupt it; this lock makes the two critical sections atomic so a
+    // late persist either runs fully before the wipe or sees the bumped epoch and skips — never writes after it.
+    private val cacheLock = Any()
+
     fun refreshRemoteConfig(appInBackground: Boolean, appUserID: String) {
-        if (isRefreshing.getAndSet(true)) {
-            debugLog { "Remote config refresh already in progress. Skipping." }
-            return
+        val requestEpoch: Int
+        // Acquire the in-flight guard and capture the epoch together under the lock that also guards
+        // clearCache()'s epoch bump + guard release. Otherwise an identity change could slip its bump
+        // between getAndSet(true) and epoch.get(), stranding this request with a stale epoch: its
+        // callbacks would drop on the mismatch and never release the guard, freezing all future syncs.
+        synchronized(cacheLock) {
+            if (isRefreshing.getAndSet(true)) {
+                debugLog { "Remote config refresh already in progress. Skipping." }
+                return
+            }
+            requestEpoch = epoch.get()
         }
         val persisted = diskCache.read()
         val storedBlobs = blobStore.cachedRefs()
@@ -52,25 +84,91 @@ internal class RemoteConfigManager(
             // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
             prefetchedBlobs = persisted?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
             onSuccess = { container, _ ->
-                // Hold the in-flight guard until persistence completes so a concurrent refresh can't read the
-                // disk cache mid-write and merge against a stale snapshot.
-                try {
-                    if (container != null) {
-                        val response = RemoteConfiguration.parse(container.config.decode())
-                        persist(previous = persisted, response = response, container = container)
+                if (epoch.get() != requestEpoch) {
+                    // The cache was cleared (identity change) after this request started. Drop the stale
+                    // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
+                    return@getRemoteConfig
+                }
+                if (container == null) {
+                    // 204: nothing changed, keep the cache. Release the guard only if we still own the sync:
+                    // clearCache() could have bumped the epoch between the check above and here.
+                    releaseGuardIfOwned(requestEpoch)
+                    return@getRemoteConfig
+                }
+                scope.launch {
+                    // Hold the in-flight guard until persistence completes so a concurrent refresh can't read
+                    // the disk cache mid-write and merge against a stale snapshot.
+                    try {
+                        val response = RemoteConfiguration.parse(container.config.data)
+                        // Re-check the epoch and persist under the lock that also guards clearCache()'s wipe, so
+                        // a racing identity change either runs entirely before this write or makes it skip — the
+                        // synchronous persist can never write the old user's config after the cache was wiped.
+                        synchronized(cacheLock) {
+                            if (epoch.get() != requestEpoch) return@launch
+                            persist(previous = persisted, response = response, container = container)
+                        }
+                    } catch (e: SerializationException) {
+                        errorLog(e) {
+                            "Failed to parse remote config response. Keeping the cached configuration."
+                        }
+                    } finally {
+                        // Only release the guard if we still own this sync; a clearCache()/newer refresh owns
+                        // it otherwise.
+                        releaseGuardIfOwned(requestEpoch)
                     }
-                    // container == null is a 204: nothing changed, keep the cache.
-                } catch (e: SerializationException) {
-                    errorLog(e) { "Failed to parse remote config response. Keeping the cached configuration." }
-                } finally {
-                    isRefreshing.set(false)
                 }
             },
             onError = { error ->
-                isRefreshing.set(false)
-                errorLog(error)
+                // Release the guard and log only if we still own the sync; a stale error response (the cache
+                // was cleared after this request started) is dropped and leaves a newer owner's guard alone.
+                if (releaseGuardIfOwned(requestEpoch)) {
+                    errorLog(error)
+                }
             },
         )
+    }
+
+    /**
+     * Wipes the cache on an identity change so configuration never bleeds across users (offerings-parity).
+     * Cancels in-flight sync work and keeps the scope usable for the next user (unlike [close]). The epoch bump,
+     * the in-flight guard release, and the wipe all run under [cacheLock]: a synchronous `persist()` that already
+     * started either finished before the wipe, or re-checks the bumped epoch under the same lock and skips — so an
+     * old user's config can never be written after the wipe. Releasing the guard here (rather than before the
+     * lock) keeps it paired with the epoch a [refreshRemoteConfig] observes, so a refresh can't acquire the guard
+     * with a stale epoch and then strand it when its callback drops on the mismatch. (`cancelChildren()` still
+     * unwinds a suspended sync, e.g. Phase 5's blob fetches, but is not load-bearing for either guarantee since
+     * `persist()` is synchronous; the lock is.)
+     */
+    fun clearCache() {
+        scope.coroutineContext.cancelChildren()
+        synchronized(cacheLock) {
+            epoch.incrementAndGet()
+            // Release the guard inside the lock, after the bump, so it stays paired with the epoch a
+            // refresh observes: a refresh either acquires the guard with the new epoch (and its callback
+            // matches, releasing it normally) or runs entirely before this block (and we release it here).
+            // Never the gap where it acquires the guard with the old epoch and then strands it on mismatch.
+            isRefreshing.set(false)
+            diskCache.clear()
+            blobStore.clear()
+        }
+    }
+
+    /** Cancels in-flight sync work. Called on SDK teardown (Phase 7 wiring). */
+    fun close() {
+        scope.cancel()
+    }
+
+    /**
+     * Atomically releases the in-flight guard iff this request still owns the sync (its captured
+     * [requestEpoch] is still current), under [cacheLock] so the epoch check and the release happen as one
+     * step — paired with clearCache()'s bump+release and a refresh's acquire+capture. Prevents releasing the
+     * guard out from under a newer owner (clearCache() or a newer refresh), which would let a duplicate
+     * refresh start. Returns true if this call released the guard (it still owned the sync).
+     */
+    private fun releaseGuardIfOwned(requestEpoch: Int): Boolean = synchronized(cacheLock) {
+        val owned = epoch.get() == requestEpoch
+        if (owned) isRefreshing.set(false)
+        owned
     }
 
     private fun persist(
@@ -87,10 +185,10 @@ internal class RemoteConfigManager(
         // Blobs the current config still wants: the prefetch set plus any active-topic blob ref.
         val blobRefsToKeep = response.prefetchBlobs.toSet() + mergedTopics.toTopicBlobRefs().values.flatten()
 
-        // Persist the configuration first: it is the source of truth (the full topic index — incl. each item's
-        // inline content — plus the manifest the server diffs against), whereas inline blobs are recoverable over
-        // the network. Persisting it IS the entire commit; only touch the blob store once the state is durably
-        // committed, so a failed persist never orphans or evicts blobs.
+        // Persist the configuration first: the full topic index (incl. each item's inline content) plus the
+        // manifest the server diffs against is the source of truth, and persisting it IS the entire commit (the
+        // manifest advances unconditionally). Inline blobs are recoverable over the network, so only touch the
+        // blob store once the state is durably committed — a failed persist never orphans or evicts blobs.
         val persisted = diskCache.write(
             PersistedRemoteConfigurationState(
                 domain = response.domain,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -99,7 +99,7 @@ internal class RemoteConfigManager(
                     // Hold the in-flight guard until persistence completes so a concurrent refresh can't read
                     // the disk cache mid-write and merge against a stale snapshot.
                     try {
-                        val response = RemoteConfiguration.parse(container.config.data)
+                        val response = RemoteConfiguration.parse(container.config.decode())
                         // Re-check the epoch and persist under the lock that also guards clearCache()'s wipe, so
                         // a racing identity change either runs entirely before this write or makes it skip — the
                         // synchronous persist can never write the old user's config after the cache was wiped.
@@ -110,6 +110,10 @@ internal class RemoteConfigManager(
                     } catch (e: SerializationException) {
                         errorLog(e) {
                             "Failed to parse remote config response. Keeping the cached configuration."
+                        }
+                    } catch (e: RCContainerFormatException) {
+                        errorLog(e) {
+                            "Failed to decode remote config response. Keeping the cached configuration."
                         }
                     } finally {
                         // Only release the guard if we still own this sync; a clearCache()/newer refresh owns

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
@@ -11,6 +11,9 @@ import com.revenuecat.purchases.common.networking.RCContainerTestData
 import com.revenuecat.purchases.common.networking.RCContentEncoding
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -30,7 +33,7 @@ import java.util.Date
  * end-to-end path: inline-blob extraction -> on-disk storage -> retrieval, plus pruning and the prefetch
  * report fed from the blobs actually held.
  */
-@OptIn(InternalRevenueCatAPI::class)
+@OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class RemoteConfigManagerIntegrationTest {
@@ -42,6 +45,9 @@ class RemoteConfigManagerIntegrationTest {
     private lateinit var diskCache: RemoteConfigDiskCache
     private lateinit var blobStore: RemoteConfigBlobStore
     private lateinit var manager: RemoteConfigManager
+
+    // Unconfined so the launched 200-path coroutine runs eagerly: settle(onSuccess) then assert still works.
+    private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
     private var capturedManifest: String? = null
     private var capturedPrefetchedBlobs: List<String>? = null
@@ -61,7 +67,7 @@ class RemoteConfigManagerIntegrationTest {
         backend = mockk()
         diskCache = RemoteConfigDiskCache(applicationContext)
         blobStore = RemoteConfigBlobStore(applicationContext)
-        manager = RemoteConfigManager(backend, diskCache, blobStore, dateProvider = FixedDateProvider)
+        manager = RemoteConfigManager(backend, diskCache, blobStore, dateProvider = FixedDateProvider, scope = testScope)
 
         every {
             backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any())

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -13,6 +13,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlin.concurrent.thread
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -20,8 +24,10 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.nio.ByteBuffer
 import java.util.Date
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
-@OptIn(InternalRevenueCatAPI::class)
+@OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class RemoteConfigManagerTest {
@@ -30,6 +36,9 @@ class RemoteConfigManagerTest {
     private lateinit var diskCache: RemoteConfigDiskCache
     private lateinit var blobStore: RemoteConfigBlobStore
     private lateinit var manager: RemoteConfigManager
+
+    // Unconfined so the launched 200-path coroutine runs eagerly: invoke(onSuccess) then verify still works.
+    private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
     private var capturedAppUserID: String? = null
     private var capturedDomain: String? = null
@@ -43,7 +52,7 @@ class RemoteConfigManagerTest {
         backend = mockk()
         diskCache = mockk(relaxed = true)
         blobStore = mockk(relaxed = true)
-        manager = RemoteConfigManager(backend, diskCache, blobStore, dateProvider = FixedDateProvider)
+        manager = RemoteConfigManager(backend, diskCache, blobStore, dateProvider = FixedDateProvider, scope = testScope)
 
         // Persist succeeds by default; the blob store is only touched once the configuration is persisted.
         every { diskCache.write(any()) } returns true
@@ -358,6 +367,99 @@ class RemoteConfigManagerTest {
         verify(exactly = 0) { diskCache.write(any()) }
     }
 
+    @Test
+    fun `clearCache wipes the disk cache and blob store`() {
+        manager.clearCache()
+
+        verify(exactly = 1) { diskCache.clear() }
+        verify(exactly = 1) { blobStore.clear() }
+    }
+
+    @Test
+    fun `a response that arrives after clearCache does not persist`() {
+        every { diskCache.read() } returns null
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.sources:etag2",
+              "active_topics": ["sources"],
+              "topics": { "sources": { "default": { "blob_ref": "newBlob" } } }
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        // Identity change wipes the cache before the in-flight request settles.
+        manager.clearCache()
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        // The stale response is dropped (epoch guard): nothing is written over the wiped cache.
+        verify(exactly = 0) { diskCache.write(any()) }
+    }
+
+    @Test
+    fun `clearCache during an in-flight persist wipes after the write, never leaving stale config`() {
+        every { diskCache.read() } returns null
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.sources:etag2",
+              "active_topics": ["sources"],
+              "topics": { "sources": { "default": { "blob_ref": "newBlob" } } }
+            }
+        """.trimIndent()
+
+        val writeEntered = CountDownLatch(1)
+        val releaseWrite = CountDownLatch(1)
+        val clearEntered = CountDownLatch(1)
+        // persist() holds cacheLock while it writes; block inside the write so a concurrent clearCache races it.
+        every { diskCache.write(any()) } answers {
+            writeEntered.countDown()
+            check(releaseWrite.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "write was not released in time" }
+            true
+        }
+        every { diskCache.clear() } answers { clearEntered.countDown() }
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        // Run the 200 path on its own thread: it enters the lock and parks inside diskCache.write.
+        val persistThread = thread { onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED) }
+        check(writeEntered.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "persist did not reach diskCache.write" }
+
+        // Identity change mid-persist: clearCache must block on the lock persist is holding.
+        val clearThread = thread { manager.clearCache() }
+
+        // While persist holds the lock, the wipe cannot run — the stale config can't be cleared out from under it.
+        assertThat(clearEntered.await(BLOCKED_MILLIS, TimeUnit.MILLISECONDS)).isFalse()
+
+        // Release the write: persist finishes and frees the lock, and only then does the wipe run.
+        releaseWrite.countDown()
+        persistThread.join(TimeUnit.SECONDS.toMillis(WAIT_SECONDS))
+        clearThread.join(TimeUnit.SECONDS.toMillis(WAIT_SECONDS))
+
+        assertThat(clearEntered.count).isZero()
+        verify(exactly = 1) { diskCache.write(any()) }
+        verify(exactly = 1) { diskCache.clear() }
+    }
+
+    @Test
+    fun `the manager can sync again after clearCache`() {
+        every { diskCache.read() } returns null
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.sources:etag2",
+              "active_topics": ["sources"],
+              "topics": { "sources": { "default": { "blob_ref": "newBlob" } } }
+            }
+        """.trimIndent()
+
+        manager.clearCache()
+        // A brand-new sync (e.g. for the new user) proceeds normally: the guard was released by clearCache.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        verify(exactly = 1) { diskCache.write(any()) }
+    }
+
     private fun persisted(
         manifest: String,
         domain: String = "app",
@@ -393,6 +495,8 @@ class RemoteConfigManagerTest {
     private companion object {
         private const val TEST_APP_USER_ID = "test-app-user-id"
         private const val FIXED_MILLIS = 1_710_000_000_000L
+        private const val WAIT_SECONDS = 5L
+        private const val BLOCKED_MILLIS = 200L
         private const val REF_VALID = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"
         private const val REF_TAMPERED = "IIIIJJJJKKKKLLLLMMMMNNNNOOOOPPPP"
         private const val REF_UNWANTED = "QQQQRRRRSSSSTTTTUUUUVVVVWWWWXXXX"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.networking.RCContainer
+import com.revenuecat.purchases.common.networking.RCContainerFormatException
 import com.revenuecat.purchases.common.networking.RCElement
 import io.mockk.every
 import io.mockk.mockk
@@ -368,6 +369,21 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `a config element that fails to decode leaves the cache untouched and releases the guard`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onSuccess.invoke(containerWithUndecodableConfig(), VerificationResult.VERIFIED)
+
+        // The decode failure is caught: nothing is persisted and the cache is left intact.
+        verify(exactly = 0) { diskCache.write(any()) }
+
+        // The guard was released in the finally block, so a subsequent refresh is allowed to start.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `clearCache wipes the disk cache and blob store`() {
         manager.clearCache()
 
@@ -489,6 +505,15 @@ class RemoteConfigManagerTest {
         val container = mockk<RCContainer>()
         every { container.config } returns element
         every { container.elements } returns elements
+        return container
+    }
+
+    private fun containerWithUndecodableConfig(): RCContainer {
+        val element = mockk<RCElement>()
+        every { element.decode() } throws RCContainerFormatException("Unsupported content encoding id 2.")
+        val container = mockk<RCContainer>()
+        every { container.config } returns element
+        every { container.elements } returns emptyMap()
         return container
     }
 


### PR DESCRIPTION
### Description
This adds support so we clear all the remote config data and stop (or ignore) any in progress operations when the user changes, so we make sure we get fully up to date data for each user.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency and cache lifecycle for remote config; incorrect epoch/lock behavior could block refreshes or persist wrong-user data, though the PR adds targeted race tests.
> 
> **Overview**
> Adds **identity-scoped remote config invalidation** via `clearCache()`, which wipes disk cache and blob store, cancels in-flight coroutine work, bumps an **epoch**, and releases the refresh guard under a shared lock so config cannot leak across users.
> 
> **`refreshRemoteConfig`** now captures epoch when starting a sync and **drops** late `/v1/config` success/error callbacks when the epoch changed (e.g. after `clearCache()`), since the HTTP call cannot be cancelled. The **200** persist path runs on an injectable **`CoroutineScope`**; persist is re-checked under `cacheLock` so a wipe cannot race with writing the previous user’s config. Guard release uses **`releaseGuardIfOwned`** so stale callbacks do not clear the guard for a newer sync.
> 
> Also adds **`close()`** for scope teardown, handles **`RCContainerFormatException`** on decode like parse failures, and extends unit tests (epoch drops, concurrent persist vs clear, decode failure releases guard) with **`UnconfinedTestDispatcher`** for the async 200 path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d22c847dbc337eaf1c8420cb4d728abf5d6d28e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->