### PR TITLE
refactor(remote-config): Migrate config to opaque-manifest wire format

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
@@ -20,9 +20,13 @@ import kotlinx.serialization.json.jsonObject
  * element) of the binary [com.revenuecat.purchases.common.networking.RCContainer], and is also the plain
  * JSON fallback body when the SDK does not request the binary format.
  *
- * The [topics] map carries **only changed topic bodies** — a topic whose client-sent etag still matches is
- * omitted, and the client keeps its locally cached topic data. [manifest] lists **every** active topic and
- * its current etag (including unchanged ones), so it is the source of truth for which topics exist.
+ * The [topics] map carries **only changed topic bodies** — a topic whose etag still matches is omitted, and
+ * the client keeps its locally cached topic data. [activeTopics] lists **every** active topic name (including
+ * unchanged ones), so it is the source of truth for which topics exist and which were removed.
+ *
+ * [manifest] is an **opaque** token: the SDK stores it verbatim and replays it on the next request so the
+ * server can diff against the exact state it issued. The SDK never parses it (the per-topic etags it encodes
+ * are server-private).
  *
  * Parsing uses the shared [JsonProvider.defaultJson], which ignores unknown keys so unknown topics and
  * unknown item metadata keys survive, keeping the SDK forward-compatible with topics it does not yet handle.
@@ -33,28 +37,16 @@ internal data class RemoteConfiguration(
     /** Other domains the SDK should also sync to assemble the full configuration. */
     val subdomains: List<String> = emptyList(),
     @SerialName("app_uuid") val appUuid: String? = null,
-    val manifest: Manifest,
+    /** Opaque server token; stored verbatim and replayed as the request `manifest`. Never parsed. */
+    val manifest: String,
+    /** The full set of active topic names, including unchanged ones. Source of truth for topic existence. */
+    @SerialName("active_topics") val activeTopics: List<String> = emptyList(),
+    /** Blob refs the server believes the SDK should have prefetched for the resolved configuration. */
+    @SerialName("prefetch_blobs") val prefetchBlobs: List<String> = emptyList(),
     /** Changed topic bodies only: TopicName -> (ItemName -> [ConfigItem]). */
     val topics: Map<String, ConfigTopic> = emptyMap(),
     @SerialName("state_hash") val stateHash: String? = null,
 ) {
-    /**
-     * A configuration manifest. The SDK persists the server-sent manifest and replays it as the request
-     * `manifest` on each subsequent call so the server can return only what changed.
-     */
-    @Serializable
-    internal data class Manifest(
-        val domain: String,
-        /** Topic name -> compact topic etag. Lists every active topic, including unchanged ones. */
-        val topics: Map<String, String> = emptyMap(),
-        /** Blob refs the server believes the SDK should have prefetched. */
-        @SerialName("prefetch_blobs") val prefetchBlobs: List<String> = emptyList(),
-        /** Blob refs the SDK has actually cached locally. Sent on the request; absent from server responses. */
-        @SerialName("prefetched_blobs") val prefetchedBlobs: List<String> = emptyList(),
-        /** Timestamp from the previous server manifest. Used only for refresh cadence. */
-        @SerialName("last_refresh_at") val lastRefreshAt: Long = 0,
-    )
-
     /**
      * A single item within a topic. An item is arbitrary, topic-specific JSON; [blobRef] and [prefetch] are
      * the only reserved conventions the SDK interprets, and every other key is preserved verbatim in

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigurationTest.kt
@@ -17,12 +17,9 @@ class RemoteConfigurationTest {
               "domain": "app",
               "subdomains": ["app_workflows"],
               "app_uuid": "1a2b3c4d",
-              "manifest": {
-                "domain": "app",
-                "topics": { "sources": "Jc83RzcK1LqA", "product_entitlement_mapping": "9v1DnUu6rXbE" },
-                "prefetch_blobs": ["blobRefA", "blobRefB"],
-                "last_refresh_at": 1710000100
-              },
+              "manifest": "v1.1710000100.sources:Jc83RzcK1LqA,product_entitlement_mapping:9v1DnUu6rXbE",
+              "active_topics": ["sources", "product_entitlement_mapping"],
+              "prefetch_blobs": ["blobRefA", "blobRefB"],
               "topics": {
                 "product_entitlement_mapping": {
                   "default": { "blob_ref": "blobRefA", "prefetch": true }
@@ -39,13 +36,11 @@ class RemoteConfigurationTest {
         assertThat(response.appUuid).isEqualTo("1a2b3c4d")
         assertThat(response.stateHash).isEqualTo("x3R7YvQw2NfM")
 
-        assertThat(response.manifest.domain).isEqualTo("app")
-        assertThat(response.manifest.topics)
-            .containsEntry("sources", "Jc83RzcK1LqA")
-            .containsEntry("product_entitlement_mapping", "9v1DnUu6rXbE")
-        assertThat(response.manifest.prefetchBlobs).containsExactly("blobRefA", "blobRefB")
-        assertThat(response.manifest.prefetchedBlobs).isEmpty()
-        assertThat(response.manifest.lastRefreshAt).isEqualTo(1710000100L)
+        // The manifest is opaque: stored verbatim, never parsed.
+        assertThat(response.manifest)
+            .isEqualTo("v1.1710000100.sources:Jc83RzcK1LqA,product_entitlement_mapping:9v1DnUu6rXbE")
+        assertThat(response.activeTopics).containsExactly("sources", "product_entitlement_mapping")
+        assertThat(response.prefetchBlobs).containsExactly("blobRefA", "blobRefB")
 
         val item = response.topics.getValue("product_entitlement_mapping").getValue("default")
         assertThat(item.blobRef).isEqualTo("blobRefA")
@@ -58,10 +53,8 @@ class RemoteConfigurationTest {
         val payload = """
             {
               "domain": "app",
-              "manifest": {
-                "domain": "app",
-                "topics": { "sources": "etag1", "product_entitlement_mapping": "etag2" }
-              },
+              "manifest": "v1.1710000200.sources:etag1,product_entitlement_mapping:etag2",
+              "active_topics": ["sources", "product_entitlement_mapping"],
               "topics": {
                 "sources": { "blob": { "blob_ref": "sourcesBlob" } }
               }
@@ -70,8 +63,8 @@ class RemoteConfigurationTest {
 
         val response = RemoteConfiguration.parse(payload.trimIndent().toByteArray())
 
-        // manifest lists every topic; topics carries only the changed one.
-        assertThat(response.manifest.topics.keys)
+        // active_topics lists every topic; topics carries only the changed one.
+        assertThat(response.activeTopics)
             .containsExactlyInAnyOrder("sources", "product_entitlement_mapping")
         assertThat(response.topics.keys).containsExactly("sources")
         assertThat(response.topics.getValue("sources").getValue("blob").blobRef).isEqualTo("sourcesBlob")
@@ -83,11 +76,9 @@ class RemoteConfigurationTest {
         val payload = """
             {
               "domain": "app",
-              "manifest": {
-                "domain": "app",
-                "topics": { "sources": "etag1" },
-                "prefetch_blobs": []
-              },
+              "manifest": "v1.1710000300.sources:etag1",
+              "active_topics": ["sources"],
+              "prefetch_blobs": [],
               "topics": {}
             }
         """
@@ -95,8 +86,8 @@ class RemoteConfigurationTest {
         val response = RemoteConfiguration.parse(payload.trimIndent().toByteArray())
 
         assertThat(response.topics).isEmpty()
-        assertThat(response.manifest.topics).containsExactlyEntriesOf(mapOf("sources" to "etag1"))
-        assertThat(response.manifest.prefetchBlobs).isEmpty()
+        assertThat(response.activeTopics).containsExactly("sources")
+        assertThat(response.prefetchBlobs).isEmpty()
     }
 
     @Test
@@ -105,10 +96,8 @@ class RemoteConfigurationTest {
         val payload = """
             {
               "domain": "app",
-              "manifest": {
-                "domain": "app",
-                "topics": { "future_topic": "etagF" }
-              },
+              "manifest": "v1.1710000400.future_topic:etagF",
+              "active_topics": ["future_topic"],
               "topics": {
                 "future_topic": { "default": { "blob_ref": "futureBlob" } }
               }
@@ -117,7 +106,7 @@ class RemoteConfigurationTest {
 
         val response = RemoteConfiguration.parse(payload.trimIndent().toByteArray())
 
-        assertThat(response.manifest.topics).containsKey("future_topic")
+        assertThat(response.activeTopics).contains("future_topic")
         assertThat(response.topics).containsKey("future_topic")
         assertThat(response.topics.getValue("future_topic").getValue("default").blobRef)
             .isEqualTo("futureBlob")
@@ -129,7 +118,8 @@ class RemoteConfigurationTest {
         val payload = """
             {
               "domain": "app",
-              "manifest": { "domain": "app", "topics": { "sources": "etag1" } },
+              "manifest": "v1.1710000500.sources:etag1",
+              "active_topics": ["sources"],
               "topics": {
                 "sources": {
                   "blob": { "blob_ref": "sourcesBlob", "prefetch": true, "future_field": "kept" }
@@ -156,7 +146,8 @@ class RemoteConfigurationTest {
         val payload = """
             {
               "domain": "app",
-              "manifest": { "domain": "app", "topics": { "sources": "etag1" } },
+              "manifest": "v1.1710000600.sources:etag1",
+              "active_topics": ["sources"],
               "topics": {
                 "sources": {
                   "api": { "id": "primary", "url": "https://api.revenuecat.com", "priority": 100, "weight": 100 }
@@ -182,7 +173,7 @@ class RemoteConfigurationTest {
         val payload = """
             {
               "domain": "app",
-              "manifest": { "domain": "app" }
+              "manifest": "v1.1710000700."
             }
         """
 
@@ -192,10 +183,8 @@ class RemoteConfigurationTest {
         assertThat(response.appUuid).isNull()
         assertThat(response.stateHash).isNull()
         assertThat(response.topics).isEmpty()
-        assertThat(response.manifest.topics).isEmpty()
-        assertThat(response.manifest.prefetchBlobs).isEmpty()
-        assertThat(response.manifest.prefetchedBlobs).isEmpty()
-        assertThat(response.manifest.lastRefreshAt).isEqualTo(0L)
+        assertThat(response.activeTopics).isEmpty()
+        assertThat(response.prefetchBlobs).isEmpty()
     }
 
     @Test
@@ -204,7 +193,8 @@ class RemoteConfigurationTest {
         val payload = """
             {
               "domain": "app",
-              "manifest": { "domain": "app", "topics": { "sources": "etag1" } },
+              "manifest": "v1.1710000800.sources:etag1",
+              "active_topics": ["sources"],
               "topics": { "sources": { "api": {} } }
             }
         """
@@ -221,7 +211,7 @@ class RemoteConfigurationTest {
         // language=json
         val payload = """
             {
-              "manifest": { "domain": "app", "topics": { "sources": "etag1" } }
+              "manifest": "v1.1710000900.sources:etag1"
             }
         """
 
@@ -248,7 +238,7 @@ class RemoteConfigurationTest {
         val payload = """
             {
               "domain": "app",
-              "manifest": { "domain": "app",
+              "manifest": "v1.123
         """
 
         assertThatThrownBy { RemoteConfiguration.parse(payload.trimIndent().toByteArray()) }
@@ -257,12 +247,12 @@ class RemoteConfigurationTest {
 
     @Test
     fun `fails to parse when a field has the wrong type`() {
-        // manifest must be an object, not a string.
+        // manifest must be a string, not an object.
         // language=json
         val payload = """
             {
               "domain": "app",
-              "manifest": "not-an-object"
+              "manifest": { "topics": {} }
             }
         """
 


### PR DESCRIPTION
### Description
After discussions, we changed the manifest from having a parseable body to an opaque string the SDK will just store and pass back to the backend to get the latest version of the config needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking wire-format change for remote config sync; callers that still read `manifest.topics` or nested manifest fields must migrate to the new fields.
> 
> **Overview**
> **Remote config `/v2/config` parsing** now treats `manifest` as an **opaque string** (store and replay on the next request) instead of a nested `Manifest` object with topic etags, `prefetch_blobs`, `prefetched_blobs`, and `last_refresh_at`.
> 
> Topic inventory and prefetch hints move to **top-level fields**: `active_topics` (full list of active topic names, including unchanged) and `prefetch_blobs`. Docs clarify that `topics` still carries **only changed** topic bodies.
> 
> The nested `RemoteConfiguration.Manifest` type is **removed**. `RemoteConfigurationTest` is updated for the new JSON shape and asserts `manifest` is wrong-type when sent as an object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 448f2baf55b3390828cca2de907a85d0beb22ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->