### PR TITLE
Fix workflow prefetch asset contention

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -65,9 +65,10 @@ import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencyManager
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import java.net.URL
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -366,19 +367,22 @@ internal class PurchasesFactory(
                 fontLoader = fontLoader,
             )
 
+            // Two dedicated thread pools for the delivery-critical workflow path, kept off Dispatchers.IO
+            // (unbounded font/image downloads) and Dispatchers.Default (image decoding) so background work
+            // can't starve workflow loading. Resolve (parse + signature verify + orchestration) and the
+            // blocking CDN downloads get SEPARATE pools — sharing one pool head-of-lines them and regressed.
+            val workflowCdnDispatcher = Executors.newScheduledThreadPool(MAX_CONCURRENT_WORKFLOW_CDN_FETCHES)
+                .asCoroutineDispatcher()
+            val workflowResolveDispatcher = Executors.newScheduledThreadPool(WORKFLOW_RESOLVE_THREADS)
+                .asCoroutineDispatcher()
             val workflowManager = workflowsCache?.let {
                 WorkflowManager(
                     backend = backend,
                     workflowDetailResolver = WorkflowDetailResolver(
                         workflowCdnFetcher = FileCachedWorkflowCdnFetcher(
-                            // Dedicated FileRepository instance with a concurrency-limited scope, so workflow
-                            // CDN downloads are capped without affecting the instances used for images/video.
                             fileRepository = DefaultFileRepository(
                                 fileCacheManager = DefaultFileCache(contextForStorage, "rc_compiled_workflows"),
-                                ioScope = CoroutineScope(
-                                    Dispatchers.IO.limitedParallelism(MAX_CONCURRENT_WORKFLOW_CDN_FETCHES) +
-                                        NonCancellable,
-                                ),
+                                ioScope = CoroutineScope(workflowCdnDispatcher + NonCancellable),
                             ),
                         ),
                     ),
@@ -391,6 +395,7 @@ internal class PurchasesFactory(
                         createConcurrentExecutor(),
                         runningIntegrationTests = runningIntegrationTests,
                     ),
+                    scope = CoroutineScope(SupervisorJob() + workflowResolveDispatcher),
                 )
             }
 
@@ -580,6 +585,7 @@ internal class PurchasesFactory(
         // Caps concurrent workflow CDN downloads on the dedicated workflows FileRepository scope, the
         // same way CONCURRENT_BACKEND_CALLS caps concurrent workflow detail fetches on prefetchDispatcher.
         private const val MAX_CONCURRENT_WORKFLOW_CDN_FETCHES = 4
+        private const val WORKFLOW_RESOLVE_THREADS = 4
 
         @VisibleForTesting
         internal fun shouldInitializeDiagnostics(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -263,12 +263,18 @@ internal class OfferingsManager(
                 handleErrorFetchingOfferings(error, onError)
             },
             onSuccess = { offeringsResultData ->
-                offeringsResultData.offerings.current?.let {
-                    offeringImagePreDownloader.preDownloadOfferingImages(it)
-                }
-                offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                 offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
-                val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
+                // Defer asset pre-download until after the workflow phase completes. The font/image
+                // downloads run unbounded on Dispatchers.IO; starting them here, before the workflow
+                // list + detail fetches, let them starve the delivery-critical workflow path. Running
+                // them once delivery is settled keeps the pre-warming without the contention.
+                val dispatchSuccess = {
+                    dispatch { onSuccess?.invoke(offeringsResultData) }
+                    offeringsResultData.offerings.current?.let {
+                        offeringImagePreDownloader.preDownloadOfferingImages(it)
+                    }
+                    offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
+                }
                 workflowManager?.getWorkflowsList(
                     appUserID,
                     appInBackground,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -73,6 +75,7 @@ internal class WorkflowManager(
         persistEnvelopeOnResolve: Boolean = false,
         staleWhileRevalidate: Boolean = true,
         recordOfferingIdMappingOnResolve: Boolean = true,
+        preDownloadAssetsOnResolve: Boolean = true,
     ) {
         // The identifier may be a workflow ID (prefetch, or a repeat render once the mapping is known)
         // or an offering ID (the on-demand render path asks by offering ID, and the backend lazily
@@ -112,6 +115,7 @@ internal class WorkflowManager(
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
                     offeringIdToRecordOnResolve = offeringIdToRecordOnResolve,
+                    preDownloadAssetsOnResolve = preDownloadAssetsOnResolve,
                     onSuccess = {},
                     onError = { error ->
                         errorLog {
@@ -130,6 +134,7 @@ internal class WorkflowManager(
                     callbackDispatcher = callbackDispatcher,
                     persistEnvelopeOnResolve = persistEnvelopeOnResolve,
                     offeringIdToRecordOnResolve = offeringIdToRecordOnResolve,
+                    preDownloadAssetsOnResolve = preDownloadAssetsOnResolve,
                     onSuccess = onSuccess,
                     onError = onError,
                 )
@@ -145,6 +150,7 @@ internal class WorkflowManager(
         callbackDispatcher: Dispatcher?,
         persistEnvelopeOnResolve: Boolean,
         offeringIdToRecordOnResolve: String?,
+        preDownloadAssetsOnResolve: Boolean,
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -162,9 +168,11 @@ internal class WorkflowManager(
                     return@launch
                 }
                 cacheResolvedWorkflow(result, response, persistEnvelopeOnResolve, offeringIdToRecordOnResolve)
-                scope.launch {
-                    runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result.workflow) }
-                        .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
+                if (preDownloadAssetsOnResolve) {
+                    scope.launch {
+                        runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result.workflow) }
+                            .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
+                    }
                 }
                 onSuccess(result)
             }
@@ -346,14 +354,19 @@ internal class WorkflowManager(
                         // sequence settles. A failed prefetch is logged and does not fail the others.
                         // Concurrency is bounded downstream, not here: detail fetches by prefetchDispatcher's
                         // thread pool, CDN downloads by the workflows FileRepository's limited scope.
-                        coroutineScope {
-                            prefetchWorkflows.forEach { summary ->
-                                launch {
-                                    prefetchWorkflow(appUserID, summary.id, appInBackground)
-                                }
-                            }
-                        }
+                        val prefetched = coroutineScope {
+                            prefetchWorkflows.map { summary ->
+                                async { prefetchWorkflow(appUserID, summary.id, appInBackground) }
+                            }.awaitAll()
+                        }.filterNotNull()
                         completePendingCallbacks(appUserID)
+                        // Offerings are delivered. Pre-download the prefetched workflows' assets now, so the
+                        // font/image downloads don't compete for bandwidth with the (now finished) workflow
+                        // detail + CDN fetches that gated delivery.
+                        prefetched.forEach { workflow ->
+                            runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(workflow) }
+                                .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
+                        }
                     }
                 },
                 onError = { error, behavior ->
@@ -414,9 +427,16 @@ internal class WorkflowManager(
      * Suspends until [getWorkflow] for [workflowId] resolves. Prefetch is best-effort, so a failure
      * is logged and the coroutine resumes normally instead of throwing, keeping one failed prefetch
      * from cancelling its siblings in the surrounding [coroutineScope].
+     *
+     * Returns the resolved [PublishedWorkflow] on success, or null on failure. Asset pre-download is
+     * deferred to the caller so it can batch the downloads after offerings delivery ([completePendingCallbacks]).
      */
-    private suspend fun prefetchWorkflow(appUserID: String, workflowId: String, appInBackground: Boolean) {
-        suspendCancellableCoroutine { continuation ->
+    private suspend fun prefetchWorkflow(
+        appUserID: String,
+        workflowId: String,
+        appInBackground: Boolean,
+    ): PublishedWorkflow? {
+        return suspendCancellableCoroutine { continuation ->
             getWorkflow(
                 appUserID = appUserID,
                 workflowOrOfferingId = workflowId,
@@ -425,10 +445,11 @@ internal class WorkflowManager(
                 persistEnvelopeOnResolve = true,
                 staleWhileRevalidate = false,
                 recordOfferingIdMappingOnResolve = false,
-                onSuccess = { continuation.safeResume(Unit) },
+                preDownloadAssetsOnResolve = false,
+                onSuccess = { continuation.safeResume(it.workflow) },
                 onError = { error ->
                     errorLog { "Failed to prefetch workflow $workflowId: ${error.underlyingErrorMessage}" }
-                    continuation.safeResume(Unit)
+                    continuation.safeResume(null)
                 },
             )
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -23,6 +23,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.json.JSONObject
@@ -645,6 +646,26 @@ class OfferingsManagerTest {
 
         verify(exactly = 1) {
             mockWorkflowManager.getWorkflowsList(appUserId, false, forceRefresh = true, onComplete = any())
+        }
+    }
+
+    @Test
+    fun `offering pre-downloads run after the workflow phase, not before`() {
+        every { cache.cachedOfferings } returns null
+        mockDeviceCache()
+        every { backend.getOfferings(any(), any(), captureLambda(), any()) } answers {
+            lambda<(JSONObject, HTTPResponseOriginalSource) -> Unit>().captured.invoke(
+                JSONObject(ONE_OFFERINGS_RESPONSE), HTTPResponseOriginalSource.MAIN,
+            )
+        }
+        mockOfferingsFactory()
+
+        offeringsManager.getOfferings(appUserId, appInBackground = false)
+
+        verifyOrder {
+            mockWorkflowManager.getWorkflowsList(any(), any(), any(), any())
+            offeringImagePreDownloader.preDownloadOfferingImages(testOfferings.current!!)
+            mockOfferingFontPreDownloader.preDownloadOfferingFontsIfNeeded(testOfferings)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -2387,4 +2387,56 @@ class WorkflowManagerTest {
     }
 
     // endregion onError envelope restore
+
+    // region prefetch asset pre-download ordering
+
+    @Test
+    fun `prefetch pre-downloads workflow assets only after onComplete fires`() {
+        val events = mutableListOf<String>()
+        // Arrange: workflows list returns one prefetched workflow; detail resolves successfully.
+        val workflow = workflowMock()
+        val detailResponse = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflow)
+        val resolvedResult = WorkflowDataResult(workflow = workflow, enrolledVariants = null)
+        coEvery { mockResolver.resolve(detailResponse) } returns resolvedResult
+
+        val listResponse = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = true),
+            ),
+        )
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any())
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            (args[3] as (WorkflowsListResponse) -> Unit).invoke(listResponse)
+        }
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            (args[3] as (WorkflowDetailResponse) -> Unit).invoke(detailResponse)
+        }
+        every { mockAssetPreDownloader.preDownloadWorkflowAssets(any()) } answers {
+            events.add("preDownloadAssets")
+        }
+
+        workflowManager.getWorkflowsList(
+            appUserID = "user_1",
+            appInBackground = false,
+            forceRefresh = true,
+            onComplete = { events.add("onComplete") },
+        )
+
+        // onComplete (offerings delivery) must come before the prefetch asset pre-download.
+        assertThat(events).containsExactly("onComplete", "preDownloadAssets")
+    }
+
+    // endregion prefetch asset pre-download ordering
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Workflow and offering asset pre-downloads could compete with delivery-critical workflow fetches and resolution work, delaying prefetched workflow availability.

### Description
This defers offering and workflow asset pre-downloads until after workflow delivery settles, returns prefetched workflow data so assets can be warmed afterward, and gives workflow CDN fetching and workflow resolution separate dedicated dispatchers. It also clarifies `AGENTS.md` so agent-opened PRs default to the `pr:other` label unless the user explicitly requests another primary label. Tested with `./gradlew :purchases:compileDefaultsBc8DebugKotlin` and `./gradlew :purchases:testDefaultsBc8DebugUnitTest --tests "com.revenuecat.purchases.common.offerings.OfferingsManagerTest" --tests "com.revenuecat.purchases.common.workflows.WorkflowManagerTest"`.
