### PR TITLE
refactor(remote-config): prefer lowest priority number for source ordering

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
@@ -102,7 +102,8 @@ internal class DefaultRemoteConfigSourceProvider(
                 if (source.priority != existing.priority || source.weight != existing.weight) {
                     warnLog {
                         "Found remote config sources sharing the same URL with conflicting priority/weight " +
-                            "(${source.url}). Keeping the highest-priority one, tie-broken by weight."
+                            "(${source.url}). Keeping the highest-priority one (lowest priority number), " +
+                            "tie-broken by weight."
                     }
                 }
                 if (source.priority < existing.priority ||

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
@@ -86,8 +86,9 @@ internal class DefaultRemoteConfigSourceProvider(
     private companion object {
 
         /**
-         * Collapses duplicate urls to the occurrence with the highest priority (tie-broken by
-         * weight), keeping first-seen order. Done once at init so reads never need to re-dedupe.
+         * Collapses duplicate urls to the occurrence with the highest priority (i.e. the lowest
+         * [RemoteConfigSource.priority] number, tie-broken by weight), keeping first-seen order.
+         * Done once at init so reads never need to re-dedupe.
          */
         fun dedupe(sources: List<RemoteConfigSource>): List<RemoteConfigSource> {
             // LinkedHashMap keeps first-seen url order for deterministic ordering downstream.
@@ -104,7 +105,7 @@ internal class DefaultRemoteConfigSourceProvider(
                             "(${source.url}). Keeping the highest-priority one, tie-broken by weight."
                     }
                 }
-                if (source.priority > existing.priority ||
+                if (source.priority < existing.priority ||
                     (source.priority == existing.priority && source.weight > existing.weight)
                 ) {
                     bestByUrl[source.url] = source

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/WeightedSourceSelector.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/WeightedSourceSelector.kt
@@ -8,7 +8,7 @@ import kotlin.random.Random
  */
 internal interface WeightedSource {
 
-    /** Higher values are preferred. A tier is exhausted before a lower one is considered. */
+    /** Lower values are preferred. A tier is exhausted before a higher one is considered. */
     val priority: Int
 
     /** Relative likelihood of being chosen among sources tied at the same [priority]. */
@@ -19,7 +19,7 @@ internal interface WeightedSource {
  * Picks which [WeightedSource] to use and exposes [current] so callers can advance through the
  * fallback order when a source is unusable.
  *
- * The order is computed up front: priority tiers from highest to lowest, each tier arranged into a
+ * The order is computed up front: priority tiers from lowest to highest, each tier arranged into a
  * weight-biased random order. Negative weights are treated as 0; when a group's weights sum to 0,
  * the next source is drawn uniformly at random.
  *
@@ -57,7 +57,7 @@ internal class WeightedSourceSelector<T : WeightedSource>(
             sources
                 .groupBy { it.priority }
                 .entries
-                .sortedByDescending { it.key }
+                .sortedBy { it.key }
                 .flatMap { weightedShuffle(it.value, random) }
 
         fun <T : WeightedSource> weightedShuffle(tier: List<T>, random: Random): List<T> {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProviderTest.kt
@@ -30,13 +30,13 @@ class RemoteConfigSourceProviderTest {
     }
 
     @Test
-    fun `current source returns highest priority source`() {
-        val low = source("low", priority = 0, weight = 100)
-        val high = source("high", priority = 10, weight = 1)
+    fun `current source returns lowest priority number source`() {
+        val low = source("low", priority = 0, weight = 1)
+        val high = source("high", priority = 10, weight = 100)
         val provider = apiProvider(listOf(low, high))
 
         val handle = provider.getCurrent(Purpose.API)
-        assertThat(handle?.url).isEqualTo(url("high"))
+        assertThat(handle?.url).isEqualTo(url("low"))
         assertThat(handle?.purpose).isEqualTo(Purpose.API)
     }
 
@@ -58,10 +58,10 @@ class RemoteConfigSourceProviderTest {
         val provider = apiProvider(listOf(high, low))
 
         val first = provider.getCurrent(Purpose.API)
-        assertThat(first?.url).isEqualTo(url("high"))
+        assertThat(first?.url).isEqualTo(url("low"))
 
         provider.reportUnhealthy(first!!)
-        assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("low"))
+        assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("high"))
     }
 
     @Test
@@ -74,9 +74,9 @@ class RemoteConfigSourceProviderTest {
 
     @Test
     fun `reportUnhealthy walks full fallback order`() {
-        val first = source("1", priority = 30, weight = 1)
+        val first = source("1", priority = 10, weight = 1)
         val second = source("2", priority = 20, weight = 1)
-        val third = source("3", priority = 10, weight = 1)
+        val third = source("3", priority = 30, weight = 1)
         val provider = apiProvider(listOf(first, second, third))
 
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("1"))
@@ -98,7 +98,7 @@ class RemoteConfigSourceProviderTest {
             listOf(
                 source("a", priority = 10, weight = 1),
                 source("a", priority = 5, weight = 1),
-                source("b", priority = 0, weight = 1),
+                source("b", priority = 20, weight = 1),
             ),
         )
 
@@ -110,18 +110,19 @@ class RemoteConfigSourceProviderTest {
     }
 
     @Test
-    fun `dedup keeps highest priority regardless of order`() {
+    fun `dedup keeps lowest priority number regardless of order`() {
         val provider = apiProvider(
             listOf(
-                source("a", priority = 0, weight = 1),
                 source("a", priority = 10, weight = 1),
+                source("a", priority = 0, weight = 1),
                 source("b", priority = 5, weight = 1),
             ),
         )
 
-        // `a` is kept at priority 10, so it outranks `b` (priority 5) despite appearing first at 0.
+        // `a` is kept at priority 0 (lowest number, i.e. highest priority), so it outranks `b`
+        // (priority 5) despite appearing first at 10.
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("a"))
-        assertThat(provider.getCurrent(Purpose.API)?.source?.priority).isEqualTo(10)
+        assertThat(provider.getCurrent(Purpose.API)?.source?.priority).isEqualTo(0)
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!)
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("b"))
     }
@@ -161,8 +162,8 @@ class RemoteConfigSourceProviderTest {
     @Test
     fun `reporting api unhealthy does not affect blob`() {
         val provider = DefaultRemoteConfigSourceProvider(
-            apiSources = listOf(source("api1", priority = 10), source("api2", priority = 0)),
-            blobSources = listOf(source("blob1", priority = 10), source("blob2", priority = 0)),
+            apiSources = listOf(source("api1", priority = 0), source("api2", priority = 10)),
+            blobSources = listOf(source("blob1", priority = 0), source("blob2", priority = 10)),
             random = FakeRandom(0),
         )
 
@@ -255,8 +256,8 @@ class RemoteConfigSourceProviderTest {
     @Test
     fun `restart only rewinds requested purpose`() {
         val provider = DefaultRemoteConfigSourceProvider(
-            apiSources = listOf(source("api1", priority = 10), source("api2", priority = 0)),
-            blobSources = listOf(source("blob1", priority = 10), source("blob2", priority = 0)),
+            apiSources = listOf(source("api1", priority = 0), source("api2", priority = 10)),
+            blobSources = listOf(source("blob1", priority = 0), source("blob2", priority = 10)),
             random = FakeRandom(0),
         )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/WeightedSourceSelectorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/WeightedSourceSelectorTest.kt
@@ -22,20 +22,20 @@ class WeightedSourceSelectorTest {
     }
 
     @Test
-    fun `highest priority wins`() {
-        val low = TestSource("low", priority = 0, weight = 100)
-        val high = TestSource("high", priority = 10, weight = 1)
+    fun `lowest priority number wins`() {
+        val low = TestSource("low", priority = 0, weight = 1)
+        val high = TestSource("high", priority = 10, weight = 100)
         val selector = WeightedSourceSelector(listOf(low, high), FakeRandom(0))
-        assertThat(selector.current).isSameAs(high)
+        assertThat(selector.current).isSameAs(low)
     }
 
     @Test
-    fun `highest priority wins regardless of order`() {
-        val low1 = TestSource("low1", priority = 0, weight = 100)
-        val high = TestSource("high", priority = 5, weight = 1)
-        val low2 = TestSource("low2", priority = 0, weight = 100)
-        val selector = WeightedSourceSelector(listOf(low1, high, low2), FakeRandom(0))
-        assertThat(selector.current).isSameAs(high)
+    fun `lowest priority number wins regardless of order`() {
+        val high1 = TestSource("high1", priority = 10, weight = 100)
+        val low = TestSource("low", priority = 5, weight = 1)
+        val high2 = TestSource("high2", priority = 10, weight = 100)
+        val selector = WeightedSourceSelector(listOf(high1, low, high2), FakeRandom(0))
+        assertThat(selector.current).isSameAs(low)
     }
 
     // endregion
@@ -100,7 +100,7 @@ class WeightedSourceSelectorTest {
         // last resort: tried after its weighted peer, yet still before any lower-priority source.
         val weighted = TestSource("weighted", priority = 10, weight = 50)
         val zero = TestSource("zero", priority = 10, weight = 0)
-        val lowerPriority = TestSource("lower", priority = 0, weight = 100)
+        val lowerPriority = TestSource("lower", priority = 20, weight = 100)
         val selector = WeightedSourceSelector(listOf(weighted, zero, lowerPriority), FakeRandom(0))
 
         assertThat(selector.current).isSameAs(weighted)
@@ -133,9 +133,9 @@ class WeightedSourceSelectorTest {
         val low = TestSource("low", priority = 0, weight = 1)
         val selector = WeightedSourceSelector(listOf(high, low), FakeRandom(0))
 
-        assertThat(selector.current).isSameAs(high)
-        assertThat(selector.advance()).isSameAs(low)
         assertThat(selector.current).isSameAs(low)
+        assertThat(selector.advance()).isSameAs(high)
+        assertThat(selector.current).isSameAs(high)
     }
 
     @Test
@@ -144,7 +144,7 @@ class WeightedSourceSelectorTest {
         val low = TestSource("low", priority = 0, weight = 1)
         val selector = WeightedSourceSelector(listOf(high, low), FakeRandom(0))
 
-        assertThat(selector.advance()).isSameAs(low)
+        assertThat(selector.advance()).isSameAs(high)
         assertThat(selector.advance()).isNull()
         assertThat(selector.current).isNull()
     }
@@ -187,10 +187,10 @@ class WeightedSourceSelectorTest {
         val low = TestSource("low", priority = 0, weight = 1)
         val selector = WeightedSourceSelector(listOf(high, low), FakeRandom(0))
 
-        assertThat(selector.advance()).isSameAs(low)
+        assertThat(selector.advance()).isSameAs(high)
         selector.reset()
-        assertThat(selector.current).isSameAs(high)
-        assertThat(selector.advance()).isSameAs(low)
+        assertThat(selector.current).isSameAs(low)
+        assertThat(selector.advance()).isSameAs(high)
     }
 
     // endregion


### PR DESCRIPTION
### Motivation
We changed how source priorities work: the lowest `priority` value now wins.

### Description
- Order sources lowest `priority` first (was highest-first).
- Dedupe of duplicate URLs keeps the lowest priority number (highest priority); weight tie-break unchanged.

iOS counterpart: https://github.com/RevenueCat/purchases-ios/pull/7112

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This inverts production failover order for remote config API/blob URLs; traffic shifts unless server-side priority values already follow the new lowest-number-wins convention.
> 
> **Overview**
> **Remote config source ordering now treats a lower `priority` integer as more preferred**, matching the updated contract and the iOS SDK (not the previous “larger number wins” behavior).
> 
> `WeightedSourceSelector` builds the fallback list by sorting priority tiers **ascending** (lowest number first), then weight-shuffled peers within each tier. URL deduplication in `DefaultRemoteConfigSourceProvider` keeps the duplicate entry with the **smallest** `priority` (weight tie-break unchanged). Comments and warn logs spell out “lowest priority number = highest priority.”
> 
> Unit tests in `RemoteConfigSourceProviderTest` and `WeightedSourceSelectorTest` are updated so expectations match the inverted ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f5c3162940ce9d4e2d58279f0c3c33c5131780e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->