### PR TITLE
feat(RevenueCatUI): evaluate state conditions in the override resolver (PWENG-57)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
@@ -11,8 +11,10 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptyList
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Result
 import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrElse
 import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.doubleOrNull
+import kotlin.math.abs
 
 /**
  * Partial components transformed and ready for presentation.
@@ -91,6 +93,8 @@ internal fun <T : PartialComponent, P : PresentedPartial<P>> List<ComponentOverr
 internal class ConditionContext(
     val selectedPackageId: String?,
     val customVariables: Map<String, CustomVariableValue>,
+    val stateValues: Map<String, JsonPrimitive> = emptyMap(),
+    val stateDefaults: Map<String, JsonPrimitive> = emptyMap(),
 )
 
 /**
@@ -147,8 +151,7 @@ private fun ComponentOverride.Condition.evaluate(
     is ComponentOverride.Condition.PromoOfferRule -> evaluate(offerEligibility)
     is ComponentOverride.Condition.SelectedPackage -> evaluate(conditionContext.selectedPackageId)
     is ComponentOverride.Condition.Variable -> evaluate(conditionContext.customVariables)
-    // State condition evaluation lands in a later phase; until then it never applies its override.
-    is ComponentOverride.Condition.State -> false
+    is ComponentOverride.Condition.State -> evaluate(conditionContext.stateValues, conditionContext.stateDefaults)
     ComponentOverride.Condition.Unsupported -> false
 }
 
@@ -197,6 +200,35 @@ private fun ComponentOverride.Condition.Variable.matchesValue(
     value.doubleOrNull != null ->
         variableValue is CustomVariableValue.Number && variableValue.value == value.doubleOrNull
     else -> false
+}
+
+private const val STATE_NUMBER_COMPARISON_EPSILON = 1e-10
+
+private fun ComponentOverride.Condition.State.evaluate(
+    stateValues: Map<String, JsonPrimitive>,
+    stateDefaults: Map<String, JsonPrimitive>,
+): Boolean {
+    // An undeclared key (absent from both the store and the declared defaults) never applies its override,
+    // regardless of operator.
+    val current = stateValues[name] ?: stateDefaults[name] ?: return false
+    val matches = matchesValue(current)
+    return when (operator) {
+        ComponentOverride.EqualityOperator.EQUALS -> matches
+        ComponentOverride.EqualityOperator.NOT_EQUALS -> !matches
+    }
+}
+
+private fun ComponentOverride.Condition.State.matchesValue(current: JsonPrimitive): Boolean = when {
+    value.isString || current.isString ->
+        value.isString && current.isString && value.content == current.content
+    value.booleanOrNull != null || current.booleanOrNull != null ->
+        value.booleanOrNull == current.booleanOrNull
+    else -> {
+        val expectedNumber = value.doubleOrNull
+        val currentNumber = current.doubleOrNull
+        expectedNumber != null && currentNumber != null &&
+            abs(expectedNumber - currentNumber) < STATE_NUMBER_COMPARISON_EPSILON
+    }
 }
 
 private val ScreenCondition.applicableConditions: Set<ComponentOverride.Condition>

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
@@ -93,8 +93,8 @@ internal fun <T : PartialComponent, P : PresentedPartial<P>> List<ComponentOverr
 internal class ConditionContext(
     val selectedPackageId: String?,
     val customVariables: Map<String, CustomVariableValue>,
-    val stateValues: Map<String, JsonPrimitive> = emptyMap(),
-    val stateDefaults: Map<String, JsonPrimitive> = emptyMap(),
+    // Calls inside derivedStateOf subscribe only to the keys condition evaluation actually reads.
+    val stateReader: (String) -> JsonPrimitive? = { null },
 )
 
 /**
@@ -151,7 +151,7 @@ private fun ComponentOverride.Condition.evaluate(
     is ComponentOverride.Condition.PromoOfferRule -> evaluate(offerEligibility)
     is ComponentOverride.Condition.SelectedPackage -> evaluate(conditionContext.selectedPackageId)
     is ComponentOverride.Condition.Variable -> evaluate(conditionContext.customVariables)
-    is ComponentOverride.Condition.State -> evaluate(conditionContext.stateValues, conditionContext.stateDefaults)
+    is ComponentOverride.Condition.State -> evaluate(conditionContext.stateReader)
     ComponentOverride.Condition.Unsupported -> false
 }
 
@@ -205,12 +205,11 @@ private fun ComponentOverride.Condition.Variable.matchesValue(
 private const val STATE_NUMBER_COMPARISON_EPSILON = 1e-10
 
 private fun ComponentOverride.Condition.State.evaluate(
-    stateValues: Map<String, JsonPrimitive>,
-    stateDefaults: Map<String, JsonPrimitive>,
+    stateReader: (String) -> JsonPrimitive?,
 ): Boolean {
     // An undeclared key (absent from both the store and the declared defaults) never applies its override,
     // regardless of operator.
-    val current = stateValues[name] ?: stateDefaults[name] ?: return false
+    val current = stateReader(name) ?: return false
     val matches = matchesValue(current)
     return when (operator) {
         ComponentOverride.EqualityOperator.EQUALS -> matches

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
@@ -2165,8 +2165,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
             conditionContext = ConditionContext(
                 selectedPackageId = args.selectedPackageId,
                 customVariables = args.customVariables,
-                stateValues = args.stateValues,
-                stateDefaults = args.stateDefaults,
+                stateReader = { key -> args.stateValues[key] ?: args.stateDefaults[key] },
             ),
         )
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
@@ -49,6 +49,8 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
         val expected: LocalizedTextPartial?,
         val selectedPackageId: String? = null,
         val customVariables: Map<String, CustomVariableValue> = emptyMap(),
+        val stateValues: Map<String, JsonPrimitive> = emptyMap(),
+        val stateDefaults: Map<String, JsonPrimitive> = emptyMap(),
     )
 
     @Suppress("LargeClass")
@@ -193,6 +195,27 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
             }
             return overrides
         }
+
+        private fun stateCondition(
+            operator: ComponentOverride.EqualityOperator,
+            name: String,
+            value: JsonPrimitive,
+        ) = ComponentOverride.Condition.State(operator = operator, name = name, value = value)
+
+        private fun stateArgs(
+            condition: ComponentOverride.Condition.State,
+            stateValues: Map<String, JsonPrimitive> = emptyMap(),
+            stateDefaults: Map<String, JsonPrimitive> = emptyMap(),
+            expected: LocalizedTextPartial?,
+        ) = Args(
+            availableOverrides = listOf(PresentedOverride(listOf(condition), selectedPartial)),
+            windowSize = COMPACT,
+            offerEligibility = Ineligible,
+            state = DEFAULT,
+            stateValues = stateValues,
+            stateDefaults = stateDefaults,
+            expected = expected,
+        )
 
         @Suppress("LongMethod")
         @JvmStatic
@@ -1169,6 +1192,91 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 ),
             ),
 
+            // State condition tests
+            arrayOf(
+                "state boolean equals: applies when the stored value matches",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "open", JsonPrimitive(true)),
+                    stateValues = mapOf("open" to JsonPrimitive(true)),
+                    expected = selectedPartial,
+                ),
+            ),
+            arrayOf(
+                "state boolean equals: does not apply when the stored value differs",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "open", JsonPrimitive(true)),
+                    stateValues = mapOf("open" to JsonPrimitive(false)),
+                    expected = null,
+                ),
+            ),
+            arrayOf(
+                "state string not-equals: applies when the stored value differs",
+                stateArgs(
+                    condition = stateCondition(
+                        ComponentOverride.EqualityOperator.NOT_EQUALS, "tab", JsonPrimitive("billing"),
+                    ),
+                    stateValues = mapOf("tab" to JsonPrimitive("usage")),
+                    expected = selectedPartial,
+                ),
+            ),
+            arrayOf(
+                "state integer equals: applies when the stored value matches",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "slide", JsonPrimitive(2)),
+                    stateValues = mapOf("slide" to JsonPrimitive(2)),
+                    expected = selectedPartial,
+                ),
+            ),
+            arrayOf(
+                "state number: integer condition matches a double-typed store value",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "slide", JsonPrimitive(2)),
+                    stateValues = mapOf("slide" to JsonPrimitive(2.0)),
+                    expected = selectedPartial,
+                ),
+            ),
+            arrayOf(
+                "state: type mismatch evaluates as not equal",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "slide", JsonPrimitive(2)),
+                    stateValues = mapOf("slide" to JsonPrimitive("2")),
+                    expected = null,
+                ),
+            ),
+            arrayOf(
+                "state: missing value falls back to the declared default",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "open", JsonPrimitive(true)),
+                    stateDefaults = mapOf("open" to JsonPrimitive(true)),
+                    expected = selectedPartial,
+                ),
+            ),
+            arrayOf(
+                "state: stored value wins over the declared default",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "open", JsonPrimitive(true)),
+                    stateValues = mapOf("open" to JsonPrimitive(true)),
+                    stateDefaults = mapOf("open" to JsonPrimitive(false)),
+                    expected = selectedPartial,
+                ),
+            ),
+            arrayOf(
+                "state: undeclared key with equals never applies",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "ghost", JsonPrimitive(true)),
+                    expected = null,
+                ),
+            ),
+            arrayOf(
+                "state: undeclared key with not-equals never applies",
+                stateArgs(
+                    condition = stateCondition(
+                        ComponentOverride.EqualityOperator.NOT_EQUALS, "ghost", JsonPrimitive(true),
+                    ),
+                    expected = null,
+                ),
+            ),
+
             // IntroOffer (legacy object) tests
             arrayOf(
                 "intro_offer: should apply when eligible",
@@ -2057,6 +2165,8 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
             conditionContext = ConditionContext(
                 selectedPackageId = args.selectedPackageId,
                 customVariables = args.customVariables,
+                stateValues = args.stateValues,
+                stateDefaults = args.stateDefaults,
             ),
         )
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
@@ -1244,6 +1244,30 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 ),
             ),
             arrayOf(
+                "state: string condition vs number store value evaluates as not equal",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "tab", JsonPrimitive("2")),
+                    stateValues = mapOf("tab" to JsonPrimitive(2)),
+                    expected = null,
+                ),
+            ),
+            arrayOf(
+                "state: boolean condition vs number store value evaluates as not equal",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "open", JsonPrimitive(true)),
+                    stateValues = mapOf("open" to JsonPrimitive(2)),
+                    expected = null,
+                ),
+            ),
+            arrayOf(
+                "state: number condition vs boolean store value evaluates as not equal",
+                stateArgs(
+                    condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "slide", JsonPrimitive(2)),
+                    stateValues = mapOf("slide" to JsonPrimitive(true)),
+                    expected = null,
+                ),
+            ),
+            arrayOf(
                 "state: missing value falls back to the declared default",
                 stateArgs(
                     condition = stateCondition(ComponentOverride.EqualityOperator.EQUALS, "open", JsonPrimitive(true)),


### PR DESCRIPTION
Threads the store into the override resolution pipeline. `ConditionContext` carries a `stateReader: (String) -> JsonPrimitive?` lambda; `Condition.State.evaluate` calls it and checks the result with the declared operator. Because reads happen inside each component's `derivedStateOf` block, Compose tracks per-key subscriptions automatically — only components whose conditions reference the changed key re-evaluate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which paywall partials render when state conditions are used; behavior is well-tested but affects presentation logic across components once `stateReader` is connected in UI.
> 
> **Overview**
> **State-based component overrides** now work in `buildPresentedPartial`: `Condition.State` is evaluated instead of always returning false.
> 
> `ConditionContext` gains a **`stateReader: (String) -> JsonPrimitive?`** hook (default no-op) so callers can supply live paywall state; evaluation reads the named key and applies **equals / not-equals** with string, boolean, and numeric matching (numbers use a small epsilon). **Missing keys** (no store value and no default from the reader) **never** apply the override, including for `not_equals`. Cross-type comparisons do not match.
> 
> `BuildPresentedPartialTests` adds parameterized coverage for booleans, strings, numbers, defaults vs stored values, and undeclared keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aaac43d64e4e11a51b067c0241e42ebb49ef7e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->