### PR TITLE
Migrate update_error_codes to the outputs parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ aliases:
 version: 2.1
 orbs:
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@3.21.2
+  revenuecat: revenuecat/sdks-common-config@4.0.0
   codecov: codecov/codecov@3.2.4
 
 parameters:
@@ -1236,7 +1236,7 @@ workflows:
     jobs:
       - revenuecat/update-error-codes:
           platform: android
-          output: purchases/src/main/kotlin/generated/com/revenuecat/purchases/PurchasesErrorCode.kt
+          outputs: "PurchasesErrorCode.kt:purchases/src/main/kotlin/generated/com/revenuecat/purchases/PurchasesErrorCode.kt"
           commit_paths: "purchases/src/main/kotlin/generated/com/revenuecat/purchases/PurchasesErrorCode.kt,purchases/api-defaults-bc7.txt,purchases/api-defauts.txt,purchases/api-entitlement.txt"
           executor:
             name: android/android_docker


### PR DESCRIPTION
Migrates the `update_error_codes` job to the orb's `outputs` parameter, required by sdks-circleci-orb v4.0.0 (which removes the `output` parameter).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no application or SDK runtime behavior changes.
> 
> **Overview**
> Updates CircleCI to **revenuecat/sdks-common-config@4.0.0** and aligns the manual `update_error_codes` workflow with the orb’s breaking API change.
> 
> The `revenuecat/update-error-codes` job now uses **`outputs`** instead of the removed **`output`** parameter, mapping generated `PurchasesErrorCode.kt` to `purchases/src/main/kotlin/generated/com/revenuecat/purchases/PurchasesErrorCode.kt`. Executor, `commit_paths`, and `update_api_steps` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2672addc31e63185c754e89507f04eb3a42a9d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->