### PR TITLE
refactor(remote-config): /v1/config path, app_user_id body, refresh dedupe

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -1313,6 +1313,7 @@ internal class Backend(
     @Suppress("LongParameterList")
     fun getRemoteConfig(
         appInBackground: Boolean,
+        appUserID: String,
         domain: String,
         manifest: String?,
         prefetchedBlobs: List<String>,
@@ -1321,7 +1322,9 @@ internal class Backend(
     ) {
         val endpoint = Endpoint.GetRemoteConfig
         val path = endpoint.getPath()
-        val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path), appInBackground)
+        // Include the app user in the key: the path is static but the request body carries app_user_id, so
+        // concurrent calls for different users must not be deduped onto a single shared request.
+        val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path, appUserID), appInBackground)
 
         val overrideURL = BuildConfig.REMOTE_CONFIG_BASE_URL
             .takeIf { it.isNotEmpty() && appConfig.isDebugBuild }
@@ -1330,6 +1333,7 @@ internal class Backend(
         val fallbackBaseURLs = if (overrideURL != null) emptyList() else appConfig.fallbackBaseURLs
         // The manifest is an opaque token replayed verbatim; omitted on the first run when there is none.
         val body = buildMap<String, Any?> {
+            put(APP_USER_ID, appUserID)
             put("domain", domain)
             manifest?.let { put("manifest", it) }
             put("prefetched_blobs", prefetchedBlobs)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -106,7 +106,7 @@ internal sealed class Endpoint(
     }
 
     object GetRemoteConfig : Endpoint(
-        pathTemplate = "/v2/config",
+        pathTemplate = "/v1/config",
         name = "remote_config",
     ) {
         override fun getPath(useFallback: Boolean) = pathTemplate

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -10,7 +10,7 @@ import java.io.File
 import java.io.IOException
 
 /**
- * The sync bookkeeping the SDK persists between `/v2/config` calls.
+ * The sync bookkeeping the SDK persists between `/v1/config` calls.
  *
  * [manifest] is the **opaque** server token, stored verbatim and replayed on the next request; the SDK never
  * parses it. [activeTopics] is the last response's full active-topic-name set (used to detect removed topics).

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -4,17 +4,23 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import kotlinx.serialization.SerializationException
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Orchestrates a single `/v2/config` sync: replays the persisted opaque manifest, then on `204` keeps the cache
+ * Orchestrates a single `/v1/config` sync: replays the persisted opaque manifest, then on `204` keeps the cache
  * untouched and on `200` persists the fresh server manifest plus the resolved per-topic blob refs.
  *
  * The manifest is opaque (stored and replayed verbatim); the active-topic set and removed-topic detection come
  * from the response's [RemoteConfiguration.activeTopics]. Blob extraction (Phase 3), topic-handler dispatch
  * (Phase 4) and lifecycle wiring (Phase 7) are not done here yet; this manager currently only owns manifest
  * replay and persistence.
+ *
+ * Overlapping refreshes are deduped: only one [refreshRemoteConfig] runs at a time. A call made while one is
+ * already in flight is skipped (the backend collapses concurrent requests but still fires every callback, which
+ * would otherwise parse and persist the same response more than once).
  */
 @OptIn(InternalRevenueCatAPI::class)
 internal class RemoteConfigManager(
@@ -22,28 +28,39 @@ internal class RemoteConfigManager(
     private val diskCache: RemoteConfigDiskCache,
     private val dateProvider: DateProvider = DefaultDateProvider(),
 ) {
-    fun refreshRemoteConfig(appInBackground: Boolean) {
+    private val isRefreshing = AtomicBoolean(false)
+
+    fun refreshRemoteConfig(appInBackground: Boolean, appUserID: String) {
+        if (isRefreshing.getAndSet(true)) {
+            debugLog { "Remote config refresh already in progress. Skipping." }
+            return
+        }
         val persisted = diskCache.read()
         backend.getRemoteConfig(
             appInBackground = appInBackground,
+            appUserID = appUserID,
             domain = persisted?.domain ?: DEFAULT_DOMAIN,
             // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
             manifest = persisted?.manifest,
             // No blob store yet (Phase 3 reports the refs actually cached); the SDK holds nothing here.
             prefetchedBlobs = emptyList(),
             onSuccess = { container, _ ->
-                if (container == null) {
-                    // 204: nothing changed, keep the cache.
-                    return@getRemoteConfig
-                }
+                // Hold the in-flight guard until persistence completes so a concurrent refresh can't read the
+                // disk cache mid-write and merge against a stale snapshot.
                 try {
-                    val response = RemoteConfiguration.parse(container.config.data)
-                    persist(previous = persisted, response = response)
+                    if (container != null) {
+                        val response = RemoteConfiguration.parse(container.config.data)
+                        persist(previous = persisted, response = response)
+                    }
+                    // container == null is a 204: nothing changed, keep the cache.
                 } catch (e: SerializationException) {
                     errorLog(e) { "Failed to parse remote config response. Keeping the cached configuration." }
+                } finally {
+                    isRefreshing.set(false)
                 }
             },
             onError = { error ->
+                isRefreshing.set(false)
                 errorLog(error)
             },
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.json.jsonObject
 import java.nio.ByteBuffer
 
 /**
- * The `/v2/config` configuration response. This is the JSON payload carried in element 0 (the config
+ * The `/v1/config` configuration response. This is the JSON payload carried in element 0 (the config
  * element) of the binary [com.revenuecat.purchases.common.networking.RCContainer], and is also the plain
  * JSON fallback body when the SDK does not request the binary format.
  *

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -36,6 +36,7 @@ class BackendGetRemoteConfigTest {
     private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
 
     private val testDomain = "app"
+    private val testAppUserID = "test-app-user-id"
     private val testManifest = "v1.1710000100.sources:etag1"
     private val testPrefetchedBlobs = listOf("blobRefA")
 
@@ -90,6 +91,7 @@ class BackendGetRemoteConfigTest {
         var verification: VerificationResult? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            appUserID = testAppUserID,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -115,6 +117,7 @@ class BackendGetRemoteConfigTest {
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            appUserID = testAppUserID,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -131,6 +134,7 @@ class BackendGetRemoteConfigTest {
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            appUserID = testAppUserID,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -153,6 +157,7 @@ class BackendGetRemoteConfigTest {
         var verification: VerificationResult? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            appUserID = testAppUserID,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -170,12 +175,13 @@ class BackendGetRemoteConfigTest {
     }
 
     @Test
-    fun `getRemoteConfig sends domain, opaque manifest and prefetched_blobs as the request body`() {
+    fun `getRemoteConfig sends app_user_id, domain, opaque manifest and prefetched_blobs as the request body`() {
         val bodySlot = mutableListOf<Map<String, Any?>?>()
         mockNoContentRequest(bodySlot)
 
         backend.getRemoteConfig(
             appInBackground = false,
+            appUserID = testAppUserID,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -185,7 +191,8 @@ class BackendGetRemoteConfigTest {
 
         val body = bodySlot.firstOrNull()
         assertThat(body).isNotNull
-        assertThat(body?.keys).containsExactlyInAnyOrder("domain", "manifest", "prefetched_blobs")
+        assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "domain", "manifest", "prefetched_blobs")
+        assertThat(body?.get("app_user_id")).isEqualTo(testAppUserID)
         assertThat(body?.get("domain")).isEqualTo("app")
         // The manifest is replayed verbatim as the opaque string the SDK received.
         assertThat(body?.get("manifest")).isEqualTo(testManifest)
@@ -199,6 +206,7 @@ class BackendGetRemoteConfigTest {
 
         backend.getRemoteConfig(
             appInBackground = false,
+            appUserID = testAppUserID,
             domain = testDomain,
             manifest = null,
             prefetchedBlobs = emptyList(),
@@ -207,7 +215,7 @@ class BackendGetRemoteConfigTest {
         )
 
         val body = bodySlot.firstOrNull()
-        assertThat(body?.keys).containsExactlyInAnyOrder("domain", "prefetched_blobs")
+        assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "domain", "prefetched_blobs")
         assertThat(body).doesNotContainKey("manifest")
     }
 
@@ -220,6 +228,7 @@ class BackendGetRemoteConfigTest {
         var obtainedError: PurchasesError? = null
         backend.getRemoteConfig(
             appInBackground = false,
+            appUserID = testAppUserID,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -235,6 +244,7 @@ class BackendGetRemoteConfigTest {
         val lock = CountDownLatch(2)
         asyncBackend.getRemoteConfig(
             appInBackground = false,
+            appUserID = testAppUserID,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -243,6 +253,7 @@ class BackendGetRemoteConfigTest {
         )
         asyncBackend.getRemoteConfig(
             appInBackground = false,
+            appUserID = testAppUserID,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -252,6 +263,42 @@ class BackendGetRemoteConfigTest {
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
+            httpClient.performRequest(
+                mockBaseURL,
+                Endpoint.GetRemoteConfig,
+                body = any(),
+                postFieldsToSign = null,
+                requestHeaders = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `getRemoteConfig does not dedup concurrent calls for different app user ids`() {
+        mockHttpResult(payload = HTTPResult.Payload.RCFormat(buildContainer()), delayMs = 200)
+        val lock = CountDownLatch(2)
+        asyncBackend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = "user-a",
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> lock.countDown() },
+            onError = { fail("Expected success. Got error: $it") },
+        )
+        asyncBackend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = "user-b",
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> lock.countDown() },
+            onError = { fail("Expected success. Got error: $it") },
+        )
+        lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
+        assertThat(lock.count).isEqualTo(0)
+        // Different users must each get their own request rather than sharing the first caller's response.
+        verify(exactly = 2) {
             httpClient.performRequest(
                 mockBaseURL,
                 Endpoint.GetRemoteConfig,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -192,7 +192,7 @@ class EndpointTest {
     @Test
     fun `GetRemoteConfig has correct path`() {
         val endpoint = Endpoint.GetRemoteConfig
-        val expectedPath = "/v2/config"
+        val expectedPath = "/v1/config"
         assertThat(endpoint.getPath()).isEqualTo(expectedPath)
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/RCContainerTestData.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/RCContainerTestData.kt
@@ -18,7 +18,7 @@ internal object RCContainerTestData {
     const val FIXTURE_DIR = "rc_container"
 
     /**
-     * A representative `/v2/config` payload, modeled on `get_remote_config_success.json`. Stored as
+     * A representative `/v1/config` payload, modeled on `get_remote_config_success.json`. Stored as
      * the config element (element 0) of most fixtures so they resemble real wire data.
      */
     // language=json

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -30,6 +30,7 @@ class RemoteConfigManagerTest {
     private lateinit var diskCache: RemoteConfigDiskCache
     private lateinit var manager: RemoteConfigManager
 
+    private var capturedAppUserID: String? = null
     private var capturedDomain: String? = null
     private var capturedManifest: String? = null
     private var capturedPrefetchedBlobs: List<String>? = null
@@ -43,13 +44,14 @@ class RemoteConfigManagerTest {
         manager = RemoteConfigManager(backend, diskCache, dateProvider = FixedDateProvider)
 
         every {
-            backend.getRemoteConfig(any(), any(), any(), any(), any(), any())
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any())
         } answers {
-            capturedDomain = arg(1)
-            capturedManifest = arg(2)
-            capturedPrefetchedBlobs = arg(3)
-            onSuccess = arg(4)
-            onError = arg(5)
+            capturedAppUserID = arg(1)
+            capturedDomain = arg(2)
+            capturedManifest = arg(3)
+            capturedPrefetchedBlobs = arg(4)
+            onSuccess = arg(5)
+            onError = arg(6)
         }
     }
 
@@ -57,8 +59,9 @@ class RemoteConfigManagerTest {
     fun `first run sends the app domain with no manifest`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
 
+        assertThat(capturedAppUserID).isEqualTo(TEST_APP_USER_ID)
         assertThat(capturedDomain).isEqualTo("app")
         assertThat(capturedManifest).isNull()
         assertThat(capturedPrefetchedBlobs).isEmpty()
@@ -68,7 +71,7 @@ class RemoteConfigManagerTest {
     fun `replays the persisted opaque manifest on subsequent runs`() {
         every { diskCache.read() } returns persisted(manifest = "v1.123.sources:etag1", domain = "app")
 
-        manager.refreshRemoteConfig(appInBackground = false)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
 
         assertThat(capturedDomain).isEqualTo("app")
         assertThat(capturedManifest).isEqualTo("v1.123.sources:etag1")
@@ -87,7 +90,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         val written = slot<PersistedRemoteConfigurationState>()
@@ -118,7 +121,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         val written = slot<PersistedRemoteConfigurationState>()
@@ -139,7 +142,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         val written = slot<PersistedRemoteConfigurationState>()
@@ -151,7 +154,7 @@ class RemoteConfigManagerTest {
     fun `a 204 response leaves the cache untouched`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfig(appInBackground = false)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onSuccess.invoke(null, VerificationResult.VERIFIED)
 
         verify(exactly = 0) { diskCache.write(any()) }
@@ -161,17 +164,50 @@ class RemoteConfigManagerTest {
     fun `an error leaves the cache untouched`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfig(appInBackground = false)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onError.invoke(PurchasesError(PurchasesErrorCode.UnknownError, "boom"))
 
         verify(exactly = 0) { diskCache.write(any()) }
     }
 
     @Test
+    fun `a refresh while one is already in flight is skipped`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        // The first refresh has not settled yet (the stub captures callbacks without invoking them).
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a new refresh is allowed after a success settles the in-flight one`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a new refresh is allowed after an error settles the in-flight one`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(PurchasesError(PurchasesErrorCode.UnknownError, "boom"))
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `a malformed config payload leaves the cache untouched`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onSuccess.invoke(containerWithConfig("{ not valid json"), VerificationResult.VERIFIED)
 
         verify(exactly = 0) { diskCache.write(any()) }
@@ -196,6 +232,7 @@ class RemoteConfigManagerTest {
     }
 
     private companion object {
+        private const val TEST_APP_USER_ID = "test-app-user-id"
         private const val FIXED_MILLIS = 1_710_000_000_000L
         private val FixedDateProvider = object : DateProvider {
             override val now: Date get() = Date(FIXED_MILLIS)


### PR DESCRIPTION
### Description
3 main changes here:
- Changed to use `/v1/config` instead of `/v2/config`
- Add `app_user_id` to request body for config
- Avoid performing multiple requests simultaneously (or even with the backend dedupe, avoid the parsing and storage multiple times)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live remote-config URL and request contract and ties sync to the current app user ID; incorrect wiring could miss or mis-scope config until the next refresh.
> 
> **Overview**
> Aligns remote config sync with the **`/v1/config`** API: the endpoint path moves from **`/v2/config`**, and **`Backend.getRemoteConfig`** / **`RemoteConfigManager.refreshRemoteConfig`** now take **`appUserID`** and send **`app_user_id`** in the POST body (including first-run requests without a manifest).
> 
> **`RemoteConfigManager`** adds an in-flight guard so overlapping **`refreshRemoteConfig`** calls are skipped and the same response is not parsed or written to disk multiple times when the backend still fans out callbacks for deduped HTTP. The lock clears on success, error, and 204.
> 
> Tests and docs/comments are updated for the new path, body fields, and dedupe behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e817f232d4b295d0b690f3acdcde503f0712ea15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->