### PR TITLE
refactor(remote-config): Resolve remote config sources lazily from the committed `sources` topic

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -21,16 +21,6 @@ import java.util.PriorityQueue
 /** The placeholder a blob source URL template carries; substituted with the blob ref before download. */
 private const val BLOB_REF_PLACEHOLDER = "{blob_ref}"
 
-/** The hardcoded blob source used until the `sources` topic feeds [RemoteConfigSourceProvider] (Phase 5 follow-up). */
-private const val DEFAULT_BLOB_URL_TEMPLATE = "https://config.revenuecat-static.com/$BLOB_REF_PLACEHOLDER"
-
-// WIP: Phase 5 follow-up: remove this hardcoded default and feed the blob sources from the `sources` topic.
-private fun defaultBlobSourceProvider(): RemoteConfigSourceProvider =
-    DefaultRemoteConfigSourceProvider(
-        apiSources = emptyList(),
-        blobSources = listOf(RemoteConfigSource(url = DEFAULT_BLOB_URL_TEMPLATE, priority = 0, weight = 1)),
-    )
-
 private const val REF_HASH_BYTES = 24
 private const val SHA_256_ALGORITHM = "SHA-256"
 
@@ -64,7 +54,7 @@ private fun contentAddressRef(bytes: ByteArray): String {
  */
 internal class RemoteConfigBlobFetcher(
     private val blobStore: RemoteConfigBlobStore,
-    private val sourceProvider: RemoteConfigSourceProvider = defaultBlobSourceProvider(),
+    private val sourceProvider: RemoteConfigSourceProvider,
     private val urlConnectionFactory: UrlConnectionFactory = DefaultUrlConnectionFactory(),
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
@@ -1,6 +1,11 @@
 package com.revenuecat.purchases.common.remoteconfig
 
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceHandle.Purpose
 import com.revenuecat.purchases.common.warnLog
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.random.Random
 
 /** A remote config source: a URL plus the metadata used to order sources. */
@@ -45,6 +50,9 @@ internal interface RemoteConfigSourceProvider {
 
     /** Rewinds the given purpose to its first source, e.g. to start fresh on a new fetch cycle. */
     fun restart(purpose: RemoteConfigSourceHandle.Purpose)
+
+    /** Drops any memoized source resolution (e.g. on identity change). No-op for fixed-source providers. */
+    fun clear() {}
 }
 
 /**
@@ -150,5 +158,120 @@ private class SourceFailover(
             selector.reset()
             token++
         }
+    }
+}
+
+/** The hardcoded blob URL template used as a last-resort fallback when the `sources` topic supplies none. */
+internal const val DEFAULT_BLOB_URL_TEMPLATE = "https://config.revenuecat-static.com/{blob_ref}"
+
+/** The hardcoded API base URL used as a last-resort fallback. Held for the future; live API rerouting is not wired. */
+internal const val DEFAULT_API_URL = "https://api.revenuecat.com"
+
+/**
+ * A [RemoteConfigSourceProvider] that resolves its sources **lazily** from the committed `sources` topic
+ * (read through [RemoteConfigTopicStore]) instead of taking fixed lists at construction. It wraps a memoized
+ * [DefaultRemoteConfigSourceProvider] — it does not reimplement the failover/token logic.
+ *
+ * - **Initialized from the cached configuration.** The first [resolve] reads the persisted `sources` topic
+ *   (from a prior session, if any), so configured sources are in effect from the very first download — the
+ *   fetcher calls [getCurrent] before downloading.
+ * - **Hardcoded fallbacks, always present, lowest priority.** Parsed sources are followed by
+ *   [DEFAULT_API_URL] / [DEFAULT_BLOB_URL_TEMPLATE] at [Int.MIN_VALUE] priority, so configured/cached
+ *   sources are always tried first and blob fetching never regresses below the hardcoded source (never empty).
+ * - **Non-blocking on the consuming thread.** The memo is keyed on the persisted manifest, which advances on
+ *   every commit, so only the first [resolve] after a config change touches disk; steady state is in-memory.
+ *   Every call here runs on the blob fetcher's IO pool (or the manager's IO scope), never the main thread.
+ */
+internal class LazyRemoteConfigSourceProvider(
+    private val topicStore: RemoteConfigTopicStore,
+    private val apiFallbacks: List<RemoteConfigSource> = listOf(
+        RemoteConfigSource(url = DEFAULT_API_URL, priority = Int.MIN_VALUE, weight = 1),
+    ),
+    private val blobFallbacks: List<RemoteConfigSource> = listOf(
+        RemoteConfigSource(url = DEFAULT_BLOB_URL_TEMPLATE, priority = Int.MIN_VALUE, weight = 1),
+    ),
+    private val random: Random = Random.Default,
+) : RemoteConfigSourceProvider {
+
+    private val lock = Any()
+
+    /** The manifest the memoized [inner] was built from. [NOT_BUILT] until the first [resolve]. */
+    private var memoKey: String? = NOT_BUILT
+    private var inner: DefaultRemoteConfigSourceProvider? = null
+
+    override fun getCurrent(purpose: Purpose): RemoteConfigSourceHandle? = resolve().getCurrent(purpose)
+
+    override fun reportUnhealthy(handle: RemoteConfigSourceHandle) = resolve().reportUnhealthy(handle)
+
+    override fun restart(purpose: Purpose) = resolve().restart(purpose)
+
+    /** Drops the memoized sources (identity change). The next call re-parses from the (cleared) disk cache. */
+    override fun clear() = synchronized(lock) {
+        memoKey = NOT_BUILT
+        inner = null
+    }
+
+    /**
+     * Returns the inner provider for the currently committed `sources`, rebuilding it only when the persisted
+     * manifest has changed since the memo was built. The lock guards the cheap read/rebuild/return; the inner
+     * provider is independently thread-safe, so no lock is held across a delegated call.
+     */
+    private fun resolve(): DefaultRemoteConfigSourceProvider = synchronized(lock) {
+        val key = topicStore.read()?.manifest
+        val current = inner
+        if (current != null && key == memoKey) return current
+
+        val (apiSources, blobSources) = parseSources(topicStore.topic(SOURCES_TOPIC))
+        DefaultRemoteConfigSourceProvider(
+            apiSources = apiSources + apiFallbacks,
+            blobSources = blobSources + blobFallbacks,
+            random = random,
+        ).also {
+            inner = it
+            memoKey = key
+        }
+    }
+
+    private fun parseSources(topic: ConfigTopic?): Pair<List<RemoteConfigSource>, List<RemoteConfigSource>> {
+        val apiSources = mutableListOf<RemoteConfigSource>()
+        val blobSources = mutableListOf<RemoteConfigSource>()
+        topic?.forEach { (key, item) ->
+            val source = item.toSource() ?: return@forEach
+            // A blob source carries the `{blob_ref}` slot; otherwise treat it as an api source. The item key
+            // (`blob`/`api`) is only a tiebreak so an unexpected shape still routes by the placeholder.
+            if (BLOB_REF_PLACEHOLDER in source.url || key == BLOB_ITEM_KEY) {
+                blobSources.add(source)
+            } else {
+                apiSources.add(source)
+            }
+        }
+        if (topic != null && blobSources.isEmpty()) {
+            warnLog { "Remote config 'sources' topic has no usable blob source; using the hardcoded fallback." }
+        }
+        return apiSources to blobSources
+    }
+
+    private fun RemoteConfiguration.ConfigItem.toSource(): RemoteConfigSource? {
+        val url = content.string(URL_FORMAT_KEY) ?: content.string(URL_KEY) ?: return null
+        return RemoteConfigSource(
+            url = url,
+            priority = content[PRIORITY_KEY]?.jsonPrimitive?.intOrNull ?: 0,
+            weight = content[WEIGHT_KEY]?.jsonPrimitive?.intOrNull ?: 1,
+        )
+    }
+
+    private fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.contentOrNull
+
+    private companion object {
+        private const val SOURCES_TOPIC = "sources"
+        private const val BLOB_ITEM_KEY = "blob"
+        private const val BLOB_REF_PLACEHOLDER = "{blob_ref}"
+        private const val URL_FORMAT_KEY = "url_format"
+        private const val URL_KEY = "url"
+        private const val PRIORITY_KEY = "priority"
+        private const val WEIGHT_KEY = "weight"
+
+        /** Sentinel distinguishing "never built" from "built from a null manifest" (first run). */
+        private const val NOT_BUILT = " <unbuilt>"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigTopicStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigTopicStore.kt
@@ -1,0 +1,21 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+/**
+ * Thin read facade over [RemoteConfigDiskCache] exposing the committed per-topic item index.
+ *
+ * Topic data is committed as the source of truth (the full [ConfigTopic] item index, metadata only — the
+ * heavy blob bytes live in [RemoteConfigBlobStore]), so reads here are cheap metadata lookups with no blob
+ * resolution and no wait. Lazy read-side collaborators (e.g. the source provider) depend on this rather than
+ * on the disk cache directly.
+ *
+ * Phase 5 introduces the minimal surface the source provider needs ([read]/[topic]); later phases extend it
+ * with the consumer `body()` resolution.
+ */
+internal class RemoteConfigTopicStore(private val diskCache: RemoteConfigDiskCache) {
+
+    /** The whole persisted state, or null if nothing has been committed yet / the file is unreadable. */
+    fun read(): PersistedRemoteConfigurationState? = diskCache.read()
+
+    /** The committed item index for [name], or null if the topic is absent / not yet synced. */
+    fun topic(name: String): ConfigTopic? = read()?.topics?.get(name)
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/LazyRemoteConfigSourceProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/LazyRemoteConfigSourceProviderTest.kt
@@ -1,0 +1,227 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceHandle.Purpose
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class LazyRemoteConfigSourceProviderTest {
+
+    // region Fallbacks
+
+    @Test
+    fun `with no sources topic, falls back to the hardcoded blob and api sources`() {
+        val provider = provider(store("m1", sources = null))
+
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo(DEFAULT_BLOB_URL_TEMPLATE)
+        assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(DEFAULT_API_URL)
+    }
+
+    @Test
+    fun `a configured blob source is tried before the hardcoded fallback`() {
+        val configured = "https://cdn.example.com/{blob_ref}"
+        val provider = provider(store("m1", sourcesOf("blob" to item("url" to configured))))
+
+        val first = provider.getCurrent(Purpose.BLOB)
+        assertThat(first?.url).isEqualTo(configured)
+
+        // Only after the configured source is condemned do we fall through to the hardcoded one (lowest priority).
+        provider.reportUnhealthy(first!!)
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo(DEFAULT_BLOB_URL_TEMPLATE)
+    }
+
+    @Test
+    fun `a sources topic with no blob source still serves the hardcoded blob fallback`() {
+        val provider = provider(store("m1", sourcesOf("api" to item("url" to "https://api.example.com"))))
+
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo(DEFAULT_BLOB_URL_TEMPLATE)
+        assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo("https://api.example.com")
+    }
+
+    // endregion
+
+    // region Parsing
+
+    @Test
+    fun `url_format is preferred over url`() {
+        val item = item("url" to "https://plain.example.com/{blob_ref}", "url_format" to "https://fmt.example.com/{blob_ref}")
+        val provider = provider(store("m1", sourcesOf("blob" to item)))
+
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo("https://fmt.example.com/{blob_ref}")
+    }
+
+    @Test
+    fun `an item with no string url is skipped`() {
+        val provider = provider(store("m1", sourcesOf("blob" to item("priority" to 5))))
+
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo(DEFAULT_BLOB_URL_TEMPLATE)
+    }
+
+    @Test
+    fun `an item is classified as a blob source by the blob_ref placeholder regardless of its key`() {
+        // Keyed "extra" (not "blob"), but its url carries the placeholder, so it routes to the blob purpose.
+        val provider = provider(store("m1", sourcesOf("extra" to item("url" to "https://cdn.example.com/{blob_ref}"))))
+
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo("https://cdn.example.com/{blob_ref}")
+    }
+
+    @Test
+    fun `configured sources are ordered by priority, then the hardcoded fallback`() {
+        val high = item("url" to "https://high.example.com/{blob_ref}", "priority" to 10)
+        val low = item("url" to "https://low.example.com/{blob_ref}", "priority" to 0)
+        val provider = provider(store("m1", sourcesOf("blob" to high, "blob2" to low)))
+
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo("https://high.example.com/{blob_ref}")
+        provider.reportUnhealthy(provider.getCurrent(Purpose.BLOB)!!)
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo("https://low.example.com/{blob_ref}")
+        provider.reportUnhealthy(provider.getCurrent(Purpose.BLOB)!!)
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo(DEFAULT_BLOB_URL_TEMPLATE)
+    }
+
+    // endregion
+
+    // region Memoization
+
+    @Test
+    fun `failover state persists across calls with the same manifest`() {
+        val provider = provider(
+            store(
+                "m1",
+                sourcesOf(
+                    "blob" to item("url" to "https://a.example.com/{blob_ref}", "priority" to 10),
+                    "blob2" to item("url" to "https://b.example.com/{blob_ref}", "priority" to 0),
+                ),
+            ),
+        )
+
+        provider.reportUnhealthy(provider.getCurrent(Purpose.BLOB)!!)
+        // A second read with the same manifest must NOT re-parse and reset to the first source.
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo("https://b.example.com/{blob_ref}")
+    }
+
+    @Test
+    fun `the memo rebuilds with fresh failover when the manifest changes`() {
+        val store = mockk<RemoteConfigTopicStore>()
+        var current = state("m1", sourcesOf("blob" to item("url" to "https://a.example.com/{blob_ref}")))
+        every { store.read() } answers { current }
+        every { store.topic("sources") } answers { current.topics["sources"] }
+        val provider = LazyRemoteConfigSourceProvider(store, random = FakeRandom(0))
+
+        provider.reportUnhealthy(provider.getCurrent(Purpose.BLOB)!!)
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo(DEFAULT_BLOB_URL_TEMPLATE)
+
+        current = state("m2", sourcesOf("blob" to item("url" to "https://b.example.com/{blob_ref}")))
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo("https://b.example.com/{blob_ref}")
+    }
+
+    @Test
+    fun `clear re-parses from the first source on the next call`() {
+        val provider = provider(store("m1", sourcesOf("blob" to item("url" to "https://a.example.com/{blob_ref}"))))
+
+        provider.reportUnhealthy(provider.getCurrent(Purpose.BLOB)!!)
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo(DEFAULT_BLOB_URL_TEMPLATE)
+
+        provider.clear()
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo("https://a.example.com/{blob_ref}")
+    }
+
+    // endregion
+
+    // region Threading
+
+    @Test
+    fun `concurrent reports never skip sources when serialized`() {
+        val urls = (0 until 50).map { "https://cdn$it.example.com/{blob_ref}" }
+        val configured = urls.withIndex().associate { (i, url) -> "blob$i" to item("url" to url) }
+        val provider = provider(store("m1", configured))
+
+        val seen = ConcurrentHashMap.newKeySet<String>()
+        val pool = Executors.newFixedThreadPool(8)
+        val latch = CountDownLatch(8)
+        repeat(8) {
+            pool.execute {
+                try {
+                    var current = provider.getCurrent(Purpose.BLOB)
+                    while (current != null) {
+                        seen.add(current.url)
+                        provider.reportUnhealthy(current)
+                        current = provider.getCurrent(Purpose.BLOB)
+                    }
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+        latch.await(10, TimeUnit.SECONDS)
+        pool.shutdown()
+
+        assertThat(seen).isEqualTo(urls.toSet() + DEFAULT_BLOB_URL_TEMPLATE)
+        assertThat(provider.getCurrent(Purpose.BLOB)).isNull()
+    }
+
+    // endregion
+
+    // region Helpers
+
+    private fun provider(store: RemoteConfigTopicStore): LazyRemoteConfigSourceProvider =
+        LazyRemoteConfigSourceProvider(store, random = FakeRandom(0))
+
+    private fun store(manifest: String, sources: ConfigTopic?): RemoteConfigTopicStore {
+        val store = mockk<RemoteConfigTopicStore>()
+        val state = state(manifest, sources)
+        every { store.read() } returns state
+        every { store.topic("sources") } returns sources
+        return store
+    }
+
+    private fun state(manifest: String, sources: ConfigTopic?): PersistedRemoteConfigurationState =
+        PersistedRemoteConfigurationState(
+            domain = "app",
+            manifest = manifest,
+            topics = sources?.let { mapOf("sources" to it) } ?: emptyMap(),
+        )
+
+    private fun sourcesOf(vararg items: Pair<String, RemoteConfiguration.ConfigItem>): ConfigTopic = items.toMap()
+
+    private fun item(vararg pairs: Pair<String, Any?>): RemoteConfiguration.ConfigItem =
+        RemoteConfiguration.ConfigItem(
+            content = buildJsonObject {
+                pairs.forEach { (key, value) ->
+                    when (value) {
+                        is String -> put(key, value)
+                        is Int -> put(key, value)
+                        else -> {}
+                    }
+                }
+            },
+        )
+
+    /** Returns queued values from [nextInt], repeating the last once drained. Mirrors `RemoteConfigSourceProviderTest`. */
+    private class FakeRandom(vararg values: Int) : Random() {
+        private val values: IntArray = if (values.isEmpty()) intArrayOf(0) else values
+        private var index = 0
+
+        override fun nextBits(bitCount: Int): Int = error("nextBits should not be used")
+
+        override fun nextInt(until: Int): Int {
+            val value = if (index < values.size) values[index] else values.last()
+            index++
+            return value.coerceIn(0, until - 1)
+        }
+    }
+
+    // endregion
+}


### PR DESCRIPTION
## Description

Part of Phase 5 of the topic-based remote-config feature (`/v1/config`). Stacked on #3679 (the blob fetcher).

Makes blob source resolution **lazy from the committed `sources` topic** instead of relying on a compile-time constant. The merged `DefaultRemoteConfigSourceProvider` takes fixed source lists at construction; this adds a lazy wrapper that reads the committed config.

### What's here
- **`RemoteConfigTopicStore`** — a thin read facade over the disk cache (`read()` / `topic(name)`). The minimal surface the source provider needs now; later phases extend it with consumer `body()` resolution.
- **`LazyRemoteConfigSourceProvider`** — wraps a memoized `DefaultRemoteConfigSourceProvider` built from the parsed `sources` topic **plus always-present hardcoded fallbacks** (API + blob) at `Int.MIN_VALUE` priority:
  - Initialized from the cached configuration on first use (before any fetch).
  - Configured/cached sources are always tried first; the hardcoded blob template is the last resort, so blob fetching never regresses to empty.
  - **Non-blocking**: the memo is keyed on the persisted manifest, so only the first resolve after a config change touches disk; every call runs on the fetcher's IO pool, never the main thread.
  - Defensive parsing: `url_format` preferred over `url`, api/blob classified by the `{blob_ref}` placeholder, missing/extra keys tolerated.
- `RemoteConfigBlobFetcher.sourceProvider` becomes a required constructor param (the lazy provider is now the source of the fallback); the dead default factory is removed.

Wiring the provider into `RemoteConfigManager` (prefetch loop, re-arming, `clearCache`) is the next stacked PR.

## Tests
- New `LazyRemoteConfigSourceProviderTest` (fallbacks, parsing, memo invalidation, `clear()`, concurrent failover).
- `./gradlew :purchases:testDefaultsBc8DebugUnitTest --tests "*RemoteConfig*"`, `detektAll`, `:purchases:lintDefaultsBc8Debug` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
