### PR TITLE
test(caching): cover workflow metadata disk round-trip

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/common/caching/LocalTransactionMetadataStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/caching/LocalTransactionMetadataStoreTest.kt
@@ -208,6 +208,37 @@ class LocalTransactionMetadataStoreTest {
         assertThat(retrieved?.paywallPostReceiptData).isEqualTo(paywallData)
     }
 
+    @Test
+    fun `cacheLocalTransactionMetadata round-trips workflow metadata`() {
+        val key = "local_transaction_metadata_${purchaseToken.sha1()}"
+        every { sharedPreferences.contains(key) } returns false
+
+        val workflowMetadata = WorkflowMetadata(
+            workflowId = "workflow_id",
+            stepId = "step_id",
+        )
+
+        val transactionMetadata = LocalTransactionMetadata(
+            token = purchaseToken,
+            receiptInfo = receiptInfo,
+            paywallPostReceiptData = null,
+            purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+            workflowMetadata = workflowMetadata,
+        )
+
+        val jsonSlot = slot<String>()
+        every { editor.putString(key, capture(jsonSlot)) } returns editor
+
+        localTransactionMetadataStore.cacheLocalTransactionMetadata(purchaseToken, transactionMetadata)
+
+        // Mock SharedPreferences to return what was actually written, so this exercises the real
+        // JSON encode/decode. Guards against workflowMetadata regressing to a non-persisted field.
+        every { sharedPreferences.getString(key, null) } answers { jsonSlot.captured }
+
+        val retrieved = localTransactionMetadataStore.getLocalTransactionMetadata(purchaseToken)
+        assertThat(retrieved?.workflowMetadata).isEqualTo(workflowMetadata)
+    }
+
     // endregion
 
     // region getLocalTransactionMetadata


### PR DESCRIPTION
### Motivation

Follow-up test coverage for #3603. That PR's refactor commit (`b2bfd86`) fixed a bug where `workflowId`/`stepId` were `@Transient` on the cached transaction metadata and were lost on the disk round-trip, so `presented_workflow_id` / `presented_step_id` would be sent as `null` on retry or unsynced replay. The field was promoted to a first-class `workflowMetadata` on `LocalTransactionMetadata` with `@SerialName("workflow_metadata")`, but there was no regression test asserting it actually survives serialization.

### What this adds

One test in `LocalTransactionMetadataStoreTest`, `cacheLocalTransactionMetadata round-trips workflow metadata`, mirroring the existing `handles paywall data` test. The JSON written to `SharedPreferences` is captured and fed back to `getLocalTransactionMetadata`, so the real `JsonTools.json` encode/decode runs (only SharedPreferences I/O is mocked).

### Verification (RED → GREEN)

- **RED**: with `workflowMetadata` marked `@Transient`, the test fails at the assertion (`retrieved?.workflowMetadata` is `null`).
- **GREEN**: with `@SerialName("workflow_metadata")` (current state), it passes.

Ran `:purchases:testDefaultsBc8DebugUnitTest --tests "...LocalTransactionMetadataStoreTest"` locally (JDK 21).

Companion to #3636 (which covers the `PostReceiptHelper` threading and replay paths). Together they close the two test gaps identified in review of #3603.

<details>
<summary>AI session context</summary>

**Task:** Review #3603 ("is anything missing?"), then close the identified test gaps.

**Findings from review of #3603:**
1. (important) Disk round-trip of `workflowMetadata` untested, the exact bug `b2bfd86` fixed. `LocalTransactionMetadataStoreTest` had the analogous `handles paywall data` round-trip test but nothing for `workflowMetadata`.
2. (important) `PostReceiptHelper` threading untested (only an `any()` count bumped). → covered by #3636.

**This PR** addresses finding #1.

**Decisions:**
- Reused the existing capture-the-written-JSON pattern so the test exercises real serialization, not a mock, which is what makes it a genuine guard for the `@Transient` regression.
- Based on `cesar/receipt-presented-paywall-workflow-ids` because the `workflowMetadata` field only exists there, not on `main`.

**Verified:** RED→GREEN as described above. Production code (`LocalTransactionMetadata.kt`) left unchanged; only the test file is added.

**Not done:** The remaining review items on #3603 were questions, not test gaps (all-or-nothing `WorkflowMetadata.from`, impression/purchase step-id divergence under dedup, `pr:other` vs `pr:fix` label). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime behavior modifications.
> 
> **Overview**
> Adds a regression test in `LocalTransactionMetadataStoreTest` so **`workflowMetadata`** on cached local transaction metadata survives the same **SharedPreferences JSON encode/decode** path used in production.
> 
> The test mirrors the existing paywall round-trip pattern: capture the JSON written on cache, feed it back on read, and assert `workflowId` / `stepId` are unchanged. It is meant to catch a prior failure mode where workflow fields were not persisted (e.g. `@Transient`), which would drop `presented_workflow_id` / `presented_step_id` on retry or replay.
> 
> **No production code changes** in this PR—test coverage only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87b623488fc71dfc8f7b709c449447620b7707e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->