### PR TITLE
Expose environment-specific Web Purchase Link URLs

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingAPI.java
@@ -4,6 +4,7 @@ import androidx.annotation.Nullable;
 
 import com.revenuecat.purchases.Offering;
 import com.revenuecat.purchases.Package;
+import com.revenuecat.purchases.WebCheckoutEnvironment;
 
 import java.net.URL;
 import java.util.List;
@@ -32,6 +33,8 @@ final class OfferingAPI {
         final Boolean hasPaywall = offering.hasPaywall();
 
         final @Nullable URL webCheckoutURL = offering.getWebCheckoutURL();
+        final @Nullable URL sandboxWebCheckoutURL =
+                offering.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX);
 
         new Offering(
                 identifier,

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PackageAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PackageAPI.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 import com.revenuecat.purchases.Package;
 import com.revenuecat.purchases.PackageType;
 import com.revenuecat.purchases.PresentedOfferingContext;
+import com.revenuecat.purchases.WebCheckoutEnvironment;
 import com.revenuecat.purchases.models.StoreProduct;
 
 import java.net.URL;
@@ -18,6 +19,7 @@ final class PackageAPI {
         final String offering = p.getOffering();
         final PresentedOfferingContext offeringContext = p.getPresentedOfferingContext();
         final @Nullable URL webCheckoutURL = p.getWebCheckoutURL();
+        final @Nullable URL sandboxWebCheckoutURL = p.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX);
     }
 
     static void check(final PackageType type) {
@@ -31,6 +33,13 @@ final class PackageAPI {
             case TWO_MONTH:
             case MONTHLY:
             case WEEKLY:
+        }
+    }
+
+    static void check(final WebCheckoutEnvironment environment) {
+        switch (environment) {
+            case PRODUCTION:
+            case SANDBOX:
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/OfferingAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/OfferingAPI.kt
@@ -2,6 +2,7 @@ package com.revenuecat.apitester.kotlin
 
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.WebCheckoutEnvironment
 import java.net.URL
 
 @Suppress("unused", "UNUSED_VARIABLE")
@@ -24,6 +25,7 @@ private class OfferingAPI {
             val metadataString: String = getMetadataString("key", "default")
             var hasPaywall: Boolean = hasPaywall
             val webCheckoutURL: URL? = webCheckoutURL
+            val sandboxWebCheckoutURL: URL? = getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX)
 
             Offering(
                 identifier = identifier,

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PackageAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PackageAPI.kt
@@ -3,6 +3,7 @@ package com.revenuecat.apitester.kotlin
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.WebCheckoutEnvironment
 import com.revenuecat.purchases.models.StoreProduct
 import java.net.URL
 
@@ -16,6 +17,7 @@ private class PackageAPI {
             val offering: String = offering
             val presentedOfferingContext: PresentedOfferingContext = presentedOfferingContext
             val webCheckoutURL: URL? = webCheckoutURL
+            val sandboxWebCheckoutURL: URL? = getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX)
         }
     }
 
@@ -30,6 +32,14 @@ private class PackageAPI {
             PackageType.TWO_MONTH,
             PackageType.MONTHLY,
             PackageType.WEEKLY,
+            -> {}
+        }.exhaustive
+    }
+
+    fun check(environment: WebCheckoutEnvironment) {
+        when (environment) {
+            WebCheckoutEnvironment.PRODUCTION,
+            WebCheckoutEnvironment.SANDBOX,
             -> {}
         }.exhaustive
     }

--- a/purchases/api-defaults-bc7.txt
+++ b/purchases/api-defaults-bc7.txt
@@ -238,6 +238,7 @@ package com.revenuecat.purchases {
     method public com.revenuecat.purchases.Package? getThreeMonth();
     method public com.revenuecat.purchases.Package? getTwoMonth();
     method public java.net.URL? getWebCheckoutURL();
+    method public java.net.URL? getWebCheckoutURL(com.revenuecat.purchases.WebCheckoutEnvironment environment);
     method public com.revenuecat.purchases.Package? getWeekly();
     method public boolean hasPaywall();
     property public final com.revenuecat.purchases.Package? annual;
@@ -284,6 +285,7 @@ package com.revenuecat.purchases {
     method public com.revenuecat.purchases.PresentedOfferingContext getPresentedOfferingContext();
     method public com.revenuecat.purchases.models.StoreProduct getProduct();
     method public java.net.URL? getWebCheckoutURL();
+    method public java.net.URL? getWebCheckoutURL(com.revenuecat.purchases.WebCheckoutEnvironment environment);
     property public final String identifier;
     property @Deprecated public final String offering;
     property public final com.revenuecat.purchases.PackageType packageType;
@@ -736,6 +738,11 @@ package com.revenuecat.purchases {
     enum_constant public static final com.revenuecat.purchases.VerificationResult NOT_REQUESTED;
     enum_constant public static final com.revenuecat.purchases.VerificationResult VERIFIED;
     enum_constant public static final com.revenuecat.purchases.VerificationResult VERIFIED_ON_DEVICE;
+  }
+
+  public enum WebCheckoutEnvironment {
+    enum_constant public static final com.revenuecat.purchases.WebCheckoutEnvironment PRODUCTION;
+    enum_constant public static final com.revenuecat.purchases.WebCheckoutEnvironment SANDBOX;
   }
 
   public final class WebPurchaseRedemption {

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -238,6 +238,7 @@ package com.revenuecat.purchases {
     method public com.revenuecat.purchases.Package? getThreeMonth();
     method public com.revenuecat.purchases.Package? getTwoMonth();
     method public java.net.URL? getWebCheckoutURL();
+    method public java.net.URL? getWebCheckoutURL(com.revenuecat.purchases.WebCheckoutEnvironment environment);
     method public com.revenuecat.purchases.Package? getWeekly();
     method public boolean hasPaywall();
     property public final com.revenuecat.purchases.Package? annual;
@@ -284,6 +285,7 @@ package com.revenuecat.purchases {
     method public com.revenuecat.purchases.PresentedOfferingContext getPresentedOfferingContext();
     method public com.revenuecat.purchases.models.StoreProduct getProduct();
     method public java.net.URL? getWebCheckoutURL();
+    method public java.net.URL? getWebCheckoutURL(com.revenuecat.purchases.WebCheckoutEnvironment environment);
     property public final String identifier;
     property @Deprecated public final String offering;
     property public final com.revenuecat.purchases.PackageType packageType;
@@ -736,6 +738,11 @@ package com.revenuecat.purchases {
     enum_constant public static final com.revenuecat.purchases.VerificationResult NOT_REQUESTED;
     enum_constant public static final com.revenuecat.purchases.VerificationResult VERIFIED;
     enum_constant public static final com.revenuecat.purchases.VerificationResult VERIFIED_ON_DEVICE;
+  }
+
+  public enum WebCheckoutEnvironment {
+    enum_constant public static final com.revenuecat.purchases.WebCheckoutEnvironment PRODUCTION;
+    enum_constant public static final com.revenuecat.purchases.WebCheckoutEnvironment SANDBOX;
   }
 
   public final class WebPurchaseRedemption {

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -206,6 +206,7 @@ package com.revenuecat.purchases {
     method public com.revenuecat.purchases.Package? getThreeMonth();
     method public com.revenuecat.purchases.Package? getTwoMonth();
     method public java.net.URL? getWebCheckoutURL();
+    method public java.net.URL? getWebCheckoutURL(com.revenuecat.purchases.WebCheckoutEnvironment environment);
     method public com.revenuecat.purchases.Package? getWeekly();
     method public boolean hasPaywall();
     property public final com.revenuecat.purchases.Package? annual;
@@ -252,6 +253,7 @@ package com.revenuecat.purchases {
     method public com.revenuecat.purchases.PresentedOfferingContext getPresentedOfferingContext();
     method public com.revenuecat.purchases.models.StoreProduct getProduct();
     method public java.net.URL? getWebCheckoutURL();
+    method public java.net.URL? getWebCheckoutURL(com.revenuecat.purchases.WebCheckoutEnvironment environment);
     property public final String identifier;
     property @Deprecated public final String offering;
     property public final com.revenuecat.purchases.PackageType packageType;
@@ -626,6 +628,11 @@ package com.revenuecat.purchases {
     enum_constant public static final com.revenuecat.purchases.VerificationResult NOT_REQUESTED;
     enum_constant public static final com.revenuecat.purchases.VerificationResult VERIFIED;
     enum_constant public static final com.revenuecat.purchases.VerificationResult VERIFIED_ON_DEVICE;
+  }
+
+  public enum WebCheckoutEnvironment {
+    enum_constant public static final com.revenuecat.purchases.WebCheckoutEnvironment PRODUCTION;
+    enum_constant public static final com.revenuecat.purchases.WebCheckoutEnvironment SANDBOX;
   }
 
   public final class WebPurchaseRedemption {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -17,7 +17,9 @@ import java.net.URL
  * @property serverDescription Offering description defined in RevenueCat dashboard.
  * @property availablePackages Array of [Package] objects available for purchase.
  * @property metadata Offering metadata defined in RevenueCat dashboard.
- * @property webCheckoutURL If the Offering has an associated Web Purchase Link, this will be the URL for it.
+ * @property webCheckoutURL If the Offering has an associated Web Purchase Link, this will be the checkout URL
+ * selected for the current request environment. Use [getWebCheckoutURL] to explicitly select a production or
+ * sandbox URL.
  */
 @Suppress("UnsafeOptInUsageError")
 @Poko
@@ -34,6 +36,30 @@ constructor(
     public val paywallComponents: PaywallComponents? = null,
     public val webCheckoutURL: URL? = null,
 ) {
+    private var environmentWebCheckoutURLs: Map<WebCheckoutEnvironment, URL> = emptyMap()
+
+    @OptIn(InternalRevenueCatAPI::class)
+    internal constructor(
+        identifier: String,
+        serverDescription: String,
+        metadata: Map<String, Any>,
+        availablePackages: List<Package>,
+        paywall: PaywallData?,
+        paywallComponents: PaywallComponents?,
+        webCheckoutURL: URL?,
+        environmentWebCheckoutURLs: Map<WebCheckoutEnvironment, URL>,
+    ) : this(
+        identifier = identifier,
+        serverDescription = serverDescription,
+        metadata = metadata,
+        availablePackages = availablePackages,
+        paywall = paywall,
+        paywallComponents = paywallComponents,
+        webCheckoutURL = webCheckoutURL,
+    ) {
+        this.environmentWebCheckoutURLs = environmentWebCheckoutURLs
+    }
+
     @OptIn(InternalRevenueCatAPI::class)
     public constructor(
         identifier: String,
@@ -164,6 +190,15 @@ constructor(
     }
 
     /**
+     * Returns this Offering's Web Purchase Link checkout URL for [environment], if available.
+     *
+     * Use this to choose a production or sandbox checkout URL explicitly.
+     */
+    public fun getWebCheckoutURL(environment: WebCheckoutEnvironment): URL? {
+        return environmentWebCheckoutURLs[environment]
+    }
+
+    /**
      * The presented offering context (placement and targeting information) derived from the
      * first available package, if any.
      */
@@ -181,6 +216,22 @@ constructor(
             paywall = this.paywall,
             paywallComponents = this.paywallComponents,
             webCheckoutURL = this.webCheckoutURL,
+        ).apply {
+            environmentWebCheckoutURLs = this@Offering.environmentWebCheckoutURLs
+        }
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    internal fun copyWithAvailablePackages(availablePackages: List<Package>): Offering {
+        return Offering(
+            identifier = this.identifier,
+            serverDescription = this.serverDescription,
+            metadata = this.metadata,
+            availablePackages = availablePackages,
+            paywall = this.paywall,
+            paywallComponents = this.paywallComponents,
+            webCheckoutURL = this.webCheckoutURL,
+            environmentWebCheckoutURLs = this.environmentWebCheckoutURLs,
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -140,24 +140,8 @@ internal fun Offering.withPresentedContext(placementId: String?, targeting: Offe
                 PresentedOfferingContext.TargetingContext(targeting.revision, targeting.ruleId)
             } ?: oldContext.targetingContext,
         )
-        val product = it.product.copyWithPresentedOfferingContext(newContext)
-
-        Package(
-            identifier = it.identifier,
-            packageType = it.packageType,
-            product = product,
-            presentedOfferingContext = newContext,
-            webCheckoutURL = it.webCheckoutURL,
-        )
+        it.copy(newContext)
     }
 
-    return Offering(
-        identifier = this.identifier,
-        serverDescription = this.serverDescription,
-        metadata = this.metadata,
-        availablePackages = updatedAvailablePackages,
-        paywall = this.paywall,
-        paywallComponents = this.paywallComponents,
-        webCheckoutURL = this.webCheckoutURL,
-    )
+    return copyWithAvailablePackages(updatedAvailablePackages)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Package.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Package.kt
@@ -12,7 +12,8 @@ import java.net.URL
  * @property offering offering Id this package was returned from.
  * @property presentedOfferingContext [PresentedOfferingContext] from which this package was obtained.
  * @property webCheckoutURL If the Offering has an associated Web Purchase Link with a product in this package,
- * this will be the URL for it linking directly to purchase this package.
+ * this will be the package-specific checkout URL selected for the current request environment. Use
+ * [getWebCheckoutURL] to explicitly select a production or sandbox URL.
  */
 @Poko
 public class Package @JvmOverloads constructor(
@@ -22,6 +23,25 @@ public class Package @JvmOverloads constructor(
     public val presentedOfferingContext: PresentedOfferingContext,
     public val webCheckoutURL: URL? = null,
 ) {
+    private var environmentWebCheckoutURLs: Map<WebCheckoutEnvironment, URL> = emptyMap()
+
+    internal constructor(
+        identifier: String,
+        packageType: PackageType,
+        product: StoreProduct,
+        presentedOfferingContext: PresentedOfferingContext,
+        webCheckoutURL: URL?,
+        environmentWebCheckoutURLs: Map<WebCheckoutEnvironment, URL>,
+    ) : this(
+        identifier = identifier,
+        packageType = packageType,
+        product = product,
+        presentedOfferingContext = presentedOfferingContext,
+        webCheckoutURL = webCheckoutURL,
+    ) {
+        this.environmentWebCheckoutURLs = environmentWebCheckoutURLs
+    }
+
     @Deprecated(
         "Use constructor with presentedOfferingContext instead",
         ReplaceWith(
@@ -49,6 +69,18 @@ public class Package @JvmOverloads constructor(
     public val offering: String
         get() = presentedOfferingContext.offeringIdentifier ?: ""
 
+    /**
+     * Returns this Package's Web Purchase Link checkout URL for [environment], if available.
+     *
+     * Use this to choose a production or sandbox checkout URL explicitly.
+     *
+     * The returned URL links directly to purchase this package and includes the package identifier, matching
+     * [webCheckoutURL].
+     */
+    public fun getWebCheckoutURL(environment: WebCheckoutEnvironment): URL? {
+        return environmentWebCheckoutURLs[environment]
+    }
+
     internal fun copy(presentedOfferingContext: PresentedOfferingContext): Package {
         return Package(
             identifier = this.identifier,
@@ -56,6 +88,7 @@ public class Package @JvmOverloads constructor(
             product = this.product.copyWithPresentedOfferingContext(presentedOfferingContext),
             presentedOfferingContext = presentedOfferingContext,
             webCheckoutURL = this.webCheckoutURL,
+            environmentWebCheckoutURLs = this.environmentWebCheckoutURLs,
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/WebCheckoutEnvironment.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/WebCheckoutEnvironment.kt
@@ -1,0 +1,16 @@
+package com.revenuecat.purchases
+
+/**
+ * Environment for selecting a Web Purchase Link checkout URL.
+ */
+public enum class WebCheckoutEnvironment {
+    /**
+     * Production Web Purchase Link checkout URL.
+     */
+    PRODUCTION,
+
+    /**
+     * Sandbox Web Purchase Link checkout URL.
+     */
+    SANDBOX,
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.common
 
+import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools.json
@@ -10,6 +11,7 @@ import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.WebCheckoutEnvironment
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
@@ -127,11 +129,12 @@ internal abstract class OfferingParser {
         val metadata = offeringJson.optJSONObject("metadata")?.toMap<Any>(deep = true) ?: emptyMap()
         val jsonPackages = offeringJson.getJSONArray("packages")
         val presentedOfferingContext = PresentedOfferingContext(offeringIdentifier)
+        val webCheckoutURLs = offeringJson.getWebCheckoutURLs()
 
         val availablePackages = mutableListOf<Package>()
         for (i in 0 until jsonPackages.length()) {
             val packageJson = jsonPackages.getJSONObject(i)
-            createPackage(packageJson, productsById, presentedOfferingContext)?.let {
+            createPackage(packageJson, productsById, presentedOfferingContext, webCheckoutURLs)?.let {
                 availablePackages.add(it)
             }
         }
@@ -174,13 +177,14 @@ internal abstract class OfferingParser {
 
         return if (availablePackages.isNotEmpty()) {
             Offering(
-                offeringIdentifier,
-                offeringJson.getString("description"),
-                metadata,
-                availablePackages,
-                paywallData,
-                paywallComponents,
-                webCheckoutURL,
+                identifier = offeringIdentifier,
+                serverDescription = offeringJson.getString("description"),
+                metadata = metadata,
+                availablePackages = availablePackages,
+                paywall = paywallData,
+                paywallComponents = paywallComponents,
+                webCheckoutURL = webCheckoutURL,
+                environmentWebCheckoutURLs = webCheckoutURLs,
             )
         } else {
             null
@@ -192,6 +196,7 @@ internal abstract class OfferingParser {
         packageJson: JSONObject,
         productsById: Map<String, List<StoreProduct>>,
         presentedOfferingContext: PresentedOfferingContext,
+        offeringWebCheckoutURLs: Map<WebCheckoutEnvironment, URL> = emptyMap(),
     ): Package? {
         val packageIdentifier = packageJson.getString("identifier")
         val product = findMatchingProduct(productsById, packageJson)
@@ -199,14 +204,18 @@ internal abstract class OfferingParser {
         val packageType = packageIdentifier.toPackageType()
 
         val webCheckoutURL = packageJson.getWebCheckoutURL()
+        val webCheckoutURLs = packageJson.getWebCheckoutURLs()
+            .ifEmpty { offeringWebCheckoutURLs }
+            .withPackageIdentifier(packageIdentifier)
 
         return product?.let {
             Package(
-                packageIdentifier,
-                packageType,
-                product.copyWithPresentedOfferingContext(presentedOfferingContext),
-                presentedOfferingContext,
-                webCheckoutURL,
+                identifier = packageIdentifier,
+                packageType = packageType,
+                product = product.copyWithPresentedOfferingContext(presentedOfferingContext),
+                presentedOfferingContext = presentedOfferingContext,
+                webCheckoutURL = webCheckoutURL,
+                environmentWebCheckoutURLs = webCheckoutURLs,
             )
         }
     }
@@ -214,13 +223,55 @@ internal abstract class OfferingParser {
 
 private fun JSONObject.getWebCheckoutURL(): URL? =
     this.optString("web_checkout_url").takeUnless { it.isNullOrEmpty() }?.let { urlString ->
-        try {
-            URL(urlString)
-        } catch (e: MalformedURLException) {
-            errorLog(e) { "Error parsing web checkout URL: $urlString" }
-            null
-        }
+        parseWebCheckoutURL(urlString)
     }
+
+private fun JSONObject.getWebCheckoutURLs(): Map<WebCheckoutEnvironment, URL> {
+    val urlsJson = optJSONObject("web_checkout_urls") ?: return emptyMap()
+    return WebCheckoutEnvironment.values().mapNotNull { environment ->
+        val urlString = urlsJson.optString(environment.jsonKey).takeUnless { it.isNullOrEmpty() }
+        val url = urlString?.let { parseWebCheckoutURL(it) }
+        url?.let { environment to it }
+    }.toMap()
+}
+
+private val WebCheckoutEnvironment.jsonKey: String
+    get() = when (this) {
+        WebCheckoutEnvironment.PRODUCTION -> "production"
+        WebCheckoutEnvironment.SANDBOX -> "sandbox"
+    }
+
+private fun parseWebCheckoutURL(urlString: String): URL? {
+    return try {
+        URL(urlString)
+    } catch (e: MalformedURLException) {
+        errorLog(e) { "Error parsing web checkout URL: $urlString" }
+        null
+    }
+}
+
+private fun Map<WebCheckoutEnvironment, URL>.withPackageIdentifier(
+    packageIdentifier: String,
+): Map<WebCheckoutEnvironment, URL> =
+    mapNotNull { (environment, url) ->
+        url.withPackageIdentifier(packageIdentifier)?.let { environment to it }
+    }.toMap()
+
+private fun URL.withPackageIdentifier(packageIdentifier: String): URL? {
+    if (hasPackageIdentifier()) return this
+
+    val urlString = toString()
+    val urlWithoutFragment = urlString.substringBefore("#")
+    val fragment = ref?.let { "#$it" } ?: ""
+    val separator = if (query.isNullOrEmpty()) "?" else "&"
+    return parseWebCheckoutURL("$urlWithoutFragment${separator}package_id=${Uri.encode(packageIdentifier)}$fragment")
+}
+
+private fun URL.hasPackageIdentifier(): Boolean =
+    query
+        ?.split("&")
+        ?.any { it.substringBefore("=") == "package_id" }
+        ?: false
 
 private fun String.toPackageType(): PackageType =
     PackageType.values().firstOrNull { it.identifier == this }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.WebCheckoutEnvironment
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.Dispatcher
@@ -220,6 +221,67 @@ class OfferingsFactoryTest {
                         }
                     ],
                     "web_checkout_url": "http://revenuecat.com"
+                }
+            ],
+            "current_offering_id": "$STUB_OFFERING_IDENTIFIER",
+            "targeting": {
+                "revision": 1,
+                "rule_id": "abc123"
+            }
+        }
+        """.trimIndent()
+    )
+    // language=JSON
+    private val oneOfferingWithEnvironmentSpecificWPL = JSONObject(
+        """
+        {
+            "offerings": [
+                {
+                    "identifier": "$STUB_OFFERING_IDENTIFIER",
+                    "description": "This is the base offering",
+                    "packages": [
+                        {
+                            "identifier": "${'$'}rc_monthly",
+                            "platform_product_identifier": "$STUB_PRODUCT_IDENTIFIER"
+                        }
+                    ],
+                    "web_checkout_url": "http://revenuecat.com",
+                    "web_checkout_urls": {
+                        "production": "http://revenuecat.com/production",
+                        "sandbox": "http://revenuecat.com/sandbox"
+                    }
+                }
+            ],
+            "current_offering_id": "$STUB_OFFERING_IDENTIFIER",
+            "targeting": {
+                "revision": 1,
+                "rule_id": "abc123"
+            }
+        }
+        """.trimIndent()
+    )
+    // language=JSON
+    private val oneOfferingWithEnvironmentSpecificPackageWPL = JSONObject(
+        """
+        {
+            "offerings": [
+                {
+                    "identifier": "$STUB_OFFERING_IDENTIFIER",
+                    "description": "This is the base offering",
+                    "packages": [
+                        {
+                            "identifier": "${'$'}rc_monthly",
+                            "platform_product_identifier": "$STUB_PRODUCT_IDENTIFIER",
+                            "web_checkout_urls": {
+                                "production": "http://revenuecat.com/package-production?package_id=${'$'}rc_monthly",
+                                "sandbox": "http://revenuecat.com/package-sandbox?package_id=${'$'}rc_monthly"
+                            }
+                        }
+                    ],
+                    "web_checkout_urls": {
+                        "production": "http://revenuecat.com/offering-production",
+                        "sandbox": "http://revenuecat.com/offering-sandbox"
+                    }
                 }
             ],
             "current_offering_id": "$STUB_OFFERING_IDENTIFIER",
@@ -656,8 +718,12 @@ class OfferingsFactoryTest {
         val offering = offerings!!.current
         assertThat(offering).isNotNull
         assertThat(offering?.webCheckoutURL).isNull()
+        assertThat(offering?.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION)).isNull()
+        assertThat(offering?.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX)).isNull()
         val pkg = offering!!.availablePackages.first()
         assertThat(pkg.webCheckoutURL).isNull()
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION)).isNull()
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX)).isNull()
     }
 
     @Test
@@ -679,8 +745,106 @@ class OfferingsFactoryTest {
         val offering = offerings!!.current
         assertThat(offering).isNotNull
         assertThat(offering?.webCheckoutURL).isEqualTo(URL("http://revenuecat.com"))
+        assertThat(offering?.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION)).isNull()
+        assertThat(offering?.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX)).isNull()
         val pkg = offering!!.availablePackages.first()
         assertThat(pkg.webCheckoutURL).isEqualTo(URL("http://revenuecat.com?package_id=\$rc_monthly"))
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION)).isNull()
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX)).isNull()
+    }
+
+    @Test
+    fun `createOfferings with environment-specific WPL`() {
+        val productIds = listOf(productId)
+        mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
+        mockStoreProduct(productIds, productIds, ProductType.INAPP)
+
+        var offerings: Offerings? = null
+        offeringsFactory.createOfferings(
+            offeringsJSON = oneOfferingWithEnvironmentSpecificWPL,
+            originalDataSource = HTTPResponseOriginalSource.MAIN,
+            loadedFromDiskCache = false,
+            onError = { fail("Error: $it") },
+            onSuccess = { offerings = it.offerings }
+        )
+
+        assertThat(offerings).isNotNull
+        val offering = offerings!!.current
+        assertThat(offering).isNotNull
+        assertThat(offering?.webCheckoutURL).isEqualTo(URL("http://revenuecat.com"))
+        assertThat(offering?.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION))
+            .isEqualTo(URL("http://revenuecat.com/production"))
+        assertThat(offering?.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX))
+            .isEqualTo(URL("http://revenuecat.com/sandbox"))
+
+        val pkg = offering!!.availablePackages.first()
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION))
+            .isEqualTo(URL("http://revenuecat.com/production?package_id=%24rc_monthly"))
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX))
+            .isEqualTo(URL("http://revenuecat.com/sandbox?package_id=%24rc_monthly"))
+    }
+
+    @Test
+    fun `createOfferings with environment-specific WPL encodes package identifier`() {
+        val productIds = listOf(productId)
+        mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
+        mockStoreProduct(productIds, productIds, ProductType.INAPP)
+
+        val packageIdentifier = "\$rc_monthly&plan=annual trial"
+        val offeringWithReservedCharactersInPackageIdentifier =
+            JSONObject(oneOfferingWithEnvironmentSpecificWPL.toString()).apply {
+                getJSONArray("offerings")
+                    .getJSONObject(0)
+                    .getJSONArray("packages")
+                    .getJSONObject(0)
+                    .put("identifier", packageIdentifier)
+            }
+
+        var offerings: Offerings? = null
+        offeringsFactory.createOfferings(
+            offeringsJSON = offeringWithReservedCharactersInPackageIdentifier,
+            originalDataSource = HTTPResponseOriginalSource.MAIN,
+            loadedFromDiskCache = false,
+            onError = { fail("Error: $it") },
+            onSuccess = { offerings = it.offerings }
+        )
+
+        val offering = offerings!!.current
+        val pkg = offering!!.availablePackages.first()
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION))
+            .isEqualTo(URL("http://revenuecat.com/production?package_id=%24rc_monthly%26plan%3Dannual%20trial"))
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX))
+            .isEqualTo(URL("http://revenuecat.com/sandbox?package_id=%24rc_monthly%26plan%3Dannual%20trial"))
+    }
+
+    @Test
+    fun `createOfferings with environment-specific package WPL`() {
+        val productIds = listOf(productId)
+        mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
+        mockStoreProduct(productIds, productIds, ProductType.INAPP)
+
+        var offerings: Offerings? = null
+        offeringsFactory.createOfferings(
+            offeringsJSON = oneOfferingWithEnvironmentSpecificPackageWPL,
+            originalDataSource = HTTPResponseOriginalSource.MAIN,
+            loadedFromDiskCache = false,
+            onError = { fail("Error: $it") },
+            onSuccess = { offerings = it.offerings }
+        )
+
+        assertThat(offerings).isNotNull
+        val offering = offerings!!.current
+        assertThat(offering).isNotNull
+        assertThat(offering?.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION))
+            .isEqualTo(URL("http://revenuecat.com/offering-production"))
+        assertThat(offering?.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX))
+            .isEqualTo(URL("http://revenuecat.com/offering-sandbox"))
+
+        val pkg = offering!!.availablePackages.first()
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION))
+            .isEqualTo(URL("http://revenuecat.com/package-production?package_id=\$rc_monthly"))
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX))
+            .isEqualTo(URL("http://revenuecat.com/package-sandbox?package_id=\$rc_monthly"))
     }
 
     @Test
@@ -689,11 +853,19 @@ class OfferingsFactoryTest {
         mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
         mockStoreProduct(productIds, productIds, ProductType.INAPP)
 
-        val invalidUrlWPL = oneOfferingWithWPL.apply {
+        val invalidUrlWPL = JSONObject(oneOfferingWithEnvironmentSpecificWPL.toString()).apply {
             val offering = getJSONArray("offerings").getJSONObject(0)
             offering.put("web_checkout_url", "ht!tp:/invalid-url")
+            offering.put("web_checkout_urls", JSONObject(mapOf(
+                "production" to "ht!tp:/invalid-production-url",
+                "sandbox" to "http://revenuecat.com/sandbox"
+            )))
             val pkg = offering.getJSONArray("packages").getJSONObject(0)
             pkg.put("web_checkout_url", "ht!tp:/invalid-url")
+            pkg.put("web_checkout_urls", JSONObject(mapOf(
+                "production" to "ht!tp:/invalid-package-production-url",
+                "sandbox" to "http://revenuecat.com/package-sandbox?package_id=${'$'}rc_monthly"
+            )))
         }
 
         var offerings: Offerings? = null
@@ -709,8 +881,14 @@ class OfferingsFactoryTest {
         val offering = offerings!!.current
         assertThat(offering).isNotNull
         assertThat(offering?.webCheckoutURL).isNull()
+        assertThat(offering?.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION)).isNull()
+        assertThat(offering?.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX))
+            .isEqualTo(URL("http://revenuecat.com/sandbox"))
         val pkg = offering!!.availablePackages.first()
         assertThat(pkg.webCheckoutURL).isNull()
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.PRODUCTION)).isNull()
+        assertThat(pkg.getWebCheckoutURL(WebCheckoutEnvironment.SANDBOX))
+            .isEqualTo(URL("http://revenuecat.com/package-sandbox?package_id=\$rc_monthly"))
     }
 
     @Test


### PR DESCRIPTION
## Motivation

The backend can now return both production and sandbox Web Purchase Link URLs in the offerings response. Android currently exposes only a single selected `webCheckoutURL`, which is derived from the request environment. That is not flexible enough for integrations that need to choose the checkout environment explicitly, especially before starting a Google Play test purchase flow.

This adds a small public API for selecting the desired Web Purchase Link environment while keeping the existing singular `webCheckoutURL` behavior unchanged.

## New public APIs

- `WebCheckoutEnvironment`
  - `PRODUCTION`
  - `SANDBOX`
- `Offering.getWebCheckoutURL(environment: WebCheckoutEnvironment): URL?`
- `Package.getWebCheckoutURL(environment: WebCheckoutEnvironment): URL?`

Package-level URLs include the package identifier in the checkout URL, matching the existing `Package.webCheckoutURL` behavior.

## Implementation details

- Parses the new `web_checkout_urls` object from offerings responses.
- Stores environment-specific checkout URLs internally and exposes them through explicit environment lookup methods.
- Preserves the existing `webCheckoutURL` property for backwards compatibility.
- Adds coverage for production and sandbox URL parsing at the offering level.
- Adds coverage for package-specific checkout URLs, including `package_id` handling.
- Updates the API tester sources that exercise the SDK public API surface.
- Regenerates the API signature files from the repo tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API and offerings parsing with existing webCheckoutURL unchanged; risk is mainly wrong checkout URLs if web_checkout_urls parsing or package_id appending regresses.
> 
> **Overview**
> Adds **`WebCheckoutEnvironment`** (`PRODUCTION`, `SANDBOX`) and **`getWebCheckoutURL(environment)`** on **`Offering`** and **`Package`** so apps can pick production vs sandbox Web Purchase Link checkout URLs explicitly. The existing **`webCheckoutURL`** property is unchanged and still reflects the URL selected for the current request environment.
> 
> **`OfferingParser`** now reads **`web_checkout_urls`** from offerings JSON, keeps per-environment URLs on offerings and packages (package-level URLs override offering-level when present), and still appends **`package_id`** to package checkout links when missing. Copy/refactor paths preserve the environment URL map when rebuilding offerings/packages.
> 
> Public API surface, api-tester samples, and signature files are updated; **`OfferingsFactoryTest`** adds coverage for offering- and package-level environment URLs and invalid URL handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e09b17066e630e0a024a04301ab51a6e75b0179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->