### PR TITLE
Fix: return ProductAlreadyPurchasedError when purchasing an already-active subscription on a paywall

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -670,8 +670,23 @@ internal class PaywallViewModelImpl(
         try {
             trackPaywallPurchaseInitiated(packageToPurchase)
 
-            val productChangeInfo = productChangeConfig?.let {
+            val productChangeResult = productChangeConfig?.let {
                 productChangeCalculator.calculateProductChangeInfo(packageToPurchase, it)
+            } ?: ProductChangeResult.NoChange
+
+            val productChangeInfo = when (productChangeResult) {
+                is ProductChangeResult.AlreadySubscribed -> {
+                    // Launching the billing flow would fail with ITEM_ALREADY_OWNED, so surface
+                    // the error without launching it.
+                    val error = PurchasesError(PurchasesErrorCode.ProductAlreadyPurchasedError)
+                    trackPaywallPurchaseError(packageToPurchase, error)
+                    listener?.onPurchaseError(error)
+                    _actionError.value = error
+                    finishAction()
+                    return
+                }
+                is ProductChangeResult.NoChange -> null
+                is ProductChangeResult.Change -> productChangeResult.info
             }
 
             when (purchases.purchasesAreCompletedBy) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/ProductChangeCalculator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/ProductChangeCalculator.kt
@@ -19,6 +19,11 @@ internal data class ProductChangeInfo(
     val replacementMode: StoreReplacementMode,
 )
 
+private sealed interface ProductLookupResult {
+    data class Success(val product: StoreProduct?) : ProductLookupResult
+    object Error : ProductLookupResult
+}
+
 /**
  * Calculates product change information for subscription upgrades/downgrades.
  *
@@ -34,14 +39,18 @@ internal class ProductChangeCalculator(
         packageToPurchase: Package,
         productChangeConfig: ProductChangeConfig,
     ): ProductChangeInfo? {
-        if (packageToPurchase.product.type != ProductType.SUBS) {
-            return null
-        }
+        return if (packageToPurchase.product.type != ProductType.SUBS) {
+            null
+        } else {
+            val customerInfo = try {
+                purchases.awaitCustomerInfo()
+            } catch (e: PurchasesException) {
+                Logger.e("Error determining product change info: ${e.message}")
+                null
+            }
 
-        return try {
-            val customerInfo = purchases.awaitCustomerInfo()
-            customerInfo.subscriptionsByProductIdentifier.values
-                .firstOrNull { subscriptionInfo ->
+            customerInfo?.subscriptionsByProductIdentifier?.values
+                ?.firstOrNull { subscriptionInfo ->
                     subscriptionInfo.isActive && subscriptionInfo.store == Store.PLAY_STORE
                 }?.let { activePlayStoreSubscription ->
                     calculateProductChange(
@@ -50,15 +59,6 @@ internal class ProductChangeCalculator(
                         productChangeConfig = productChangeConfig,
                     )
                 }
-        } catch (e: PurchasesException) {
-            // The user is trying to purchase a subscription they already actively own (same product
-            // and base plan). Propagate so the purchase flow is not launched and the developer's
-            // error callback receives ProductAlreadyPurchasedError.
-            if (e.code == PurchasesErrorCode.ProductAlreadyPurchasedError) {
-                throw e
-            }
-            Logger.e("Error determining product change info: ${e.message}")
-            null
         }
     }
 
@@ -72,7 +72,7 @@ internal class ProductChangeCalculator(
 
         val (newSubscriptionId, newBasePlanId) = packageToPurchase.product.subscriptionIdentifiers()
 
-        if (oldSubscriptionId == newSubscriptionId) {
+        return if (oldSubscriptionId == newSubscriptionId) {
             if (oldBasePlanId == newBasePlanId) {
                 // The user already actively owns this exact subscription (same product and base
                 // plan). Launching the billing flow would fail with ITEM_ALREADY_OWNED, so we
@@ -87,37 +87,47 @@ internal class ProductChangeCalculator(
             }
             // Same product, different base plan: Google handles the base plan change automatically.
             Logger.d("Same product ($newSubscriptionId), Google handles base plan change automatically")
-            return null
-        }
-
-        val oldProduct = purchases.awaitGetProduct(oldSubscriptionId, oldBasePlanId)
-        val isSandbox = activePlayStoreSubscription.isSandbox
-
-        val oldNormalizedPrice = oldProduct?.getNormalizedPrice(isSandbox)
-        val newNormalizedPrice = packageToPurchase.product.getNormalizedPrice(isSandbox)
-
-        val isUpgrade = oldNormalizedPrice != null &&
-            newNormalizedPrice != null &&
-            newNormalizedPrice > oldNormalizedPrice
-
-        val replacementMode = if (isUpgrade) {
-            Logger.d(
-                "Detected upgrade: $oldSubscriptionId -> $newSubscriptionId " +
-                    "(old: $oldNormalizedPrice, new: $newNormalizedPrice, sandbox: $isSandbox)",
-            )
-            productChangeConfig.upgradeReplacementMode
+            null
         } else {
-            Logger.d(
-                "Detected downgrade: $oldSubscriptionId -> $newSubscriptionId " +
-                    "(old: $oldNormalizedPrice, new: $newNormalizedPrice, sandbox: $isSandbox)",
-            )
-            productChangeConfig.downgradeReplacementMode
-        }
+            val oldProductLookup = try {
+                ProductLookupResult.Success(purchases.awaitGetProduct(oldSubscriptionId, oldBasePlanId))
+            } catch (e: PurchasesException) {
+                Logger.e("Error determining product change info: ${e.message}")
+                ProductLookupResult.Error
+            }
+            val isSandbox = activePlayStoreSubscription.isSandbox
 
-        return ProductChangeInfo(
-            oldProductId = oldSubscriptionId,
-            replacementMode = replacementMode,
-        )
+            when (oldProductLookup) {
+                ProductLookupResult.Error -> null
+                is ProductLookupResult.Success -> {
+                    val oldNormalizedPrice = oldProductLookup.product?.getNormalizedPrice(isSandbox)
+                    val newNormalizedPrice = packageToPurchase.product.getNormalizedPrice(isSandbox)
+
+                    val isUpgrade = oldNormalizedPrice != null &&
+                        newNormalizedPrice != null &&
+                        newNormalizedPrice > oldNormalizedPrice
+
+                    val replacementMode = if (isUpgrade) {
+                        Logger.d(
+                            "Detected upgrade: $oldSubscriptionId -> $newSubscriptionId " +
+                                "(old: $oldNormalizedPrice, new: $newNormalizedPrice, sandbox: $isSandbox)",
+                        )
+                        productChangeConfig.upgradeReplacementMode
+                    } else {
+                        Logger.d(
+                            "Detected downgrade: $oldSubscriptionId -> $newSubscriptionId " +
+                                "(old: $oldNormalizedPrice, new: $newNormalizedPrice, sandbox: $isSandbox)",
+                        )
+                        productChangeConfig.downgradeReplacementMode
+                    }
+
+                    ProductChangeInfo(
+                        oldProductId = oldSubscriptionId,
+                        replacementMode = replacementMode,
+                    )
+                }
+            }
+        }
     }
 
     companion object {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/ProductChangeCalculator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/ProductChangeCalculator.kt
@@ -2,6 +2,8 @@ package com.revenuecat.purchases.ui.revenuecatui.data
 
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.SubscriptionInfo
@@ -49,6 +51,12 @@ internal class ProductChangeCalculator(
                     )
                 }
         } catch (e: PurchasesException) {
+            // The user is trying to purchase a subscription they already actively own (same product
+            // and base plan). Propagate so the purchase flow is not launched and the developer's
+            // error callback receives ProductAlreadyPurchasedError.
+            if (e.code == PurchasesErrorCode.ProductAlreadyPurchasedError) {
+                throw e
+            }
             Logger.e("Error determining product change info: ${e.message}")
             null
         }
@@ -62,9 +70,22 @@ internal class ProductChangeCalculator(
         val oldSubscriptionId = activePlayStoreSubscription.productIdentifier
         val oldBasePlanId = activePlayStoreSubscription.productPlanIdentifier
 
-        val (newSubscriptionId, _) = packageToPurchase.product.subscriptionIdentifiers()
+        val (newSubscriptionId, newBasePlanId) = packageToPurchase.product.subscriptionIdentifiers()
 
         if (oldSubscriptionId == newSubscriptionId) {
+            if (oldBasePlanId == newBasePlanId) {
+                // The user already actively owns this exact subscription (same product and base
+                // plan). Launching the billing flow would fail with ITEM_ALREADY_OWNED, so we
+                // surface the error to the developer instead.
+                Logger.d("Already subscribed to $newSubscriptionId ($newBasePlanId)")
+                throw PurchasesException(
+                    PurchasesError(
+                        PurchasesErrorCode.ProductAlreadyPurchasedError,
+                        "This product is already active for the user.",
+                    ),
+                )
+            }
+            // Same product, different base plan: Google handles the base plan change automatically.
             Logger.d("Same product ($newSubscriptionId), Google handles base plan change automatically")
             return null
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/ProductChangeCalculator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/ProductChangeCalculator.kt
@@ -2,8 +2,6 @@ package com.revenuecat.purchases.ui.revenuecatui.data
 
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.ProductType
-import com.revenuecat.purchases.PurchasesError
-import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.SubscriptionInfo
@@ -19,9 +17,12 @@ internal data class ProductChangeInfo(
     val replacementMode: StoreReplacementMode,
 )
 
-private sealed interface ProductLookupResult {
-    data class Success(val product: StoreProduct?) : ProductLookupResult
-    object Error : ProductLookupResult
+internal sealed interface ProductChangeResult {
+    data class Change(val info: ProductChangeInfo) : ProductChangeResult
+
+    object NoChange : ProductChangeResult
+
+    object AlreadySubscribed : ProductChangeResult
 }
 
 /**
@@ -35,99 +36,92 @@ private sealed interface ProductLookupResult {
 internal class ProductChangeCalculator(
     private val purchases: PurchasesType,
 ) {
+    @Suppress("ReturnCount")
     suspend fun calculateProductChangeInfo(
         packageToPurchase: Package,
         productChangeConfig: ProductChangeConfig,
-    ): ProductChangeInfo? {
-        return if (packageToPurchase.product.type != ProductType.SUBS) {
-            null
-        } else {
-            val customerInfo = try {
-                purchases.awaitCustomerInfo()
-            } catch (e: PurchasesException) {
-                Logger.e("Error determining product change info: ${e.message}")
-                null
-            }
-
-            customerInfo?.subscriptionsByProductIdentifier?.values
-                ?.firstOrNull { subscriptionInfo ->
-                    subscriptionInfo.isActive && subscriptionInfo.store == Store.PLAY_STORE
-                }?.let { activePlayStoreSubscription ->
-                    calculateProductChange(
-                        activePlayStoreSubscription = activePlayStoreSubscription,
-                        packageToPurchase = packageToPurchase,
-                        productChangeConfig = productChangeConfig,
-                    )
-                }
+    ): ProductChangeResult {
+        if (packageToPurchase.product.type != ProductType.SUBS) {
+            return ProductChangeResult.NoChange
         }
+
+        val customerInfo = try {
+            purchases.awaitCustomerInfo()
+        } catch (e: PurchasesException) {
+            Logger.e("Error fetching customer info to determine product change: ${e.message}")
+            return ProductChangeResult.NoChange
+        }
+
+        val activePlayStoreSubscription = customerInfo.subscriptionsByProductIdentifier.values
+            .firstOrNull { subscriptionInfo ->
+                subscriptionInfo.isActive && subscriptionInfo.store == Store.PLAY_STORE
+            } ?: return ProductChangeResult.NoChange
+
+        return calculateProductChange(
+            activePlayStoreSubscription = activePlayStoreSubscription,
+            packageToPurchase = packageToPurchase,
+            productChangeConfig = productChangeConfig,
+        )
     }
 
+    @Suppress("ReturnCount")
     private suspend fun calculateProductChange(
         activePlayStoreSubscription: SubscriptionInfo,
         packageToPurchase: Package,
         productChangeConfig: ProductChangeConfig,
-    ): ProductChangeInfo? {
+    ): ProductChangeResult {
         val oldSubscriptionId = activePlayStoreSubscription.productIdentifier
         val oldBasePlanId = activePlayStoreSubscription.productPlanIdentifier
 
         val (newSubscriptionId, newBasePlanId) = packageToPurchase.product.subscriptionIdentifiers()
 
-        return if (oldSubscriptionId == newSubscriptionId) {
+        if (oldSubscriptionId == newSubscriptionId) {
             if (oldBasePlanId == newBasePlanId) {
                 // The user already actively owns this exact subscription (same product and base
-                // plan). Launching the billing flow would fail with ITEM_ALREADY_OWNED, so we
-                // surface the error to the developer instead.
+                // plan). Launching the billing flow would fail with ITEM_ALREADY_OWNED.
                 Logger.d("Already subscribed to $newSubscriptionId ($newBasePlanId)")
-                throw PurchasesException(
-                    PurchasesError(
-                        PurchasesErrorCode.ProductAlreadyPurchasedError,
-                        "This product is already active for the user.",
-                    ),
-                )
+                return ProductChangeResult.AlreadySubscribed
             }
             // Same product, different base plan: Google handles the base plan change automatically.
             Logger.d("Same product ($newSubscriptionId), Google handles base plan change automatically")
-            null
-        } else {
-            val oldProductLookup = try {
-                ProductLookupResult.Success(purchases.awaitGetProduct(oldSubscriptionId, oldBasePlanId))
-            } catch (e: PurchasesException) {
-                Logger.e("Error determining product change info: ${e.message}")
-                ProductLookupResult.Error
-            }
-            val isSandbox = activePlayStoreSubscription.isSandbox
-
-            when (oldProductLookup) {
-                ProductLookupResult.Error -> null
-                is ProductLookupResult.Success -> {
-                    val oldNormalizedPrice = oldProductLookup.product?.getNormalizedPrice(isSandbox)
-                    val newNormalizedPrice = packageToPurchase.product.getNormalizedPrice(isSandbox)
-
-                    val isUpgrade = oldNormalizedPrice != null &&
-                        newNormalizedPrice != null &&
-                        newNormalizedPrice > oldNormalizedPrice
-
-                    val replacementMode = if (isUpgrade) {
-                        Logger.d(
-                            "Detected upgrade: $oldSubscriptionId -> $newSubscriptionId " +
-                                "(old: $oldNormalizedPrice, new: $newNormalizedPrice, sandbox: $isSandbox)",
-                        )
-                        productChangeConfig.upgradeReplacementMode
-                    } else {
-                        Logger.d(
-                            "Detected downgrade: $oldSubscriptionId -> $newSubscriptionId " +
-                                "(old: $oldNormalizedPrice, new: $newNormalizedPrice, sandbox: $isSandbox)",
-                        )
-                        productChangeConfig.downgradeReplacementMode
-                    }
-
-                    ProductChangeInfo(
-                        oldProductId = oldSubscriptionId,
-                        replacementMode = replacementMode,
-                    )
-                }
-            }
+            return ProductChangeResult.NoChange
         }
+
+        val oldProduct = try {
+            purchases.awaitGetProduct(oldSubscriptionId, oldBasePlanId)
+        } catch (e: PurchasesException) {
+            Logger.e("Error fetching currently subscribed product to determine product change: ${e.message}")
+            return ProductChangeResult.NoChange
+        }
+        val isSandbox = activePlayStoreSubscription.isSandbox
+
+        val oldNormalizedPrice = oldProduct?.getNormalizedPrice(isSandbox)
+        val newNormalizedPrice = packageToPurchase.product.getNormalizedPrice(isSandbox)
+
+        val isUpgrade = oldNormalizedPrice != null &&
+            newNormalizedPrice != null &&
+            newNormalizedPrice > oldNormalizedPrice
+
+        val replacementMode = if (isUpgrade) {
+            Logger.d(
+                "Detected upgrade: $oldSubscriptionId -> $newSubscriptionId " +
+                    "(old: $oldNormalizedPrice, new: $newNormalizedPrice, sandbox: $isSandbox)",
+            )
+            productChangeConfig.upgradeReplacementMode
+        } else {
+            Logger.d(
+                "Detected downgrade: $oldSubscriptionId -> $newSubscriptionId " +
+                    "(old: $oldNormalizedPrice, new: $newNormalizedPrice, sandbox: $isSandbox)",
+            )
+            productChangeConfig.downgradeReplacementMode
+        }
+
+        return ProductChangeResult.Change(
+            ProductChangeInfo(
+                oldProductId = oldSubscriptionId,
+                replacementMode = replacementMode,
+            ),
+        )
     }
 
     companion object {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -2395,9 +2395,11 @@ class PaywallViewModelTest {
         val productChangeCalculator = mockk<ProductChangeCalculator>()
         coEvery {
             productChangeCalculator.calculateProductChangeInfo(any(), any())
-        } returns ProductChangeInfo(
-            oldProductId = "old_product",
-            replacementMode = StoreReplacementMode.CHARGE_PRORATED_PRICE,
+        } returns ProductChangeResult.Change(
+            ProductChangeInfo(
+                oldProductId = "old_product",
+                replacementMode = StoreReplacementMode.CHARGE_PRORATED_PRICE,
+            ),
         )
 
         val transaction = mockk<StoreTransaction>()
@@ -2524,7 +2526,7 @@ class PaywallViewModelTest {
         val productChangeCalculator = mockk<ProductChangeCalculator>()
         coEvery {
             productChangeCalculator.calculateProductChangeInfo(any(), any())
-        } returns null
+        } returns ProductChangeResult.NoChange
 
         val transaction = mockk<StoreTransaction>()
         coEvery {
@@ -2594,7 +2596,7 @@ class PaywallViewModelTest {
         val productChangeCalculator = mockk<ProductChangeCalculator>()
         coEvery {
             productChangeCalculator.calculateProductChangeInfo(any(), any())
-        } throws PurchasesException(expectedError)
+        } returns ProductChangeResult.AlreadySubscribed
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
@@ -2715,9 +2717,11 @@ class PaywallViewModelTest {
         val productChangeCalculator = mockk<ProductChangeCalculator>()
         coEvery {
             productChangeCalculator.calculateProductChangeInfo(any(), any())
-        } returns ProductChangeInfo(
-            oldProductId = "old_product",
-            replacementMode = StoreReplacementMode.CHARGE_PRORATED_PRICE,
+        } returns ProductChangeResult.Change(
+            ProductChangeInfo(
+                oldProductId = "old_product",
+                replacementMode = StoreReplacementMode.CHARGE_PRORATED_PRICE,
+            ),
         )
 
         val model = PaywallViewModelImpl(
@@ -2793,9 +2797,11 @@ class PaywallViewModelTest {
         val productChangeCalculator = mockk<ProductChangeCalculator>()
         coEvery {
             productChangeCalculator.calculateProductChangeInfo(any(), any())
-        } returns ProductChangeInfo(
-            oldProductId = "old_product",
-            replacementMode = StoreReplacementMode.DEFERRED,
+        } returns ProductChangeResult.Change(
+            ProductChangeInfo(
+                oldProductId = "old_product",
+                replacementMode = StoreReplacementMode.DEFERRED,
+            ),
         )
 
         val model = PaywallViewModelImpl(
@@ -2871,7 +2877,7 @@ class PaywallViewModelTest {
         val productChangeCalculator = mockk<ProductChangeCalculator>()
         coEvery {
             productChangeCalculator.calculateProductChangeInfo(any(), any())
-        } returns null
+        } returns ProductChangeResult.NoChange
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -2562,6 +2562,70 @@ class PaywallViewModelTest {
     }
 
     @Test
+    fun `purchase surfaces ProductAlreadyPurchasedError without launching billing flow`(): Unit = runBlocking {
+        val productChangeConfig = ProductChangeConfig()
+        val paywallComponentsDataWithProductChange = PaywallComponentsData(
+            id = "paywall_id",
+            templateName = "template",
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(components = listOf(TestData.Components.monthlyPackageComponent)),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    stickyFooter = null,
+                ),
+            ),
+            componentsLocalizations = localizations,
+            defaultLocaleIdentifier = defaultLocaleIdentifier,
+            productChangeConfig = productChangeConfig,
+        )
+        val offeringWithProductChange = Offering(
+            identifier = "offering-id",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
+            paywallComponents = Offering.PaywallComponents(
+                UiConfig(),
+                paywallComponentsDataWithProductChange,
+            ),
+        )
+
+        val expectedError = PurchasesError(PurchasesErrorCode.ProductAlreadyPurchasedError)
+        val productChangeCalculator = mockk<ProductChangeCalculator>()
+        coEvery {
+            productChangeCalculator.calculateProductChangeInfo(any(), any())
+        } throws PurchasesException(expectedError)
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offeringWithProductChange)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            productChangeCalculator = productChangeCalculator,
+        )
+
+        val state = model.state.value as PaywallState.Loaded.Components
+        state.update(TestData.Packages.monthly.identifier)
+
+        model.handlePackagePurchase(activity, pkg = null)
+
+        coVerify(exactly = 0) {
+            purchases.awaitPurchase(any())
+        }
+        verify {
+            listener.onPurchaseError(expectedError)
+        }
+        assertThat(model.actionInProgress.value).isFalse
+        assertThat(model.actionError.value).isEqualTo(expectedError)
+        assertThat(dismissInvoked).isFalse
+    }
+
+    @Test
     fun `purchase from package button uses configured promotional offer`(): Unit = runBlocking {
         val promoSubscriptionOption = TestData.Packages.monthly.product.defaultOption!!
         val resolvedOffer = ResolvedOffer.ConfiguredOffer(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/ProductChangeCalculatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/ProductChangeCalculatorTest.kt
@@ -51,7 +51,7 @@ class ProductChangeCalculatorTest {
     }
 
     @Test
-    fun `returns null for non-subscription products`() = runTest {
+    fun `returns NoChange for non-subscription products`() = runTest {
         val lifetimePackage = createPackage(
             productId = "com.test.lifetime",
             period = null,
@@ -64,11 +64,11 @@ class ProductChangeCalculatorTest {
             defaultProductChangeConfig,
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(ProductChangeResult.NoChange)
     }
 
     @Test
-    fun `returns null when user has no active subscriptions`() = runTest {
+    fun `returns NoChange when user has no active subscriptions`() = runTest {
         every { customerInfo.subscriptionsByProductIdentifier } returns emptyMap()
 
         val packageToPurchase = createSubscriptionPackage(
@@ -82,11 +82,11 @@ class ProductChangeCalculatorTest {
             defaultProductChangeConfig,
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(ProductChangeResult.NoChange)
     }
 
     @Test
-    fun `returns null when active subscription is not from Play Store`() = runTest {
+    fun `returns NoChange when active subscription is not from Play Store`() = runTest {
         val appStoreSubscription = createSubscriptionInfo(
             productIdentifier = "com.test.subscription.basic",
             store = Store.APP_STORE,
@@ -108,11 +108,11 @@ class ProductChangeCalculatorTest {
             defaultProductChangeConfig,
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(ProductChangeResult.NoChange)
     }
 
     @Test
-    fun `returns null when purchasing same product with different base plan`() = runTest {
+    fun `returns NoChange when purchasing same product with different base plan`() = runTest {
         val activeSubscription = createSubscriptionInfo(
             productIdentifier = "com.test.subscription",
             productPlanIdentifier = "monthly_plan",
@@ -135,11 +135,11 @@ class ProductChangeCalculatorTest {
             defaultProductChangeConfig,
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(ProductChangeResult.NoChange)
     }
 
     @Test
-    fun `throws ProductAlreadyPurchasedError when purchasing same product and base plan`() = runTest {
+    fun `returns AlreadySubscribed when purchasing same product and base plan`() = runTest {
         val activeSubscription = createSubscriptionInfo(
             productIdentifier = "com.test.subscription",
             productPlanIdentifier = "monthly_plan",
@@ -157,16 +157,12 @@ class ProductChangeCalculatorTest {
             priceMicros = 9_990_000,
         )
 
-        val exception = runCatching {
-            calculator.calculateProductChangeInfo(
-                sameProductSameBasePlan,
-                defaultProductChangeConfig,
-            )
-        }.exceptionOrNull()
+        val result = calculator.calculateProductChangeInfo(
+            sameProductSameBasePlan,
+            defaultProductChangeConfig,
+        )
 
-        assertThat(exception).isInstanceOf(PurchasesException::class.java)
-        assertThat((exception as PurchasesException).code)
-            .isEqualTo(PurchasesErrorCode.ProductAlreadyPurchasedError)
+        assertThat(result).isEqualTo(ProductChangeResult.AlreadySubscribed)
     }
 
     @Test
@@ -200,9 +196,10 @@ class ProductChangeCalculatorTest {
             defaultProductChangeConfig,
         )
 
-        assertThat(result).isNotNull
-        assertThat(result!!.oldProductId).isEqualTo("com.test.subscription.basic")
-        assertThat(result.replacementMode).isEqualTo(StoreReplacementMode.CHARGE_PRORATED_PRICE)
+        assertThat(result).isInstanceOf(ProductChangeResult.Change::class.java)
+        val info = (result as ProductChangeResult.Change).info
+        assertThat(info.oldProductId).isEqualTo("com.test.subscription.basic")
+        assertThat(info.replacementMode).isEqualTo(StoreReplacementMode.CHARGE_PRORATED_PRICE)
     }
 
     @Test
@@ -236,9 +233,10 @@ class ProductChangeCalculatorTest {
             defaultProductChangeConfig,
         )
 
-        assertThat(result).isNotNull
-        assertThat(result!!.oldProductId).isEqualTo("com.test.subscription.premium")
-        assertThat(result.replacementMode).isEqualTo(StoreReplacementMode.DEFERRED)
+        assertThat(result).isInstanceOf(ProductChangeResult.Change::class.java)
+        val info = (result as ProductChangeResult.Change).info
+        assertThat(info.oldProductId).isEqualTo("com.test.subscription.premium")
+        assertThat(info.replacementMode).isEqualTo(StoreReplacementMode.DEFERRED)
     }
 
     @Test
@@ -272,9 +270,10 @@ class ProductChangeCalculatorTest {
             defaultProductChangeConfig,
         )
 
-        assertThat(result).isNotNull
-        assertThat(result!!.oldProductId).isEqualTo("com.test.subscription.basic")
-        assertThat(result.replacementMode).isEqualTo(StoreReplacementMode.CHARGE_PRORATED_PRICE)
+        assertThat(result).isInstanceOf(ProductChangeResult.Change::class.java)
+        val info = (result as ProductChangeResult.Change).info
+        assertThat(info.oldProductId).isEqualTo("com.test.subscription.basic")
+        assertThat(info.replacementMode).isEqualTo(StoreReplacementMode.CHARGE_PRORATED_PRICE)
     }
 
     @Test
@@ -313,8 +312,9 @@ class ProductChangeCalculatorTest {
             customConfig,
         )
 
-        assertThat(result).isNotNull
-        assertThat(result!!.replacementMode).isEqualTo(StoreReplacementMode.CHARGE_FULL_PRICE)
+        assertThat(result).isInstanceOf(ProductChangeResult.Change::class.java)
+        assertThat((result as ProductChangeResult.Change).info.replacementMode)
+            .isEqualTo(StoreReplacementMode.CHARGE_FULL_PRICE)
     }
 
     @Test
@@ -343,12 +343,13 @@ class ProductChangeCalculatorTest {
             defaultProductChangeConfig,
         )
 
-        assertThat(result).isNotNull
-        assertThat(result!!.replacementMode).isEqualTo(StoreReplacementMode.DEFERRED)
+        assertThat(result).isInstanceOf(ProductChangeResult.Change::class.java)
+        assertThat((result as ProductChangeResult.Change).info.replacementMode)
+            .isEqualTo(StoreReplacementMode.DEFERRED)
     }
 
     @Test
-    fun `returns null when exception is thrown`() = runTest {
+    fun `returns NoChange when exception is thrown`() = runTest {
         coEvery { purchases.awaitCustomerInfo() } throws PurchasesException(
             PurchasesError(PurchasesErrorCode.NetworkError, "Network error"),
         )
@@ -364,7 +365,7 @@ class ProductChangeCalculatorTest {
             defaultProductChangeConfig,
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(ProductChangeResult.NoChange)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/ProductChangeCalculatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/ProductChangeCalculatorTest.kt
@@ -115,6 +115,7 @@ class ProductChangeCalculatorTest {
     fun `returns null when purchasing same product with different base plan`() = runTest {
         val activeSubscription = createSubscriptionInfo(
             productIdentifier = "com.test.subscription",
+            productPlanIdentifier = "monthly_plan",
             store = Store.PLAY_STORE,
             isActive = true,
             isSandbox = false,
@@ -135,6 +136,37 @@ class ProductChangeCalculatorTest {
         )
 
         assertThat(result).isNull()
+    }
+
+    @Test
+    fun `throws ProductAlreadyPurchasedError when purchasing same product and base plan`() = runTest {
+        val activeSubscription = createSubscriptionInfo(
+            productIdentifier = "com.test.subscription",
+            productPlanIdentifier = "monthly_plan",
+            store = Store.PLAY_STORE,
+            isActive = true,
+            isSandbox = false,
+        )
+        every { customerInfo.subscriptionsByProductIdentifier } returns mapOf(
+            "com.test.subscription" to activeSubscription,
+        )
+
+        val sameProductSameBasePlan = createSubscriptionPackage(
+            productId = "com.test.subscription:monthly_plan",
+            period = Period(1, Period.Unit.MONTH, "P1M"),
+            priceMicros = 9_990_000,
+        )
+
+        val exception = runCatching {
+            calculator.calculateProductChangeInfo(
+                sameProductSameBasePlan,
+                defaultProductChangeConfig,
+            )
+        }.exceptionOrNull()
+
+        assertThat(exception).isInstanceOf(PurchasesException::class.java)
+        assertThat((exception as PurchasesException).code)
+            .isEqualTo(PurchasesErrorCode.ProductAlreadyPurchasedError)
     }
 
     @Test


### PR DESCRIPTION
[Slack thread](https://revenuecat.slack.com/archives/C093NCRHZ0T/p1782505752177769?thread_ts=1782505752.177769&cid=C093NCRHZ0T)

On an Android paywall with proration modes configured, tapping purchase on a subscription the user already actively owns (same product + same base plan) opens the Google Play billing flow just to fail. The product-change path errors with "One or more of the arguments provided are invalid", and a plain purchase is rejected by Google Play as `ITEM_ALREADY_OWNED`.

After this change the SDK detects this case client-side and surfaces `PurchasesErrorCode.ProductAlreadyPurchasedError` without opening the billing flow at all. The error goes through the normal paywall purchase-error path, so developers already handling purchase errors receive it on the same callback as any real purchase failure.

Note: re-enabling auto-renew on a cancelled-but-still-active subscription is not possible programmatically. Google treats that as a restore, only available via the Play Store Resubscribe button or the server-side API, so erroring out is the correct behavior here.