### PR TITLE
feat(remote-config): support fallback base URL for the config endpoint

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -108,8 +108,12 @@ internal sealed class Endpoint(
     data class GetRemoteConfig(val domain: String) : Endpoint(
         pathTemplate = "/v1/config/%s",
         name = "remote_config",
+        fallbackPath = "/v1/config/%s",
     ) {
-        override fun getPath(useFallback: Boolean) = pathTemplate.format(Uri.encode(domain))
+        override fun getPath(useFallback: Boolean): String {
+            val template = if (useFallback && fallbackPath != null) fallbackPath else pathTemplate
+            return template.format(Uri.encode(domain))
+        }
         override val expectsRCFormatResponse: Boolean = true
     }
     object PostCreateSupportTicket : Endpoint(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -204,6 +204,26 @@ class EndpointTest {
     }
 
     @Test
+    fun `GetRemoteConfig supports fallback base URLs`() {
+        val endpoint = Endpoint.GetRemoteConfig("app")
+        assertThat(endpoint.supportsFallbackBaseURLs).isTrue
+    }
+
+    @Test
+    fun `GetRemoteConfig fallback path is correct`() {
+        val endpoint = Endpoint.GetRemoteConfig("app")
+        val expectedPath = "/v1/config/app"
+        assertThat(endpoint.getPath(useFallback = true)).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `GetRemoteConfig encodes the domain in the fallback path`() {
+        val endpoint = Endpoint.GetRemoteConfig("my domain")
+        val expectedPath = "/v1/config/my%20domain"
+        assertThat(endpoint.getPath(useFallback = true)).isEqualTo(expectedPath)
+    }
+
+    @Test
     fun `AliasUsers has correct name`() {
         val endpoint = Endpoint.AliasUsers(userId = "test user-id")
         assertThat(endpoint.name).isEqualTo("alias_users")


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Adds fallback base URL support for the config endpoint, so config requests stay resilient when the main API host is unavailable.

### Description
Gives `Endpoint.GetRemoteConfig` a fallback path so `HTTPClient` retries the request against the fallback API host on server failure.

> Note: this behavior is already implemented on `purchases-ios`; this brings Android to parity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small endpoint wiring change reusing established fallback behavior; no new auth or data paths beyond existing config fetching.
> 
> **Overview**
> **`Endpoint.GetRemoteConfig`** now declares a **`fallbackPath`** and builds paths from it when **`useFallback`** is true, so remote config requests can participate in the existing **`HTTPClient`** fallback-host retry flow (same pattern as offerings/workflows).
> 
> The fallback route keeps **`/v1/config/{domain}`** with URI-encoded domains; primary vs fallback paths match here—the change is mainly opting the endpoint into **`supportsFallbackBaseURLs`**. Unit tests cover fallback support, path shape, and encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68b15f166da3cfcc0740aa1e7c766a575093fbd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->