### PR TITLE
refactor(remote-config): Add `RemoteConfigBlobFetcher`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -180,9 +180,7 @@ internal class RemoteConfigBlobFetcher(
             val url = handle.url.replace(BLOB_REF_PLACEHOLDER, ref)
             when (tryDownloadVerifyStore(url, ref)) {
                 DownloadOutcome.SUCCESS -> result = true
-                // The blob is absent/corrupt on a healthy source — fail this blob without condemning the source.
                 DownloadOutcome.BLOB_UNAVAILABLE -> result = false
-                // The source itself is failing — fall over to the next one and retry.
                 DownloadOutcome.SOURCE_UNHEALTHY -> {
                     sourceProvider.reportUnhealthy(handle)
                     handle = sourceProvider.getCurrent(Purpose.BLOB)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -24,6 +24,7 @@ private const val BLOB_REF_PLACEHOLDER = "{blob_ref}"
 /** The hardcoded blob source used until the `sources` topic feeds [RemoteConfigSourceProvider] (Phase 5 follow-up). */
 private const val DEFAULT_BLOB_URL_TEMPLATE = "https://config.revenuecat-static.com/$BLOB_REF_PLACEHOLDER"
 
+// WIP: Phase 5 follow-up: remove this hardcoded default and feed the blob sources from the `sources` topic.
 private fun defaultBlobSourceProvider(): RemoteConfigSourceProvider =
     DefaultRemoteConfigSourceProvider(
         apiSources = emptyList(),
@@ -86,7 +87,9 @@ internal class RemoteConfigBlobFetcher(
     private val inFlight = HashSet<String>()
 
     /** Queued, not-yet-claimed downloads, ordered by priority (HIGH first) then enqueue order (FIFO). */
+    // The (initialCapacity, comparator) constructor is API 1; the comparator-only overload is API 24+.
     private val queue = PriorityQueue<PendingDownload>(
+        QUEUE_INITIAL_CAPACITY,
         compareByDescending<PendingDownload> { it.priority }.thenBy { it.seq },
     )
 
@@ -223,5 +226,8 @@ internal class RemoteConfigBlobFetcher(
 
     private companion object {
         private const val MAX_CONCURRENT_DOWNLOADS = 4
+
+        // Matches java.util.PriorityQueue's own default; it grows as needed.
+        private const val QUEUE_INITIAL_CAPACITY = 11
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -1,0 +1,243 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import android.util.Base64
+import androidx.annotation.VisibleForTesting
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceHandle.Purpose
+import com.revenuecat.purchases.utils.DefaultUrlConnectionFactory
+import com.revenuecat.purchases.utils.UrlConnection
+import com.revenuecat.purchases.utils.UrlConnectionFactory
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+import java.util.PriorityQueue
+
+/** The placeholder a blob source URL template carries; substituted with the blob ref before download. */
+private const val BLOB_REF_PLACEHOLDER = "{blob_ref}"
+
+/** The hardcoded blob source used until the `sources` topic feeds [RemoteConfigSourceProvider] (Phase 5 follow-up). */
+private const val DEFAULT_BLOB_URL_TEMPLATE = "https://config.revenuecat-static.com/$BLOB_REF_PLACEHOLDER"
+
+private fun defaultBlobSourceProvider(): RemoteConfigSourceProvider =
+    DefaultRemoteConfigSourceProvider(
+        apiSources = emptyList(),
+        blobSources = listOf(RemoteConfigSource(url = DEFAULT_BLOB_URL_TEMPLATE, priority = 0, weight = 1)),
+    )
+
+private const val REF_HASH_BYTES = 24
+private const val SHA_256_ALGORITHM = "SHA-256"
+
+/**
+ * The content-address ref of [bytes]: SHA-256 truncated to [REF_HASH_BYTES] (192 bits), URL-safe base64 with no
+ * padding. Mirrors `RCElement.checksumBase64`, so inline and fetched blobs verify against the same ref shape.
+ */
+private fun contentAddressRef(bytes: ByteArray): String {
+    val digest = MessageDigest.getInstance(SHA_256_ALGORITHM).digest(bytes)
+    val truncated = digest.copyOf(REF_HASH_BYTES)
+    return Base64.encodeToString(truncated, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+}
+
+/**
+ * Downloads remote-config blobs by their content-address ref and stores them in the **same** on-disk cache
+ * inline blobs use ([RemoteConfigBlobStore]). It is the single primitive behind both background prefetch and
+ * on-demand reads:
+ *
+ * - **Bounded concurrency**: a fixed pool of [MAX_CONCURRENT_DOWNLOADS] worker coroutines downloads at most that
+ *   many blobs at once — the worker count *is* the cap (no semaphore needed).
+ * - **Priority**: workers drain a priority queue, so an on-demand [ensureDownloaded] (HIGH) is served ahead of any
+ *   backlog of [prefetch] (LOW) work. An on-demand request for a ref still queued as a prefetch **raises** its
+ *   priority so it is picked next rather than stranded behind the backlog.
+ * - **Dedupe**: a ref already queued or in flight is joined, not downloaded twice; every joiner gets the same
+ *   result. A foreground prefetch and an explicit read of the same blob share one download.
+ * - **Failure tolerant**: nothing thrown to callers; a failed or un-verifiable blob just yields `false` (it is
+ *   recoverable — re-fetched on demand or on the next sync).
+ *
+ * Each download is verified against its ref (truncated SHA-256, URL-safe base64 — see [contentAddressRef],
+ * matching `RCElement.checksumBase64`) before it is stored, so a tampered or corrupt payload is never cached.
+ */
+internal class RemoteConfigBlobFetcher(
+    private val blobStore: RemoteConfigBlobStore,
+    private val sourceProvider: RemoteConfigSourceProvider = defaultBlobSourceProvider(),
+    private val urlConnectionFactory: UrlConnectionFactory = DefaultUrlConnectionFactory(),
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    maxConcurrentDownloads: Int = MAX_CONCURRENT_DOWNLOADS,
+) {
+    /** Scheduling priority. Natural (ordinal) order is used by the queue, so HIGH must sort after LOW. */
+    private enum class Priority { LOW, HIGH }
+
+    private class PendingDownload(
+        val ref: String,
+        var priority: Priority,
+        var seq: Long,
+        val awaiters: MutableList<CompletableDeferred<Boolean>> = mutableListOf(),
+    )
+
+    private val lock = Any()
+
+    /** Every ref that is queued or in flight, for dedupe/boost. Kept until the download completes. */
+    private val pending = HashMap<String, PendingDownload>()
+
+    /** Refs a worker is currently downloading (a raise can no longer reorder these). */
+    private val inFlight = HashSet<String>()
+
+    /** Queued, not-yet-claimed downloads, ordered by priority (HIGH first) then enqueue order (FIFO). */
+    private val queue = PriorityQueue<PendingDownload>(
+        compareByDescending<PendingDownload> { it.priority }.thenBy { it.seq },
+    )
+
+    private var seqCounter = 0L
+
+    /** One token per queued item; idle workers suspend on it (no thread held) until work arrives. */
+    private val signal = Channel<Unit>(Channel.UNLIMITED)
+
+    init {
+        repeat(maxConcurrentDownloads) { scope.launch { runWorker() } }
+    }
+
+    /**
+     * Ensures the blob for [ref] is in the store, downloading it if needed. Returns whether it ended up cached.
+     * Cached → immediate `true`; otherwise the request is scheduled at HIGH priority and deduped against any
+     * queued/in-flight download for the same ref.
+     */
+    suspend fun ensureDownloaded(ref: String): Boolean {
+        if (blobStore.contains(ref)) return true
+        return enqueue(ref, Priority.HIGH).await()
+    }
+
+    /** Best-effort background warm of [refs] at LOW priority. Fire-and-forget; failures are tolerated. */
+    fun prefetch(refs: List<String>) {
+        scope.launch {
+            refs.forEach { ref ->
+                if (!blobStore.contains(ref)) {
+                    enqueue(ref, Priority.LOW)
+                }
+            }
+        }
+    }
+
+    private fun enqueue(ref: String, priority: Priority): CompletableDeferred<Boolean> = synchronized(lock) {
+        val deferred = CompletableDeferred<Boolean>()
+        val existing = pending[ref]
+        if (existing != null) {
+            existing.awaiters.add(deferred)
+            // Raising priority only matters while the ref is still queued; an in-flight download can't be reordered.
+            if (priority > existing.priority && ref !in inFlight) {
+                queue.remove(existing)
+                existing.priority = priority
+                existing.seq = seqCounter++
+                queue.offer(existing)
+            }
+            return deferred
+        }
+        val download = PendingDownload(ref, priority, seqCounter++).apply { awaiters.add(deferred) }
+        pending[ref] = download
+        queue.offer(download)
+        signal.trySend(Unit)
+        return deferred
+    }
+
+    private suspend fun runWorker() {
+        while (true) {
+            signal.receive()
+            val download = claimNext() ?: continue
+            complete(download, downloadAndStore(download.ref))
+        }
+    }
+
+    private fun claimNext(): PendingDownload? = synchronized(lock) {
+        queue.poll()?.also { inFlight.add(it.ref) }
+    }
+
+    private fun complete(download: PendingDownload, result: Boolean) {
+        val awaiters = synchronized(lock) {
+            pending.remove(download.ref)
+            inFlight.remove(download.ref)
+            download.awaiters.toList()
+        }
+        awaiters.forEach { it.complete(result) }
+    }
+
+    private fun downloadAndStore(ref: String): Boolean {
+        // Another worker (or a just-completed prefetch) may have cached it between scheduling and now.
+        if (blobStore.contains(ref)) return true
+
+        var handle = sourceProvider.getCurrent(Purpose.BLOB)
+        if (handle == null) {
+            // The provider stays exhausted (getCurrent == null) until restart; give its sources a fresh chance on
+            // each new download so a transient outage doesn't permanently disable blob fetching.
+            sourceProvider.restart(Purpose.BLOB)
+            handle = sourceProvider.getCurrent(Purpose.BLOB)
+        }
+        var result: Boolean? = null
+        while (handle != null && result == null) {
+            val url = handle.url.replace(BLOB_REF_PLACEHOLDER, ref)
+            when (tryDownloadVerifyStore(url, ref)) {
+                DownloadOutcome.SUCCESS -> result = true
+                // The blob is absent/corrupt on a healthy source — fail this blob without condemning the source.
+                DownloadOutcome.BLOB_UNAVAILABLE -> result = false
+                // The source itself is failing — fall over to the next one and retry.
+                DownloadOutcome.SOURCE_UNHEALTHY -> {
+                    sourceProvider.reportUnhealthy(handle)
+                    handle = sourceProvider.getCurrent(Purpose.BLOB)
+                }
+            }
+        }
+        return result ?: false
+    }
+
+    private fun tryDownloadVerifyStore(url: String, ref: String): DownloadOutcome {
+        var connection: UrlConnection? = null
+        return try {
+            connection = urlConnectionFactory.createConnection(url)
+            when (val code = connection.responseCode) {
+                HttpURLConnection.HTTP_OK -> {
+                    val bytes = connection.inputStream.use { it.readBytes() }
+                    if (contentAddressRef(bytes) == ref) {
+                        blobStore.write(ref, ByteBuffer.wrap(bytes))
+                        DownloadOutcome.SUCCESS
+                    } else {
+                        errorLog { "Remote config blob '$ref' from $url failed content-address verification." }
+                        DownloadOutcome.BLOB_UNAVAILABLE
+                    }
+                }
+                HttpURLConnection.HTTP_NOT_FOUND -> {
+                    errorLog { "Remote config blob '$ref' not found at $url (404)." }
+                    DownloadOutcome.BLOB_UNAVAILABLE
+                }
+                else -> {
+                    errorLog { "HTTP $code downloading remote config blob '$ref' from $url." }
+                    DownloadOutcome.SOURCE_UNHEALTHY
+                }
+            }
+        } catch (e: IOException) {
+            errorLog(e) { "Failed to download remote config blob '$ref' from $url." }
+            DownloadOutcome.SOURCE_UNHEALTHY
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    private enum class DownloadOutcome { SUCCESS, SOURCE_UNHEALTHY, BLOB_UNAVAILABLE }
+
+    /** The currently-queued (not yet claimed) refs in the order workers will pick them. Tests only. */
+    @VisibleForTesting
+    internal fun queuedRefsInPriorityOrder(): List<String> = synchronized(lock) {
+        val copy = PriorityQueue(queue)
+        generateSequence { copy.poll() }.map { it.ref }.toList()
+    }
+
+    /** How many callers are awaiting the download of [ref] (queued or in flight). Tests only. */
+    @VisibleForTesting
+    internal fun awaiterCount(ref: String): Int = synchronized(lock) { pending[ref]?.awaiters?.size ?: 0 }
+
+    private companion object {
+        private const val MAX_CONCURRENT_DOWNLOADS = 4
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -21,16 +21,6 @@ import java.util.PriorityQueue
 /** The placeholder a blob source URL template carries; substituted with the blob ref before download. */
 private const val BLOB_REF_PLACEHOLDER = "{blob_ref}"
 
-/** The hardcoded blob source used until the `sources` topic feeds [RemoteConfigSourceProvider] (Phase 5 follow-up). */
-private const val DEFAULT_BLOB_URL_TEMPLATE = "https://config.revenuecat-static.com/$BLOB_REF_PLACEHOLDER"
-
-// WIP: Phase 5 follow-up: remove this hardcoded default and feed the blob sources from the `sources` topic.
-private fun defaultBlobSourceProvider(): RemoteConfigSourceProvider =
-    DefaultRemoteConfigSourceProvider(
-        apiSources = emptyList(),
-        blobSources = listOf(RemoteConfigSource(url = DEFAULT_BLOB_URL_TEMPLATE, priority = 0, weight = 1)),
-    )
-
 private const val REF_HASH_BYTES = 24
 private const val SHA_256_ALGORITHM = "SHA-256"
 
@@ -64,7 +54,7 @@ private fun contentAddressRef(bytes: ByteArray): String {
  */
 internal class RemoteConfigBlobFetcher(
     private val blobStore: RemoteConfigBlobStore,
-    private val sourceProvider: RemoteConfigSourceProvider = defaultBlobSourceProvider(),
+    private val sourceProvider: RemoteConfigSourceProvider,
     private val urlConnectionFactory: UrlConnectionFactory = DefaultUrlConnectionFactory(),
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -138,7 +138,15 @@ internal class RemoteConfigBlobFetcher(
         while (true) {
             signal.receive()
             val download = claimNext() ?: continue
-            complete(download, downloadAndStore(download.ref))
+            // A stray Throwable (e.g. OOM from readBytes(), or a bug) must not strand awaiters on an unresolved
+            // deferred nor silently kill this worker; log it (so it surfaces) and fail the blob as recoverable.
+            val result = try {
+                downloadAndStore(download.ref)
+            } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+                errorLog(e) { "Unexpected failure downloading remote config blob '${download.ref}'." }
+                false
+            }
+            complete(download, result)
         }
     }
 
@@ -187,13 +195,7 @@ internal class RemoteConfigBlobFetcher(
             when (val code = connection.responseCode) {
                 HttpURLConnection.HTTP_OK -> {
                     val bytes = connection.inputStream.use { it.readBytes() }
-                    if (contentAddressRef(bytes) == ref) {
-                        blobStore.write(ref, ByteBuffer.wrap(bytes))
-                        DownloadOutcome.SUCCESS
-                    } else {
-                        errorLog { "Remote config blob '$ref' from $url failed content-address verification." }
-                        DownloadOutcome.BLOB_UNAVAILABLE
-                    }
+                    verifyAndStore(bytes, ref, url)
                 }
                 HttpURLConnection.HTTP_NOT_FOUND -> {
                     errorLog { "Remote config blob '$ref' not found at $url (404)." }
@@ -209,6 +211,20 @@ internal class RemoteConfigBlobFetcher(
             DownloadOutcome.SOURCE_UNHEALTHY
         } finally {
             connection?.disconnect()
+        }
+    }
+
+    private fun verifyAndStore(bytes: ByteArray, ref: String, url: String): DownloadOutcome {
+        if (contentAddressRef(bytes) != ref) {
+            errorLog { "Remote config blob '$ref' from $url failed content-address verification." }
+            return DownloadOutcome.BLOB_UNAVAILABLE
+        }
+        // A failed disk write isn't a source problem, so don't condemn the source: report the blob as unavailable
+        // (yields false, stops) and let a later sync/on-demand read re-fetch it.
+        return if (blobStore.write(ref, ByteBuffer.wrap(bytes))) {
+            DownloadOutcome.SUCCESS
+        } else {
+            DownloadOutcome.BLOB_UNAVAILABLE
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -146,7 +146,10 @@ internal class RemoteConfigBlobFetcher(
                 errorLog(e) { "Unexpected failure downloading remote config blob '${download.ref}'." }
                 false
             }
-            complete(download, result)
+            // The store is shared: a concurrent writer (e.g. inline extraction during a config sync) may have cached
+            // the ref while our download failed. Report the truthful "is it cached now?" so a benign race isn't a
+            // false negative. Short-circuits on success, so the extra stat only happens on the failure path.
+            complete(download, result || blobStore.contains(download.ref))
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -168,13 +168,10 @@ internal class RemoteConfigBlobFetcher(
         // Another worker (or a just-completed prefetch) may have cached it between scheduling and now.
         if (blobStore.contains(ref)) return true
 
+        // Each SOURCE_UNHEALTHY failure falls over to the next source; once the provider has none left
+        // (getCurrent == null) the operation fails and stops. We never restart here, so we can't spin retrying
+        // sources already known to be bad. Re-arming the provider (restart) is the caller's job — a new sync cycle.
         var handle = sourceProvider.getCurrent(Purpose.BLOB)
-        if (handle == null) {
-            // The provider stays exhausted (getCurrent == null) until restart; give its sources a fresh chance on
-            // each new download so a transient outage doesn't permanently disable blob fetching.
-            sourceProvider.restart(Purpose.BLOB)
-            handle = sourceProvider.getCurrent(Purpose.BLOB)
-        }
         var result: Boolean? = null
         while (handle != null && result == null) {
             val url = handle.url.replace(BLOB_REF_PLACEHOLDER, ref)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.common.remoteconfig
 
-import android.util.Base64
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceHandle.Purpose
 import com.revenuecat.purchases.utils.DefaultUrlConnectionFactory
@@ -10,29 +9,18 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.nio.ByteBuffer
-import java.security.MessageDigest
 import java.util.PriorityQueue
 
 /** The placeholder a blob source URL template carries; substituted with the blob ref before download. */
 private const val BLOB_REF_PLACEHOLDER = "{blob_ref}"
-
-private const val REF_HASH_BYTES = 24
-private const val SHA_256_ALGORITHM = "SHA-256"
-
-/**
- * The content-address ref of [bytes]: SHA-256 truncated to [REF_HASH_BYTES] (192 bits), URL-safe base64 with no
- * padding. Mirrors `RCElement.checksumBase64`, so inline and fetched blobs verify against the same ref shape.
- */
-private fun contentAddressRef(bytes: ByteArray): String {
-    val digest = MessageDigest.getInstance(SHA_256_ALGORITHM).digest(bytes)
-    val truncated = digest.copyOf(REF_HASH_BYTES)
-    return Base64.encodeToString(truncated, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
-}
 
 /**
  * Downloads remote-config blobs by their content-address ref and stores them in the **same** on-disk cache
@@ -49,8 +37,9 @@ private fun contentAddressRef(bytes: ByteArray): String {
  * - **Failure tolerant**: nothing thrown to callers; a failed or un-verifiable blob just yields `false` (it is
  *   recoverable — re-fetched on demand or on the next sync).
  *
- * Each download is verified against its ref (truncated SHA-256, URL-safe base64 — see [contentAddressRef],
- * matching `RCElement.checksumBase64`) before it is stored, so a tampered or corrupt payload is never cached.
+ * Each download is verified against its ref (truncated SHA-256, URL-safe base64 — see
+ * [RemoteConfigUtils.contentAddressRef], matching `RCElement.checksumBase64`) before it is stored, so a tampered
+ * or corrupt payload is never cached.
  */
 internal class RemoteConfigBlobFetcher(
     private val blobStore: RemoteConfigBlobStore,
@@ -98,15 +87,27 @@ internal class RemoteConfigBlobFetcher(
      * queued/in-flight download for the same ref.
      */
     suspend fun ensureDownloaded(ref: String): Boolean {
-        if (blobStore.contains(ref)) return true
-        return enqueue(ref, Priority.HIGH).await()
+        if (!RemoteConfigUtils.isValidRef(ref)) {
+            errorLog { "Refusing to download remote config blob with malformed ref '$ref'." }
+            return false
+        }
+        return if (blobStore.contains(ref)) true else enqueue(ref, Priority.HIGH).await()
+    }
+
+    /**
+     * Ensures every ref in [refs] is in the store, downloading missing ones concurrently at HIGH priority.
+     * Returns whether they *all* ended up cached. Deduping and per-ref validation are inherited from the
+     * single-ref [ensureDownloaded].
+     */
+    suspend fun ensureDownloaded(refs: List<String>): Boolean = coroutineScope {
+        refs.map { async { ensureDownloaded(it) } }.awaitAll().all { it }
     }
 
     /** Best-effort background warm of [refs] at LOW priority. Fire-and-forget; failures are tolerated. */
     fun prefetch(refs: List<String>) {
         scope.launch {
             refs.forEach { ref ->
-                if (!blobStore.contains(ref)) {
+                if (RemoteConfigUtils.isValidRef(ref) && !blobStore.contains(ref)) {
                     enqueue(ref, Priority.LOW)
                 }
             }
@@ -218,7 +219,7 @@ internal class RemoteConfigBlobFetcher(
     }
 
     private fun verifyAndStore(bytes: ByteArray, ref: String, url: String): DownloadOutcome {
-        if (contentAddressRef(bytes) != ref) {
+        if (RemoteConfigUtils.contentAddressRef(bytes) != ref) {
             errorLog { "Remote config blob '$ref' from $url failed content-address verification." }
             return DownloadOutcome.BLOB_UNAVAILABLE
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.common.remoteconfig
 
 import android.util.Base64
-import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceHandle.Purpose
 import com.revenuecat.purchases.utils.DefaultUrlConnectionFactory
@@ -67,7 +66,6 @@ internal class RemoteConfigBlobFetcher(
     private val sourceProvider: RemoteConfigSourceProvider = defaultBlobSourceProvider(),
     private val urlConnectionFactory: UrlConnectionFactory = DefaultUrlConnectionFactory(),
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
-    maxConcurrentDownloads: Int = MAX_CONCURRENT_DOWNLOADS,
 ) {
     /** Scheduling priority. Natural (ordinal) order is used by the queue, so HIGH must sort after LOW. */
     private enum class Priority { LOW, HIGH }
@@ -98,7 +96,7 @@ internal class RemoteConfigBlobFetcher(
     private val signal = Channel<Unit>(Channel.UNLIMITED)
 
     init {
-        repeat(maxConcurrentDownloads) { scope.launch { runWorker() } }
+        repeat(MAX_CONCURRENT_DOWNLOADS) { scope.launch { runWorker() } }
     }
 
     /**
@@ -222,17 +220,6 @@ internal class RemoteConfigBlobFetcher(
     }
 
     private enum class DownloadOutcome { SUCCESS, SOURCE_UNHEALTHY, BLOB_UNAVAILABLE }
-
-    /** The currently-queued (not yet claimed) refs in the order workers will pick them. Tests only. */
-    @VisibleForTesting
-    internal fun queuedRefsInPriorityOrder(): List<String> = synchronized(lock) {
-        val copy = PriorityQueue(queue)
-        generateSequence { copy.poll() }.map { it.ref }.toList()
-    }
-
-    /** How many callers are awaiting the download of [ref] (queued or in flight). Tests only. */
-    @VisibleForTesting
-    internal fun awaiterCount(ref: String): Int = synchronized(lock) { pending[ref]?.awaiters?.size ?: 0 }
 
     private companion object {
         private const val MAX_CONCURRENT_DOWNLOADS = 4

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
@@ -33,14 +33,15 @@ internal class RemoteConfigBlobStore(
         }
     }
 
-    fun write(ref: String, data: ByteBuffer) {
+    /** Returns whether the blob was actually persisted; IO failures are logged, swallowed, and reported as `false`. */
+    fun write(ref: String, data: ByteBuffer): Boolean {
         val target = blobFile(ref)
         if (target == null) {
             errorLog { "Refusing to write remote config blob with malformed ref '$ref'." }
-            return
+            return false
         }
         val parent = blobsDir()
-        try {
+        return try {
             if (!parent.exists()) {
                 parent.mkdirs()
             }
@@ -58,8 +59,10 @@ internal class RemoteConfigBlobStore(
                     tempFile.delete()
                 }
             }
+            true
         } catch (e: IOException) {
             errorLog(e) { "Failed to persist remote config blob '$ref' to disk." }
+            false
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
@@ -72,7 +72,7 @@ internal class RemoteConfigBlobStore(
         if (!parent.exists()) return emptySet()
         return parent.listFiles()
             ?.asSequence()
-            ?.filter { it.isFile && isValidRef(it.name) }
+            ?.filter { it.isFile && RemoteConfigUtils.isValidRef(it.name) }
             ?.map { it.name }
             ?.toSet()
             ?: emptySet()
@@ -111,15 +111,11 @@ internal class RemoteConfigBlobStore(
         File(File(applicationContext.noBackupFilesDir, REMOTE_CONFIG_ROOT), BLOBS_DIR)
 
     /** The target file for [ref], or `null` when [ref] is not a valid content-address ref. */
-    private fun blobFile(ref: String): File? = if (isValidRef(ref)) File(blobsDir(), ref) else null
+    private fun blobFile(ref: String): File? =
+        if (RemoteConfigUtils.isValidRef(ref)) File(blobsDir(), ref) else null
 
     private companion object {
         private const val REMOTE_CONFIG_ROOT = "RevenueCat"
         private const val BLOBS_DIR = "blobs"
-
-        /** 24-byte hash -> 32 URL-safe base64 chars, unpadded. */
-        private val REF_REGEX = Regex("^[A-Za-z0-9_-]{32}$")
-
-        private fun isValidRef(ref: String): Boolean = REF_REGEX.matches(ref)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigUtils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigUtils.kt
@@ -1,0 +1,32 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import android.util.Base64
+import java.security.MessageDigest
+
+/**
+ * Shared helpers for remote-config blob refs. A ref is a content address: the blob's SHA-256 truncated to
+ * [REF_HASH_BYTES] (192 bits), URL-safe base64 with no padding — a fixed 32-char, filename-safe string that
+ * mirrors `RCElement.checksumBase64`, so inline and fetched blobs share the same ref shape.
+ *
+ * Centralizes the validate/create logic that [RemoteConfigBlobStore] and [RemoteConfigBlobFetcher] both need.
+ */
+internal object RemoteConfigUtils {
+    private const val REF_HASH_BYTES = 24
+    private const val SHA_256_ALGORITHM = "SHA-256"
+
+    /** 24-byte hash -> 32 URL-safe base64 chars, unpadded. */
+    private val REF_REGEX = Regex("^[A-Za-z0-9_-]{32}$")
+
+    /** Whether [ref] matches the content-address ref shape; the guard that keeps a malformed ref filename-safe. */
+    fun isValidRef(ref: String): Boolean = REF_REGEX.matches(ref)
+
+    /**
+     * The content-address ref of [bytes]: SHA-256 truncated to [REF_HASH_BYTES] (192 bits), URL-safe base64 with
+     * no padding. Mirrors `RCElement.checksumBase64`, so inline and fetched blobs verify against the same ref shape.
+     */
+    fun contentAddressRef(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance(SHA_256_ALGORITHM).digest(bytes)
+        val truncated = digest.copyOf(REF_HASH_BYTES)
+        return Base64.encodeToString(truncated, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -10,12 +10,17 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
-import kotlin.concurrent.thread
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -31,20 +36,22 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class RemoteConfigBlobFetcherTest {
 
     private lateinit var blobStore: RemoteConfigBlobStore
     private lateinit var urlConnectionFactory: UrlConnectionFactory
-    private lateinit var scope: CoroutineScope
+
+    // Real multi-threaded scope for the behavioural / real-concurrency tests; cancelled in tearDown.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     @Before
     fun setup() {
         blobStore = mockk(relaxed = true)
         every { blobStore.contains(any()) } returns false
         urlConnectionFactory = mockk()
-        scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     }
 
     @After
@@ -55,7 +62,7 @@ class RemoteConfigBlobFetcherTest {
     @Test
     fun `returns true without downloading when the blob is already cached`() {
         every { blobStore.contains(REF_A) } returns true
-        val fetcher = fetcher(provider(blobSource(TEMPLATE)))
+        val fetcher = realFetcher(provider(blobSource(TEMPLATE)))
 
         assertThat(download(fetcher, REF_A)).isTrue()
 
@@ -68,7 +75,7 @@ class RemoteConfigBlobFetcherTest {
         val bytes = "a workflow body".toByteArray()
         val ref = refOf(bytes)
         stubConnection(urlFor(ref), code = 200, body = bytes)
-        val fetcher = fetcher(provider(blobSource(TEMPLATE)))
+        val fetcher = realFetcher(provider(blobSource(TEMPLATE)))
 
         assertThat(download(fetcher, ref)).isTrue()
 
@@ -84,7 +91,7 @@ class RemoteConfigBlobFetcherTest {
         val ref = refOf("expected".toByteArray())
         stubConnection(urlFor(ref), code = 200, body = "tampered".toByteArray())
         val provider = provider(blobSource(TEMPLATE))
-        val fetcher = fetcher(provider)
+        val fetcher = realFetcher(provider)
 
         assertThat(download(fetcher, ref)).isFalse()
 
@@ -97,7 +104,7 @@ class RemoteConfigBlobFetcherTest {
         val ref = refOf("missing".toByteArray())
         stubConnection(urlFor(ref), code = 404)
         val provider = provider(blobSource(TEMPLATE))
-        val fetcher = fetcher(provider)
+        val fetcher = realFetcher(provider)
 
         assertThat(download(fetcher, ref)).isFalse()
 
@@ -115,7 +122,7 @@ class RemoteConfigBlobFetcherTest {
         val provider = provider(blobSource(primary, priority = 2), blobSource(secondary, priority = 1))
         stubConnection(primary.replace(PLACEHOLDER, ref), code = 500)
         stubConnection(secondary.replace(PLACEHOLDER, ref), code = 200, body = bytes)
-        val fetcher = fetcher(provider)
+        val fetcher = realFetcher(provider)
 
         assertThat(download(fetcher, ref)).isTrue()
 
@@ -129,7 +136,7 @@ class RemoteConfigBlobFetcherTest {
         val provider = provider(blobSource(TEMPLATE))
         // The only source errors, so it is reported unhealthy and the provider becomes exhausted.
         stubConnection(urlFor(ref), code = 500)
-        val fetcher = fetcher(provider)
+        val fetcher = realFetcher(provider)
 
         // First download fails over to exhaustion; a later download must not re-arm the provider and retry.
         assertThat(download(fetcher, ref)).isFalse()
@@ -142,35 +149,7 @@ class RemoteConfigBlobFetcherTest {
     }
 
     @Test
-    fun `concurrent requests for the same ref share a single download`() {
-        val bytes = "shared".toByteArray()
-        val ref = refOf(bytes)
-        val downloadStarted = CountDownLatch(1)
-        val releaseDownload = CountDownLatch(1)
-        every { urlConnectionFactory.createConnection(urlFor(ref), any()) } answers {
-            downloadStarted.countDown()
-            releaseDownload.await(WAIT_SECONDS, TimeUnit.SECONDS)
-            connection(code = 200, body = bytes)
-        }
-        val fetcher = fetcher(provider(blobSource(TEMPLATE)))
-
-        val results = CopyOnWriteArrayList<Boolean>()
-        val first = thread { results.add(download(fetcher, ref)) }
-        check(downloadStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "first download did not start" }
-        // Second request arrives while the first is in flight: it must join, not start a new download.
-        val second = thread { results.add(download(fetcher, ref)) }
-        awaitUntil { fetcher.awaiterCount(ref) == 2 } // both callers attached to the one in-flight download
-
-        releaseDownload.countDown()
-        first.join(WAIT_MS)
-        second.join(WAIT_MS)
-
-        assertThat(results).containsExactly(true, true)
-        verify(exactly = 1) { urlConnectionFactory.createConnection(urlFor(ref), any()) }
-    }
-
-    @Test
-    fun `never runs more downloads at once than the configured concurrency`() {
+    fun `never runs more downloads at once than the worker pool allows`() {
         val concurrency = 4
         val live = AtomicInteger(0)
         val maxLive = AtomicInteger(0)
@@ -183,9 +162,9 @@ class RemoteConfigBlobFetcherTest {
             live.decrementAndGet()
             connection(code = 200)
         }
-        val fetcher = fetcher(provider(blobSource(TEMPLATE)), maxConcurrentDownloads = concurrency)
+        val fetcher = realFetcher(provider(blobSource(TEMPLATE)))
 
-        // Far more work than workers; only `concurrency` may run at once.
+        // Far more work than workers; only the pool size may run at once.
         fetcher.prefetch((1..12).map { refOf("blob-$it".toByteArray()) })
 
         check(allBlocked.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "workers did not all start" }
@@ -196,62 +175,68 @@ class RemoteConfigBlobFetcherTest {
     }
 
     @Test
-    fun `an on-demand request is queued ahead of the prefetch backlog`() {
-        val (started, release) = blockingConnections()
-        val fetcher = fetcher(provider(blobSource(TEMPLATE)), maxConcurrentDownloads = 4)
+    fun `concurrent requests for the same ref share a single download`() = runTest {
+        val bytes = "shared".toByteArray()
+        val ref = refOf(bytes)
+        stubConnection(urlFor(ref), code = 200, body = bytes)
+        val fetcherScope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val fetcher = RemoteConfigBlobFetcher(blobStore, provider(blobSource(TEMPLATE)), urlConnectionFactory, fetcherScope)
 
-        val busy = (1..4).map { refOf("busy-$it".toByteArray()) }
-        val queued = (5..8).map { refOf("queued-$it".toByteArray()) }
-        val onDemand = refOf("on-demand".toByteArray())
+        // Both requests are enqueued before any worker runs (StandardTestDispatcher), so the second joins the first.
+        val first = async { fetcher.ensureDownloaded(ref) }
+        val second = async { fetcher.ensureDownloaded(ref) }
+        advanceUntilIdle()
 
-        fetcher.prefetch(busy)
-        awaitUntil { started.size == 4 }                                 // all workers occupied
-        fetcher.prefetch(queued)                                          // LOW backlog
-        thread { download(fetcher, onDemand) }                            // HIGH, must jump the backlog
-        awaitUntil { fetcher.awaiterCount(onDemand) == 1 }                // on-demand request has landed
-
-        // The HIGH request sits at the head of the queue, ahead of the whole LOW backlog (which keeps its FIFO order).
-        assertThat(fetcher.queuedRefsInPriorityOrder()).containsExactly(onDemand, *queued.toTypedArray())
-
-        release.countDown()
+        assertThat(first.await()).isTrue()
+        assertThat(second.await()).isTrue()
+        verify(exactly = 1) { urlConnectionFactory.createConnection(urlFor(ref), any()) }
+        fetcherScope.cancel()
     }
 
     @Test
-    fun `an on-demand request boosts and joins a blob already queued for prefetch`() {
-        val (started, release) = blockingConnections()
-        val fetcher = fetcher(provider(blobSource(TEMPLATE)), maxConcurrentDownloads = 4)
+    fun `an on-demand request is downloaded ahead of the prefetch backlog`() = runTest {
+        val started = CopyOnWriteArrayList<String>()
+        recordStartedConnections(started)
+        val fetcherScope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val fetcher = RemoteConfigBlobFetcher(blobStore, provider(blobSource(TEMPLATE)), urlConnectionFactory, fetcherScope)
 
-        val busy = (1..4).map { refOf("busy-$it".toByteArray()) }
-        val queued = (5..7).map { refOf("queued-$it".toByteArray()) }
+        val backlog = (1..3).map { refOf("low-$it".toByteArray()) }
+        val onDemand = refOf("on-demand".toByteArray())
+
+        fetcher.prefetch(backlog)                        // LOW backlog
+        fetcherScope.launch { fetcher.ensureDownloaded(onDemand) } // HIGH
+        advanceUntilIdle()
+
+        // The HIGH request is served first, ahead of the whole LOW backlog (which keeps its FIFO order).
+        assertThat(started).containsExactly(onDemand, *backlog.toTypedArray())
+        fetcherScope.cancel()
+    }
+
+    @Test
+    fun `an on-demand request boosts and joins a blob already queued for prefetch`() = runTest {
+        val started = CopyOnWriteArrayList<String>()
+        recordStartedConnections(started)
+        val fetcherScope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val fetcher = RemoteConfigBlobFetcher(blobStore, provider(blobSource(TEMPLATE)), urlConnectionFactory, fetcherScope)
+
+        val others = (1..3).map { refOf("low-$it".toByteArray()) }
         val boosted = refOf("boosted".toByteArray())
 
-        fetcher.prefetch(busy)
-        awaitUntil { started.size == 4 }
-        fetcher.prefetch(queued)                                          // queued LOW first
-        fetcher.prefetch(listOf(boosted))                                 // boosted enqueued LOW, behind the others
-        awaitUntil { fetcher.queuedRefsInPriorityOrder().containsAll(queued + boosted) }
-        // On-demand request for the already-queued ref: it must be raised to the front, joining the same download.
-        thread { download(fetcher, boosted) }
-        awaitUntil { fetcher.awaiterCount(boosted) == 2 }                 // prefetch + on-demand share one download
+        // `boosted` is enqueued LOW, last in the backlog; the on-demand request must raise it to the front.
+        fetcher.prefetch(others + boosted)
+        fetcherScope.launch { fetcher.ensureDownloaded(boosted) }
+        advanceUntilIdle()
 
-        assertThat(fetcher.queuedRefsInPriorityOrder().first()).isEqualTo(boosted)
-        assertThat(fetcher.queuedRefsInPriorityOrder()).containsExactly(boosted, *queued.toTypedArray())
-
-        release.countDown()
+        assertThat(started.first()).isEqualTo(boosted)
+        assertThat(started.count { it == boosted }).isEqualTo(1) // prefetch + on-demand shared one download
+        assertThat(started).containsExactlyInAnyOrderElementsOf(others + boosted)
+        fetcherScope.cancel()
     }
 
     // region helpers
 
-    private fun fetcher(
-        provider: RemoteConfigSourceProvider,
-        maxConcurrentDownloads: Int = 4,
-    ) = RemoteConfigBlobFetcher(
-        blobStore = blobStore,
-        sourceProvider = provider,
-        urlConnectionFactory = urlConnectionFactory,
-        scope = scope,
-        maxConcurrentDownloads = maxConcurrentDownloads,
-    )
+    private fun realFetcher(provider: RemoteConfigSourceProvider) =
+        RemoteConfigBlobFetcher(blobStore, provider, urlConnectionFactory, scope)
 
     /** A spy over a real provider so we get real failover behaviour and can still verify calls. */
     private fun provider(vararg blobSources: RemoteConfigSource): RemoteConfigSourceProvider =
@@ -274,30 +259,11 @@ class RemoteConfigBlobFetcherTest {
         return connection
     }
 
-    /**
-     * Stubs every connection to record the requested ref (in start order) then block until released, so callers can
-     * keep the worker pool occupied and observe scheduling order. Returns the start log and the release latch.
-     */
-    private fun blockingConnections(): Pair<CopyOnWriteArrayList<String>, CountDownLatch> {
-        val started = CopyOnWriteArrayList<String>()
-        val release = CountDownLatch(1)
-        val live = AtomicInteger(0)
+    /** Records the requested ref of every connection (in start order) so tests can assert scheduling order. */
+    private fun recordStartedConnections(started: MutableList<String>) {
         every { urlConnectionFactory.createConnection(any(), any()) } answers {
             started.add(refFromUrl(firstArg<String>()))
-            // Block only while workers are saturated; later (post-release) downloads pass straight through.
-            if (live.incrementAndGet() <= 4) {
-                release.await(WAIT_SECONDS, TimeUnit.SECONDS)
-            }
             connection(code = 200)
-        }
-        return started to release
-    }
-
-    private fun awaitUntil(condition: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + WAIT_MS
-        while (!condition()) {
-            check(System.currentTimeMillis() < deadline) { "condition not met within ${WAIT_MS}ms" }
-            Thread.sleep(POLL_MS)
         }
     }
 
@@ -324,6 +290,5 @@ class RemoteConfigBlobFetcherTest {
         private const val REF_A = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"
         private const val WAIT_SECONDS = 5L
         private const val WAIT_MS = 5_000L
-        private const val POLL_MS = 5L
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -22,6 +22,10 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -35,6 +39,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.random.Random
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -118,8 +123,8 @@ class RemoteConfigBlobFetcherTest {
         val ref = refOf(bytes)
         val primary = "https://primary.example/$PLACEHOLDER"
         val secondary = "https://secondary.example/$PLACEHOLDER"
-        // Higher priority is tried first.
-        val provider = provider(blobSource(primary, priority = 2), blobSource(secondary, priority = 1))
+        // The lower priority number is tried first.
+        val provider = provider(blobSource(primary, priority = 1), blobSource(secondary, priority = 2))
         stubConnection(primary.replace(PLACEHOLDER, ref), code = 500)
         stubConnection(secondary.replace(PLACEHOLDER, ref), code = 200, body = bytes)
         val fetcher = realFetcher(provider)
@@ -238,9 +243,31 @@ class RemoteConfigBlobFetcherTest {
     private fun realFetcher(provider: RemoteConfigSourceProvider) =
         RemoteConfigBlobFetcher(blobStore, provider, urlConnectionFactory, scope)
 
-    /** A spy over a real provider so we get real failover behaviour and can still verify calls. */
+    /**
+     * A spy over a real provider (fed a `sources` topic with only blob entries) so we get real failover
+     * behaviour and can still verify calls. Lower `priority` numbers are tried first.
+     */
     private fun provider(vararg blobSources: RemoteConfigSource): RemoteConfigSourceProvider =
-        spyk(DefaultRemoteConfigSourceProvider(apiSources = emptyList(), blobSources = blobSources.toList()))
+        spyk(DefaultRemoteConfigSourceProvider(FakeTopicStore(sourcesTopic(blobSources.toList())), FakeRandom(0)))
+
+    /** Builds a `sources` ConfigTopic carrying only blob entries (blob sources use the `url_format` key). */
+    private fun sourcesTopic(blob: List<RemoteConfigSource>): ConfigTopic = ConfigTopic(
+        mapOf(
+            "blob" to RemoteConfiguration.ConfigItem(
+                content = buildJsonObject {
+                    putJsonArray("sources") {
+                        blob.forEach { s ->
+                            addJsonObject {
+                                put("url_format", s.url)
+                                put("priority", s.priority)
+                                put("weight", s.weight)
+                            }
+                        }
+                    }
+                },
+            ),
+        ),
+    )
 
     private fun blobSource(url: String, priority: Int = 0, weight: Int = 1) =
         RemoteConfigSource(url = url, priority = priority, weight = weight)
@@ -279,6 +306,24 @@ class RemoteConfigBlobFetcherTest {
     private fun ByteBuffer.toBytes(): ByteArray {
         val view = duplicate().apply { rewind() }
         return ByteArray(view.remaining()).also { view.get(it) }
+    }
+
+    private class FakeTopicStore(private val sources: ConfigTopic?) : RemoteConfigTopicStore {
+        override fun topic(name: String): ConfigTopic? = if (name == "sources") sources else null
+    }
+
+    /** Deterministic randomizer for weighted source selection: always returns the first candidate. */
+    private class FakeRandom(vararg values: Int) : Random() {
+        private val values: IntArray = if (values.isEmpty()) intArrayOf(0) else values
+        private var index = 0
+
+        override fun nextBits(bitCount: Int): Int = error("nextBits should not be used")
+
+        override fun nextInt(until: Int): Int {
+            val value = if (index < values.size) values[index] else values.last()
+            index++
+            return value.coerceIn(0, until - 1)
+        }
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -38,6 +38,7 @@ import java.security.MessageDigest
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
 
@@ -119,6 +120,22 @@ class RemoteConfigBlobFetcherTest {
 
         // A local write failure isn't a source problem, so the source is not condemned.
         verify(exactly = 0) { provider.reportUnhealthy(any()) }
+    }
+
+    @Test
+    fun `reports true when the blob is cached concurrently while the download fails`() {
+        val ref = refOf("body".toByteArray())
+        val cachedConcurrently = AtomicBoolean(false)
+        every { blobStore.contains(ref) } answers { cachedConcurrently.get() }
+        // The download fails, but a concurrent writer (e.g. inline extraction) lands the blob mid-fetch.
+        every { urlConnectionFactory.createConnection(urlFor(ref), any()) } answers {
+            cachedConcurrently.set(true)
+            connection(code = 404)
+        }
+        val fetcher = realFetcher(provider(blobSource(TEMPLATE)))
+
+        assertThat(download(fetcher, ref)).isTrue()
+        verify(exactly = 0) { blobStore.write(any(), any()) }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -1,0 +1,328 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceHandle.Purpose
+import com.revenuecat.purchases.utils.UrlConnection
+import com.revenuecat.purchases.utils.UrlConnectionFactory
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import kotlin.concurrent.thread
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.ByteArrayInputStream
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class RemoteConfigBlobFetcherTest {
+
+    private lateinit var blobStore: RemoteConfigBlobStore
+    private lateinit var urlConnectionFactory: UrlConnectionFactory
+    private lateinit var scope: CoroutineScope
+
+    @Before
+    fun setup() {
+        blobStore = mockk(relaxed = true)
+        every { blobStore.contains(any()) } returns false
+        urlConnectionFactory = mockk()
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `returns true without downloading when the blob is already cached`() {
+        every { blobStore.contains(REF_A) } returns true
+        val fetcher = fetcher(provider(blobSource(TEMPLATE)))
+
+        assertThat(download(fetcher, REF_A)).isTrue()
+
+        verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
+        verify(exactly = 0) { blobStore.write(any(), any()) }
+    }
+
+    @Test
+    fun `downloads, verifies against the ref, and stores the blob`() {
+        val bytes = "a workflow body".toByteArray()
+        val ref = refOf(bytes)
+        stubConnection(urlFor(ref), code = 200, body = bytes)
+        val fetcher = fetcher(provider(blobSource(TEMPLATE)))
+
+        assertThat(download(fetcher, ref)).isTrue()
+
+        // The placeholder is substituted with the ref before the request is made.
+        verify { urlConnectionFactory.createConnection(urlFor(ref), any()) }
+        val written = slot<ByteBuffer>()
+        verify { blobStore.write(ref, capture(written)) }
+        assertThat(written.captured.toBytes()).isEqualTo(bytes)
+    }
+
+    @Test
+    fun `a checksum mismatch fails the blob without condemning the source`() {
+        val ref = refOf("expected".toByteArray())
+        stubConnection(urlFor(ref), code = 200, body = "tampered".toByteArray())
+        val provider = provider(blobSource(TEMPLATE))
+        val fetcher = fetcher(provider)
+
+        assertThat(download(fetcher, ref)).isFalse()
+
+        verify(exactly = 0) { blobStore.write(any(), any()) }
+        verify(exactly = 0) { provider.reportUnhealthy(any()) }
+    }
+
+    @Test
+    fun `a 404 fails the blob without condemning the source`() {
+        val ref = refOf("missing".toByteArray())
+        stubConnection(urlFor(ref), code = 404)
+        val provider = provider(blobSource(TEMPLATE))
+        val fetcher = fetcher(provider)
+
+        assertThat(download(fetcher, ref)).isFalse()
+
+        verify(exactly = 0) { blobStore.write(any(), any()) }
+        verify(exactly = 0) { provider.reportUnhealthy(any()) }
+    }
+
+    @Test
+    fun `a server error fails over to the next source`() {
+        val bytes = "body".toByteArray()
+        val ref = refOf(bytes)
+        val primary = "https://primary.example/$PLACEHOLDER"
+        val secondary = "https://secondary.example/$PLACEHOLDER"
+        // Higher priority is tried first.
+        val provider = provider(blobSource(primary, priority = 2), blobSource(secondary, priority = 1))
+        stubConnection(primary.replace(PLACEHOLDER, ref), code = 500)
+        stubConnection(secondary.replace(PLACEHOLDER, ref), code = 200, body = bytes)
+        val fetcher = fetcher(provider)
+
+        assertThat(download(fetcher, ref)).isTrue()
+
+        verify { provider.reportUnhealthy(match { it.url == primary }) }
+        verify { blobStore.write(ref, any()) }
+    }
+
+    @Test
+    fun `restarts the exhausted provider on a later download so a transient outage recovers`() {
+        val bytes = "recovered".toByteArray()
+        val ref = refOf(bytes)
+        val provider = provider(blobSource(TEMPLATE))
+        // First attempt errors (source becomes unhealthy -> exhausted); the second succeeds.
+        every { urlConnectionFactory.createConnection(urlFor(ref), any()) } returnsMany
+            listOf(connection(code = 500), connection(code = 200, body = bytes))
+        val fetcher = fetcher(provider)
+
+        assertThat(download(fetcher, ref)).isFalse()
+        assertThat(download(fetcher, ref)).isTrue()
+
+        verify { provider.restart(Purpose.BLOB) }
+        verify { blobStore.write(ref, any()) }
+    }
+
+    @Test
+    fun `concurrent requests for the same ref share a single download`() {
+        val bytes = "shared".toByteArray()
+        val ref = refOf(bytes)
+        val downloadStarted = CountDownLatch(1)
+        val releaseDownload = CountDownLatch(1)
+        every { urlConnectionFactory.createConnection(urlFor(ref), any()) } answers {
+            downloadStarted.countDown()
+            releaseDownload.await(WAIT_SECONDS, TimeUnit.SECONDS)
+            connection(code = 200, body = bytes)
+        }
+        val fetcher = fetcher(provider(blobSource(TEMPLATE)))
+
+        val results = CopyOnWriteArrayList<Boolean>()
+        val first = thread { results.add(download(fetcher, ref)) }
+        check(downloadStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "first download did not start" }
+        // Second request arrives while the first is in flight: it must join, not start a new download.
+        val second = thread { results.add(download(fetcher, ref)) }
+        awaitUntil { fetcher.awaiterCount(ref) == 2 } // both callers attached to the one in-flight download
+
+        releaseDownload.countDown()
+        first.join(WAIT_MS)
+        second.join(WAIT_MS)
+
+        assertThat(results).containsExactly(true, true)
+        verify(exactly = 1) { urlConnectionFactory.createConnection(urlFor(ref), any()) }
+    }
+
+    @Test
+    fun `never runs more downloads at once than the configured concurrency`() {
+        val concurrency = 4
+        val live = AtomicInteger(0)
+        val maxLive = AtomicInteger(0)
+        val allBlocked = CountDownLatch(concurrency)
+        val release = CountDownLatch(1)
+        every { urlConnectionFactory.createConnection(any(), any()) } answers {
+            maxLive.accumulateAndGet(live.incrementAndGet()) { a, b -> maxOf(a, b) }
+            allBlocked.countDown()
+            release.await(WAIT_SECONDS, TimeUnit.SECONDS)
+            live.decrementAndGet()
+            connection(code = 200)
+        }
+        val fetcher = fetcher(provider(blobSource(TEMPLATE)), maxConcurrentDownloads = concurrency)
+
+        // Far more work than workers; only `concurrency` may run at once.
+        fetcher.prefetch((1..12).map { refOf("blob-$it".toByteArray()) })
+
+        check(allBlocked.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "workers did not all start" }
+        assertThat(live.get()).isEqualTo(concurrency)
+        assertThat(maxLive.get()).isEqualTo(concurrency)
+
+        release.countDown()
+    }
+
+    @Test
+    fun `an on-demand request is queued ahead of the prefetch backlog`() {
+        val (started, release) = blockingConnections()
+        val fetcher = fetcher(provider(blobSource(TEMPLATE)), maxConcurrentDownloads = 4)
+
+        val busy = (1..4).map { refOf("busy-$it".toByteArray()) }
+        val queued = (5..8).map { refOf("queued-$it".toByteArray()) }
+        val onDemand = refOf("on-demand".toByteArray())
+
+        fetcher.prefetch(busy)
+        awaitUntil { started.size == 4 }                                 // all workers occupied
+        fetcher.prefetch(queued)                                          // LOW backlog
+        thread { download(fetcher, onDemand) }                            // HIGH, must jump the backlog
+        awaitUntil { fetcher.awaiterCount(onDemand) == 1 }                // on-demand request has landed
+
+        // The HIGH request sits at the head of the queue, ahead of the whole LOW backlog (which keeps its FIFO order).
+        assertThat(fetcher.queuedRefsInPriorityOrder()).containsExactly(onDemand, *queued.toTypedArray())
+
+        release.countDown()
+    }
+
+    @Test
+    fun `an on-demand request boosts and joins a blob already queued for prefetch`() {
+        val (started, release) = blockingConnections()
+        val fetcher = fetcher(provider(blobSource(TEMPLATE)), maxConcurrentDownloads = 4)
+
+        val busy = (1..4).map { refOf("busy-$it".toByteArray()) }
+        val queued = (5..7).map { refOf("queued-$it".toByteArray()) }
+        val boosted = refOf("boosted".toByteArray())
+
+        fetcher.prefetch(busy)
+        awaitUntil { started.size == 4 }
+        fetcher.prefetch(queued)                                          // queued LOW first
+        fetcher.prefetch(listOf(boosted))                                 // boosted enqueued LOW, behind the others
+        awaitUntil { fetcher.queuedRefsInPriorityOrder().containsAll(queued + boosted) }
+        // On-demand request for the already-queued ref: it must be raised to the front, joining the same download.
+        thread { download(fetcher, boosted) }
+        awaitUntil { fetcher.awaiterCount(boosted) == 2 }                 // prefetch + on-demand share one download
+
+        assertThat(fetcher.queuedRefsInPriorityOrder().first()).isEqualTo(boosted)
+        assertThat(fetcher.queuedRefsInPriorityOrder()).containsExactly(boosted, *queued.toTypedArray())
+
+        release.countDown()
+    }
+
+    // region helpers
+
+    private fun fetcher(
+        provider: RemoteConfigSourceProvider,
+        maxConcurrentDownloads: Int = 4,
+    ) = RemoteConfigBlobFetcher(
+        blobStore = blobStore,
+        sourceProvider = provider,
+        urlConnectionFactory = urlConnectionFactory,
+        scope = scope,
+        maxConcurrentDownloads = maxConcurrentDownloads,
+    )
+
+    /** A spy over a real provider so we get real failover behaviour and can still verify calls. */
+    private fun provider(vararg blobSources: RemoteConfigSource): RemoteConfigSourceProvider =
+        spyk(DefaultRemoteConfigSourceProvider(apiSources = emptyList(), blobSources = blobSources.toList()))
+
+    private fun blobSource(url: String, priority: Int = 0, weight: Int = 1) =
+        RemoteConfigSource(url = url, priority = priority, weight = weight)
+
+    private fun download(fetcher: RemoteConfigBlobFetcher, ref: String): Boolean =
+        runBlocking { withTimeout(WAIT_MS) { fetcher.ensureDownloaded(ref) } }
+
+    private fun stubConnection(url: String, code: Int, body: ByteArray = ByteArray(0)) {
+        every { urlConnectionFactory.createConnection(url, any()) } returns connection(code, body)
+    }
+
+    private fun connection(code: Int, body: ByteArray = ByteArray(0)): UrlConnection {
+        val connection = mockk<UrlConnection>(relaxed = true)
+        every { connection.responseCode } returns code
+        every { connection.inputStream } returns ByteArrayInputStream(body)
+        return connection
+    }
+
+    /**
+     * Stubs every connection to record the requested ref (in start order) then block until released, so callers can
+     * keep the worker pool occupied and observe scheduling order. Returns the start log and the release latch.
+     */
+    private fun blockingConnections(): Pair<CopyOnWriteArrayList<String>, CountDownLatch> {
+        val started = CopyOnWriteArrayList<String>()
+        val release = CountDownLatch(1)
+        val live = AtomicInteger(0)
+        every { urlConnectionFactory.createConnection(any(), any()) } answers {
+            started.add(refFromUrl(firstArg<String>()))
+            // Block only while workers are saturated; later (post-release) downloads pass straight through.
+            if (live.incrementAndGet() <= 4) {
+                release.await(WAIT_SECONDS, TimeUnit.SECONDS)
+            }
+            connection(code = 200)
+        }
+        return started to release
+    }
+
+    private fun awaitUntil(condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + WAIT_MS
+        while (!condition()) {
+            check(System.currentTimeMillis() < deadline) { "condition not met within ${WAIT_MS}ms" }
+            Thread.sleep(POLL_MS)
+        }
+    }
+
+    private fun urlFor(ref: String) = TEMPLATE.replace(PLACEHOLDER, ref)
+
+    private fun refFromUrl(url: String) = url.substringAfterLast('/')
+
+    private fun refOf(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+        return Base64.encodeToString(digest.copyOf(REF_HASH_BYTES), Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+    }
+
+    private fun ByteBuffer.toBytes(): ByteArray {
+        val view = duplicate().apply { rewind() }
+        return ByteArray(view.remaining()).also { view.get(it) }
+    }
+
+    // endregion
+
+    private companion object {
+        private const val PLACEHOLDER = "{blob_ref}"
+        private const val TEMPLATE = "https://config.revenuecat-static.com/$PLACEHOLDER"
+        private const val REF_HASH_BYTES = 24
+        private const val REF_A = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"
+        private const val WAIT_SECONDS = 5L
+        private const val WAIT_MS = 5_000L
+        private const val POLL_MS = 5L
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -124,20 +124,21 @@ class RemoteConfigBlobFetcherTest {
     }
 
     @Test
-    fun `restarts the exhausted provider on a later download so a transient outage recovers`() {
-        val bytes = "recovered".toByteArray()
-        val ref = refOf(bytes)
+    fun `stops and fails once the provider has exhausted its sources, without restarting`() {
+        val ref = refOf("body".toByteArray())
         val provider = provider(blobSource(TEMPLATE))
-        // First attempt errors (source becomes unhealthy -> exhausted); the second succeeds.
-        every { urlConnectionFactory.createConnection(urlFor(ref), any()) } returnsMany
-            listOf(connection(code = 500), connection(code = 200, body = bytes))
+        // The only source errors, so it is reported unhealthy and the provider becomes exhausted.
+        stubConnection(urlFor(ref), code = 500)
         val fetcher = fetcher(provider)
 
+        // First download fails over to exhaustion; a later download must not re-arm the provider and retry.
         assertThat(download(fetcher, ref)).isFalse()
-        assertThat(download(fetcher, ref)).isTrue()
+        assertThat(download(fetcher, ref)).isFalse()
 
-        verify { provider.restart(Purpose.BLOB) }
-        verify { blobStore.write(ref, any()) }
+        verify(exactly = 0) { provider.restart(any()) }
+        verify(exactly = 0) { blobStore.write(any(), any()) }
+        // Only the first download reached a source; the second saw no current source and stopped immediately.
+        verify(exactly = 1) { urlConnectionFactory.createConnection(urlFor(ref), any()) }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -56,6 +56,7 @@ class RemoteConfigBlobFetcherTest {
     fun setup() {
         blobStore = mockk(relaxed = true)
         every { blobStore.contains(any()) } returns false
+        every { blobStore.write(any(), any()) } returns true
         urlConnectionFactory = mockk()
     }
 
@@ -102,6 +103,40 @@ class RemoteConfigBlobFetcherTest {
 
         verify(exactly = 0) { blobStore.write(any(), any()) }
         verify(exactly = 0) { provider.reportUnhealthy(any()) }
+    }
+
+    @Test
+    fun `reports failure when the blob store fails to persist the download`() {
+        val bytes = "unpersisted".toByteArray()
+        val ref = refOf(bytes)
+        stubConnection(urlFor(ref), code = 200, body = bytes)
+        // The download verifies, but the disk write fails (swallowed inside the store), so it never got cached.
+        every { blobStore.write(ref, any()) } returns false
+        val provider = provider(blobSource(TEMPLATE))
+        val fetcher = realFetcher(provider)
+
+        assertThat(download(fetcher, ref)).isFalse()
+
+        // A local write failure isn't a source problem, so the source is not condemned.
+        verify(exactly = 0) { provider.reportUnhealthy(any()) }
+    }
+
+    @Test
+    fun `an unexpected throw fails the blob without stranding the worker`() {
+        val firstBytes = "boom".toByteArray()
+        val firstRef = refOf(firstBytes)
+        val secondBytes = "healthy".toByteArray()
+        val secondRef = refOf(secondBytes)
+        stubConnection(urlFor(firstRef), code = 200, body = firstBytes)
+        stubConnection(urlFor(secondRef), code = 200, body = secondBytes)
+        // A non-IOException escapes the download for the first ref.
+        every { blobStore.write(firstRef, any()) } throws OutOfMemoryError("simulated")
+        val fetcher = realFetcher(provider(blobSource(TEMPLATE)))
+
+        // The awaiter resolves (does not hang) with false rather than propagating the throwable.
+        assertThat(download(fetcher, firstRef)).isFalse()
+        // A subsequent download for a different ref still succeeds, proving the worker pool survived.
+        assertThat(download(fetcher, secondRef)).isTrue()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -290,6 +290,69 @@ class RemoteConfigBlobFetcherTest {
         fetcherScope.cancel()
     }
 
+    @Test
+    fun `a malformed ref is rejected without attempting a download`() {
+        val fetcher = realFetcher(provider(blobSource(TEMPLATE)))
+
+        assertThat(download(fetcher, "not-a-valid-ref")).isFalse()
+
+        verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
+        verify(exactly = 0) { blobStore.write(any(), any()) }
+    }
+
+    @Test
+    fun `prefetch skips malformed refs`() = runTest {
+        val started = CopyOnWriteArrayList<String>()
+        recordStartedConnections(started)
+        val fetcherScope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val fetcher = RemoteConfigBlobFetcher(blobStore, provider(blobSource(TEMPLATE)), urlConnectionFactory, fetcherScope)
+
+        val valid = refOf("valid".toByteArray())
+        fetcher.prefetch(listOf("malformed", valid))
+        advanceUntilIdle()
+
+        assertThat(started).containsExactly(valid)
+        fetcherScope.cancel()
+    }
+
+    @Test
+    fun `list ensureDownloaded returns true only when every ref ends up cached`() {
+        val cached = refOf("cached".toByteArray())
+        val downloadable = refOf("downloadable".toByteArray())
+        every { blobStore.contains(cached) } returns true
+        stubConnection(urlFor(downloadable), code = 200, body = "downloadable".toByteArray())
+        val fetcher = realFetcher(provider(blobSource(TEMPLATE)))
+
+        assertThat(downloadAll(fetcher, listOf(cached, downloadable))).isTrue()
+    }
+
+    @Test
+    fun `list ensureDownloaded returns false when any ref fails`() {
+        val ok = refOf("ok".toByteArray())
+        val missing = refOf("missing".toByteArray())
+        stubConnection(urlFor(ok), code = 200, body = "ok".toByteArray())
+        stubConnection(urlFor(missing), code = 404)
+        val fetcher = realFetcher(provider(blobSource(TEMPLATE)))
+
+        assertThat(downloadAll(fetcher, listOf(ok, missing))).isFalse()
+    }
+
+    @Test
+    fun `list ensureDownloaded dedupes repeated refs into a single download`() = runTest {
+        val bytes = "shared".toByteArray()
+        val ref = refOf(bytes)
+        stubConnection(urlFor(ref), code = 200, body = bytes)
+        val fetcherScope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val fetcher = RemoteConfigBlobFetcher(blobStore, provider(blobSource(TEMPLATE)), urlConnectionFactory, fetcherScope)
+
+        val result = async { fetcher.ensureDownloaded(listOf(ref, ref)) }
+        advanceUntilIdle()
+
+        assertThat(result.await()).isTrue()
+        verify(exactly = 1) { urlConnectionFactory.createConnection(urlFor(ref), any()) }
+        fetcherScope.cancel()
+    }
+
     // region helpers
 
     private fun realFetcher(provider: RemoteConfigSourceProvider) =
@@ -326,6 +389,9 @@ class RemoteConfigBlobFetcherTest {
 
     private fun download(fetcher: RemoteConfigBlobFetcher, ref: String): Boolean =
         runBlocking { withTimeout(WAIT_MS) { fetcher.ensureDownloaded(ref) } }
+
+    private fun downloadAll(fetcher: RemoteConfigBlobFetcher, refs: List<String>): Boolean =
+        runBlocking { withTimeout(WAIT_MS) { fetcher.ensureDownloaded(refs) } }
 
     private fun stubConnection(url: String, code: Int, body: ByteArray = ByteArray(0)) {
         every { urlConnectionFactory.createConnection(url, any()) } returns connection(code, body)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStoreTest.kt
@@ -55,6 +55,16 @@ class RemoteConfigBlobStoreTest {
     }
 
     @Test
+    fun `write returns true when the blob is persisted`() {
+        assertThat(blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1, 2, 3)))).isTrue
+    }
+
+    @Test
+    fun `write returns false for a malformed ref`() {
+        assertThat(blobStore.write("../escape", ByteBuffer.wrap(byteArrayOf(6, 6, 6)))).isFalse
+    }
+
+    @Test
     fun `write does not consume the caller's buffer`() {
         val buffer = ByteBuffer.wrap(byteArrayOf(9, 8, 7))
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigUtilsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigUtilsTest.kt
@@ -1,0 +1,51 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.security.MessageDigest
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class RemoteConfigUtilsTest {
+
+    @Test
+    fun `isValidRef accepts a well-formed 32-char base64url ref`() {
+        assertThat(RemoteConfigUtils.isValidRef("AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH")).isTrue()
+        // The full URL-safe, unpadded alphabet (A-Z a-z 0-9 - _) at exactly 32 chars is valid.
+        assertThat(RemoteConfigUtils.isValidRef("aB0_-cDeFgHiJkLmNoPqRsTuVwXyZ012")).isTrue()
+    }
+
+    @Test
+    fun `isValidRef rejects malformed refs`() {
+        assertThat(RemoteConfigUtils.isValidRef("")).isFalse()
+        assertThat(RemoteConfigUtils.isValidRef("too-short")).isFalse()
+        assertThat(RemoteConfigUtils.isValidRef("AAAABBBBCCCCDDDDEEEEFFFFGGGGHHH")).isFalse() // 31 chars
+        assertThat(RemoteConfigUtils.isValidRef("AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHI")).isFalse() // 33 chars
+        // '+' and '/' and '=' are not part of the URL-safe, unpadded alphabet.
+        assertThat(RemoteConfigUtils.isValidRef("AAAABBBBCCCCDDDDEEEEFFFFGGGGHHH+")).isFalse()
+        assertThat(RemoteConfigUtils.isValidRef("AAAABBBBCCCCDDDDEEEEFFFFGGGGHH==")).isFalse()
+    }
+
+    @Test
+    fun `contentAddressRef is the truncated SHA-256 as unpadded base64url`() {
+        val bytes = "a workflow body".toByteArray()
+        val expected = Base64.encodeToString(
+            MessageDigest.getInstance("SHA-256").digest(bytes).copyOf(REF_HASH_BYTES),
+            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+        )
+
+        val ref = RemoteConfigUtils.contentAddressRef(bytes)
+
+        assertThat(ref).isEqualTo(expected)
+        // A computed ref is always a valid ref shape, so it round-trips through the store guard.
+        assertThat(RemoteConfigUtils.isValidRef(ref)).isTrue()
+    }
+
+    private companion object {
+        private const val REF_HASH_BYTES = 24
+    }
+}


### PR DESCRIPTION
### Description
Adds initial version of the `RemoteConfigBlobFetcher` that will be in charge of downloading blobs that are not inlined in the remote config response. It includes a priority system so requested blobs have higher priority than others, so we minimize waiting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New networked remote-config download path with integrity checks and concurrency, but isolated behind new types and not yet implied as wired into production sync from this diff alone.
> 
> **Overview**
> Introduces **`RemoteConfigBlobFetcher`** to download remote-config blobs by content-address ref into **`RemoteConfigBlobStore`**, with **`ensureDownloaded`** (HIGH) for on-demand reads, **`prefetch`** (LOW) for background warming, deduped in-flight work, a 4-worker cap, and priority boosting when a prefetch item is needed immediately.
> 
> Downloads substitute `{blob_ref}` in configured source URLs, verify payloads with **`RemoteConfigUtils.contentAddressRef`**, fail over unhealthy sources via **`RemoteConfigSourceProvider`**, and return **`Boolean`** without throwing; completion treats a concurrent cache write as success.
> 
> Adds **`RemoteConfigUtils`** for shared ref validation and checksum computation; **`RemoteConfigBlobStore.write`** now returns whether persistence succeeded, using the shared ref guard. Broad unit coverage for fetcher scheduling, verification, failover, and store write outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 756e5ae4108305dd2959c4e0f955a6009c8942fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->