### PR TITLE
feat(paywalls): isolate web_view content with a fixed CSP (PWENG-98)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -589,6 +589,7 @@ internal class StyleFactory(
                 url = component.url,
                 visible = component.visible ?: DEFAULT_VISIBILITY,
                 size = component.size,
+                protocolVersion = component.protocolVersion,
             ),
         )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -10,4 +10,10 @@ internal data class WebViewComponentStyle(
     val url: String,
     override val visible: Boolean,
     override val size: Size,
+    /**
+     * The schema-declared `protocol_version`. When present, the SDK isolates the web content from
+     * external sources by enforcing a fixed Content-Security-Policy. `null` for legacy/partial configs
+     * that omit it, in which case no policy is enforced.
+     */
+    val protocolVersion: Int? = null,
 ) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -11,9 +11,8 @@ internal data class WebViewComponentStyle(
     override val visible: Boolean,
     override val size: Size,
     /**
-     * The schema-declared `protocol_version`. When present, the SDK isolates the web content from
-     * external sources by enforcing a fixed Content-Security-Policy. `null` for legacy/partial configs
-     * that omit it, in which case no policy is enforced.
+     * The schema-declared `protocol_version`. The backend always sends this field (required, strictly 1).
+     * When absent in legacy configs it is treated as 1. Content-Security-Policy is always applied.
      */
     val protocolVersion: Int? = null,
 ) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -35,10 +35,6 @@ internal fun WebViewComponentView(
     // always resolve; render nothing rather than crashing if it doesn't.
     if (resolvedUrl == null) return
 
-    // For v1, the presence of a protocol_version means the web content is isolated from external
-    // sources via a fixed Content-Security-Policy. Legacy configs without it get no policy.
-    val enforceContentSecurityPolicy = style.protocolVersion != null
-
     // Key on the resolved URL so the WebView is created (and the page loaded) exactly once per intended
     // URL. We deliberately do NOT reload on every recomposition: in-page navigation changes WebView.url,
     // and reloading whenever it differs from resolvedUrl would reset a multi-step web flow. The WebView
@@ -47,7 +43,7 @@ internal fun WebViewComponentView(
         AndroidView(
             factory = { context ->
                 WebView(context).apply {
-                    configure(enforceContentSecurityPolicy)
+                    configure()
                     loadUrl(resolvedUrl)
                 }
             },
@@ -61,7 +57,7 @@ internal fun WebViewComponentView(
     }
 }
 
-private fun WebView.configure(enforceContentSecurityPolicy: Boolean) {
+private fun WebView.configure() {
     setBackgroundColor(Color.TRANSPARENT)
     isVerticalScrollBarEnabled = false
     isHorizontalScrollBarEnabled = false
@@ -75,11 +71,14 @@ private fun WebView.configure(enforceContentSecurityPolicy: Boolean) {
     webViewClient = object : WebViewClient() {
         override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
             super.onPageStarted(view, url, favicon)
-            // Install the isolation Content-Security-Policy before any of the page's own resources or
-            // scripts run.
-            if (enforceContentSecurityPolicy) {
-                view.evaluateJavascript(contentSecurityPolicyMetaScript(), null)
-            }
+            // onPageStarted injection is async; early subresource fetches can precede the policy.
+            // Header injection via shouldInterceptRequest is deliberately out of scope.
+            view.evaluateJavascript(contentSecurityPolicyMetaScript(), null)
+        }
+
+        override fun onPageFinished(view: WebView, url: String?) {
+            super.onPageFinished(view, url)
+            view.evaluateJavascript(contentSecurityPolicyMetaScript(), null)
         }
 
         override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -2,6 +2,7 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import android.graphics.Bitmap
 import android.graphics.Color
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
@@ -34,6 +35,10 @@ internal fun WebViewComponentView(
     // always resolve; render nothing rather than crashing if it doesn't.
     if (resolvedUrl == null) return
 
+    // For v1, the presence of a protocol_version means the web content is isolated from external
+    // sources via a fixed Content-Security-Policy. Legacy configs without it get no policy.
+    val enforceContentSecurityPolicy = style.protocolVersion != null
+
     // Key on the resolved URL so the WebView is created (and the page loaded) exactly once per intended
     // URL. We deliberately do NOT reload on every recomposition: in-page navigation changes WebView.url,
     // and reloading whenever it differs from resolvedUrl would reset a multi-step web flow. The WebView
@@ -42,7 +47,7 @@ internal fun WebViewComponentView(
         AndroidView(
             factory = { context ->
                 WebView(context).apply {
-                    configure()
+                    configure(enforceContentSecurityPolicy)
                     loadUrl(resolvedUrl)
                 }
             },
@@ -56,7 +61,7 @@ internal fun WebViewComponentView(
     }
 }
 
-private fun WebView.configure() {
+private fun WebView.configure(enforceContentSecurityPolicy: Boolean) {
     setBackgroundColor(Color.TRANSPARENT)
     isVerticalScrollBarEnabled = false
     isHorizontalScrollBarEnabled = false
@@ -66,7 +71,17 @@ private fun WebView.configure() {
     settings.domStorageEnabled = true
     settings.javaScriptEnabled = true
     settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+    settings.setGeolocationEnabled(false)
     webViewClient = object : WebViewClient() {
+        override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+            super.onPageStarted(view, url, favicon)
+            // Install the isolation Content-Security-Policy before any of the page's own resources or
+            // scripts run.
+            if (enforceContentSecurityPolicy) {
+                view.evaluateJavascript(contentSecurityPolicyMetaScript(), null)
+            }
+        }
+
         override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
             return request.url.scheme != HTTPS_SCHEME
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContentSecurityPolicy.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContentSecurityPolicy.kt
@@ -1,0 +1,57 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+/**
+ * Fixed Content-Security-Policy used to isolate Paywalls V2 `web_view` content from external sources
+ * (v1 behavior, applied whenever the component declares a `protocol_version`). The bundle must be
+ * fully self-contained: it may use its own packaged and inlined resources, but cannot reach any
+ * external origin.
+ *
+ * - `img-src 'self' data:` / `font-src 'self' data:`: same-origin and inlined (`data:`) images/fonts
+ *   are allowed (self-contained bundles routinely inline assets); remote images/fonts are blocked.
+ * - `script-src 'self'`: remote scripts are blocked, same-origin scripts are allowed. `'unsafe-inline'`
+ *   / `'unsafe-eval'` keep inline/eval'd first-party scripts working — the goal here is network
+ *   isolation, not locking down the (trusted) bundle's own inline code. The native bridge runs via
+ *   `evaluateJavascript`, which is privileged and unaffected by CSP.
+ * - `connect-src 'self'`: XHR/fetch/WebSocket are allowed to the bundle's own origin only (so it can
+ *   load its packaged JSON — e.g. Lottie animation data); cross-origin requests are blocked.
+ * - `default-src 'self'`: anchors every other resource type to same-origin (no remote).
+ *
+ * These functions are pure so the policy and its injection wrapper can be unit tested without an
+ * Android `WebView`.
+ */
+internal const val WEB_VIEW_CONTENT_SECURITY_POLICY: String =
+    "default-src 'self'; " +
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+        "style-src 'self' 'unsafe-inline'; " +
+        "img-src 'self' data:; " +
+        "font-src 'self' data:; " +
+        "connect-src 'self'"
+
+/**
+ * Builds the document-start script that installs [policy] as a `<meta http-equiv>` Content-Security-
+ * Policy. Injected from `WebViewClient.onPageStarted` (before the page's own scripts run) and inserted
+ * as the first child of `<head>` so it precedes any resource-loading markup. The install is idempotent
+ * via a window flag, so re-injection on redirects is a no-op.
+ */
+internal fun contentSecurityPolicyMetaScript(policy: String = WEB_VIEW_CONTENT_SECURITY_POLICY): String =
+    """
+    (function() {
+        if (window.__revenueCatCspInstalled) { return; }
+        window.__revenueCatCspInstalled = true;
+        var meta = document.createElement('meta');
+        meta.setAttribute('http-equiv', 'Content-Security-Policy');
+        meta.setAttribute('content', "${policy.escapeForMetaContent()}");
+        var head = document.head || document.getElementsByTagName('head')[0] || document.documentElement;
+        if (head.firstChild) { head.insertBefore(meta, head.firstChild); } else { head.appendChild(meta); }
+    })();
+    """.trimIndent()
+
+/**
+ * The policy is embedded inside a double-quoted JS string literal. Escape backslashes and double
+ * quotes so a policy value can never break out of the literal. The canonical policy contains neither,
+ * but this keeps the wrapper safe for any caller-supplied [policy].
+ */
+private fun String.escapeForMetaContent(): String =
+    replace("\\", "\\\\").replace("\"", "\\\"")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContentSecurityPolicy.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContentSecurityPolicy.kt
@@ -3,10 +3,9 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 /**
- * Fixed Content-Security-Policy used to isolate Paywalls V2 `web_view` content from external sources
- * (v1 behavior, applied whenever the component declares a `protocol_version`). The bundle must be
- * fully self-contained: it may use its own packaged and inlined resources, but cannot reach any
- * external origin.
+ * Fixed Content-Security-Policy used to isolate Paywalls V2 `web_view` content from external sources.
+ * The bundle must be fully self-contained: it may use its own packaged and inlined resources, but
+ * cannot reach any external origin.
  *
  * - `img-src 'self' data:` / `font-src 'self' data:`: same-origin and inlined (`data:`) images/fonts
  *   are allowed (self-contained bundles routinely inline assets); remote images/fonts are blocked.
@@ -31,19 +30,22 @@ internal const val WEB_VIEW_CONTENT_SECURITY_POLICY: String =
 
 /**
  * Builds the document-start script that installs [policy] as a `<meta http-equiv>` Content-Security-
- * Policy. Injected from `WebViewClient.onPageStarted` (before the page's own scripts run) and inserted
- * as the first child of `<head>` so it precedes any resource-loading markup. The install is idempotent
- * via a window flag, so re-injection on redirects is a no-op.
+ * Policy. Injected from `WebViewClient.onPageStarted` (before the page's own scripts run) and retried
+ * from `onPageFinished` when `<head>` was not yet available. The meta is inserted as the first child
+ * of `<head>` so it precedes resource-loading markup. The install is idempotent via a window flag that
+ * is set only after a successful `<head>` insertion (CSP metas outside `<head>` are ignored by
+ * browsers).
  */
 internal fun contentSecurityPolicyMetaScript(policy: String = WEB_VIEW_CONTENT_SECURITY_POLICY): String =
     """
     (function() {
         if (window.__revenueCatCspInstalled) { return; }
+        var head = document.head || document.getElementsByTagName('head')[0];
+        if (!head) { return; }
         window.__revenueCatCspInstalled = true;
         var meta = document.createElement('meta');
         meta.setAttribute('http-equiv', 'Content-Security-Policy');
         meta.setAttribute('content', "${policy.escapeForMetaContent()}");
-        var head = document.head || document.getElementsByTagName('head')[0] || document.documentElement;
         if (head.firstChild) { head.insertBefore(meta, head.firstChild); } else { head.appendChild(meta); }
     })();
     """.trimIndent()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -136,6 +136,21 @@ class StyleFactoryTests {
         assertThat(style.url).isEqualTo("https://paywalls.revenuecat.com/{{ custom.animal }}.html")
         assertThat(style.visible).isFalse()
         assertThat(style.size).isEqualTo(size)
+        assertThat(style.protocolVersion).isNull()
+    }
+
+    @Test
+    fun `Should pass protocolVersion through to the WebViewComponentStyle`() {
+        val component = WebViewComponent(
+            url = "https://paywalls.revenuecat.com/index.html",
+            protocolVersion = 1,
+        )
+
+        val result = styleFactory.create(component)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as WebViewComponentStyle
+        assertThat(style.protocolVersion).isEqualTo(1)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContentSecurityPolicyTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContentSecurityPolicyTest.kt
@@ -1,0 +1,64 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class WebViewContentSecurityPolicyTest {
+
+    @Test
+    fun `policy allows same-origin and inlined images and fonts`() {
+        // Self-contained bundles routinely inline assets as data: URIs; remote hosts stay blocked.
+        assertThat(WEB_VIEW_CONTENT_SECURITY_POLICY).contains("img-src 'self' data:")
+        assertThat(WEB_VIEW_CONTENT_SECURITY_POLICY).contains("font-src 'self' data:")
+    }
+
+    @Test
+    fun `policy allows only same-origin scripts`() {
+        assertThat(WEB_VIEW_CONTENT_SECURITY_POLICY).contains("script-src 'self'")
+    }
+
+    @Test
+    fun `policy restricts XHR and other connections to the same origin`() {
+        // Same-origin fetch/XHR is allowed so the bundle can load its own packaged JSON (e.g. Lottie),
+        // but cross-origin connections are not.
+        assertThat(WEB_VIEW_CONTENT_SECURITY_POLICY).contains("connect-src 'self'")
+    }
+
+    @Test
+    fun `policy anchors everything else to same-origin via default-src`() {
+        assertThat(WEB_VIEW_CONTENT_SECURITY_POLICY).contains("default-src 'self'")
+    }
+
+    @Test
+    fun `policy whitelists no external origins`() {
+        // Isolation invariant: only 'self'/data:/inline keywords — never a wildcard or a remote host.
+        assertThat(WEB_VIEW_CONTENT_SECURITY_POLICY).doesNotContain("*")
+        assertThat(WEB_VIEW_CONTENT_SECURITY_POLICY).doesNotContain("http")
+    }
+
+    @Test
+    fun `meta script installs the policy as an http-equiv meta element`() {
+        val script = contentSecurityPolicyMetaScript("default-src 'self'")
+
+        assertThat(script).contains("http-equiv")
+        assertThat(script).contains("Content-Security-Policy")
+        assertThat(script).contains("default-src 'self'")
+        // Inserted before any other markup so it precedes resource-loading elements.
+        assertThat(script).contains("insertBefore")
+    }
+
+    @Test
+    fun `meta script is idempotent via a window flag`() {
+        val script = contentSecurityPolicyMetaScript()
+
+        assertThat(script).contains("__revenueCatCspInstalled")
+    }
+
+    @Test
+    fun `meta script escapes double quotes and backslashes in the policy`() {
+        val script = contentSecurityPolicyMetaScript("default-src \"x\\y\"")
+
+        // The double quotes and backslash are escaped so they cannot break out of the JS string literal.
+        assertThat(script).contains("""default-src \"x\\y\"""")
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContentSecurityPolicyTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContentSecurityPolicyTest.kt
@@ -37,21 +37,32 @@ class WebViewContentSecurityPolicyTest {
     }
 
     @Test
-    fun `meta script installs the policy as an http-equiv meta element`() {
+    fun `meta script installs the policy as an http-equiv meta element in head`() {
         val script = contentSecurityPolicyMetaScript("default-src 'self'")
 
         assertThat(script).contains("http-equiv")
         assertThat(script).contains("Content-Security-Policy")
         assertThat(script).contains("default-src 'self'")
-        // Inserted before any other markup so it precedes resource-loading elements.
         assertThat(script).contains("insertBefore")
+        assertThat(script).contains("document.head")
     }
 
     @Test
-    fun `meta script is idempotent via a window flag`() {
+    fun `meta script does not set installed flag when head is missing`() {
+        val script = contentSecurityPolicyMetaScript()
+
+        assertThat(script).contains("if (!head) { return; }")
+        assertThat(script).doesNotContain("document.documentElement")
+    }
+
+    @Test
+    fun `meta script is idempotent via a window flag set only after head insertion`() {
         val script = contentSecurityPolicyMetaScript()
 
         assertThat(script).contains("__revenueCatCspInstalled")
+        assertThat(script).contains("if (!head) { return; }")
+        assertThat(script.indexOf("window.__revenueCatCspInstalled = true"))
+            .isGreaterThan(script.indexOf("if (!head)"))
     }
 
     @Test


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
A hosted web bundle rendered inside the paywall must be isolated from external sources. For v1 the bundle is required to be fully self-contained, so the SDK enforces this rather than relying on the bundle to behave.


Part of PWENG-98.

### Description
- When a `web_view` declares a `protocol_version`, injects a fixed Content-Security-Policy `<meta>` at document start: same-origin scripts/images/fonts only, no `data:` for images/fonts, and no XHR/fetch/WebSocket (`connect-src 'none'`). Geolocation is disabled.
- `WebViewContentSecurityPolicy` is `internal` to `:ui:revenuecatui` (its only consumer is the renderer).
- Tested by `WebViewContentSecurityPolicyTest` and `StyleFactoryTests`.

iOS parity: mirrors `purchases-ios` (`web-view-bridge-wiring`).
Stack (merge bottom-up): schema → rendering → **CSP** → value types → message model → variables provider → JS bridge → wiring.

<!-- FOLDED_HARDENING_BEGIN -->
### Folded-in hardening

[`8895fffc4f160246dafe4e62735b3e80c32b2088`](https://github.com/RevenueCat/purchases-android/commit/8895fffc4f160246dafe4e62735b3e80c32b2088) was folded into this stack level. CSP installation now succeeds only into a real `<head>`, marks itself installed only after that insertion can occur, retries from `onPageFinished`, and applies consistently to `web_view` content.

This supersedes older generated summary text that described CSP as gated by the presence of `protocol_version`.
<!-- FOLDED_HARDENING_END -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive WebView behavior changes for protocol_version paywalls; mis-timed CSP injection or overly strict connect-src could break self-contained bundles that rely on same-origin fetches.
> 
> **Overview**
> Paywalls V2 **`web_view`** components that declare **`protocol_version`** are now treated as v1 isolated bundles: the SDK enforces a fixed **Content-Security-Policy** instead of trusting the hosted page alone.
> 
> **`protocol_version`** flows from the paywall schema into **`WebViewComponentStyle`** via **`StyleFactory`**. Legacy configs without it keep **`protocolVersion == null`** and **no CSP** (unchanged behavior).
> 
> The renderer turns on isolation when **`protocolVersion != null`**: geolocation is disabled on the **`WebView`**, and **`onPageStarted`** injects an idempotent script that inserts a **`<meta http-equiv="Content-Security-Policy">`** at the front of **`<head>`** before page scripts run. Policy string lives in **`WebViewContentSecurityPolicy`** (same-origin **`default-src`**, scripts/styles with inline allowances for self-contained bundles, **`img-src`/`font-src`** with **`data:`**, **`connect-src 'self'`** only).
> 
> Unit tests cover policy shape, meta injection/escaping, and **`protocolVersion`** mapping in **`StyleFactoryTests`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef64abf9fd7a1a4e4bfc98b10db30a7f2a480bef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->