### PR TITLE
refactor(ads): move reward verification primitives to core

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -42,8 +42,11 @@ prod_code_files = (git.modified_files + git.added_files).uniq.select do |f|
 end
 
 total_changed = prod_code_files.sum do |f|
-  info = git.info_for_file(f)
-  info ? info[:insertions] + info[:deletions] : 0
+  # Read diff stats directly with a nil guard instead of git.info_for_file, which
+  # crashes on renamed files: git keys `diff.stats[:files]` with brace-arrow rename
+  # notation rather than the resolved new path, so the lookup returns nil.
+  stats = git.diff.stats[:files][f]
+  stats ? stats[:insertions] + stats[:deletions] : 0
 end
 
 if total_changed > PROD_LINES_LIMIT

--- a/examples/admob-sample/src/main/java/com/revenuecat/sample/admob/ui/ads/verification/RewardedVerificationMessage.kt
+++ b/examples/admob-sample/src/main/java/com/revenuecat/sample/admob/ui/ads/verification/RewardedVerificationMessage.kt
@@ -1,8 +1,8 @@
 package com.revenuecat.sample.admob.ui.ads.verification
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import com.revenuecat.purchases.admob.RewardVerificationResult
-import com.revenuecat.purchases.admob.VerifiedReward
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 
 /**
  * Status message surfaced in the sample UI while loading, showing and verifying a rewarded ad.

--- a/feature/admob/api.txt
+++ b/feature/admob/api.txt
@@ -31,36 +31,10 @@ package com.revenuecat.purchases.admob {
   public final class RewardVerificationExtensionsKt {
     method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void enableRewardVerification(com.google.android.gms.ads.rewarded.RewardedAd);
     method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void enableRewardVerification(com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd);
-    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void show(com.google.android.gms.ads.rewarded.RewardedAd, android.app.Activity activity, String? placement, optional kotlin.jvm.functions.Function0<kotlin.Unit>? rewardVerificationStarted, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.admob.RewardVerificationResult,kotlin.Unit> rewardVerificationCompleted);
-    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void show(com.google.android.gms.ads.rewarded.RewardedAd, android.app.Activity activity, optional kotlin.jvm.functions.Function0<kotlin.Unit>? rewardVerificationStarted, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.admob.RewardVerificationResult,kotlin.Unit> rewardVerificationCompleted);
-    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void show(com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd, android.app.Activity activity, String? placement, optional kotlin.jvm.functions.Function0<kotlin.Unit>? rewardVerificationStarted, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.admob.RewardVerificationResult,kotlin.Unit> rewardVerificationCompleted);
-    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void show(com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd, android.app.Activity activity, optional kotlin.jvm.functions.Function0<kotlin.Unit>? rewardVerificationStarted, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.admob.RewardVerificationResult,kotlin.Unit> rewardVerificationCompleted);
-  }
-
-  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public final class RewardVerificationResult {
-    method public boolean getFailed();
-    method public com.revenuecat.purchases.admob.VerifiedReward? getVerifiedReward();
-    property public final boolean failed;
-    property public final com.revenuecat.purchases.admob.VerifiedReward? verifiedReward;
-  }
-
-  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public interface VerifiedReward {
-  }
-
-  public static final class VerifiedReward.NoReward implements com.revenuecat.purchases.admob.VerifiedReward {
-    field public static final com.revenuecat.purchases.admob.VerifiedReward.NoReward INSTANCE;
-  }
-
-  public static final class VerifiedReward.UnsupportedReward implements com.revenuecat.purchases.admob.VerifiedReward {
-    field public static final com.revenuecat.purchases.admob.VerifiedReward.UnsupportedReward INSTANCE;
-  }
-
-  @dev.drewhamilton.poko.Poko public static final class VerifiedReward.VirtualCurrency implements com.revenuecat.purchases.admob.VerifiedReward {
-    ctor public VerifiedReward.VirtualCurrency(String code, int amount);
-    method public int getAmount();
-    method public String getCode();
-    property public final int amount;
-    property public final String code;
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void show(com.google.android.gms.ads.rewarded.RewardedAd, android.app.Activity activity, String? placement, optional kotlin.jvm.functions.Function0<kotlin.Unit>? rewardVerificationStarted, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult,kotlin.Unit> rewardVerificationCompleted);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void show(com.google.android.gms.ads.rewarded.RewardedAd, android.app.Activity activity, optional kotlin.jvm.functions.Function0<kotlin.Unit>? rewardVerificationStarted, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult,kotlin.Unit> rewardVerificationCompleted);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void show(com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd, android.app.Activity activity, String? placement, optional kotlin.jvm.functions.Function0<kotlin.Unit>? rewardVerificationStarted, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult,kotlin.Unit> rewardVerificationCompleted);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void show(com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd, android.app.Activity activity, optional kotlin.jvm.functions.Function0<kotlin.Unit>? rewardVerificationStarted, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult,kotlin.Unit> rewardVerificationCompleted);
   }
 
 }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/RewardVerificationExtensions.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/RewardVerificationExtensions.kt
@@ -6,6 +6,7 @@ import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.admob.rewardverification.RewardVerificationManager
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import kotlin.jvm.JvmSynthetic
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/RewardVerificationResult.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/RewardVerificationResult.kt
@@ -1,0 +1,17 @@
+package com.revenuecat.purchases.admob
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+
+/**
+ * Moved to [com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult].
+ */
+@Deprecated(
+    "Moved to com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult",
+    ReplaceWith(
+        "RewardVerificationResult",
+        "com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult",
+    ),
+)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+public typealias RewardVerificationResult =
+    com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/VerifiedReward.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/VerifiedReward.kt
@@ -1,0 +1,17 @@
+package com.revenuecat.purchases.admob
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+
+/**
+ * Moved to [com.revenuecat.purchases.ads.rewardverification.VerifiedReward].
+ */
+@Deprecated(
+    "Moved to com.revenuecat.purchases.ads.rewardverification.VerifiedReward",
+    ReplaceWith(
+        "VerifiedReward",
+        "com.revenuecat.purchases.ads.rewardverification.VerifiedReward",
+    ),
+)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+public typealias VerifiedReward =
+    com.revenuecat.purchases.ads.rewardverification.VerifiedReward

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManager.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManager.kt
@@ -8,11 +8,10 @@ import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.RewardVerificationToken
 import com.revenuecat.purchases.admob.Logger
-import com.revenuecat.purchases.admob.RewardVerificationResult
 import com.revenuecat.purchases.admob.threading.runOnMainIfPresent
-import org.json.JSONObject
-import java.util.UUID
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 internal object RewardVerificationManager {
@@ -70,40 +69,23 @@ internal object RewardVerificationManager {
                         "Try enabling reward verification after Purchases is configured.",
                 )
             else -> {
-                val purchases = Purchases.sharedInstance
-                val clientTransactionId = UUID.randomUUID().toString()
+                val token = Purchases.sharedInstance.generateRewardVerificationToken(impressionId = adResponseId)
                 runtime.setClientTransactionId(
                     adResponseId = adResponseId,
-                    clientTransactionId = clientTransactionId,
+                    clientTransactionId = token.clientTransactionId,
                 )
                 // Correlate the ad with the backend verification through AdMob's server-side verification options. The
                 // SSV callback forwards these to RevenueCat, which keys the verification by the client transaction id.
-                attachOptions(
-                    serverSideVerificationOptions(
-                        apiKey = purchases.currentConfiguration.apiKey,
-                        appUserID = purchases.appUserID,
-                        clientTransactionId = clientTransactionId,
-                    ),
-                )
+                attachOptions(serverSideVerificationOptions(token))
             }
         }
     }
 
-    private fun serverSideVerificationOptions(
-        apiKey: String,
-        appUserID: String,
-        clientTransactionId: String,
-    ): ServerSideVerificationOptions =
+    private fun serverSideVerificationOptions(token: RewardVerificationToken): ServerSideVerificationOptions =
         ServerSideVerificationOptions.Builder()
-            .setCustomData(customData(apiKey = apiKey, clientTransactionId = clientTransactionId))
-            .setUserId(appUserID)
+            .setCustomData(token.customData)
+            .setUserId(token.appUserID)
             .build()
-
-    private fun customData(apiKey: String, clientTransactionId: String): String =
-        JSONObject()
-            .put("api_key", apiKey)
-            .put("client_transaction_id", clientTransactionId)
-            .toString()
 
     private fun handleRewardEarnedInternal(
         adResponseId: String?,

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManager.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManager.kt
@@ -8,10 +8,10 @@ import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.RewardVerificationToken
 import com.revenuecat.purchases.admob.Logger
 import com.revenuecat.purchases.admob.threading.runOnMainIfPresent
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 internal object RewardVerificationManager {

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntime.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntime.kt
@@ -5,9 +5,8 @@ import android.os.Looper
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.Logger
-import com.revenuecat.purchases.admob.RewardVerificationResult
-import com.revenuecat.purchases.admob.VerifiedReward
 import com.revenuecat.purchases.admob.threading.runOnMainIfPresent
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -27,9 +26,8 @@ internal class RewardVerificationRuntime(
         CoroutineScope(SupervisorJob() + Dispatchers.IO)
     },
     private val poll: suspend (String) -> RewardVerificationResult = { clientTransactionId ->
-        Poller.poll(clientTransactionId)
+        Purchases.sharedInstance.pollRewardVerification(clientTransactionId)
     },
-    private val invalidateVirtualCurrenciesCache: () -> Unit = { invalidateVirtualCurrenciesCacheIfConfigured() },
 ) {
     private val clientTransactionIdByAdResponseId = mutableMapOf<String, String>()
     private val verificationScope: CoroutineScope = createVerificationScope()
@@ -50,9 +48,6 @@ internal class RewardVerificationRuntime(
         val completionDelivered = AtomicBoolean(false)
         fun deliverOnce(result: RewardVerificationResult) {
             if (completionDelivered.compareAndSet(false, true)) {
-                if (result.verifiedReward is VerifiedReward.VirtualCurrency) {
-                    invalidateVirtualCurrenciesCache()
-                }
                 notifyCompleted(result, rewardVerificationCompleted)
             }
         }
@@ -117,26 +112,5 @@ internal class RewardVerificationRuntime(
     fun close() {
         verificationScope.cancel()
         clientTransactionIdByAdResponseId.clear()
-    }
-
-    private companion object {
-
-        /**
-         * Invalidates the virtual currencies cache if the SDK is configured.
-         *
-         * Called after reward verification grants a virtual-currency reward so the next
-         * [Purchases.getVirtualCurrencies] fetch returns the updated balance instead of a stale cached value.
-         * If [Purchases] has not been configured yet, logs a warning and skips invalidation.
-         */
-        fun invalidateVirtualCurrenciesCacheIfConfigured() {
-            if (!Purchases.isConfigured) {
-                Logger.w(
-                    "Purchases is not configured. " +
-                        "Skipping virtual currencies cache invalidation after reward verification.",
-                )
-                return
-            }
-            Purchases.sharedInstance.invalidateVirtualCurrenciesCache()
-        }
     }
 }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntime.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntime.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.Logger
 import com.revenuecat.purchases.admob.threading.runOnMainIfPresent
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.awaitPollRewardVerification
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -26,7 +27,7 @@ internal class RewardVerificationRuntime(
         CoroutineScope(SupervisorJob() + Dispatchers.IO)
     },
     private val poll: suspend (String) -> RewardVerificationResult = { clientTransactionId ->
-        Purchases.sharedInstance.pollRewardVerification(clientTransactionId)
+        Purchases.sharedInstance.awaitPollRewardVerification(clientTransactionId)
     },
 ) {
     private val clientTransactionIdByAdResponseId = mutableMapOf<String, String>()

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationStrings.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationStrings.kt
@@ -2,31 +2,6 @@ package com.revenuecat.purchases.admob.rewardverification
 
 internal object RewardVerificationStrings {
 
-    const val BACKEND_REJECTED_WITHOUT_MESSAGE: String =
-        "Reward verification was rejected by AdMob server-side verification."
-
-    fun backendRejectedWithReason(reason: String): String =
-        "Reward verification was rejected by AdMob server-side verification (reason: $reason)."
-
-    const val EXHAUSTED_WHILE_PENDING: String =
-        "Reward verification timed out: the AdMob server-side verification (SSV) callback was not " +
-            "received in time. Possible causes: SSV is not enabled/configured for this ad unit in the " +
-            "AdMob Dashboard, the SSV callback URL is misconfigured in the AdMob Dashboard, AdMob delayed " +
-            "delivering the callback, or RevenueCat failed to process the SSV webhook."
-
-    const val EXHAUSTED_WHILE_TRANSIENT_ERRORING: String =
-        "Reward verification timed out after repeated transient errors while polling — typically " +
-            "unstable device network connectivity. The reward couldn't be verified."
-
-    const val UNEXPECTED_RESPONSE: String =
-        "Reward verification stopped after the server returned a status this SDK version doesn't " +
-            "recognize. Update to the latest SDK version; if you're already on the latest, contact " +
-            "RevenueCat support."
-
     const val CANCELLED: String =
         "Reward verification was cancelled before completion."
-
-    fun terminalError(error: String): String =
-        "Reward verification stopped after an unrecoverable error: $error. This is unexpected; if it " +
-            "persists, contact RevenueCat support with the error above."
 }

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
@@ -68,8 +68,12 @@ internal class RewardVerificationManagerTest {
         val mockPurchases = mockk<Purchases>(relaxed = true)
         every { mockPurchases.generateRewardVerificationToken("ad-response-id") } returns token
         val polledClientTransactionId = slot<String>()
-        coEvery { mockPurchases.pollRewardVerification(capture(polledClientTransactionId)) } returns
-            RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 7))
+        coEvery {
+            mockPurchases.pollRewardVerification(
+                capture(polledClientTransactionId),
+                any<suspend (String) -> RewardVerificationResult>(),
+            )
+        } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 7))
 
         // Configure Purchases and drive the dispatcher so the reward verification runtime is created.
         Purchases.backingFieldSharedInstance = mockPurchases
@@ -124,8 +128,12 @@ internal class RewardVerificationManagerTest {
         val mockPurchases = mockk<Purchases>(relaxed = true)
         every { mockPurchases.generateRewardVerificationToken("interstitial-response-id") } returns token
         val polledClientTransactionId = slot<String>()
-        coEvery { mockPurchases.pollRewardVerification(capture(polledClientTransactionId)) } returns
-            RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 3))
+        coEvery {
+            mockPurchases.pollRewardVerification(
+                capture(polledClientTransactionId),
+                any<suspend (String) -> RewardVerificationResult>(),
+            )
+        } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 3))
 
         Purchases.backingFieldSharedInstance = mockPurchases
         originalServiceDispatcher.initialize(mockPurchases)

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
@@ -14,17 +14,17 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesServiceDispatcher
-import com.revenuecat.purchases.admob.RewardVerificationResult
-import com.revenuecat.purchases.admob.VerifiedReward
+import com.revenuecat.purchases.RewardVerificationToken
 import com.revenuecat.purchases.admob.enableRewardVerification
 import com.revenuecat.purchases.admob.show as showWithRewardVerification
-import com.revenuecat.purchases.interfaces.GetRewardVerificationResultCallback
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
-import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -37,8 +37,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
-import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
 
 @RunWith(RobolectricTestRunner::class)
 internal class RewardVerificationManagerTest {
@@ -62,20 +60,18 @@ internal class RewardVerificationManagerTest {
 
     @Test
     fun `verified result flows from enable through show to completed callback`() {
-        val verifiedReward = CoreVerifiedReward.VirtualCurrency(code = "gems", amount = 7)
+        val token = RewardVerificationToken(
+            customData = "custom-data",
+            clientTransactionId = "client-transaction-id",
+            appUserID = "app-user-id",
+        )
         val mockPurchases = mockk<Purchases>(relaxed = true)
+        every { mockPurchases.generateRewardVerificationToken("ad-response-id") } returns token
         val polledClientTransactionId = slot<String>()
-        every {
-            mockPurchases.getRewardVerificationResult(capture(polledClientTransactionId), any())
-        } answers {
-            secondArg<GetRewardVerificationResultCallback>().onReceived(
-                CoreRewardVerificationResult.Verified(verifiedReward),
-            )
-        }
+        coEvery { mockPurchases.pollRewardVerification(capture(polledClientTransactionId)) } returns
+            RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 7))
 
         // Configure Purchases and drive the dispatcher so the reward verification runtime is created.
-        every { mockPurchases.currentConfiguration.apiKey } returns "test_api_key"
-        every { mockPurchases.appUserID } returns "app-user-id"
         Purchases.backingFieldSharedInstance = mockPurchases
         originalServiceDispatcher.initialize(mockPurchases)
 
@@ -89,14 +85,10 @@ internal class RewardVerificationManagerTest {
 
         ad.enableRewardVerification()
 
-        // enableRewardVerification() must attach the api key, app user id, and a client transaction id so the backend
-        // can correlate the reward.
+        // enableRewardVerification() must attach the token's custom data and user id so the backend can correlate.
         assertTrue(ssvOptions.isCaptured)
         assertEquals("app-user-id", ssvOptions.captured.userId)
-        val payload = JSONObject(ssvOptions.captured.customData)
-        assertEquals("test_api_key", payload.getString("api_key"))
-        val attachedClientTransactionId = payload.getString("client_transaction_id")
-        assertTrue(attachedClientTransactionId.isNotBlank())
+        assertEquals("custom-data", ssvOptions.captured.customData)
 
         var completedResult: RewardVerificationResult? = null
         val completed = CountDownLatch(1)
@@ -118,25 +110,23 @@ internal class RewardVerificationManagerTest {
             VerifiedReward.VirtualCurrency(code = "gems", amount = 7),
             completedResult!!.verifiedReward,
         )
-        // The id polled from the backend must match the custom data attached to the ad so correlation round-trips.
-        assertEquals(attachedClientTransactionId, polledClientTransactionId.captured)
+        // The id polled from the backend must match the token's client transaction id so correlation round-trips.
+        assertEquals("client-transaction-id", polledClientTransactionId.captured)
     }
 
     @Test
     fun `interstitial verified result flows from enable through show with custom data correlation`() {
-        val verifiedReward = CoreVerifiedReward.VirtualCurrency(code = "coins", amount = 3)
+        val token = RewardVerificationToken(
+            customData = "custom-data",
+            clientTransactionId = "client-transaction-id",
+            appUserID = "app-user-id",
+        )
         val mockPurchases = mockk<Purchases>(relaxed = true)
+        every { mockPurchases.generateRewardVerificationToken("interstitial-response-id") } returns token
         val polledClientTransactionId = slot<String>()
-        every {
-            mockPurchases.getRewardVerificationResult(capture(polledClientTransactionId), any())
-        } answers {
-            secondArg<GetRewardVerificationResultCallback>().onReceived(
-                CoreRewardVerificationResult.Verified(verifiedReward),
-            )
-        }
+        coEvery { mockPurchases.pollRewardVerification(capture(polledClientTransactionId)) } returns
+            RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 3))
 
-        every { mockPurchases.currentConfiguration.apiKey } returns "test_api_key"
-        every { mockPurchases.appUserID } returns "app-user-id"
         Purchases.backingFieldSharedInstance = mockPurchases
         originalServiceDispatcher.initialize(mockPurchases)
 
@@ -152,10 +142,7 @@ internal class RewardVerificationManagerTest {
 
         assertTrue(ssvOptions.isCaptured)
         assertEquals("app-user-id", ssvOptions.captured.userId)
-        val payload = JSONObject(ssvOptions.captured.customData)
-        assertEquals("test_api_key", payload.getString("api_key"))
-        val attachedClientTransactionId = payload.getString("client_transaction_id")
-        assertTrue(attachedClientTransactionId.isNotBlank())
+        assertEquals("custom-data", ssvOptions.captured.customData)
 
         var completedResult: RewardVerificationResult? = null
         val completed = CountDownLatch(1)
@@ -173,7 +160,7 @@ internal class RewardVerificationManagerTest {
         assertTrue(delivered)
         assertNotNull(completedResult)
         assertFalse(completedResult!!.failed)
-        assertEquals(attachedClientTransactionId, polledClientTransactionId.captured)
+        assertEquals("client-transaction-id", polledClientTransactionId.captured)
     }
 
     @Test

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
@@ -14,10 +14,10 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesServiceDispatcher
-import com.revenuecat.purchases.RewardVerificationToken
 import com.revenuecat.purchases.admob.enableRewardVerification
 import com.revenuecat.purchases.admob.show as showWithRewardVerification
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import io.mockk.coEvery
 import io.mockk.every

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntimeTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntimeTest.kt
@@ -3,8 +3,9 @@ package com.revenuecat.purchases.admob.rewardverification
 import android.os.Handler
 import android.os.Looper
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import com.revenuecat.purchases.admob.RewardVerificationResult
-import com.revenuecat.purchases.admob.VerifiedReward
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -22,7 +23,7 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowLog
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 @RunWith(RobolectricTestRunner::class)
 internal class RewardVerificationRuntimeTest {
 
@@ -107,90 +108,6 @@ internal class RewardVerificationRuntimeTest {
         assertNotNull(completedResult)
         assertFalse(completedResult!!.failed)
         assertEquals(verifiedReward, completedResult!!.verifiedReward)
-    }
-
-    @Test
-    fun `verified virtual currency reward invalidates virtual currencies cache`() {
-        var invalidationCount = 0
-        val runtime = runtimeDeliveringResult(
-            result = RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 5)),
-            invalidateVirtualCurrenciesCache = { invalidationCount++ },
-        )
-
-        deliverRewardEarned(runtime)
-
-        assertEquals(1, invalidationCount)
-    }
-
-    @Test
-    fun `verified no reward does not invalidate virtual currencies cache`() {
-        var invalidationCount = 0
-        val runtime = runtimeDeliveringResult(
-            result = RewardVerificationResult.verified(VerifiedReward.NoReward),
-            invalidateVirtualCurrenciesCache = { invalidationCount++ },
-        )
-
-        deliverRewardEarned(runtime)
-
-        assertEquals(0, invalidationCount)
-    }
-
-    @Test
-    fun `verified unsupported reward does not invalidate virtual currencies cache`() {
-        var invalidationCount = 0
-        val runtime = runtimeDeliveringResult(
-            result = RewardVerificationResult.verified(VerifiedReward.UnsupportedReward),
-            invalidateVirtualCurrenciesCache = { invalidationCount++ },
-        )
-
-        deliverRewardEarned(runtime)
-
-        assertEquals(0, invalidationCount)
-    }
-
-    @Test
-    fun `failed result does not invalidate virtual currencies cache`() {
-        var invalidationCount = 0
-        val runtime = runtimeDeliveringResult(
-            result = RewardVerificationResult.failed,
-            invalidateVirtualCurrenciesCache = { invalidationCount++ },
-        )
-
-        deliverRewardEarned(runtime)
-
-        assertEquals(0, invalidationCount)
-    }
-
-    private fun runtimeDeliveringResult(
-        result: RewardVerificationResult,
-        invalidateVirtualCurrenciesCache: () -> Unit,
-    ): RewardVerificationRuntime {
-        return RewardVerificationRuntime(
-            mainHandler = Handler(Looper.getMainLooper()),
-            createVerificationScope = {
-                CoroutineScope(SupervisorJob() + Dispatchers.Default)
-            },
-            poll = { result },
-            invalidateVirtualCurrenciesCache = invalidateVirtualCurrenciesCache,
-        )
-    }
-
-    private fun deliverRewardEarned(runtime: RewardVerificationRuntime) {
-        val adResponseId = "ad-response-id"
-        val completed = CountDownLatch(1)
-
-        runtime.setClientTransactionId(adResponseId, "client-transaction-id")
-
-        runtime.handleRewardEarned(
-            adResponseId = adResponseId,
-            rewardVerificationStarted = null,
-            rewardVerificationCompleted = { completed.countDown() },
-        )
-        val completionDelivered = (1..10).any {
-            shadowOf(Looper.getMainLooper()).idle()
-            completed.await(100, TimeUnit.MILLISECONDS)
-        }
-        assertTrue(completionDelivered)
     }
 
     @Test

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/ShowBehaviorTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/ShowBehaviorTest.kt
@@ -11,7 +11,7 @@ import com.google.android.gms.ads.rewarded.RewardItem
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.ads.events.types.AdFormat
-import com.revenuecat.purchases.admob.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.admob.show as showWithRewardVerification
 import com.revenuecat.purchases.admob.tracking.TrackingFullScreenContentCallback
 import io.mockk.every

--- a/purchases/api-defaults-bc7.txt
+++ b/purchases/api-defaults-bc7.txt
@@ -381,7 +381,7 @@ package com.revenuecat.purchases {
     method public void close();
     method public void collectDeviceIdentifiers();
     method public static com.revenuecat.purchases.Purchases configure(com.revenuecat.purchases.PurchasesConfiguration configuration);
-    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public com.revenuecat.purchases.RewardVerificationToken generateRewardVerificationToken(String impressionId);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken generateRewardVerificationToken(String impressionId);
     method @Deprecated @kotlin.jvm.Synchronized public boolean getAllowSharingPlayStoreAccount();
     method public void getAmazonLWAConsentStatus(com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback callback);
     method @kotlin.jvm.Synchronized public String getAppUserID();
@@ -670,20 +670,6 @@ package com.revenuecat.purchases {
     property public abstract String name;
   }
 
-  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public final class RewardVerificationToken {
-    ctor public RewardVerificationToken(String customData, String clientTransactionId, String appUserID);
-    method public String component1();
-    method public String component2();
-    method public String component3();
-    method public com.revenuecat.purchases.RewardVerificationToken copy(String customData, String clientTransactionId, String appUserID);
-    method public String getAppUserID();
-    method public String getClientTransactionId();
-    method public String getCustomData();
-    property public final String appUserID;
-    property public final String clientTransactionId;
-    property public final String customData;
-  }
-
   @kotlinx.serialization.Serializable(with=StoreSerializer::class) public enum Store {
     enum_constant public static final com.revenuecat.purchases.Store AMAZON;
     enum_constant public static final com.revenuecat.purchases.Store APP_STORE;
@@ -921,6 +907,16 @@ package com.revenuecat.purchases.ads.rewardverification {
   }
 
   public static final class RewardVerificationResult.Companion {
+  }
+
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @dev.drewhamilton.poko.Poko public final class RewardVerificationToken {
+    ctor public RewardVerificationToken(String customData, String clientTransactionId, String appUserID);
+    method public String getAppUserID();
+    method public String getClientTransactionId();
+    method public String getCustomData();
+    property public final String appUserID;
+    property public final String clientTransactionId;
+    property public final String customData;
   }
 
   @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public interface VerifiedReward {

--- a/purchases/api-defaults-bc7.txt
+++ b/purchases/api-defaults-bc7.txt
@@ -36,6 +36,7 @@ package com.revenuecat.purchases {
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitGetVirtualCurrencies(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesTransactionException::class) public static suspend Object? awaitLogIn(com.revenuecat.purchases.Purchases, String appUserID, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.data.LogInResult>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesTransactionException::class) public static suspend Object? awaitLogOut(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.CustomerInfo>);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static suspend Object? awaitPollRewardVerification(com.revenuecat.purchases.Purchases, String clientTransactionId, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitSetAppstackAttributionParams(com.revenuecat.purchases.Purchases, java.util.Map<java.lang.String,java.lang.String> data, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.Offerings>);
     method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitStorefrontLocale(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.util.Locale>) throws com.revenuecat.purchases.PurchasesException;
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitSyncAttributesAndOfferingsIfNeeded(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.Offerings>);
@@ -427,7 +428,7 @@ package com.revenuecat.purchases {
     method public boolean overridePreferredUILocale(String? localeString);
     method public static com.revenuecat.purchases.WebPurchaseRedemption? parseAsWebPurchaseRedemption(android.content.Intent intent);
     method public static com.revenuecat.purchases.WebPurchaseRedemption? parseAsWebPurchaseRedemption(String string);
-    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public suspend Object? pollRewardVerification(String clientTransactionId, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult>);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public void pollRewardVerification(String clientTransactionId, com.revenuecat.purchases.interfaces.PollRewardVerificationCallback callback);
     method public void purchase(com.revenuecat.purchases.PurchaseParams purchaseParams, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
     method @Deprecated public void purchasePackage(android.app.Activity activity, com.revenuecat.purchases.Package packageToPurchase, com.revenuecat.purchases.interfaces.PurchaseCallback listener);
     method @Deprecated public void purchaseProduct(android.app.Activity activity, com.revenuecat.purchases.models.StoreProduct storeProduct, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
@@ -1145,6 +1146,10 @@ package com.revenuecat.purchases.interfaces {
   public interface LogInCallback {
     method public void onError(com.revenuecat.purchases.PurchasesError error);
     method public void onReceived(com.revenuecat.purchases.CustomerInfo customerInfo, boolean created);
+  }
+
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public fun interface PollRewardVerificationCallback {
+    method public void onCompleted(com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult result);
   }
 
   @Deprecated public interface ProductChangeCallback extends com.revenuecat.purchases.interfaces.PurchaseErrorCallback {

--- a/purchases/api-defaults-bc7.txt
+++ b/purchases/api-defaults-bc7.txt
@@ -381,6 +381,7 @@ package com.revenuecat.purchases {
     method public void close();
     method public void collectDeviceIdentifiers();
     method public static com.revenuecat.purchases.Purchases configure(com.revenuecat.purchases.PurchasesConfiguration configuration);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public com.revenuecat.purchases.RewardVerificationToken generateRewardVerificationToken(String impressionId);
     method @Deprecated @kotlin.jvm.Synchronized public boolean getAllowSharingPlayStoreAccount();
     method public void getAmazonLWAConsentStatus(com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback callback);
     method @kotlin.jvm.Synchronized public String getAppUserID();
@@ -426,6 +427,7 @@ package com.revenuecat.purchases {
     method public boolean overridePreferredUILocale(String? localeString);
     method public static com.revenuecat.purchases.WebPurchaseRedemption? parseAsWebPurchaseRedemption(android.content.Intent intent);
     method public static com.revenuecat.purchases.WebPurchaseRedemption? parseAsWebPurchaseRedemption(String string);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public suspend Object? pollRewardVerification(String clientTransactionId, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult>);
     method public void purchase(com.revenuecat.purchases.PurchaseParams purchaseParams, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
     method @Deprecated public void purchasePackage(android.app.Activity activity, com.revenuecat.purchases.Package packageToPurchase, com.revenuecat.purchases.interfaces.PurchaseCallback listener);
     method @Deprecated public void purchaseProduct(android.app.Activity activity, com.revenuecat.purchases.models.StoreProduct storeProduct, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
@@ -668,6 +670,20 @@ package com.revenuecat.purchases {
     property public abstract String name;
   }
 
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public final class RewardVerificationToken {
+    ctor public RewardVerificationToken(String customData, String clientTransactionId, String appUserID);
+    method public String component1();
+    method public String component2();
+    method public String component3();
+    method public com.revenuecat.purchases.RewardVerificationToken copy(String customData, String clientTransactionId, String appUserID);
+    method public String getAppUserID();
+    method public String getClientTransactionId();
+    method public String getCustomData();
+    property public final String appUserID;
+    property public final String clientTransactionId;
+    property public final String customData;
+  }
+
   @kotlinx.serialization.Serializable(with=StoreSerializer::class) public enum Store {
     enum_constant public static final com.revenuecat.purchases.Store AMAZON;
     enum_constant public static final com.revenuecat.purchases.Store APP_STORE;
@@ -889,6 +905,41 @@ package com.revenuecat.purchases.ads.events.types {
     property public final String EXACT;
     property public final String PUBLISHER_DEFINED;
     property public final String UNKNOWN;
+  }
+
+}
+
+package com.revenuecat.purchases.ads.rewardverification {
+
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public final class RewardVerificationResult {
+    method public boolean getFailed();
+    method public com.revenuecat.purchases.ads.rewardverification.VerifiedReward? getVerifiedReward();
+    property public final boolean failed;
+    property public final com.revenuecat.purchases.ads.rewardverification.VerifiedReward? verifiedReward;
+    field public static final com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult.Companion Companion;
+    field public static final com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult failed;
+  }
+
+  public static final class RewardVerificationResult.Companion {
+  }
+
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public interface VerifiedReward {
+  }
+
+  public static final class VerifiedReward.NoReward implements com.revenuecat.purchases.ads.rewardverification.VerifiedReward {
+    field public static final com.revenuecat.purchases.ads.rewardverification.VerifiedReward.NoReward INSTANCE;
+  }
+
+  public static final class VerifiedReward.UnsupportedReward implements com.revenuecat.purchases.ads.rewardverification.VerifiedReward {
+    field public static final com.revenuecat.purchases.ads.rewardverification.VerifiedReward.UnsupportedReward INSTANCE;
+  }
+
+  @dev.drewhamilton.poko.Poko public static final class VerifiedReward.VirtualCurrency implements com.revenuecat.purchases.ads.rewardverification.VerifiedReward {
+    ctor public VerifiedReward.VirtualCurrency(String code, int amount);
+    method public int getAmount();
+    method public String getCode();
+    property public final int amount;
+    property public final String code;
   }
 
 }

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -381,7 +381,7 @@ package com.revenuecat.purchases {
     method public void close();
     method public void collectDeviceIdentifiers();
     method public static com.revenuecat.purchases.Purchases configure(com.revenuecat.purchases.PurchasesConfiguration configuration);
-    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public com.revenuecat.purchases.RewardVerificationToken generateRewardVerificationToken(String impressionId);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken generateRewardVerificationToken(String impressionId);
     method @Deprecated @kotlin.jvm.Synchronized public boolean getAllowSharingPlayStoreAccount();
     method public void getAmazonLWAConsentStatus(com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback callback);
     method @kotlin.jvm.Synchronized public String getAppUserID();
@@ -670,20 +670,6 @@ package com.revenuecat.purchases {
     property public abstract String name;
   }
 
-  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public final class RewardVerificationToken {
-    ctor public RewardVerificationToken(String customData, String clientTransactionId, String appUserID);
-    method public String component1();
-    method public String component2();
-    method public String component3();
-    method public com.revenuecat.purchases.RewardVerificationToken copy(String customData, String clientTransactionId, String appUserID);
-    method public String getAppUserID();
-    method public String getClientTransactionId();
-    method public String getCustomData();
-    property public final String appUserID;
-    property public final String clientTransactionId;
-    property public final String customData;
-  }
-
   @kotlinx.serialization.Serializable(with=StoreSerializer::class) public enum Store {
     enum_constant public static final com.revenuecat.purchases.Store AMAZON;
     enum_constant public static final com.revenuecat.purchases.Store APP_STORE;
@@ -921,6 +907,16 @@ package com.revenuecat.purchases.ads.rewardverification {
   }
 
   public static final class RewardVerificationResult.Companion {
+  }
+
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @dev.drewhamilton.poko.Poko public final class RewardVerificationToken {
+    ctor public RewardVerificationToken(String customData, String clientTransactionId, String appUserID);
+    method public String getAppUserID();
+    method public String getClientTransactionId();
+    method public String getCustomData();
+    property public final String appUserID;
+    property public final String clientTransactionId;
+    property public final String customData;
   }
 
   @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public interface VerifiedReward {

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -36,6 +36,7 @@ package com.revenuecat.purchases {
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitGetVirtualCurrencies(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesTransactionException::class) public static suspend Object? awaitLogIn(com.revenuecat.purchases.Purchases, String appUserID, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.data.LogInResult>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesTransactionException::class) public static suspend Object? awaitLogOut(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.CustomerInfo>);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static suspend Object? awaitPollRewardVerification(com.revenuecat.purchases.Purchases, String clientTransactionId, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitSetAppstackAttributionParams(com.revenuecat.purchases.Purchases, java.util.Map<java.lang.String,java.lang.String> data, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.Offerings>);
     method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitStorefrontLocale(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.util.Locale>) throws com.revenuecat.purchases.PurchasesException;
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitSyncAttributesAndOfferingsIfNeeded(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.Offerings>);
@@ -427,7 +428,7 @@ package com.revenuecat.purchases {
     method public boolean overridePreferredUILocale(String? localeString);
     method public static com.revenuecat.purchases.WebPurchaseRedemption? parseAsWebPurchaseRedemption(android.content.Intent intent);
     method public static com.revenuecat.purchases.WebPurchaseRedemption? parseAsWebPurchaseRedemption(String string);
-    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public suspend Object? pollRewardVerification(String clientTransactionId, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult>);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public void pollRewardVerification(String clientTransactionId, com.revenuecat.purchases.interfaces.PollRewardVerificationCallback callback);
     method public void purchase(com.revenuecat.purchases.PurchaseParams purchaseParams, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
     method @Deprecated public void purchasePackage(android.app.Activity activity, com.revenuecat.purchases.Package packageToPurchase, com.revenuecat.purchases.interfaces.PurchaseCallback listener);
     method @Deprecated public void purchaseProduct(android.app.Activity activity, com.revenuecat.purchases.models.StoreProduct storeProduct, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
@@ -1145,6 +1146,10 @@ package com.revenuecat.purchases.interfaces {
   public interface LogInCallback {
     method public void onError(com.revenuecat.purchases.PurchasesError error);
     method public void onReceived(com.revenuecat.purchases.CustomerInfo customerInfo, boolean created);
+  }
+
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public fun interface PollRewardVerificationCallback {
+    method public void onCompleted(com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult result);
   }
 
   @Deprecated public interface ProductChangeCallback extends com.revenuecat.purchases.interfaces.PurchaseErrorCallback {

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -381,6 +381,7 @@ package com.revenuecat.purchases {
     method public void close();
     method public void collectDeviceIdentifiers();
     method public static com.revenuecat.purchases.Purchases configure(com.revenuecat.purchases.PurchasesConfiguration configuration);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public com.revenuecat.purchases.RewardVerificationToken generateRewardVerificationToken(String impressionId);
     method @Deprecated @kotlin.jvm.Synchronized public boolean getAllowSharingPlayStoreAccount();
     method public void getAmazonLWAConsentStatus(com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback callback);
     method @kotlin.jvm.Synchronized public String getAppUserID();
@@ -667,6 +668,20 @@ package com.revenuecat.purchases {
   public interface ReplacementMode extends android.os.Parcelable {
     method public String getName();
     property public abstract String name;
+  }
+
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public final class RewardVerificationToken {
+    ctor public RewardVerificationToken(String customData, String clientTransactionId, String appUserID);
+    method public String component1();
+    method public String component2();
+    method public String component3();
+    method public com.revenuecat.purchases.RewardVerificationToken copy(String customData, String clientTransactionId, String appUserID);
+    method public String getAppUserID();
+    method public String getClientTransactionId();
+    method public String getCustomData();
+    property public final String appUserID;
+    property public final String clientTransactionId;
+    property public final String customData;
   }
 
   @kotlinx.serialization.Serializable(with=StoreSerializer::class) public enum Store {

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -426,6 +426,7 @@ package com.revenuecat.purchases {
     method public boolean overridePreferredUILocale(String? localeString);
     method public static com.revenuecat.purchases.WebPurchaseRedemption? parseAsWebPurchaseRedemption(android.content.Intent intent);
     method public static com.revenuecat.purchases.WebPurchaseRedemption? parseAsWebPurchaseRedemption(String string);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public suspend Object? pollRewardVerification(String clientTransactionId, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult>);
     method public void purchase(com.revenuecat.purchases.PurchaseParams purchaseParams, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
     method @Deprecated public void purchasePackage(android.app.Activity activity, com.revenuecat.purchases.Package packageToPurchase, com.revenuecat.purchases.interfaces.PurchaseCallback listener);
     method @Deprecated public void purchaseProduct(android.app.Activity activity, com.revenuecat.purchases.models.StoreProduct storeProduct, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
@@ -889,6 +890,41 @@ package com.revenuecat.purchases.ads.events.types {
     property public final String EXACT;
     property public final String PUBLISHER_DEFINED;
     property public final String UNKNOWN;
+  }
+
+}
+
+package com.revenuecat.purchases.ads.rewardverification {
+
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public final class RewardVerificationResult {
+    method public boolean getFailed();
+    method public com.revenuecat.purchases.ads.rewardverification.VerifiedReward? getVerifiedReward();
+    property public final boolean failed;
+    property public final com.revenuecat.purchases.ads.rewardverification.VerifiedReward? verifiedReward;
+    field public static final com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult.Companion Companion;
+    field public static final com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult failed;
+  }
+
+  public static final class RewardVerificationResult.Companion {
+  }
+
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public interface VerifiedReward {
+  }
+
+  public static final class VerifiedReward.NoReward implements com.revenuecat.purchases.ads.rewardverification.VerifiedReward {
+    field public static final com.revenuecat.purchases.ads.rewardverification.VerifiedReward.NoReward INSTANCE;
+  }
+
+  public static final class VerifiedReward.UnsupportedReward implements com.revenuecat.purchases.ads.rewardverification.VerifiedReward {
+    field public static final com.revenuecat.purchases.ads.rewardverification.VerifiedReward.UnsupportedReward INSTANCE;
+  }
+
+  @dev.drewhamilton.poko.Poko public static final class VerifiedReward.VirtualCurrency implements com.revenuecat.purchases.ads.rewardverification.VerifiedReward {
+    ctor public VerifiedReward.VirtualCurrency(String code, int amount);
+    method public int getAmount();
+    method public String getCode();
+    property public final int amount;
+    property public final String code;
   }
 
 }

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -558,6 +558,20 @@ package com.revenuecat.purchases {
     property public abstract String name;
   }
 
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public final class RewardVerificationToken {
+    ctor public RewardVerificationToken(String customData, String clientTransactionId, String appUserID);
+    method public String component1();
+    method public String component2();
+    method public String component3();
+    method public com.revenuecat.purchases.RewardVerificationToken copy(String customData, String clientTransactionId, String appUserID);
+    method public String getAppUserID();
+    method public String getClientTransactionId();
+    method public String getCustomData();
+    property public final String appUserID;
+    property public final String clientTransactionId;
+    property public final String customData;
+  }
+
   @kotlinx.serialization.Serializable(with=StoreSerializer::class) public enum Store {
     enum_constant public static final com.revenuecat.purchases.Store AMAZON;
     enum_constant public static final com.revenuecat.purchases.Store APP_STORE;

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -558,20 +558,6 @@ package com.revenuecat.purchases {
     property public abstract String name;
   }
 
-  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public final class RewardVerificationToken {
-    ctor public RewardVerificationToken(String customData, String clientTransactionId, String appUserID);
-    method public String component1();
-    method public String component2();
-    method public String component3();
-    method public com.revenuecat.purchases.RewardVerificationToken copy(String customData, String clientTransactionId, String appUserID);
-    method public String getAppUserID();
-    method public String getClientTransactionId();
-    method public String getCustomData();
-    property public final String appUserID;
-    property public final String clientTransactionId;
-    property public final String customData;
-  }
-
   @kotlinx.serialization.Serializable(with=StoreSerializer::class) public enum Store {
     enum_constant public static final com.revenuecat.purchases.Store AMAZON;
     enum_constant public static final com.revenuecat.purchases.Store APP_STORE;

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -781,7 +781,7 @@ public class Purchases internal constructor(
         return pollRewardVerification(clientTransactionId) { Poller.poll(it) }
     }
 
-    @ExperimentalPreviewRevenueCatPurchasesAPI
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     internal suspend fun pollRewardVerification(
         clientTransactionId: String,
         poll: suspend (String) -> RewardVerificationResult,

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -9,6 +9,9 @@ import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.Purchases.Companion.configure
 import com.revenuecat.purchases.Purchases.Companion.debugLogsEnabled
 import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.rewardverification.Poller
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.errorLog
@@ -749,6 +752,45 @@ public class Purchases internal constructor(
         onError: (PurchasesError) -> Unit,
     ) {
         purchasesOrchestrator.createSupportTicket(email, description, onSuccess, onError)
+    }
+
+    /**
+     * Generates a reward verification token for a loaded rewarded ad.
+     *
+     * Call after the ad has loaded. Forward [RewardVerificationToken.customData] and
+     * [RewardVerificationToken.appUserID] to your ad network's server-side verification options, then keep
+     * [RewardVerificationToken.clientTransactionId] for use with [pollRewardVerification] when the reward
+     * callback fires.
+     *
+     * @param impressionId The ad network's impression identifier for the loaded ad.
+     */
+    @InternalRevenueCatAPI
+    public fun generateRewardVerificationToken(impressionId: String): RewardVerificationToken {
+        return purchasesOrchestrator.generateRewardVerificationToken(impressionId)
+    }
+
+    /**
+     * Polls the backend until reward verification completes or the attempt budget is exhausted.
+     *
+     * Call when your ad network's reward callback fires, passing the `clientTransactionId` returned by
+     * [generateRewardVerificationToken]. Invalidates the virtual currencies cache automatically on a
+     * verified virtual-currency reward.
+     */
+    @ExperimentalPreviewRevenueCatPurchasesAPI
+    public suspend fun pollRewardVerification(clientTransactionId: String): RewardVerificationResult {
+        return pollRewardVerification(clientTransactionId) { Poller.poll(it) }
+    }
+
+    @ExperimentalPreviewRevenueCatPurchasesAPI
+    internal suspend fun pollRewardVerification(
+        clientTransactionId: String,
+        poll: suspend (String) -> RewardVerificationResult,
+    ): RewardVerificationResult {
+        val result = poll(clientTransactionId)
+        if (result.verifiedReward is VerifiedReward.VirtualCurrency) {
+            purchasesOrchestrator.invalidateVirtualCurrenciesCache()
+        }
+        return result
     }
 
     @OptIn(InternalRevenueCatAPI::class)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -572,6 +572,7 @@ public class Purchases internal constructor(
     public fun close() {
         notifyLifecycleClosed()
         purchasesOrchestrator.close()
+        rewardVerificationPollLauncher.close()
         backingFieldSharedInstance = null
     }
 

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -9,7 +9,7 @@ import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.Purchases.Companion.configure
 import com.revenuecat.purchases.Purchases.Companion.debugLogsEnabled
 import com.revenuecat.purchases.ads.events.AdTracker
-import com.revenuecat.purchases.ads.rewardverification.Poller
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationPollLauncher
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
@@ -31,6 +31,7 @@ import com.revenuecat.purchases.interfaces.GetStorefrontCallback
 import com.revenuecat.purchases.interfaces.GetStorefrontLocaleCallback
 import com.revenuecat.purchases.interfaces.GetVirtualCurrenciesCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
+import com.revenuecat.purchases.interfaces.PollRewardVerificationCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
@@ -68,6 +69,9 @@ import kotlin.coroutines.suspendCoroutine
 public class Purchases internal constructor(
     @get:JvmSynthetic internal val purchasesOrchestrator: PurchasesOrchestrator,
 ) : LifecycleDelegate {
+
+    private val rewardVerificationPollLauncher = RewardVerificationPollLauncher()
+
     /**
      * The current configuration parameters of the Purchases SDK.
      */
@@ -789,11 +793,19 @@ public class Purchases internal constructor(
      *
      * Call when your ad network's reward callback fires, passing the `clientTransactionId` returned by
      * [generateRewardVerificationToken]. Invalidates the virtual currencies cache automatically on a
-     * verified virtual-currency reward.
+     * verified virtual-currency reward. The [callback] is invoked on the main thread.
+     *
+     * For coroutines, use the `awaitPollRewardVerification` suspend extension instead.
      */
     @ExperimentalPreviewRevenueCatPurchasesAPI
-    public suspend fun pollRewardVerification(clientTransactionId: String): RewardVerificationResult {
-        return pollRewardVerification(clientTransactionId) { Poller.poll(it) }
+    public fun pollRewardVerification(
+        clientTransactionId: String,
+        callback: PollRewardVerificationCallback,
+    ) {
+        rewardVerificationPollLauncher.launch(
+            poll = { awaitPollRewardVerification(clientTransactionId) },
+            onCompleted = { callback.onCompleted(it) },
+        )
     }
 
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.Purchases.Companion.debugLogsEnabled
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.rewardverification.Poller
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
@@ -48,8 +49,10 @@ import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.utils.DefaultIsDebugBuildProvider
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
+import org.json.JSONObject
 import java.net.URL
 import java.util.Locale
+import java.util.UUID
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -766,7 +769,19 @@ public class Purchases internal constructor(
      */
     @ExperimentalPreviewRevenueCatPurchasesAPI
     public fun generateRewardVerificationToken(impressionId: String): RewardVerificationToken {
-        return purchasesOrchestrator.generateRewardVerificationToken(impressionId)
+        val clientTransactionId = UUID.randomUUID().toString()
+        // Keys inserted in sorted order so the serialized customData is deterministic and matches the
+        // other SDKs byte-for-byte. The backend parses by key, so order is not semantically significant.
+        val customData = JSONObject()
+            .put("api_key", purchasesOrchestrator.currentConfiguration.apiKey)
+            .put("client_transaction_id", clientTransactionId)
+            .put("impression_id", impressionId)
+            .toString()
+        return RewardVerificationToken(
+            customData = customData,
+            clientTransactionId = clientTransactionId,
+            appUserID = purchasesOrchestrator.appUserID,
+        )
     }
 
     /**

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -764,7 +764,7 @@ public class Purchases internal constructor(
      *
      * @param impressionId The ad network's impression identifier for the loaded ad.
      */
-    @InternalRevenueCatAPI
+    @ExperimentalPreviewRevenueCatPurchasesAPI
     public fun generateRewardVerificationToken(impressionId: String): RewardVerificationToken {
         return purchasesOrchestrator.generateRewardVerificationToken(impressionId)
     }

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Outcome.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Outcome.kt
@@ -1,8 +1,7 @@
-package com.revenuecat.purchases.admob.rewardverification
+package com.revenuecat.purchases.ads.rewardverification
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import com.revenuecat.purchases.admob.RewardVerificationResult
-import com.revenuecat.purchases.admob.VerifiedReward
+import com.revenuecat.purchases.InternalRevenueCatAPI
 
 // Internal poll result. The public [RewardVerificationResult] stays binary (verified/failed); these subtypes
 // capture *why* polling ended so the poller can log an actionable reason without adding public cases.
@@ -51,7 +50,7 @@ internal sealed interface Outcome {
     }
 }
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 internal fun Outcome.toResult(): RewardVerificationResult {
     return when (this) {
         is Outcome.Verified -> RewardVerificationResult.verified(reward)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Poller.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Poller.kt
@@ -1,13 +1,14 @@
-package com.revenuecat.purchases.admob.rewardverification
+package com.revenuecat.purchases.ads.rewardverification
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.RewardVerificationException
-import com.revenuecat.purchases.admob.Logger
-import com.revenuecat.purchases.admob.RewardVerificationResult
-import com.revenuecat.purchases.admob.VerifiedReward
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.verboseLog
+import com.revenuecat.purchases.common.warnLog
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlin.random.Random
@@ -71,15 +72,15 @@ internal object Poller {
         jitterSeconds: () -> Double,
         maxAttempts: Int,
     ): Outcome {
-        Logger.d("Reward verification poll start transactionId=$clientTransactionId maxAttempts=$maxAttempts")
+        debugLog { "Reward verification poll start transactionId=$clientTransactionId maxAttempts=$maxAttempts" }
         var sawUnknownStatus = false
         var lastRetryWasTransientError = false
         var finalOutcome: Outcome? = null
         var attempt = 0
         while (finalOutcome == null && attempt < maxAttempts) {
-            Logger.v(
-                "Reward verification poll attempt ${attempt + 1}/$maxAttempts transactionId=$clientTransactionId",
-            )
+            verboseLog {
+                "Reward verification poll attempt ${attempt + 1}/$maxAttempts transactionId=$clientTransactionId"
+            }
             if (attempt > 0 && !awaitBackoff(sleepSeconds, jitterSeconds)) {
                 finalOutcome = Outcome.Failed.TerminalError(BACKOFF_SCHEDULING_FAILED_DESCRIPTION)
             } else {
@@ -130,7 +131,9 @@ internal object Poller {
     ): Step {
         return try {
             val result = fetcher.fetch(clientTransactionId)
-            Logger.v("Reward verification poll result=${result.logDescription()} transactionId=$clientTransactionId")
+            verboseLog {
+                "Reward verification poll result=${result.logDescription()} transactionId=$clientTransactionId"
+            }
             when (result) {
                 is CoreRewardVerificationResult.Verified ->
                     Step.Terminal(Outcome.Verified(result.reward.toAdMobReward()))
@@ -143,10 +146,10 @@ internal object Poller {
             throw e
         } catch (e: PurchasesException) {
             if (e.isTransientPollingError()) {
-                Logger.v(
+                verboseLog {
                     "Reward verification poll transient error, retrying: ${e.code} " +
-                        "transactionId=$clientTransactionId",
-                )
+                        "transactionId=$clientTransactionId"
+                }
                 Step.RetryTransientError
             } else {
                 Step.Terminal(Outcome.Failed.TerminalError(e.describeForLog()))
@@ -176,7 +179,7 @@ internal object Poller {
     }
 
     private fun logFailureToLogcat(message: String, isError: Boolean) {
-        if (isError) Logger.e(message) else Logger.w(message)
+        if (isError) errorLog { message } else warnLog { message }
     }
 
     // Readable log form: object statuses log their name; Verified inlines the reward payload.

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Poller.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Poller.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.RewardVerificationException
+import com.revenuecat.purchases.RewardVerificationPollStatus
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.verboseLog
@@ -12,7 +13,6 @@ import com.revenuecat.purchases.common.warnLog
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlin.random.Random
-import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
 import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
@@ -135,12 +135,12 @@ internal object Poller {
                 "Reward verification poll result=${result.logDescription()} transactionId=$clientTransactionId"
             }
             when (result) {
-                is CoreRewardVerificationResult.Verified ->
+                is RewardVerificationPollStatus.Verified ->
                     Step.Terminal(Outcome.Verified(result.reward.toAdMobReward()))
-                is CoreRewardVerificationResult.Failed ->
+                is RewardVerificationPollStatus.Failed ->
                     Step.Terminal(Outcome.Failed.BackendRejected(result.message, result.failureReason))
-                CoreRewardVerificationResult.PENDING -> Step.RetryPending
-                CoreRewardVerificationResult.UNKNOWN -> Step.RetryUnknown
+                RewardVerificationPollStatus.PENDING -> Step.RetryPending
+                RewardVerificationPollStatus.UNKNOWN -> Step.RetryUnknown
             }
         } catch (e: CancellationException) {
             throw e
@@ -183,12 +183,12 @@ internal object Poller {
     }
 
     // Readable log form: object statuses log their name; Verified inlines the reward payload.
-    private fun CoreRewardVerificationResult.logDescription(): String {
+    private fun RewardVerificationPollStatus.logDescription(): String {
         return when (this) {
-            is CoreRewardVerificationResult.Verified -> "verified(reward=$reward)"
-            CoreRewardVerificationResult.PENDING -> "pending"
-            is CoreRewardVerificationResult.Failed -> "failed"
-            CoreRewardVerificationResult.UNKNOWN -> "unknown"
+            is RewardVerificationPollStatus.Verified -> "verified(reward=$reward)"
+            RewardVerificationPollStatus.PENDING -> "pending"
+            is RewardVerificationPollStatus.Failed -> "failed"
+            RewardVerificationPollStatus.UNKNOWN -> "unknown"
         }
     }
 

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationFetcher.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationFetcher.kt
@@ -3,12 +3,12 @@ package com.revenuecat.purchases.ads.rewardverification
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.RewardVerificationPollStatus
 import com.revenuecat.purchases.awaitGetRewardVerificationResult
-import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
 
 @OptIn(InternalRevenueCatAPI::class)
 internal fun interface RewardVerificationFetcher {
-    suspend fun fetch(clientTransactionId: String): CoreRewardVerificationResult
+    suspend fun fetch(clientTransactionId: String): RewardVerificationPollStatus
 
     companion object {
         @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationFetcher.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationFetcher.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.admob.rewardverification
+package com.revenuecat.purchases.ads.rewardverification
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationPollLauncher.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationPollLauncher.kt
@@ -5,20 +5,24 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Bridges the suspend reward-verification poll to the callback-based public API, so coroutine usage stays
- * out of [com.revenuecat.purchases.Purchases]. The poll loop only suspends (never blocks), so running it on
- * [Dispatchers.Main] keeps the callback on the main thread like the SDK's other callback APIs.
+ * out of [com.revenuecat.purchases.Purchases]. Polling runs off the main thread and the result is delivered
+ * back on the main thread, like the SDK's other callback APIs.
  */
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal class RewardVerificationPollLauncher(
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main),
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
     fun launch(
         poll: suspend () -> RewardVerificationResult,
         onCompleted: (RewardVerificationResult) -> Unit,
     ) {
-        scope.launch { onCompleted(poll()) }
+        scope.launch {
+            val result = poll()
+            withContext(Dispatchers.Main) { onCompleted(result) }
+        }
     }
 }

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationPollLauncher.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationPollLauncher.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -24,5 +25,13 @@ internal class RewardVerificationPollLauncher(
             val result = poll()
             withContext(Dispatchers.Main) { onCompleted(result) }
         }
+    }
+
+    /**
+     * Cancels any in-flight poll. Called when the owning [com.revenuecat.purchases.Purchases] instance is
+     * closed so a poll started on it cannot survive close/reconfigure and run against a different SDK.
+     */
+    fun close() {
+        scope.cancel()
     }
 }

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationPollLauncher.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationPollLauncher.kt
@@ -1,0 +1,24 @@
+package com.revenuecat.purchases.ads.rewardverification
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Bridges the suspend reward-verification poll to the callback-based public API, so coroutine usage stays
+ * out of [com.revenuecat.purchases.Purchases]. The poll loop only suspends (never blocks), so running it on
+ * [Dispatchers.Main] keeps the callback on the main thread like the SDK's other callback APIs.
+ */
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+internal class RewardVerificationPollLauncher(
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main),
+) {
+    fun launch(
+        poll: suspend () -> RewardVerificationResult,
+        onCompleted: (RewardVerificationResult) -> Unit,
+    ) {
+        scope.launch { onCompleted(poll()) }
+    }
+}

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationResult.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationResult.kt
@@ -1,6 +1,7 @@
-package com.revenuecat.purchases.admob
+package com.revenuecat.purchases.ads.rewardverification
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
 
 /**
  * Result delivered to the app after reward verification polling for a rewarded or rewarded interstitial ad.
@@ -27,13 +28,14 @@ public class RewardVerificationResult private constructor(
     public val failed: Boolean
         get() = this.storage is Storage.Failed
 
-    internal companion object {
+    public companion object {
 
         /**
          * Server verification succeeded for this ad transaction.
          */
         @JvmStatic
-        internal fun verified(reward: VerifiedReward): RewardVerificationResult {
+        @InternalRevenueCatAPI
+        public fun verified(reward: VerifiedReward): RewardVerificationResult {
             return RewardVerificationResult(Storage.Verified(reward))
         }
 
@@ -41,6 +43,6 @@ public class RewardVerificationResult private constructor(
          * Verification did not complete successfully (rejected, timeout, network, etc.).
          */
         @JvmField
-        internal val failed: RewardVerificationResult = RewardVerificationResult(Storage.Failed)
+        public val failed: RewardVerificationResult = RewardVerificationResult(Storage.Failed)
     }
 }

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationStrings.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationStrings.kt
@@ -1,0 +1,29 @@
+package com.revenuecat.purchases.ads.rewardverification
+
+internal object RewardVerificationStrings {
+
+    const val BACKEND_REJECTED_WITHOUT_MESSAGE: String =
+        "Reward verification was rejected by AdMob server-side verification."
+
+    fun backendRejectedWithReason(reason: String): String =
+        "Reward verification was rejected by AdMob server-side verification (reason: $reason)."
+
+    const val EXHAUSTED_WHILE_PENDING: String =
+        "Reward verification timed out: the AdMob server-side verification (SSV) callback was not " +
+            "received in time. Possible causes: SSV is not enabled/configured for this ad unit in the " +
+            "AdMob Dashboard, the SSV callback URL is misconfigured in the AdMob Dashboard, AdMob delayed " +
+            "delivering the callback, or RevenueCat failed to process the SSV webhook."
+
+    const val EXHAUSTED_WHILE_TRANSIENT_ERRORING: String =
+        "Reward verification timed out after repeated transient errors while polling — typically " +
+            "unstable device network connectivity. The reward couldn't be verified."
+
+    const val UNEXPECTED_RESPONSE: String =
+        "Reward verification stopped after the server returned a status this SDK version doesn't " +
+            "recognize. Update to the latest SDK version; if you're already on the latest, contact " +
+            "RevenueCat support."
+
+    fun terminalError(error: String): String =
+        "Reward verification stopped after an unrecoverable error: $error. This is unexpected; if it " +
+            "persists, contact RevenueCat support with the error above."
+}

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationToken.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardVerificationToken.kt
@@ -1,4 +1,8 @@
-package com.revenuecat.purchases
+package com.revenuecat.purchases.ads.rewardverification
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.Purchases
+import dev.drewhamilton.poko.Poko
 
 /**
  * Ties a loaded rewarded ad to its server-side reward verification.
@@ -8,11 +12,12 @@ package com.revenuecat.purchases
  * callback with [Purchases.pollRewardVerification].
  */
 @ExperimentalPreviewRevenueCatPurchasesAPI
-public data class RewardVerificationToken(
+@Poko
+public class RewardVerificationToken(
     /** Set as the ad network's server-side verification custom data. */
-    val customData: String,
+    public val customData: String,
     /** Correlates the ad with its verification. */
-    val clientTransactionId: String,
+    public val clientTransactionId: String,
     /** The app user the reward is attributed to; set as the ad network's SSV user identifier. */
-    val appUserID: String,
+    public val appUserID: String,
 )

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/VerifiedReward.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/VerifiedReward.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.admob
+package com.revenuecat.purchases.ads.rewardverification
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import dev.drewhamilton.poko.Poko

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -12,7 +12,6 @@ import com.revenuecat.purchases.interfaces.GetRewardVerificationResultCallback
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.Locale
-import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
 
 /**
  * Get latest available customer info.
@@ -239,12 +238,12 @@ public suspend fun Purchases.awaitCustomerCenterConfigData(): CustomerCenterConf
 @InternalRevenueCatAPI
 public suspend fun Purchases.awaitGetRewardVerificationResult(
     clientTransactionId: String,
-): CoreRewardVerificationResult {
+): RewardVerificationPollStatus {
     return suspendCancellableCoroutine { continuation ->
         getRewardVerificationResult(
             clientTransactionId = clientTransactionId,
             callback = object : GetRewardVerificationResultCallback {
-                override fun onReceived(result: CoreRewardVerificationResult) {
+                override fun onReceived(result: RewardVerificationPollStatus) {
                     continuation.safeResume(result)
                 }
 

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -1,6 +1,8 @@
 package com.revenuecat.purchases
 
 import com.revenuecat.purchases.CacheFetchPolicy.CACHED_OR_FETCHED
+import com.revenuecat.purchases.ads.rewardverification.Poller
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.safeResumeWithException
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
@@ -10,6 +12,7 @@ import com.revenuecat.purchases.interfaces.GetRewardVerificationResultCallback
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.Locale
+import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
 
 /**
  * Get latest available customer info.
@@ -33,6 +36,21 @@ public suspend fun Purchases.awaitCustomerInfo(
             onError = { continuation.safeResumeWithException(PurchasesException(it)) },
         )
     }
+}
+
+/**
+ * Polls the backend until reward verification completes or the attempt budget is exhausted.
+ *
+ * Coroutine friendly version of [Purchases.pollRewardVerification].
+ *
+ * @return The [RewardVerificationResult] (verified reward or a failed result).
+ */
+@JvmSynthetic
+@ExperimentalPreviewRevenueCatPurchasesAPI
+public suspend fun Purchases.awaitPollRewardVerification(
+    clientTransactionId: String,
+): RewardVerificationResult {
+    return pollRewardVerification(clientTransactionId) { Poller.poll(it) }
 }
 
 /**
@@ -221,12 +239,12 @@ public suspend fun Purchases.awaitCustomerCenterConfigData(): CustomerCenterConf
 @InternalRevenueCatAPI
 public suspend fun Purchases.awaitGetRewardVerificationResult(
     clientTransactionId: String,
-): RewardVerificationResult {
+): CoreRewardVerificationResult {
     return suspendCancellableCoroutine { continuation ->
         getRewardVerificationResult(
             clientTransactionId = clientTransactionId,
             callback = object : GetRewardVerificationResultCallback {
-                override fun onReceived(result: RewardVerificationResult) {
+                override fun onReceived(result: CoreRewardVerificationResult) {
                     continuation.safeResume(result)
                 }
 

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/interfaces/PollRewardVerificationCallback.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/interfaces/PollRewardVerificationCallback.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.interfaces
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+
+/**
+ * Callback for [com.revenuecat.purchases.Purchases.pollRewardVerification].
+ */
+@ExperimentalPreviewRevenueCatPurchasesAPI
+public fun interface PollRewardVerificationCallback {
+    /**
+     * Called when polling completes, with the verified reward or a failed result.
+     */
+    public fun onCompleted(result: RewardVerificationResult)
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -945,7 +945,7 @@ internal class PurchasesOrchestrator(
         )
     }
 
-    @OptIn(InternalRevenueCatAPI::class)
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun generateRewardVerificationToken(impressionId: String): RewardVerificationToken {
         val clientTransactionId = UUID.randomUUID().toString()
         // Keys inserted in sorted order so the serialized customData is deterministic and matches the

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -105,12 +105,10 @@ import com.revenuecat.purchases.utils.Result
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencyManager
-import org.json.JSONObject
 import java.net.URL
 import java.util.Collections
 import java.util.Date
 import java.util.Locale
-import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -942,23 +940,6 @@ internal class PurchasesOrchestrator(
             description,
             onSuccessHandler = onSuccess,
             onErrorHandler = onError,
-        )
-    }
-
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-    fun generateRewardVerificationToken(impressionId: String): RewardVerificationToken {
-        val clientTransactionId = UUID.randomUUID().toString()
-        // Keys inserted in sorted order so the serialized customData is deterministic and matches the
-        // other SDKs byte-for-byte. The backend parses by key, so order is not semantically significant.
-        val customData = JSONObject()
-            .put("api_key", currentConfiguration.apiKey)
-            .put("client_transaction_id", clientTransactionId)
-            .put("impression_id", impressionId)
-            .toString()
-        return RewardVerificationToken(
-            customData = customData,
-            clientTransactionId = clientTransactionId,
-            appUserID = appUserID,
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -105,10 +105,12 @@ import com.revenuecat.purchases.utils.Result
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencyManager
+import org.json.JSONObject
 import java.net.URL
 import java.util.Collections
 import java.util.Date
 import java.util.Locale
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -940,6 +942,23 @@ internal class PurchasesOrchestrator(
             description,
             onSuccessHandler = onSuccess,
             onErrorHandler = onError,
+        )
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    fun generateRewardVerificationToken(impressionId: String): RewardVerificationToken {
+        val clientTransactionId = UUID.randomUUID().toString()
+        // Keys inserted in sorted order so the serialized customData is deterministic and matches the
+        // other SDKs byte-for-byte. The backend parses by key, so order is not semantically significant.
+        val customData = JSONObject()
+            .put("api_key", currentConfiguration.apiKey)
+            .put("client_transaction_id", clientTransactionId)
+            .put("impression_id", impressionId)
+            .toString()
+        return RewardVerificationToken(
+            customData = customData,
+            clientTransactionId = clientTransactionId,
+            appUserID = appUserID,
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationPollStatus.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationPollStatus.kt
@@ -4,16 +4,16 @@ package com.revenuecat.purchases
  * Result of a single reward verification status request.
  */
 @InternalRevenueCatAPI
-public sealed interface RewardVerificationResult {
+public sealed interface RewardVerificationPollStatus {
     /**
      * Verified by the backend with the associated reward payload.
      */
-    public data class Verified(val reward: VerifiedReward) : RewardVerificationResult
+    public data class Verified(val reward: VerifiedReward) : RewardVerificationPollStatus
 
     /**
      * Verification has started but has not yet reached a terminal state.
      */
-    public object PENDING : RewardVerificationResult
+    public object PENDING : RewardVerificationPollStatus
 
     /**
      * Verification reached a terminal failure state.
@@ -24,10 +24,10 @@ public sealed interface RewardVerificationResult {
     public data class Failed(
         val failureReason: String? = null,
         val message: String? = null,
-    ) : RewardVerificationResult
+    ) : RewardVerificationPollStatus
 
     /**
      * The backend returned a status value that is not recognized by this SDK version.
      */
-    public object UNKNOWN : RewardVerificationResult
+    public object UNKNOWN : RewardVerificationPollStatus
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationToken.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationToken.kt
@@ -1,0 +1,18 @@
+package com.revenuecat.purchases
+
+/**
+ * Ties a loaded rewarded ad to its server-side reward verification.
+ *
+ * Produced by [Purchases.generateRewardVerificationToken]. Forward [customData] and [appUserID] to your
+ * ad network's server-side verification options, and keep [clientTransactionId] to correlate the reward
+ * callback with [Purchases.pollRewardVerification].
+ */
+@InternalRevenueCatAPI
+public data class RewardVerificationToken(
+    /** Set as the ad network's server-side verification custom data. */
+    val customData: String,
+    /** Correlates the ad with its verification. */
+    val clientTransactionId: String,
+    /** The app user the reward is attributed to; set as the ad network's SSV user identifier. */
+    val appUserID: String,
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationToken.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationToken.kt
@@ -7,7 +7,7 @@ package com.revenuecat.purchases
  * ad network's server-side verification options, and keep [clientTransactionId] to correlate the reward
  * callback with [Purchases.pollRewardVerification].
  */
-@InternalRevenueCatAPI
+@ExperimentalPreviewRevenueCatPurchasesAPI
 public data class RewardVerificationToken(
     /** Set as the ad network's server-side verification custom data. */
     val customData: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -13,7 +13,7 @@ import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.RewardVerificationError
-import com.revenuecat.purchases.RewardVerificationResult
+import com.revenuecat.purchases.RewardVerificationPollStatus
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.backendName
@@ -109,7 +109,7 @@ internal typealias WebBillingProductsCallback = Pair<(WebBillingProductsResponse
 
 @OptIn(InternalRevenueCatAPI::class)
 internal typealias RewardVerificationResultCallback =
-    Pair<(RewardVerificationResult) -> Unit, (RewardVerificationError) -> Unit>
+    Pair<(RewardVerificationPollStatus) -> Unit, (RewardVerificationError) -> Unit>
 
 internal typealias RemoteConfigCallback =
     Pair<(RCContainer?, VerificationResult) -> Unit, (PurchasesError) -> Unit>
@@ -1239,7 +1239,7 @@ internal class Backend(
     fun getRewardVerificationResult(
         appUserID: String,
         clientTransactionId: String,
-        onSuccess: (RewardVerificationResult) -> Unit,
+        onSuccess: (RewardVerificationPollStatus) -> Unit,
         onError: (RewardVerificationError) -> Unit,
     ) {
         val endpoint = Endpoint.GetRewardVerification(
@@ -1277,7 +1277,7 @@ internal class Backend(
                             val response = json.decodeFromString<RewardVerificationResponse>(
                                 result.payloadText,
                             )
-                            onSuccessHandler(response.toRewardVerificationResult())
+                            onSuccessHandler(response.toRewardVerificationPollStatus())
                         } catch (e: SerializationException) {
                             onErrorHandler(
                                 RewardVerificationError(e.toPurchasesError().also { errorLog(it) }, false),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RewardVerificationResponse.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RewardVerificationResponse.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.common.networking
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.RewardVerificationResult
+import com.revenuecat.purchases.RewardVerificationPollStatus
 import com.revenuecat.purchases.VerifiedReward
 import com.revenuecat.purchases.common.warnLog
 import kotlinx.serialization.SerialName
@@ -21,14 +21,14 @@ internal data class RewardVerificationResponse(
     val message: String? = null,
 ) {
     @OptIn(InternalRevenueCatAPI::class)
-    fun toRewardVerificationResult(): RewardVerificationResult {
+    fun toRewardVerificationPollStatus(): RewardVerificationPollStatus {
         return when (status.lowercase()) {
-            "pending" -> RewardVerificationResult.PENDING
-            "verified" -> RewardVerificationResult.Verified(reward = reward.toVerifiedReward())
-            "failed" -> RewardVerificationResult.Failed(failureReason = failureReason, message = message)
+            "pending" -> RewardVerificationPollStatus.PENDING
+            "verified" -> RewardVerificationPollStatus.Verified(reward = reward.toVerifiedReward())
+            "failed" -> RewardVerificationPollStatus.Failed(failureReason = failureReason, message = message)
             else -> {
                 warnLog { "Unknown reward verification status: $status" }
-                RewardVerificationResult.UNKNOWN
+                RewardVerificationPollStatus.UNKNOWN
             }
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetRewardVerificationResultCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetRewardVerificationResultCallback.kt
@@ -2,17 +2,17 @@ package com.revenuecat.purchases.interfaces
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.RewardVerificationError
-import com.revenuecat.purchases.RewardVerificationResult
+import com.revenuecat.purchases.RewardVerificationPollStatus
 
 /**
- * Interface to be implemented when making calls that return a [RewardVerificationResult].
+ * Interface to be implemented when making calls that return a [RewardVerificationPollStatus].
  */
 @OptIn(InternalRevenueCatAPI::class)
 internal interface GetRewardVerificationResultCallback {
     /**
      * Called when the reward verification result has been fetched successfully.
      */
-    fun onReceived(result: RewardVerificationResult)
+    fun onReceived(result: RewardVerificationPollStatus)
 
     /**
      * Called after the request fails. The error carries whether the failure was a transient

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRewardVerificationResultTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRewardVerificationResultTest.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.common.backend
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
-import com.revenuecat.purchases.RewardVerificationResult
+import com.revenuecat.purchases.RewardVerificationPollStatus
 import com.revenuecat.purchases.VerifiedReward
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.AppConfig
@@ -84,7 +84,7 @@ class BackendGetRewardVerificationResultTest {
             payload = """{"status":"verified","reward":{"type":"virtual_currency","code":"coins","amount":10}}""",
         )
 
-        var receivedResult: RewardVerificationResult? = null
+        var receivedResult: RewardVerificationPollStatus? = null
         backend.getRewardVerificationResult(
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
@@ -93,7 +93,7 @@ class BackendGetRewardVerificationResultTest {
         )
 
         assertThat(receivedResult).isEqualTo(
-            RewardVerificationResult.Verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 10)),
+            RewardVerificationPollStatus.Verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 10)),
         )
         verify(exactly = 1) {
             httpClient.performRequest(
@@ -110,7 +110,7 @@ class BackendGetRewardVerificationResultTest {
     fun `getRewardVerificationResult maps unknown statuses`() {
         mockHttpResult(payload = """{"status":"new_status"}""")
 
-        var receivedResult: RewardVerificationResult? = null
+        var receivedResult: RewardVerificationPollStatus? = null
         backend.getRewardVerificationResult(
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
@@ -118,14 +118,14 @@ class BackendGetRewardVerificationResultTest {
             onError = { error -> fail("Expected success. Got error: $error") },
         )
 
-        assertThat(receivedResult).isEqualTo(RewardVerificationResult.UNKNOWN)
+        assertThat(receivedResult).isEqualTo(RewardVerificationPollStatus.UNKNOWN)
     }
 
     @Test
     fun `getRewardVerificationResult maps unsupported reward payload`() {
         mockHttpResult(payload = """{"status":"verified","reward":{"type":"new_type"}}""")
 
-        var receivedResult: RewardVerificationResult? = null
+        var receivedResult: RewardVerificationPollStatus? = null
         backend.getRewardVerificationResult(
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
@@ -134,7 +134,7 @@ class BackendGetRewardVerificationResultTest {
         )
 
         assertThat(receivedResult).isEqualTo(
-            RewardVerificationResult.Verified(VerifiedReward.UnsupportedReward),
+            RewardVerificationPollStatus.Verified(VerifiedReward.UnsupportedReward),
         )
     }
 
@@ -142,7 +142,7 @@ class BackendGetRewardVerificationResultTest {
     fun `getRewardVerificationResult maps malformed virtual currency reward payload`() {
         mockHttpResult(payload = """{"status":"verified","reward":{"type":"virtual_currency","code":"","amount":0}}""")
 
-        var receivedResult: RewardVerificationResult? = null
+        var receivedResult: RewardVerificationPollStatus? = null
         backend.getRewardVerificationResult(
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
@@ -151,7 +151,7 @@ class BackendGetRewardVerificationResultTest {
         )
 
         assertThat(receivedResult).isEqualTo(
-            RewardVerificationResult.Verified(VerifiedReward.UnsupportedReward),
+            RewardVerificationPollStatus.Verified(VerifiedReward.UnsupportedReward),
         )
     }
 
@@ -161,7 +161,7 @@ class BackendGetRewardVerificationResultTest {
             payload = """{"status":"verified","reward":null}""",
         )
 
-        var receivedResult: RewardVerificationResult? = null
+        var receivedResult: RewardVerificationPollStatus? = null
         backend.getRewardVerificationResult(
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
@@ -170,7 +170,7 @@ class BackendGetRewardVerificationResultTest {
         )
 
         assertThat(receivedResult).isEqualTo(
-            RewardVerificationResult.Verified(VerifiedReward.NoReward),
+            RewardVerificationPollStatus.Verified(VerifiedReward.NoReward),
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/RewardVerificationResponseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/RewardVerificationResponseTest.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.common.networking
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.RewardVerificationResult
+import com.revenuecat.purchases.RewardVerificationPollStatus
 import com.revenuecat.purchases.VerifiedReward
 import com.revenuecat.purchases.common.JsonProvider
 import org.assertj.core.api.Assertions.assertThat
@@ -21,7 +21,7 @@ class RewardVerificationResponseTest {
             """{"status":"pending"}""",
         )
 
-        assertThat(response.toRewardVerificationResult()).isEqualTo(RewardVerificationResult.PENDING)
+        assertThat(response.toRewardVerificationPollStatus()).isEqualTo(RewardVerificationPollStatus.PENDING)
     }
 
     @Test
@@ -30,8 +30,8 @@ class RewardVerificationResponseTest {
             """{"status":"verified"}""",
         )
 
-        assertThat(response.toRewardVerificationResult())
-            .isEqualTo(RewardVerificationResult.Verified(VerifiedReward.NoReward))
+        assertThat(response.toRewardVerificationPollStatus())
+            .isEqualTo(RewardVerificationPollStatus.Verified(VerifiedReward.NoReward))
     }
 
     @Test
@@ -40,7 +40,7 @@ class RewardVerificationResponseTest {
             """{"status":"failed"}""",
         )
 
-        assertThat(response.toRewardVerificationResult()).isEqualTo(RewardVerificationResult.Failed())
+        assertThat(response.toRewardVerificationPollStatus()).isEqualTo(RewardVerificationPollStatus.Failed())
     }
 
     @Test
@@ -55,8 +55,8 @@ class RewardVerificationResponseTest {
             """.trimIndent(),
         )
 
-        assertThat(response.toRewardVerificationResult()).isEqualTo(
-            RewardVerificationResult.Failed(
+        assertThat(response.toRewardVerificationPollStatus()).isEqualTo(
+            RewardVerificationPollStatus.Failed(
                 failureReason = "ssv_not_enabled",
                 message = "AdMob server-side reward verification is not enabled for this app.",
             ),
@@ -69,7 +69,7 @@ class RewardVerificationResponseTest {
             """{"status":"something_new"}""",
         )
 
-        assertThat(response.toRewardVerificationResult()).isEqualTo(RewardVerificationResult.UNKNOWN)
+        assertThat(response.toRewardVerificationPollStatus()).isEqualTo(RewardVerificationPollStatus.UNKNOWN)
     }
 
     @Test
@@ -87,8 +87,8 @@ class RewardVerificationResponseTest {
             """.trimIndent(),
         )
 
-        assertThat(response.toRewardVerificationResult()).isEqualTo(
-            RewardVerificationResult.Verified(
+        assertThat(response.toRewardVerificationPollStatus()).isEqualTo(
+            RewardVerificationPollStatus.Verified(
                 VerifiedReward.VirtualCurrency(code = "coins", amount = 10),
             ),
         )
@@ -109,8 +109,8 @@ class RewardVerificationResponseTest {
             """.trimIndent(),
         )
 
-        assertThat(response.toRewardVerificationResult()).isEqualTo(
-            RewardVerificationResult.Verified(VerifiedReward.UnsupportedReward),
+        assertThat(response.toRewardVerificationPollStatus()).isEqualTo(
+            RewardVerificationPollStatus.Verified(VerifiedReward.UnsupportedReward),
         )
     }
 
@@ -129,8 +129,8 @@ class RewardVerificationResponseTest {
             """.trimIndent(),
         )
 
-        assertThat(response.toRewardVerificationResult()).isEqualTo(
-            RewardVerificationResult.Verified(VerifiedReward.UnsupportedReward),
+        assertThat(response.toRewardVerificationPollStatus()).isEqualTo(
+            RewardVerificationPollStatus.Verified(VerifiedReward.UnsupportedReward),
         )
     }
 
@@ -140,8 +140,8 @@ class RewardVerificationResponseTest {
             """{"status":"verified","reward":null}""",
         )
 
-        assertThat(response.toRewardVerificationResult()).isEqualTo(
-            RewardVerificationResult.Verified(VerifiedReward.NoReward),
+        assertThat(response.toRewardVerificationPollStatus()).isEqualTo(
+            RewardVerificationPollStatus.Verified(VerifiedReward.NoReward),
         )
     }
 
@@ -151,8 +151,8 @@ class RewardVerificationResponseTest {
             """{"status":"verified","reward":"bad"}""",
         )
 
-        assertThat(response.toRewardVerificationResult()).isEqualTo(
-            RewardVerificationResult.Verified(VerifiedReward.UnsupportedReward),
+        assertThat(response.toRewardVerificationPollStatus()).isEqualTo(
+            RewardVerificationPollStatus.Verified(VerifiedReward.UnsupportedReward),
         )
     }
 }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -22,7 +22,6 @@ import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import com.revenuecat.purchases.interfaces.GetRewardVerificationResultCallback
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
-import com.revenuecat.purchases.interfaces.PollRewardVerificationCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.RedeemWebPurchaseListener
@@ -59,6 +58,11 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult as PollResult
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward as PollReward
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationPollLauncher
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.junit.Assert.fail
@@ -1984,15 +1988,35 @@ internal class PurchasesTest : BasePurchasesTest() {
 
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
     @Test
-    fun `pollRewardVerification callback delivers the verified reward`() {
-        mockVerifiedVirtualCurrencyRewardBackend()
-        every { mockVirtualCurrencyManager.invalidateVirtualCurrenciesCache() } returns Unit
+    fun `reward verification poll launcher delivers the result to the callback`() {
+        val launcher = RewardVerificationPollLauncher(
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+        )
+        val expected = PollResult.verified(PollReward.VirtualCurrency(code = "coins", amount = 10))
 
         var delivered: PollResult? = null
-        purchases.pollRewardVerification("ct_1", PollRewardVerificationCallback { delivered = it })
+        launcher.launch(poll = { expected }, onCompleted = { delivered = it })
         shadowOf(Looper.getMainLooper()).idle()
 
         assertThat(delivered?.verifiedReward).isEqualTo(PollReward.VirtualCurrency(code = "coins", amount = 10))
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+    @Test
+    fun `closing the reward verification poll launcher cancels an in-flight poll`() {
+        val launcher = RewardVerificationPollLauncher(
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+        )
+        val gate = CompletableDeferred<PollResult>()
+
+        var delivered: PollResult? = null
+        launcher.launch(poll = { gate.await() }, onCompleted = { delivered = it })
+
+        launcher.close()
+        gate.complete(PollResult.verified(PollReward.VirtualCurrency(code = "coins", amount = 10)))
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertThat(delivered).isNull()
     }
 
     @OptIn(InternalRevenueCatAPI::class)

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -5,6 +5,7 @@
 
 package com.revenuecat.purchases
 
+import android.os.Looper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.Purchase
 import com.revenuecat.purchases.common.CustomerInfoFactory
@@ -21,6 +22,7 @@ import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import com.revenuecat.purchases.interfaces.GetRewardVerificationResultCallback
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
+import com.revenuecat.purchases.interfaces.PollRewardVerificationCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.RedeemWebPurchaseListener
@@ -62,6 +64,7 @@ import org.json.JSONObject
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import java.net.URL
 import java.util.Locale
@@ -1965,6 +1968,47 @@ internal class PurchasesTest : BasePurchasesTest() {
         }
 
         verify(exactly = 0) { mockVirtualCurrencyManager.invalidateVirtualCurrenciesCache() }
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+    @Test
+    fun `awaitPollRewardVerification polls the backend and returns the verified reward`() = runTest {
+        mockVerifiedVirtualCurrencyRewardBackend()
+        every { mockVirtualCurrencyManager.invalidateVirtualCurrenciesCache() } returns Unit
+
+        val result = purchases.awaitPollRewardVerification("ct_1")
+
+        assertThat(result.verifiedReward).isEqualTo(PollReward.VirtualCurrency(code = "coins", amount = 10))
+        verify(exactly = 1) { mockVirtualCurrencyManager.invalidateVirtualCurrenciesCache() }
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+    @Test
+    fun `pollRewardVerification callback delivers the verified reward`() {
+        mockVerifiedVirtualCurrencyRewardBackend()
+        every { mockVirtualCurrencyManager.invalidateVirtualCurrenciesCache() } returns Unit
+
+        var delivered: PollResult? = null
+        purchases.pollRewardVerification("ct_1", PollRewardVerificationCallback { delivered = it })
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertThat(delivered?.verifiedReward).isEqualTo(PollReward.VirtualCurrency(code = "coins", amount = 10))
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    private fun mockVerifiedVirtualCurrencyRewardBackend() {
+        every {
+            mockBackend.getRewardVerificationResult(
+                appUserID = appUserId,
+                clientTransactionId = "ct_1",
+                onSuccess = captureLambda(),
+                onError = any(),
+            )
+        } answers {
+            lambda<(RewardVerificationResult) -> Unit>().captured.invoke(
+                RewardVerificationResult.Verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 10)),
+            )
+        }
     }
 
     @OptIn(InternalRevenueCatAPI::class)

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -55,6 +55,9 @@ import io.mockk.verify
 import io.mockk.verifyAll
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult as PollResult
+import com.revenuecat.purchases.ads.rewardverification.VerifiedReward as PollReward
+import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.junit.Assert.fail
 import org.junit.Test
@@ -1912,6 +1915,56 @@ internal class PurchasesTest : BasePurchasesTest() {
         )
 
         assertThat(receivedResult).isEqualTo(expectedResult)
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    @Test
+    fun `generateRewardVerificationToken builds custom data with impression id and unique transaction id`() {
+        val token = purchases.generateRewardVerificationToken(impressionId = "imp-1")
+
+        val payload = JSONObject(token.customData)
+        assertThat(payload.getString("api_key")).isEqualTo(purchases.purchasesOrchestrator.currentConfiguration.apiKey)
+        assertThat(payload.getString("client_transaction_id")).isEqualTo(token.clientTransactionId)
+        assertThat(payload.getString("impression_id")).isEqualTo("imp-1")
+        assertThat(token.clientTransactionId).isNotBlank()
+        assertThat(token.appUserID).isEqualTo(appUserId)
+
+        // Each call mints a distinct client transaction id so concurrent verifications don't collide.
+        assertThat(purchases.generateRewardVerificationToken(impressionId = "imp-1").clientTransactionId)
+            .isNotEqualTo(token.clientTransactionId)
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    @Test
+    fun `pollRewardVerification invalidates virtual currencies cache on verified virtual currency reward`() {
+        every { mockVirtualCurrencyManager.invalidateVirtualCurrenciesCache() } returns Unit
+
+        val result = runBlocking {
+            purchases.pollRewardVerification(
+                clientTransactionId = "ct_1",
+                poll = { PollResult.verified(PollReward.VirtualCurrency(code = "gems", amount = 5)) },
+            )
+        }
+
+        assertThat(result.verifiedReward).isEqualTo(PollReward.VirtualCurrency(code = "gems", amount = 5))
+        verify(exactly = 1) { mockVirtualCurrencyManager.invalidateVirtualCurrenciesCache() }
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    @Test
+    fun `pollRewardVerification does not invalidate virtual currencies cache on non virtual currency reward`() {
+        runBlocking {
+            purchases.pollRewardVerification(
+                clientTransactionId = "ct_1",
+                poll = { PollResult.verified(PollReward.NoReward) },
+            )
+            purchases.pollRewardVerification(
+                clientTransactionId = "ct_2",
+                poll = { PollResult.failed },
+            )
+        }
+
+        verify(exactly = 0) { mockVirtualCurrencyManager.invalidateVirtualCurrenciesCache() }
     }
 
     @OptIn(InternalRevenueCatAPI::class)

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -1891,7 +1891,7 @@ internal class PurchasesTest : BasePurchasesTest() {
     @OptIn(InternalRevenueCatAPI::class)
     @Test
     fun `getRewardVerificationResult returns result from backend on success`() {
-        val expectedResult = RewardVerificationResult.Verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 10))
+        val expectedResult = RewardVerificationPollStatus.Verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 10))
         every {
             mockBackend.getRewardVerificationResult(
                 appUserID = appUserId,
@@ -1900,14 +1900,14 @@ internal class PurchasesTest : BasePurchasesTest() {
                 onError = any(),
             )
         } answers {
-            lambda<(RewardVerificationResult) -> Unit>().captured.invoke(expectedResult)
+            lambda<(RewardVerificationPollStatus) -> Unit>().captured.invoke(expectedResult)
         }
 
-        var receivedResult: RewardVerificationResult? = null
+        var receivedResult: RewardVerificationPollStatus? = null
         purchases.getRewardVerificationResult(
             clientTransactionId = "ct_1",
             callback = object : GetRewardVerificationResultCallback {
-                override fun onReceived(result: RewardVerificationResult) {
+                override fun onReceived(result: RewardVerificationPollStatus) {
                     receivedResult = result
                 }
 
@@ -2005,8 +2005,8 @@ internal class PurchasesTest : BasePurchasesTest() {
                 onError = any(),
             )
         } answers {
-            lambda<(RewardVerificationResult) -> Unit>().captured.invoke(
-                RewardVerificationResult.Verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 10)),
+            lambda<(RewardVerificationPollStatus) -> Unit>().captured.invoke(
+                RewardVerificationPollStatus.Verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 10)),
             )
         }
     }
@@ -2032,7 +2032,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         purchases.getRewardVerificationResult(
             clientTransactionId = "ct_1",
             callback = object : GetRewardVerificationResultCallback {
-                override fun onReceived(result: RewardVerificationResult) {
+                override fun onReceived(result: RewardVerificationPollStatus) {
                     fail("should be error")
                 }
 
@@ -2048,7 +2048,7 @@ internal class PurchasesTest : BasePurchasesTest() {
     @OptIn(InternalRevenueCatAPI::class)
     @Test
     fun `awaitGetRewardVerificationResult returns backend result`() = runTest {
-        val expectedResult = RewardVerificationResult.PENDING
+        val expectedResult = RewardVerificationPollStatus.PENDING
         every {
             mockBackend.getRewardVerificationResult(
                 appUserID = appUserId,
@@ -2057,7 +2057,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 onError = any(),
             )
         } answers {
-            lambda<(RewardVerificationResult) -> Unit>().captured.invoke(expectedResult)
+            lambda<(RewardVerificationPollStatus) -> Unit>().captured.invoke(expectedResult)
         }
 
         val result = purchases.awaitGetRewardVerificationResult(clientTransactionId = "ct_1")

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/ads/rewardverification/PollerTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/ads/rewardverification/PollerTest.kt
@@ -5,7 +5,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.RewardVerificationException
-import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
+import com.revenuecat.purchases.RewardVerificationPollStatus
 import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
@@ -45,7 +45,7 @@ class PollerTest {
             clientTransactionId = "ct_1",
             fetcher = { clientTransactionId ->
                 receivedClientTransactionId = clientTransactionId
-                CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
+                RewardVerificationPollStatus.Verified(CoreVerifiedReward.NoReward)
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
@@ -66,7 +66,7 @@ class PollerTest {
             clientTransactionId = "ct_1",
             fetcher = {
                 attempts++
-                CoreRewardVerificationResult.Verified(CoreVerifiedReward.VirtualCurrency(code = "gems", amount = 10))
+                RewardVerificationPollStatus.Verified(CoreVerifiedReward.VirtualCurrency(code = "gems", amount = 10))
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
@@ -86,7 +86,7 @@ class PollerTest {
             clientTransactionId = "ct_1",
             fetcher = {
                 attempts++
-                CoreRewardVerificationResult.Failed(failureReason = "ssv_not_enabled", message = backendMessage)
+                RewardVerificationPollStatus.Failed(failureReason = "ssv_not_enabled", message = backendMessage)
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
@@ -104,7 +104,7 @@ class PollerTest {
     fun `poll logs a fallback message when the backend rejects without a message`() = runBlocking {
         val result = Poller.poll(
             clientTransactionId = "ct_1",
-            fetcher = { CoreRewardVerificationResult.Failed() },
+            fetcher = { RewardVerificationPollStatus.Failed() },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
             logFailure = captureFailure,
@@ -121,7 +121,7 @@ class PollerTest {
     fun `poll falls back to the failure reason when the backend rejects without a message`() = runBlocking {
         val result = Poller.poll(
             clientTransactionId = "ct_1",
-            fetcher = { CoreRewardVerificationResult.Failed(failureReason = "no_reward_rule") },
+            fetcher = { RewardVerificationPollStatus.Failed(failureReason = "no_reward_rule") },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
             logFailure = captureFailure,
@@ -149,9 +149,9 @@ class PollerTest {
             fetcher = {
                 attempts++
                 if (attempts < 3) {
-                    CoreRewardVerificationResult.PENDING
+                    RewardVerificationPollStatus.PENDING
                 } else {
-                    CoreRewardVerificationResult.Verified(CoreVerifiedReward.VirtualCurrency(code = "gems", amount = 5))
+                    RewardVerificationPollStatus.Verified(CoreVerifiedReward.VirtualCurrency(code = "gems", amount = 5))
                 }
             },
             sleepSeconds = noSleep,
@@ -173,7 +173,7 @@ class PollerTest {
             clientTransactionId = "ct_1",
             fetcher = {
                 attempts++
-                CoreRewardVerificationResult.PENDING
+                RewardVerificationPollStatus.PENDING
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
@@ -200,7 +200,7 @@ class PollerTest {
             clientTransactionId = "ct_1",
             fetcher = {
                 attempts++
-                CoreRewardVerificationResult.UNKNOWN
+                RewardVerificationPollStatus.UNKNOWN
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
@@ -229,7 +229,7 @@ class PollerTest {
                 attempts++
                 // Unknown first, then transient errors until exhaustion: the unknown status wins.
                 if (attempts == 1) {
-                    CoreRewardVerificationResult.UNKNOWN
+                    RewardVerificationPollStatus.UNKNOWN
                 } else {
                     throw RewardVerificationException(
                         PurchasesError(PurchasesErrorCode.NetworkError),
@@ -287,7 +287,7 @@ class PollerTest {
                         isServerError = false,
                     )
                 }
-                CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
+                RewardVerificationPollStatus.Verified(CoreVerifiedReward.NoReward)
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
@@ -312,7 +312,7 @@ class PollerTest {
                         isServerError = true,
                     )
                 }
-                CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
+                RewardVerificationPollStatus.Verified(CoreVerifiedReward.NoReward)
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
@@ -383,7 +383,7 @@ class PollerTest {
                         isServerError = true,
                     )
                 }
-                CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
+                RewardVerificationPollStatus.Verified(CoreVerifiedReward.NoReward)
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
@@ -458,7 +458,7 @@ class PollerTest {
             clientTransactionId = "ct_1",
             fetcher = {
                 attempts++
-                CoreRewardVerificationResult.PENDING
+                RewardVerificationPollStatus.PENDING
             },
             sleepSeconds = { throw IllegalStateException("scheduler down") },
             jitterSeconds = fixedJitter,
@@ -495,7 +495,7 @@ class PollerTest {
         try {
             Poller.poll(
                 clientTransactionId = "ct_1",
-                fetcher = { CoreRewardVerificationResult.PENDING },
+                fetcher = { RewardVerificationPollStatus.PENDING },
                 sleepSeconds = { throw CancellationException("cancelled") },
                 jitterSeconds = fixedJitter,
             )

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/ads/rewardverification/PollerTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/ads/rewardverification/PollerTest.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.admob.rewardverification
+package com.revenuecat.purchases.ads.rewardverification
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -7,7 +7,6 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.RewardVerificationException
 import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
 import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
-import com.revenuecat.purchases.admob.VerifiedReward
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -17,8 +16,11 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+@RunWith(RobolectricTestRunner::class)
 class PollerTest {
 
     private val recordedSleeps = mutableListOf<Double>()


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids 

Also tested it fully locally with the sample admob app and the refactored code.

### Motivation

The goal of this change is purely technical: move two rewarded ad primitives to the core module so in a future iteration it will be possible to work with it from hybrids - and it makes it possible today for app developers to roll their own hybrid bridges, if they would choose to do so.

### Description

The two primitives are:

1. `generateRewardVerificationToken`
2. `pollRewardVerification`

These can be used to implement a semi-custom reward verification flow without having our admob adapter as dependency.

#### Main changes

- carved out admob-adapter-independent code parts to the core module
- moved and adapted tests to the new code location
- we are now using the core primitives from the admob adapter and it is purely for convenience

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches experimental public SDK surface and rewarded-ad/virtual-currency correlation, but behavior is largely relocated with deprecated aliases and broad test updates rather than new product logic.
> 
> **Overview**
> Moves rewarded-ad **server verification** building blocks from the AdMob feature module into **`com.revenuecat.purchases.ads.rewardverification`** on the core `Purchases` SDK, so apps (and future hybrids) can run verification without depending on the AdMob adapter.
> 
> **New public primitives on `Purchases`:** `generateRewardVerificationToken(impressionId)` (SSV custom data + `clientTransactionId`), `pollRewardVerification` / `awaitPollRewardVerification`, plus `RewardVerificationToken`, `RewardVerificationResult`, and `VerifiedReward`. Polling, retry/backoff, and user-facing failure strings live in core; verified **virtual currency** rewards now invalidate the virtual currencies cache from `Purchases` (removed from the AdMob runtime).
> 
> The AdMob module is rewired to call those APIs for SSV setup and polling; former `com.revenuecat.purchases.admob` result types are **deprecated typealiases** to the new package. The internal per-request backend status type is renamed to **`RewardVerificationPollStatus`** to avoid clashing with the public poll result. API dumps, samples, and tests follow the new types.
> 
> **CI:** `Dangerfile` counts production line churn via `git.diff.stats[:files]` with a nil guard so renamed files no longer crash the size check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8feed858b2aca1b7cef466f890b402f5861975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->