### PR TITLE
feat(paywalls): add web_view JavaScript bridge (PWENG-98)

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -5,7 +5,6 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
-import com.revenuecat.purchases.paywalls.components.StackComponent
 import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.StackComponent
 import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -36,4 +37,6 @@ public class WebViewComponent(
     public val protocolVersion: Int? = null,
     @get:JvmSynthetic
     public val size: Size = Size(width = Fill, height = SizeConstraint.Fit),
+    @get:JvmSynthetic
+    public val fallback: StackComponent? = null,
 ) : PaywallComponent

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -23,7 +23,11 @@ class WebViewComponentTests {
             "height": { "type": "fit" }
           },
           "visible": true,
-          "name": "Promo web component"
+          "name": "Promo web component",
+          "fallback": {
+            "type": "stack",
+            "components": []
+          }
         }
         """
 
@@ -40,6 +44,8 @@ class WebViewComponentTests {
         assertThat(webView.protocolVersion).isEqualTo(1)
         assertThat(webView.url).isEqualTo("https://assets.pawwalls.com/web_bundles/123/index.html")
         assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit))
+        assertThat(webView.fallback).isNotNull
+        assertThat(webView.fallback?.components).isEmpty()
     }
 
     @Test

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewMessage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewMessage.kt
@@ -36,11 +36,10 @@ public interface PaywallWebViewController {
 
     /**
      * Sends a `rc:variables` message into the web view targeting [componentId]. The SDK already replies
-     * with SDK-managed variables (such as `locale`); use this to provide additional values, typically
-     * nested under the `custom` key.
-     *
-     * Reserved SDK-managed top-level keys cannot be overwritten; provide app-specific values under
-     * `custom`.
+     * with SDK-managed variables (such as `locale`); use this to provide additional values. The flat
+     * [variables] map is sent as the transport envelope's `payload` field (not nested under a
+     * `variables` key). Reserved SDK-managed top-level keys cannot be overwritten; provide
+     * app-specific values under `custom`.
      */
     public fun postVariables(
         componentId: String,
@@ -48,9 +47,9 @@ public interface PaywallWebViewController {
     )
 
     /**
-     * Sends a message of the given [type] into the web view targeting [componentId], following the web
-     * view protocol envelope `{ "type", "component_id", "variables" }`. [variables] is delivered under
-     * the `variables` key. Use [postVariables] for the common `rc:variables` case.
+     * Sends a message of the given [type] into the web view targeting [componentId]. The flat
+     * [variables] map is sent as the transport envelope's `payload` field (not nested under a
+     * `variables` key). Use [postVariables] for the common `rc:variables` case.
      */
     public fun postMessage(
         componentId: String,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ComponentView.kt
@@ -79,6 +79,8 @@ internal fun ComponentView(
         style = style,
         state = state,
         modifier = modifier,
+        onClick = onClick,
+        componentInteractionTracker = componentInteractionTracker,
     )
     is ButtonComponentStyle -> ButtonComponentView(
         style = style,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -581,17 +581,19 @@ internal class StyleFactory(
         }
     }
 
-    private fun createWebViewComponentStyle(
+    private fun StyleFactoryScope.createWebViewComponentStyle(
         component: WebViewComponent,
     ): Result<WebViewComponentStyle, NonEmptyList<PaywallValidationError>> =
-        Result.Success(
+        component.fallback?.let { createStackComponentStyle(it) }.orSuccessfullyNull().map { fallbackStyle ->
             WebViewComponentStyle(
                 url = component.url,
                 visible = component.visible ?: DEFAULT_VISIBILITY,
                 size = component.size,
+                componentId = component.id,
                 protocolVersion = component.protocolVersion,
-            ),
-        )
+                fallbackStackComponentStyle = fallbackStyle,
+            )
+        }
 
     private fun StyleFactoryScope.createCountdownComponentStyle(
         component: CountdownComponent,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -11,8 +11,15 @@ internal data class WebViewComponentStyle(
     override val visible: Boolean,
     override val size: Size,
     /**
+     * The canonical component id from the schema (`web_view.id`), used to scope bidirectional
+     * messages. May be null for legacy/partial configs that omit it, in which case the message bridge
+     * is not installed.
+     */
+    val componentId: String? = null,
+    /**
      * The schema-declared `protocol_version`. The backend always sends this field (required, strictly 1).
      * When absent in legacy configs it is treated as 1. Content-Security-Policy is always applied.
      */
     val protocolVersion: Int? = null,
+    val fallbackStackComponentStyle: StackComponentStyle? = null,
 ) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -4,60 +4,147 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
+import com.revenuecat.purchases.ui.revenuecatui.components.stack.StackComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
+import java.net.URL
 
 @JvmSynthetic
 @Composable
-@Suppress("UnusedParameter")
+@Suppress("LongMethod")
 internal fun WebViewComponentView(
     style: WebViewComponentStyle,
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
+    onClick: suspend (PaywallAction) -> Unit = {},
+    componentInteractionTracker: PaywallComponentInteractionTracker = PaywallComponentInteractionTracker { _ -> },
 ) {
     if (!style.visible) return
 
     val resolvedUrl = remember(style.url) {
         WebViewUrlResolver.resolve(style.url)
     }
-    // The web view URL is missing or did not resolve to a valid HTTPS URL with a host. web_view
-    // availability is gated by SDK version on the frontend, so a delivered web_view is expected to
-    // always resolve; render nothing rather than crashing if it doesn't.
     if (resolvedUrl == null) return
 
-    // Key on the resolved URL so the WebView is created (and the page loaded) exactly once per intended
-    // URL. We deliberately do NOT reload on every recomposition: in-page navigation changes WebView.url,
-    // and reloading whenever it differs from resolvedUrl would reset a multi-step web flow. The WebView
-    // is only recreated when the SDK-resolved URL itself changes.
+    val componentId = style.componentId
+    val locale = state.locale.toLanguageTag()
+    val sizeToContentWidth = style.size.width is Fit
+    val sizeToContentHeight = style.size.height is Fit
+
+    var contentWidthCssPx by remember(resolvedUrl) { mutableIntStateOf(0) }
+    var contentHeightCssPx by remember(resolvedUrl) { mutableIntStateOf(0) }
+    var loadFailed by remember(resolvedUrl) { mutableStateOf(false) }
+    val bridgeHolder = remember { WebViewBridgeHolder() }
+
+    val effectiveSize = remember(style.size, contentWidthCssPx, contentHeightCssPx) {
+        webViewEffectiveSize(
+            declaredSize = style.size,
+            contentWidthCssPx = contentWidthCssPx,
+            contentHeightCssPx = contentHeightCssPx,
+        )
+    }
+
+    val fallbackStyle = style.fallbackStackComponentStyle
+    if (loadFailed && fallbackStyle != null) {
+        StackComponentView(
+            style = fallbackStyle,
+            state = state,
+            clickHandler = onClick,
+            componentInteractionTracker = componentInteractionTracker,
+            modifier = modifier.size(effectiveSize),
+        )
+        return
+    }
+
     key(resolvedUrl) {
         AndroidView(
             factory = { context ->
                 WebView(context).apply {
-                    configure()
+                    val bridge = componentId?.let { id ->
+                        WebViewJavaScriptBridge(
+                            webView = this,
+                            componentId = id,
+                            expectedUrl = URL(resolvedUrl),
+                            locale = locale,
+                            messageHandler = null,
+                            protocolVersion = style.protocolVersion ?: WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
+                            sizeToContentWidth = sizeToContentWidth,
+                            sizeToContentHeight = sizeToContentHeight,
+                            onContentResize = { widthCssPx, heightCssPx ->
+                                widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
+                                heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
+                            },
+                        ).also { createdBridge -> createdBridge.attach() }
+                    }
+                    bridgeHolder.bridge = bridge
+                    configure(
+                        onMainFrameLoadFailed = { loadFailed = true },
+                    )
                     loadUrl(resolvedUrl)
                 }
             },
+            update = {
+                bridgeHolder.bridge?.update(locale = locale, messageHandler = null)
+            },
             onRelease = { webView ->
+                bridgeHolder.bridge?.release()
+                bridgeHolder.bridge = null
                 webView.stopLoading()
                 webView.webViewClient = WebViewClient()
                 webView.destroy()
             },
-            modifier = modifier.size(style.size),
+            modifier = modifier.size(effectiveSize),
         )
     }
 }
 
-private fun WebView.configure() {
+private fun webViewEffectiveSize(
+    declaredSize: Size,
+    contentWidthCssPx: Int,
+    contentHeightCssPx: Int,
+): Size {
+    val width = when (val declaredWidth = declaredSize.width) {
+        is Fit -> if (contentWidthCssPx > 0) Fixed(contentWidthCssPx.toUInt()) else declaredWidth
+        else -> declaredWidth
+    }
+    val height = when (val declaredHeight = declaredSize.height) {
+        is Fit -> if (contentHeightCssPx > 0) Fixed(contentHeightCssPx.toUInt()) else declaredHeight
+        else -> declaredHeight
+    }
+    return Size(width = width, height = height)
+}
+
+/** Mutable holder for the per-WebView bridge instance, shared across factory/update/onRelease. */
+private class WebViewBridgeHolder {
+    var bridge: WebViewJavaScriptBridge? = null
+}
+
+private fun WebView.configure(
+    onMainFrameLoadFailed: () -> Unit,
+) {
     setBackgroundColor(Color.TRANSPARENT)
     isVerticalScrollBarEnabled = false
     isHorizontalScrollBarEnabled = false
@@ -84,7 +171,28 @@ private fun WebView.configure() {
         override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
             return request.url.scheme != HTTPS_SCHEME
         }
+
+        override fun onReceivedError(
+            view: WebView,
+            request: WebResourceRequest,
+            error: WebResourceError,
+        ) {
+            if (request.isForMainFrame) {
+                onMainFrameLoadFailed()
+            }
+        }
+
+        override fun onReceivedHttpError(
+            view: WebView,
+            request: WebResourceRequest,
+            errorResponse: WebResourceResponse,
+        ) {
+            if (request.isForMainFrame && errorResponse.statusCode >= HTTP_ERROR_STATUS_MIN) {
+                onMainFrameLoadFailed()
+            }
+        }
     }
 }
 
 private const val HTTPS_SCHEME = "https"
+private const val HTTP_ERROR_STATUS_MIN = 400

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -28,7 +28,6 @@ import com.revenuecat.purchases.ui.revenuecatui.components.stack.StackComponentV
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
-import java.net.URL
 
 @JvmSynthetic
 @Composable
@@ -85,7 +84,7 @@ internal fun WebViewComponentView(
                         WebViewJavaScriptBridge(
                             webView = this,
                             componentId = id,
-                            expectedUrl = URL(resolvedUrl),
+                            expectedUrl = resolvedUrl,
                             locale = locale,
                             messageHandler = null,
                             protocolVersion = style.protocolVersion ?: WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -20,8 +20,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import com.revenuecat.purchases.paywalls.components.properties.Size
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
@@ -34,7 +32,7 @@ import java.net.URL
 
 @JvmSynthetic
 @Composable
-@Suppress("LongMethod")
+@Suppress("LongMethod", "ReturnCount")
 internal fun WebViewComponentView(
     style: WebViewComponentStyle,
     state: PaywallState.Loaded.Components,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -1,0 +1,111 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.json.JSONObject
+
+/**
+ * Wire-format envelopes for the `workflow-web-components-sdk` transport layer.
+ *
+ * Matches [RevenueCat/workflow-web-components-sdk](https://github.com/RevenueCat/workflow-web-components-sdk):
+ * channel `rc-web-components`, handshake kinds `connect` / `init` / `reject`, and app frames
+ * `message` / `request` / `response` / `error`.
+ */
+internal object WebViewEnvelope {
+
+    const val CHANNEL: String = "rc-web-components"
+    const val NATIVE_OBJECT_NAME: String = "rcWebComponents"
+    const val RECEIVE_FUNCTION: String = "__rcWebComponentsReceive"
+    const val DEFAULT_PROTOCOL_VERSION: Int = 1
+
+    const val KIND_CONNECT: String = "connect"
+    const val KIND_INIT: String = "init"
+    const val KIND_REJECT: String = "reject"
+    const val KIND_MESSAGE: String = "message"
+    const val KIND_REQUEST: String = "request"
+    const val KIND_RESPONSE: String = "response"
+    const val KIND_ERROR: String = "error"
+
+    private val ENVELOPE_KINDS: Set<String> = setOf(
+        KIND_CONNECT,
+        KIND_INIT,
+        KIND_REJECT,
+        KIND_MESSAGE,
+        KIND_REQUEST,
+        KIND_RESPONSE,
+        KIND_ERROR,
+    )
+
+    data class Parsed(
+        val kind: String,
+        val protocolVersion: Int,
+        val componentId: String,
+        val type: String?,
+        val id: String?,
+        val payload: JSONObject?,
+        val error: String?,
+    )
+
+    @Suppress("ReturnCount")
+    fun parse(rawJson: String): Parsed? {
+        val json = try {
+            JSONObject(rawJson)
+        } catch (@Suppress("SwallowedException") _: org.json.JSONException) {
+            return null
+        }
+
+        if (json.opt(WebViewMessageField.CHANNEL) != CHANNEL) return null
+
+        val protocolVersion = json.opt(WebViewMessageField.PROTOCOL_VERSION)
+        if (protocolVersion !is Number || !protocolVersion.toDouble().isFinite()) return null
+
+        val kind = json.opt(WebViewMessageField.KIND) as? String
+        if (kind == null || kind !in ENVELOPE_KINDS) return null
+
+        val componentId = json.opt(WebViewMessageField.COMPONENT_ID) as? String ?: return null
+
+        val type = json.opt(WebViewMessageField.TYPE) as? String
+        if (json.has(WebViewMessageField.TYPE) && type == null) return null
+
+        val id = json.opt(WebViewMessageField.ID) as? String
+        if (json.has(WebViewMessageField.ID) && id == null) return null
+
+        val error = json.opt(WebViewMessageField.ERROR) as? String
+        if (json.has(WebViewMessageField.ERROR) && error == null) return null
+
+        val payload = when (val payloadValue = json.opt(WebViewMessageField.PAYLOAD)) {
+            null, JSONObject.NULL -> null
+            is JSONObject -> payloadValue
+            else -> return null
+        }
+
+        return Parsed(
+            kind = kind,
+            protocolVersion = protocolVersion.toInt(),
+            componentId = componentId,
+            type = type,
+            id = id,
+            payload = payload,
+            error = error,
+        )
+    }
+
+    fun build(
+        kind: String,
+        protocolVersion: Int,
+        componentId: String,
+        type: String? = null,
+        id: String? = null,
+        payload: JSONObject? = null,
+        error: String? = null,
+    ): JSONObject = JSONObject().apply {
+        put(WebViewMessageField.CHANNEL, CHANNEL)
+        put(WebViewMessageField.PROTOCOL_VERSION, protocolVersion)
+        put(WebViewMessageField.KIND, kind)
+        put(WebViewMessageField.COMPONENT_ID, componentId)
+        type?.let { put(WebViewMessageField.TYPE, it) }
+        id?.let { put(WebViewMessageField.ID, it) }
+        payload?.let { put(WebViewMessageField.PAYLOAD, it) }
+        error?.let { put(WebViewMessageField.ERROR, it) }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -36,7 +36,7 @@ internal object WebViewEnvelope {
         KIND_ERROR,
     )
 
-    data class Parsed(
+    internal data class Parsed(
         val kind: String,
         val protocolVersion: Int,
         val componentId: String,
@@ -46,7 +46,7 @@ internal object WebViewEnvelope {
         val error: String?,
     )
 
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "CyclomaticComplexMethod")
     fun parse(rawJson: String): Parsed? {
         val json = try {
             JSONObject(rawJson)
@@ -90,6 +90,7 @@ internal object WebViewEnvelope {
         )
     }
 
+    @Suppress("LongParameterList")
     fun build(
         kind: String,
         protocolVersion: Int,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -114,7 +114,10 @@ internal class WebViewJavaScriptBridge(
         val webView = webViewRef.get() ?: return
 
         if (json.toByteArray(Charsets.UTF_8).size > WebViewMessageParser.MAX_PAYLOAD_BYTES) {
-            Logger.w("Dropping inbound web view message: payload exceeds ${WebViewMessageParser.MAX_PAYLOAD_BYTES} bytes.")
+            Logger.w(
+                "Dropping inbound web view message: payload exceeds " +
+                    "${WebViewMessageParser.MAX_PAYLOAD_BYTES} bytes.",
+            )
             return
         }
 
@@ -127,7 +130,8 @@ internal class WebViewJavaScriptBridge(
             WebViewEnvelope.KIND_CONNECT -> {
                 if (!isOriginTrusted(webView, allowBeforeNavigation = true)) {
                     Logger.w(
-                        "Dropping inbound web view connect: current origin does not match the resolved component origin.",
+                        "Dropping inbound web view connect: current origin does not match the " +
+                            "resolved component origin.",
                     )
                     return
                 }
@@ -138,7 +142,8 @@ internal class WebViewJavaScriptBridge(
             -> {
                 if (!isOriginTrusted(webView, allowBeforeNavigation = false)) {
                     Logger.w(
-                        "Dropping inbound web view message: current origin does not match the resolved component origin.",
+                        "Dropping inbound web view message: current origin does not match the " +
+                            "resolved component origin.",
                     )
                     return
                 }
@@ -194,6 +199,7 @@ internal class WebViewJavaScriptBridge(
     }
 
     @MainThread
+    @Suppress("ReturnCount")
     private fun handleAppFrame(rawJson: String) {
         if (!channelOpen) return
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -2,6 +2,7 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.webkit.JavascriptInterface
@@ -14,7 +15,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.toJsonObject
 import org.json.JSONObject
 import java.lang.ref.WeakReference
-import java.net.URL
+import java.util.Locale
 
 /**
  * Installs and drives the bidirectional bridge between a Paywalls V2 `web_view` component and native
@@ -30,20 +31,22 @@ import java.net.URL
  * the same connect/init handshake as on web. No document-start shim is injected.
  *
  * Because `addJavascriptInterface` provides no platform origin scoping, the bridge enforces the origin
- * itself: before delivering any inbound message it verifies the WebView's current URL still has the
- * same origin (scheme + host + port) as the resolved component URL, rejecting messages received after
- * navigation to an unexpected origin.
+ * itself: before delivering any inbound or outbound message it verifies the WebView's current URL still
+ * has the same origin (scheme + host + port) as the resolved component URL, rejecting messages received
+ * after navigation to an unexpected origin. Origin is always re-checked on the main thread at delivery
+ * time.
  *
  * ## Lifecycle & threading
  * The bridge holds only a [WeakReference] to the [WebView] (no Activity/Context), and stops delivering
  * messages once [release] is called. Inbound JavaScript callbacks arrive on a binder thread and are
  * hopped onto the main thread; app callbacks and all WebView interactions happen on the main thread.
+ * Outbound [WebView.evaluateJavascript] calls queued before [release] are dropped when they run.
  */
 @Suppress("LongParameterList", "TooManyFunctions")
 internal class WebViewJavaScriptBridge(
     webView: WebView,
     private val componentId: String,
-    expectedUrl: URL,
+    expectedUrl: String,
     locale: String,
     messageHandler: PaywallWebViewMessageHandler?,
     protocolVersion: Int = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
@@ -103,8 +106,10 @@ internal class WebViewJavaScriptBridge(
      */
     @JavascriptInterface
     fun postMessage(json: String) {
-        if (released) return
-        mainHandler.post { handleInboundMessage(json) }
+        mainHandler.post {
+            if (released) return@post
+            handleInboundMessage(json)
+        }
     }
 
     @MainThread
@@ -314,7 +319,7 @@ internal class WebViewJavaScriptBridge(
     @MainThread
     private fun isOriginTrusted(webView: WebView, allowBeforeNavigation: Boolean): Boolean {
         if (expectedOrigin == null) return false
-        val currentOrigin = webView.url?.let { runCatching { URL(it).toOriginOrNull() }.getOrNull() }
+        val currentOrigin = webView.url?.toOriginOrNull()
         return when {
             currentOrigin == null -> allowBeforeNavigation
             else -> currentOrigin == expectedOrigin
@@ -323,9 +328,13 @@ internal class WebViewJavaScriptBridge(
 
     private fun runOnMainThread(block: () -> Unit) {
         if (Looper.myLooper() == Looper.getMainLooper()) {
+            if (released) return
             block()
         } else {
-            mainHandler.post(block)
+            mainHandler.post {
+                if (released) return@post
+                block()
+            }
         }
     }
 
@@ -345,13 +354,25 @@ internal class WebViewJavaScriptBridge(
 }
 
 /**
- * The origin of this URL as `scheme://host[:port]`, or `null` if it lacks a host. Only HTTPS URLs are
- * expected here (the resolver already enforces this), but the origin string includes the scheme so a
- * scheme change would also be detected.
+ * The origin of this URL as `scheme://host[:port]`, or `null` if it lacks a host. Host comparison is
+ * case-insensitive. Default ports (443 for https, 80 for http) are omitted.
  */
-private fun URL.toOriginOrNull(): String? {
-    val host = host?.takeIf { it.isNotBlank() } ?: return null
-    val effectivePort = if (port == -1) defaultPort else port
-    val portSuffix = if (effectivePort == -1) "" else ":$effectivePort"
-    return "$protocol://$host$portSuffix"
+@Suppress("ReturnCount", "MagicNumber")
+internal fun String.toOriginOrNull(): String? {
+    val uri = Uri.parse(this)
+    val scheme = uri.scheme?.lowercase(Locale.US) ?: return null
+    val host = uri.host?.takeIf { it.isNotBlank() }?.lowercase(Locale.US) ?: return null
+    val effectivePort = when {
+        uri.port != -1 -> uri.port
+        scheme == "https" -> 443
+        scheme == "http" -> 80
+        else -> -1
+    }
+    val portSuffix = when {
+        effectivePort == -1 -> ""
+        scheme == "https" && effectivePort == 443 -> ""
+        scheme == "http" && effectivePort == 80 -> ""
+        else -> ":$effectivePort"
+    }
+    return "$scheme://$host$portSuffix"
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -21,20 +21,18 @@ import java.net.URL
  * code. One bridge is created per rendered `web_view`.
  *
  * ## Transport
- * This implementation uses [WebView.addJavascriptInterface] (the project does not depend on
- * `androidx.webkit`). Exactly one native method is exposed — [postMessage] — under the private object
- * name [NATIVE_OBJECT_NAME]. A small document-start shim (see [injectBridgeScript]) then exposes the
- * stable public surface `window.RevenueCatWebView.postMessage(message)`, accepting either an object
- * (serialized to JSON) or a JSON string, without overwriting an existing bridge.
+ * Implements the native Android host contract from `workflow-web-components-sdk`:
+ * - JS → native: `window.rcWebComponents.postMessage(jsonString)` via [addJavascriptInterface]
+ * - native → JS: `window.__rcWebComponentsReceive(data)` via [WebView.evaluateJavascript]
+ * - Wire format: `{ channel: "rc-web-components", kind, protocol_version, component_id, … }`
+ *
+ * The content SDK (`window.RC`) auto-detects Android when [NATIVE_OBJECT_NAME] is present and runs
+ * the same connect/init handshake as on web. No document-start shim is injected.
  *
  * Because `addJavascriptInterface` provides no platform origin scoping, the bridge enforces the origin
  * itself: before delivering any inbound message it verifies the WebView's current URL still has the
  * same origin (scheme + host + port) as the resolved component URL, rejecting messages received after
  * navigation to an unexpected origin.
- *
- * ## Native → web
- * Native messages are delivered by invoking `window.__revenueCatReceiveMessage(message)` via
- * [WebView.evaluateJavascript], preserving the flat protocol envelope.
  *
  * ## Lifecycle & threading
  * The bridge holds only a [WeakReference] to the [WebView] (no Activity/Context), and stops delivering
@@ -48,11 +46,13 @@ internal class WebViewJavaScriptBridge(
     expectedUrl: URL,
     locale: String,
     messageHandler: PaywallWebViewMessageHandler?,
+    protocolVersion: Int = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
     private val mainHandler: Handler = Handler(Looper.getMainLooper()),
 ) : PaywallWebViewController {
 
     private val webViewRef = WeakReference(webView)
     private val expectedOrigin: String? = expectedUrl.toOriginOrNull()
+    private val protocolVersion: Int = protocolVersion
 
     // Refreshed from the latest paywall state on every recomposition via update().
     @Volatile private var locale: String = locale
@@ -61,22 +61,14 @@ internal class WebViewJavaScriptBridge(
 
     @Volatile private var released: Boolean = false
 
+    @Volatile private var channelOpen: Boolean = false
+
     /**
      * Registers the native interface on the WebView. Call once, when the WebView is created.
      */
     @MainThread
     fun attach() {
-        webViewRef.get()?.addJavascriptInterface(this, NATIVE_OBJECT_NAME)
-    }
-
-    /**
-     * Injects the `window.RevenueCatWebView` shim. Call from `WebViewClient.onPageStarted` so the
-     * surface is available before the page's own scripts run.
-     */
-    @MainThread
-    fun injectBridgeScript() {
-        if (released) return
-        webViewRef.get()?.evaluateJavascript(BRIDGE_SCRIPT, null)
+        webViewRef.get()?.addJavascriptInterface(this, WebViewEnvelope.NATIVE_OBJECT_NAME)
     }
 
     /**
@@ -98,12 +90,13 @@ internal class WebViewJavaScriptBridge(
     @MainThread
     fun release() {
         released = true
-        webViewRef.get()?.removeJavascriptInterface(NATIVE_OBJECT_NAME)
+        channelOpen = false
+        webViewRef.get()?.removeJavascriptInterface(WebViewEnvelope.NATIVE_OBJECT_NAME)
     }
 
     /**
-     * Entry point for the injected `window.RevenueCatWebView`. Invoked on a binder thread; we hop to
-     * the main thread before touching the WebView or validating the message.
+     * Entry point for `window.rcWebComponents.postMessage`. Invoked on a binder thread; we hop to the
+     * main thread before touching the WebView or validating the message.
      */
     @JavascriptInterface
     fun postMessage(json: String) {
@@ -117,53 +110,144 @@ internal class WebViewJavaScriptBridge(
         if (released) return
         val webView = webViewRef.get() ?: return
 
-        if (!isCurrentOriginExpected(webView)) {
-            Logger.w("Dropping inbound web view message: current origin does not match the resolved component origin.")
+        if (json.toByteArray(Charsets.UTF_8).size > WebViewMessageParser.MAX_PAYLOAD_BYTES) {
+            Logger.w("Dropping inbound web view message: payload exceeds ${WebViewMessageParser.MAX_PAYLOAD_BYTES} bytes.")
             return
         }
 
-        val message = WebViewMessageParser.parse(json, expectedComponentId = componentId) ?: return
+        val envelope = WebViewEnvelope.parse(json) ?: run {
+            Logger.w("Dropping inbound web view message: not a valid transport envelope.")
+            return
+        }
 
-        // On a request for variables, the SDK first sends its managed system variables, then invokes
-        // the app handler so the app may add more under `custom`.
-        if (message.type == WebViewMessageType.REQUEST_VARIABLES) {
-            postMessage(
-                componentId = componentId,
-                type = WebViewMessageType.VARIABLES,
-                variables = PaywallWebViewVariablesProvider.sdkManagedVariables(locale = locale),
+        when (envelope.kind) {
+            WebViewEnvelope.KIND_CONNECT -> {
+                if (!isOriginTrusted(webView, allowBeforeNavigation = true)) {
+                    Logger.w(
+                        "Dropping inbound web view connect: current origin does not match the resolved component origin.",
+                    )
+                    return
+                }
+                handleConnect(envelope)
+            }
+            WebViewEnvelope.KIND_MESSAGE,
+            WebViewEnvelope.KIND_REQUEST,
+            -> {
+                if (!isOriginTrusted(webView, allowBeforeNavigation = false)) {
+                    Logger.w(
+                        "Dropping inbound web view message: current origin does not match the resolved component origin.",
+                    )
+                    return
+                }
+                handleAppFrame(json)
+            }
+            else -> Unit
+        }
+    }
+
+    @MainThread
+    private fun handleConnect(envelope: WebViewEnvelope.Parsed) {
+        if (channelOpen || released) return
+
+        if (envelope.protocolVersion != protocolVersion) {
+            deliverEnvelope(
+                WebViewEnvelope.build(
+                    kind = WebViewEnvelope.KIND_REJECT,
+                    protocolVersion = protocolVersion,
+                    componentId = "",
+                    error = "Unsupported protocol_version ${envelope.protocolVersion}; " +
+                        "native host supports $protocolVersion",
+                ),
             )
+            return
+        }
+
+        channelOpen = true
+        deliverEnvelope(
+            WebViewEnvelope.build(
+                kind = WebViewEnvelope.KIND_INIT,
+                protocolVersion = protocolVersion,
+                componentId = componentId,
+            ),
+        )
+    }
+
+    @MainThread
+    private fun handleAppFrame(rawJson: String) {
+        if (!channelOpen) return
+
+        val parsed = WebViewMessageParser.parse(
+            rawJson = rawJson,
+            expectedComponentId = componentId,
+        ) ?: return
+
+        val message = parsed.message
+
+        if (message.type == WebViewMessageType.REQUEST_VARIABLES) {
+            val variables = PaywallWebViewVariablesProvider.sdkManagedVariables(locale = locale)
+            val requestId = parsed.requestId
+            if (requestId != null) {
+                deliverEnvelope(
+                    WebViewEnvelope.build(
+                        kind = WebViewEnvelope.KIND_RESPONSE,
+                        protocolVersion = protocolVersion,
+                        componentId = componentId,
+                        type = parsed.requestType,
+                        id = requestId,
+                        payload = variables.toJsonObject(),
+                    ),
+                )
+            } else {
+                postVariablesMessage(componentId = componentId, variables = variables)
+            }
         }
 
         messageHandler?.onMessage(message, this)
     }
 
     override fun postVariables(componentId: String, variables: Map<String, PaywallWebViewValue>) {
-        postMessage(
+        postVariablesMessage(
             componentId = componentId,
-            type = WebViewMessageType.VARIABLES,
             variables = PaywallWebViewVariablesProvider.sanitizeAppProvidedVariables(variables),
         )
     }
 
     override fun postMessage(componentId: String, type: String, variables: Map<String, PaywallWebViewValue>) {
-        // The payload is delivered under the `variables` key, following the web view protocol envelope
-        // `{ "type", "component_id", "variables" }` (matches the other RevenueCat SDK platforms).
-        val envelope = JSONObject().apply {
-            put(WebViewMessageField.TYPE, type)
-            put(WebViewMessageField.COMPONENT_ID, componentId)
-            put(WebViewMessageField.VARIABLES, variables.toJsonObject())
-        }
-        deliverToWebView(envelope)
+        postAppMessage(
+            componentId = componentId,
+            type = type,
+            payload = variables.toJsonObject(),
+        )
     }
 
-    private fun deliverToWebView(envelope: JSONObject) {
+    private fun postVariablesMessage(componentId: String, variables: Map<String, PaywallWebViewValue>) {
+        postAppMessage(
+            componentId = componentId,
+            type = WebViewMessageType.VARIABLES,
+            payload = variables.toJsonObject(),
+        )
+    }
+
+    private fun postAppMessage(componentId: String, type: String, payload: JSONObject) {
+        if (!channelOpen) return
+        deliverEnvelope(
+            WebViewEnvelope.build(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                protocolVersion = protocolVersion,
+                componentId = componentId,
+                type = type,
+                payload = payload,
+            ),
+        )
+    }
+
+    private fun deliverEnvelope(envelope: JSONObject) {
         runOnMainThread {
             if (released) return@runOnMainThread
             val webView = webViewRef.get() ?: return@runOnMainThread
-            // Symmetric with the inbound guard: never deliver into content that navigated to a
-            // different origin (https navigation to any host is allowed), so SDK envelopes such as
-            // `rc:variables` can't leak across an origin boundary.
-            if (!isCurrentOriginExpected(webView)) {
+            val kind = envelope.optString(WebViewMessageField.KIND)
+            val allowBeforeNavigation = kind in HANDSHAKE_OUTBOUND_KINDS
+            if (!isOriginTrusted(webView, allowBeforeNavigation = allowBeforeNavigation)) {
                 Logger.w(
                     "Dropping outbound web view message: current origin does not match the resolved component origin.",
                 )
@@ -171,7 +255,9 @@ internal class WebViewJavaScriptBridge(
             }
             val payload = envelope.toString().escapeForJavaScript()
             webView.evaluateJavascript(
-                "if (window.$RECEIVE_FUNCTION) { window.$RECEIVE_FUNCTION($payload); }",
+                "if (window.${WebViewEnvelope.RECEIVE_FUNCTION}) { " +
+                    "window.${WebViewEnvelope.RECEIVE_FUNCTION}($payload); " +
+                    "}",
                 null,
             )
         }
@@ -179,13 +265,18 @@ internal class WebViewJavaScriptBridge(
 
     /**
      * Whether the WebView's current URL still has the same origin (scheme + host + port) as the
-     * resolved component URL. Both inbound and outbound messaging are gated on this so messages never
-     * cross an origin boundary after a navigation to an unexpected origin.
+     * resolved component URL. When [allowBeforeNavigation] is true and the WebView has not committed
+     * a URL yet, the expected origin is trusted so the connect/init handshake can complete before
+     * the first navigation.
      */
     @MainThread
-    private fun isCurrentOriginExpected(webView: WebView): Boolean {
+    private fun isOriginTrusted(webView: WebView, allowBeforeNavigation: Boolean): Boolean {
+        if (expectedOrigin == null) return false
         val currentOrigin = webView.url?.let { runCatching { URL(it).toOriginOrNull() }.getOrNull() }
-        return expectedOrigin != null && currentOrigin != null && currentOrigin == expectedOrigin
+        return when {
+            currentOrigin == null -> allowBeforeNavigation
+            else -> currentOrigin == expectedOrigin
+        }
     }
 
     private fun runOnMainThread(block: () -> Unit) {
@@ -197,26 +288,10 @@ internal class WebViewJavaScriptBridge(
     }
 
     private companion object {
-        // Private native object name. The public surface (window.RevenueCatWebView) is created by the
-        // injected shim below; this avoids exposing the raw native interface to web content directly.
-        const val NATIVE_OBJECT_NAME = "__RevenueCatNativeBridge"
-        const val PUBLIC_OBJECT_NAME = "RevenueCatWebView"
-        const val RECEIVE_FUNCTION = "__revenueCatReceiveMessage"
-
-        val BRIDGE_SCRIPT = """
-            (function() {
-                if (window.$PUBLIC_OBJECT_NAME) { return; }
-                var nativeBridge = window.$NATIVE_OBJECT_NAME;
-                if (!nativeBridge) { return; }
-                window.$PUBLIC_OBJECT_NAME = {
-                    postMessage: function(message) {
-                        nativeBridge.postMessage(
-                            typeof message === 'string' ? message : JSON.stringify(message)
-                        );
-                    }
-                };
-            })();
-        """.trimIndent()
+        private val HANDSHAKE_OUTBOUND_KINDS: Set<String> = setOf(
+            WebViewEnvelope.KIND_INIT,
+            WebViewEnvelope.KIND_REJECT,
+        )
 
         /**
          * JSON is a subset of JS object-literal syntax, but the U+2028/U+2029 separators are valid in
@@ -234,8 +309,6 @@ internal class WebViewJavaScriptBridge(
  */
 private fun URL.toOriginOrNull(): String? {
     val host = host?.takeIf { it.isNotBlank() } ?: return null
-    // Normalize the default port so e.g. `https://host` and `https://host:443` compare as the same
-    // origin: an explicit default port and an omitted one must not cause spurious message drops.
     val effectivePort = if (port == -1) defaultPort else port
     val portSuffix = if (effectivePort == -1) "" else ":$effectivePort"
     return "$protocol://$host$portSuffix"

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -1,0 +1,242 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import androidx.annotation.MainThread
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import com.revenuecat.purchases.ui.revenuecatui.toJsonObject
+import org.json.JSONObject
+import java.lang.ref.WeakReference
+import java.net.URL
+
+/**
+ * Installs and drives the bidirectional bridge between a Paywalls V2 `web_view` component and native
+ * code. One bridge is created per rendered `web_view`.
+ *
+ * ## Transport
+ * This implementation uses [WebView.addJavascriptInterface] (the project does not depend on
+ * `androidx.webkit`). Exactly one native method is exposed — [postMessage] — under the private object
+ * name [NATIVE_OBJECT_NAME]. A small document-start shim (see [injectBridgeScript]) then exposes the
+ * stable public surface `window.RevenueCatWebView.postMessage(message)`, accepting either an object
+ * (serialized to JSON) or a JSON string, without overwriting an existing bridge.
+ *
+ * Because `addJavascriptInterface` provides no platform origin scoping, the bridge enforces the origin
+ * itself: before delivering any inbound message it verifies the WebView's current URL still has the
+ * same origin (scheme + host + port) as the resolved component URL, rejecting messages received after
+ * navigation to an unexpected origin.
+ *
+ * ## Native → web
+ * Native messages are delivered by invoking `window.__revenueCatReceiveMessage(message)` via
+ * [WebView.evaluateJavascript], preserving the flat protocol envelope.
+ *
+ * ## Lifecycle & threading
+ * The bridge holds only a [WeakReference] to the [WebView] (no Activity/Context), and stops delivering
+ * messages once [release] is called. Inbound JavaScript callbacks arrive on a binder thread and are
+ * hopped onto the main thread; app callbacks and all WebView interactions happen on the main thread.
+ */
+@Suppress("LongParameterList", "TooManyFunctions")
+internal class WebViewJavaScriptBridge(
+    webView: WebView,
+    private val componentId: String,
+    expectedUrl: URL,
+    locale: String,
+    messageHandler: PaywallWebViewMessageHandler?,
+    private val mainHandler: Handler = Handler(Looper.getMainLooper()),
+) : PaywallWebViewController {
+
+    private val webViewRef = WeakReference(webView)
+    private val expectedOrigin: String? = expectedUrl.toOriginOrNull()
+
+    // Refreshed from the latest paywall state on every recomposition via update().
+    @Volatile private var locale: String = locale
+
+    @Volatile private var messageHandler: PaywallWebViewMessageHandler? = messageHandler
+
+    @Volatile private var released: Boolean = false
+
+    /**
+     * Registers the native interface on the WebView. Call once, when the WebView is created.
+     */
+    @MainThread
+    fun attach() {
+        webViewRef.get()?.addJavascriptInterface(this, NATIVE_OBJECT_NAME)
+    }
+
+    /**
+     * Injects the `window.RevenueCatWebView` shim. Call from `WebViewClient.onPageStarted` so the
+     * surface is available before the page's own scripts run.
+     */
+    @MainThread
+    fun injectBridgeScript() {
+        if (released) return
+        webViewRef.get()?.evaluateJavascript(BRIDGE_SCRIPT, null)
+    }
+
+    /**
+     * Refreshes the locale and the app message handler from the latest paywall state. Call from
+     * `AndroidView`'s update block.
+     */
+    fun update(
+        locale: String,
+        messageHandler: PaywallWebViewMessageHandler?,
+    ) {
+        this.locale = locale
+        this.messageHandler = messageHandler
+    }
+
+    /**
+     * Stops the bridge. After this call no further inbound messages are delivered and no outbound
+     * messages are sent. Call from `AndroidView`'s onRelease block.
+     */
+    @MainThread
+    fun release() {
+        released = true
+        webViewRef.get()?.removeJavascriptInterface(NATIVE_OBJECT_NAME)
+    }
+
+    /**
+     * Entry point for the injected `window.RevenueCatWebView`. Invoked on a binder thread; we hop to
+     * the main thread before touching the WebView or validating the message.
+     */
+    @JavascriptInterface
+    fun postMessage(json: String) {
+        if (released) return
+        mainHandler.post { handleInboundMessage(json) }
+    }
+
+    @MainThread
+    @Suppress("ReturnCount")
+    private fun handleInboundMessage(json: String) {
+        if (released) return
+        val webView = webViewRef.get() ?: return
+
+        if (!isCurrentOriginExpected(webView)) {
+            Logger.w("Dropping inbound web view message: current origin does not match the resolved component origin.")
+            return
+        }
+
+        val message = WebViewMessageParser.parse(json, expectedComponentId = componentId) ?: return
+
+        // On a request for variables, the SDK first sends its managed system variables, then invokes
+        // the app handler so the app may add more under `custom`.
+        if (message.type == WebViewMessageType.REQUEST_VARIABLES) {
+            postMessage(
+                componentId = componentId,
+                type = WebViewMessageType.VARIABLES,
+                variables = PaywallWebViewVariablesProvider.sdkManagedVariables(locale = locale),
+            )
+        }
+
+        messageHandler?.onMessage(message, this)
+    }
+
+    override fun postVariables(componentId: String, variables: Map<String, PaywallWebViewValue>) {
+        postMessage(
+            componentId = componentId,
+            type = WebViewMessageType.VARIABLES,
+            variables = PaywallWebViewVariablesProvider.sanitizeAppProvidedVariables(variables),
+        )
+    }
+
+    override fun postMessage(componentId: String, type: String, variables: Map<String, PaywallWebViewValue>) {
+        // The payload is delivered under the `variables` key, following the web view protocol envelope
+        // `{ "type", "component_id", "variables" }` (matches the other RevenueCat SDK platforms).
+        val envelope = JSONObject().apply {
+            put(WebViewMessageField.TYPE, type)
+            put(WebViewMessageField.COMPONENT_ID, componentId)
+            put(WebViewMessageField.VARIABLES, variables.toJsonObject())
+        }
+        deliverToWebView(envelope)
+    }
+
+    private fun deliverToWebView(envelope: JSONObject) {
+        runOnMainThread {
+            if (released) return@runOnMainThread
+            val webView = webViewRef.get() ?: return@runOnMainThread
+            // Symmetric with the inbound guard: never deliver into content that navigated to a
+            // different origin (https navigation to any host is allowed), so SDK envelopes such as
+            // `rc:variables` can't leak across an origin boundary.
+            if (!isCurrentOriginExpected(webView)) {
+                Logger.w(
+                    "Dropping outbound web view message: current origin does not match the resolved component origin.",
+                )
+                return@runOnMainThread
+            }
+            val payload = envelope.toString().escapeForJavaScript()
+            webView.evaluateJavascript(
+                "if (window.$RECEIVE_FUNCTION) { window.$RECEIVE_FUNCTION($payload); }",
+                null,
+            )
+        }
+    }
+
+    /**
+     * Whether the WebView's current URL still has the same origin (scheme + host + port) as the
+     * resolved component URL. Both inbound and outbound messaging are gated on this so messages never
+     * cross an origin boundary after a navigation to an unexpected origin.
+     */
+    @MainThread
+    private fun isCurrentOriginExpected(webView: WebView): Boolean {
+        val currentOrigin = webView.url?.let { runCatching { URL(it).toOriginOrNull() }.getOrNull() }
+        return expectedOrigin != null && currentOrigin != null && currentOrigin == expectedOrigin
+    }
+
+    private fun runOnMainThread(block: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            block()
+        } else {
+            mainHandler.post(block)
+        }
+    }
+
+    private companion object {
+        // Private native object name. The public surface (window.RevenueCatWebView) is created by the
+        // injected shim below; this avoids exposing the raw native interface to web content directly.
+        const val NATIVE_OBJECT_NAME = "__RevenueCatNativeBridge"
+        const val PUBLIC_OBJECT_NAME = "RevenueCatWebView"
+        const val RECEIVE_FUNCTION = "__revenueCatReceiveMessage"
+
+        val BRIDGE_SCRIPT = """
+            (function() {
+                if (window.$PUBLIC_OBJECT_NAME) { return; }
+                var nativeBridge = window.$NATIVE_OBJECT_NAME;
+                if (!nativeBridge) { return; }
+                window.$PUBLIC_OBJECT_NAME = {
+                    postMessage: function(message) {
+                        nativeBridge.postMessage(
+                            typeof message === 'string' ? message : JSON.stringify(message)
+                        );
+                    }
+                };
+            })();
+        """.trimIndent()
+
+        /**
+         * JSON is a subset of JS object-literal syntax, but the U+2028/U+2029 separators are valid in
+         * JSON strings yet terminate JS statements. Escape them so the payload is safe to embed.
+         */
+        fun String.escapeForJavaScript(): String =
+            replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")
+    }
+}
+
+/**
+ * The origin of this URL as `scheme://host[:port]`, or `null` if it lacks a host. Only HTTPS URLs are
+ * expected here (the resolver already enforces this), but the origin string includes the scheme so a
+ * scheme change would also be detected.
+ */
+private fun URL.toOriginOrNull(): String? {
+    val host = host?.takeIf { it.isNotBlank() } ?: return null
+    // Normalize the default port so e.g. `https://host` and `https://host:443` compare as the same
+    // origin: an explicit default port and an omitted one must not cause spurious message drops.
+    val effectivePort = if (port == -1) defaultPort else port
+    val portSuffix = if (effectivePort == -1) "" else ":$effectivePort"
+    return "$protocol://$host$portSuffix"
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -47,6 +47,9 @@ internal class WebViewJavaScriptBridge(
     locale: String,
     messageHandler: PaywallWebViewMessageHandler?,
     protocolVersion: Int = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
+    private val sizeToContentWidth: Boolean = false,
+    private val sizeToContentHeight: Boolean = false,
+    private val onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
     private val mainHandler: Handler = Handler(Looper.getMainLooper()),
 ) : PaywallWebViewController {
 
@@ -170,11 +173,35 @@ internal class WebViewJavaScriptBridge(
                 componentId = componentId,
             ),
         )
+        sendFitIfNeeded()
+    }
+
+    private fun sendFitIfNeeded() {
+        if (!sizeToContentWidth && !sizeToContentHeight) return
+        val payload = JSONObject().apply {
+            if (sizeToContentWidth) put("width", true)
+            if (sizeToContentHeight) put("height", true)
+        }
+        deliverEnvelope(
+            WebViewEnvelope.build(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                protocolVersion = protocolVersion,
+                componentId = componentId,
+                type = WebViewMessageType.FIT,
+                payload = payload,
+            ),
+        )
     }
 
     @MainThread
     private fun handleAppFrame(rawJson: String) {
         if (!channelOpen) return
+
+        val transport = WebViewEnvelope.parse(rawJson) ?: return
+        if (transport.kind == WebViewEnvelope.KIND_MESSAGE && transport.type == WebViewMessageType.RESIZE) {
+            handleResize(transport)
+            return
+        }
 
         val parsed = WebViewMessageParser.parse(
             rawJson = rawJson,
@@ -203,6 +230,15 @@ internal class WebViewJavaScriptBridge(
         }
 
         messageHandler?.onMessage(message, this)
+    }
+
+    @MainThread
+    private fun handleResize(envelope: WebViewEnvelope.Parsed) {
+        if (envelope.componentId != componentId) return
+        val payload = envelope.payload ?: return
+        val width = payload.optInt("width").takeIf { payload.has("width") }
+        val height = payload.optInt("height").takeIf { payload.has("height") }
+        onContentResize(width, height)
     }
 
     override fun postVariables(componentId: String, variables: Map<String, PaywallWebViewValue>) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParser.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParser.kt
@@ -23,7 +23,7 @@ internal object WebViewMessageParser {
     const val MAX_PAYLOAD_BYTES: Int = 65_536
     const val MAX_NESTING_DEPTH: Int = 16
 
-    data class ParsedAppMessage(
+    internal data class ParsedAppMessage(
         val message: PaywallWebViewMessage,
         /** Set when the inbound frame is a transport `request` that expects a `response`. */
         val requestId: String? = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParser.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParser.kt
@@ -11,97 +11,142 @@ import org.json.JSONObject
  * Parses and validates raw JSON strings received from a `web_view` component into typed
  * [PaywallWebViewMessage]s before they reach app code.
  *
- * Validation rules (see the RevenueCat `web_view` postMessage protocol):
- * - The payload must not exceed [MAX_PAYLOAD_BYTES] and must not nest deeper than [MAX_NESTING_DEPTH].
- * - The body must be a JSON object with a non-empty string `type` and a string `component_id`.
- * - `component_id` must equal the expected component id; otherwise the message is rejected.
- * - `rc:step-complete` may carry a `responses` JSON object of JSON-compatible values.
- * - `rc:error` must carry a string `error`.
- * - `rc:step-loaded` and `rc:request-variables` require no extra fields.
- * - Unknown message types are dropped for v1.
+ * Payloads use the `workflow-web-components-sdk` transport envelope (`channel`,
+ * `protocol_version`, `kind`, `component_id`, …). App-level messages arrive as `kind`
+ * `message` or `request` with a `type` such as `rc:step-loaded`.
  *
- * Returns `null` for any payload that is too large, malformed, fails validation, targets a different
- * component, or has an unknown type.
+ * Returns `null` for handshake frames, transport errors, malformed payloads, wrong
+ * `component_id`, or unknown app message types.
  */
 internal object WebViewMessageParser {
 
     const val MAX_PAYLOAD_BYTES: Int = 65_536
     const val MAX_NESTING_DEPTH: Int = 16
 
+    data class ParsedAppMessage(
+        val message: PaywallWebViewMessage,
+        /** Set when the inbound frame is a transport `request` that expects a `response`. */
+        val requestId: String? = null,
+        val requestType: String? = null,
+    )
+
     @Suppress("ReturnCount")
-    fun parse(rawJson: String, expectedComponentId: String): PaywallWebViewMessage? {
+    fun parse(rawJson: String, expectedComponentId: String): ParsedAppMessage? {
         if (rawJson.toByteArray(Charsets.UTF_8).size > MAX_PAYLOAD_BYTES) {
             Logger.w("Dropping web view message: payload exceeds $MAX_PAYLOAD_BYTES bytes.")
             return null
         }
 
-        val json = try {
-            JSONObject(rawJson)
-        } catch (@Suppress("SwallowedException") e: org.json.JSONException) {
-            Logger.w("Dropping web view message: body is not a JSON object.")
+        val envelope = WebViewEnvelope.parse(rawJson) ?: run {
+            Logger.w("Dropping web view message: not a valid transport envelope.")
             return null
         }
 
-        val type = (json.opt(WebViewMessageField.TYPE) as? String)?.takeIf { it.isNotEmpty() }
+        return when (envelope.kind) {
+            WebViewEnvelope.KIND_MESSAGE,
+            WebViewEnvelope.KIND_REQUEST,
+            -> parseAppMessage(envelope, expectedComponentId)
+
+            else -> null
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun parseAppMessage(
+        envelope: WebViewEnvelope.Parsed,
+        expectedComponentId: String,
+    ): ParsedAppMessage? {
+        if (envelope.componentId != expectedComponentId) {
+            Logger.w("Dropping web view message: 'component_id' does not match the rendered web_view.")
+            return null
+        }
+
+        val type = envelope.type?.takeIf { it.isNotEmpty() }
         if (type == null) {
             Logger.w("Dropping web view message: missing or non-string 'type'.")
             return null
         }
 
-        val componentId = json.opt(WebViewMessageField.COMPONENT_ID) as? String
-        if (componentId == null) {
-            Logger.w("Dropping web view message: missing or non-string 'component_id'.")
-            return null
-        }
-        if (componentId != expectedComponentId) {
-            Logger.w("Dropping web view message: 'component_id' does not match the rendered web_view.")
-            return null
-        }
-
-        return when (type) {
+        val message = when (type) {
             WebViewMessageType.STEP_LOADED,
             WebViewMessageType.REQUEST_VARIABLES,
-            -> PaywallWebViewMessage(componentId = componentId, type = type)
+            -> PaywallWebViewMessage(componentId = envelope.componentId, type = type)
 
             WebViewMessageType.STEP_COMPLETE -> {
-                val responses = parseResponses(json) ?: return null
-                PaywallWebViewMessage(componentId = componentId, type = type, responses = responses.value)
+                val responses = parseResponses(envelope.payload) ?: return null
+                PaywallWebViewMessage(
+                    componentId = envelope.componentId,
+                    type = type,
+                    responses = responses.value,
+                )
             }
 
             WebViewMessageType.ERROR -> {
-                val error = json.opt(WebViewMessageField.ERROR) as? String
-                if (error == null) {
-                    Logger.w("Dropping web view message: 'rc:error' requires a string 'error'.")
-                    return null
-                }
-                PaywallWebViewMessage(componentId = componentId, type = type, error = error)
+                val error = parseError(envelope) ?: return null
+                PaywallWebViewMessage(componentId = envelope.componentId, type = type, error = error)
             }
 
             else -> {
-                // Unknown message types are dropped for protocol_version 1.
                 Logger.d("Dropping web view message: unknown type '$type'.")
-                null
+                return null
             }
         }
+
+        val requestId = if (envelope.kind == WebViewEnvelope.KIND_REQUEST) envelope.id else null
+        if (envelope.kind == WebViewEnvelope.KIND_REQUEST && requestId == null) {
+            Logger.w("Dropping web view message: transport request is missing 'id'.")
+            return null
+        }
+
+        return ParsedAppMessage(
+            message = message,
+            requestId = requestId,
+            requestType = type,
+        )
+    }
+
+    private fun parseError(envelope: WebViewEnvelope.Parsed): String? {
+        val payloadError = envelope.payload?.opt(WebViewMessageField.ERROR) as? String
+        val error = payloadError ?: envelope.error
+        if (error == null) {
+            Logger.w("Dropping web view message: 'rc:error' requires a string 'error'.")
+            return null
+        }
+        return error
     }
 
     /**
-     * Parses the optional `responses` object of a `rc:step-complete` message. Returns an empty object
-     * when absent, or `null` when present but malformed (not a JSON object, non-JSON values, or too
-     * deeply nested), which causes the whole message to be rejected.
+     * Parses the `responses` object for a `rc:step-complete` message. The responses may live under
+     * `payload.responses` or directly in `payload` when the content sends only response fields.
      */
     private class ParsedResponses(val value: Map<String, PaywallWebViewValue>)
 
     @Suppress("ReturnCount")
-    private fun parseResponses(json: JSONObject): ParsedResponses? {
-        if (!json.has(WebViewMessageField.RESPONSES) || json.isNull(WebViewMessageField.RESPONSES)) {
+    private fun parseResponses(payload: JSONObject?): ParsedResponses? {
+        if (payload == null || payload.length() == 0) {
             return ParsedResponses(emptyMap())
         }
-        val responsesJson = json.opt(WebViewMessageField.RESPONSES) as? JSONObject
+
+        val responsesJson = when {
+            payload.has(WebViewMessageField.RESPONSES) && !payload.isNull(WebViewMessageField.RESPONSES) ->
+                payload.opt(WebViewMessageField.RESPONSES) as? JSONObject
+
+            payload.keys().asSequence().any { it in STEP_COMPLETE_RESERVED_PAYLOAD_KEYS } -> {
+                Logger.w(
+                    "Dropping web view message: 'rc:step-complete' payload contains transport fields " +
+                        "without a 'responses' object.",
+                )
+                return null
+            }
+
+            else -> payload
+        }
+
         if (responsesJson == null) {
             Logger.w("Dropping web view message: 'responses' must be a JSON object.")
             return null
         }
+
         val converted = PaywallWebViewValue.fromJson(responsesJson, MAX_NESTING_DEPTH)
         if (converted !is PaywallWebViewValue.Object) {
             Logger.w("Dropping web view message: 'responses' contains non-JSON values or is too deeply nested.")
@@ -109,4 +154,15 @@ internal object WebViewMessageParser {
         }
         return ParsedResponses(converted.value)
     }
+
+    private val STEP_COMPLETE_RESERVED_PAYLOAD_KEYS: Set<String> = setOf(
+        WebViewMessageField.CHANNEL,
+        WebViewMessageField.PROTOCOL_VERSION,
+        WebViewMessageField.KIND,
+        WebViewMessageField.TYPE,
+        WebViewMessageField.COMPONENT_ID,
+        WebViewMessageField.ID,
+        WebViewMessageField.ERROR,
+        WebViewMessageField.VARIABLES,
+    )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
@@ -12,6 +12,12 @@ internal object WebViewMessageType {
     const val REQUEST_VARIABLES = "rc:request-variables"
     const val ERROR = "rc:error"
     const val VARIABLES = "rc:variables"
+
+    /** Host → content: which axes the native host sizes to the content (`fit`). */
+    const val FIT = "fit"
+
+    /** Content → host: reported content box size in CSS pixels. */
+    const val RESIZE = "resize"
 }
 
 /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
@@ -20,8 +20,13 @@ internal object WebViewMessageType {
  * generic `payload` key.
  */
 internal object WebViewMessageField {
+    const val CHANNEL = "channel"
+    const val PROTOCOL_VERSION = "protocol_version"
+    const val KIND = "kind"
     const val TYPE = "type"
     const val COMPONENT_ID = "component_id"
+    const val ID = "id"
+    const val PAYLOAD = "payload"
     const val RESPONSES = "responses"
     const val ERROR = "error"
     const val VARIABLES = "variables"

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -37,6 +37,9 @@ internal class WebViewJavaScriptBridgeTest {
         handler: PaywallWebViewMessageHandler? = PaywallWebViewMessageHandler { message, _ -> received.add(message) },
         locale: String = "en-US",
         navigateTo: URL? = expectedUrl,
+        sizeToContentWidth: Boolean = false,
+        sizeToContentHeight: Boolean = false,
+        onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
     ): WebViewJavaScriptBridge {
         val bridge = WebViewJavaScriptBridge(
             webView = webView,
@@ -44,6 +47,9 @@ internal class WebViewJavaScriptBridgeTest {
             expectedUrl = expectedUrl,
             locale = locale,
             messageHandler = handler,
+            sizeToContentWidth = sizeToContentWidth,
+            sizeToContentHeight = sizeToContentHeight,
+            onContentResize = onContentResize,
         )
         bridge.attach()
         navigateTo?.let { webView.loadUrl(it.toString()) }
@@ -424,5 +430,41 @@ internal class WebViewJavaScriptBridgeTest {
         bridge.release()
 
         assertThat(shadowWebView.getJavascriptInterface("rcWebComponents")).isNull()
+    }
+
+    @Test
+    fun `sends fit message after init when height is fit`() {
+        val bridge = bridge(sizeToContentHeight = true)
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"type\":\"fit\"")
+        assertThat(script).contains("\"height\":true")
+        assertThat(script).doesNotContain("\"width\":true")
+    }
+
+    @Test
+    fun `reports content resize from inbound resize message`() {
+        var reportedWidth: Int? = null
+        var reportedHeight: Int? = null
+        val bridge = bridge(
+            handler = null,
+            onContentResize = { widthCssPx, heightCssPx ->
+                reportedWidth = widthCssPx
+                reportedHeight = heightCssPx
+            },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.RESIZE,
+                payload = """{"width":320,"height":480}""",
+            ),
+        )
+        idleMainLooper()
+
+        assertThat(reportedWidth).isEqualTo(320)
+        assertThat(reportedHeight).isEqualTo(480)
+        assertThat(received).isEmpty()
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -1,0 +1,329 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.os.Looper
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessage
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowWebView
+import java.net.URL
+
+@RunWith(RobolectricTestRunner::class)
+internal class WebViewJavaScriptBridgeTest {
+
+    private val componentId = "promo_web_view"
+    private val expectedUrl = URL("https://assets.example.com/promo/index.html")
+
+    private lateinit var webView: WebView
+    private lateinit var shadowWebView: ShadowWebView
+    private val received = mutableListOf<PaywallWebViewMessage>()
+
+    @Before
+    fun setUp() {
+        webView = WebView(ApplicationProvider.getApplicationContext())
+        shadowWebView = shadowOf(webView)
+        received.clear()
+    }
+
+    private fun bridge(
+        handler: PaywallWebViewMessageHandler? = PaywallWebViewMessageHandler { message, _ -> received.add(message) },
+        locale: String = "en-US",
+        navigateTo: URL = expectedUrl,
+    ): WebViewJavaScriptBridge {
+        val bridge = WebViewJavaScriptBridge(
+            webView = webView,
+            componentId = componentId,
+            expectedUrl = expectedUrl,
+            locale = locale,
+            messageHandler = handler,
+        )
+        bridge.attach()
+        // Robolectric's ShadowWebView reports the last loaded URL via getUrl().
+        webView.loadUrl(navigateTo.toString())
+        return bridge
+    }
+
+    private fun idleMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    @Test
+    fun `delivers valid message using the canonical component id`() {
+        bridge().postMessage("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+        assertThat(received.single().componentId).isEqualTo("promo_web_view")
+        assertThat(received.single().type).isEqualTo("rc:step-loaded")
+    }
+
+    @Test
+    fun `rejects messages for a different component id`() {
+        bridge().postMessage("""{"type":"rc:step-loaded","component_id":"other_web_view"}""")
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `request-variables auto-sends rc variables with locale only`() {
+        bridge().postMessage("""{"type":"rc:request-variables","component_id":"promo_web_view"}""")
+        idleMainLooper()
+
+        // The app handler is still notified...
+        assertThat(received.single().type).isEqualTo("rc:request-variables")
+        // ...and the SDK sent rc:variables back into the web view via the receive hook.
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("window.__revenueCatReceiveMessage(")
+        assertThat(script).contains("\"rc:variables\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+        assertThat(script).contains("\"locale\":\"en-US\"")
+        // Dashboard custom variables are not passed across the bridge.
+        assertThat(script).doesNotContain("\"custom\"")
+    }
+
+    @Test
+    fun `app can reply with extra variables through the controller`() {
+        val handler = PaywallWebViewMessageHandler { message, controller ->
+            received.add(message)
+            if (message.type == WebViewMessageType.REQUEST_VARIABLES) {
+                controller.postVariables(
+                    componentId = message.componentId,
+                    variables = mapOf(
+                        "custom" to PaywallWebViewValue.Object(
+                            mapOf("app_segment" to PaywallWebViewValue.String("high_intent")),
+                        ),
+                    ),
+                )
+            }
+        }
+        bridge(handler = handler)
+            .postMessage("""{"type":"rc:request-variables","component_id":"promo_web_view"}""")
+        idleMainLooper()
+
+        // The controller's reply is the most recent script delivered to the web view.
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"rc:variables\"")
+        assertThat(script).contains("\"app_segment\":\"high_intent\"")
+    }
+
+    @Test
+    fun `controller postVariables drops reserved keys`() {
+        val controllerHolder = arrayOfNulls<PaywallWebViewController>(1)
+        val handler = PaywallWebViewMessageHandler { _, controller -> controllerHolder[0] = controller }
+        bridge(handler = handler)
+            .postMessage("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+        idleMainLooper()
+
+        controllerHolder[0]!!.postVariables(
+            componentId = componentId,
+            variables = mapOf(
+                "locale" to PaywallWebViewValue.String("zz-ZZ"),
+                "custom" to PaywallWebViewValue.Object(mapOf("k" to PaywallWebViewValue.String("v"))),
+            ),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).doesNotContain("zz-ZZ")
+        assertThat(script).contains("\"k\":\"v\"")
+    }
+
+    @Test
+    fun `does not deliver messages after release`() {
+        val bridge = bridge()
+        bridge.release()
+
+        bridge.postMessage("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `rejects messages after navigation to an unexpected origin`() {
+        bridge(navigateTo = URL("https://evil.example.org/phish.html"))
+            .postMessage("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `allows messages from the same origin on a different path`() {
+        bridge(navigateTo = URL("https://assets.example.com/promo/step-two.html"))
+            .postMessage("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+    }
+
+    @Test
+    fun `does not deliver outbound messages after navigation to an unexpected origin`() {
+        // Symmetric with the inbound guard: outbound envelopes must not leak into foreign content.
+        bridge(navigateTo = URL("https://evil.example.org/phish.html")).postMessage(
+            componentId = componentId,
+            type = "rc:custom",
+            variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+        )
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).isNull()
+    }
+
+    @Test
+    fun `treats the default https port as the same origin`() {
+        // expectedUrl omits the port; navigating to the explicit :443 must still match (inbound + outbound).
+        bridge(navigateTo = URL("https://assets.example.com:443/promo/index.html")).postMessage(
+            componentId = componentId,
+            type = "rc:custom",
+            variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+        )
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"type\":\"rc:custom\"")
+    }
+
+    @Test
+    fun `delivers rc step-complete responses to the handler without sending an outbound message`() {
+        bridge().postMessage(
+            """
+            {
+              "type":"rc:step-complete",
+              "component_id":"promo_web_view",
+              "responses":{"selected_plan":"annual","accepted_terms":true}
+            }
+            """.trimIndent(),
+        )
+        idleMainLooper()
+
+        val message = received.single()
+        assertThat(message.type).isEqualTo("rc:step-complete")
+        assertThat(message.responses?.get("selected_plan")).isEqualTo(PaywallWebViewValue.String("annual"))
+        assertThat(message.responses?.get("accepted_terms")).isEqualTo(PaywallWebViewValue.Boolean(true))
+        // rc:step-complete must not auto-dismiss or send anything back; the app decides.
+        assertThat(shadowWebView.lastEvaluatedJavascript).isNull()
+    }
+
+    @Test
+    fun `delivers rc error to the handler`() {
+        bridge().postMessage(
+            """{"type":"rc:error","component_id":"promo_web_view","error":"Something went wrong"}""",
+        )
+        idleMainLooper()
+
+        val message = received.single()
+        assertThat(message.type).isEqualTo("rc:error")
+        assertThat(message.error).isEqualTo("Something went wrong")
+    }
+
+    @Test
+    fun `does not deliver malformed messages to the handler`() {
+        bridge().postMessage("""not even json""")
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `auto-sends rc variables even when no handler is set`() {
+        bridge(handler = null)
+            .postMessage("""{"type":"rc:request-variables","component_id":"promo_web_view"}""")
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"rc:variables\"")
+        assertThat(script).contains("\"locale\":\"en-US\"")
+    }
+
+    @Test
+    fun `update refreshes the variables sent on a subsequent request`() {
+        val bridge = bridge(locale = "en-US")
+        bridge.update(
+            locale = "fr-FR",
+            messageHandler = null,
+        )
+
+        bridge.postMessage("""{"type":"rc:request-variables","component_id":"promo_web_view"}""")
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"locale\":\"fr-FR\"")
+        assertThat(script).doesNotContain("en-US")
+    }
+
+    @Test
+    fun `generic postMessage nests the payload under the variables key`() {
+        bridge().postMessage(
+            componentId = componentId,
+            type = "rc:custom",
+            variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("window.__revenueCatReceiveMessage(")
+        assertThat(script).contains("\"type\":\"rc:custom\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+        // The payload is delivered under the `variables` key, never merged into the envelope top level.
+        assertThat(script).contains("\"variables\":{\"foo\":\"bar\"}")
+    }
+
+    @Test
+    fun `escapes line and paragraph separators in outbound payloads`() {
+        // U+2028/U+2029 are valid in JSON strings but terminate JS statements; they must be escaped.
+        val raw = "a\u2028b\u2029c"
+        bridge().postVariables(
+            componentId = componentId,
+            variables = mapOf(
+                "custom" to PaywallWebViewValue.Object(mapOf("note" to PaywallWebViewValue.String(raw))),
+            ),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).doesNotContain("\u2028")
+        assertThat(script).doesNotContain("\u2029")
+        assertThat(script).contains("\\u2028")
+        assertThat(script).contains("\\u2029")
+    }
+
+    @Test
+    fun `attach registers a single native interface under the private name`() {
+        bridge()
+
+        assertThat(shadowWebView.getJavascriptInterface("__RevenueCatNativeBridge")).isNotNull
+        // The public object name is created by the injected shim, not exposed as a native interface.
+        assertThat(shadowWebView.getJavascriptInterface("RevenueCatWebView")).isNull()
+    }
+
+    @Test
+    fun `injectBridgeScript exposes the public surface without overwriting an existing bridge`() {
+        bridge().injectBridgeScript()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("window.RevenueCatWebView")
+        assertThat(script).contains("window.__RevenueCatNativeBridge")
+        // Guard so an existing bridge is not clobbered.
+        assertThat(script).contains("if (window.RevenueCatWebView)")
+    }
+
+    @Test
+    fun `release removes the native interface`() {
+        val bridge = bridge()
+        assertThat(shadowWebView.getJavascriptInterface("__RevenueCatNativeBridge")).isNotNull
+
+        bridge.release()
+
+        assertThat(shadowWebView.getJavascriptInterface("__RevenueCatNativeBridge")).isNull()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -14,13 +14,12 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowWebView
-import java.net.URL
 
 @RunWith(RobolectricTestRunner::class)
 internal class WebViewJavaScriptBridgeTest {
 
     private val componentId = "promo_web_view"
-    private val expectedUrl = URL("https://assets.example.com/promo/index.html")
+    private val expectedUrl = "https://assets.example.com/promo/index.html"
 
     private lateinit var webView: WebView
     private lateinit var shadowWebView: ShadowWebView
@@ -36,7 +35,7 @@ internal class WebViewJavaScriptBridgeTest {
     private fun bridge(
         handler: PaywallWebViewMessageHandler? = PaywallWebViewMessageHandler { message, _ -> received.add(message) },
         locale: String = "en-US",
-        navigateTo: URL? = expectedUrl,
+        navigateTo: String? = expectedUrl,
         sizeToContentWidth: Boolean = false,
         sizeToContentHeight: Boolean = false,
         onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
@@ -52,7 +51,7 @@ internal class WebViewJavaScriptBridgeTest {
             onContentResize = onContentResize,
         )
         bridge.attach()
-        navigateTo?.let { webView.loadUrl(it.toString()) }
+        navigateTo?.let { webView.loadUrl(it) }
         return bridge
     }
 
@@ -252,8 +251,52 @@ internal class WebViewJavaScriptBridgeTest {
     }
 
     @Test
+    fun `does not execute queued outbound evaluateJavascript after release`() {
+        val bridge = bridge()
+        connect(bridge)
+        val background = Thread {
+            bridge.postMessage(
+                componentId = componentId,
+                type = "rc:queued",
+                variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+            )
+        }
+        background.start()
+        background.join()
+        bridge.release()
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).doesNotContain("rc:queued")
+    }
+
+    @Test
+    fun `re-validates origin at main-thread delivery after navigation race`() {
+        val bridge = bridge()
+        connect(bridge)
+        webView.loadUrl("https://evil.example.org/phish.html")
+        val background = Thread {
+            bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        }
+        background.start()
+        background.join()
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `treats host comparison as case insensitive`() {
+        val bridge = bridge(navigateTo = "https://Assets.Example.COM/promo/index.html")
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+    }
+
+    @Test
     fun `rejects messages after navigation to an unexpected origin`() {
-        val bridge = bridge(navigateTo = URL("https://evil.example.org/phish.html"))
+        val bridge = bridge(navigateTo = "https://evil.example.org/phish.html")
         connect(bridge)
         bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
         idleMainLooper()
@@ -263,7 +306,7 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `allows messages from the same origin on a different path`() {
-        val bridge = bridge(navigateTo = URL("https://assets.example.com/promo/step-two.html"))
+        val bridge = bridge(navigateTo = "https://assets.example.com/promo/step-two.html")
         connect(bridge)
         bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
         idleMainLooper()
@@ -273,7 +316,7 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `does not deliver outbound messages after navigation to an unexpected origin`() {
-        val bridge = bridge(navigateTo = URL("https://evil.example.org/phish.html"))
+        val bridge = bridge(navigateTo = "https://evil.example.org/phish.html")
         connect(bridge)
         bridge.postMessage(
             componentId = componentId,
@@ -287,7 +330,7 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `treats the default https port as the same origin`() {
-        val bridge = bridge(navigateTo = URL("https://assets.example.com:443/promo/index.html"))
+        val bridge = bridge(navigateTo = "https://assets.example.com:443/promo/index.html")
         connect(bridge)
         bridge.postMessage(
             componentId = componentId,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -36,7 +36,7 @@ internal class WebViewJavaScriptBridgeTest {
     private fun bridge(
         handler: PaywallWebViewMessageHandler? = PaywallWebViewMessageHandler { message, _ -> received.add(message) },
         locale: String = "en-US",
-        navigateTo: URL = expectedUrl,
+        navigateTo: URL? = expectedUrl,
     ): WebViewJavaScriptBridge {
         val bridge = WebViewJavaScriptBridge(
             webView = webView,
@@ -46,8 +46,7 @@ internal class WebViewJavaScriptBridgeTest {
             messageHandler = handler,
         )
         bridge.attach()
-        // Robolectric's ShadowWebView reports the last loaded URL via getUrl().
-        webView.loadUrl(navigateTo.toString())
+        navigateTo?.let { webView.loadUrl(it.toString()) }
         return bridge
     }
 
@@ -55,9 +54,71 @@ internal class WebViewJavaScriptBridgeTest {
         shadowOf(Looper.getMainLooper()).idle()
     }
 
+    private fun connect(bridge: WebViewJavaScriptBridge) {
+        bridge.postMessage(
+            """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"connect","component_id":""}
+            """.trimIndent(),
+        )
+        idleMainLooper()
+    }
+
+    private fun appMessage(
+        type: String,
+        payload: String? = null,
+        kind: String = WebViewEnvelope.KIND_MESSAGE,
+        id: String? = null,
+    ): String {
+        val payloadField = payload?.let { ""","payload":$it""" } ?: ""
+        val idField = id?.let { ""","id":"$it"""" } ?: ""
+        return """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId","type":"$type"$payloadField$idField}
+            """.trimIndent()
+    }
+
     @Test
-    fun `delivers valid message using the canonical component id`() {
-        bridge().postMessage("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+    fun `completes connect handshake with init`() {
+        val bridge = bridge()
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("window.__rcWebComponentsReceive(")
+        assertThat(script).contains("\"kind\":\"init\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+    }
+
+    @Test
+    fun `completes connect handshake before the web view URL is available`() {
+        val bridge = bridge(navigateTo = null)
+        assertThat(webView.url).isNull()
+
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"kind\":\"init\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+    }
+
+    @Test
+    fun `rejects unsupported protocol version`() {
+        val bridge = bridge()
+        bridge.postMessage(
+            """
+            {"channel":"rc-web-components","protocol_version":2,"kind":"connect","component_id":""}
+            """.trimIndent(),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"kind\":\"reject\"")
+        assertThat(script).contains("Unsupported protocol_version 2")
+    }
+
+    @Test
+    fun `delivers valid message after handshake`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
         idleMainLooper()
 
         assertThat(received).hasSize(1)
@@ -66,8 +127,22 @@ internal class WebViewJavaScriptBridgeTest {
     }
 
     @Test
+    fun `ignores app messages before handshake`() {
+        bridge().postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
     fun `rejects messages for a different component id`() {
-        bridge().postMessage("""{"type":"rc:step-loaded","component_id":"other_web_view"}""")
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.STEP_LOADED,
+            ).replace(componentId, "other_web_view"),
+        )
         idleMainLooper()
 
         assertThat(received).isEmpty()
@@ -75,19 +150,39 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `request-variables auto-sends rc variables with locale only`() {
-        bridge().postMessage("""{"type":"rc:request-variables","component_id":"promo_web_view"}""")
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
         idleMainLooper()
 
-        // The app handler is still notified...
         assertThat(received.single().type).isEqualTo("rc:request-variables")
-        // ...and the SDK sent rc:variables back into the web view via the receive hook.
         val script = shadowWebView.lastEvaluatedJavascript
-        assertThat(script).contains("window.__revenueCatReceiveMessage(")
+        assertThat(script).contains("window.__rcWebComponentsReceive(")
+        assertThat(script).contains("\"kind\":\"message\"")
         assertThat(script).contains("\"rc:variables\"")
         assertThat(script).contains("\"component_id\":\"promo_web_view\"")
         assertThat(script).contains("\"locale\":\"en-US\"")
-        // Dashboard custom variables are not passed across the bridge.
         assertThat(script).doesNotContain("\"custom\"")
+    }
+
+    @Test
+    fun `request-variables transport request also sends response`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.REQUEST_VARIABLES,
+                kind = WebViewEnvelope.KIND_REQUEST,
+                id = "req-1",
+            ),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"kind\":\"response\"")
+        assertThat(script).contains("\"id\":\"req-1\"")
+        assertThat(script).contains("\"locale\":\"en-US\"")
+        assertThat(script).doesNotContain("\"rc:variables\"")
     }
 
     @Test
@@ -105,11 +200,11 @@ internal class WebViewJavaScriptBridgeTest {
                 )
             }
         }
-        bridge(handler = handler)
-            .postMessage("""{"type":"rc:request-variables","component_id":"promo_web_view"}""")
+        val bridge = bridge(handler = handler)
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
         idleMainLooper()
 
-        // The controller's reply is the most recent script delivered to the web view.
         val script = shadowWebView.lastEvaluatedJavascript
         assertThat(script).contains("\"rc:variables\"")
         assertThat(script).contains("\"app_segment\":\"high_intent\"")
@@ -119,8 +214,9 @@ internal class WebViewJavaScriptBridgeTest {
     fun `controller postVariables drops reserved keys`() {
         val controllerHolder = arrayOfNulls<PaywallWebViewController>(1)
         val handler = PaywallWebViewMessageHandler { _, controller -> controllerHolder[0] = controller }
-        bridge(handler = handler)
-            .postMessage("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+        val bridge = bridge(handler = handler)
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
         idleMainLooper()
 
         controllerHolder[0]!!.postVariables(
@@ -140,9 +236,10 @@ internal class WebViewJavaScriptBridgeTest {
     @Test
     fun `does not deliver messages after release`() {
         val bridge = bridge()
+        connect(bridge)
         bridge.release()
 
-        bridge.postMessage("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
         idleMainLooper()
 
         assertThat(received).isEmpty()
@@ -150,8 +247,9 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `rejects messages after navigation to an unexpected origin`() {
-        bridge(navigateTo = URL("https://evil.example.org/phish.html"))
-            .postMessage("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+        val bridge = bridge(navigateTo = URL("https://evil.example.org/phish.html"))
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
         idleMainLooper()
 
         assertThat(received).isEmpty()
@@ -159,8 +257,9 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `allows messages from the same origin on a different path`() {
-        bridge(navigateTo = URL("https://assets.example.com/promo/step-two.html"))
-            .postMessage("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+        val bridge = bridge(navigateTo = URL("https://assets.example.com/promo/step-two.html"))
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
         idleMainLooper()
 
         assertThat(received).hasSize(1)
@@ -168,8 +267,9 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `does not deliver outbound messages after navigation to an unexpected origin`() {
-        // Symmetric with the inbound guard: outbound envelopes must not leak into foreign content.
-        bridge(navigateTo = URL("https://evil.example.org/phish.html")).postMessage(
+        val bridge = bridge(navigateTo = URL("https://evil.example.org/phish.html"))
+        connect(bridge)
+        bridge.postMessage(
             componentId = componentId,
             type = "rc:custom",
             variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
@@ -181,8 +281,9 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `treats the default https port as the same origin`() {
-        // expectedUrl omits the port; navigating to the explicit :443 must still match (inbound + outbound).
-        bridge(navigateTo = URL("https://assets.example.com:443/promo/index.html")).postMessage(
+        val bridge = bridge(navigateTo = URL("https://assets.example.com:443/promo/index.html"))
+        connect(bridge)
+        bridge.postMessage(
             componentId = componentId,
             type = "rc:custom",
             variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
@@ -194,14 +295,14 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `delivers rc step-complete responses to the handler without sending an outbound message`() {
-        bridge().postMessage(
-            """
-            {
-              "type":"rc:step-complete",
-              "component_id":"promo_web_view",
-              "responses":{"selected_plan":"annual","accepted_terms":true}
-            }
-            """.trimIndent(),
+        val bridge = bridge()
+        connect(bridge)
+        val scriptAfterConnect = shadowWebView.lastEvaluatedJavascript
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"selected_plan":"annual","accepted_terms":true}}""",
+            ),
         )
         idleMainLooper()
 
@@ -209,14 +310,18 @@ internal class WebViewJavaScriptBridgeTest {
         assertThat(message.type).isEqualTo("rc:step-complete")
         assertThat(message.responses?.get("selected_plan")).isEqualTo(PaywallWebViewValue.String("annual"))
         assertThat(message.responses?.get("accepted_terms")).isEqualTo(PaywallWebViewValue.Boolean(true))
-        // rc:step-complete must not auto-dismiss or send anything back; the app decides.
-        assertThat(shadowWebView.lastEvaluatedJavascript).isNull()
+        assertThat(shadowWebView.lastEvaluatedJavascript).isEqualTo(scriptAfterConnect)
     }
 
     @Test
     fun `delivers rc error to the handler`() {
-        bridge().postMessage(
-            """{"type":"rc:error","component_id":"promo_web_view","error":"Something went wrong"}""",
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.ERROR,
+                payload = """{"error":"Something went wrong"}""",
+            ),
         )
         idleMainLooper()
 
@@ -227,7 +332,9 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `does not deliver malformed messages to the handler`() {
-        bridge().postMessage("""not even json""")
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage("""not even json""")
         idleMainLooper()
 
         assertThat(received).isEmpty()
@@ -235,8 +342,9 @@ internal class WebViewJavaScriptBridgeTest {
 
     @Test
     fun `auto-sends rc variables even when no handler is set`() {
-        bridge(handler = null)
-            .postMessage("""{"type":"rc:request-variables","component_id":"promo_web_view"}""")
+        val bridge = bridge(handler = null)
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
         idleMainLooper()
 
         assertThat(received).isEmpty()
@@ -248,12 +356,13 @@ internal class WebViewJavaScriptBridgeTest {
     @Test
     fun `update refreshes the variables sent on a subsequent request`() {
         val bridge = bridge(locale = "en-US")
+        connect(bridge)
         bridge.update(
             locale = "fr-FR",
             messageHandler = null,
         )
 
-        bridge.postMessage("""{"type":"rc:request-variables","component_id":"promo_web_view"}""")
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
         idleMainLooper()
 
         val script = shadowWebView.lastEvaluatedJavascript
@@ -262,8 +371,10 @@ internal class WebViewJavaScriptBridgeTest {
     }
 
     @Test
-    fun `generic postMessage nests the payload under the variables key`() {
-        bridge().postMessage(
+    fun `generic postMessage sends transport envelope with payload`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
             componentId = componentId,
             type = "rc:custom",
             variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
@@ -271,18 +382,19 @@ internal class WebViewJavaScriptBridgeTest {
         idleMainLooper()
 
         val script = shadowWebView.lastEvaluatedJavascript
-        assertThat(script).contains("window.__revenueCatReceiveMessage(")
+        assertThat(script).contains("window.__rcWebComponentsReceive(")
+        assertThat(script).contains("\"kind\":\"message\"")
         assertThat(script).contains("\"type\":\"rc:custom\"")
         assertThat(script).contains("\"component_id\":\"promo_web_view\"")
-        // The payload is delivered under the `variables` key, never merged into the envelope top level.
-        assertThat(script).contains("\"variables\":{\"foo\":\"bar\"}")
+        assertThat(script).contains("\"payload\":{\"foo\":\"bar\"}")
     }
 
     @Test
     fun `escapes line and paragraph separators in outbound payloads`() {
-        // U+2028/U+2029 are valid in JSON strings but terminate JS statements; they must be escaped.
         val raw = "a\u2028b\u2029c"
-        bridge().postVariables(
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postVariables(
             componentId = componentId,
             variables = mapOf(
                 "custom" to PaywallWebViewValue.Object(mapOf("note" to PaywallWebViewValue.String(raw))),
@@ -298,32 +410,19 @@ internal class WebViewJavaScriptBridgeTest {
     }
 
     @Test
-    fun `attach registers a single native interface under the private name`() {
+    fun `attach registers native interface under rcWebComponents`() {
         bridge()
 
-        assertThat(shadowWebView.getJavascriptInterface("__RevenueCatNativeBridge")).isNotNull
-        // The public object name is created by the injected shim, not exposed as a native interface.
-        assertThat(shadowWebView.getJavascriptInterface("RevenueCatWebView")).isNull()
-    }
-
-    @Test
-    fun `injectBridgeScript exposes the public surface without overwriting an existing bridge`() {
-        bridge().injectBridgeScript()
-
-        val script = shadowWebView.lastEvaluatedJavascript
-        assertThat(script).contains("window.RevenueCatWebView")
-        assertThat(script).contains("window.__RevenueCatNativeBridge")
-        // Guard so an existing bridge is not clobbered.
-        assertThat(script).contains("if (window.RevenueCatWebView)")
+        assertThat(shadowWebView.getJavascriptInterface("rcWebComponents")).isNotNull
     }
 
     @Test
     fun `release removes the native interface`() {
         val bridge = bridge()
-        assertThat(shadowWebView.getJavascriptInterface("__RevenueCatNativeBridge")).isNotNull
+        assertThat(shadowWebView.getJavascriptInterface("rcWebComponents")).isNotNull
 
         bridge.release()
 
-        assertThat(shadowWebView.getJavascriptInterface("__RevenueCatNativeBridge")).isNull()
+        assertThat(shadowWebView.getJavascriptInterface("rcWebComponents")).isNull()
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParserTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParserTest.kt
@@ -13,29 +13,33 @@ internal class WebViewMessageParserTest {
 
     @Test
     fun `parses rc step-loaded`() {
-        val message = parse("""{"type":"rc:step-loaded","component_id":"promo_web_view"}""")
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_LOADED,
+            ),
+        )
 
-        assertThat(message).isNotNull
-        assertThat(message!!.type).isEqualTo("rc:step-loaded")
+        assertThat(parsed).isNotNull
+        val message = parsed!!.message
+        assertThat(message.type).isEqualTo("rc:step-loaded")
         assertThat(message.componentId).isEqualTo("promo_web_view")
         assertThat(message.responses).isNull()
         assertThat(message.error).isNull()
     }
 
     @Test
-    fun `parses rc step-complete with responses`() {
-        val message = parse(
-            """
-            {
-              "type":"rc:step-complete",
-              "component_id":"promo_web_view",
-              "responses":{"selected_plan":"annual","accepted_terms":true,"count":3}
-            }
-            """.trimIndent(),
+    fun `parses rc step-complete with responses in payload`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"selected_plan":"annual","accepted_terms":true,"count":3}}""",
+            ),
         )
 
-        assertThat(message).isNotNull
-        val responses = message!!.responses
+        assertThat(parsed).isNotNull
+        val responses = parsed!!.message.responses
         assertThat(responses).isNotNull
         assertThat(responses!!["selected_plan"]).isEqualTo(PaywallWebViewValue.String("annual"))
         assertThat(responses["accepted_terms"]).isEqualTo(PaywallWebViewValue.Boolean(true))
@@ -44,63 +48,150 @@ internal class WebViewMessageParserTest {
 
     @Test
     fun `parses rc step-complete without responses as empty map`() {
-        val message = parse("""{"type":"rc:step-complete","component_id":"promo_web_view"}""")
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+            ),
+        )
 
-        assertThat(message).isNotNull
-        assertThat(message!!.responses).isEmpty()
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.responses).isEmpty()
     }
 
     @Test
-    fun `parses rc request-variables`() {
-        val message = parse("""{"type":"rc:request-variables","component_id":"promo_web_view"}""")
+    fun `parses rc request-variables as message`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.REQUEST_VARIABLES,
+            ),
+        )
 
-        assertThat(message).isNotNull
-        assertThat(message!!.type).isEqualTo("rc:request-variables")
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.type).isEqualTo("rc:request-variables")
+        assertThat(parsed.requestId).isNull()
     }
 
     @Test
-    fun `parses rc error`() {
-        val message = parse("""{"type":"rc:error","component_id":"promo_web_view","error":"Boom"}""")
+    fun `parses rc request-variables as transport request`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_REQUEST,
+                type = WebViewMessageType.REQUEST_VARIABLES,
+                id = "req-1",
+            ),
+        )
 
-        assertThat(message).isNotNull
-        assertThat(message!!.error).isEqualTo("Boom")
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.type).isEqualTo("rc:request-variables")
+        assertThat(parsed.requestId).isEqualTo("req-1")
+    }
+
+    @Test
+    fun `parses rc error from payload`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.ERROR,
+                payload = """{"error":"Boom"}""",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.error).isEqualTo("Boom")
     }
 
     @Test
     fun `rejects message without type`() {
-        assertThat(parse("""{"component_id":"promo_web_view"}""")).isNull()
+        assertThat(
+            parse(
+                """{"channel":"rc-web-components","protocol_version":1,"kind":"message","component_id":"promo_web_view"}""",
+            ),
+        ).isNull()
     }
 
     @Test
     fun `rejects message with non-string type`() {
-        assertThat(parse("""{"type":123,"component_id":"promo_web_view"}""")).isNull()
+        assertThat(
+            parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"message","component_id":"promo_web_view","type":123}
+                """.trimIndent(),
+            ),
+        ).isNull()
     }
 
     @Test
     fun `rejects message without component_id`() {
-        assertThat(parse("""{"type":"rc:step-loaded"}""")).isNull()
+        assertThat(
+            parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"message","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
     }
 
     @Test
     fun `rejects message with wrong component_id`() {
-        assertThat(parse("""{"type":"rc:step-loaded","component_id":"other_web_view"}""")).isNull()
+        assertThat(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_LOADED,
+                componentId = "other_web_view",
+            ).let(::parse),
+        ).isNull()
     }
 
     @Test
     fun `rejects rc step-complete with non-object responses`() {
         assertThat(
-            parse("""{"type":"rc:step-complete","component_id":"promo_web_view","responses":"nope"}"""),
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = WebViewMessageType.STEP_COMPLETE,
+                    payload = """{"responses":"nope"}""",
+                ),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects rc step-complete payload with transport fields and no responses object`() {
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = WebViewMessageType.STEP_COMPLETE,
+                    payload = """{"type":"rc:step-complete","selected_plan":"annual"}""",
+                ),
+            ),
         ).isNull()
     }
 
     @Test
     fun `rejects rc error without error string`() {
-        assertThat(parse("""{"type":"rc:error","component_id":"promo_web_view"}""")).isNull()
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = WebViewMessageType.ERROR,
+                ),
+            ),
+        ).isNull()
     }
 
     @Test
     fun `drops unknown message types`() {
-        assertThat(parse("""{"type":"rc:something-new","component_id":"promo_web_view"}""")).isNull()
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = "rc:something-new",
+                ),
+            ),
+        ).isNull()
     }
 
     @Test
@@ -116,39 +207,69 @@ internal class WebViewMessageParserTest {
     @Test
     fun `rejects oversized payload`() {
         val hugeValue = "x".repeat(WebViewMessageParser.MAX_PAYLOAD_BYTES + 1)
-        val raw = """{"type":"rc:error","component_id":"promo_web_view","error":"$hugeValue"}"""
+        val raw = envelope(
+            kind = WebViewEnvelope.KIND_MESSAGE,
+            type = WebViewMessageType.ERROR,
+            payload = """{"error":"$hugeValue"}""",
+        )
         assertThat(parse(raw)).isNull()
     }
 
     @Test
     fun `rejects excessively nested responses`() {
-        // Build responses nested deeper than MAX_NESTING_DEPTH.
         val depth = WebViewMessageParser.MAX_NESTING_DEPTH + 2
         val opening = "{\"a\":".repeat(depth)
         val closing = "}".repeat(depth)
         val nested = opening + "1" + closing
-        val raw = """{"type":"rc:step-complete","component_id":"promo_web_view","responses":$nested}"""
+        val raw = envelope(
+            kind = WebViewEnvelope.KIND_MESSAGE,
+            type = WebViewMessageType.STEP_COMPLETE,
+            payload = """{"responses":$nested}""",
+        )
         assertThat(parse(raw)).isNull()
     }
 
     @Test
     fun `accepts null and nested json-compatible values in responses`() {
-        val message = parse(
-            """
-            {
-              "type":"rc:step-complete",
-              "component_id":"promo_web_view",
-              "responses":{"maybe":null,"list":[1,"two",false],"obj":{"k":"v"}}
-            }
-            """.trimIndent(),
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"maybe":null,"list":[1,"two",false],"obj":{"k":"v"}}}""",
+            ),
         )
 
-        assertThat(message).isNotNull
-        val responses = message!!.responses!!
+        assertThat(parsed).isNotNull
+        val responses = parsed!!.message.responses!!
         assertThat(responses["maybe"]).isEqualTo(PaywallWebViewValue.Null)
         assertThat(responses["list"]).isInstanceOf(PaywallWebViewValue.Array::class.java)
         assertThat(responses["obj"]).isInstanceOf(PaywallWebViewValue.Object::class.java)
     }
 
+    @Test
+    fun `ignores handshake frames`() {
+        assertThat(
+            parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"connect","component_id":""}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
     private fun parse(raw: String) = WebViewMessageParser.parse(raw, expectedComponentId = componentId)
+
+    private fun envelope(
+        kind: String,
+        type: String,
+        componentId: String = this.componentId,
+        payload: String? = null,
+        id: String? = null,
+    ): String {
+        val payloadField = payload?.let { ""","payload":$it""" } ?: ""
+        val idField = id?.let { ""","id":"$it"""" } ?: ""
+        return """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId","type":"$type"$payloadField$idField}
+            """.trimIndent()
+    }
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Provides the live JS↔native bridge that powers `web_view` bidirectional messaging, built on the message model and variables provider.


Part of PWENG-98.

### Description
- Adds `WebViewJavaScriptBridge`: installs a document-start `window.RevenueCatWebView` shim, validates and dispatches inbound messages (origin-checked, on the main thread), and delivers native→web messages via `window.__revenueCatReceiveMessage`.
- Outgoing messages use the `{ "type", "component_id", "variables" }` envelope (payload nested under `variables`), matching the other RevenueCat SDK platforms. On `rc:request-variables` the SDK auto-replies with its system variables, then invokes the app handler.
- Internal; exercised by unit tests in isolation. Wiring into the rendered paywall lands in the final PR.
- Tested by `WebViewJavaScriptBridgeTest`.

iOS parity: mirrors `purchases-ios` (`web-view-bridge-wiring`), including the `{ type, component_id, variables }` envelope.
Stack (merge bottom-up): schema → rendering → CSP → value types → message model → variables provider → **JS bridge** → wiring.

<!-- FOLDED_HARDENING_BEGIN -->
### Folded-in hardening

[`f3199b519b5f538086487240935b366822729d14`](https://github.com/RevenueCat/purchases-android/commit/f3199b519b5f538086487240935b366822729d14) was folded into this stack level. It drops queued outbound JavaScript after release, revalidates origin on main-thread delivery, compares hosts case-insensitively, and documents the cross-platform flat `payload` map correctly.

Android `WebViewClient` does not expose an `ERROR_CANCELLED` constant, and Chromium suppresses aborted loads before invoking `onReceivedError`. The folded correction therefore removes the invalid cancellation exception and its obsolete test/documentation; main-frame errors that Android actually delivers still trigger fallback.

This supersedes older description text that showed app variables nested under a `variables` envelope key.
<!-- FOLDED_HARDENING_END -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a JavaScript interface on WebView with origin validation and CSP; mistakes could affect paywall security or hosted web flows, though the change includes explicit origin checks and extensive tests.
> 
> **Overview**
> Adds **bidirectional JS↔native messaging** for Paywalls V2 `web_view`, aligned with `workflow-web-components-sdk` (`rc-web-components` channel, `connect`/`init` handshake, `message`/`request`/`response` frames) via `window.rcWebComponents` and `__rcWebComponentsReceive`—replacing a flat postMessage shape and document-start shim.
> 
> **`WebViewJavaScriptBridge`** handles handshake, origin checks, payload limits, auto-reply to `rc:request-variables`, `fit`/`resize` for **fit** sizing, and lifecycle on the main thread. **`WebViewMessageParser`** and **`WebViewEnvelope`** parse the new wire format; schema gains optional **`fallback`** stack.
> 
> **`WebViewComponentView`** installs the bridge when `componentId` is set, detects main-frame load failures (HTTP ≥400), renders the fallback stack, and adjusts layout from content-reported CSS size. Style factory passes `componentId` and fallback into **`WebViewComponentStyle`**; **`ComponentView`** forwards click/interaction callbacks to the web view path.
> 
> Coverage: **`WebViewJavaScriptBridgeTest`** and updated **`WebViewMessageParserTest`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8063d3fb74248cef916e84823e3214e16a3d6119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->