### PR TITLE
feat(RevenueCatUI): Enable tab state store and state-driven overrides

### DIFF
--- a/examples/paywall-tester/build.gradle.kts
+++ b/examples/paywall-tester/build.gradle.kts
@@ -138,6 +138,7 @@ dependencies {
     implementation(project(":feature:amazon"))
     implementation(project(":ui:debugview"))
     implementation(project(":ui:revenuecatui"))
+    implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/paywalls/TabsWithButtons.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/paywalls/TabsWithButtons.kt
@@ -20,6 +20,9 @@ import com.revenuecat.purchases.paywalls.components.common.LocalizationData
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
+import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
+import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.paywalls.components.properties.CornerRadiuses
@@ -37,6 +40,7 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fi
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.TwoDimensionalAlignment
 import com.revenuecat.purchases.paywalls.components.properties.VerticalAlignment
+import kotlinx.serialization.json.JsonPrimitive
 import java.net.URL
 
 @Suppress("LongMethod")
@@ -72,6 +76,12 @@ internal fun tabsWithButtons(font: FontAlias? = null): SampleData.Components {
             id = "sample_tabs_with_buttons_paywall_id",
             templateName = "template",
             assetBaseURL = URL("https://assets.pawwalls.com"),
+            stateDeclarations = mapOf(
+                "selectedTab" to StateDeclaration(
+                    type = StateDeclaration.ValueType.STRING,
+                    defaultValue = JsonPrimitive("tab-0"),
+                ),
+            ),
             componentsConfig = ComponentsConfig(
                 base = PaywallComponentsConfig(
                     stack = StackComponent(
@@ -278,6 +288,12 @@ internal fun tabsWithButtons(font: FontAlias? = null): SampleData.Components {
                                         ),
                                     ),
                                 ),
+                                stateUpdates = listOf(
+                                    StateUpdate.Set(
+                                        key = "selectedTab",
+                                        value = StateUpdateValue.PayloadReference,
+                                    ),
+                                ),
                                 size = Size(width = Fill, height = Fill),
                             ),
 
@@ -290,6 +306,20 @@ internal fun tabsWithButtons(font: FontAlias? = null): SampleData.Components {
                                         horizontalAlignment = LEADING,
                                         size = Size(width = Fill, height = Fit()),
                                         margin = Padding(top = 48.0, bottom = 8.0, leading = 0.0, trailing = 0.0),
+                                        overrides = listOf(
+                                            ComponentOverride(
+                                                conditions = listOf(
+                                                    ComponentOverride.Condition.State(
+                                                        operator = ComponentOverride.EqualityOperator.EQUALS,
+                                                        name = "selectedTab",
+                                                        value = JsonPrimitive("tab-1"),
+                                                    ),
+                                                ),
+                                                properties = PartialTextComponent(
+                                                    text = LocalizationKey("offer-tab-1"),
+                                                ),
+                                            ),
+                                        ),
                                     ),
                                     StackComponent(
                                         components = listOf(
@@ -346,6 +376,9 @@ internal fun tabsWithButtons(font: FontAlias? = null): SampleData.Components {
                     ),
                     LocalizationKey("offer") to LocalizationData.Text(
                         "Try 7 days free, then $19.98/year. Cancel anytime.",
+                    ),
+                    LocalizationKey("offer-tab-1") to LocalizationData.Text(
+                        "Tab 2 selected: try annual at $9.99/year.",
                     ),
                     LocalizationKey("cta") to LocalizationData.Text("Continue"),
                     LocalizationKey("terms") to LocalizationData.Text("Privacy & Terms"),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentState.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDel
 import com.revenuecat.purchases.ui.revenuecatui.components.style.IconComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallStateStore
 
 @Stable
 @JvmSynthetic
@@ -39,17 +40,20 @@ internal fun rememberUpdatedIconComponentState(
     selectedTabIndexProvider = { paywallState.selectedTabIndex },
     selectedOfferEligibilityProvider = { paywallState.selectedOfferEligibility },
     customVariablesProvider = { paywallState.mergedCustomVariables },
+    stateStoreProvider = { paywallState.stateStore },
 )
 
 @Stable
 @JvmSynthetic
 @Composable
+@Suppress("LongParameterList")
 private fun rememberUpdatedIconComponentState(
     style: IconComponentStyle,
     selectedPackageInfoProvider: () -> PaywallState.Loaded.Components.SelectedPackageInfo?,
     selectedTabIndexProvider: () -> Int,
     selectedOfferEligibilityProvider: () -> OfferEligibility,
     customVariablesProvider: () -> Map<String, CustomVariableValue>,
+    stateStoreProvider: () -> PaywallStateStore,
 ): IconComponentState {
     val windowSize = currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass
     val layoutDirection = LocalLayoutDirection.current
@@ -63,6 +67,7 @@ private fun rememberUpdatedIconComponentState(
             selectedTabIndexProvider = selectedTabIndexProvider,
             selectedOfferEligibilityProvider = selectedOfferEligibilityProvider,
             customVariablesProvider = customVariablesProvider,
+            stateStoreProvider = stateStoreProvider,
         )
     }.apply {
         update(windowSize = windowSize)
@@ -79,6 +84,7 @@ internal class IconComponentState(
     private val selectedTabIndexProvider: () -> Int,
     private val selectedOfferEligibilityProvider: () -> OfferEligibility,
     private val customVariablesProvider: () -> Map<String, CustomVariableValue> = { emptyMap() },
+    private val stateStoreProvider: () -> PaywallStateStore = { PaywallStateStore(emptyMap()) },
 ) {
     private var windowSize by mutableStateOf(initialWindowSize)
     private var layoutDirection by mutableStateOf(initialLayoutDirection)
@@ -102,6 +108,7 @@ internal class IconComponentState(
             conditionContext = ConditionContext(
                 selectedPackageId = selectedPackageInfoProvider()?.rcPackage?.identifier,
                 customVariables = customVariablesProvider(),
+                stateReader = stateStoreProvider()::currentValueOrDefault,
             ),
         )
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentState.kt
@@ -42,6 +42,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDel
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ImageComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallStateStore
 
 @Stable
 @JvmSynthetic
@@ -56,6 +57,7 @@ internal fun rememberUpdatedImageComponentState(
     selectedTabIndexProvider = { paywallState.selectedTabIndex },
     selectedOfferEligibilityProvider = { paywallState.selectedOfferEligibility },
     customVariablesProvider = { paywallState.mergedCustomVariables },
+    stateStoreProvider = { paywallState.stateStore },
 )
 
 @Suppress("LongParameterList")
@@ -69,6 +71,7 @@ private fun rememberUpdatedImageComponentState(
     selectedTabIndexProvider: () -> Int,
     selectedOfferEligibilityProvider: () -> OfferEligibility,
     customVariablesProvider: () -> Map<String, CustomVariableValue>,
+    stateStoreProvider: () -> PaywallStateStore,
 ): ImageComponentState {
     val windowSize = currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass
     val density = LocalDensity.current
@@ -87,6 +90,7 @@ private fun rememberUpdatedImageComponentState(
             selectedTabIndexProvider = selectedTabIndexProvider,
             selectedOfferEligibilityProvider = selectedOfferEligibilityProvider,
             customVariablesProvider = customVariablesProvider,
+            stateStoreProvider = stateStoreProvider,
         )
     }.apply {
         update(
@@ -111,6 +115,7 @@ internal class ImageComponentState(
     private val selectedTabIndexProvider: () -> Int,
     private val selectedOfferEligibilityProvider: () -> OfferEligibility,
     private val customVariablesProvider: () -> Map<String, CustomVariableValue> = { emptyMap() },
+    private val stateStoreProvider: () -> PaywallStateStore = { PaywallStateStore(emptyMap()) },
 ) {
     private var windowSize by mutableStateOf(initialWindowSize)
     private var density by mutableStateOf(initialDensity)
@@ -136,6 +141,7 @@ internal class ImageComponentState(
             conditionContext = ConditionContext(
                 selectedPackageId = selectedPackageInfoProvider()?.rcPackage?.identifier,
                 customVariables = customVariablesProvider(),
+                stateReader = stateStoreProvider()::currentValueOrDefault,
             ),
         )
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -29,6 +29,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDel
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallStateStore
 import com.revenuecat.purchases.ui.revenuecatui.extensions.toOrientation
 
 @Stable
@@ -43,17 +44,20 @@ internal fun rememberUpdatedStackComponentState(
     selectedTabIndexProvider = { paywallState.selectedTabIndex },
     selectedOfferEligibilityProvider = { paywallState.selectedOfferEligibility },
     customVariablesProvider = { paywallState.mergedCustomVariables },
+    stateStoreProvider = { paywallState.stateStore },
 )
 
 @Stable
 @JvmSynthetic
 @Composable
+@Suppress("LongParameterList")
 private fun rememberUpdatedStackComponentState(
     style: StackComponentStyle,
     selectedPackageInfoProvider: () -> PaywallState.Loaded.Components.SelectedPackageInfo?,
     selectedTabIndexProvider: () -> Int,
     selectedOfferEligibilityProvider: () -> OfferEligibility,
     customVariablesProvider: () -> Map<String, CustomVariableValue>,
+    stateStoreProvider: () -> PaywallStateStore,
 ): StackComponentState {
     val windowSize = currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass
     val layoutDirection = LocalLayoutDirection.current
@@ -67,6 +71,7 @@ private fun rememberUpdatedStackComponentState(
             selectedTabIndexProvider = selectedTabIndexProvider,
             selectedOfferEligibilityProvider = selectedOfferEligibilityProvider,
             customVariablesProvider = customVariablesProvider,
+            stateStoreProvider = stateStoreProvider,
         )
     }.apply {
         update(
@@ -86,6 +91,7 @@ internal class StackComponentState(
     private val selectedTabIndexProvider: () -> Int,
     private val selectedOfferEligibilityProvider: () -> OfferEligibility,
     private val customVariablesProvider: () -> Map<String, CustomVariableValue> = { emptyMap() },
+    private val stateStoreProvider: () -> PaywallStateStore = { PaywallStateStore(emptyMap()) },
 ) {
     private var windowSize by mutableStateOf(initialWindowSize)
     private var layoutDirection by mutableStateOf(initialLayoutDirection)
@@ -109,6 +115,7 @@ internal class StackComponentState(
             conditionContext = ConditionContext(
                 selectedPackageId = selectedPackageInfoProvider()?.rcPackage?.identifier,
                 customVariables = customVariablesProvider(),
+                stateReader = stateStoreProvider()::currentValueOrDefault,
             ),
         )
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -1307,6 +1307,7 @@ internal class StyleFactory(
                         control = control,
                         tabs = tabs,
                         overrides = overrides,
+                        stateUpdates = component.stateUpdates,
                     )
                 }
             }
@@ -1350,7 +1351,7 @@ internal class StyleFactory(
             withTabIndex(tabIndex) {
                 withTabControl(control) {
                     createStackComponentStyle(componentTab.stack)
-                        .map { stack -> TabsComponentStyle.Tab(stack) }
+                        .map { stack -> TabsComponentStyle.Tab(id = componentTab.id, stack = stack) }
                 }
             }
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/TabsComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/TabsComponentStyle.kt
@@ -4,6 +4,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components.style
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Immutable
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
 import com.revenuecat.purchases.paywalls.components.properties.Shape
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
@@ -79,10 +80,15 @@ internal data class TabsComponentStyle(
     val tabs: NonEmptyList<Tab>,
     @get:JvmSynthetic
     val overrides: List<PresentedOverride<PresentedTabsPartial>>,
+    @get:JvmSynthetic
+    val stateUpdates: List<StateUpdate>? = null,
 ) : ComponentStyle {
 
     @Immutable
-    data class Tab(@get:JvmSynthetic val stack: StackComponentStyle)
+    data class Tab(
+        @get:JvmSynthetic val id: String,
+        @get:JvmSynthetic val stack: StackComponentStyle,
+    )
 }
 
 @Immutable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentView.kt
@@ -81,17 +81,18 @@ internal fun TabsComponentView(
         style = style,
         paywallState = state,
     )
+
+    if (!tabsState.visible) return
+
     // State-driven paywalls: publish the selected tab id into the state store so components that react to it via a
-    // `state_condition` override recompose. Done before the visibility check so a hidden Tabs still publishes its
-    // selected state. Runs on first composition (seed) and whenever the selection changes.
+    // `state_condition` override recompose. Gated behind visibility (parity with iOS): a hidden Tabs never
+    // publishes. Runs on first composition (seed) and whenever the selection changes.
     val selectedTabId = style.tabs[state.selectedTabIndex.coerceIn(0..style.tabs.lastIndex)].id
     LaunchedEffect(selectedTabId) {
         style.stateUpdates?.takeIf { it.isNotEmpty() }?.let { updates ->
             state.stateStore.applyUpdates(updates, payload = JsonPrimitive(selectedTabId))
         }
     }
-
-    if (!tabsState.visible) return
 
     val backgroundStyle = tabsState.background?.let { rememberBackgroundStyle(it) }
     val borderStyle = tabsState.border?.let { rememberBorderStyle(border = it) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentView.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -82,17 +84,23 @@ internal fun TabsComponentView(
         paywallState = state,
     )
 
-    if (!tabsState.visible) return
-
     // State-driven paywalls: publish the selected tab id into the state store so components that react to it via a
     // `state_condition` override recompose. Gated behind visibility (parity with iOS): a hidden Tabs never
-    // publishes. Runs on first composition (seed) and whenever the selection changes.
+    // publishes. Seeds once and then publishes only when the selection actually changes. Remembering the last
+    // published id above the visibility gate keeps a hidden -> visible transition from republishing and
+    // clobbering a value another component already set (mirrors iOS's didSeedInitialState). The declared state
+    // default is expected to match default_tab_id.
     val selectedTabId = style.tabs[state.selectedTabIndex.coerceIn(0..style.tabs.lastIndex)].id
-    LaunchedEffect(selectedTabId) {
+    val lastPublishedTabId = remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(tabsState.visible, selectedTabId) {
+        if (!tabsState.visible || selectedTabId == lastPublishedTabId.value) return@LaunchedEffect
+        lastPublishedTabId.value = selectedTabId
         style.stateUpdates?.takeIf { it.isNotEmpty() }?.let { updates ->
             state.stateStore.applyUpdates(updates, payload = JsonPrimitive(selectedTabId))
         }
     }
+
+    if (!tabsState.visible) return
 
     val backgroundStyle = tabsState.background?.let { rememberBackgroundStyle(it) }
     val borderStyle = tabsState.border?.let { rememberBorderStyle(border = it) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentView.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -63,6 +64,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteract
 import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyListOf
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
+import kotlinx.serialization.json.JsonPrimitive
 
 private const val DURATION_MS_CROSS_FADE = 220
 
@@ -80,6 +82,15 @@ internal fun TabsComponentView(
         paywallState = state,
     )
     if (!tabsState.visible) return
+
+    // State-driven paywalls: publish the selected tab id into the state store so components that react to it via a
+    // `state_condition` override recompose. Runs on first composition (seed) and whenever the selection changes.
+    val selectedTabId = style.tabs[state.selectedTabIndex.coerceIn(0..style.tabs.lastIndex)].id
+    LaunchedEffect(selectedTabId) {
+        style.stateUpdates?.takeIf { it.isNotEmpty() }?.let { updates ->
+            state.stateStore.applyUpdates(updates, payload = JsonPrimitive(selectedTabId))
+        }
+    }
 
     val backgroundStyle = tabsState.background?.let { rememberBackgroundStyle(it) }
     val borderStyle = tabsState.border?.let { rememberBorderStyle(border = it) }
@@ -214,6 +225,7 @@ private fun TabsComponentView_Preview() {
             control = TabControlStyle.Buttons(stack = previewStackComponentStyle(emptyList())),
             tabs = nonEmptyListOf(
                 TabsComponentStyle.Tab(
+                    id = "tab1",
                     stack = previewStackComponentStyle(
                         children = listOf(
                             controlButtons,
@@ -228,6 +240,7 @@ private fun TabsComponentView_Preview() {
                     ),
                 ),
                 TabsComponentStyle.Tab(
+                    id = "tab2",
                     stack = previewStackComponentStyle(
                         children = listOf(
                             controlButtons,
@@ -242,6 +255,7 @@ private fun TabsComponentView_Preview() {
                     ),
                 ),
                 TabsComponentStyle.Tab(
+                    id = "tab3",
                     stack = previewStackComponentStyle(
                         children = listOf(
                             controlButtons,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentView.kt
@@ -81,16 +81,17 @@ internal fun TabsComponentView(
         style = style,
         paywallState = state,
     )
-    if (!tabsState.visible) return
-
     // State-driven paywalls: publish the selected tab id into the state store so components that react to it via a
-    // `state_condition` override recompose. Runs on first composition (seed) and whenever the selection changes.
+    // `state_condition` override recompose. Done before the visibility check so a hidden Tabs still publishes its
+    // selected state. Runs on first composition (seed) and whenever the selection changes.
     val selectedTabId = style.tabs[state.selectedTabIndex.coerceIn(0..style.tabs.lastIndex)].id
     LaunchedEffect(selectedTabId) {
         style.stateUpdates?.takeIf { it.isNotEmpty() }?.let { updates ->
             state.stateStore.applyUpdates(updates, payload = JsonPrimitive(selectedTabId))
         }
     }
+
+    if (!tabsState.visible) return
 
     val backgroundStyle = tabsState.background?.let { rememberBackgroundStyle(it) }
     val borderStyle = tabsState.border?.let { rememberBorderStyle(border = it) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentState.kt
@@ -34,6 +34,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDel
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallStateStore
 
 @Stable
 @JvmSynthetic
@@ -48,6 +49,7 @@ internal fun rememberUpdatedTextComponentState(
     selectedTabIndexProvider = { paywallState.selectedTabIndex },
     selectedOfferEligibilityProvider = { paywallState.selectedOfferEligibility },
     customVariablesProvider = { paywallState.mergedCustomVariables },
+    stateStoreProvider = { paywallState.stateStore },
 )
 
 @Suppress("LongParameterList")
@@ -61,6 +63,7 @@ private fun rememberUpdatedTextComponentState(
     selectedTabIndexProvider: () -> Int,
     selectedOfferEligibilityProvider: () -> OfferEligibility,
     customVariablesProvider: () -> Map<String, CustomVariableValue>,
+    stateStoreProvider: () -> PaywallStateStore,
 ): TextComponentState {
     val windowSize = currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass
 
@@ -77,6 +80,7 @@ private fun rememberUpdatedTextComponentState(
             selectedTabIndexProvider = selectedTabIndexProvider,
             selectedOfferEligibilityProvider = selectedOfferEligibilityProvider,
             customVariablesProvider = customVariablesProvider,
+            stateStoreProvider = stateStoreProvider,
         )
     }.apply {
         update(
@@ -96,6 +100,7 @@ internal class TextComponentState(
     private val selectedTabIndexProvider: () -> Int,
     private val selectedOfferEligibilityProvider: () -> OfferEligibility,
     private val customVariablesProvider: () -> Map<String, CustomVariableValue> = { emptyMap() },
+    private val stateStoreProvider: () -> PaywallStateStore = { PaywallStateStore(emptyMap()) },
 ) {
     private var windowSize by mutableStateOf(initialWindowSize)
 
@@ -148,6 +153,7 @@ internal class TextComponentState(
             conditionContext = ConditionContext(
                 selectedPackageId = selectedPackageInfoProvider()?.rcPackage?.identifier,
                 customVariables = customVariablesProvider(),
+                stateReader = stateStoreProvider()::currentValueOrDefault,
             ),
         )
     }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabStateTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabStateTests.kt
@@ -1,0 +1,192 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.tabs
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.paywalls.components.PartialTextComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.TabControlButtonComponent
+import com.revenuecat.purchases.paywalls.components.TabControlComponent
+import com.revenuecat.purchases.paywalls.components.TabsComponent
+import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.LocalizationData
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
+import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
+import com.revenuecat.purchases.paywalls.components.common.StateUpdate
+import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabsComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.text.TextComponentView
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.extensions.toComponentsPaywallState
+import com.revenuecat.purchases.ui.revenuecatui.extensions.validatePaywallComponentsDataOrNull
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.StyleFactory
+import com.revenuecat.purchases.ui.revenuecatui.helpers.UiConfig
+import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
+import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlinx.serialization.json.JsonPrimitive
+import java.net.URL
+
+@OptIn(InternalRevenueCatAPI::class)
+@RunWith(AndroidJUnit4::class)
+class TabStateTests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val localeId = LocaleId("en_US")
+    private val textColor = ColorScheme(light = ColorInfo.Hex(Color.Black.toArgb()))
+    private val assetBaseURL = URL("https://assets.pawwalls.com")
+    private val stateKey = "selectedTab"
+
+    /**
+     * A component reacting via a `state_condition` override recomposes when the store value changes.
+     * Proves the read path: the store snapshot is threaded into the resolver and a write triggers re-resolution.
+     */
+    @Test
+    fun `Component re-resolves its state_condition override when the store value changes`(): Unit =
+        with(composeTestRule) {
+            val defaultTextKey = LocalizationKey("default_text")
+            val annualTextKey = LocalizationKey("annual_text")
+            val localizations = nonEmptyMapOf(
+                localeId to nonEmptyMapOf(
+                    defaultTextKey to LocalizationData.Text("Default copy"),
+                    annualTextKey to LocalizationData.Text("Annual copy"),
+                ),
+            )
+            val component = TextComponent(
+                text = defaultTextKey,
+                color = textColor,
+                overrides = listOf(
+                    ComponentOverride(
+                        conditions = listOf(
+                            ComponentOverride.Condition.State(
+                                operator = ComponentOverride.EqualityOperator.EQUALS,
+                                name = stateKey,
+                                value = JsonPrimitive("annual"),
+                            ),
+                        ),
+                        properties = PartialTextComponent(text = annualTextKey),
+                    ),
+                ),
+            )
+            val state = FakePaywallState(
+                localizations = localizations,
+                defaultLocaleIdentifier = localeId,
+                components = listOf(component),
+                packages = listOf(TestData.Packages.monthly),
+            )
+            // Seed the declaration the override reads (default selection is "monthly").
+            state.stateStore.registerDeclarations(
+                mapOf(stateKey to StateDeclaration(type = StateDeclaration.ValueType.STRING, defaultValue = JsonPrimitive("monthly"))),
+            )
+            val styleFactory = StyleFactory(localizations = localizations)
+            val style = styleFactory.create(component).getOrThrow().componentStyle as TextComponentStyle
+
+            setContent { TextComponentView(style = style, state = state) }
+
+            // Default selection: override does not apply.
+            onNodeWithText("Default copy").assertExists()
+            onNodeWithText("Annual copy").assertDoesNotExist()
+
+            // Simulate another component publishing the "annual" tab selection.
+            state.stateStore.applyUpdates(
+                listOf(StateUpdate.Set(stateKey, StateUpdateValue.Literal(JsonPrimitive("annual")))),
+            )
+            waitForIdle()
+
+            // The override now applies and the component recomposed.
+            onNodeWithText("Annual copy").assertExists()
+            onNodeWithText("Default copy").assertDoesNotExist()
+        }
+
+    /**
+     * Selecting a tab publishes the selected tab id into the store via the component's `state_updates`.
+     * Proves the write path: seed on first appearance plus republish on selection change.
+     */
+    @Test
+    fun `Selecting a tab publishes its id into the state store`(): Unit = with(composeTestRule) {
+        val tab0LabelKey = LocalizationKey("tab0_label")
+        val tab1LabelKey = LocalizationKey("tab1_label")
+        val localizations = nonEmptyMapOf(
+            localeId to nonEmptyMapOf(
+                tab0LabelKey to LocalizationData.Text("Monthly"),
+                tab1LabelKey to LocalizationData.Text("Annual"),
+            ),
+        )
+        val tabControlButtons = listOf(tab0LabelKey to "monthly", tab1LabelKey to "annual")
+            .mapIndexed { index, (labelKey, _) ->
+                TabControlButtonComponent(
+                    tabIndex = index,
+                    tabId = listOf("monthly", "annual")[index],
+                    stack = StackComponent(components = listOf(TextComponent(text = labelKey, color = textColor))),
+                )
+            }
+        val tabsComponent = TabsComponent(
+            tabs = listOf("monthly", "annual").map { id ->
+                TabsComponent.Tab(id = id, stack = StackComponent(components = listOf(TabControlComponent)))
+            },
+            control = TabsComponent.TabControl.Buttons(stack = StackComponent(components = tabControlButtons)),
+            stateUpdates = listOf(StateUpdate.Set(stateKey, StateUpdateValue.PayloadReference)),
+        )
+        val data = PaywallComponentsData(
+            id = "paywall_id",
+            templateName = "template",
+            assetBaseURL = assetBaseURL,
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(components = listOf(tabsComponent)),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    stickyFooter = null,
+                ),
+            ),
+            componentsLocalizations = localizations,
+            defaultLocaleIdentifier = localeId,
+            stateDeclarations = mapOf(
+                stateKey to StateDeclaration(type = StateDeclaration.ValueType.STRING, defaultValue = JsonPrimitive("monthly")),
+            ),
+        )
+        val offering = Offering(
+            identifier = "offering-id",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly),
+            paywallComponents = Offering.PaywallComponents(UiConfig(), data),
+        )
+        val validated = offering.validatePaywallComponentsDataOrNull()?.getOrThrow()!!
+        val state = offering.toComponentsPaywallState(validated)
+        val styleFactory = StyleFactory(localizations = localizations, offering = offering)
+        val style = styleFactory.create(tabsComponent).getOrThrow().componentStyle as TabsComponentStyle
+
+        setContent { TabsComponentView(style = style, state = state, clickHandler = { }) }
+        waitForIdle()
+
+        // Seeded on first appearance with the default tab id.
+        assertThat(state.stateStore.values[stateKey]).isEqualTo(JsonPrimitive("monthly"))
+
+        onNodeWithText("Annual").assertHasClickAction().performClick()
+        waitForIdle()
+
+        // Selection republished the new tab id.
+        assertThat(state.stateStore.values[stateKey]).isEqualTo(JsonPrimitive("annual"))
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabStateTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabStateTests.kt
@@ -58,10 +58,6 @@ class TabStateTests {
     private val assetBaseURL = URL("https://assets.pawwalls.com")
     private val stateKey = "selectedTab"
 
-    /**
-     * A component reacting via a `state_condition` override recomposes when the store value changes.
-     * Proves the read path: the store snapshot is threaded into the resolver and a write triggers re-resolution.
-     */
     @Test
     fun `Component re-resolves its state_condition override when the store value changes`(): Unit =
         with(composeTestRule) {
@@ -119,10 +115,6 @@ class TabStateTests {
             onNodeWithText("Default copy").assertDoesNotExist()
         }
 
-    /**
-     * Selecting a tab publishes the selected tab id into the store via the component's `state_updates`.
-     * Proves the write path: seed on first appearance plus republish on selection change.
-     */
     @Test
     fun `Selecting a tab publishes its id into the state store`(): Unit = with(composeTestRule) {
         val tab0LabelKey = LocalizationKey("tab0_label")
@@ -190,11 +182,6 @@ class TabStateTests {
         assertThat(state.stateStore.currentValueOrDefault(stateKey)).isEqualTo(JsonPrimitive("annual"))
     }
 
-    /**
-     * A hidden tabs container still publishes its selected tab id, so sibling components reacting to it are not
-     * left on a stale value. The declared default differs from the initial (default_tab_id) selection, so only the
-     * publish (not the declaration seed) can produce the expected value.
-     */
     @Test
     fun `A hidden tabs component still publishes its selected tab id`(): Unit = with(composeTestRule) {
         val tab0LabelKey = LocalizationKey("tab0_label")

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabStateTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabStateTests.kt
@@ -181,12 +181,78 @@ class TabStateTests {
         waitForIdle()
 
         // Seeded on first appearance with the default tab id.
-        assertThat(state.stateStore.values[stateKey]).isEqualTo(JsonPrimitive("monthly"))
+        assertThat(state.stateStore.currentValueOrDefault(stateKey)).isEqualTo(JsonPrimitive("monthly"))
 
         onNodeWithText("Annual").assertHasClickAction().performClick()
         waitForIdle()
 
         // Selection republished the new tab id.
-        assertThat(state.stateStore.values[stateKey]).isEqualTo(JsonPrimitive("annual"))
+        assertThat(state.stateStore.currentValueOrDefault(stateKey)).isEqualTo(JsonPrimitive("annual"))
+    }
+
+    /**
+     * A hidden tabs container still publishes its selected tab id, so sibling components reacting to it are not
+     * left on a stale value. The declared default differs from the initial (default_tab_id) selection, so only the
+     * publish (not the declaration seed) can produce the expected value.
+     */
+    @Test
+    fun `A hidden tabs component still publishes its selected tab id`(): Unit = with(composeTestRule) {
+        val tab0LabelKey = LocalizationKey("tab0_label")
+        val tab1LabelKey = LocalizationKey("tab1_label")
+        val localizations = nonEmptyMapOf(
+            localeId to nonEmptyMapOf(
+                tab0LabelKey to LocalizationData.Text("Monthly"),
+                tab1LabelKey to LocalizationData.Text("Annual"),
+            ),
+        )
+        val tabControlButtons = listOf(tab0LabelKey, tab1LabelKey).mapIndexed { index, labelKey ->
+            TabControlButtonComponent(
+                tabIndex = index,
+                tabId = listOf("monthly", "annual")[index],
+                stack = StackComponent(components = listOf(TextComponent(text = labelKey, color = textColor))),
+            )
+        }
+        val tabsComponent = TabsComponent(
+            visible = false,
+            tabs = listOf("monthly", "annual").map { id ->
+                TabsComponent.Tab(id = id, stack = StackComponent(components = listOf(TabControlComponent)))
+            },
+            control = TabsComponent.TabControl.Buttons(stack = StackComponent(components = tabControlButtons)),
+            defaultTabId = "annual",
+            stateUpdates = listOf(StateUpdate.Set(stateKey, StateUpdateValue.PayloadReference)),
+        )
+        val data = PaywallComponentsData(
+            id = "paywall_id",
+            templateName = "template",
+            assetBaseURL = assetBaseURL,
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(components = listOf(tabsComponent)),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    stickyFooter = null,
+                ),
+            ),
+            componentsLocalizations = localizations,
+            defaultLocaleIdentifier = localeId,
+            stateDeclarations = mapOf(
+                stateKey to StateDeclaration(type = StateDeclaration.ValueType.STRING, defaultValue = JsonPrimitive("monthly")),
+            ),
+        )
+        val offering = Offering(
+            identifier = "offering-id",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly),
+            paywallComponents = Offering.PaywallComponents(UiConfig(), data),
+        )
+        val validated = offering.validatePaywallComponentsDataOrNull()?.getOrThrow()!!
+        val state = offering.toComponentsPaywallState(validated)
+        val styleFactory = StyleFactory(localizations = localizations, offering = offering)
+        val style = styleFactory.create(tabsComponent).getOrThrow().componentStyle as TabsComponentStyle
+
+        setContent { TabsComponentView(style = style, state = state, clickHandler = { }) }
+        waitForIdle()
+
+        assertThat(state.stateStore.currentValueOrDefault(stateKey)).isEqualTo(JsonPrimitive("annual"))
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabStateTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabStateTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.tabs
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.test.assertHasClickAction
@@ -242,4 +243,92 @@ class TabStateTests {
 
         assertThat(state.stateStore.currentValueOrDefault(stateKey)).isEqualTo(JsonPrimitive("monthly"))
     }
+
+    @Test
+    fun `Becoming visible again does not republish and clobber a value another component set`(): Unit =
+        with(composeTestRule) {
+            val tab0LabelKey = LocalizationKey("tab0_label")
+            val tab1LabelKey = LocalizationKey("tab1_label")
+            val localizations = nonEmptyMapOf(
+                localeId to nonEmptyMapOf(
+                    tab0LabelKey to LocalizationData.Text("Monthly"),
+                    tab1LabelKey to LocalizationData.Text("Annual"),
+                ),
+            )
+            val tabControlButtons = listOf(tab0LabelKey, tab1LabelKey).mapIndexed { index, labelKey ->
+                TabControlButtonComponent(
+                    tabIndex = index,
+                    tabId = listOf("monthly", "annual")[index],
+                    stack = StackComponent(components = listOf(TextComponent(text = labelKey, color = textColor))),
+                )
+            }
+            fun tabsComponent(visible: Boolean) = TabsComponent(
+                visible = visible,
+                tabs = listOf("monthly", "annual").map { id ->
+                    TabsComponent.Tab(id = id, stack = StackComponent(components = listOf(TabControlComponent)))
+                },
+                control = TabsComponent.TabControl.Buttons(stack = StackComponent(components = tabControlButtons)),
+                defaultTabId = "monthly",
+                stateUpdates = listOf(StateUpdate.Set(stateKey, StateUpdateValue.PayloadReference)),
+            )
+            val visibleTabs = tabsComponent(visible = true)
+            val data = PaywallComponentsData(
+                id = "paywall_id",
+                templateName = "template",
+                assetBaseURL = assetBaseURL,
+                componentsConfig = ComponentsConfig(
+                    base = PaywallComponentsConfig(
+                        stack = StackComponent(components = listOf(visibleTabs)),
+                        background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                        stickyFooter = null,
+                    ),
+                ),
+                componentsLocalizations = localizations,
+                defaultLocaleIdentifier = localeId,
+                stateDeclarations = mapOf(
+                    stateKey to StateDeclaration(type = StateDeclaration.ValueType.STRING, defaultValue = JsonPrimitive("monthly")),
+                ),
+            )
+            val offering = Offering(
+                identifier = "offering-id",
+                serverDescription = "description",
+                metadata = emptyMap(),
+                availablePackages = listOf(TestData.Packages.monthly),
+                paywallComponents = Offering.PaywallComponents(UiConfig(), data),
+            )
+            val validated = offering.validatePaywallComponentsDataOrNull()?.getOrThrow()!!
+            val state = offering.toComponentsPaywallState(validated)
+            val styleFactory = StyleFactory(localizations = localizations, offering = offering)
+            val visibleStyle = styleFactory.create(visibleTabs).getOrThrow().componentStyle as TabsComponentStyle
+            val hiddenStyle =
+                styleFactory.create(tabsComponent(visible = false)).getOrThrow().componentStyle as TabsComponentStyle
+
+            // Toggle visibility at the same call site so the composable stays mounted (only its internal
+            // visibility gate flips), reproducing a hidden -> visible transition rather than a full remount.
+            val visible = mutableStateOf(true)
+            setContent {
+                TabsComponentView(
+                    style = if (visible.value) visibleStyle else hiddenStyle,
+                    state = state,
+                    clickHandler = { },
+                )
+            }
+            waitForIdle()
+
+            // Another component sets the key to a value no tab would ever publish.
+            state.stateStore.applyUpdates(
+                listOf(StateUpdate.Set(stateKey, StateUpdateValue.PayloadReference)),
+                payload = JsonPrimitive("external"),
+            )
+            waitForIdle()
+            assertThat(state.stateStore.currentValueOrDefault(stateKey)).isEqualTo(JsonPrimitive("external"))
+
+            visible.value = false
+            waitForIdle()
+            visible.value = true
+            waitForIdle()
+
+            // Selection never changed, so becoming visible again must not republish and overwrite "external".
+            assertThat(state.stateStore.currentValueOrDefault(stateKey)).isEqualTo(JsonPrimitive("external"))
+        }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabStateTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabStateTests.kt
@@ -183,7 +183,7 @@ class TabStateTests {
     }
 
     @Test
-    fun `A hidden tabs component still publishes its selected tab id`(): Unit = with(composeTestRule) {
+    fun `A hidden tabs component does not publish its selected tab id`(): Unit = with(composeTestRule) {
         val tab0LabelKey = LocalizationKey("tab0_label")
         val tab1LabelKey = LocalizationKey("tab1_label")
         val localizations = nonEmptyMapOf(
@@ -240,6 +240,6 @@ class TabStateTests {
         setContent { TabsComponentView(style = style, state = state, clickHandler = { }) }
         waitForIdle()
 
-        assertThat(state.stateStore.currentValueOrDefault(stateKey)).isEqualTo(JsonPrimitive("annual"))
+        assertThat(state.stateStore.currentValueOrDefault(stateKey)).isEqualTo(JsonPrimitive("monthly"))
     }
 }


### PR DESCRIPTION
Wires tab selection into the store: `TabsComponent.stateUpdates` fires on selection, publishing the selected tab id as a `$value` payload. Hidden tabs still publish on first composition so sibling components aren't left on stale state. The 4 reader component states (Text, Image, Stack, Icon) pass `stateReader = stateStoreProvider()::currentValueOrDefault` into `ConditionContext`.

End-to-end instrumentation tests for the read path (state condition drives a text swap) and write path (tab click publishes to store). Paywall-tester example (bottom text):

[Screen_recording_20260629_125906.webm](https://github.com/user-attachments/assets/8e10d23b-6333-4cbf-85a2-f3ad1ff474c9)

Last PR of a series for V1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall override resolution and shared state across many component types; behavior is guarded by tests but incorrect publishing could cause wrong UI copy or stale overrides on complex paywalls.
> 
> **Overview**
> Connects **tab selection** to the shared **`PaywallStateStore`** so other components can react via **`state_condition`** overrides.
> 
> **Write path:** `TabsComponent` now carries **`stateUpdates`** through styling; **`TabsComponentView`** publishes the selected tab’s **`id`** into the store when the user changes tabs (payload reference). Publishing is **gated on visibility** and tracks the last published id so hidden tabs don’t write, and showing tabs again doesn’t overwrite values set elsewhere (iOS parity).
> 
> **Read path:** **Text, Image, Stack, and Icon** component states pass **`stateReader = stateStore::currentValueOrDefault`** into **`ConditionContext`**, so overrides keyed on store state recompose when the store changes.
> 
> **Supporting changes:** **`TabsComponentStyle.Tab`** includes **`id`**; paywall-tester **`TabsWithButtons`** demo adds **`selectedTab`** declaration, tab **`stateUpdates`**, and offer text swap on **`tab-1`**; new **`TabStateTests`** cover read/write and visibility edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a9325778bf5e8be4a7c4688ebccd183284174af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->