### PR TITLE
refactor(remote-config): perform remote config requests behind `ENABLE_REMOTE_CONFIG` flag

### DIFF
--- a/local.properties.example
+++ b/local.properties.example
@@ -76,15 +76,6 @@
 #ENABLE_EXTRA_REQUEST_LOGGING=true
 
 ## ──────────────────────────────────────────────
-## Remote Config Base URL Override
-## When set, redirects only GET /v2/config to this host.
-## All other endpoints continue to use the production base URL.
-## Useful for pointing the remote-config endpoint at a local backend.
-## Only takes effect in debug builds.
-## ──────────────────────────────────────────────
-#REMOTE_CONFIG_BASE_URL=http://localhost:8080/
-
-## ──────────────────────────────────────────────
 ## Enable Remote Config (test-only)
 ## When true, the SDK instantiates the /v1/config manager and refreshes it on app
 ## foreground (staleness-gated). The response is not consumed yet; this only exercises

--- a/local.properties.example
+++ b/local.properties.example
@@ -83,3 +83,11 @@
 ## Only takes effect in debug builds.
 ## ──────────────────────────────────────────────
 #REMOTE_CONFIG_BASE_URL=http://localhost:8080/
+
+## ──────────────────────────────────────────────
+## Enable Remote Config (test-only)
+## When true, the SDK instantiates the /v1/config manager and refreshes it on app
+## foreground (staleness-gated). The response is not consumed yet; this only exercises
+## the request/parse/persist path from test apps ahead of the production wiring.
+## ──────────────────────────────────────────────
+#ENABLE_REMOTE_CONFIG=true

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -70,12 +70,6 @@ android {
             value = (localProperties["ENABLE_REMOTE_CONFIG"] as? String ?: "false"),
         )
 
-        buildConfigField(
-            type = "String",
-            name = "REMOTE_CONFIG_BASE_URL",
-            value = "\"${(localProperties["REMOTE_CONFIG_BASE_URL"] as? String) ?: ""}\"",
-        )
-
         packagingOptions.resources.excludes.addAll(
             listOf("META-INF/LICENSE.md", "META-INF/LICENSE-notice.md"),
         )

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -65,6 +65,12 @@ android {
         )
 
         buildConfigField(
+            type = "boolean",
+            name = "ENABLE_REMOTE_CONFIG",
+            value = (localProperties["ENABLE_REMOTE_CONFIG"] as? String ?: "false"),
+        )
+
+        buildConfigField(
             type = "String",
             name = "REMOTE_CONFIG_BASE_URL",
             value = "\"${(localProperties["REMOTE_CONFIG_BASE_URL"] as? String) ?: ""}\"",

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -274,18 +274,6 @@ internal class PurchasesFactory(
 
             val workflowsCache = if (appConfig.useWorkflows) WorkflowsCache(deviceCache = cache) else null
 
-            val identityManager = IdentityManager(
-                cache,
-                subscriberAttributesCache,
-                subscriberAttributesManager,
-                offeringsCache,
-                workflowsCache,
-                backend,
-                offlineEntitlementsManager,
-                dispatcher,
-                uiPreviewMode = appConfig.uiPreviewMode,
-            )
-
             val remoteConfigManager = if (BuildConfig.ENABLE_REMOTE_CONFIG) {
                 RemoteConfigManager(
                     backend = backend,
@@ -295,6 +283,19 @@ internal class PurchasesFactory(
             } else {
                 null
             }
+
+            val identityManager = IdentityManager(
+                cache,
+                subscriberAttributesCache,
+                subscriberAttributesManager,
+                offeringsCache,
+                workflowsCache,
+                remoteConfigManager,
+                backend,
+                offlineEntitlementsManager,
+                dispatcher,
+                uiPreviewMode = appConfig.uiPreviewMode,
+            )
 
             val customerInfoUpdateHandler = CustomerInfoUpdateHandler(
                 cache,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.UserManagerCompat
+import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
@@ -36,6 +37,9 @@ import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineCustomerInfoCalculator
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.offlineentitlements.PurchasedProductsFetcher
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.common.warnLog
@@ -282,6 +286,16 @@ internal class PurchasesFactory(
                 uiPreviewMode = appConfig.uiPreviewMode,
             )
 
+            val remoteConfigManager = if (BuildConfig.ENABLE_REMOTE_CONFIG) {
+                RemoteConfigManager(
+                    backend = backend,
+                    diskCache = RemoteConfigDiskCache(contextForStorage),
+                    blobStore = RemoteConfigBlobStore(contextForStorage),
+                )
+            } else {
+                null
+            }
+
             val customerInfoUpdateHandler = CustomerInfoUpdateHandler(
                 cache,
                 identityManager,
@@ -474,6 +488,7 @@ internal class PurchasesFactory(
                 purchaseParamsValidator = purchaseParamsValidator,
                 workflowManager = workflowManager,
                 fileRepository = fileRepository,
+                remoteConfigManager = remoteConfigManager,
             )
 
             return Purchases(purchasesOrchestrator)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -805,6 +805,7 @@ internal class PurchasesOrchestrator(
                             callback?.onReceived(customerInfo, created)
                             customerInfoUpdateHandler.notifyListeners(customerInfo)
                         }
+                        remoteConfigManager?.refreshRemoteConfig(state.appInBackground, newAppUserID)
                         offeringsManager.fetchAndCacheOfferings(newAppUserID, state.appInBackground)
                         backupManager.dataChanged()
                     },
@@ -1313,6 +1314,7 @@ internal class PurchasesOrchestrator(
         identityManager.switchUser(newAppUserID)
 
         offeringsManager.fetchAndCacheOfferings(newAppUserID, state.appInBackground)
+        remoteConfigManager?.refreshRemoteConfig(state.appInBackground, newAppUserID)
     }
     //endregion
 
@@ -1388,6 +1390,7 @@ internal class PurchasesOrchestrator(
         completion: ReceiveCustomerInfoCallback? = null,
     ) {
         state.appInBackground.let { appInBackground ->
+            remoteConfigManager?.refreshRemoteConfig(appInBackground, appUserID)
             customerInfoHelper.retrieveCustomerInfo(
                 appUserID,
                 CacheFetchPolicy.FETCH_CURRENT,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -849,6 +849,7 @@ internal class PurchasesOrchestrator(
             state = state.copy(purchaseCallbacksByProductId = Collections.emptyMap())
         }
         this.backend.close()
+        this.remoteConfigManager?.close()
         this.workflowManager?.close()
 
         billing.close()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -47,6 +47,7 @@ import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
 import com.revenuecat.purchases.common.verboseLog
@@ -160,6 +161,7 @@ internal class PurchasesOrchestrator(
     private val blockstoreHelper: BlockstoreHelper = BlockstoreHelper(application, identityManager),
     private val backupManager: BackupManager = BackupManager(application),
     val fileRepository: FileRepository = DefaultFileRepository(application),
+    private val remoteConfigManager: RemoteConfigManager? = null,
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     val adTracker: AdTracker = AdTracker(adEventsManager),
 ) : LifecycleDelegate, CustomActivityLifecycleHandler {
@@ -315,6 +317,11 @@ internal class PurchasesOrchestrator(
 
         enqueue {
             if (appConfig.uiPreviewMode) return@enqueue
+
+            remoteConfigManager?.refreshRemoteConfigIfStale(
+                appInBackground = false,
+                appUserID = identityManager.currentAppUserID,
+            )
 
             if (shouldRefreshCustomerInfo(firstTimeInForeground)) {
                 log(LogIntent.DEBUG) { CustomerInfoStrings.CUSTOMERINFO_STALE_UPDATING_FOREGROUND }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -1326,11 +1326,8 @@ internal class Backend(
         // request body), so concurrent calls for different users must not be deduped onto a single shared request.
         val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path, appUserID), appInBackground)
 
-        val overrideURL = BuildConfig.REMOTE_CONFIG_BASE_URL
-            .takeIf { it.isNotEmpty() && appConfig.isDebugBuild }
-            ?.let { runCatching { URL(it) }.getOrNull() }
-        val baseURL = overrideURL ?: appConfig.baseURL
-        val fallbackBaseURLs = if (overrideURL != null) emptyList() else appConfig.fallbackBaseURLs
+        val baseURL = appConfig.baseURL
+        val fallbackBaseURLs = appConfig.fallbackBaseURLs
         // The manifest is an opaque token replayed verbatim; omitted on the first run when there is none.
         val body = buildMap<String, Any?> {
             put(APP_USER_ID, appUserID)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -15,7 +15,6 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.RewardVerificationError
 import com.revenuecat.purchases.RewardVerificationResult
 import com.revenuecat.purchases.VerificationResult
-import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.backendName
 import com.revenuecat.purchases.common.caching.WorkflowMetadata
 import com.revenuecat.purchases.common.events.EventsRequest

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -14,8 +14,7 @@ import java.io.IOException
  *
  * [manifest] is the **opaque** server token, stored verbatim and replayed on the next request; the SDK never
  * parses it. [activeTopics] is the last response's full active-topic-name set (used to detect removed topics).
- * [prefetchBlobs] is the last response's prefetch set (retention input + which blobs to fetch). [lastRefreshAt]
- * is the SDK's own wall-clock of the last sync attempt, used only for refresh cadence.
+ * [prefetchBlobs] is the last response's prefetch set (retention input + which blobs to fetch).
  *
  * [topics] is the full per-topic item index — the configuration itself (each item's `blob_ref` plus its inline
  * `content`), which is the **source of truth**: persisting it is the whole sync commit, and consumers read their
@@ -29,7 +28,6 @@ internal data class PersistedRemoteConfigurationState(
     val activeTopics: List<String> = emptyList(),
     val prefetchBlobs: List<String> = emptyList(),
     val topics: Map<String, ConfigTopic> = emptyMap(),
-    val lastRefreshAt: Long = 0,
 )
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.networking.RCContainer
@@ -15,6 +16,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
+import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -60,6 +62,15 @@ internal class RemoteConfigManager(
     // late persist either runs fully before the wipe or sees the bumped epoch and skips — never writes after it.
     private val cacheLock = Any()
 
+    @Volatile
+    private var lastRefreshedAt: Date? = null
+
+    fun refreshRemoteConfigIfStale(appInBackground: Boolean, appUserID: String) {
+        if (lastRefreshedAt.isCacheStale(appInBackground, dateProvider)) {
+            refreshRemoteConfig(appInBackground, appUserID)
+        }
+    }
+
     fun refreshRemoteConfig(appInBackground: Boolean, appUserID: String) {
         val requestEpoch: Int
         // Acquire the in-flight guard and capture the epoch together under the lock that also guards
@@ -90,19 +101,18 @@ internal class RemoteConfigManager(
                     return@getRemoteConfig
                 }
                 if (container == null) {
-                    // 204: nothing changed, keep the cache. Release the guard only if we still own the sync:
-                    // clearCache() could have bumped the epoch between the check above and here.
-                    releaseGuardIfOwned(requestEpoch)
+                    // 204: nothing changed
+                    synchronized(cacheLock) {
+                        if (epoch.get() == requestEpoch) {
+                            lastRefreshedAt = dateProvider.now
+                            isRefreshing.set(false)
+                        }
+                    }
                     return@getRemoteConfig
                 }
                 scope.launch {
-                    // Hold the in-flight guard until persistence completes so a concurrent refresh can't read
-                    // the disk cache mid-write and merge against a stale snapshot.
                     try {
                         val response = RemoteConfiguration.parse(container.config.decode())
-                        // Re-check the epoch and persist under the lock that also guards clearCache()'s wipe, so
-                        // a racing identity change either runs entirely before this write or makes it skip — the
-                        // synchronous persist can never write the old user's config after the cache was wiped.
                         synchronized(cacheLock) {
                             if (epoch.get() != requestEpoch) return@launch
                             persist(previous = persisted, response = response, container = container)
@@ -116,15 +126,11 @@ internal class RemoteConfigManager(
                             "Failed to decode remote config response. Keeping the cached configuration."
                         }
                     } finally {
-                        // Only release the guard if we still own this sync; a clearCache()/newer refresh owns
-                        // it otherwise.
                         releaseGuardIfOwned(requestEpoch)
                     }
                 }
             },
             onError = { error ->
-                // Release the guard and log only if we still own the sync; a stale error response (the cache
-                // was cleared after this request started) is dropped and leaves a newer owner's guard alone.
                 if (releaseGuardIfOwned(requestEpoch)) {
                     errorLog(error)
                 }
@@ -134,24 +140,13 @@ internal class RemoteConfigManager(
 
     /**
      * Wipes the cache on an identity change so configuration never bleeds across users (offerings-parity).
-     * Cancels in-flight sync work and keeps the scope usable for the next user (unlike [close]). The epoch bump,
-     * the in-flight guard release, and the wipe all run under [cacheLock]: a synchronous `persist()` that already
-     * started either finished before the wipe, or re-checks the bumped epoch under the same lock and skips — so an
-     * old user's config can never be written after the wipe. Releasing the guard here (rather than before the
-     * lock) keeps it paired with the epoch a [refreshRemoteConfig] observes, so a refresh can't acquire the guard
-     * with a stale epoch and then strand it when its callback drops on the mismatch. (`cancelChildren()` still
-     * unwinds a suspended sync, e.g. Phase 5's blob fetches, but is not load-bearing for either guarantee since
-     * `persist()` is synchronous; the lock is.)
      */
     fun clearCache() {
         scope.coroutineContext.cancelChildren()
         synchronized(cacheLock) {
             epoch.incrementAndGet()
-            // Release the guard inside the lock, after the bump, so it stays paired with the epoch a
-            // refresh observes: a refresh either acquires the guard with the new epoch (and its callback
-            // matches, releasing it normally) or runs entirely before this block (and we release it here).
-            // Never the gap where it acquires the guard with the old epoch and then strands it on mismatch.
             isRefreshing.set(false)
+            lastRefreshedAt = null
             diskCache.clear()
             blobStore.clear()
         }
@@ -193,6 +188,7 @@ internal class RemoteConfigManager(
         // manifest the server diffs against is the source of truth, and persisting it IS the entire commit (the
         // manifest advances unconditionally). Inline blobs are recoverable over the network, so only touch the
         // blob store once the state is durably committed — a failed persist never orphans or evicts blobs.
+        val now = dateProvider.now
         val persisted = diskCache.write(
             PersistedRemoteConfigurationState(
                 domain = response.domain,
@@ -200,11 +196,11 @@ internal class RemoteConfigManager(
                 activeTopics = response.activeTopics,
                 prefetchBlobs = response.prefetchBlobs,
                 topics = mergedTopics,
-                lastRefreshAt = dateProvider.now.time,
             ),
         )
 
         if (persisted) {
+            lastRefreshedAt = now
             extractInlineBlobs(container, blobRefsToKeep)
             blobStore.retainOnly(blobRefsToKeep)
         } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -188,7 +188,6 @@ internal class RemoteConfigManager(
         // manifest the server diffs against is the source of truth, and persisting it IS the entire commit (the
         // manifest advances unconditionally). Inline blobs are recoverable over the network, so only touch the
         // blob store once the state is durably committed — a failed persist never orphans or evicts blobs.
-        val now = dateProvider.now
         val persisted = diskCache.write(
             PersistedRemoteConfigurationState(
                 domain = response.domain,
@@ -200,7 +199,7 @@ internal class RemoteConfigManager(
         )
 
         if (persisted) {
-            lastRefreshedAt = now
+            lastRefreshedAt = dateProvider.now
             extractInlineBlobs(container, blobRefsToKeep)
             blobStore.retainOnly(blobRefsToKeep)
         } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -152,7 +152,6 @@ internal class RemoteConfigManager(
         }
     }
 
-    /** Cancels in-flight sync work. Called on SDK teardown (Phase 7 wiring). */
     fun close() {
         scope.cancel()
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offerings.OfferingsCache
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.safeResumeWithException
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
@@ -36,6 +37,7 @@ internal class IdentityManager(
     private val subscriberAttributesManager: SubscriberAttributesManager,
     private val offeringsCache: OfferingsCache,
     private val workflowsCache: WorkflowsCache?,
+    private val remoteConfigManager: RemoteConfigManager?,
     private val backend: Backend,
     private val offlineEntitlementsManager: OfflineEntitlementsManager,
     private val dispatcher: Dispatcher,
@@ -105,6 +107,7 @@ internal class IdentityManager(
                         }
                         offeringsCache.clearCache()
                         workflowsCache?.clearCache()
+                        remoteConfigManager?.clearCache()
                         deviceCache.clearCustomerInfoCache(newAppUserID)
                         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     }
@@ -158,6 +161,7 @@ internal class IdentityManager(
                         deviceCache.clearCachesForAppUserID(oldAppUserID)
                         offeringsCache.clearCache()
                         workflowsCache?.clearCache()
+                        remoteConfigManager?.clearCache()
                         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
 
                         deviceCache.cacheAppUserID(newAppUserID)
@@ -261,6 +265,7 @@ internal class IdentityManager(
         deviceCache.clearCachesForAppUserID(currentAppUserID)
         offeringsCache.clearCache()
         workflowsCache?.clearCache()
+        remoteConfigManager?.clearCache()
         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(currentAppUserID)
         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
         deviceCache.cacheAppUserID(newUserID)

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.events.EventsManager
 import com.revenuecat.purchases.common.offerings.OfferingsManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.deeplinks.WebPurchaseRedemptionHelper
@@ -93,6 +94,7 @@ internal open class BasePurchasesTest {
     internal val mockVirtualCurrencyManager = mockk<VirtualCurrencyManager>()
     internal val mockPurchaseParamsValidator = mockk<PurchaseParamsValidator>()
     internal val mockWorkflowManager = mockk<WorkflowManager>(relaxed = true)
+    internal val mockRemoteConfigManager = mockk<RemoteConfigManager>(relaxed = true)
     private val mockBlockstoreHelper = mockk<BlockstoreHelper>()
     private val purchasesStateProvider = PurchasesStateCache(PurchasesState())
 
@@ -510,6 +512,7 @@ internal open class BasePurchasesTest {
             backupManager = mockBackupManager,
             purchaseParamsValidator = mockPurchaseParamsValidator,
             workflowManager = mockWorkflowManager,
+            remoteConfigManager = mockRemoteConfigManager,
         )
 
         purchases = Purchases(

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -2818,6 +2818,17 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         verifyClose()
     }
 
+    @Test
+    fun `when closing instance, the remote config manager is closed`() {
+        mockCloseActions()
+
+        purchases.close()
+
+        verify(exactly = 1) {
+            mockRemoteConfigManager.close()
+        }
+    }
+
     // endregion
 
     // region getWorkflow
@@ -2958,6 +2969,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     private fun verifyClose() {
         verify {
             mockBackend.close()
+            mockRemoteConfigManager.close()
             mockBillingAbstract.close()
         }
         assertThat(purchases.updatedCustomerInfoListener).isNull()

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesLifecycleTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesLifecycleTest.kt
@@ -74,6 +74,19 @@ internal class PurchasesLifecycleTest: BasePurchasesTest() {
     }
 
     @Test
+    fun `onAppForegrounded refreshes remote config if stale`() {
+        mockOfferingsManagerAppForeground()
+        purchases.purchasesOrchestrator.state = purchases.purchasesOrchestrator.state.copy(appInBackground = false)
+        Purchases.sharedInstance.purchasesOrchestrator.onAppForegrounded()
+        verify(exactly = 1) {
+            mockRemoteConfigManager.refreshRemoteConfigIfStale(
+                appInBackground = false,
+                appUserID = appUserId,
+            )
+        }
+    }
+
+    @Test
     fun `don't force update of caches when app foregrounded not for the first time`() {
         every {
             mockCache.isCustomerInfoCacheStale(appInBackground = false, appUserID = appUserId)
@@ -130,6 +143,7 @@ internal class PurchasesLifecycleTest: BasePurchasesTest() {
         verify(exactly = 0) {
             mockCustomerInfoHelper.retrieveCustomerInfo(any(), any(), any(), any(), callback = any())
         }
+        verify(exactly = 0) { mockRemoteConfigManager.refreshRemoteConfigIfStale(any(), any()) }
         verify(exactly = 0) { mockOfferingsManager.onAppForeground(any()) }
         verify(exactly = 0) { mockPostPendingTransactionsHelper.syncPendingPurchaseQueue(any()) }
         verify(exactly = 0) { mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any()) }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
@@ -60,7 +60,6 @@ class RemoteConfigDiskCacheTest {
                     mapOf("pem" to RemoteConfiguration.ConfigItem(blobRef = "pemBlob")),
                 ),
             ),
-            lastRefreshAt = 1710000100L,
         )
 
         diskCache.write(config)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -41,6 +41,12 @@ class RemoteConfigManagerTest {
     // Unconfined so the launched 200-path coroutine runs eagerly: invoke(onSuccess) then verify still works.
     private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
+    // Mutable clock so staleness tests can advance time past the refresh window.
+    private var currentTimeMillis = FIXED_MILLIS
+    private val dateProvider = object : DateProvider {
+        override val now: Date get() = Date(currentTimeMillis)
+    }
+
     private var capturedAppUserID: String? = null
     private var capturedDomain: String? = null
     private var capturedManifest: String? = null
@@ -53,7 +59,8 @@ class RemoteConfigManagerTest {
         backend = mockk()
         diskCache = mockk(relaxed = true)
         blobStore = mockk(relaxed = true)
-        manager = RemoteConfigManager(backend, diskCache, blobStore, dateProvider = FixedDateProvider, scope = testScope)
+        currentTimeMillis = FIXED_MILLIS
+        manager = RemoteConfigManager(backend, diskCache, blobStore, dateProvider = dateProvider, scope = testScope)
 
         // Persist succeeds by default; the blob store is only touched once the configuration is persisted.
         every { diskCache.write(any()) } returns true
@@ -80,6 +87,57 @@ class RemoteConfigManagerTest {
         assertThat(capturedDomain).isEqualTo("app")
         assertThat(capturedManifest).isNull()
         assertThat(capturedPrefetchedBlobs).isEmpty()
+    }
+
+    @Test
+    fun `refreshRemoteConfigIfStale refreshes on the first call in a process`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `refreshRemoteConfigIfStale skips within the staleness window after a successful sync`() {
+        every { diskCache.read() } returns null
+
+        // First refresh completes (204), stamping the in-memory last-sync time.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+
+        // Same clock: still within the foreground window, so no new request.
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `refreshRemoteConfigIfStale refreshes again once the window elapses`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+
+        currentTimeMillis = FIXED_MILLIS + STALE_FOREGROUND_AGE_MILLIS
+
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `clearCache makes refreshRemoteConfigIfStale refresh again within the window`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+
+        // Identity change wipes the cache and the in-memory marker, so the next user refreshes immediately.
+        manager.clearCache()
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -128,7 +186,6 @@ class RemoteConfigManagerTest {
         assertThat(written.captured.prefetchBlobs).containsExactly("newBlob")
         assertThat(written.captured.topics).containsOnlyKeys("sources")
         assertThat(written.captured.topics["sources"]!!["default"]!!.blobRef).isEqualTo("newBlob")
-        assertThat(written.captured.lastRefreshAt).isEqualTo(FIXED_MILLIS)
     }
 
     @Test
@@ -520,13 +577,13 @@ class RemoteConfigManagerTest {
     private companion object {
         private const val TEST_APP_USER_ID = "test-app-user-id"
         private const val FIXED_MILLIS = 1_710_000_000_000L
+
+        // Older than the 5-minute foreground staleness window (see Date?.isCacheStale).
+        private const val STALE_FOREGROUND_AGE_MILLIS = 6 * 60 * 1000L
         private const val WAIT_SECONDS = 5L
         private const val BLOCKED_MILLIS = 200L
         private const val REF_VALID = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"
         private const val REF_TAMPERED = "IIIIJJJJKKKKLLLLMMMMNNNNOOOOPPPP"
         private const val REF_UNWANTED = "QQQQRRRRSSSSTTTTUUUUVVVVWWWWXXXX"
-        private val FixedDateProvider = object : DateProvider {
-            override val now: Date get() = Date(FIXED_MILLIS)
-        }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.offerings.OfferingsCache
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.workflows.WorkflowsCache
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
@@ -43,6 +44,7 @@ class IdentityManagerTests {
     private lateinit var mockSubscriberAttributesManager: SubscriberAttributesManager
     private lateinit var mockOfferingsCache: OfferingsCache
     private lateinit var mockWorkflowsCache: WorkflowsCache
+    private lateinit var mockRemoteConfigManager: RemoteConfigManager
     private lateinit var mockBackend: Backend
     private lateinit var mockOfflineEntitlementsManager: OfflineEntitlementsManager
     private lateinit var identityManager: IdentityManager
@@ -77,6 +79,9 @@ class IdentityManagerTests {
             every { clearCache() } just Runs
         }
         mockWorkflowsCache = mockk<WorkflowsCache>().apply {
+            every { clearCache() } just Runs
+        }
+        mockRemoteConfigManager = mockk<RemoteConfigManager>().apply {
             every { clearCache() } just Runs
         }
 
@@ -251,6 +256,7 @@ class IdentityManagerTests {
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
         verify(exactly = 1) { mockWorkflowsCache.clearCache() }
+        verify(exactly = 1) { mockRemoteConfigManager.clearCache() }
     }
 
     @Test
@@ -406,6 +412,7 @@ class IdentityManagerTests {
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
         verify(exactly = 1) { mockWorkflowsCache.clearCache() }
+        verify(exactly = 1) { mockRemoteConfigManager.clearCache() }
     }
 
     @Test
@@ -631,6 +638,7 @@ class IdentityManagerTests {
         verify(exactly = 1) { mockDeviceCache.clearCachesForAppUserID(oldAppUserID) }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
         verify(exactly = 1) { mockWorkflowsCache.clearCache() }
+        verify(exactly = 1) { mockRemoteConfigManager.clearCache() }
         verify(exactly = 1) {
             mockSubscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
         }
@@ -763,6 +771,7 @@ class IdentityManagerTests {
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
         verify(exactly = 1) { mockWorkflowsCache.clearCache() }
+        verify(exactly = 1) { mockRemoteConfigManager.clearCache() }
         verify(exactly = 1) { mockDeviceCache.clearCustomerInfoCache(newAppUserId) }
         verify(exactly = 1) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }
@@ -802,6 +811,7 @@ class IdentityManagerTests {
         }
         verify(exactly = 0) { mockOfferingsCache.clearCache() }
         verify(exactly = 0) { mockWorkflowsCache.clearCache() }
+        verify(exactly = 0) { mockRemoteConfigManager.clearCache() }
         verify(exactly = 0) { mockDeviceCache.clearCustomerInfoCache(newAppUserId) }
         verify(exactly = 0) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }
@@ -896,6 +906,7 @@ class IdentityManagerTests {
         subscriberAttributesManager: SubscriberAttributesManager = mockSubscriberAttributesManager,
         offeringsCache: OfferingsCache = mockOfferingsCache,
         workflowsCache: WorkflowsCache = mockWorkflowsCache,
+        remoteConfigManager: RemoteConfigManager = mockRemoteConfigManager,
         backend: Backend = mockBackend,
         offlineEntitlementsManager: OfflineEntitlementsManager = mockOfflineEntitlementsManager,
         uiPreviewMode: Boolean = false,
@@ -906,6 +917,7 @@ class IdentityManagerTests {
             subscriberAttributesManager,
             offeringsCache,
             workflowsCache,
+            remoteConfigManager,
             backend,
             offlineEntitlementsManager,
             SyncDispatcher(),

--- a/purchases/src/testCustomEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesLoginTests.kt
+++ b/purchases/src/testCustomEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesLoginTests.kt
@@ -41,6 +41,19 @@ internal class PurchasesLoginTests : BasePurchasesTest() {
     }
 
     @Test
+    fun `switchUser refreshes remote config`() {
+        val newAppUserID = "newUser"
+        every {
+            mockIdentityManager.switchUser(newAppUserID)
+        } just Runs
+        mockOfferingsManagerFetchOfferings(newAppUserID)
+
+        purchases.switchUser(newAppUserID)
+
+        verify(exactly = 1) { mockRemoteConfigManager.refreshRemoteConfig(false, newAppUserID) }
+    }
+
+    @Test
     fun `switchUser no ops if new app user ID is same as current`() {
         val newAppUserID = appUserId
         every {
@@ -52,6 +65,7 @@ internal class PurchasesLoginTests : BasePurchasesTest() {
 
         verify(exactly = 0) { mockIdentityManager.switchUser(newAppUserID) }
         verify(exactly = 0) { mockOfferingsManager.fetchAndCacheOfferings(newAppUserID, false, any(), any()) }
+        verify(exactly = 0) { mockRemoteConfigManager.refreshRemoteConfig(any(), any()) }
     }
     // endregion
 }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -664,6 +664,28 @@ internal class PurchasesTest : BasePurchasesTest() {
     }
 
     @Test
+    fun `login successful with new appUserID refreshes remote config`() {
+        val mockCreated = Random.nextBoolean()
+        every { mockIdentityManager.currentAppUserID } returns "oldAppUserID"
+
+        every {
+            mockIdentityManager.logIn(any(), onSuccess = captureLambda(), any())
+        } answers {
+            lambda<(CustomerInfo, Boolean) -> Unit>().captured.invoke(mockInfo, mockCreated)
+        }
+
+        val mockCompletion = mockk<LogInCallback>(relaxed = true)
+        val newAppUserID = "newAppUserID"
+        mockOfferingsManagerFetchOfferings(newAppUserID)
+
+        purchases.logIn(newAppUserID, mockCompletion)
+
+        verify(exactly = 1) {
+            mockRemoteConfigManager.refreshRemoteConfig(false, newAppUserID)
+        }
+    }
+
+    @Test
     fun `logout called with identified user makes right calls`() {
         val appUserID = "fakeUserID"
         every {
@@ -689,6 +711,22 @@ internal class PurchasesTest : BasePurchasesTest() {
         }
         verify(exactly = 1) {
             mockBackupManager.dataChanged()
+        }
+    }
+
+    @Test
+    fun `logout refreshes remote config`() {
+        val appUserID = "fakeUserID"
+        every {
+            mockCache.cleanupOldAttributionData()
+        } just Runs
+        mockIdentityManagerLogout()
+        mockOfferingsManagerFetchOfferings()
+
+        purchases.logOut()
+
+        verify(exactly = 1) {
+            mockRemoteConfigManager.refreshRemoteConfig(false, appUserID)
         }
     }
 


### PR DESCRIPTION
### Description
This adds a compile time flag to instantiate the remote config classes that were unused until now and then perform a refresh on app foreground after a staleness check. Behavior shouldn't be used still in released SDKs. The downloaded config is still unused for now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds optional background `/v1/config` traffic and disk writes when the flag is enabled, plus identity-scoped cache clearing; default-off in shipped builds limits production exposure.
> 
> **Overview**
> Remote config is now **opt-in at compile time** via `ENABLE_REMOTE_CONFIG` (replacing the debug-only `REMOTE_CONFIG_BASE_URL` override). When enabled, the SDK wires `RemoteConfigManager` through configure, lifecycle, identity, and teardown; when disabled, the manager stays `null` and no `/v1/config` work runs.
> 
> **Refresh triggers** (only when the manager exists): staleness-gated refresh on app foreground (`refreshRemoteConfigIfStale`, same 5-minute foreground window as other caches), plus explicit refresh on login, logout, `switchUser`, and `updateAllCaches`. `close()` shuts the manager down.
> 
> **Staleness** no longer persists `lastRefreshAt` on disk; it uses in-memory `lastRefreshedAt`, updated on successful 204/200 sync and cleared on `clearCache()`. **Identity** changes clear remote config alongside offerings/workflows (`IdentityManager`).
> 
> `Backend.getRemoteConfig` always uses the normal production base URL and fallbacks (no local host redirect). Persisted config shape drops `lastRefreshAt`. Tests cover staleness, lifecycle, identity clears, and close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180329f40fe70655d75dbddca06aa8027cf820d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->