### PR TITLE
Publish SNAPSHOT versions to GitHub Packages instead of Maven Central

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -970,7 +970,9 @@ workflows:
       equal: [ deploy_snapshot_release, << pipeline.parameters.action >> ]
     jobs:
       - deploy-snapshot:
-          context: maven-central-publishing
+          context:
+            - maven-central-publishing
+            - github-packages-publishing
 
   snapshot-deploy-sample-app-tests:
     when:
@@ -981,11 +983,15 @@ workflows:
         - equal: [ "default", << pipeline.parameters.action >> ]
     jobs:
       - deploy-snapshot:
-          context: maven-central-publishing
+          context:
+            - maven-central-publishing
+            - github-packages-publishing
       - assemble-magic-weather-compose-sample-app:
+          context: github-packages-publishing
           requires:
             - deploy-snapshot
       - assemble-custom-entitlement-computation-sample-app:
+          context: github-packages-publishing
           requires:
             - deploy-snapshot
       - assemble-admob-integration-sample-app

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,3 +52,29 @@ Sonatype might fail when performing the `closeAndRelease` step. Fortunately, we 
 - Head to https://central.sonatype.com/publishing/deployments, login using the credentials in 1Password
 - You should see one staging repository there. If there are more than one, drop all of them and rerun the failing job in CircleCI.
 - Select the only repository available, then do Close. When close finishes, do Release and automatically drop the repository.
+
+Snapshot builds
+=========
+Snapshot versions (those ending in `-SNAPSHOT`) are published to GitHub Packages, not Maven Central. Release versions still go to Maven Central. Snapshots are published automatically on every merge to `main`, and can be triggered manually with the `deploy_snapshot_release` CircleCI action. They are GPG-signed like releases.
+
+GitHub Packages requires authentication to download artifacts even though the packages are public, so consumers need a GitHub personal access token (classic) with the `read:packages` scope.
+
+To consume snapshots, add the repository to your Gradle build:
+
+```kotlin
+repositories {
+    maven(url = "https://maven.pkg.github.com/RevenueCat/purchases-android") {
+        content { includeGroup("com.revenuecat.purchases") }
+        credentials {
+            username = providers.gradleProperty("githubPackagesUsername").orNull
+                ?: System.getenv("GITHUB_PACKAGES_USERNAME")
+            password = providers.gradleProperty("githubPackagesToken").orNull
+                ?: System.getenv("GITHUB_PACKAGES_TOKEN")
+        }
+    }
+}
+```
+
+Provide the credentials as the `githubPackagesUsername` (your GitHub username) and `githubPackagesToken` (the PAT) Gradle properties in `~/.gradle/gradle.properties`, or as the `GITHUB_PACKAGES_USERNAME` / `GITHUB_PACKAGES_TOKEN` environment variables. The sample apps under `examples/` are already configured this way.
+
+Publishing uses the same credential names; CI provides them through the `github-packages-publishing` context, where the token needs the `write:packages` scope.

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -3,6 +3,7 @@ import java.lang.Runtime.Version
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    id("revenuecat-snapshot-publishing")
 }
 
 private val kotlinPlugin = plugins

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -40,5 +40,10 @@ gradlePlugin {
             implementationClass =
                 "com.revenuecat.purchases.android.buildlogic.plugin.ApiTesterApplicationConventionPlugin"
         }
+        register("SnapshotPublishing") {
+            id = "revenuecat-snapshot-publishing"
+            implementationClass =
+                "com.revenuecat.purchases.android.buildlogic.plugin.SnapshotPublishingConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigureSnapshotPublishing.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigureSnapshotPublishing.kt
@@ -1,0 +1,51 @@
+package com.revenuecat.purchases.android.buildlogic.convention
+
+import com.revenuecat.purchases.android.buildlogic.ktx.libs
+import com.revenuecat.purchases.android.buildlogic.ktx.plugins
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.maven
+
+private const val GITHUB_PACKAGES_REPOSITORY_NAME = "GitHubPackages"
+private const val GITHUB_PACKAGES_URL = "https://maven.pkg.github.com/RevenueCat/purchases-android"
+
+/**
+ * Points SNAPSHOT publishing at GitHub Packages and blocks Maven Central; releases are unaffected
+ * and keep publishing to Maven Central.
+ *
+ * For SNAPSHOT versions this registers the GitHub Packages repository and disables every Maven
+ * Central publish task, so a snapshot cannot reach Central even via `publish` or
+ * `publishToMavenCentral`.
+ *
+ * Credentials come from the `githubPackagesUsername` / `githubPackagesToken` Gradle properties,
+ * falling back to the `GITHUB_PACKAGES_USERNAME` / `GITHUB_PACKAGES_TOKEN` environment variables.
+ */
+internal fun Project.configureSnapshotPublishing() {
+    val versionName = providers.gradleProperty("VERSION_NAME").orNull ?: version.toString()
+    if (!versionName.endsWith("-SNAPSHOT")) return
+
+    val githubPackagesUsername = providers.gradleProperty("githubPackagesUsername").orNull
+        ?: System.getenv("GITHUB_PACKAGES_USERNAME")
+    val githubPackagesToken = providers.gradleProperty("githubPackagesToken").orNull
+        ?: System.getenv("GITHUB_PACKAGES_TOKEN")
+
+    pluginManager.withPlugin(libs.plugins.mavenPublish.get().pluginId) {
+        extensions.configure<PublishingExtension> {
+            repositories.maven(GITHUB_PACKAGES_URL) {
+                name = GITHUB_PACKAGES_REPOSITORY_NAME
+                credentials {
+                    username = githubPackagesUsername
+                    password = githubPackagesToken
+                }
+            }
+        }
+
+        tasks.withType(PublishToMavenRepository::class.java)
+            .matching { !it.name.contains(GITHUB_PACKAGES_REPOSITORY_NAME) }
+            .configureEach { enabled = false }
+        tasks.matching { it.name == "publishToMavenCentral" || it.name == "publishAndReleaseToMavenCentral" }
+            .configureEach { enabled = false }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/PublicLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/PublicLibraryConventionPlugin.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.android.buildlogic.convention.configureApisFlavo
 import com.revenuecat.purchases.android.buildlogic.convention.configureConditionalPublishing
 import com.revenuecat.purchases.android.buildlogic.convention.configureDokka
 import com.revenuecat.purchases.android.buildlogic.convention.configureMetalava
+import com.revenuecat.purchases.android.buildlogic.convention.configureSnapshotPublishing
 import com.revenuecat.purchases.android.buildlogic.ktx.libs
 import com.revenuecat.purchases.android.buildlogic.ktx.plugins
 import org.gradle.api.Plugin
@@ -27,6 +28,7 @@ class PublicLibraryConventionPlugin : Plugin<Project> {
         configureAndroidLibrary()
         configureApisFlavors()
         configureConditionalPublishing()
+        configureSnapshotPublishing()
         configureMetalava()
         configureDokka()
 

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/SnapshotPublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/SnapshotPublishingConventionPlugin.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.android.buildlogic.plugin
+
+import com.revenuecat.purchases.android.buildlogic.convention.configureSnapshotPublishing
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Applies SNAPSHOT publishing config to modules that apply the Maven publish plugin directly
+ * instead of through [PublicLibraryConventionPlugin], such as `:bom` and `:codegen`.
+ */
+class SnapshotPublishingConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.configureSnapshotPublishing()
+    }
+}

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     `java-gradle-plugin`
+    id("revenuecat-snapshot-publishing")
 }
 
 if (!project.properties["ANDROID_VARIANT_TO_PUBLISH"].toString().contains("customEntitlementComputation")) {

--- a/examples/CustomEntitlementComputationSample/settings.gradle.kts
+++ b/examples/CustomEntitlementComputationSample/settings.gradle.kts
@@ -10,8 +10,14 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
+        maven(url = "https://maven.pkg.github.com/RevenueCat/purchases-android") {
             content { includeGroup("com.revenuecat.purchases") }
+            credentials {
+                username = providers.gradleProperty("githubPackagesUsername").orNull
+                    ?: System.getenv("GITHUB_PACKAGES_USERNAME")
+                password = providers.gradleProperty("githubPackagesToken").orNull
+                    ?: System.getenv("GITHUB_PACKAGES_TOKEN")
+            }
         }
     }
 }

--- a/examples/MagicWeather/build.gradle.kts
+++ b/examples/MagicWeather/build.gradle.kts
@@ -8,8 +8,14 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
+        maven(url = "https://maven.pkg.github.com/RevenueCat/purchases-android") {
             content { includeGroup("com.revenuecat.purchases") }
+            credentials {
+                username = providers.gradleProperty("githubPackagesUsername").orNull
+                    ?: System.getenv("GITHUB_PACKAGES_USERNAME")
+                password = providers.gradleProperty("githubPackagesToken").orNull
+                    ?: System.getenv("GITHUB_PACKAGES_TOKEN")
+            }
         }
     }
 }

--- a/examples/MagicWeatherCompose/settings.gradle.kts
+++ b/examples/MagicWeatherCompose/settings.gradle.kts
@@ -10,8 +10,14 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
+        maven(url = "https://maven.pkg.github.com/RevenueCat/purchases-android") {
             content { includeGroup("com.revenuecat.purchases") }
+            credentials {
+                username = providers.gradleProperty("githubPackagesUsername").orNull
+                    ?: System.getenv("GITHUB_PACKAGES_USERNAME")
+                password = providers.gradleProperty("githubPackagesToken").orNull
+                    ?: System.getenv("GITHUB_PACKAGES_TOKEN")
+            }
         }
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -255,18 +255,28 @@ platform :android do
   desc "Upload and close a release"
   lane :deploy do |options|
     version = current_version_number
+    snapshot = is_snapshot_version?(version)
+
     gradle_properties = {
       "signing.keyId" => ENV['GPG_SIGNING_KEY_ID_NEW'],
       "signing.password" => ENV['GPG_SIGNING_KEY_PW_NEW'],
       "signing.secretKeyRingFile" => "/home/circleci/.gnupg/secring.gpg",
-      "mavenCentralUsername" => ENV['MAVEN_CENTRAL_PORTAL_USERNAME'],
-      "mavenCentralPassword" => ENV['MAVEN_CENTRAL_PORTAL_PASSWORD'],
       "RELEASE_SIGNING_ENABLED" => true
     }
+    if snapshot
+      gradle_properties["githubPackagesUsername"] = ENV['GITHUB_PACKAGES_USERNAME']
+      gradle_properties["githubPackagesToken"] = ENV['GITHUB_PACKAGES_TOKEN']
+      publish_task = "publishAllPublicationsToGitHubPackagesRepository"
+    else
+      gradle_properties["mavenCentralUsername"] = ENV['MAVEN_CENTRAL_PORTAL_USERNAME']
+      gradle_properties["mavenCentralPassword"] = ENV['MAVEN_CENTRAL_PORTAL_PASSWORD']
+      publish_task = "publish"
+    end
+
     UI.verbose("Deploying #{version}")
     gradle(
       tasks: [
-        "publish --no-daemon --no-parallel"
+        "#{publish_task} --no-daemon --no-parallel"
       ],
       properties: gradle_properties
     )
@@ -276,7 +286,8 @@ platform :android do
       "defaultsBc7Release",
       "purchases-bc7",
       "purchases",
-      gradle_properties
+      gradle_properties,
+      publish_task
     )
 
     UI.verbose("Deploying purchases-ui Billing Client 7 version")
@@ -284,7 +295,8 @@ platform :android do
       "defaultsBc7Release",
       "purchases-ui-bc7",
       "ui:revenuecatui",
-      gradle_properties
+      gradle_properties,
+      publish_task
     )
 
     UI.verbose("Deploying amazon Billing Client 7 version")
@@ -292,7 +304,8 @@ platform :android do
       "defaultsBc7Release",
       "purchases-store-amazon-bc7",
       "feature:amazon",
-      gradle_properties
+      gradle_properties,
+      publish_task
     )
 
     UI.verbose("Deploying galaxy Billing Client 7 version")
@@ -300,7 +313,8 @@ platform :android do
       "defaultsBc7Release",
       "purchases-store-galaxy-bc7",
       "feature:galaxy",
-      gradle_properties
+      gradle_properties,
+      publish_task
     )
 
     UI.verbose("Deploying Custom Entitlements Computation version")
@@ -308,7 +322,8 @@ platform :android do
       "customEntitlementComputationBc8Release",
       "purchases-custom-entitlement-computation",
       "purchases",
-      gradle_properties
+      gradle_properties,
+      publish_task
     )
 
     UI.verbose("Deploying Debug view version")
@@ -316,17 +331,18 @@ platform :android do
       "defaultsBc8Debug",
       "purchases-debug-view",
       "ui:debugview",
-      gradle_properties
+      gradle_properties,
+      publish_task
     )
 
-    github_release(version: version) unless is_snapshot_version?(version)
+    github_release(version: version) unless snapshot
   end
 
-  def deploy_specific_package(variant, artifact_id, module_to_deploy, gradle_properties)
+  def deploy_specific_package(variant, artifact_id, module_to_deploy, gradle_properties, publish_task = "publish")
     gradle_properties["ANDROID_VARIANT_TO_PUBLISH"] = variant
     gradle_properties["POM_ARTIFACT_ID"] = artifact_id
 
-    command = module_to_deploy == nil ? "publish" : "#{module_to_deploy}:publish"
+    command = module_to_deploy == nil ? publish_task : "#{module_to_deploy}:#{publish_task}"
     gradle(
       tasks: [
         "#{command} --no-daemon --no-parallel"


### PR DESCRIPTION
WIP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes artifact distribution for every snapshot deploy and consumer repo config; release paths are gated on version suffix and Central tasks are disabled for snapshots, but CI credential or task misconfiguration could break mainline snapshot publishing.
> 
> **Overview**
> **`-SNAPSHOT` builds now publish to GitHub Packages instead of Maven Central; release publishing is unchanged.**
> 
> Gradle convention adds `configureSnapshotPublishing()` for public library modules: when `VERSION_NAME` ends in `-SNAPSHOT`, it registers `https://maven.pkg.github.com/RevenueCat/purchases-android` and disables Maven Central publish tasks so snapshots cannot ship to Central.
> 
> Fastlane `deploy` picks credentials and Gradle publish tasks by version—snapshots use `publishAllPublicationsToGitHubPackagesRepository` with GitHub Packages env vars and skip GitHub release creation; releases still use Maven Central and `publish`.
> 
> CircleCI snapshot workflows add the `github-packages-publishing` context for deploy and for sample apps that resolve snapshot dependencies after deploy. Example apps switch their snapshot Maven repo from Sonatype to GitHub Packages with the same credential properties/env vars.
> 
> `RELEASING.md` documents snapshot behavior, PAT scopes, and consumer Gradle setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57cba542169ed5bb9ec4772e3d2a413ea919eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->