### PR TITLE
refactor(remote-config): fix remote config signature verification + add integration tests

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -1320,10 +1320,10 @@ internal class Backend(
         onSuccess: (RCContainer?, VerificationResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
-        val endpoint = Endpoint.GetRemoteConfig
+        val endpoint = Endpoint.GetRemoteConfig(domain)
         val path = endpoint.getPath()
-        // Include the app user in the key: the path is static but the request body carries app_user_id, so
-        // concurrent calls for different users must not be deduped onto a single shared request.
+        // Include the app user in the key: the path carries the domain but not the app_user_id (sent in the
+        // request body), so concurrent calls for different users must not be deduped onto a single shared request.
         val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path, appUserID), appInBackground)
 
         val overrideURL = BuildConfig.REMOTE_CONFIG_BASE_URL
@@ -1334,7 +1334,6 @@ internal class Backend(
         // The manifest is an opaque token replayed verbatim; omitted on the first run when there is none.
         val body = buildMap<String, Any?> {
             put(APP_USER_ID, appUserID)
-            put("domain", domain)
             manifest?.let { put("manifest", it) }
             put("prefetched_blobs", prefetchedBlobs)
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -398,9 +398,9 @@ internal class HTTPClient(
         ) {
             if (endpoint.expectsRCFormatResponse) {
                 if (responseCode == RCHTTPStatusCodes.NO_CONTENT && bodyBytes.isEmpty()) {
-                    VerificationResult.VERIFIED
+                    verifyRCFormatNoContentResponse(path, connection, nonce)
                 } else {
-                    verifyRCFormatResponse(path, connection, bodyBytes)
+                    verifyRCFormatResponse(path, connection, bodyBytes, nonce)
                 }
             } else {
                 verifyResponse(path, connection, payloadText, nonce, postFieldsToSignHeader)
@@ -594,16 +594,18 @@ internal class HTTPClient(
     }
 
     /**
-     * Verifies an RC Container Format response. The backend signs the config element's (element 0)
-     * 24-byte truncated SHA-256 checksum, so we verify the signature over that checksum and
-     * independently confirm the config bytes hash to it. Both checks are required: the signature ties
-     * the checksum to the backend, and [RCElement.isChecksumValid] ties the checksum to the data.
-     * This endpoint is not ETag-cached and sends no nonce / post params.
+     * Verifies an RC Container Format response. The backend signs the leading config element's (element 0)
+     * bytes exactly as received — the config part / `main_body` — so we verify the signature over those bytes.
+     * The per-element container checksums are untrusted lookup hints, not a trust anchor: inline blob elements
+     * are not signed and are instead authenticated transitively by hashing against the `blob_ref` in the signed
+     * config. This endpoint is not ETag-cached and sends no post params, but the signature does cover the request
+     * [nonce].
      */
     private fun verifyRCFormatResponse(
         urlPath: String,
         connection: URLConnection,
         payloadBytes: ByteArray,
+        nonce: String?,
     ): VerificationResult {
         val config = try {
             RCContainer.parse(payloadBytes).config
@@ -611,20 +613,36 @@ internal class HTTPClient(
             errorLog(e) { NetworkStrings.VERIFICATION_ERROR.format(urlPath) }
             return VerificationResult.FAILED
         }
-        return if (!config.isChecksumValid()) {
-            errorLog { NetworkStrings.VERIFICATION_ERROR.format(urlPath) }
-            VerificationResult.FAILED
-        } else {
-            signingManager.verifyResponse(
-                urlPath = urlPath,
-                signatureString = connection.getHeaderField(HTTPResult.SIGNATURE_HEADER_NAME),
-                nonce = null,
-                bodyBytes = config.checksumBytes(),
-                requestTime = getRequestTimeHeader(connection),
-                eTag = getETagHeader(connection),
-                postFieldsToSignHeader = null,
-            )
-        }
+        return signingManager.verifyResponse(
+            urlPath = urlPath,
+            signatureString = connection.getHeaderField(HTTPResult.SIGNATURE_HEADER_NAME),
+            nonce = nonce,
+            bodyBytes = config.dataBytes(),
+            requestTime = getRequestTimeHeader(connection),
+            eTag = getETagHeader(connection),
+            postFieldsToSignHeader = null,
+        )
+    }
+
+    /**
+     * Verifies a `204 No Content` RC Container Format response. There is no body to sign, but the signature still
+     * covers the request context (api key, [nonce], path, request time), so the empty response remains replay-
+     * and tamper-evident. This endpoint emits no ETag, so the empty body is the only signed payload component.
+     */
+    private fun verifyRCFormatNoContentResponse(
+        urlPath: String,
+        connection: URLConnection,
+        nonce: String?,
+    ): VerificationResult {
+        return signingManager.verifyResponse(
+            urlPath = urlPath,
+            signatureString = connection.getHeaderField(HTTPResult.SIGNATURE_HEADER_NAME),
+            nonce = nonce,
+            bodyBytes = ByteArray(0),
+            requestTime = getRequestTimeHeader(connection),
+            eTag = getETagHeader(connection),
+            postFieldsToSignHeader = null,
+        )
     }
 
     private fun getETagHeader(connection: URLConnection) = connection.getHeaderField(HTTPResult.ETAG_HEADER_NAME)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -184,6 +184,7 @@ internal sealed class Endpoint(
             PostRedeemWebPurchase,
             is GetVirtualCurrencies,
             is GetRewardVerification,
+            GetRemoteConfig,
             ->
                 true
             is GetAmazonReceipt,
@@ -198,8 +199,6 @@ internal sealed class Endpoint(
             PostCreateSupportTicket,
             is WebBillingGetProducts,
             is AliasUsers,
-            // WIP: Move to true when we have the final endpoint for remote config, and we can remove the fallback
-            GetRemoteConfig,
             ->
                 false
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -105,11 +105,11 @@ internal sealed class Endpoint(
         override fun getPath(useFallback: Boolean) = pathTemplate.format(Uri.encode(userId))
     }
 
-    object GetRemoteConfig : Endpoint(
-        pathTemplate = "/v1/config",
+    data class GetRemoteConfig(val domain: String) : Endpoint(
+        pathTemplate = "/v1/config/%s",
         name = "remote_config",
     ) {
-        override fun getPath(useFallback: Boolean) = pathTemplate
+        override fun getPath(useFallback: Boolean) = pathTemplate.format(Uri.encode(domain))
         override val expectsRCFormatResponse: Boolean = true
     }
     object PostCreateSupportTicket : Endpoint(
@@ -161,7 +161,7 @@ internal sealed class Endpoint(
             PostRedeemWebPurchase,
             is GetVirtualCurrencies,
             is GetRewardVerification,
-            GetRemoteConfig,
+            is GetRemoteConfig,
             ->
                 true
             is GetAmazonReceipt,
@@ -184,7 +184,7 @@ internal sealed class Endpoint(
             PostRedeemWebPurchase,
             is GetVirtualCurrencies,
             is GetRewardVerification,
-            GetRemoteConfig,
+            is GetRemoteConfig,
             ->
                 true
             is GetAmazonReceipt,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCElement.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCElement.kt
@@ -49,9 +49,9 @@ internal class RCElement(
         return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
     }
 
-    /** A copy of the stored [checksum] bytes (the truncated SHA-256 of [data]). */
-    fun checksumBytes(): ByteArray {
-        val view = checksum.duplicate()
+    /** A copy of this element's [data] bytes (the payload exactly as received). */
+    fun dataBytes(): ByteArray {
+        val view = data.duplicate().apply { rewind() }
         val bytes = ByteArray(view.remaining())
         view.get(bytes)
         return bytes

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -1,0 +1,139 @@
+package com.revenuecat.purchases.backend_integration_tests
+
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.JsonProvider
+import com.revenuecat.purchases.common.networking.RCContainer
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
+import io.mockk.every
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTest() {
+    override fun apiKey() = Constants.apiKey
+
+    @Test
+    fun `can fetch remote config`() {
+        setupTest(SignatureVerificationMode.Informational())
+
+        val (error, container, verification) = fetchRemoteConfig(manifest = null)
+
+        assertThat(error).isNull()
+        assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
+        val rcContainer = requireNotNull(container) { "Expected a 200 container, got 204 (no content)." }
+
+        val config = RemoteConfiguration.parse(rcContainer.config.data)
+        assertThat(config.domain).isEqualTo("app")
+        assertThat(config.manifest).isNotEmpty()
+        assertThat(config.activeTopics).containsExactly("sources")
+        assertThat(rcContainer.contentElements).isEmpty()
+
+        val topicsSerializer = MapSerializer(
+            String.serializer(),
+            MapSerializer(String.serializer(), RemoteConfiguration.ConfigItem.serializer()),
+        )
+        val actualTopics = JsonProvider.defaultJson.encodeToJsonElement(topicsSerializer, config.topics)
+        val expectedTopics = JsonProvider.defaultJson.parseToJsonElement(
+            """
+            {
+              "sources": {
+                "api": {
+                  "sources": [
+                    { "id": "primary", "url": "https://api.revenuecat.com/", "priority": 0, "weight": 100 }
+                  ]
+                },
+                "blob": { "sources": [] }
+              }
+            }
+            """.trimIndent(),
+        )
+        assertThat(actualTopics).isEqualTo(expectedTopics)
+    }
+
+    @Test
+    fun `replaying the manifest returns no content`() {
+        setupTest(SignatureVerificationMode.Informational())
+
+        // First run: full resolve -> 200 with a fresh opaque manifest.
+        val (firstError, firstContainer, firstVerification) = fetchRemoteConfig(manifest = null)
+        assertThat(firstError).isNull()
+        assertThat(firstVerification).isEqualTo(VerificationResult.VERIFIED)
+        val rcContainer = requireNotNull(firstContainer) { "Expected a 200 container on the first run." }
+        val manifest = RemoteConfiguration.parse(rcContainer.config.data).manifest
+
+        // Replaying that manifest with nothing changed server-side -> 204 (success, but no container to parse).
+        val (secondError, secondContainer, secondVerification) = fetchRemoteConfig(manifest = manifest)
+        assertThat(secondError).isNull()
+        assertThat(secondContainer).isNull()
+        assertThat(secondVerification).isEqualTo(VerificationResult.VERIFIED)
+    }
+
+    @Test
+    fun `verifies the signed response when verification is enforced`() {
+        setupTest(SignatureVerificationMode.Enforced())
+
+        val (error, container, verification) = fetchRemoteConfig(manifest = null)
+
+        // With enforcement on, a failed verification surfaces as an error, so a null error already implies the
+        // signature verified; assert the result explicitly too.
+        assertThat(error).isNull()
+        assertThat(container).isNotNull
+        assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
+        assertSigningPerformed()
+    }
+
+    @Test
+    fun `verifies the no content response when verification is enforced`() {
+        setupTest(SignatureVerificationMode.Enforced())
+
+        // Get a fresh manifest from a full resolve, then replay it to force a signed 204.
+        val (firstError, firstContainer, _) = fetchRemoteConfig(manifest = null)
+        assertThat(firstError).isNull()
+        val rcContainer = requireNotNull(firstContainer) { "Expected a 200 container on the first run." }
+        val manifest = RemoteConfiguration.parse(rcContainer.config.data).manifest
+
+        // The 204 carries no body, but its signature covers the request context. Under enforcement a verification
+        // failure would surface as an error, so a null error with a VERIFIED result confirms the 204 was verified.
+        val (secondError, secondContainer, secondVerification) = fetchRemoteConfig(manifest = manifest)
+        assertThat(secondError).isNull()
+        assertThat(secondContainer).isNull()
+        assertThat(secondVerification).isEqualTo(VerificationResult.VERIFIED)
+    }
+
+    /**
+     * Performs a single `/v1/config` request and blocks until it completes, returning the error (or `null`), the
+     * container (`null` on a `204`), and the verification result (`null` on error).
+     */
+    private fun fetchRemoteConfig(
+        manifest: String?,
+        prefetchedBlobs: List<String> = emptyList(),
+    ): Triple<PurchasesError?, RCContainer?, VerificationResult?> {
+        every { appConfig.isDebugBuild } returns false
+
+        var error: PurchasesError? = null
+        var container: RCContainer? = null
+        var verification: VerificationResult? = null
+        ensureBlockFinishes { latch ->
+            backend.getRemoteConfig(
+                appInBackground = false,
+                appUserID = "integrationTestRemoteConfigUser",
+                domain = "app",
+                manifest = manifest,
+                prefetchedBlobs = prefetchedBlobs,
+                onSuccess = { rcContainer, verificationResult ->
+                    container = rcContainer
+                    verification = verificationResult
+                    latch.countDown()
+                },
+                onError = { purchasesError ->
+                    error = purchasesError
+                    latch.countDown()
+                },
+            )
+        }
+        return Triple(error, container, verification)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -97,7 +97,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
 
     @Test
     fun `GetRemoteConfig sends the RC format Accept header, skips ETags, and exposes an RC Format payload`() {
-        val endpoint = Endpoint.GetRemoteConfig
+        val endpoint = Endpoint.GetRemoteConfig("app")
         val containerBytes = byteArrayOf('R'.code.toByte(), 'C'.code.toByte(), 1, 0, 0, 0, 0, 0)
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(containerBytes)))
 
@@ -124,7 +124,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
 
         val result = spyClient.performRequest(
             baseURL,
-            Endpoint.GetRemoteConfig,
+            Endpoint.GetRemoteConfig("app"),
             body = null,
             postFieldsToSign = null,
             mapOf("" to ""),
@@ -143,7 +143,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
 
         spyClient.performRequest(
             baseURL,
-            Endpoint.GetRemoteConfig,
+            Endpoint.GetRemoteConfig("app"),
             body = null,
             postFieldsToSign = null,
             mapOf("" to ""),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -407,7 +407,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
     @Test
     fun `performRequest verifies an RC Container Format response over the config part bytes`() {
-        val endpoint = Endpoint.GetRemoteConfig
+        val endpoint = Endpoint.GetRemoteConfig("app")
         val configBytes = "{\"config\":true}".toByteArray()
         val container = buildContainer(configBytes)
 
@@ -444,7 +444,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
     @Test
     fun `performRequest verifies the config part bytes regardless of the element checksum`() {
-        val endpoint = Endpoint.GetRemoteConfig
+        val endpoint = Endpoint.GetRemoteConfig("app")
         val configBytes = "{\"config\":true}".toByteArray()
         // The element checksum is an untrusted lookup hint: a mismatch must not affect verification, which is
         // anchored on the signature over the config part bytes.
@@ -479,7 +479,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
     @Test
     fun `performRequest fails RC Format verification when the response is not a valid RC Container`() {
-        val endpoint = Endpoint.GetRemoteConfig
+        val endpoint = Endpoint.GetRemoteConfig("app")
 
         mockSigningResult(VerificationResult.VERIFIED)
         enqueueRCFormat(byteArrayOf(1, 2, 3, 4))
@@ -501,7 +501,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
     @Test
     fun `performRequest on enforced client throws when RC Format verification fails`() {
         every { mockSigningManager.signatureVerificationMode } returns mockk<SignatureVerificationMode.Enforced>()
-        val endpoint = Endpoint.GetRemoteConfig
+        val endpoint = Endpoint.GetRemoteConfig("app")
         val container = buildContainer("{\"config\":true}".toByteArray())
 
         mockSigningResult(VerificationResult.FAILED)
@@ -520,7 +520,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
     @Test
     fun `performRequest verifies a 204 empty response over the request context with an empty body`() {
-        val endpoint = Endpoint.GetRemoteConfig
+        val endpoint = Endpoint.GetRemoteConfig("app")
 
         mockSigningResult(VerificationResult.VERIFIED)
         enqueueRCFormat(ByteArray(0), responseCode = RCHTTPStatusCodes.NO_CONTENT)
@@ -554,7 +554,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
     @Test
     fun `performRequest on enforced client throws when a 204 fails verification`() {
         every { mockSigningManager.signatureVerificationMode } returns mockk<SignatureVerificationMode.Enforced>()
-        val endpoint = Endpoint.GetRemoteConfig
+        val endpoint = Endpoint.GetRemoteConfig("app")
 
         mockSigningResult(VerificationResult.FAILED)
         enqueueRCFormat(ByteArray(0), responseCode = RCHTTPStatusCodes.NO_CONTENT)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -406,11 +406,10 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
     // region RC Container Format verification
 
     @Test
-    fun `performRequest verifies an RC Container Format response over the config checksum`() {
+    fun `performRequest verifies an RC Container Format response over the config part bytes`() {
         val endpoint = Endpoint.GetRemoteConfig
         val configBytes = "{\"config\":true}".toByteArray()
         val container = buildContainer(configBytes)
-        val expectedChecksum = sha256Truncated(configBytes)
 
         mockSigningResult(VerificationResult.VERIFIED)
         enqueueRCFormat(container)
@@ -423,16 +422,19 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             requestHeaders = emptyMap()
         )
 
-        server.takeRequest()
+        val recordedRequest = server.takeRequest()
 
         assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
         assertThat(result.payload).isInstanceOf(HTTPResult.Payload.RCFormat::class.java)
+        // The endpoint requires a nonce, so it is sent on the request and covered by the signature.
+        assertThat(recordedRequest.getHeader("X-Nonce")).isEqualTo("test-nonce")
+        // The signed payload is the config part bytes exactly as received, not the element checksum.
         verify(exactly = 1) {
             mockSigningManager.verifyResponse(
                 urlPath = endpoint.getPath(),
                 "test-signature",
-                null,
-                match<ByteArray> { it.contentEquals(expectedChecksum) },
+                "test-nonce",
+                match<ByteArray> { it.contentEquals(configBytes) },
                 "1234567890",
                 "test-etag",
                 postFieldsToSignHeader = null
@@ -441,10 +443,11 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
     }
 
     @Test
-    fun `performRequest fails RC Format verification when the config data does not match its checksum`() {
+    fun `performRequest verifies the config part bytes regardless of the element checksum`() {
         val endpoint = Endpoint.GetRemoteConfig
         val configBytes = "{\"config\":true}".toByteArray()
-        // Store a checksum that does not match the config data.
+        // The element checksum is an untrusted lookup hint: a mismatch must not affect verification, which is
+        // anchored on the signature over the config part bytes.
         val container = buildContainer(configBytes, configChecksum = ByteArray(24) { 0x7F })
 
         mockSigningResult(VerificationResult.VERIFIED)
@@ -460,8 +463,18 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         server.takeRequest()
 
-        assertThat(result.verificationResult).isEqualTo(VerificationResult.FAILED)
-        assertSigningNotPerformed()
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
+        verify(exactly = 1) {
+            mockSigningManager.verifyResponse(
+                urlPath = endpoint.getPath(),
+                "test-signature",
+                "test-nonce",
+                match<ByteArray> { it.contentEquals(configBytes) },
+                "1234567890",
+                "test-etag",
+                postFieldsToSignHeader = null
+            )
+        }
     }
 
     @Test
@@ -506,7 +519,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
     }
 
     @Test
-    fun `performRequest skips RC Format verification and returns VERIFIED for a 204 empty response`() {
+    fun `performRequest verifies a 204 empty response over the request context with an empty body`() {
         val endpoint = Endpoint.GetRemoteConfig
 
         mockSigningResult(VerificationResult.VERIFIED)
@@ -524,7 +537,37 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         assertThat(result.responseCode).isEqualTo(RCHTTPStatusCodes.NO_CONTENT)
         assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
-        assertSigningNotPerformed()
+        // A 204 has no body, so the signed payload is the request context plus an empty body.
+        verify(exactly = 1) {
+            mockSigningManager.verifyResponse(
+                urlPath = endpoint.getPath(),
+                "test-signature",
+                "test-nonce",
+                match<ByteArray> { it.isEmpty() },
+                "1234567890",
+                "test-etag",
+                postFieldsToSignHeader = null
+            )
+        }
+    }
+
+    @Test
+    fun `performRequest on enforced client throws when a 204 fails verification`() {
+        every { mockSigningManager.signatureVerificationMode } returns mockk<SignatureVerificationMode.Enforced>()
+        val endpoint = Endpoint.GetRemoteConfig
+
+        mockSigningResult(VerificationResult.FAILED)
+        enqueueRCFormat(ByteArray(0), responseCode = RCHTTPStatusCodes.NO_CONTENT)
+
+        assertThatExceptionOfType(SignatureVerificationException::class.java).isThrownBy {
+            client.performRequest(
+                baseURL,
+                endpoint,
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = emptyMap()
+            )
+        }
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
@@ -175,7 +176,7 @@ class BackendGetRemoteConfigTest {
     }
 
     @Test
-    fun `getRemoteConfig sends app_user_id, domain, opaque manifest and prefetched_blobs as the request body`() {
+    fun `getRemoteConfig sends app_user_id, opaque manifest and prefetched_blobs as the request body`() {
         val bodySlot = mutableListOf<Map<String, Any?>?>()
         mockNoContentRequest(bodySlot)
 
@@ -191,12 +192,47 @@ class BackendGetRemoteConfigTest {
 
         val body = bodySlot.firstOrNull()
         assertThat(body).isNotNull
-        assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "domain", "manifest", "prefetched_blobs")
+        assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "manifest", "prefetched_blobs")
         assertThat(body?.get("app_user_id")).isEqualTo(testAppUserID)
-        assertThat(body?.get("domain")).isEqualTo("app")
         // The manifest is replayed verbatim as the opaque string the SDK received.
         assertThat(body?.get("manifest")).isEqualTo(testManifest)
         assertThat(body?.get("prefetched_blobs")).isEqualTo(listOf("blobRefA"))
+    }
+
+    @Test
+    fun `getRemoteConfig sends the domain as a path segment`() {
+        val endpointSlot = slot<Endpoint>()
+        every {
+            httpClient.performRequest(
+                any(),
+                capture(endpointSlot),
+                body = any(),
+                postFieldsToSign = any(),
+                requestHeaders = any(),
+                fallbackBaseURLs = any(),
+            )
+        } returns HTTPResult(
+            RCHTTPStatusCodes.NO_CONTENT,
+            HTTPResult.Payload.RCFormat(ByteArray(0)),
+            HTTPResult.Origin.BACKEND,
+            requestDate = null,
+            VerificationResult.NOT_REQUESTED,
+            isLoadShedderResponse = false,
+            isFallbackURL = false,
+        )
+
+        backend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = testAppUserID,
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> },
+            onError = { error -> fail("Expected success. Got error: $error") },
+        )
+
+        assertThat(endpointSlot.captured).isEqualTo(Endpoint.GetRemoteConfig(testDomain))
+        assertThat(endpointSlot.captured.getPath()).isEqualTo("/v1/config/app")
     }
 
     @Test
@@ -215,7 +251,7 @@ class BackendGetRemoteConfigTest {
         )
 
         val body = bodySlot.firstOrNull()
-        assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "domain", "prefetched_blobs")
+        assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "prefetched_blobs")
         assertThat(body).doesNotContainKey("manifest")
     }
 
@@ -265,7 +301,7 @@ class BackendGetRemoteConfigTest {
         verify(exactly = 1) {
             httpClient.performRequest(
                 mockBaseURL,
-                Endpoint.GetRemoteConfig,
+                Endpoint.GetRemoteConfig(testDomain),
                 body = any(),
                 postFieldsToSign = null,
                 requestHeaders = any(),
@@ -301,7 +337,7 @@ class BackendGetRemoteConfigTest {
         verify(exactly = 2) {
             httpClient.performRequest(
                 mockBaseURL,
-                Endpoint.GetRemoteConfig,
+                Endpoint.GetRemoteConfig(testDomain),
                 body = any(),
                 postFieldsToSign = null,
                 requestHeaders = any(),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -261,6 +261,7 @@ class EndpointTest {
             Endpoint.PostRedeemWebPurchase,
             Endpoint.GetVirtualCurrencies(userId = "test-user-id"),
             Endpoint.GetRewardVerification("test-user-id", "client-transaction-id"),
+            Endpoint.GetRemoteConfig,
         )
         for (endpoint in expectedEndpoints) {
             assertThat(endpoint.needsNonceToPerformSigning)
@@ -282,7 +283,6 @@ class EndpointTest {
             Endpoint.WebBillingGetProducts("test-user-id", setOf("product1", "product2")),
             Endpoint.AliasUsers("test-user-id"),
             Endpoint.GetWorkflows("test-user-id"),
-            Endpoint.GetRemoteConfig,
         )
         for (endpoint in expectedEndpoints) {
             assertThat(endpoint.needsNonceToPerformSigning)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -26,7 +26,7 @@ class EndpointTest {
         Endpoint.GetWorkflow("test-user-id", "wf_test"),
         Endpoint.GetWorkflows("test-user-id"),
         Endpoint.AliasUsers("test-user-id"),
-        Endpoint.GetRemoteConfig,
+        Endpoint.GetRemoteConfig("app"),
     )
 
     @Test
@@ -191,8 +191,15 @@ class EndpointTest {
 
     @Test
     fun `GetRemoteConfig has correct path`() {
-        val endpoint = Endpoint.GetRemoteConfig
-        val expectedPath = "/v1/config"
+        val endpoint = Endpoint.GetRemoteConfig("app")
+        val expectedPath = "/v1/config/app"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `GetRemoteConfig encodes the domain in the path`() {
+        val endpoint = Endpoint.GetRemoteConfig("my domain")
+        val expectedPath = "/v1/config/my%20domain"
         assertThat(endpoint.getPath()).isEqualTo(expectedPath)
     }
 
@@ -215,7 +222,7 @@ class EndpointTest {
             Endpoint.PostRedeemWebPurchase,
             Endpoint.GetVirtualCurrencies(userId = "test-user-id"),
             Endpoint.GetRewardVerification("test-user-id", "client-transaction-id"),
-            Endpoint.GetRemoteConfig,
+            Endpoint.GetRemoteConfig("app"),
         )
         for (endpoint in expectedSupportsValidationEndpoints) {
             assertThat(endpoint.supportsSignatureVerification)
@@ -261,7 +268,7 @@ class EndpointTest {
             Endpoint.PostRedeemWebPurchase,
             Endpoint.GetVirtualCurrencies(userId = "test-user-id"),
             Endpoint.GetRewardVerification("test-user-id", "client-transaction-id"),
-            Endpoint.GetRemoteConfig,
+            Endpoint.GetRemoteConfig("app"),
         )
         for (endpoint in expectedEndpoints) {
             assertThat(endpoint.needsNonceToPerformSigning)


### PR DESCRIPTION
## Summary

- Fixes remote config endpoint signature verification by:
   - Requiring a nonce
   - Using the whole config data to verify the signature instead of the checksum
   - Verify on 204 responses as well.
- We change the domain to be sent as part of the url `/v1/config/{domain}` instead of as part of the body.
- We add some integration tests that verify that the endpoint parsing and verification work as expected


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication/signature verification for remote config and alters trust model (checksum vs signed config bytes); incorrect verification could block config or accept bad responses under Enforced mode.
> 
> **Overview**
> Aligns **remote config** (`GetRemoteConfig` / RC container format) signature verification with how the backend signs responses.
> 
> **`GetRemoteConfig`** now **requires a nonce** for signing (`needsNonceToPerformSigning`), so requests send `X-Nonce` and verification includes it. RC format verification no longer checks the config element’s checksum or signs over `checksumBytes()`; it verifies the signature over the **config element’s raw `data` bytes** via new `RCElement.dataBytes()`. Element checksums are treated as untrusted hints only.
> 
> **204 No Content** RC responses are no longer auto-`VERIFIED` without crypto: a new `verifyRCFormatNoContentResponse` runs `signingManager.verifyResponse` with an **empty body** plus request context (nonce, path, request time). Enforced mode can throw on failed 204 verification.
> 
> Unit tests in `HTTPClientVerificationTest` and `EndpointTest` were updated; **`ProductionRemoteConfigIntegrationTest`** hits live `/v1/config` for 200/204, manifest replay, and enforced verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536fd3050cedb27f184dbe7a6ad6c8b0fb2f7eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->