### PR TITLE
Update sdks-common-config orb to 3.21.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ aliases:
 version: 2.1
 orbs:
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@3.21.1
+  revenuecat: revenuecat/sdks-common-config@3.21.2
   codecov: codecov/codecov@3.2.4
 
 parameters:


### PR DESCRIPTION
### Motivation
Pull in [sdks-circleci-orb#69](https://github.com/RevenueCat/sdks-circleci-orb/pull/69), which fixes the `merge-release-pr` job failing after a successful merge.

### Description
Bump the CircleCI orb from `3.21.1` to `3.21.2`.
