### PR TITLE
feat(paywalls): render web_view component (PWENG-98)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ComponentView.kt
@@ -30,12 +30,14 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.TabsComponentSt
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TimelineComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabControlButtonView
 import com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabControlToggleView
 import com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabsComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.text.TextComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.timeline.TimelineComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.video.VideoComponentView
+import com.revenuecat.purchases.ui.revenuecatui.components.webview.WebViewComponentView
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
 
@@ -73,6 +75,11 @@ internal fun ComponentView(
             modifier = modifier,
         )
     }
+    is WebViewComponentStyle -> WebViewComponentView(
+        style = style,
+        state = state,
+        modifier = modifier,
+    )
     is ButtonComponentStyle -> ButtonComponentView(
         style = style,
         state = state,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -574,12 +574,23 @@ internal class StyleFactory(
             is TabsComponent -> createTabsComponentStyle(component)
             is VideoComponent -> createVideoComponentStyle(component)
             is FallbackHeaderComponent -> Result.Success(null)
-            is WebViewComponent -> Result.Success(null)
+            is WebViewComponent -> createWebViewComponentStyle(component)
             is CountdownComponent -> createCountdownComponentStyle(
                 component,
             )
         }
     }
+
+    private fun createWebViewComponentStyle(
+        component: WebViewComponent,
+    ): Result<WebViewComponentStyle, NonEmptyList<PaywallValidationError>> =
+        Result.Success(
+            WebViewComponentStyle(
+                urlTemplate = component.url,
+                visible = component.visible ?: DEFAULT_VISIBILITY,
+                size = component.size,
+            ),
+        )
 
     private fun StyleFactoryScope.createCountdownComponentStyle(
         component: CountdownComponent,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -586,7 +586,7 @@ internal class StyleFactory(
     ): Result<WebViewComponentStyle, NonEmptyList<PaywallValidationError>> =
         Result.Success(
             WebViewComponentStyle(
-                urlTemplate = component.url,
+                url = component.url,
                 visible = component.visible ?: DEFAULT_VISIBILITY,
                 size = component.size,
             ),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.paywalls.components.properties.Size
 
 @Immutable
 internal data class WebViewComponentStyle(
-    val urlTemplate: String,
+    val url: String,
     override val visible: Boolean,
     override val size: Size,
 ) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -1,0 +1,13 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.style
+
+import androidx.compose.runtime.Immutable
+import com.revenuecat.purchases.paywalls.components.properties.Size
+
+@Immutable
+internal data class WebViewComponentStyle(
+    val urlTemplate: String,
+    override val visible: Boolean,
+    override val size: Size,
+) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -18,6 +18,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 
 @JvmSynthetic
 @Composable
+@Suppress("UnusedParameter")
 internal fun WebViewComponentView(
     style: WebViewComponentStyle,
     state: PaywallState.Loaded.Components,
@@ -25,11 +26,8 @@ internal fun WebViewComponentView(
 ) {
     if (!style.visible) return
 
-    // Key on state.locale (a derivedState over the paywall's mutable locale) as well: a locale change
-    // mutates the same PaywallState instance in place, so without it the resolved URL — and the
-    // key(resolvedUrl) below — would stay stale for a locale-dependent template.
-    val resolvedUrl = remember(style.urlTemplate, state, state.locale) {
-        WebViewUrlResolver.resolve(style.urlTemplate, state)
+    val resolvedUrl = remember(style.url) {
+        WebViewUrlResolver.resolve(style.url)
     }
     // The web view URL is missing or did not resolve to a valid HTTPS URL with a host. web_view
     // availability is gated by SDK version on the frontend, so a delivered web_view is expected to
@@ -39,13 +37,13 @@ internal fun WebViewComponentView(
     // Key on the resolved URL so the WebView is created (and the page loaded) exactly once per intended
     // URL. We deliberately do NOT reload on every recomposition: in-page navigation changes WebView.url,
     // and reloading whenever it differs from resolvedUrl would reset a multi-step web flow. The WebView
-    // is only recreated when the SDK-resolved URL itself changes (e.g. a locale-dependent template).
+    // is only recreated when the SDK-resolved URL itself changes.
     key(resolvedUrl) {
         AndroidView(
             factory = { context ->
                 WebView(context).apply {
                     configure()
-                    loadUrl(resolvedUrl.toString())
+                    loadUrl(resolvedUrl)
                 }
             },
             onRelease = { webView ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -1,0 +1,78 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.graphics.Color
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+
+@JvmSynthetic
+@Composable
+internal fun WebViewComponentView(
+    style: WebViewComponentStyle,
+    state: PaywallState.Loaded.Components,
+    modifier: Modifier = Modifier,
+) {
+    if (!style.visible) return
+
+    // Key on state.locale (a derivedState over the paywall's mutable locale) as well: a locale change
+    // mutates the same PaywallState instance in place, so without it the resolved URL — and the
+    // key(resolvedUrl) below — would stay stale for a locale-dependent template.
+    val resolvedUrl = remember(style.urlTemplate, state, state.locale) {
+        WebViewUrlResolver.resolve(style.urlTemplate, state)
+    }
+    // The web view URL is missing or did not resolve to a valid HTTPS URL with a host. web_view
+    // availability is gated by SDK version on the frontend, so a delivered web_view is expected to
+    // always resolve; render nothing rather than crashing if it doesn't.
+    if (resolvedUrl == null) return
+
+    // Key on the resolved URL so the WebView is created (and the page loaded) exactly once per intended
+    // URL. We deliberately do NOT reload on every recomposition: in-page navigation changes WebView.url,
+    // and reloading whenever it differs from resolvedUrl would reset a multi-step web flow. The WebView
+    // is only recreated when the SDK-resolved URL itself changes (e.g. a locale-dependent template).
+    key(resolvedUrl) {
+        AndroidView(
+            factory = { context ->
+                WebView(context).apply {
+                    configure()
+                    loadUrl(resolvedUrl.toString())
+                }
+            },
+            onRelease = { webView ->
+                webView.stopLoading()
+                webView.webViewClient = WebViewClient()
+                webView.destroy()
+            },
+            modifier = modifier.size(style.size),
+        )
+    }
+}
+
+private fun WebView.configure() {
+    setBackgroundColor(Color.TRANSPARENT)
+    isVerticalScrollBarEnabled = false
+    isHorizontalScrollBarEnabled = false
+    settings.allowContentAccess = false
+    settings.allowFileAccess = false
+    settings.cacheMode = WebSettings.LOAD_DEFAULT
+    settings.domStorageEnabled = true
+    settings.javaScriptEnabled = true
+    settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+    webViewClient = object : WebViewClient() {
+        override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+            return request.url.scheme != HTTPS_SCHEME
+        }
+    }
+}
+
+private const val HTTPS_SCHEME = "https"

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
@@ -2,45 +2,17 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
-import com.revenuecat.purchases.UiConfig
-import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
-import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toJavaLocale
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
-import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableProcessorV2
-import java.net.URL
-import java.util.Locale
+import android.net.Uri
 
 internal object WebViewUrlResolver {
 
-    fun resolve(
-        urlTemplate: String,
-        state: PaywallState.Loaded.Components,
-    ): URL? = resolve(
-        urlTemplate = urlTemplate,
-        variableConfig = state.variableConfig,
-        customVariables = state.customVariables,
-        defaultCustomVariables = state.defaultCustomVariables,
-        locale = state.locale.toJavaLocale(),
-    )
+    fun resolve(url: String): String? {
+        if (url.contains("{{")) return null
 
-    fun resolve(
-        urlTemplate: String,
-        variableConfig: UiConfig.VariableConfig,
-        customVariables: Map<String, CustomVariableValue>,
-        defaultCustomVariables: Map<String, CustomVariableValue>,
-        locale: Locale,
-    ): URL? {
-        val resolvedUrl = VariableProcessorV2.processVariables(
-            template = urlTemplate,
-            variableConfig = variableConfig,
-            dateLocale = locale,
-            customVariables = customVariables,
-            defaultCustomVariables = defaultCustomVariables,
-        )
-
-        return runCatching { URL(resolvedUrl) }
-            .getOrNull()
-            ?.takeIf { it.protocol == HTTPS_SCHEME && it.host.isNotBlank() }
+        val uri = Uri.parse(url)
+        return url.takeIf {
+            uri.scheme == HTTPS_SCHEME && !uri.host.isNullOrBlank()
+        }
     }
 
     private const val HTTPS_SCHEME = "https"

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
@@ -1,0 +1,47 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toJavaLocale
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableProcessorV2
+import java.net.URL
+import java.util.Locale
+
+internal object WebViewUrlResolver {
+
+    fun resolve(
+        urlTemplate: String,
+        state: PaywallState.Loaded.Components,
+    ): URL? = resolve(
+        urlTemplate = urlTemplate,
+        variableConfig = state.variableConfig,
+        customVariables = state.customVariables,
+        defaultCustomVariables = state.defaultCustomVariables,
+        locale = state.locale.toJavaLocale(),
+    )
+
+    fun resolve(
+        urlTemplate: String,
+        variableConfig: UiConfig.VariableConfig,
+        customVariables: Map<String, CustomVariableValue>,
+        defaultCustomVariables: Map<String, CustomVariableValue>,
+        locale: Locale,
+    ): URL? {
+        val resolvedUrl = VariableProcessorV2.processVariables(
+            template = urlTemplate,
+            variableConfig = variableConfig,
+            dateLocale = locale,
+            customVariables = customVariables,
+            defaultCustomVariables = defaultCustomVariables,
+        )
+
+        return runCatching { URL(resolvedUrl) }
+            .getOrNull()
+            ?.takeIf { it.protocol == HTTPS_SCHEME && it.host.isNotBlank() }
+    }
+
+    private const val HTTPS_SCHEME = "https"
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.paywalls.components.TabControlComponent
 import com.revenuecat.purchases.paywalls.components.TabControlToggleComponent
 import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
@@ -116,6 +117,25 @@ class StyleFactoryTests {
             .isEqualTo(localizations.getValue(localeId)[LOCALIZATION_KEY_TEXT_1]!!.value)
         val colorStyle = style.color.light as ColorStyle.Solid
         assertThat(colorStyle.color).isEqualTo(expectedColor)
+    }
+
+    @Test
+    fun `Should create a WebViewComponentStyle for a WebViewComponent`() {
+        val size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit)
+        val component = WebViewComponent(
+            url = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
+            id = "promo_web_view",
+            visible = false,
+            size = size,
+        )
+
+        val result = styleFactory.create(component)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as WebViewComponentStyle
+        assertThat(style.urlTemplate).isEqualTo("https://paywalls.revenuecat.com/{{ custom.animal }}.html")
+        assertThat(style.visible).isFalse()
+        assertThat(style.size).isEqualTo(size)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -133,7 +133,7 @@ class StyleFactoryTests {
 
         assertThat(result).isInstanceOf(Result.Success::class.java)
         val style = (result as Result.Success).value.componentStyle as WebViewComponentStyle
-        assertThat(style.urlTemplate).isEqualTo("https://paywalls.revenuecat.com/{{ custom.animal }}.html")
+        assertThat(style.url).isEqualTo("https://paywalls.revenuecat.com/{{ custom.animal }}.html")
         assertThat(style.visible).isFalse()
         assertThat(style.size).isEqualTo(size)
     }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
@@ -1,0 +1,83 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+class WebViewUrlResolverTest {
+
+    @Test
+    fun `resolves static https url unchanged`() {
+        val result = resolve("https://paywalls.revenuecat.com/index.html")
+
+        assertThat(result?.toString()).isEqualTo("https://paywalls.revenuecat.com/index.html")
+    }
+
+    @Test
+    fun `resolves static https url with characters accepted by WebView`() {
+        val result = resolve("https://paywalls.revenuecat.com/index.html?filters=a|b")
+
+        assertThat(result?.toString()).isEqualTo("https://paywalls.revenuecat.com/index.html?filters=a|b")
+    }
+
+    @Test
+    fun `substitutes custom variables into the template before validating`() {
+        val result = resolve(
+            template = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
+            customVariables = mapOf("animal" to CustomVariableValue.String("dog")),
+        )
+
+        assertThat(result?.toString()).isEqualTo("https://paywalls.revenuecat.com/dog.html")
+    }
+
+    @Test
+    fun `returns null for malformed url`() {
+        val result = resolve("not a url")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for malformed https url`() {
+        val result = resolve("https:///missing-host")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for non https url`() {
+        val result = resolve("http://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for file url`() {
+        val result = resolve("file:///android_asset/index.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for custom scheme url`() {
+        val result = resolve("myapp://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isNull()
+    }
+
+    private fun resolve(
+        template: String,
+        customVariables: Map<String, CustomVariableValue> = emptyMap(),
+    ) = WebViewUrlResolver.resolve(
+        urlTemplate = template,
+        variableConfig = UiConfig.VariableConfig(),
+        customVariables = customVariables,
+        defaultCustomVariables = emptyMap(),
+        locale = Locale.US,
+    )
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
@@ -1,83 +1,66 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
-import com.revenuecat.purchases.UiConfig
-import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 class WebViewUrlResolverTest {
 
     @Test
     fun `resolves static https url unchanged`() {
-        val result = resolve("https://paywalls.revenuecat.com/index.html")
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/index.html")
 
-        assertThat(result?.toString()).isEqualTo("https://paywalls.revenuecat.com/index.html")
+        assertThat(result).isEqualTo("https://paywalls.revenuecat.com/index.html")
     }
 
     @Test
     fun `resolves static https url with characters accepted by WebView`() {
-        val result = resolve("https://paywalls.revenuecat.com/index.html?filters=a|b")
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/index.html?filters=a|b")
 
-        assertThat(result?.toString()).isEqualTo("https://paywalls.revenuecat.com/index.html?filters=a|b")
+        assertThat(result).isEqualTo("https://paywalls.revenuecat.com/index.html?filters=a|b")
     }
 
     @Test
-    fun `substitutes custom variables into the template before validating`() {
-        val result = resolve(
-            template = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
-            customVariables = mapOf("animal" to CustomVariableValue.String("dog")),
-        )
+    fun `returns null for url containing template placeholders`() {
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/{{ custom.animal }}.html")
 
-        assertThat(result?.toString()).isEqualTo("https://paywalls.revenuecat.com/dog.html")
+        assertThat(result).isNull()
     }
 
     @Test
     fun `returns null for malformed url`() {
-        val result = resolve("not a url")
+        val result = WebViewUrlResolver.resolve("not a url")
 
         assertThat(result).isNull()
     }
 
     @Test
     fun `returns null for malformed https url`() {
-        val result = resolve("https:///missing-host")
+        val result = WebViewUrlResolver.resolve("https:///missing-host")
 
         assertThat(result).isNull()
     }
 
     @Test
     fun `returns null for non https url`() {
-        val result = resolve("http://paywalls.revenuecat.com/index.html")
+        val result = WebViewUrlResolver.resolve("http://paywalls.revenuecat.com/index.html")
 
         assertThat(result).isNull()
     }
 
     @Test
     fun `returns null for file url`() {
-        val result = resolve("file:///android_asset/index.html")
+        val result = WebViewUrlResolver.resolve("file:///android_asset/index.html")
 
         assertThat(result).isNull()
     }
 
     @Test
     fun `returns null for custom scheme url`() {
-        val result = resolve("myapp://paywalls.revenuecat.com/index.html")
+        val result = WebViewUrlResolver.resolve("myapp://paywalls.revenuecat.com/index.html")
 
         assertThat(result).isNull()
     }
-
-    private fun resolve(
-        template: String,
-        customVariables: Map<String, CustomVariableValue> = emptyMap(),
-    ) = WebViewUrlResolver.resolve(
-        urlTemplate = template,
-        variableConfig = UiConfig.VariableConfig(),
-        customVariables = customVariables,
-        defaultCustomVariables = emptyMap(),
-        locale = Locale.US,
-    )
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
With the `web_view` schema in place, the component needs to actually render its hosted content in a Paywalls V2 paywall.


Part of PWENG-98.

### Description
- Adds `WebViewComponentView` (a `WebView` hosted via `AndroidView`), `WebViewComponentStyle`, the `StyleFactory` mapping, and `ComponentView` dispatch.
- Adds `WebViewUrlResolver`: resolves the URL template against paywall variables natively, then validates it is an HTTPS URL with a host. If it does not resolve, the component renders nothing (availability is gated by SDK version on the frontend).
- No bridge or CSP yet — those land in later PRs.
- Tested by `StyleFactoryTests` and `WebViewUrlResolverTest`.

iOS parity: mirrors `purchases-ios` (`web-view-bridge-wiring`).
Stack (merge bottom-up): schema → **rendering** → CSP → value types → message model → variables provider → JS bridge → wiring.

<!-- FOLDED_HARDENING_BEGIN -->
### Folded-in hardening

[`ece0920d88772848811b3ae260a5ba2f9ab4920c`](https://github.com/RevenueCat/purchases-android/commit/ece0920d88772848811b3ae260a5ba2f9ab4920c) was folded into this stack level. It removes custom-variable substitution from `web_view` URLs, so the component validates and loads a literal HTTPS URL while runtime variables flow only through bridge messaging. It also removes `java.net.URL` from the Compose identity path, avoiding DNS-backed equality and hashing during recomposition.

This supersedes older generated summary text that described native URL-template substitution.
<!-- FOLDED_HARDENING_END -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces WebView with JavaScript enabled and external URL loading in the paywall surface; mitigations are HTTPS-only validation and navigation blocking, but CSP/bridge are still out of scope for this PR.
> 
> **Overview**
> Paywalls V2 **`web_view`** components now render hosted HTTPS content instead of being dropped during style creation.
> 
> **Style pipeline:** `StyleFactory` maps `WebViewComponent` to `WebViewComponentStyle` (URL template, visibility, size), and `ComponentView` dispatches to the new composable.
> 
> **Rendering:** `WebViewComponentView` hosts an `AndroidView` `WebView` that resolves the URL via `WebViewUrlResolver` (paywall variables + locale), accepts only **HTTPS** URLs with a host, and renders nothing on failure. The WebView is keyed on the resolved URL so in-page navigation is not reset on recomposition; locale changes still refresh locale-dependent templates. Settings restrict file/content access, disallow mixed content, enable JS/DOM storage, and block non-HTTPS navigations in `shouldOverrideUrlLoading`.
> 
> **Tests:** `StyleFactoryTests` for style mapping and `WebViewUrlResolverTest` for URL resolution and rejection of non-HTTPS/malformed URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb98441f25058247c3c7ffd6ca98c3c515b3615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->