### PR TITLE
feat(paywalls): add web_view SDK variables provider (PWENG-98)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProvider.kt
@@ -1,0 +1,58 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+
+/**
+ * Builds the `variables` payload sent to a `web_view` component in response to `rc:request-variables`.
+ *
+ * Produces a flat map shaped like:
+ * ```json
+ * { "locale": "en-US" }
+ * ```
+ *
+ * Only safe, already-available system context is exposed: the paywall locale. The paywall's
+ * dashboard-defined custom variables are intentionally NOT passed across the bridge in v1. API keys,
+ * email addresses, the Purchases SDK instance, and storage are never included.
+ *
+ * [KEY_LOCALE] is a reserved SDK-managed top-level key: app-provided variables may not overwrite it.
+ */
+internal object PaywallWebViewVariablesProvider {
+
+    const val KEY_LOCALE: String = "locale"
+
+    val reservedKeys: Set<String> = setOf(KEY_LOCALE)
+
+    /**
+     * The SDK-managed system variables exposed to the web view.
+     *
+     * @param locale a BCP-47-ish locale string, e.g. `en-US`.
+     */
+    fun sdkManagedVariables(
+        locale: String,
+    ): Map<String, PaywallWebViewValue> = linkedMapOf(
+        KEY_LOCALE to PaywallWebViewValue.String(locale),
+    )
+
+    /**
+     * Removes reserved SDK-managed top-level keys from app-provided variables so they cannot overwrite
+     * SDK values, logging a warning for any that were dropped.
+     */
+    fun sanitizeAppProvidedVariables(
+        variables: Map<String, PaywallWebViewValue>,
+    ): Map<String, PaywallWebViewValue> {
+        val sanitized = variables.filterKeys { key ->
+            val reserved = key in reservedKeys
+            if (reserved) {
+                Logger.w(
+                    "Ignoring reserved web view variable key '$key'. Reserved SDK-managed keys cannot be " +
+                        "overwritten.",
+                )
+            }
+            !reserved
+        }
+        return sanitized
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProviderTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProviderTest.kt
@@ -1,0 +1,34 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class PaywallWebViewVariablesProviderTest {
+
+    @Test
+    fun `sdkManagedVariables exposes only the locale system variable`() {
+        val variables = PaywallWebViewVariablesProvider.sdkManagedVariables(locale = "en-US")
+
+        // Only the locale system variable is exposed; nothing else is passed across the bridge in v1.
+        assertThat(variables).hasSize(1)
+        assertThat(variables[PaywallWebViewVariablesProvider.KEY_LOCALE])
+            .isEqualTo(PaywallWebViewValue.String("en-US"))
+    }
+
+    @Test
+    fun `sanitizeAppProvidedVariables drops reserved keys`() {
+        val sanitized = PaywallWebViewVariablesProvider.sanitizeAppProvidedVariables(
+            mapOf(
+                "locale" to PaywallWebViewValue.String("zz-ZZ"),
+                "app_segment" to PaywallWebViewValue.String("high_intent"),
+            ),
+        )
+
+        assertThat(sanitized).doesNotContainKey("locale")
+        assertThat(sanitized).containsKey("app_segment")
+    }
+}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
When web content sends `rc:request-variables`, the SDK replies with safe, already-available system context. v1 exposes only `locale`; the paywall's dashboard-defined custom variables are intentionally not passed across the bridge.


Part of PWENG-98.

### Description
- Adds `PaywallWebViewVariablesProvider`: builds the SDK-managed variables payload (`{ locale }` only) and `sanitizeAppProvidedVariables`, which strips reserved top-level keys so app-provided values cannot overwrite SDK-managed ones (they nest under `custom`).
- Internal; consumed by the JS bridge in the next PR.
- Tested by `PaywallWebViewVariablesProviderTest`.

iOS parity: mirrors `purchases-ios` (`web-view-bridge-wiring`), which likewise exposes `locale` only and treats custom variables as out of scope for v1.
Stack (merge bottom-up): schema → rendering → CSP → value types → message model → **variables provider** → JS bridge → wiring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New internal helper with a narrow v1 surface (locale only) and explicit sanitization; not yet integrated into the live bridge.
> 
> **Overview**
> Adds internal **`PaywallWebViewVariablesProvider`** so the SDK can answer `rc:request-variables` with a minimal, safe variables map for paywall `web_view` components.
> 
> **`sdkManagedVariables(locale)`** returns only `{ "locale": "<BCP-47>" }` in v1—no dashboard custom variables, credentials, or SDK internals cross the bridge. **`sanitizeAppProvidedVariables`** strips reserved top-level keys (starting with `locale`) from app-supplied maps and logs when values are dropped, so apps cannot override SDK-managed fields.
> 
> Unit tests cover locale-only SDK output and reserved-key filtering. Wiring into the JS bridge is planned in a follow-up PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e94849bad9e68ed1d8f535b9275f193a4e884cd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->