### PR TITLE
Align Android paywall preview mocks with web/dashboard catalog

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PreviewOfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PreviewOfferingParser.kt
@@ -24,104 +24,90 @@ private class PreviewOfferingParser : OfferingParser() {
         val identifier = packageJson.getString("identifier")
         val packageType = PackageType.values().first { packageType -> packageType.identifier == identifier }
 
-        // These products are the same as those in TestData in revenuecatui.
+        // Prices, periods, and the single introductory offer ($1.99 for 1 week) are kept in
+        // sync with the web/dashboard preview variable tables so the paywall rendering-validation
+        // screenshots show the same products, prices, and offers across platforms. (This
+        // intentionally diverges from TestData in revenuecatui, which is used for other previews.)
         return when (packageType) {
             PackageType.LIFETIME -> TestStoreProduct(
                 id = "com.revenuecat.lifetime_product",
-                name = "Lifetime",
+                name = "Pro Access",
                 title = "Lifetime (App name)",
-                price = Price(amountMicros = 1_000_000_000, currencyCode = "USD", formatted = "$ 1,000.00"),
+                price = Price(amountMicros = 119_990_000, currencyCode = "USD", formatted = "$119.99"),
                 description = "Lifetime",
                 period = null,
             )
 
             PackageType.ANNUAL -> TestStoreProduct(
                 id = "com.revenuecat.annual_product",
-                name = "Annual",
+                name = "Pro Access",
                 title = "Annual (App name)",
-                price = Price(amountMicros = 67_990_000, currencyCode = "USD", formatted = "$ 67.99"),
+                price = Price(amountMicros = 69_990_000, currencyCode = "USD", formatted = "$69.99"),
                 description = "Annual",
                 period = Period(value = 1, unit = Period.Unit.YEAR, iso8601 = "P1Y"),
-                freeTrialPricingPhase = PricingPhase(
-                    billingPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
-                    recurrenceMode = RecurrenceMode.FINITE_RECURRING,
-                    billingCycleCount = 1,
-                    price = Price(
-                        amountMicros = 0L,
-                        currencyCode = "USD",
-                        formatted = "Free",
-                    ),
-                ),
+                introPricePricingPhase = introductoryOfferPhase(),
             )
 
             PackageType.SIX_MONTH -> TestStoreProduct(
                 id = "com.revenuecat.semester_product",
-                name = "6 month",
+                name = "Pro Access",
                 title = "6 month (App name)",
-                price = Price(amountMicros = 39_990_000, currencyCode = "USD", formatted = "$ 39.99"),
+                price = Price(amountMicros = 39_990_000, currencyCode = "USD", formatted = "$39.99"),
                 description = "6 month",
                 period = Period(value = 6, unit = Period.Unit.MONTH, iso8601 = "P6M"),
+                introPricePricingPhase = introductoryOfferPhase(),
             )
 
             PackageType.THREE_MONTH -> TestStoreProduct(
                 id = "com.revenuecat.quarterly_product",
-                name = "3 month",
+                name = "Pro Access",
                 title = "3 month (App name)",
-                price = Price(amountMicros = 23_990_000, currencyCode = "USD", formatted = "$ 23.99"),
+                price = Price(amountMicros = 24_990_000, currencyCode = "USD", formatted = "$24.99"),
                 description = "3 month",
                 period = Period(value = 3, unit = Period.Unit.MONTH, iso8601 = "P3M"),
-                freeTrialPricingPhase = PricingPhase(
-                    billingPeriod = Period(value = 2, unit = Period.Unit.WEEK, iso8601 = "P2W"),
-                    recurrenceMode = RecurrenceMode.FINITE_RECURRING,
-                    billingCycleCount = 1,
-                    price = Price(
-                        amountMicros = 0L,
-                        currencyCode = "USD",
-                        formatted = "Free",
-                    ),
-                ),
-                introPricePricingPhase = PricingPhase(
-                    billingPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
-                    recurrenceMode = RecurrenceMode.FINITE_RECURRING,
-                    billingCycleCount = 1,
-                    price = Price(amountMicros = 3_990_000, currencyCode = "USD", formatted = "$ 3.99"),
-                ),
+                introPricePricingPhase = introductoryOfferPhase(),
             )
 
             PackageType.TWO_MONTH -> TestStoreProduct(
                 id = "com.revenuecat.bimonthly_product",
-                name = "2 month",
+                name = "Pro Access",
                 title = "2 month (App name)",
-                price = Price(amountMicros = 15_990_000, currencyCode = "USD", formatted = "$ 15.99"),
+                price = Price(amountMicros = 17_990_000, currencyCode = "USD", formatted = "$17.99"),
                 description = "2 month",
                 period = Period(value = 2, unit = Period.Unit.MONTH, iso8601 = "P2M"),
-                introPricePricingPhase = PricingPhase(
-                    billingPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
-                    recurrenceMode = RecurrenceMode.FINITE_RECURRING,
-                    billingCycleCount = 1,
-                    price = Price(amountMicros = 3_990_000, currencyCode = "USD", formatted = "$ 3.99"),
-                ),
+                introPricePricingPhase = introductoryOfferPhase(),
             )
 
             PackageType.MONTHLY -> TestStoreProduct(
                 id = "com.revenuecat.monthly_product",
-                name = "Monthly",
+                name = "Pro Access",
                 title = "Monthly (App name)",
-                price = Price(amountMicros = 7_990_000, currencyCode = "USD", formatted = "$ 7.99"),
+                price = Price(amountMicros = 9_990_000, currencyCode = "USD", formatted = "$9.99"),
                 description = "Monthly",
                 period = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+                introPricePricingPhase = introductoryOfferPhase(),
             )
 
             PackageType.WEEKLY -> TestStoreProduct(
                 id = "com.revenuecat.weekly_product",
-                name = "Weekly",
+                name = "Pro Access",
                 title = "Weekly (App name)",
-                price = Price(amountMicros = 1_490_000, currencyCode = "USD", formatted = "$ 1.49"),
+                price = Price(amountMicros = 2_990_000, currencyCode = "USD", formatted = "$2.99"),
                 description = "Weekly",
                 period = Period(value = 1, unit = Period.Unit.WEEK, iso8601 = "P1W"),
+                introPricePricingPhase = introductoryOfferPhase(),
             )
 
             else -> null
         }
     }
+
+    // A single introductory offer of $1.99 for 1 week, attached to every subscription, matching
+    // the offer values in the web/dashboard preview tables and the iOS preview harness.
+    private fun introductoryOfferPhase(): PricingPhase = PricingPhase(
+        billingPeriod = Period(value = 1, unit = Period.Unit.WEEK, iso8601 = "P1W"),
+        recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+        billingCycleCount = 1,
+        price = Price(amountMicros = 1_990_000, currencyCode = "USD", formatted = "$1.99"),
+    )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation

One of four coordinated PRs (iOS, Android, web SDK, dashboard) to reconcile the products/prices/offers shown on the cross-platform paywall rendering-validation screenshots. Each platform mocks the product data missing from the shared `offerings.json`/`packages.json` (which have no prices or offers) from its own hard-coded table, so the screenshots diverged. Android used its own price tiers and an inconsistent mix of free trials / intro prices across packages.

### Description

Updates `PreviewOfferingParser` (the preview-only parser used for `@Preview`s and the Paparazzi validation recorder) to match the web + dashboard preview variable tables, which are identical and are treated as the source of truth (they can't be changed without touching production dashboard code):

- Canonical prices/periods: weekly $2.99, monthly $9.99, 2-month $17.99, 3-month $24.99, 6-month $39.99, annual $69.99, lifetime $119.99.
- A uniform single **$1.99 / 1-week introductory offer** on every subscription (replacing the previous mix of free trials and intro prices), so all platforms show the same offer.
- `"Pro Access"` as the store product `name`, matching the web/dashboard `product.store_product_name`.

This only changes preview/sample data; no purchasing logic is affected.

Known residual: the `relative_discount` badge is a hard-coded "19%" string on web/dashboard but computed from prices on the SDKs, so that percentage may still differ.

### Testing

I could not run the Paparazzi recorder or detekt in this environment (heavy Gradle/network setup). Please regenerate the Android validation screenshots via `recordPaparazziBc8Debug` / the `record-and-push-paywall-template-screenshots` job in CI and confirm.

Note: this also changes Android Studio `@Preview` sample prices for V2 paywall templates, since the same parser feeds those previews.

---
- [ ] Add `pr:other` + `pr:RevenueCatUI` + `feat:Paywalls_V2` labels on review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73d3a58b-e36d-4085-8e65-48900f62e89f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73d3a58b-e36d-4085-8e65-48900f62e89f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

