### PR TITLE
refactor(remote-config): Re-arm blob sources only when exhausted + in-memory blob-store index

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -91,7 +91,14 @@ internal class RemoteConfigBlobFetcher(
             errorLog { "Refusing to download remote config blob with malformed ref '$ref'." }
             return false
         }
-        return if (blobStore.contains(ref)) true else enqueue(ref, Priority.HIGH).await()
+        return if (blobStore.contains(ref)) {
+            true
+        } else {
+            // An on-demand read is worth a fresh pass: if a prior cycle exhausted the blob sources, re-arm them
+            // so a source that has since recovered is retried. No-op (and keeps failover progress) otherwise.
+            sourceProvider.restartIfExhausted(Purpose.BLOB)
+            enqueue(ref, Priority.HIGH).await()
+        }
     }
 
     /**
@@ -172,8 +179,10 @@ internal class RemoteConfigBlobFetcher(
         if (blobStore.contains(ref)) return true
 
         // Each SOURCE_UNHEALTHY failure falls over to the next source; once the provider has none left
-        // (getCurrent == null) the operation fails and stops. We never restart here, so we can't spin retrying
-        // sources already known to be bad. Re-arming the provider (restart) is the caller's job — a new sync cycle.
+        // (getCurrent == null) the operation fails and stops. We never restart here, so a backlog of downloads
+        // can't each spin re-walking sources already known to be bad. Re-arming an exhausted provider happens at
+        // the operation entry instead (on-demand ensureDownloaded, and the manager's per-sync prefetch), bounding
+        // it to one re-arm per request/cycle.
         var handle = sourceProvider.getCurrent(Purpose.BLOB)
         var result: Boolean? = null
         while (handle != null && result == null) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
@@ -25,14 +25,20 @@ internal class RemoteConfigBlobStore(
 
     // Refs known to be on disk. Loaded once from a disk scan on first access, then kept in sync by write /
     // retainOnly / clear, so contains() and cachedRefs() answer from memory instead of stat-ing the disk each
-    // call. The store is the sole writer of its directory, so this stays authoritative; read() is still forgiving
-    // (returns null if a file is unexpectedly gone), so a rare divergence is tolerated.
+    // call. The store is the sole writer of its directory, so this stays authoritative; if disk and index ever
+    // diverge, read() self-heals by evicting the ref on a miss, so a stale "cached" flag can't strand a re-fetch.
     private var knownRefs: MutableSet<String>? = null
 
     fun contains(ref: String): Boolean = synchronized(lock) { loadedRefs().contains(ref) }
 
     fun read(ref: String): ByteArray? {
-        val target = blobFile(ref)?.takeIf { it.exists() } ?: return null
+        val target = blobFile(ref)?.takeIf { it.exists() }
+        if (target == null) {
+            // Disk and index disagree (ref gone from under us): correct the index so a later
+            // ensureDownloaded/prefetch re-fetches instead of trusting a stale "cached" flag.
+            synchronized(lock) { knownRefs?.remove(ref) }
+            return null
+        }
         return try {
             target.readBytes()
         } catch (e: IOException) {
@@ -78,13 +84,19 @@ internal class RemoteConfigBlobStore(
     /** The refs currently cached on disk (only files whose name is a valid ref). */
     fun cachedRefs(): Set<String> = synchronized(lock) { loadedRefs().toSet() }
 
-    /** Deletes every cached blob whose ref is not in [refs]. */
+    /**
+     * Deletes every cached blob whose ref is not in [refs]. Scans the directory (not just the in-memory index)
+     * so orphans the index never tracks are pruned too: leftover `rc_blob_*.tmp` files from a write interrupted
+     * by a process kill, and any invalid-named file. Runs once per sync, so the scan is not on a hot path.
+     */
     fun retainOnly(refs: Set<String>) {
-        val toDelete = synchronized(lock) { loadedRefs().filterNot { it in refs } }
-        if (toDelete.isEmpty()) return
         val parent = blobsDir()
-        toDelete.forEach { deleteQuietly(File(parent, it)) }
-        synchronized(lock) { loadedRefs().removeAll(toDelete.toSet()) }
+        if (parent.exists()) {
+            parent.listFiles()
+                ?.filter { it.isFile && it.name !in refs }
+                ?.forEach { deleteQuietly(it) }
+        }
+        synchronized(lock) { loadedRefs().retainAll(refs) }
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
@@ -21,7 +21,15 @@ import java.nio.ByteBuffer
 internal class RemoteConfigBlobStore(
     private val applicationContext: Context,
 ) {
-    fun contains(ref: String): Boolean = blobFile(ref)?.exists() == true
+    private val lock = Any()
+
+    // Refs known to be on disk. Loaded once from a disk scan on first access, then kept in sync by write /
+    // retainOnly / clear, so contains() and cachedRefs() answer from memory instead of stat-ing the disk each
+    // call. The store is the sole writer of its directory, so this stays authoritative; read() is still forgiving
+    // (returns null if a file is unexpectedly gone), so a rare divergence is tolerated.
+    private var knownRefs: MutableSet<String>? = null
+
+    fun contains(ref: String): Boolean = synchronized(lock) { loadedRefs().contains(ref) }
 
     fun read(ref: String): ByteArray? {
         val target = blobFile(ref)?.takeIf { it.exists() } ?: return null
@@ -59,6 +67,7 @@ internal class RemoteConfigBlobStore(
                     tempFile.delete()
                 }
             }
+            synchronized(lock) { loadedRefs().add(ref) }
             true
         } catch (e: IOException) {
             errorLog(e) { "Failed to persist remote config blob '$ref' to disk." }
@@ -67,24 +76,15 @@ internal class RemoteConfigBlobStore(
     }
 
     /** The refs currently cached on disk (only files whose name is a valid ref). */
-    fun cachedRefs(): Set<String> {
-        val parent = blobsDir()
-        if (!parent.exists()) return emptySet()
-        return parent.listFiles()
-            ?.asSequence()
-            ?.filter { it.isFile && RemoteConfigUtils.isValidRef(it.name) }
-            ?.map { it.name }
-            ?.toSet()
-            ?: emptySet()
-    }
+    fun cachedRefs(): Set<String> = synchronized(lock) { loadedRefs().toSet() }
 
     /** Deletes every cached blob whose ref is not in [refs]. */
     fun retainOnly(refs: Set<String>) {
+        val toDelete = synchronized(lock) { loadedRefs().filterNot { it in refs } }
+        if (toDelete.isEmpty()) return
         val parent = blobsDir()
-        if (!parent.exists()) return
-        parent.listFiles()
-            ?.filter { it.isFile && it.name !in refs }
-            ?.forEach { deleteQuietly(it) }
+        toDelete.forEach { deleteQuietly(File(parent, it)) }
+        synchronized(lock) { loadedRefs().removeAll(toDelete.toSet()) }
     }
 
     /**
@@ -92,9 +92,27 @@ internal class RemoteConfigBlobStore(
      * users (unlike [retainOnly], which only prunes unreferenced blobs).
      */
     fun clear() {
+        synchronized(lock) {
+            val parent = blobsDir()
+            if (parent.exists()) parent.listFiles()?.forEach { deleteQuietly(it) }
+            knownRefs = mutableSetOf()
+        }
+    }
+
+    /**
+     * The in-memory ref index, populated on first access from a one-time scan of the blobs directory for files
+     * whose name is a valid ref. Callers must hold [lock].
+     */
+    private fun loadedRefs(): MutableSet<String> = knownRefs ?: run {
         val parent = blobsDir()
-        if (!parent.exists()) return
-        parent.listFiles()?.forEach { deleteQuietly(it) }
+        val scanned = parent.takeIf { it.exists() }
+            ?.listFiles()
+            ?.asSequence()
+            ?.filter { it.isFile && RemoteConfigUtils.isValidRef(it.name) }
+            ?.map { it.name }
+            ?.toMutableSet()
+            ?: mutableSetOf()
+        scanned.also { knownRefs = it }
     }
 
     private fun deleteQuietly(file: File) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -217,12 +217,13 @@ internal class RemoteConfigManager(
     /**
      * Best-effort, topic-agnostic warm of the blobs the committed config wants prefetched: the server's
      * [RemoteConfiguration.prefetchBlobs] plus any item flagged `prefetch`. Re-arms the blob source provider
-     * first (a prior cycle may have exhausted its sources), then hands the not-yet-cached refs to the fetcher's
-     * LOW-priority queue. Runs on the manager's IO scope (inside [persist]), so it never blocks the main thread;
-     * a failed download is tolerated (re-fetched next sync / on demand).
+     * first **only if a prior cycle exhausted its sources** (otherwise failover progress is kept, so a
+     * known-bad higher-priority source isn't re-tried every sync), then hands the not-yet-cached refs to the
+     * fetcher's LOW-priority queue. Runs on the manager's IO scope (inside [persist]), so it never blocks the
+     * main thread; a failed download is tolerated (re-fetched next sync / on demand).
      */
     private fun prefetchBlobs(response: RemoteConfiguration, mergedTopics: Map<String, ConfigTopic>) {
-        sourceProvider.restart(RemoteConfigSourceHandle.Purpose.BLOB)
+        sourceProvider.restartIfExhausted(RemoteConfigSourceHandle.Purpose.BLOB)
         val refs = buildSet {
             addAll(response.prefetchBlobs)
             mergedTopics.values.forEach { topic ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
@@ -51,6 +51,13 @@ internal interface RemoteConfigSourceProvider {
     fun restart(purpose: RemoteConfigSourceHandle.Purpose)
 
     /**
+     * Rewinds [purpose] to its first source only if it is currently exhausted (no healthy source left),
+     * e.g. so an on-demand read or a new sync can retry sources that may have recovered. No-op when a
+     * healthy source is still current, preserving failover progress. Returns whether it re-armed.
+     */
+    fun restartIfExhausted(purpose: RemoteConfigSourceHandle.Purpose): Boolean
+
+    /**
      * Drops any resolved sources and returns to the embedded defaults, e.g. on an identity change so a new
      * user's sources are re-resolved from a fresh config. No-op for providers that hold no per-user state.
      */
@@ -114,6 +121,19 @@ internal class DefaultRemoteConfigSourceProvider(
             }
         }
     }
+
+    override fun restartIfExhausted(purpose: RemoteConfigSourceHandle.Purpose): Boolean =
+        synchronized(lock) {
+            // A config change already re-armed both lists from the top; nothing more to do here.
+            if (rebuildIfChanged()) return true
+            val failover = failoverFor(purpose)
+            if (failover.current == null) {
+                failover.restart()
+                true
+            } else {
+                false
+            }
+        }
 
     override fun clear() {
         // Identity change: rebuild from an empty topic, back to the embedded defaults. The next access after the

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -188,20 +188,35 @@ class RemoteConfigBlobFetcherTest {
     }
 
     @Test
-    fun `stops and fails once the provider has exhausted its sources, without restarting`() {
+    fun `an on-demand request re-arms exhausted blob sources and retries on a later download`() {
         val ref = refOf("body".toByteArray())
         val provider = provider(blobSource(TEMPLATE))
-        // The only source errors, so it is reported unhealthy and the provider becomes exhausted.
+        // The only source keeps erroring, so each attempt reports it unhealthy and exhausts the provider.
         stubConnection(urlFor(ref), code = 500)
         val fetcher = realFetcher(provider)
 
-        // First download fails over to exhaustion; a later download must not re-arm the provider and retry.
+        // First download exhausts the single source; the second, on-demand, re-arms it and tries again.
         assertThat(download(fetcher, ref)).isFalse()
         assertThat(download(fetcher, ref)).isFalse()
 
-        verify(exactly = 0) { provider.restart(any()) }
         verify(exactly = 0) { blobStore.write(any(), any()) }
-        // Only the first download reached a source; the second saw no current source and stopped immediately.
+        // The provider was re-armed once exhausted, so the second download reached the source again.
+        verify { provider.restartIfExhausted(Purpose.BLOB) }
+        verify(exactly = 2) { urlConnectionFactory.createConnection(urlFor(ref), any()) }
+    }
+
+    @Test
+    fun `an on-demand request does not re-arm while a healthy source is still current`() {
+        val bytes = "body".toByteArray()
+        val ref = refOf(bytes)
+        val provider = provider(blobSource(TEMPLATE))
+        stubConnection(urlFor(ref), code = 200, body = bytes)
+        val fetcher = realFetcher(provider)
+
+        assertThat(download(fetcher, ref)).isTrue()
+
+        // The source was healthy, so restartIfExhausted was a no-op and never rewound the failover.
+        verify(exactly = 0) { provider.restart(any()) }
         verify(exactly = 1) { urlConnectionFactory.createConnection(urlFor(ref), any()) }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStoreTest.kt
@@ -123,6 +123,35 @@ class RemoteConfigBlobStoreTest {
     }
 
     @Test
+    fun `retainOnly prunes orphan temp files and invalid-named files the index never tracks`() {
+        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
+        // Simulate a temp file left by a write interrupted mid-flight, plus a stray invalid-named file.
+        val blobsDir = File(File(testFolder, "RevenueCat"), "blobs")
+        val orphanTemp = File(blobsDir, "rc_blob_orphan.tmp").apply { writeBytes(byteArrayOf(9)) }
+        val invalidNamed = File(blobsDir, "not-a-valid-ref").apply { writeBytes(byteArrayOf(9)) }
+
+        blobStore.retainOnly(setOf(refA))
+
+        assertThat(orphanTemp.exists()).isFalse
+        assertThat(invalidNamed.exists()).isFalse
+        assertThat(blobStore.contains(refA)).isTrue
+        assertThat(blobStore.cachedRefs()).containsExactly(refA)
+    }
+
+    @Test
+    fun `read self-heals the index when the underlying file is gone`() {
+        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
+        assertThat(blobStore.contains(refA)).isTrue
+
+        // The file disappears from under us (e.g. external removal); the index still claims it.
+        File(File(File(testFolder, "RevenueCat"), "blobs"), refA).delete()
+
+        assertThat(blobStore.read(refA)).isNull()
+        // The read miss corrected the index, so a later ensureDownloaded/prefetch would re-fetch it.
+        assertThat(blobStore.contains(refA)).isFalse
+    }
+
+    @Test
     fun `retainOnly with an empty set clears the cache`() {
         blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStoreTest.kt
@@ -88,6 +88,17 @@ class RemoteConfigBlobStoreTest {
     }
 
     @Test
+    fun `contains and cachedRefs load blobs already on disk from a previous instance`() {
+        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
+
+        // A fresh instance over the same directory must discover the existing blob via its one-time disk scan.
+        val reopened = RemoteConfigBlobStore(applicationContext)
+
+        assertThat(reopened.contains(refA)).isTrue
+        assertThat(reopened.cachedRefs()).containsExactly(refA)
+    }
+
+    @Test
     fun `cachedRefs reflects the written blobs`() {
         blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
         blobStore.write(refB, ByteBuffer.wrap(byteArrayOf(2)))

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -392,8 +392,8 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
-        // Re-arm the (possibly exhausted) blob sources before fetching.
-        verify(exactly = 1) { sourceProvider.restart(RemoteConfigSourceHandle.Purpose.BLOB) }
+        // Re-arm the blob sources before fetching, but only if a prior cycle exhausted them.
+        verify(exactly = 1) { sourceProvider.restartIfExhausted(RemoteConfigSourceHandle.Purpose.BLOB) }
         // The server prefetch set and any item flagged prefetch=true are warmed; non-flagged items are not.
         val prefetched = slot<List<String>>()
         verify(exactly = 1) { blobFetcher.prefetch(capture(prefetched)) }
@@ -439,7 +439,7 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
-        verify(exactly = 0) { sourceProvider.restart(any()) }
+        verify(exactly = 0) { sourceProvider.restartIfExhausted(any()) }
         verify(exactly = 0) { blobFetcher.prefetch(any()) }
     }
 
@@ -450,7 +450,7 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onSuccess.invoke(null, VerificationResult.VERIFIED)
 
-        verify(exactly = 0) { sourceProvider.restart(any()) }
+        verify(exactly = 0) { sourceProvider.restartIfExhausted(any()) }
         verify(exactly = 0) { blobFetcher.prefetch(any()) }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProviderTest.kt
@@ -308,6 +308,64 @@ class RemoteConfigSourceProviderTest {
 
     // endregion
 
+    // region restartIfExhausted
+
+    @Test
+    fun `restartIfExhausted rewinds and returns true once the sources are exhausted`() {
+        val provider = apiProvider(listOf(source("a"), source("b")))
+
+        provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!)
+        provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!)
+        assertThat(provider.getCurrent(Purpose.API)).isNull()
+
+        assertThat(provider.restartIfExhausted(Purpose.API)).isTrue()
+        assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("a"))
+    }
+
+    @Test
+    fun `restartIfExhausted is a no-op and returns false while a healthy source is current`() {
+        val provider = apiProvider(listOf(source("a"), source("b")))
+
+        provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // a -> b, still healthy
+        assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("b"))
+
+        // Not exhausted, so it must keep failover progress instead of rewinding to `a`.
+        assertThat(provider.restartIfExhausted(Purpose.API)).isFalse()
+        assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("b"))
+    }
+
+    @Test
+    fun `restartIfExhausted only rewinds the requested purpose`() {
+        val provider = provider(
+            api = listOf(source("api1", priority = 0)),
+            blob = listOf(source("blob1", priority = 0), source("blob2", priority = 10)),
+        )
+
+        provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // api exhausted
+        provider.reportUnhealthy(provider.getCurrent(Purpose.BLOB)!!) // blob1 -> blob2, still healthy
+        assertThat(provider.getCurrent(Purpose.API)).isNull()
+
+        assertThat(provider.restartIfExhausted(Purpose.API)).isTrue()
+        assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("api1"))
+        // Blob was not exhausted, so its progress is untouched.
+        assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo(url("blob2"))
+    }
+
+    @Test
+    fun `restartIfExhausted returns true when a changed sources topic already re-armed the list`() {
+        val store = FakeTopicStore(sourcesTopic(api = listOf(source("a"), source("b")), blob = emptyList()))
+        val provider = DefaultRemoteConfigSourceProvider(store, FakeRandom(0))
+
+        provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // a -> b
+
+        // A changed topic rebuilds from the top; restartIfExhausted reports the re-arm and leaves it at the top.
+        store.sources = sourcesTopic(api = listOf(source("x"), source("y")), blob = emptyList())
+        assertThat(provider.restartIfExhausted(Purpose.API)).isTrue()
+        assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("x"))
+    }
+
+    // endregion
+
     // region Sources topic changes
 
     @Test


### PR DESCRIPTION
## Changes

- Add `restartIfExhausted(purpose)` to the source provider: re-arms a purpose only if it is currently exhausted, otherwise a no-op that preserves failover progress.
- On-demand `ensureDownloaded` now re-arms exhausted blob sources before enqueuing, so a read after a prior cycle drained the sources retries instead of failing silently.
- `RemoteConfigManager.prefetchBlobs` re-arms blob sources only when exhausted rather than unconditionally every sync.
- `RemoteConfigBlobStore` keeps an in-memory index of on-disk refs so `contains`/`cachedRefs` no longer stat the disk on every call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path blob cache checks and network source selection for remote config; behavior shifts from always retrying primary blob sources each sync to preserving failover state, which could delay recovery if exhaustion detection is wrong.
> 
> **Overview**
> Remote config blob **source failover** no longer resets every sync or on every download. **`restartIfExhausted`** re-winds blob (and API) sources to the first entry only when that purpose has no healthy source left; otherwise failover progress is kept so a known-bad primary is not retried on each sync.
> 
> **On-demand** `ensureDownloaded` calls `restartIfExhausted` before enqueueing a missing blob so reads after an exhausted cycle can retry recovered sources. **Sync prefetch** uses the same conditional re-arm instead of unconditional `restart`. Individual download workers still do not restart inside the failover loop (one re-arm per on-demand request or prefetch cycle).
> 
> **`RemoteConfigBlobStore`** maintains a synchronized in-memory ref index (lazy one-time disk scan, updated on write / `retainOnly` / `clear`). `contains` and `cachedRefs` avoid per-call disk stats; **`read`** drops stale index entries when the file is missing. **`retainOnly`** still scans the blobs directory so orphan temp and invalid-named files are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9c39d09080b685c95a52ed112dd263f2de87e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->