### PR TITLE
test(receipts): cover PostReceiptHelper workflow metadata resolution

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.common.ago
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.caching.LocalTransactionMetadata
 import com.revenuecat.purchases.common.caching.LocalTransactionMetadataStore
+import com.revenuecat.purchases.common.caching.WorkflowMetadata
 import com.revenuecat.purchases.common.networking.PostReceiptProductInfo
 import com.revenuecat.purchases.common.networking.PostReceiptResponse
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
@@ -1465,6 +1466,79 @@ class PostReceiptHelperTest {
     }
 
     @Test
+    fun `postReceipt posts workflow metadata resolved from the presented paywall event`() {
+        val workflowEvent = event.copy(
+            data = event.data.copy(workflowId = "workflow-id-xyz", stepId = "step-id-123"),
+        )
+
+        mockPostReceiptSuccess()
+
+        paywallPresentedCache.receiveEvent(workflowEvent)
+        postReceiptHelper.postTransactionAndConsumeIfNeeded(
+            purchase = mockStoreTransaction,
+            storeProduct = mockStoreProduct,
+            subscriptionOptionForProductIDs = null,
+            isRestore = false,
+            appUserID = appUserID,
+            initiationSource = PostReceiptInitiationSource.PURCHASE,
+            onSuccess = { _, _ -> },
+            onError = { _, _ -> fail("Should succeed") }
+        )
+        verify(exactly = 1) {
+            backend.postReceiptData(
+                purchaseToken = any(),
+                appUserID = any(),
+                isRestore = any(),
+                finishTransactions = any(),
+                purchasesAreCompletedBy = any(),
+                subscriberAttributes = any(),
+                receiptInfo = any(),
+                initiationSource = any(),
+                paywallPostReceiptData = any(),
+                workflowMetadata = WorkflowMetadata(
+                    workflowId = "workflow-id-xyz",
+                    stepId = "step-id-123",
+                ),
+                onSuccess = any(),
+                onError = any()
+            )
+        }
+    }
+
+    @Test
+    fun `postReceipt does not post workflow metadata when presented paywall event has no workflow`() {
+        mockPostReceiptSuccess()
+
+        paywallPresentedCache.receiveEvent(event)
+        postReceiptHelper.postTransactionAndConsumeIfNeeded(
+            purchase = mockStoreTransaction,
+            storeProduct = mockStoreProduct,
+            subscriptionOptionForProductIDs = null,
+            isRestore = false,
+            appUserID = appUserID,
+            initiationSource = PostReceiptInitiationSource.PURCHASE,
+            onSuccess = { _, _ -> },
+            onError = { _, _ -> fail("Should succeed") }
+        )
+        verify(exactly = 1) {
+            backend.postReceiptData(
+                purchaseToken = any(),
+                appUserID = any(),
+                isRestore = any(),
+                finishTransactions = any(),
+                purchasesAreCompletedBy = any(),
+                subscriberAttributes = any(),
+                receiptInfo = any(),
+                initiationSource = any(),
+                paywallPostReceiptData = any(),
+                workflowMetadata = null,
+                onSuccess = any(),
+                onError = any()
+            )
+        }
+    }
+
+    @Test
     fun `postReceipt does not post paywall data if purchase product does not match paywall event`() {
         mockPostReceiptSuccess()
 
@@ -2421,6 +2495,7 @@ class PostReceiptHelperTest {
                 receiptInfo = capture(postedReceiptInfoSlot),
                 initiationSource = postReceiptInitiationSource,
                 paywallPostReceiptData = any(),
+                workflowMetadata = any(),
                 purchasesAreCompletedBy = any(),
                 onSuccess = captureLambda(),
                 onError = any()
@@ -2612,6 +2687,80 @@ class PostReceiptHelperTest {
         assertThat(successCalled).isTrue
         verify(exactly = 1) {
             localTransactionMetadataStore.clearLocalTransactionMetadata(setOf("cached-token"))
+        }
+    }
+
+    @Test
+    fun `postRemainingCachedTransactionMetadata posts cached metadata with workflowMetadata`() {
+        val workflowMetadata = WorkflowMetadata(
+            workflowId = "workflow-id-xyz",
+            stepId = "step-id-123",
+        )
+        val metadata = LocalTransactionMetadata(
+            token = "cached-token",
+            receiptInfo = testReceiptInfo,
+            paywallPostReceiptData = event.toPaywallPostReceiptData(),
+            purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+            workflowMetadata = workflowMetadata,
+        )
+        every { localTransactionMetadataStore.getAllLocalTransactionMetadata() } returns listOf(metadata)
+        mockUnsyncedSubscriberAttributes()
+        every { offlineEntitlementsManager.resetOfflineCustomerInfoCache() } just Runs
+        every { subscriberAttributesManager.markAsSynced(appUserID, emptyMap(), emptyList()) } just Runs
+        every { customerInfoUpdateHandler.cacheAndNotifyListeners(defaultCustomerInfo) } just Runs
+        every { deviceCache.addSuccessfullyPostedToken("cached-token") } just Runs
+        every { localTransactionMetadataStore.clearLocalTransactionMetadata(setOf("cached-token")) } just Runs
+
+        every {
+            backend.postReceiptData(
+                purchaseToken = "cached-token",
+                appUserID = appUserID,
+                isRestore = true,
+                finishTransactions = defaultFinishTransactions,
+                subscriberAttributes = emptyMap(),
+                receiptInfo = testReceiptInfo,
+                initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+                paywallPostReceiptData = any(),
+                workflowMetadata = workflowMetadata,
+                purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+                onSuccess = captureLambda(),
+                onError = any()
+            )
+        } answers {
+            lambda<PostReceiptDataSuccessCallback>().captured.invoke(
+                PostReceiptResponse(defaultCustomerInfo, emptyMap(), JSONObject())
+            )
+        }
+
+        var successCalled = false
+        postReceiptHelper.postRemainingCachedTransactionMetadata(
+            appUserID = appUserID,
+            allowSharingPlayStoreAccount = true,
+            pendingTransactionsTokens = emptySet(),
+            onNoTransactionsToSync = { fail("Should not call onNoTransactionsToSync") },
+            onError = { fail("Should not call onError") },
+            onSuccess = { customerInfo ->
+                assertThat(customerInfo).isEqualTo(defaultCustomerInfo)
+                successCalled = true
+            }
+        )
+
+        assertThat(successCalled).isTrue
+        verify(exactly = 1) {
+            backend.postReceiptData(
+                purchaseToken = "cached-token",
+                appUserID = appUserID,
+                isRestore = true,
+                finishTransactions = defaultFinishTransactions,
+                subscriberAttributes = emptyMap(),
+                receiptInfo = testReceiptInfo,
+                initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+                paywallPostReceiptData = any(),
+                workflowMetadata = workflowMetadata,
+                purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+                onSuccess = any(),
+                onError = any()
+            )
         }
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -1492,12 +1492,29 @@ class PaywallViewModelWorkflowTest {
             customerInfo = mockk(relaxed = true),
         )
         val vm = createVm()
+
+        // Both steps render the same screen, so the visual presentation fingerprint is identical
+        // across the re-presentation and the impression is de-duped. Only the workflow step id
+        // changes, which is exactly what withCurrentWorkflowMetadata must refresh on the
+        // already-tracked presentation data.
+        val sharedScreenSteps = mapOf(
+            "step-1" to step1.copy(screenId = screenId2),
+            "step-2" to step2.copy(screenId = screenId2),
+        )
         val step1Result = WorkflowDataResult(
-            workflow = workflow.copy(initialStepId = "step-1", singleStepFallbackId = "step-1"),
+            workflow = workflow.copy(
+                initialStepId = "step-1",
+                singleStepFallbackId = "step-1",
+                steps = sharedScreenSteps,
+            ),
             enrolledVariants = null,
         )
         val step2Result = WorkflowDataResult(
-            workflow = workflow.copy(initialStepId = "step-2", singleStepFallbackId = "step-2"),
+            workflow = workflow.copy(
+                initialStepId = "step-2",
+                singleStepFallbackId = "step-2",
+                steps = sharedScreenSteps,
+            ),
             enrolledVariants = null,
         )
 
@@ -1507,6 +1524,11 @@ class PaywallViewModelWorkflowTest {
 
         vm.startWorkflowPresentationFromResult(step2Result, testOfferings, null)
         vm.trackPaywallImpressionIfNeeded()
+        // Same visual fingerprint, so no new impression is emitted: this proves the de-dup branch
+        // (the one withCurrentWorkflowMetadata lives in) was taken, not a fresh re-creation.
+        assertThat(
+            captured.filterIsInstance<PaywallEvent>().none { it.type == PaywallEventType.IMPRESSION },
+        ).isTrue
         vm.handlePackagePurchase(activity = mockk<Activity>(), pkg = TestData.Packages.monthly)
         advanceUntilIdle()
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -30,6 +30,7 @@ import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.workflows.events.WorkflowEvent
+import com.revenuecat.purchases.paywalls.events.ExitOfferType
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
 import com.revenuecat.purchases.paywalls.components.StackComponent
@@ -1513,6 +1514,57 @@ class PaywallViewModelWorkflowTest {
             .single { it.type == PaywallEventType.PURCHASE_INITIATED }
         assertThat(purchaseInitiated.data.workflowId).isEqualTo(step2Result.workflow.id)
         assertThat(purchaseInitiated.data.stepId).isEqualTo("step-2")
+    }
+
+    @Test
+    fun `exit offer after same paywall workflow re-presentation carries current step metadata`() = runTest {
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+        val vm = createVm()
+
+        // Both steps render the same screen, so the visual presentation fingerprint is identical
+        // across the re-presentation and the impression is de-duped. Only the workflow step id
+        // changes, which is exactly what withCurrentWorkflowMetadata must refresh on the
+        // already-tracked presentation data.
+        val sharedScreenSteps = mapOf(
+            "step-1" to step1.copy(screenId = screenId2),
+            "step-2" to step2.copy(screenId = screenId2),
+        )
+        val step1Result = WorkflowDataResult(
+            workflow = workflow.copy(
+                initialStepId = "step-1",
+                singleStepFallbackId = "step-1",
+                steps = sharedScreenSteps,
+            ),
+            enrolledVariants = null,
+        )
+        val step2Result = WorkflowDataResult(
+            workflow = workflow.copy(
+                initialStepId = "step-2",
+                singleStepFallbackId = "step-2",
+                steps = sharedScreenSteps,
+            ),
+            enrolledVariants = null,
+        )
+
+        vm.startWorkflowPresentationFromResult(step1Result, testOfferings, null)
+        vm.trackPaywallImpressionIfNeeded()
+        captured.clear()
+
+        vm.startWorkflowPresentationFromResult(step2Result, testOfferings, null)
+        vm.trackPaywallImpressionIfNeeded()
+        // Same visual fingerprint, so no new impression is emitted: this proves the de-dup branch
+        // (the one withCurrentWorkflowMetadata lives in) was taken, not a fresh re-creation.
+        assertThat(
+            captured.filterIsInstance<PaywallEvent>().none { it.type == PaywallEventType.IMPRESSION },
+        ).isTrue
+        vm.trackExitOffer(ExitOfferType.DISMISS, exitOfferingIdentifier = "exit-offering-id")
+        advanceUntilIdle()
+
+        val exitOffer = captured.filterIsInstance<PaywallEvent>()
+            .single { it.type == PaywallEventType.EXIT_OFFER }
+        assertThat(exitOffer.data.workflowId).isEqualTo(step2Result.workflow.id)
+        assertThat(exitOffer.data.stepId).isEqualTo("step-2")
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Follow-up to #3603 (cc @vegaro). That PR threads `presented_workflow_id` / `presented_step_id` through the post-receipt pipeline. While reviewing it I found two coverage gaps, one of which is significant. This PR **targets the #3603 branch** so the tests land with the feature.

### Changes

**1. `PostReceiptHelper` resolution coverage** (`PostReceiptHelperTest`)

The new resolution logic in `PostReceiptHelper` was only exercised indirectly (`BackendTest` covers the wire format given explicit metadata; `PaywallViewModelWorkflowTest` covers event creation). Added:

- resolves workflow metadata from the live presented paywall event
- omits workflow metadata when the presented event has no workflow (pins the "both-or-neither" rule of `WorkflowMetadata.from`)
- replays cached workflow metadata on unsynced retry (`postRemainingCachedTransactionMetadata`)

Supporting: `mockPostReceiptSuccess` now matches `workflowMetadata = any()` (an omitted defaulted arg in MockK binds `eq(null)`), so the success path can post non-null workflow metadata. Existing tests unaffected.

**2. Fixed a vacuous re-presentation test + added EXIT_OFFER coverage** (`PaywallViewModelWorkflowTest`)

The feature's own regression test, `purchase initiated after same paywall workflow re-presentation carries current step metadata`, did **not** actually exercise `withCurrentWorkflowMetadata`. Its two steps pointed at different screens (`screen-1` vs `screen-2`), producing different presentation fingerprints, so the second impression took the **else** branch and recreated fresh event data, reading the live step. The test passed even with `withCurrentWorkflowMetadata` removed.

- Reworked that test so both steps render the **same screen** (identical fingerprint → de-dup branch is taken), with a "no new impression" assertion proving the branch was reached.
- Added a sibling test for `EXIT_OFFER` after the same-fingerprint re-presentation.
- Both verified **RED → GREEN**: with `withCurrentWorkflowMetadata` neutralized they fail (`expected "step-2" but was "step-1"`); restored, they pass.

### Validation

- `./gradlew :purchases:testDefaultsBc8DebugUnitTest --tests "com.revenuecat.purchases.PostReceiptHelperTest"` , 86 tests, 0 failures.
- `./gradlew :ui:revenuecatui:testDefaultsBc8DebugUnitTest --tests "com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelWorkflowTest"` , 0 failures.
- RED→GREEN proof captured by neutralizing the `withCurrentWorkflowMetadata` line (run under JDK 21).

> [!IMPORTANT]
> Before #3603 merges: its `withCurrentWorkflowMetadata` change had no test that exercised it (the existing regression test was vacuous). This PR closes that gap. Recommend not approving #3603 until these tests are in.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR (base: `cesar/receipt-presented-paywall-workflow-ids`, the #3603 branch)
- Branch: `facu/pr3603-postreceipt-workflow-tests`
- Author / human owner: facumenzella
- Agent(s): Claude Code, Opus 4.8 (1M context)
- Session source: current conversation
- Generated: 2026-06-22
- Context document version: 2

## Goal

Close test-coverage gaps found while reviewing #3603: (a) `PostReceiptHelper`-layer workflow-metadata resolution, and (b) the `withCurrentWorkflowMetadata` re-presentation behavior, whose existing regression test turned out to be vacuous.

## Initial Prompt

Review #3603. The review surfaced coverage gaps; follow-ups were "write a test for 1", "open a draft targeting this pr and mention this", then "write it [finding #2] and put it in the same pr".

## Important Follow-up Prompts

- "Can you write a test for 1" , PostReceiptHelper coverage.
- "open a draft targetting this pr and mention this" , open this PR against the #3603 branch.
- "write it and put it in the same pr" , add the finding #2 (CLOSE/EXIT_OFFER) test.
- Decision: "Fix it in my PR" , rework vegaro's vacuous PURCHASE_INITIATED test here rather than only flagging it.

## Agent Contribution

- Added 3 `PostReceiptHelperTest` tests + made `mockPostReceiptSuccess` workflow-agnostic.
- Added an `EXIT_OFFER` re-presentation test in `PaywallViewModelWorkflowTest`.
- Discovered (via a neutralize + sentinel experiment) that the existing PURCHASE_INITIATED re-presentation test never reached the `withCurrentWorkflowMetadata` branch; reworked it to share one screen and added a "no new impression" guard.
- Verified RED→GREEN for both UI tests by neutralizing the production line.

## Human Decisions

- Open a separate branch / draft PR against the #3603 feature branch rather than pushing onto @vegaro's branch.
- Fix the vacuous existing test inside this PR.

## Key Implementation Decisions

- Decision: force the same presentation fingerprint by pointing both workflow steps at the same `screenId`.
  - Rationale: the de-dup branch (where `withCurrentWorkflowMetadata` lives) only runs when fingerprints match; different screens silently routed the test through fresh re-creation.
  - Rejected: leaving the original different-screen fixture (it does not test the fix).
- Decision: assert "no new IMPRESSION" after the re-presentation.
  - Rationale: proves the de-dup branch was taken; this is the guard that distinguishes a real test from a vacuous one.
- Decision: `mockPostReceiptSuccess` uses `workflowMetadata = any()`.
  - Rationale: omitted defaulted MockK arg binds `eq(null)`.

## Files / Symbols Touched

- `purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt`
  - Why: PostReceiptHelper-layer resolution coverage.
  - Symbols: `mockPostReceiptSuccess`, new `@Test`s (presented-paywall resolution, no-workflow omission, `postRemainingCachedTransactionMetadata`).
- `ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt`
  - Why: make the re-presentation test exercise `withCurrentWorkflowMetadata`; add EXIT_OFFER coverage.
  - Symbols: `purchase initiated after same paywall workflow re-presentation...`, `exit offer after same paywall workflow re-presentation...`.

## Dependencies / Config / Migrations

- None.

## Validation

- Commands run:
  - `:purchases:testDefaultsBc8DebugUnitTest --tests "...PostReceiptHelperTest"`: 86 tests, 0 failures.
  - `:ui:revenuecatui:testDefaultsBc8DebugUnitTest --tests "...PaywallViewModelWorkflowTest"`: 0 failures.
  - RED check: with `withCurrentWorkflowMetadata` neutralized, both re-presentation tests fail (`expected "step-2" but was "step-1"`); restored, they pass.
- Manual verification: Not run (test-only change).
- CI: Not captured at time of writing.

## Validation Gaps

- The cached-vs-live precedence in `PostReceiptHelper` is exercised via the live and retry paths but not via a dedicated synchronous-purchase test where `getLocalTransactionMetadata` returns metadata.
- Local runs required JDK 21 (project `.sdkmanrc` pins `21.0.6-librca`); default daemon here was JDK 17, which Robolectric rejects for Android SDK 36.

## Review Focus

- Confirm the "no new impression" assertion correctly captures the de-dup branch for both UI tests.
- Confirm `mockPostReceiptSuccess`'s `workflowMetadata = any()` relaxation does not weaken the negative-case test (`...has no workflow`), which asserts `workflowMetadata = null` explicitly.

## Risks / Reviewer Notes

- Risk: test-only change; no production behavior altered.
  - Evidence: diff touches only `*Test.kt` files (the PaywallViewModel edit during RED→GREEN was reverted; prod tree confirmed clean).
  - Mitigation: none needed.

## Non-goals / Out of Scope

- No production code changes; `withCurrentWorkflowMetadata` itself is unchanged.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test files change; behavior under test lives in the feature branch, not in this diff.
> 
> **Overview**
> **Test-only** follow-up that locks in workflow `presented_workflow_id` / `presented_step_id` behavior from the parent feature PR—no production code changes.
> 
> **`PostReceiptHelperTest`** adds coverage for how `workflowMetadata` is chosen when calling `backend.postReceiptData`: from the presented paywall event when workflow ids are present, **`null`** when they are not, and replay from **`LocalTransactionMetadata`** on `postRemainingCachedTransactionMetadata`. **`mockPostReceiptSuccess`** now stubs `workflowMetadata = any()` so success-path mocks accept non-null metadata (MockK default binding issue).
> 
> **`PaywallViewModelWorkflowTest`** fixes a regression test that never hit the impression **de-dup** path: both workflow steps now share the same screen so `withCurrentWorkflowMetadata` must refresh step ids on re-presentation. Adds a **no new IMPRESSION** assertion and a sibling **`EXIT_OFFER`** test for the same scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8527bcd0f72234f2d51d8fab9dfbd97ba5233576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->