### PR TITLE
feat(paywalls): add web_view message value types (PWENG-98)

### DIFF
--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -150,6 +150,46 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public abstract void performRestoreWithCompletion(com.revenuecat.purchases.CustomerInfo customerInfo, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult,kotlin.Unit> completion);
   }
 
+  public abstract class PaywallWebViewValue {
+  }
+
+  public static final class PaywallWebViewValue.Array extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Array(java.util.List<? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value);
+    method public java.util.List<com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> getValue();
+    property public final java.util.List<com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value;
+  }
+
+  public static final class PaywallWebViewValue.Boolean extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Boolean(boolean value);
+    method public boolean getValue();
+    property public final boolean value;
+  }
+
+  public static final class PaywallWebViewValue.Null extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue.Null INSTANCE;
+  }
+
+  public static final class PaywallWebViewValue.Number extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Number(double value);
+    ctor public PaywallWebViewValue.Number(float value);
+    ctor public PaywallWebViewValue.Number(int value);
+    ctor public PaywallWebViewValue.Number(long value);
+    method public double getValue();
+    property public final double value;
+  }
+
+  public static final class PaywallWebViewValue.Object extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Object(java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value);
+    method public java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> getValue();
+    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value;
+  }
+
+  public static final class PaywallWebViewValue.String extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.String(String value);
+    method public String getValue();
+    property public final String value;
+  }
+
   @Deprecated public interface PurchaseLogic extends com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic {
     method @Deprecated public suspend Object? performPurchase(android.app.Activity activity, com.revenuecat.purchases.Package rcPackage, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult>);
     method @Deprecated public default suspend Object? performPurchase(android.app.Activity activity, com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogicParams params, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult>);

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
@@ -1,0 +1,135 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A JSON-compatible value used in messages exchanged with a Paywalls V2 `web_view` component.
+ *
+ * Only JSON-like values are supported: [String], [Number], [Boolean], [Object], [Array] and [Null].
+ * Functions, binary blobs, dates, and platform-specific objects are intentionally not representable.
+ *
+ * @see PaywallWebViewMessage
+ * @see PaywallWebViewController
+ */
+// Modeled as an abstract class with a closed set of subtypes (mirroring [CustomVariableValue]) rather
+// than a sealed class, to stay binary-compatible as public API.
+public abstract class PaywallWebViewValue internal constructor() {
+
+    /**
+     * A string value.
+     */
+    public class String(public val value: kotlin.String) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is String && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.String(value=$value)"
+    }
+
+    /**
+     * A numeric value (integer or decimal). Stored as a [Double].
+     */
+    public class Number(public val value: kotlin.Double) : PaywallWebViewValue() {
+        public constructor(value: kotlin.Int) : this(value.toDouble())
+        public constructor(value: kotlin.Long) : this(value.toDouble())
+        public constructor(value: kotlin.Float) : this(value.toDouble())
+
+        override fun equals(other: Any?): kotlin.Boolean = other is Number && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Number(value=$value)"
+    }
+
+    /**
+     * A boolean value.
+     */
+    public class Boolean(public val value: kotlin.Boolean) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Boolean && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Boolean(value=$value)"
+    }
+
+    /**
+     * A JSON object: a map of string keys to [PaywallWebViewValue]s.
+     */
+    public class Object(public val value: Map<kotlin.String, PaywallWebViewValue>) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Object && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Object(value=$value)"
+    }
+
+    /**
+     * A JSON array: an ordered list of [PaywallWebViewValue]s.
+     */
+    public class Array(public val value: List<PaywallWebViewValue>) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Array && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Array(value=$value)"
+    }
+
+    /**
+     * A JSON `null` value.
+     */
+    public object Null : PaywallWebViewValue() {
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Null"
+    }
+
+    internal companion object {
+        /**
+         * Converts an `org.json` value (or Kotlin primitive) into a [PaywallWebViewValue], rejecting
+         * anything that is not JSON-compatible or that exceeds [remainingDepth] levels of nesting.
+         *
+         * @return the converted value, or `null` if the value is not JSON-compatible or too deeply nested.
+         */
+        @Suppress("ReturnCount", "CyclomaticComplexMethod")
+        fun fromJson(value: Any?, remainingDepth: Int): PaywallWebViewValue? {
+            return when (value) {
+                null, JSONObject.NULL -> Null
+                is kotlin.String -> String(value)
+                is kotlin.Boolean -> Boolean(value)
+                is Int -> Number(value)
+                is Long -> Number(value)
+                is Double -> Number(value)
+                is Float -> Number(value)
+                is JSONObject -> {
+                    if (remainingDepth <= 0) return null
+                    val map = LinkedHashMap<kotlin.String, PaywallWebViewValue>(value.length())
+                    for (key in value.keys()) {
+                        map[key] = fromJson(value.get(key), remainingDepth - 1) ?: return null
+                    }
+                    Object(map)
+                }
+                is JSONArray -> {
+                    if (remainingDepth <= 0) return null
+                    val list = ArrayList<PaywallWebViewValue>(value.length())
+                    for (index in 0 until value.length()) {
+                        list.add(fromJson(value.get(index), remainingDepth - 1) ?: return null)
+                    }
+                    Array(list)
+                }
+                // Numbers stored by org.json as BigDecimal/BigInteger, or any other type, are not supported.
+                else -> (value as? kotlin.Number)?.let { Number(it.toDouble()) }
+            }
+        }
+    }
+}
+
+/**
+ * Converts this value into a representation accepted by [JSONObject]/[JSONArray] when serializing a
+ * message to send into the web view. Whole numbers are emitted as integers (e.g. `100`, not `100.0`).
+ */
+internal fun PaywallWebViewValue.toJsonRepresentation(): Any = when (this) {
+    is PaywallWebViewValue.String -> value
+    is PaywallWebViewValue.Boolean -> value
+    is PaywallWebViewValue.Number ->
+        if (value % 1.0 == 0.0 && !value.isInfinite()) value.toLong() else value
+    is PaywallWebViewValue.Object -> JSONObject().apply {
+        value.forEach { (key, child) -> put(key, child.toJsonRepresentation()) }
+    }
+    is PaywallWebViewValue.Array -> JSONArray().apply {
+        value.forEach { child -> put(child.toJsonRepresentation()) }
+    }
+    else -> JSONObject.NULL
+}
+
+internal fun Map<String, PaywallWebViewValue>.toJsonObject(): JSONObject = JSONObject().apply {
+    forEach { (key, value) -> put(key, value.toJsonRepresentation()) }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValueTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValueTest.kt
@@ -1,0 +1,85 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+
+internal class PaywallWebViewValueTest {
+
+    @Test
+    fun `fromJson converts primitives`() {
+        assertThat(PaywallWebViewValue.fromJson("hello", 8)).isEqualTo(PaywallWebViewValue.String("hello"))
+        assertThat(PaywallWebViewValue.fromJson(true, 8)).isEqualTo(PaywallWebViewValue.Boolean(true))
+        assertThat(PaywallWebViewValue.fromJson(42, 8)).isEqualTo(PaywallWebViewValue.Number(42))
+        assertThat(PaywallWebViewValue.fromJson(3.5, 8)).isEqualTo(PaywallWebViewValue.Number(3.5))
+        assertThat(PaywallWebViewValue.fromJson(null, 8)).isEqualTo(PaywallWebViewValue.Null)
+        assertThat(PaywallWebViewValue.fromJson(JSONObject.NULL, 8)).isEqualTo(PaywallWebViewValue.Null)
+    }
+
+    @Test
+    fun `fromJson converts nested objects and arrays`() {
+        val json = JSONObject("""{"a":1,"b":["x",false],"c":{"d":null}}""")
+
+        val value = PaywallWebViewValue.fromJson(json, 8)
+
+        assertThat(value).isInstanceOf(PaywallWebViewValue.Object::class.java)
+        val obj = (value as PaywallWebViewValue.Object).value
+        assertThat(obj["a"]).isEqualTo(PaywallWebViewValue.Number(1))
+        assertThat(obj["b"]).isEqualTo(
+            PaywallWebViewValue.Array(listOf(PaywallWebViewValue.String("x"), PaywallWebViewValue.Boolean(false))),
+        )
+        assertThat(obj["c"]).isEqualTo(
+            PaywallWebViewValue.Object(mapOf("d" to PaywallWebViewValue.Null)),
+        )
+    }
+
+    @Test
+    fun `fromJson returns null when too deeply nested`() {
+        val json = JSONObject("""{"a":{"b":{"c":1}}}""")
+
+        // Allow only 2 levels: top object (1) -> a (2) -> b would exceed.
+        assertThat(PaywallWebViewValue.fromJson(json, 2)).isNull()
+    }
+
+    @Test
+    fun `toJsonRepresentation emits whole numbers as integers`() {
+        assertThat(PaywallWebViewValue.Number(100.0).toJsonRepresentation()).isEqualTo(100L)
+        assertThat(PaywallWebViewValue.Number(99.99).toJsonRepresentation()).isEqualTo(99.99)
+    }
+
+    @Test
+    fun `toJsonRepresentation keeps non-finite numbers as doubles`() {
+        // Infinity/NaN are not whole numbers, so they must not be collapsed to Long.
+        assertThat(PaywallWebViewValue.Number(Double.POSITIVE_INFINITY).toJsonRepresentation())
+            .isEqualTo(Double.POSITIVE_INFINITY)
+        assertThat(PaywallWebViewValue.Number(Double.NaN).toJsonRepresentation())
+            .isEqualTo(Double.NaN)
+    }
+
+    @Test
+    fun `toJsonObject round-trips a map`() {
+        val map = mapOf(
+            "locale" to PaywallWebViewValue.String("en-US"),
+            "custom" to PaywallWebViewValue.Object(
+                mapOf(
+                    "plan" to PaywallWebViewValue.String("annual"),
+                    "count" to PaywallWebViewValue.Number(3),
+                    "flag" to PaywallWebViewValue.Boolean(true),
+                    "list" to PaywallWebViewValue.Array(listOf(PaywallWebViewValue.Number(1))),
+                    "nothing" to PaywallWebViewValue.Null,
+                ),
+            ),
+        )
+
+        val json = map.toJsonObject()
+
+        assertThat(json.getString("locale")).isEqualTo("en-US")
+        val custom = json.getJSONObject("custom")
+        assertThat(custom.getString("plan")).isEqualTo("annual")
+        assertThat(custom.getInt("count")).isEqualTo(3)
+        assertThat(custom.getBoolean("flag")).isTrue()
+        assertThat(custom.get("list")).isInstanceOf(JSONArray::class.java)
+        assertThat(custom.isNull("nothing")).isTrue()
+    }
+}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
The `web_view` bidirectional-messaging bridge needs a JSON-compatible value type to represent message payloads in a type-safe, public-API-friendly way.


Part of PWENG-98.

### Description
- Adds the public `PaywallWebViewValue` sealed type (`String` / `Number` / `Boolean` / `Object` / `Array` / `Null`) plus JSON conversion helpers.
- Pure data type — no message envelope, parser, or bridge yet.
- Tested by `PaywallWebViewValueTest`.

iOS parity: mirrors `purchases-ios` (`web-view-bridge-wiring`).
Stack (merge bottom-up): schema → rendering → CSP → **value types** → message model → variables provider → JS bridge → wiring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API and internal helpers only; no changes to purchase, auth, or existing paywall runtime behavior.
> 
> **Overview**
> Introduces **`PaywallWebViewValue`**, a new public JSON-shaped type for Paywalls V2 **`web_view`** message payloads, ahead of the JS bridge stack (PWENG-98).
> 
> The type is an **abstract class** with nested variants (`String`, `Number`, `Boolean`, `Object`, `Array`, `Null`)—same pattern as **`CustomVariableValue`** for stable public API. **`api.txt`** documents the new surface.
> 
> **Internal** helpers add **`fromJson`** (with a nesting depth cap and rejection of non-JSON types) and outbound serialization via **`toJsonRepresentation`** / **`toJsonObject`** (whole numbers emitted as integers). No message envelope, parser, or WebView wiring in this PR—data layer only.
> 
> **`PaywallWebViewValueTest`** covers primitives, nested structures, depth limits, and round-trip JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf8d3d011285282ca45d81aafe7a289b80c7f3cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->