### PR TITLE
Bump sdks-common-config orb to 4.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ aliases:
 version: 2.1
 orbs:
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@4.0.0
+  revenuecat: revenuecat/sdks-common-config@4.1.0
   codecov: codecov/codecov@3.2.4
 
 parameters:


### PR DESCRIPTION
Bump common config orb to 4.1.0 to include error codes reminder

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI orb version pin with no application or SDK code changes; risk is limited to possible CI behavior differences from sdks-common-config 4.1.0.
> 
> **Overview**
> Updates the CircleCI **`revenuecat/sdks-common-config`** orb from **4.0.0** to **4.1.0** in `.circleci/config.yml`.
> 
> This pulls in the orb release that adds an **error codes reminder** in CI (per the PR intent). Existing workflows that call `revenuecat/*` jobs—e.g. `danger`, `install-sdkman`, and the manual **`update_error_codes`** pipeline—will run against the new orb version on the next build; no other repo files change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b54a960957971ccc4855c63ea674c4d7a89c0be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->