### PR TITLE
feat(paywalls): add state-driven paywalls data layer (PWENG-57)

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
@@ -29,7 +29,7 @@ public class ButtonComponent(
     @get:JvmSynthetic public val transition: PaywallTransition? = null,
     @get:JvmSynthetic public val name: String? = null,
     @get:JvmSynthetic public val id: String? = null,
-    @get:JvmSynthetic public val stateUpdates: List<StateUpdate>? = null,
+    @get:JvmSynthetic @SerialName("state_updates") public val stateUpdates: List<StateUpdate>? = null,
 ) : PaywallComponent {
 
     @InternalRevenueCatAPI

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.paywalls.components.ButtonComponent.Action
 import com.revenuecat.purchases.paywalls.components.ButtonComponent.Destination
 import com.revenuecat.purchases.paywalls.components.ButtonComponent.UrlMethod
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.utils.serializers.EnumDeserializerWithDefault
 import dev.drewhamilton.poko.Poko
@@ -28,6 +29,7 @@ public class ButtonComponent(
     @get:JvmSynthetic public val transition: PaywallTransition? = null,
     @get:JvmSynthetic public val name: String? = null,
     @get:JvmSynthetic public val id: String? = null,
+    @get:JvmSynthetic public val stateUpdates: List<StateUpdate>? = null,
 ) : PaywallComponent {
 
     @InternalRevenueCatAPI

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/CarouselComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/CarouselComponent.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.CarouselComponent.PageControl
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
 import com.revenuecat.purchases.paywalls.components.properties.Border
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.paywalls.components.properties.Padding
@@ -70,6 +71,8 @@ public class CarouselComponent(
     public val overrides: List<ComponentOverride<PartialCarouselComponent>> = emptyList(),
     @get:JvmSynthetic
     public val name: String? = null,
+    @get:JvmSynthetic
+    public val stateUpdates: List<StateUpdate>? = null,
 ) : PaywallComponent {
 
     @Poko

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/CarouselComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/CarouselComponent.kt
@@ -72,6 +72,7 @@ public class CarouselComponent(
     @get:JvmSynthetic
     public val name: String? = null,
     @get:JvmSynthetic
+    @SerialName("state_updates")
     public val stateUpdates: List<StateUpdate>? = null,
 ) : PaywallComponent {
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/TabsComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/TabsComponent.kt
@@ -103,6 +103,7 @@ public class TabsComponent(
     @get:JvmSynthetic
     public val overrides: List<ComponentOverride<PartialTabsComponent>> = emptyList(),
     @get:JvmSynthetic
+    @SerialName("state_updates")
     public val stateUpdates: List<StateUpdate>? = null,
 ) : PaywallComponent {
     @InternalRevenueCatAPI

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/TabsComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/TabsComponent.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Immutable
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
 import com.revenuecat.purchases.paywalls.components.properties.Border
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.paywalls.components.properties.Padding
@@ -101,6 +102,8 @@ public class TabsComponent(
     public val defaultTabId: String? = null,
     @get:JvmSynthetic
     public val overrides: List<ComponentOverride<PartialTabsComponent>> = emptyList(),
+    @get:JvmSynthetic
+    public val stateUpdates: List<StateUpdate>? = null,
 ) : PaywallComponent {
     @InternalRevenueCatAPI
     @Poko

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverride.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverride.kt
@@ -94,6 +94,13 @@ public class ComponentOverride<T : PartialComponent>(
         ) : Condition { override val isRule: Boolean get() = true }
 
         @Serializable
+        public data class State(
+            public val operator: EqualityOperator,
+            public val name: String,
+            public val value: JsonPrimitive,
+        ) : Condition { override val isRule: Boolean get() = true }
+
+        @Serializable
         public object Unsupported : Condition
     }
 }
@@ -113,6 +120,7 @@ internal object ConditionSerializer : SealedDeserializerWithDefault<Condition>(
         "promo_offer_condition" to { Condition.PromoOfferRule.serializer() },
         "selected_package_condition" to { Condition.SelectedPackage.serializer() },
         "variable_condition" to { Condition.Variable.serializer() },
+        "state_condition" to { Condition.State.serializer() },
     ),
     defaultValue = { Condition.Unsupported },
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverride.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverride.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.utils.serializers.SealedDeserializerWithDefault
 import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 
 @InternalRevenueCatAPI
@@ -98,7 +99,14 @@ public class ComponentOverride<T : PartialComponent>(
             public val operator: EqualityOperator,
             public val name: String,
             public val value: JsonPrimitive,
-        ) : Condition { override val isRule: Boolean get() = true }
+        ) : Condition {
+            override val isRule: Boolean get() = true
+
+            init {
+                // Parity with iOS, where a null value fails ConditionValue decoding: fall back to Unsupported.
+                require(value !is JsonNull) { "State condition value must not be null" }
+            }
+        }
 
         @Serializable
         public object Unsupported : Condition

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/PaywallComponentsData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/PaywallComponentsData.kt
@@ -48,6 +48,10 @@ public class PaywallComponentsData(
     @get:JvmSynthetic
     @SerialName("automatically_scale_font_size")
     public val automaticallyScaleFontSize: Boolean = true,
+    @get:JvmSynthetic
+    @Serializable(with = StateDeclarationMapSerializer::class)
+    @SerialName("state_declarations")
+    public val stateDeclarations: Map<String, StateDeclaration>? = null,
 )
 
 @OptIn(InternalRevenueCatAPI::class)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/StateDeclaration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/StateDeclaration.kt
@@ -1,0 +1,61 @@
+package com.revenuecat.purchases.paywalls.components.common
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * A named state key declared in a paywall's top-level `state_declarations` map (state-driven paywalls).
+ */
+@InternalRevenueCatAPI
+@Poko
+@Serializable
+public class StateDeclaration(
+    // Raw String rather than an enum so unknown types decode without failing.
+    @get:JvmSynthetic public val type: String,
+    @get:JvmSynthetic @SerialName("default") public val defaultValue: JsonPrimitive,
+) {
+
+    // Constants rather than an enum so unrecognized wire types are preserved.
+    @InternalRevenueCatAPI
+    public object ValueType {
+        public const val BOOLEAN: String = "boolean"
+        public const val INTEGER: String = "integer"
+        public const val DOUBLE: String = "double"
+        public const val STRING: String = "string"
+    }
+}
+
+/**
+ * Decodes the top-level `state_declarations` map resiliently: individual malformed entries are dropped and a
+ * non-object value decodes to an empty map, so a broken declaration never fails the whole paywall.
+ */
+@OptIn(InternalRevenueCatAPI::class)
+internal object StateDeclarationMapSerializer : KSerializer<Map<String, StateDeclaration>> {
+    override val descriptor: SerialDescriptor = JsonObject.serializer().descriptor
+
+    @Suppress("ReturnCount")
+    override fun deserialize(decoder: Decoder): Map<String, StateDeclaration> {
+        val jsonDecoder = decoder as? JsonDecoder ?: return emptyMap()
+        val jsonObject = jsonDecoder.decodeJsonElement() as? JsonObject ?: return emptyMap()
+        return jsonObject.mapNotNull { (key, element) ->
+            try {
+                key to jsonDecoder.json.decodeFromJsonElement(StateDeclaration.serializer(), element)
+            } catch (_: IllegalArgumentException) {
+                null
+            }
+        }.toMap()
+    }
+
+    override fun serialize(encoder: Encoder, value: Map<String, StateDeclaration>) {
+        throw NotImplementedError("Serialization is not implemented because it is not needed.")
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/StateDeclaration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/StateDeclaration.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
@@ -55,7 +56,9 @@ internal object StateDeclarationMapSerializer : KSerializer<Map<String, StateDec
         val jsonObject = jsonDecoder.decodeJsonElement() as? JsonObject ?: return emptyMap()
         return jsonObject.mapNotNull { (key, element) ->
             try {
-                key to jsonDecoder.json.decodeFromJsonElement(StateDeclaration.serializer(), element)
+                val declaration = jsonDecoder.json.decodeFromJsonElement(StateDeclaration.serializer(), element)
+                // Parity with iOS, where a null default fails ConditionValue decoding: drop the declaration.
+                declaration.takeIf { it.defaultValue !is JsonNull }?.let { key to it }
             } catch (_: IllegalArgumentException) {
                 null
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/StateDeclaration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/StateDeclaration.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.paywalls.components.common
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.utils.serializers.EnumDeserializerWithDefault
 import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -19,20 +20,26 @@ import kotlinx.serialization.json.JsonPrimitive
 @Poko
 @Serializable
 public class StateDeclaration(
-    // Raw String rather than an enum so unknown types decode without failing.
-    @get:JvmSynthetic public val type: String,
+    @get:JvmSynthetic public val type: ValueType,
     @get:JvmSynthetic @SerialName("default") public val defaultValue: JsonPrimitive,
 ) {
 
-    // Constants rather than an enum so unrecognized wire types are preserved.
-    @InternalRevenueCatAPI
-    public object ValueType {
-        public const val BOOLEAN: String = "boolean"
-        public const val INTEGER: String = "integer"
-        public const val DOUBLE: String = "double"
-        public const val STRING: String = "string"
+    /** Declared type of a state key. Unrecognized wire types decode to [UNKNOWN]. */
+    @Serializable(with = ValueTypeSerializer::class)
+    public enum class ValueType {
+        // SerialNames are handled by the ValueTypeSerializer.
+        BOOLEAN,
+        INTEGER,
+        DOUBLE,
+        STRING,
+        UNKNOWN,
     }
 }
+
+@OptIn(InternalRevenueCatAPI::class)
+internal object ValueTypeSerializer : EnumDeserializerWithDefault<StateDeclaration.ValueType>(
+    defaultValue = StateDeclaration.ValueType.UNKNOWN,
+)
 
 /**
  * Decodes the top-level `state_declarations` map resiliently: individual malformed entries are dropped and a

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/StateUpdate.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/StateUpdate.kt
@@ -20,14 +20,12 @@ import kotlinx.serialization.json.JsonPrimitive
 public sealed interface StateUpdate {
 
     /** Wire shape: `{ "set": "<key>", "to": <value | "$value"> }`. */
-    @InternalRevenueCatAPI
     @Poko
     public class Set(
         @get:JvmSynthetic public val key: String,
         @get:JvmSynthetic public val value: StateUpdateValue,
     ) : StateUpdate
 
-    @InternalRevenueCatAPI
     public object Unsupported : StateUpdate
 }
 
@@ -37,14 +35,11 @@ public sealed interface StateUpdate {
 @InternalRevenueCatAPI
 public sealed interface StateUpdateValue {
 
-    @InternalRevenueCatAPI
     @Poko
     public class Literal(@get:JvmSynthetic public val value: JsonPrimitive) : StateUpdateValue
 
-    @InternalRevenueCatAPI
     public object PayloadReference : StateUpdateValue
 
-    @InternalRevenueCatAPI
     public companion object {
         public const val PAYLOAD_REFERENCE_TOKEN: String = "\$value"
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/StateUpdate.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/StateUpdate.kt
@@ -1,0 +1,78 @@
+package com.revenuecat.purchases.paywalls.components.common
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * A declarative state mutation on an interactive component (state-driven paywalls). Decode-only in this phase: only
+ * `set` is defined, and unknown or malformed shapes decode to [Unsupported] so future operations stay additive.
+ */
+@InternalRevenueCatAPI
+@Serializable(with = StateUpdateSerializer::class)
+public sealed interface StateUpdate {
+
+    /** Wire shape: `{ "set": "<key>", "to": <value | "$value"> }`. */
+    @InternalRevenueCatAPI
+    @Poko
+    public class Set(
+        @get:JvmSynthetic public val key: String,
+        @get:JvmSynthetic public val value: StateUpdateValue,
+    ) : StateUpdate
+
+    @InternalRevenueCatAPI
+    public object Unsupported : StateUpdate
+}
+
+/**
+ * The `to` value of a [StateUpdate.Set]: a [Literal] value or a [PayloadReference] (the wire sentinel `"$value"`).
+ */
+@InternalRevenueCatAPI
+public sealed interface StateUpdateValue {
+
+    @InternalRevenueCatAPI
+    @Poko
+    public class Literal(@get:JvmSynthetic public val value: JsonPrimitive) : StateUpdateValue
+
+    @InternalRevenueCatAPI
+    public object PayloadReference : StateUpdateValue
+
+    @InternalRevenueCatAPI
+    public companion object {
+        public const val PAYLOAD_REFERENCE_TOKEN: String = "\$value"
+    }
+}
+
+@OptIn(InternalRevenueCatAPI::class)
+internal object StateUpdateSerializer : KSerializer<StateUpdate> {
+    private const val KEY_SET = "set"
+    private const val KEY_TO = "to"
+
+    override val descriptor: SerialDescriptor = JsonObject.serializer().descriptor
+
+    @Suppress("ReturnCount")
+    override fun deserialize(decoder: Decoder): StateUpdate {
+        val jsonDecoder = decoder as? JsonDecoder ?: return StateUpdate.Unsupported
+        val jsonObject = jsonDecoder.decodeJsonElement() as? JsonObject ?: return StateUpdate.Unsupported
+        val key = (jsonObject[KEY_SET] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: return StateUpdate.Unsupported
+        val toElement = jsonObject[KEY_TO] as? JsonPrimitive ?: return StateUpdate.Unsupported
+        val value = if (toElement.isString && toElement.content == StateUpdateValue.PAYLOAD_REFERENCE_TOKEN) {
+            StateUpdateValue.PayloadReference
+        } else {
+            StateUpdateValue.Literal(toElement)
+        }
+        return StateUpdate.Set(key = key, value = value)
+    }
+
+    override fun serialize(encoder: Encoder, value: StateUpdate) {
+        throw NotImplementedError("Serialization is not implemented because it is not needed.")
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
@@ -3,6 +3,8 @@ package com.revenuecat.purchases.paywalls.components
 import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
+import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.paywalls.components.properties.Size
@@ -12,6 +14,7 @@ import org.junit.Test
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import kotlinx.serialization.json.JsonPrimitive
 
 @RunWith(Enclosed::class)
 internal class ButtonComponentTests {
@@ -57,7 +60,10 @@ internal class ButtonComponentTests {
                                 "type": "text"
                               }
                             ]
-                          }
+                          },
+                          "state_updates": [
+                            { "set": "planComparisonOpen", "to": true }
+                          ]
                         }
                         """.trimIndent(),
                         expected = ButtonComponent(
@@ -70,7 +76,13 @@ internal class ButtonComponentTests {
                                         name = "Text",
                                     )
                                 ),
-                            )
+                            ),
+                            stateUpdates = listOf(
+                                StateUpdate.Set(
+                                    key = "planComparisonOpen",
+                                    value = StateUpdateValue.Literal(JsonPrimitive(true)),
+                                ),
+                            ),
                         )
                     ),
                 ),

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/CarouselComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/CarouselComponentTests.kt
@@ -3,6 +3,8 @@ package com.revenuecat.purchases.paywalls.components
 import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
+import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
 import com.revenuecat.purchases.paywalls.components.properties.Border
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
@@ -195,7 +197,10 @@ internal class CarouselComponentTests {
                               "components": []
                             }
                           ],
-                          "visible": false
+                          "visible": false,
+                          "state_updates": [
+                            { "set": "activeSlide", "to": "${'$'}value" }
+                          ]
                         }
                         """.trimIndent(),
                         expected = CarouselComponent(
@@ -291,7 +296,10 @@ internal class CarouselComponentTests {
                                 msTimePerPage = 1000,
                                 msTransitionTime = 500,
                                 transitionType = CarouselComponent.AutoAdvancePages.TransitionType.FADE,
-                            )
+                            ),
+                            stateUpdates = listOf(
+                                StateUpdate.Set(key = "activeSlide", value = StateUpdateValue.PayloadReference),
+                            ),
                         )
                     ),
                 ),

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/TabsComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/TabsComponentTests.kt
@@ -4,6 +4,8 @@ import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
+import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
 import com.revenuecat.purchases.paywalls.components.properties.Border
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
@@ -270,7 +272,10 @@ internal class TabsComponentTests {
                             "x": 23.6,
                             "y": 45.2
                           },
-                          "visible": false
+                          "visible": false,
+                          "state_updates": [
+                            { "set": "selectedFeatureTab", "to": "${'$'}value" }
+                          ]
                         }
                         """.trimIndent(),
                         expected = TabsComponent(
@@ -321,6 +326,9 @@ internal class TabsComponentTests {
                                 y = 45.2
                             ),
                             name = "Tabs",
+                            stateUpdates = listOf(
+                                StateUpdate.Set(key = "selectedFeatureTab", value = StateUpdateValue.PayloadReference),
+                            ),
                         )
                     ),
                 ),

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
@@ -467,6 +467,74 @@ internal class ComponentOverridesTests {
                         value = JsonPrimitive("premium"),
                     ),
                 ),
+
+                // State condition with boolean value
+                arrayOf(
+                    """{ "type": "state_condition", "operator": "=", "name": "planComparisonOpen", "value": true }""",
+                    ComponentOverride.Condition.State(
+                        operator = ComponentOverride.EqualityOperator.EQUALS,
+                        name = "planComparisonOpen",
+                        value = JsonPrimitive(true),
+                    ),
+                ),
+                // State condition with integer value
+                arrayOf(
+                    """{ "type": "state_condition", "operator": "=", "name": "activeSlide", "value": 2 }""",
+                    ComponentOverride.Condition.State(
+                        operator = ComponentOverride.EqualityOperator.EQUALS,
+                        name = "activeSlide",
+                        value = JsonPrimitive(2),
+                    ),
+                ),
+                // State condition with double value
+                arrayOf(
+                    """{ "type": "state_condition", "operator": "=", "name": "discountMultiplier", "value": 0.5 }""",
+                    ComponentOverride.Condition.State(
+                        operator = ComponentOverride.EqualityOperator.EQUALS,
+                        name = "discountMultiplier",
+                        value = JsonPrimitive(0.5),
+                    ),
+                ),
+                // State condition with string value and not-equals
+                arrayOf(
+                    """{ "type": "state_condition", "operator": "!=", "name": "selectedFeatureTab", "value": "billing" }""",
+                    ComponentOverride.Condition.State(
+                        operator = ComponentOverride.EqualityOperator.NOT_EQUALS,
+                        name = "selectedFeatureTab",
+                        value = JsonPrimitive("billing"),
+                    ),
+                ),
+                // State condition with extra unknown fields deserializes successfully
+                arrayOf(
+                    """{ "type": "state_condition", "operator": "=", "name": "k", "value": true, "future_field": 1 }""",
+                    ComponentOverride.Condition.State(
+                        operator = ComponentOverride.EqualityOperator.EQUALS,
+                        name = "k",
+                        value = JsonPrimitive(true),
+                    ),
+                ),
+                // State condition with missing name / value / unknown operator falls back to Unsupported
+                arrayOf(
+                    """{ "type": "state_condition", "operator": "=", "value": true }""",
+                    ComponentOverride.Condition.Unsupported,
+                ),
+                arrayOf(
+                    """{ "type": "state_condition", "operator": "=", "name": "k" }""",
+                    ComponentOverride.Condition.Unsupported,
+                ),
+                arrayOf(
+                    """{ "type": "state_condition", "operator": ">", "name": "k", "value": 1 }""",
+                    ComponentOverride.Condition.Unsupported,
+                ),
+                // State condition with non-scalar value falls back to Unsupported
+                arrayOf(
+                    """{ "type": "state_condition", "operator": "=", "name": "k", "value": [1, 2] }""",
+                    ComponentOverride.Condition.Unsupported,
+                ),
+                arrayOf(
+                    """{ "type": "state_condition", "operator": "=", "name": "k", "value": {"nested": true} }""",
+                    ComponentOverride.Condition.Unsupported,
+                ),
                 // SelectedPackage with extra unknown fields deserializes successfully
                 arrayOf(
                     """{ "type": "selected_package_condition", "operator": "in", "packages": ["a"], "future_field": true }""",

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
@@ -531,6 +531,11 @@ internal class ComponentOverridesTests {
                     """{ "type": "state_condition", "operator": "=", "name": "k", "value": [1, 2] }""",
                     ComponentOverride.Condition.Unsupported,
                 ),
+                // State condition with a null value falls back to Unsupported (parity with iOS)
+                arrayOf(
+                    """{ "type": "state_condition", "operator": "!=", "name": "k", "value": null }""",
+                    ComponentOverride.Condition.Unsupported,
+                ),
                 arrayOf(
                     """{ "type": "state_condition", "operator": "=", "name": "k", "value": {"nested": true} }""",
                     ComponentOverride.Condition.Unsupported,

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/PaywallComponentStateTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/PaywallComponentStateTests.kt
@@ -75,6 +75,22 @@ internal class PaywallComponentStateTests {
     }
 
     @Test
+    fun `drops entries with a missing field or a non-object value`() {
+        @Language("json")
+        val json = """
+            {
+              "good":        { "type": "string", "default": "v" },
+              "missingType": { "default": "v" },
+              "notAnObject": "oops"
+            }
+        """.trimIndent()
+
+        val actual = JsonTools.json.decodeFromString(StateDeclarationMapSerializer, json)
+
+        assertThat(actual.keys).containsExactly("good")
+    }
+
+    @Test
     fun `decodes a non-object state_declarations value as an empty map`() {
         val actual = JsonTools.json.decodeFromString(StateDeclarationMapSerializer, """"not_an_object"""")
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/PaywallComponentStateTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/PaywallComponentStateTests.kt
@@ -91,6 +91,21 @@ internal class PaywallComponentStateTests {
     }
 
     @Test
+    fun `drops a declaration with a null default`() {
+        @Language("json")
+        val json = """
+            {
+              "good": { "type": "string", "default": "v" },
+              "bad":  { "type": "string", "default": null }
+            }
+        """.trimIndent()
+
+        val actual = JsonTools.json.decodeFromString(StateDeclarationMapSerializer, json)
+
+        assertThat(actual.keys).containsExactly("good")
+    }
+
+    @Test
     fun `decodes a non-object state_declarations value as an empty map`() {
         val actual = JsonTools.json.decodeFromString(StateDeclarationMapSerializer, """"not_an_object"""")
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/PaywallComponentStateTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/PaywallComponentStateTests.kt
@@ -1,0 +1,161 @@
+package com.revenuecat.purchases.paywalls.components.common
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.paywalls.components.ButtonComponent
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+import kotlinx.serialization.json.JsonPrimitive
+
+@OptIn(InternalRevenueCatAPI::class)
+internal class PaywallComponentStateTests {
+
+    @Test
+    fun `decodes a state_declarations map with all value types`() {
+        @Language("json")
+        val json = """
+            {
+              "planComparisonOpen": { "type": "boolean", "default": false },
+              "activeSlide":        { "type": "integer", "default": 0 },
+              "discountMultiplier": { "type": "double",  "default": 0.5 },
+              "selectedFeatureTab": { "type": "string",  "default": "billing" }
+            }
+        """.trimIndent()
+
+        val actual = JsonTools.json.decodeFromString(StateDeclarationMapSerializer, json)
+
+        assertThat(actual).hasSize(4)
+        assertThat(actual["planComparisonOpen"]?.type).isEqualTo(StateDeclaration.ValueType.BOOLEAN)
+        assertThat(actual["planComparisonOpen"]?.defaultValue).isEqualTo(JsonPrimitive(false))
+        assertThat(actual["activeSlide"]?.type).isEqualTo(StateDeclaration.ValueType.INTEGER)
+        assertThat(actual["activeSlide"]?.defaultValue).isEqualTo(JsonPrimitive(0))
+        assertThat(actual["discountMultiplier"]?.type).isEqualTo(StateDeclaration.ValueType.DOUBLE)
+        assertThat(actual["discountMultiplier"]?.defaultValue).isEqualTo(JsonPrimitive(0.5))
+        assertThat(actual["selectedFeatureTab"]?.type).isEqualTo(StateDeclaration.ValueType.STRING)
+        assertThat(actual["selectedFeatureTab"]?.defaultValue).isEqualTo(JsonPrimitive("billing"))
+    }
+
+    @Test
+    fun `ignores unknown fields in a state declaration`() {
+        @Language("json")
+        val json = """{ "k": { "type": "string", "default": "v", "future_field": 42 } }"""
+
+        val actual = JsonTools.json.decodeFromString(StateDeclarationMapSerializer, json)
+
+        assertThat(actual["k"]).isEqualTo(StateDeclaration(type = "string", defaultValue = JsonPrimitive("v")))
+    }
+
+    @Test
+    fun `drops a malformed entry without failing the rest of the map`() {
+        @Language("json")
+        val json = """
+            {
+              "good": { "type": "string", "default": "v" },
+              "bad":  { "type": "string", "default": { "nested": true } }
+            }
+        """.trimIndent()
+
+        val actual = JsonTools.json.decodeFromString(StateDeclarationMapSerializer, json)
+
+        assertThat(actual.keys).containsExactly("good")
+    }
+
+    @Test
+    fun `decodes a non-object state_declarations value as an empty map`() {
+        val actual = JsonTools.json.decodeFromString(StateDeclarationMapSerializer, """"not_an_object"""")
+
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `decodes a set update with each literal type`() {
+        assertThat(decodeUpdate("""{ "set": "k", "to": "billing" }"""))
+            .isEqualTo(StateUpdate.Set("k", StateUpdateValue.Literal(JsonPrimitive("billing"))))
+        assertThat(decodeUpdate("""{ "set": "k", "to": 3 }"""))
+            .isEqualTo(StateUpdate.Set("k", StateUpdateValue.Literal(JsonPrimitive(3))))
+        assertThat(decodeUpdate("""{ "set": "k", "to": 0.5 }"""))
+            .isEqualTo(StateUpdate.Set("k", StateUpdateValue.Literal(JsonPrimitive(0.5))))
+        assertThat(decodeUpdate("""{ "set": "k", "to": true }"""))
+            .isEqualTo(StateUpdate.Set("k", StateUpdateValue.Literal(JsonPrimitive(true))))
+    }
+
+    @Test
+    fun `decodes a set update with the value payload reference`() {
+        assertThat(decodeUpdate("""{ "set": "activeSlide", "to": "${'$'}value" }"""))
+            .isEqualTo(StateUpdate.Set("activeSlide", StateUpdateValue.PayloadReference))
+    }
+
+    @Test
+    fun `ignores unknown fields in a set update`() {
+        assertThat(decodeUpdate("""{ "set": "k", "to": true, "op": "future" }"""))
+            .isEqualTo(StateUpdate.Set("k", StateUpdateValue.Literal(JsonPrimitive(true))))
+    }
+
+    @Test
+    fun `decodes unknown or malformed update shapes as Unsupported`() {
+        assertThat(decodeUpdate("""{ "toggle": "k" }""")).isEqualTo(StateUpdate.Unsupported)
+        assertThat(decodeUpdate("""{ "set": "k" }""")).isEqualTo(StateUpdate.Unsupported)
+        assertThat(decodeUpdate("""{ "to": true }""")).isEqualTo(StateUpdate.Unsupported)
+        assertThat(decodeUpdate("""{ "set": "k", "to": [1, 2] }""")).isEqualTo(StateUpdate.Unsupported)
+        assertThat(decodeUpdate(""""not_an_object"""")).isEqualTo(StateUpdate.Unsupported)
+    }
+
+    @Test
+    fun `degrades a malformed entry in a stateUpdates list without failing the others`() {
+        @Language("json")
+        val json = """
+            [
+              { "set": "a", "to": true },
+              { "unknown": "shape" },
+              { "set": "b", "to": "${'$'}value" }
+            ]
+        """.trimIndent()
+
+        val actual = JsonTools.json.decodeFromString<List<StateUpdate>>(json)
+
+        assertThat(actual).containsExactly(
+            StateUpdate.Set("a", StateUpdateValue.Literal(JsonPrimitive(true))),
+            StateUpdate.Unsupported,
+            StateUpdate.Set("b", StateUpdateValue.PayloadReference),
+        )
+    }
+
+    @Test
+    fun `decodes stateUpdates wired onto an interactive component`() {
+        @Language("json")
+        val json = """
+            {
+              "type": "button",
+              "action": { "type": "restore_purchases" },
+              "stack": { "type": "stack", "components": [] },
+              "state_updates": [ { "set": "planComparisonOpen", "to": true } ]
+            }
+        """.trimIndent()
+
+        val actual = JsonTools.json.decodeFromString<ButtonComponent>(json)
+
+        assertThat(actual.stateUpdates).containsExactly(
+            StateUpdate.Set("planComparisonOpen", StateUpdateValue.Literal(JsonPrimitive(true))),
+        )
+    }
+
+    @Test
+    fun `decodes a component without stateUpdates as null`() {
+        @Language("json")
+        val json = """
+            {
+              "type": "button",
+              "action": { "type": "restore_purchases" },
+              "stack": { "type": "stack", "components": [] }
+            }
+        """.trimIndent()
+
+        val actual = JsonTools.json.decodeFromString<ButtonComponent>(json)
+
+        assertThat(actual.stateUpdates).isNull()
+    }
+
+    private fun decodeUpdate(@Language("json") json: String): StateUpdate =
+        JsonTools.json.decodeFromString(json)
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/PaywallComponentStateTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/PaywallComponentStateTests.kt
@@ -3,6 +3,8 @@ package com.revenuecat.purchases.paywalls.components.common
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
+import com.revenuecat.purchases.paywalls.components.CarouselComponent
+import com.revenuecat.purchases.paywalls.components.TabsComponent
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -43,7 +45,18 @@ internal class PaywallComponentStateTests {
 
         val actual = JsonTools.json.decodeFromString(StateDeclarationMapSerializer, json)
 
-        assertThat(actual["k"]).isEqualTo(StateDeclaration(type = "string", defaultValue = JsonPrimitive("v")))
+        assertThat(actual["k"])
+            .isEqualTo(StateDeclaration(type = StateDeclaration.ValueType.STRING, defaultValue = JsonPrimitive("v")))
+    }
+
+    @Test
+    fun `decodes an unrecognized declaration type as UNKNOWN`() {
+        @Language("json")
+        val json = """{ "k": { "type": "date", "default": "v" } }"""
+
+        val actual = JsonTools.json.decodeFromString(StateDeclarationMapSerializer, json)
+
+        assertThat(actual["k"]?.type).isEqualTo(StateDeclaration.ValueType.UNKNOWN)
     }
 
     @Test
@@ -137,6 +150,44 @@ internal class PaywallComponentStateTests {
 
         assertThat(actual.stateUpdates).containsExactly(
             StateUpdate.Set("planComparisonOpen", StateUpdateValue.Literal(JsonPrimitive(true))),
+        )
+    }
+
+    @Test
+    fun `decodes stateUpdates wired onto a carousel`() {
+        @Language("json")
+        val json = """
+            {
+              "type": "carousel",
+              "pages": [],
+              "page_alignment": "center",
+              "state_updates": [ { "set": "activeSlide", "to": 1 } ]
+            }
+        """.trimIndent()
+
+        val actual = JsonTools.json.decodeFromString<CarouselComponent>(json)
+
+        assertThat(actual.stateUpdates).containsExactly(
+            StateUpdate.Set("activeSlide", StateUpdateValue.Literal(JsonPrimitive(1))),
+        )
+    }
+
+    @Test
+    fun `decodes stateUpdates wired onto tabs`() {
+        @Language("json")
+        val json = """
+            {
+              "type": "tabs",
+              "control": { "type": "toggle", "stack": { "type": "stack", "components": [] } },
+              "tabs": [],
+              "state_updates": [ { "set": "selectedFeatureTab", "to": "annual" } ]
+            }
+        """.trimIndent()
+
+        val actual = JsonTools.json.decodeFromString<TabsComponent>(json)
+
+        assertThat(actual.stateUpdates).containsExactly(
+            StateUpdate.Set("selectedFeatureTab", StateUpdateValue.Literal(JsonPrimitive("annual"))),
         )
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
@@ -147,6 +147,8 @@ private fun ComponentOverride.Condition.evaluate(
     is ComponentOverride.Condition.PromoOfferRule -> evaluate(offerEligibility)
     is ComponentOverride.Condition.SelectedPackage -> evaluate(conditionContext.selectedPackageId)
     is ComponentOverride.Condition.Variable -> evaluate(conditionContext.customVariables)
+    // State condition evaluation lands in a later phase; until then it never applies its override.
+    is ComponentOverride.Condition.State -> false
     ComponentOverride.Condition.Unsupported -> false
 }
 


### PR DESCRIPTION
Decodes the new server-driven state schema from `PaywallComponentsData`:
- `state_declarations`: a top-level map of named, typed (string/bool/int/double) variables with declared defaults.
- `state_updates` on interactive components (tabs, carousels, buttons): write operations that fire when the component is triggered. Supports literal values and a `$value` payload reference for the triggering component's identity.
- `state_condition` in `ComponentOverride.Condition`: evaluates a named variable against an expected value with `EQUALS`/`NOT_EQUALS` operators.

Pure data model — no runtime behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive JSON models and resilient decoders with no purchase/auth logic; the UI stub means state-based overrides are inert until a later runtime phase.
> 
> **Overview**
> Adds **decode-only** support for server-driven paywall **state**: top-level `state_declarations` on `PaywallComponentsData`, optional `state_updates` on **buttons**, **carousels**, and **tabs**, and a new **`state_condition`** override type.
> 
> **`state_declarations`** maps names to typed defaults (`boolean` / `integer` / `double` / `string`) via `StateDeclaration` and a tolerant `StateDeclarationMapSerializer` that drops bad entries instead of failing the whole paywall.
> 
> **`state_updates`** decode as `StateUpdate.Set` with literal `to` values or the `"$value"` payload reference; unknown shapes become `Unsupported`.
> 
> **`state_condition`** compares a named state key with `=` / `!=` (scalar primitives only; null/non-scalar → `Unsupported`). It is marked **`isRule`** like other conditional rules.
> 
> In **revenuecatui**, `ComponentOverride.Condition.State` is wired to **always evaluate false** until runtime state exists—overrides gated only on state will not apply yet.
> 
> Tests cover deserialization for declarations, updates, conditions, and component wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc087cd7a614c8ea538425919f24e0e0cc8a62f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->