### PR TITLE
feat(RevenueCatUI): add presentation-session state store (PWENG-57)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -120,6 +120,10 @@ internal sealed interface PaywallState {
             initialSelectedTabIndex: Int? = null,
             initialSheetState: SimpleSheetState = SimpleSheetState(),
             private val purchases: PurchasesType,
+            /**
+             * Presentation-session store for state-driven paywalls, seeded from the paywall's declared state defaults.
+             */
+            val stateStore: PaywallStateStore = PaywallStateStore(emptyMap()),
         ) : Loaded {
 
             /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
@@ -31,7 +31,11 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
 
     fun currentValueOrDefault(key: String): JsonPrimitive? = currentValues[key]?.value ?: declaredDefaults[key]
 
-    /** Adds new keys from [declarations]; keys already in the store keep their current value. */
+    /**
+     * Adds new keys from [declarations]; keys already in the store keep their current value.
+     * Synchronized: workflow prewarm (background) and navigation (main) can hit the same store.
+     */
+    @Synchronized
     fun registerDeclarations(declarations: Map<String, StateDeclaration>) {
         declarations.forEach { (key, declaration) ->
             if (key !in declaredDefaults) {
@@ -42,6 +46,7 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
         }
     }
 
+    @Synchronized
     fun applyUpdates(updates: List<StateUpdate>, payload: JsonPrimitive? = null) {
         updates.forEach { update ->
             val setUpdate = update as? StateUpdate.Set ?: return@forEach

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentHashMap
 internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
 
     private val declaredTypes = ConcurrentHashMap<String, StateDeclaration.ValueType>()
-    private val declaredDefaults = mutableStateMapOf<String, JsonPrimitive>()
+    private val declaredDefaults = ConcurrentHashMap<String, JsonPrimitive>()
 
     // Per-key MutableState so mutating one key doesn't invalidate derivedStateOf blocks reading other keys.
     private val currentValues = mutableStateMapOf<String, MutableState<JsonPrimitive>>()
@@ -38,7 +38,7 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
     @Synchronized
     fun registerDeclarations(declarations: Map<String, StateDeclaration>) {
         declarations.forEach { (key, declaration) ->
-            if (key !in declaredDefaults) {
+            if (!declaredDefaults.containsKey(key)) {
                 declaredTypes[key] = declaration.type
                 declaredDefaults[key] = declaration.defaultValue
                 currentValues[key] = mutableStateOf(declaration.defaultValue)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
@@ -14,13 +14,7 @@ import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.longOrNull
 import java.util.concurrent.ConcurrentHashMap
 
-/**
- * In-memory state store for state-driven paywalls, scoped to a single presentation session: one store per workflow
- * presentation (shared across its screens) or per standalone paywall. Seeded from the declared state defaults;
- * interactive components mutate it via [applyUpdates] and condition evaluation reads via [currentValueOrDefault].
- *
- * State persists across screen navigation within a workflow and is never persisted across presentations.
- */
+/** In-memory state store for state-driven paywalls, scoped to one presentation session. */
 @OptIn(InternalRevenueCatAPI::class)
 @Stable
 internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
@@ -35,18 +29,9 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
         registerDeclarations(declarations)
     }
 
-    /**
-     * Returns the current value for [key], falling back to the declared default if the key has never been written.
-     * Reading this inside a `derivedStateOf` block subscribes only to [key]'s individual state, so a write to an
-     * unrelated key does not invalidate the block.
-     */
     fun currentValueOrDefault(key: String): JsonPrimitive? = currentValues[key]?.value ?: declaredDefaults[key]
 
-    /**
-     * Adds any keys from [declarations] not already known, seeding each with its declared default. Keys that already
-     * exist keep their current value, so registering a workflow screen's declarations never resets state another
-     * screen set.
-     */
+    /** Adds new keys from [declarations]; keys already in the store keep their current value. */
     fun registerDeclarations(declarations: Map<String, StateDeclaration>) {
         declarations.forEach { (key, declaration) ->
             if (key !in declaredDefaults) {
@@ -57,10 +42,6 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
         }
     }
 
-    /**
-     * Applies [updates] in declared order. A `$value` reference resolves to [payload]; a reference with no payload is
-     * skipped. Writes to undeclared keys, or values whose type does not match the declared type, are ignored.
-     */
     fun applyUpdates(updates: List<StateUpdate>, payload: JsonPrimitive? = null) {
         updates.forEach { update ->
             val setUpdate = update as? StateUpdate.Set ?: return@forEach

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
@@ -67,7 +67,8 @@ private fun JsonPrimitive.matchesDeclaredType(declaredType: StateDeclaration.Val
     when (declaredType) {
         StateDeclaration.ValueType.BOOLEAN -> !isString && booleanOrNull != null
         StateDeclaration.ValueType.STRING -> isString
-        StateDeclaration.ValueType.INTEGER -> !isString && longOrNull != null
+        // Integral doubles are accepted for parity with iOS, which coerces them via Int(exactly:).
+        StateDeclaration.ValueType.INTEGER -> !isString && (longOrNull != null || doubleOrNull?.rem(1.0) == 0.0)
         StateDeclaration.ValueType.DOUBLE -> !isString && doubleOrNull != null
         StateDeclaration.ValueType.UNKNOWN -> false
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
@@ -8,11 +8,11 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
 import com.revenuecat.purchases.paywalls.components.common.StateUpdate
 import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
-import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.longOrNull
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * In-memory state store for state-driven paywalls, scoped to a single presentation session: one store per workflow
@@ -27,6 +27,7 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
 
     private val declaredTypes = ConcurrentHashMap<String, String>()
     private val declaredDefaults = mutableStateMapOf<String, JsonPrimitive>()
+
     // Per-key MutableState so mutating one key doesn't invalidate derivedStateOf blocks reading other keys.
     private val currentValues = mutableStateMapOf<String, MutableState<JsonPrimitive>>()
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.ConcurrentHashMap
 @Stable
 internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
 
-    private val declaredTypes = ConcurrentHashMap<String, String>()
+    private val declaredTypes = ConcurrentHashMap<String, StateDeclaration.ValueType>()
     private val declaredDefaults = mutableStateMapOf<String, JsonPrimitive>()
 
     // Per-key MutableState so mutating one key doesn't invalidate derivedStateOf blocks reading other keys.
@@ -63,10 +63,11 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
     }
 }
 
-private fun JsonPrimitive.matchesDeclaredType(declaredType: String): Boolean = when (declaredType) {
-    StateDeclaration.ValueType.BOOLEAN -> !isString && booleanOrNull != null
-    StateDeclaration.ValueType.STRING -> isString
-    StateDeclaration.ValueType.INTEGER -> !isString && longOrNull != null
-    StateDeclaration.ValueType.DOUBLE -> !isString && doubleOrNull != null
-    else -> false
-}
+private fun JsonPrimitive.matchesDeclaredType(declaredType: StateDeclaration.ValueType): Boolean =
+    when (declaredType) {
+        StateDeclaration.ValueType.BOOLEAN -> !isString && booleanOrNull != null
+        StateDeclaration.ValueType.STRING -> isString
+        StateDeclaration.ValueType.INTEGER -> !isString && longOrNull != null
+        StateDeclaration.ValueType.DOUBLE -> !isString && doubleOrNull != null
+        StateDeclaration.ValueType.UNKNOWN -> false
+    }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
@@ -1,0 +1,90 @@
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateMapOf
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
+import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.longOrNull
+
+/**
+ * In-memory state store for state-driven paywalls, scoped to a single presentation session: one store per workflow
+ * presentation (shared across its screens) or per standalone paywall. Seeded from the declared state defaults;
+ * interactive components mutate it via [apply] and condition evaluation reads the current [values].
+ *
+ * State persists across screen navigation within a workflow and is never persisted across presentations.
+ */
+@OptIn(InternalRevenueCatAPI::class)
+@Stable
+internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
+
+    // Snapshot-backed so registration/mutations are both thread-safe (workflow pre-warm registers screens off the
+    // main thread) and observable (dependent components recompose when state changes).
+    private val declaredTypes = mutableStateMapOf<String, String>()
+    private val declaredDefaults = mutableStateMapOf<String, JsonPrimitive>()
+    private val currentValues = mutableStateMapOf<String, JsonPrimitive>()
+
+    init {
+        registerDeclarations(declarations)
+    }
+
+    /**
+     * The declared default for each key, used as the fallback when a key has not been written.
+     */
+    val defaults: Map<String, JsonPrimitive> get() = declaredDefaults.toMap()
+
+    /**
+     * The current value of each key. Reads are observable so dependent components recompose when a value changes.
+     */
+    val values: Map<String, JsonPrimitive> get() = currentValues.toMap()
+
+    /**
+     * Adds any keys from [declarations] not already known, seeding each with its declared default. Keys that already
+     * exist keep their current value, so registering a workflow screen's declarations never resets state another
+     * screen set.
+     */
+    fun registerDeclarations(declarations: Map<String, StateDeclaration>) {
+        declarations.forEach { (key, declaration) ->
+            if (key !in declaredDefaults) {
+                declaredTypes[key] = declaration.type
+                declaredDefaults[key] = declaration.defaultValue
+                currentValues[key] = declaration.defaultValue
+            }
+        }
+    }
+
+    /**
+     * Applies [updates] in declared order. A `$value` reference resolves to [payload]; a reference with no payload is
+     * skipped. Writes to undeclared keys, or values whose type does not match the declared type, are ignored.
+     */
+    fun applyUpdates(updates: List<StateUpdate>, payload: JsonPrimitive? = null) {
+        updates.forEach { update ->
+            val setUpdate = update as? StateUpdate.Set ?: return@forEach
+            val value = when (val updateValue = setUpdate.value) {
+                is StateUpdateValue.Literal -> updateValue.value
+                StateUpdateValue.PayloadReference -> payload ?: return@forEach
+            }
+            val declaredType = declaredTypes[setUpdate.key] ?: return@forEach
+            if (value.matchesDeclaredType(declaredType)) {
+                currentValues[setUpdate.key] = value
+            }
+        }
+    }
+
+    fun reset() {
+        currentValues.clear()
+        currentValues.putAll(declaredDefaults)
+    }
+}
+
+private fun JsonPrimitive.matchesDeclaredType(declaredType: String): Boolean = when (declaredType) {
+    StateDeclaration.ValueType.BOOLEAN -> !isString && booleanOrNull != null
+    StateDeclaration.ValueType.STRING -> isString
+    StateDeclaration.ValueType.INTEGER -> !isString && longOrNull != null
+    StateDeclaration.ValueType.DOUBLE -> !isString && doubleOrNull != null
+    else -> false
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
@@ -35,12 +35,12 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
     /**
      * The declared default for each key, used as the fallback when a key has not been written.
      */
-    val defaults: Map<String, JsonPrimitive> get() = declaredDefaults.toMap()
+    val defaults: Map<String, JsonPrimitive> get() = declaredDefaults
 
     /**
      * The current value of each key. Reads are observable so dependent components recompose when a value changes.
      */
-    val values: Map<String, JsonPrimitive> get() = currentValues.toMap()
+    val values: Map<String, JsonPrimitive> get() = currentValues
 
     /**
      * Adds any keys from [declarations] not already known, seeding each with its declared default. Keys that already
@@ -73,11 +73,6 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
                 currentValues[setUpdate.key] = value
             }
         }
-    }
-
-    fun reset() {
-        currentValues.clear()
-        currentValues.putAll(declaredDefaults)
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStore.kt
@@ -1,11 +1,14 @@
 package com.revenuecat.purchases.ui.revenuecatui.data
 
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
 import com.revenuecat.purchases.paywalls.components.common.StateUpdate
 import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.doubleOrNull
@@ -14,7 +17,7 @@ import kotlinx.serialization.json.longOrNull
 /**
  * In-memory state store for state-driven paywalls, scoped to a single presentation session: one store per workflow
  * presentation (shared across its screens) or per standalone paywall. Seeded from the declared state defaults;
- * interactive components mutate it via [apply] and condition evaluation reads the current [values].
+ * interactive components mutate it via [applyUpdates] and condition evaluation reads via [currentValueOrDefault].
  *
  * State persists across screen navigation within a workflow and is never persisted across presentations.
  */
@@ -22,25 +25,21 @@ import kotlinx.serialization.json.longOrNull
 @Stable
 internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
 
-    // Snapshot-backed so registration/mutations are both thread-safe (workflow pre-warm registers screens off the
-    // main thread) and observable (dependent components recompose when state changes).
-    private val declaredTypes = mutableStateMapOf<String, String>()
+    private val declaredTypes = ConcurrentHashMap<String, String>()
     private val declaredDefaults = mutableStateMapOf<String, JsonPrimitive>()
-    private val currentValues = mutableStateMapOf<String, JsonPrimitive>()
+    // Per-key MutableState so mutating one key doesn't invalidate derivedStateOf blocks reading other keys.
+    private val currentValues = mutableStateMapOf<String, MutableState<JsonPrimitive>>()
 
     init {
         registerDeclarations(declarations)
     }
 
     /**
-     * The declared default for each key, used as the fallback when a key has not been written.
+     * Returns the current value for [key], falling back to the declared default if the key has never been written.
+     * Reading this inside a `derivedStateOf` block subscribes only to [key]'s individual state, so a write to an
+     * unrelated key does not invalidate the block.
      */
-    val defaults: Map<String, JsonPrimitive> get() = declaredDefaults
-
-    /**
-     * The current value of each key. Reads are observable so dependent components recompose when a value changes.
-     */
-    val values: Map<String, JsonPrimitive> get() = currentValues
+    fun currentValueOrDefault(key: String): JsonPrimitive? = currentValues[key]?.value ?: declaredDefaults[key]
 
     /**
      * Adds any keys from [declarations] not already known, seeding each with its declared default. Keys that already
@@ -52,7 +51,7 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
             if (key !in declaredDefaults) {
                 declaredTypes[key] = declaration.type
                 declaredDefaults[key] = declaration.defaultValue
-                currentValues[key] = declaration.defaultValue
+                currentValues[key] = mutableStateOf(declaration.defaultValue)
             }
         }
     }
@@ -70,7 +69,8 @@ internal class PaywallStateStore(declarations: Map<String, StateDeclaration>) {
             }
             val declaredType = declaredTypes[setUpdate.key] ?: return@forEach
             if (value.matchesDeclaredType(declaredType)) {
-                currentValues[setUpdate.key] = value
+                // Mutate .value, not the map entry: reassigning the entry would invalidate all-key readers.
+                currentValues[setUpdate.key]?.value = value
             }
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -211,6 +211,9 @@ internal class PaywallViewModelImpl(
     private var currentWorkflowPresentedOfferingContext: PresentedOfferingContext? = null
     private var currentWorkflowStepTracksPaywallEvents = true
     private val workflowStepStateCache = mutableMapOf<String, PaywallState.Loaded.Components>()
+
+    // Shared across all screens of a workflow presentation so state-driven values survive screen navigation.
+    private var currentWorkflowStateStore: PaywallStateStore? = null
     private var preWarmJob: Job? = null
     private var transitionIdCounter: Int = 0
 
@@ -371,6 +374,7 @@ internal class PaywallViewModelImpl(
         currentWorkflowPresentedOfferingContext = null
         currentWorkflowStepTracksPaywallEvents = true
         workflowStepStateCache.clear()
+        currentWorkflowStateStore = null
         _workflowState.value = null
         // The dismiss is the session boundary: the next presentation on this ViewModel is a new session,
         // so completion from this one must not suppress its abandonment. Runs after closePaywall has
@@ -1114,6 +1118,9 @@ internal class PaywallViewModelImpl(
         _workflowState.value = null
         if (isNewWorkflowImpression) {
             workflowTraceId = UUID.randomUUID().toString()
+            // Fresh presentation: start the shared store empty; each step registers its declarations as it builds.
+            // Rebuilds (navigation, color change) reuse the existing store so values persist across screens.
+            currentWorkflowStateStore = PaywallStateStore(emptyMap())
         }
 
         // Pre-compute the package step so its default package is available in cache
@@ -1239,6 +1246,7 @@ internal class PaywallViewModelImpl(
             colorScheme = _colorScheme.value,
             storefrontCountryCode = purchases.storefrontCountryCode,
             mode = options.mode,
+            stateStore = currentWorkflowStateStore,
         )
     }
 
@@ -1495,6 +1503,7 @@ internal class PaywallViewModelImpl(
         colorScheme: ColorScheme,
         storefrontCountryCode: String?,
         mode: PaywallMode,
+        stateStore: PaywallStateStore? = null,
     ): PaywallState {
         if (offering.availablePackages.isEmpty()) {
             return PaywallState.Error("No packages available")
@@ -1533,6 +1542,7 @@ internal class PaywallViewModelImpl(
                 purchases = purchases,
                 customVariables = options.customVariables,
                 defaultCustomVariables = extractDefaultCustomVariables(offering),
+                stateStore = stateStore,
             )
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -1167,7 +1167,8 @@ internal class PaywallViewModelImpl(
         shouldApplyState: Boolean = true,
     ) {
         val cached = workflowStepStateCache[step.id]
-        val newState = cached ?: computeStateForStep(step, workflow, uiConfig, offerings, presentedOfferingContext)
+        val newState = cached
+            ?: computeStateForStep(step, workflow, uiConfig, offerings, presentedOfferingContext, currentWorkflowStateStore)
         if (cached == null && newState is PaywallState.Loaded.Components) {
             workflowStepStateCache[step.id] = newState
         }
@@ -1228,6 +1229,7 @@ internal class PaywallViewModelImpl(
         uiConfig: UiConfig,
         offerings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,
+        stateStore: PaywallStateStore?,
     ): PaywallState {
         val screenId = step.screenId
             ?: return PaywallState.Error("Step '${step.id}' has no screen_id in workflow '${workflow.id}'")
@@ -1254,7 +1256,7 @@ internal class PaywallViewModelImpl(
             colorScheme = _colorScheme.value,
             storefrontCountryCode = purchases.storefrontCountryCode,
             mode = options.mode,
-            stateStore = currentWorkflowStateStore,
+            stateStore = stateStore,
         )
     }
 
@@ -1268,11 +1270,14 @@ internal class PaywallViewModelImpl(
         offerings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,
     ) {
+        // Capture on the main thread: cancellation is cooperative and can't stop an in-flight
+        // computeStateForStep, so a late prewarm must not write into a store swapped in by a newer session.
+        val stateStore = currentWorkflowStateStore
         preWarmJob = viewModelScope.launch {
             for ((stepId, step) in workflow.steps) {
                 if (stepId in workflowStepStateCache) continue
                 val computed = withContext(backgroundDispatcher) {
-                    computeStateForStep(step, workflow, uiConfig, offerings, presentedOfferingContext)
+                    computeStateForStep(step, workflow, uiConfig, offerings, presentedOfferingContext, stateStore)
                 }
                 if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {
                     workflowStepStateCache[stepId] = computed

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -1168,7 +1168,14 @@ internal class PaywallViewModelImpl(
     ) {
         val cached = workflowStepStateCache[step.id]
         val newState = cached
-            ?: computeStateForStep(step, workflow, uiConfig, offerings, presentedOfferingContext, currentWorkflowStateStore)
+            ?: computeStateForStep(
+                step,
+                workflow,
+                uiConfig,
+                offerings,
+                presentedOfferingContext,
+                currentWorkflowStateStore,
+            )
         if (cached == null && newState is PaywallState.Loaded.Components) {
             workflowStepStateCache[step.id] = newState
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -350,6 +350,7 @@ internal class PaywallViewModelImpl(
             trackExitOffer(ExitOfferType.DISMISS, exitOffering.identifier)
         }
         paywallPresentationData = null
+        standaloneStateStore = null
         clearWorkflowState()
         val dismissWithExitOffering = options.dismissRequestWithExitOffering
         if (dismissWithExitOffering != null) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -1279,6 +1279,9 @@ internal class PaywallViewModelImpl(
                 val computed = withContext(backgroundDispatcher) {
                     computeStateForStep(step, workflow, uiConfig, offerings, presentedOfferingContext, stateStore)
                 }
+                // A newer presentation may have swapped in a different session store while we computed.
+                // Abandon this stale prewarm so we never cache a step bound to the old store.
+                if (stateStore !== currentWorkflowStateStore) return@launch
                 if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {
                     workflowStepStateCache[stepId] = computed
                     computed.update(localeList = _lastLocaleList.value.toFrameworkLocaleList())

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -214,6 +214,10 @@ internal class PaywallViewModelImpl(
 
     // Shared across all screens of a workflow presentation so state-driven values survive screen navigation.
     private var currentWorkflowStateStore: PaywallStateStore? = null
+
+    // Reused across full state refreshes (e.g. color changes) of a standalone paywall so its state-driven values
+    // are not lost. Tied to this ViewModel's lifetime, so it resets when the paywall is presented again.
+    private var standaloneStateStore: PaywallStateStore? = null
     private var preWarmJob: Job? = null
     private var transitionIdCounter: Int = 0
 
@@ -1011,11 +1015,14 @@ internal class PaywallViewModelImpl(
                 "You do not have a current offering configured in the RevenueCat dashboard.",
             )
         } else {
+            val stateStore = standaloneStateStore
+                ?: PaywallStateStore(emptyMap()).also { standaloneStateStore = it }
             _state.value = calculateState(
                 currentOffering,
                 _colorScheme.value,
                 purchases.storefrontCountryCode,
                 options.mode,
+                stateStore = stateStore,
             )
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -44,6 +44,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentS
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StyleFactory
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallStateStore
 import com.revenuecat.purchases.ui.revenuecatui.data.PurchasesType
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PackageConfigurationType
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
@@ -245,6 +246,7 @@ internal fun Offering.validatePaywallComponentsDataOrNull(
                 ?: headerResult?.defaultTabIndex
                 ?: stickyFooterResult?.defaultTabIndex,
             mainStackHasHeroImage = backendRootComponentResult.heroImageDetected,
+            stateDeclarations = componentsData.stateDeclarations.orEmpty(),
         )
     }
 }
@@ -367,10 +369,17 @@ internal fun Offering.toComponentsPaywallState(
     purchases: PurchasesType,
     customVariables: Map<String, CustomVariableValue> = emptyMap(),
     defaultCustomVariables: Map<String, CustomVariableValue> = emptyMap(),
+    stateStore: PaywallStateStore? = null,
 ): PaywallState.Loaded.Components {
     val showPricesWithDecimals = storefrontCountryCode?.let {
         !validationResult.zeroDecimalPlaceCountries.contains(it)
     } ?: true
+
+    // A workflow shares one store across its screens, accumulating each screen's declarations; a standalone paywall
+    // gets its own store seeded from its declarations.
+    val resolvedStateStore = stateStore
+        ?.also { it.registerDeclarations(validationResult.stateDeclarations) }
+        ?: PaywallStateStore(validationResult.stateDeclarations)
 
     return PaywallState.Loaded.Components(
         stack = validationResult.stack,
@@ -390,6 +399,7 @@ internal fun Offering.toComponentsPaywallState(
         initialSelectedTabIndex = validationResult.initialSelectedTabIndex,
         mainStackHasHeroImage = validationResult.mainStackHasHeroImage,
         purchases = purchases,
+        stateStore = resolvedStateStore,
     )
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallValidationResult.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallValidationResult.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.helpers
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState.Loaded.Components.AvailablePackages
@@ -53,6 +54,7 @@ internal sealed interface PaywallValidationResult {
         val packages: AvailablePackages,
         val initialSelectedTabIndex: Int?,
         val mainStackHasHeroImage: Boolean = false,
+        val stateDeclarations: Map<String, StateDeclaration> = emptyMap(),
     ) : PaywallValidationResult {
         // If a Components Paywall has an error, it will be reflected as a Legacy type so we can use the Legacy
         // fallback.

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStoreTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStoreTests.kt
@@ -75,6 +75,24 @@ internal class PaywallStateStoreTests {
     }
 
     @Test
+    fun `accepts an integral double write to an integer-typed key`() {
+        val store = PaywallStateStore(mapOf("slide" to declaration(StateDeclaration.ValueType.INTEGER, JsonPrimitive(0))))
+
+        store.applyUpdates(listOf(setUpdate("slide", StateUpdateValue.Literal(JsonPrimitive(2.0)))))
+
+        assertThat(store.currentValueOrDefault("slide")).isEqualTo(JsonPrimitive(2.0))
+    }
+
+    @Test
+    fun `ignores a fractional double write to an integer-typed key`() {
+        val store = PaywallStateStore(mapOf("slide" to declaration(StateDeclaration.ValueType.INTEGER, JsonPrimitive(0))))
+
+        store.applyUpdates(listOf(setUpdate("slide", StateUpdateValue.Literal(JsonPrimitive(2.5)))))
+
+        assertThat(store.currentValueOrDefault("slide")).isEqualTo(JsonPrimitive(0))
+    }
+
+    @Test
     fun `accepts an integer write to a double-typed key`() {
         val store = PaywallStateStore(mapOf("ratio" to declaration(StateDeclaration.ValueType.DOUBLE, JsonPrimitive(0.0))))
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStoreTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStoreTests.kt
@@ -11,7 +11,8 @@ import kotlinx.serialization.json.JsonPrimitive
 @OptIn(InternalRevenueCatAPI::class)
 internal class PaywallStateStoreTests {
 
-    private fun declaration(type: String, default: JsonPrimitive) = StateDeclaration(type = type, defaultValue = default)
+    private fun declaration(type: StateDeclaration.ValueType, default: JsonPrimitive) =
+        StateDeclaration(type = type, defaultValue = default)
 
     private fun setUpdate(key: String, value: StateUpdateValue): StateUpdate = StateUpdate.Set(key, value)
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStoreTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStoreTests.kt
@@ -24,8 +24,8 @@ internal class PaywallStateStoreTests {
             ),
         )
 
-        assertThat(store.values).isEqualTo(mapOf("open" to JsonPrimitive(false), "tab" to JsonPrimitive("billing")))
-        assertThat(store.defaults).isEqualTo(store.values)
+        assertThat(store.values.toMap()).isEqualTo(mapOf("open" to JsonPrimitive(false), "tab" to JsonPrimitive("billing")))
+        assertThat(store.defaults.toMap()).isEqualTo(store.values.toMap())
     }
 
     @Test
@@ -111,7 +111,7 @@ internal class PaywallStateStoreTests {
 
         store.registerDeclarations(mapOf("b" to declaration(StateDeclaration.ValueType.INTEGER, JsonPrimitive(7))))
 
-        assertThat(store.values).isEqualTo(mapOf("a" to JsonPrimitive("x"), "b" to JsonPrimitive(7)))
+        assertThat(store.values.toMap()).isEqualTo(mapOf("a" to JsonPrimitive("x"), "b" to JsonPrimitive(7)))
     }
 
     @Test
@@ -125,13 +125,4 @@ internal class PaywallStateStoreTests {
         assertThat(store.values["tab"]).isEqualTo(JsonPrimitive("b"))
     }
 
-    @Test
-    fun `reset restores declared defaults`() {
-        val store = PaywallStateStore(mapOf("open" to declaration(StateDeclaration.ValueType.BOOLEAN, JsonPrimitive(false))))
-        store.applyUpdates(listOf(setUpdate("open", StateUpdateValue.Literal(JsonPrimitive(true)))))
-
-        store.reset()
-
-        assertThat(store.values["open"]).isEqualTo(JsonPrimitive(false))
-    }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStoreTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStoreTests.kt
@@ -1,0 +1,137 @@
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
+import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import kotlinx.serialization.json.JsonPrimitive
+
+@OptIn(InternalRevenueCatAPI::class)
+internal class PaywallStateStoreTests {
+
+    private fun declaration(type: String, default: JsonPrimitive) = StateDeclaration(type = type, defaultValue = default)
+
+    private fun setUpdate(key: String, value: StateUpdateValue): StateUpdate = StateUpdate.Set(key, value)
+
+    @Test
+    fun `seeds current values and defaults from declarations`() {
+        val store = PaywallStateStore(
+            mapOf(
+                "open" to declaration(StateDeclaration.ValueType.BOOLEAN, JsonPrimitive(false)),
+                "tab" to declaration(StateDeclaration.ValueType.STRING, JsonPrimitive("billing")),
+            ),
+        )
+
+        assertThat(store.values).isEqualTo(mapOf("open" to JsonPrimitive(false), "tab" to JsonPrimitive("billing")))
+        assertThat(store.defaults).isEqualTo(store.values)
+    }
+
+    @Test
+    fun `applies a set update with a literal value`() {
+        val store = PaywallStateStore(mapOf("open" to declaration(StateDeclaration.ValueType.BOOLEAN, JsonPrimitive(false))))
+
+        store.applyUpdates(listOf(setUpdate("open", StateUpdateValue.Literal(JsonPrimitive(true)))))
+
+        assertThat(store.values["open"]).isEqualTo(JsonPrimitive(true))
+    }
+
+    @Test
+    fun `substitutes the payload for a payload reference`() {
+        val store = PaywallStateStore(mapOf("slide" to declaration(StateDeclaration.ValueType.INTEGER, JsonPrimitive(0))))
+
+        store.applyUpdates(listOf(setUpdate("slide", StateUpdateValue.PayloadReference)), payload = JsonPrimitive(3))
+
+        assertThat(store.values["slide"]).isEqualTo(JsonPrimitive(3))
+    }
+
+    @Test
+    fun `ignores a payload reference when there is no payload`() {
+        val store = PaywallStateStore(mapOf("slide" to declaration(StateDeclaration.ValueType.INTEGER, JsonPrimitive(0))))
+
+        store.applyUpdates(listOf(setUpdate("slide", StateUpdateValue.PayloadReference)), payload = null)
+
+        assertThat(store.values["slide"]).isEqualTo(JsonPrimitive(0))
+    }
+
+    @Test
+    fun `ignores a write to an undeclared key`() {
+        val store = PaywallStateStore(emptyMap())
+
+        store.applyUpdates(listOf(setUpdate("ghost", StateUpdateValue.Literal(JsonPrimitive(true)))))
+
+        assertThat(store.values).isEmpty()
+    }
+
+    @Test
+    fun `ignores a write whose type does not match the declared type`() {
+        val store = PaywallStateStore(mapOf("open" to declaration(StateDeclaration.ValueType.BOOLEAN, JsonPrimitive(false))))
+
+        store.applyUpdates(listOf(setUpdate("open", StateUpdateValue.Literal(JsonPrimitive("true")))))
+
+        assertThat(store.values["open"]).isEqualTo(JsonPrimitive(false))
+    }
+
+    @Test
+    fun `accepts an integer write to a double-typed key`() {
+        val store = PaywallStateStore(mapOf("ratio" to declaration(StateDeclaration.ValueType.DOUBLE, JsonPrimitive(0.0))))
+
+        store.applyUpdates(listOf(setUpdate("ratio", StateUpdateValue.Literal(JsonPrimitive(2)))))
+
+        assertThat(store.values["ratio"]).isEqualTo(JsonPrimitive(2))
+    }
+
+    @Test
+    fun `ignores an unsupported update`() {
+        val store = PaywallStateStore(mapOf("open" to declaration(StateDeclaration.ValueType.BOOLEAN, JsonPrimitive(false))))
+
+        store.applyUpdates(listOf(StateUpdate.Unsupported))
+
+        assertThat(store.values["open"]).isEqualTo(JsonPrimitive(false))
+    }
+
+    @Test
+    fun `applies updates in declared order`() {
+        val store = PaywallStateStore(mapOf("tab" to declaration(StateDeclaration.ValueType.STRING, JsonPrimitive("a"))))
+
+        store.applyUpdates(
+            listOf(
+                setUpdate("tab", StateUpdateValue.Literal(JsonPrimitive("b"))),
+                setUpdate("tab", StateUpdateValue.Literal(JsonPrimitive("c"))),
+            ),
+        )
+
+        assertThat(store.values["tab"]).isEqualTo(JsonPrimitive("c"))
+    }
+
+    @Test
+    fun `registerDeclarations adds new keys seeded from their defaults`() {
+        val store = PaywallStateStore(mapOf("a" to declaration(StateDeclaration.ValueType.STRING, JsonPrimitive("x"))))
+
+        store.registerDeclarations(mapOf("b" to declaration(StateDeclaration.ValueType.INTEGER, JsonPrimitive(7))))
+
+        assertThat(store.values).isEqualTo(mapOf("a" to JsonPrimitive("x"), "b" to JsonPrimitive(7)))
+    }
+
+    @Test
+    fun `registerDeclarations does not reset a key that already has a value`() {
+        // Mirrors workflow navigation: re-registering a screen's declarations must preserve state set elsewhere.
+        val store = PaywallStateStore(mapOf("tab" to declaration(StateDeclaration.ValueType.STRING, JsonPrimitive("a"))))
+        store.applyUpdates(listOf(setUpdate("tab", StateUpdateValue.Literal(JsonPrimitive("b")))))
+
+        store.registerDeclarations(mapOf("tab" to declaration(StateDeclaration.ValueType.STRING, JsonPrimitive("a"))))
+
+        assertThat(store.values["tab"]).isEqualTo(JsonPrimitive("b"))
+    }
+
+    @Test
+    fun `reset restores declared defaults`() {
+        val store = PaywallStateStore(mapOf("open" to declaration(StateDeclaration.ValueType.BOOLEAN, JsonPrimitive(false))))
+        store.applyUpdates(listOf(setUpdate("open", StateUpdateValue.Literal(JsonPrimitive(true)))))
+
+        store.reset()
+
+        assertThat(store.values["open"]).isEqualTo(JsonPrimitive(false))
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStoreTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateStoreTests.kt
@@ -24,8 +24,8 @@ internal class PaywallStateStoreTests {
             ),
         )
 
-        assertThat(store.values.toMap()).isEqualTo(mapOf("open" to JsonPrimitive(false), "tab" to JsonPrimitive("billing")))
-        assertThat(store.defaults.toMap()).isEqualTo(store.values.toMap())
+        assertThat(store.currentValueOrDefault("open")).isEqualTo(JsonPrimitive(false))
+        assertThat(store.currentValueOrDefault("tab")).isEqualTo(JsonPrimitive("billing"))
     }
 
     @Test
@@ -34,7 +34,7 @@ internal class PaywallStateStoreTests {
 
         store.applyUpdates(listOf(setUpdate("open", StateUpdateValue.Literal(JsonPrimitive(true)))))
 
-        assertThat(store.values["open"]).isEqualTo(JsonPrimitive(true))
+        assertThat(store.currentValueOrDefault("open")).isEqualTo(JsonPrimitive(true))
     }
 
     @Test
@@ -43,7 +43,7 @@ internal class PaywallStateStoreTests {
 
         store.applyUpdates(listOf(setUpdate("slide", StateUpdateValue.PayloadReference)), payload = JsonPrimitive(3))
 
-        assertThat(store.values["slide"]).isEqualTo(JsonPrimitive(3))
+        assertThat(store.currentValueOrDefault("slide")).isEqualTo(JsonPrimitive(3))
     }
 
     @Test
@@ -52,7 +52,7 @@ internal class PaywallStateStoreTests {
 
         store.applyUpdates(listOf(setUpdate("slide", StateUpdateValue.PayloadReference)), payload = null)
 
-        assertThat(store.values["slide"]).isEqualTo(JsonPrimitive(0))
+        assertThat(store.currentValueOrDefault("slide")).isEqualTo(JsonPrimitive(0))
     }
 
     @Test
@@ -61,7 +61,7 @@ internal class PaywallStateStoreTests {
 
         store.applyUpdates(listOf(setUpdate("ghost", StateUpdateValue.Literal(JsonPrimitive(true)))))
 
-        assertThat(store.values).isEmpty()
+        assertThat(store.currentValueOrDefault("ghost")).isNull()
     }
 
     @Test
@@ -70,7 +70,7 @@ internal class PaywallStateStoreTests {
 
         store.applyUpdates(listOf(setUpdate("open", StateUpdateValue.Literal(JsonPrimitive("true")))))
 
-        assertThat(store.values["open"]).isEqualTo(JsonPrimitive(false))
+        assertThat(store.currentValueOrDefault("open")).isEqualTo(JsonPrimitive(false))
     }
 
     @Test
@@ -79,7 +79,7 @@ internal class PaywallStateStoreTests {
 
         store.applyUpdates(listOf(setUpdate("ratio", StateUpdateValue.Literal(JsonPrimitive(2)))))
 
-        assertThat(store.values["ratio"]).isEqualTo(JsonPrimitive(2))
+        assertThat(store.currentValueOrDefault("ratio")).isEqualTo(JsonPrimitive(2))
     }
 
     @Test
@@ -88,7 +88,7 @@ internal class PaywallStateStoreTests {
 
         store.applyUpdates(listOf(StateUpdate.Unsupported))
 
-        assertThat(store.values["open"]).isEqualTo(JsonPrimitive(false))
+        assertThat(store.currentValueOrDefault("open")).isEqualTo(JsonPrimitive(false))
     }
 
     @Test
@@ -102,7 +102,7 @@ internal class PaywallStateStoreTests {
             ),
         )
 
-        assertThat(store.values["tab"]).isEqualTo(JsonPrimitive("c"))
+        assertThat(store.currentValueOrDefault("tab")).isEqualTo(JsonPrimitive("c"))
     }
 
     @Test
@@ -111,7 +111,8 @@ internal class PaywallStateStoreTests {
 
         store.registerDeclarations(mapOf("b" to declaration(StateDeclaration.ValueType.INTEGER, JsonPrimitive(7))))
 
-        assertThat(store.values.toMap()).isEqualTo(mapOf("a" to JsonPrimitive("x"), "b" to JsonPrimitive(7)))
+        assertThat(store.currentValueOrDefault("a")).isEqualTo(JsonPrimitive("x"))
+        assertThat(store.currentValueOrDefault("b")).isEqualTo(JsonPrimitive(7))
     }
 
     @Test
@@ -122,7 +123,7 @@ internal class PaywallStateStoreTests {
 
         store.registerDeclarations(mapOf("tab" to declaration(StateDeclaration.ValueType.STRING, JsonPrimitive("a"))))
 
-        assertThat(store.values["tab"]).isEqualTo(JsonPrimitive("b"))
+        assertThat(store.currentValueOrDefault("tab")).isEqualTo(JsonPrimitive("b"))
     }
 
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -34,6 +34,9 @@ import com.revenuecat.purchases.paywalls.components.common.LocalizationData
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
+import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
+import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
@@ -85,6 +88,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -1509,6 +1513,27 @@ class PaywallViewModelTest {
 
         coVerify(exactly = 1) { purchases.awaitGetWorkflow(any()) }
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+    }
+
+    @Test
+    fun `standalone state store is reused across a color-scheme refresh`() {
+        val model = create(offering = offeringWithWPL)
+        val initialState = model.state.value as PaywallState.Loaded.Components
+        initialState.stateStore.registerDeclarations(
+            mapOf("flag" to StateDeclaration(type = StateDeclaration.ValueType.BOOLEAN, defaultValue = JsonPrimitive(false))),
+        )
+        initialState.stateStore.applyUpdates(
+            listOf(StateUpdate.Set("flag", StateUpdateValue.Literal(JsonPrimitive(true)))),
+        )
+
+        model.refreshStateIfColorsChanged(
+            colorScheme = TestData.Constants.currentColorScheme.copy(primary = Color.Black),
+            isDark = true,
+        )
+
+        val refreshedState = model.state.value as PaywallState.Loaded.Components
+        assertThat(refreshedState.stateStore).isSameAs(initialState.stateStore)
+        assertThat(refreshedState.stateStore.currentValueOrDefault("flag")).isEqualTo(JsonPrimitive(true))
     }
 
     // region events

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -645,6 +645,25 @@ class PaywallViewModelWorkflowTest {
         ).isEqualTo("gold")
     }
 
+    @Test
+    fun `swapping workflow sessions before the previous prewarm starts does not pollute the new cache`() = runTest {
+        val vm = createVm()
+
+        vm.startWorkflowPresentationFromResult(fetchResult, testOfferings, null, uiConfig)
+        val staleStore = (vm.state.value as PaywallState.Loaded.Components).stateStore
+
+        // A second session starts before the first session's prewarm job has run at all: cancel() marks the
+        // still-unscheduled job so its body (and any writes tied to staleStore) never executes.
+        vm.startWorkflowPresentationFromResult(fetchResult, testOfferings, null, uiConfig)
+        val currentStore = (vm.state.value as PaywallState.Loaded.Components).stateStore
+        assertThat(currentStore).isNotSameAs(staleStore)
+
+        advanceUntilIdle()
+
+        val cachedStep2Store = vm.workflowState.value?.stepStates?.get("step-2")?.stateStore
+        assertThat(cachedStep2Store).isSameAs(currentStore)
+    }
+
     // endregion
 
     // region onTransitionComplete


### PR DESCRIPTION
Introduces `PaywallStateStore`, the runtime state container. Seeded from `state_declarations` defaults; `applyUpdates` writes to it and `currentValueOrDefault` reads with default fallback.

Scoping: standalone paywalls own one store for the duration of the presentation; workflow paywalls share one store across all screens. Re-registering a screen's declarations (on navigation) preserves any values already written by other screens.

Internally uses `mutableStateMapOf<String, MutableState<JsonPrimitive>>` so a write to one key only invalidates `derivedStateOf` blocks reading that key, not every component. `declaredTypes` is a plain `ConcurrentHashMap` (never snapshot-read).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New shared mutable state across workflow steps and async prewarm adds concurrency/session-boundary edge cases; changes are localized to RevenueCatUI paywall presentation with tests, but incorrect scoping could leak or drop user-driven state between screens.
> 
> **Overview**
> Adds **`PaywallStateStore`**, a per-presentation-session container for dashboard **state-driven** paywall values: seeded from `state_declarations`, updated via typed `StateUpdate` writes (including payload references), and read through `currentValueOrDefault`. Compose uses per-key `MutableState` so updates only invalidate readers of that key.
> 
> **`PaywallState.Loaded.Components`** now carries a `stateStore`. Validation/mapping threads **`stateDeclarations`** from paywall components data into component paywall state creation.
> 
> **`PaywallViewModel`** owns session scoping: one reused store for standalone paywalls across refreshes (e.g. color scheme) until dismiss; one shared store per workflow impression across steps/screens, with declarations registered as each step builds. Prewarm captures the workflow store and bails if a newer session replaces it, avoiding stale cache pollution.
> 
> Unit tests cover store behavior and ViewModel reuse/session-swap edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e436d71eaffdf7c7a629fc9f8d17a22f83974cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->