### PR TITLE
refactor(remote-config): Disable /v1/config for the session on a 4xx response

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -110,8 +110,10 @@ internal typealias WebBillingProductsCallback = Pair<(WebBillingProductsResponse
 internal typealias RewardVerificationResultCallback =
     Pair<(RewardVerificationPollStatus) -> Unit, (RewardVerificationError) -> Unit>
 
-internal typealias RemoteConfigCallback =
-    Pair<(RCContainer?, VerificationResult) -> Unit, (PurchasesError) -> Unit>
+internal typealias RemoteConfigCallback = Pair<
+    (RCContainer?, VerificationResult) -> Unit,
+    (PurchasesError, errorHandlingBehavior: GetRemoteConfigErrorHandlingBehavior) -> Unit,
+    >
 
 @OptIn(InternalRevenueCatAPI::class)
 internal typealias WorkflowDetailCallback = Pair<
@@ -138,6 +140,15 @@ internal enum class GetOfferingsErrorHandlingBehavior {
 internal enum class GetWorkflowsErrorHandlingBehavior {
     SHOULD_FALLBACK_TO_CACHED_WORKFLOWS,
     SHOULD_NOT_FALLBACK,
+}
+
+internal enum class GetRemoteConfigErrorHandlingBehavior {
+    // 5xx, transport, or parse failures: the endpoint may recover, keep retrying on future syncs.
+    SHOULD_RETRY,
+
+    // A 4xx client error: the endpoint intentionally refused the request (bad shape, feature not provisioned,
+    // auth rejection). Stop hitting it for the rest of the session.
+    SHOULD_DISABLE,
 }
 
 @OptIn(InternalRevenueCatAPI::class)
@@ -1317,7 +1328,7 @@ internal class Backend(
         manifest: String?,
         prefetchedBlobs: List<String>,
         onSuccess: (RCContainer?, VerificationResult) -> Unit,
-        onError: (PurchasesError) -> Unit,
+        onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit,
     ) {
         val endpoint = Endpoint.GetRemoteConfig(domain)
         val path = endpoint.getPath()
@@ -1350,7 +1361,8 @@ internal class Backend(
                 synchronized(this@Backend) {
                     remoteConfigCallbacks.remove(cacheKey)
                 }?.forEach { (_, onErrorHandler) ->
-                    onErrorHandler(error)
+                    // Transport/IO failure: no HTTP status, the endpoint may recover on a future sync.
+                    onErrorHandler(error, GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY)
                 }
             }
 
@@ -1371,16 +1383,31 @@ internal class Backend(
                                     PurchasesErrorCode.UnknownError,
                                     "Expected an RC Container Format payload for remote config.",
                                 ).also { errorLog(it) },
+                                // A 2xx with an unexpected payload is not a client error; keep retrying.
+                                GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
                             )
                             return@forEach
                         }
                         try {
                             onSuccessHandler(RCContainer.parse(payload.bytes), result.verificationResult)
                         } catch (e: RCContainerFormatException) {
-                            onErrorHandler(e.toPurchasesError().also { errorLog(it) })
+                            // Parse failure of an otherwise-successful response; keep retrying.
+                            onErrorHandler(
+                                e.toPurchasesError().also { errorLog(it) },
+                                GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+                            )
                         }
                     } else {
-                        onErrorHandler(result.toPurchasesError().also { errorLog(it) })
+                        // A 4xx means the endpoint intentionally refused: disable it for the session. Any other
+                        // non-success (5xx) may recover, so keep retrying.
+                        val isClientError = !RCHTTPStatusCodes.isSuccessful(result.responseCode) &&
+                            !RCHTTPStatusCodes.isServerError(result.responseCode)
+                        val behavior = if (isClientError) {
+                            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE
+                        } else {
+                            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY
+                        }
+                        onErrorHandler(result.toPurchasesError().also { errorLog(it) }, behavior)
                     }
                 }
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -1,9 +1,11 @@
 package com.revenuecat.purchases.common.remoteconfig
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
 import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
@@ -71,6 +73,20 @@ internal class RemoteConfigManager(
     @Volatile
     private var lastRefreshedAt: Date? = null
 
+    // Session-scoped kill-switch. Set when `/v1/config` returns a 4xx (the endpoint intentionally refused the
+    // request). While set, no config request is issued and — since blob prefetch only runs after a successful
+    // persist — no blob fetch happens either. Memory-only: an app restart re-enables the endpoint. Intentionally
+    // NOT reset by clearCache() (a 4xx is an endpoint/app-level fact, not per-user).
+    @Volatile
+    private var unavailable = false
+
+    /**
+     * Whether `/v1/config` has been disabled for this session after a 4xx client error. Consumers can read this
+     * to know the remote config endpoint is not being used. Resets only on app restart.
+     */
+    val isUnavailable: Boolean
+        get() = unavailable
+
     fun refreshRemoteConfigIfStale(appInBackground: Boolean, appUserID: String) {
         if (lastRefreshedAt.isCacheStale(appInBackground, dateProvider)) {
             refreshRemoteConfig(appInBackground, appUserID)
@@ -78,6 +94,10 @@ internal class RemoteConfigManager(
     }
 
     fun refreshRemoteConfig(appInBackground: Boolean, appUserID: String) {
+        if (unavailable) {
+            debugLog { "Remote config is unavailable for this session (4xx). Skipping refresh." }
+            return
+        }
         val requestEpoch: Int
         // Acquire the in-flight guard and capture the epoch together under the lock that also guards
         // clearCache()'s epoch bump + guard release. Otherwise an identity change could slip its bump
@@ -136,12 +156,24 @@ internal class RemoteConfigManager(
                     }
                 }
             },
-            onError = { error ->
-                if (releaseGuardIfOwned(requestEpoch)) {
-                    errorLog(error)
-                }
-            },
+            onError = { error, behavior -> handleRefreshError(requestEpoch, error, behavior) },
         )
+    }
+
+    private fun handleRefreshError(
+        requestEpoch: Int,
+        error: PurchasesError,
+        behavior: GetRemoteConfigErrorHandlingBehavior,
+    ) {
+        if (behavior == GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE) {
+            // A 4xx: disable the endpoint for the rest of the session. This is an endpoint-level fact, so set it
+            // regardless of epoch ownership (a late response for an old identity is still a valid signal that the
+            // endpoint refuses this app's requests).
+            unavailable = true
+        }
+        if (releaseGuardIfOwned(requestEpoch)) {
+            errorLog(error)
+        }
     }
 
     /**
@@ -153,6 +185,8 @@ internal class RemoteConfigManager(
             epoch.incrementAndGet()
             isRefreshing.set(false)
             lastRefreshedAt = null
+            // Intentionally NOT resetting `unavailable`: a 4xx is an endpoint/app-level fact that outlives an
+            // identity change. It clears only on app restart.
             diskCache.clear()
             blobStore.clear()
             sourceProvider.clear()

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -158,7 +158,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
                     verification = verificationResult
                     latch.countDown()
                 },
-                onError = { purchasesError ->
+                onError = { purchasesError, _ ->
                     error = purchasesError
                     latch.countDown()
                 },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.SyncDispatcher
 import com.revenuecat.purchases.common.networking.Endpoint
@@ -100,7 +101,7 @@ class BackendGetRemoteConfigTest {
                 container = result
                 verification = verificationResult
             },
-            onError = { error -> fail("Expected success. Got error: $error") },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
         val parsed = container ?: fail("Expected container to be non-null").let { return }
@@ -116,6 +117,7 @@ class BackendGetRemoteConfigTest {
         mockHttpResult(payload = HTTPResult.Payload.RCFormat("not a container".toByteArray()))
 
         var obtainedError: PurchasesError? = null
+        var obtainedBehavior: GetRemoteConfigErrorHandlingBehavior? = null
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
@@ -123,9 +125,14 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
-            onError = { error -> obtainedError = error },
+            onError = { error, behavior ->
+                obtainedError = error
+                obtainedBehavior = behavior
+            },
         )
         assertThat(obtainedError).isNotNull
+        // A 2xx with an undecodable payload is not a client error; keep retrying.
+        assertThat(obtainedBehavior).isEqualTo(GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY)
     }
 
     @Test
@@ -140,7 +147,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
-            onError = { error -> obtainedError = error },
+            onError = { error, _ -> obtainedError = error },
         )
         assertThat(obtainedError).isNotNull
     }
@@ -167,7 +174,7 @@ class BackendGetRemoteConfigTest {
                 container = result
                 verification = verificationResult
             },
-            onError = { error -> fail("Expected success. Got error: $error") },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
         assertThat(callbackCount).isEqualTo(1)
@@ -187,7 +194,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> },
-            onError = { error -> fail("Expected success. Got error: $error") },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
         val body = bodySlot.firstOrNull()
@@ -228,7 +235,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> },
-            onError = { error -> fail("Expected success. Got error: $error") },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
         assertThat(endpointSlot.captured).isEqualTo(Endpoint.GetRemoteConfig(testDomain))
@@ -247,7 +254,7 @@ class BackendGetRemoteConfigTest {
             manifest = null,
             prefetchedBlobs = emptyList(),
             onSuccess = { _, _ -> },
-            onError = { error -> fail("Expected success. Got error: $error") },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
         val body = bodySlot.firstOrNull()
@@ -256,12 +263,13 @@ class BackendGetRemoteConfigTest {
     }
 
     @Test
-    fun `getRemoteConfig propagates HTTP errors`() {
+    fun `getRemoteConfig propagates HTTP errors and marks a 5xx as retryable`() {
         mockHttpResult(
             responseCode = RCHTTPStatusCodes.ERROR,
             payload = HTTPResult.Payload.Text("""{"code": 7000, "message": "internal error"}"""),
         )
         var obtainedError: PurchasesError? = null
+        var obtainedBehavior: GetRemoteConfigErrorHandlingBehavior? = null
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
@@ -269,9 +277,39 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
-            onError = { error -> obtainedError = error },
+            onError = { error, behavior ->
+                obtainedError = error
+                obtainedBehavior = behavior
+            },
         )
         assertThat(obtainedError).isNotNull
+        // A 5xx may recover, so the endpoint stays enabled for future syncs.
+        assertThat(obtainedBehavior).isEqualTo(GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY)
+    }
+
+    @Test
+    fun `getRemoteConfig marks a 4xx as should-disable`() {
+        mockHttpResult(
+            responseCode = RCHTTPStatusCodes.BAD_REQUEST,
+            payload = HTTPResult.Payload.Text("""{"code": 7000, "message": "bad request"}"""),
+        )
+        var obtainedError: PurchasesError? = null
+        var obtainedBehavior: GetRemoteConfigErrorHandlingBehavior? = null
+        backend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = testAppUserID,
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> fail("Expected error. Got success") },
+            onError = { error, behavior ->
+                obtainedError = error
+                obtainedBehavior = behavior
+            },
+        )
+        assertThat(obtainedError).isNotNull
+        // A 4xx means the endpoint intentionally refused: disable it for the session.
+        assertThat(obtainedBehavior).isEqualTo(GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE)
     }
 
     @Test
@@ -285,7 +323,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> lock.countDown() },
-            onError = { fail("Expected success. Got error: $it") },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
         asyncBackend.getRemoteConfig(
             appInBackground = false,
@@ -294,7 +332,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> lock.countDown() },
-            onError = { fail("Expected success. Got error: $it") },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
         assertThat(lock.count).isEqualTo(0)
@@ -320,7 +358,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> lock.countDown() },
-            onError = { fail("Expected success. Got error: $it") },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
         asyncBackend.getRemoteConfig(
             appInBackground = false,
@@ -329,7 +367,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> lock.countDown() },
-            onError = { fail("Expected success. Got error: $it") },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
         assertThat(lock.count).isEqualTo(0)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerFormatException
 import com.revenuecat.purchases.common.networking.RCElement
@@ -54,7 +55,7 @@ class RemoteConfigManagerTest {
     private var capturedManifest: String? = null
     private var capturedPrefetchedBlobs: List<String>? = null
     private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
-    private lateinit var onError: (PurchasesError) -> Unit
+    private lateinit var onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit
 
     @Before
     fun setup() {
@@ -471,9 +472,66 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        onError.invoke(PurchasesError(PurchasesErrorCode.UnknownError, "boom"))
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownError, "boom"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
 
         verify(exactly = 0) { diskCache.write(any()) }
+    }
+
+    @Test
+    fun `a 4xx disables the endpoint for the session and blocks further refreshes and blob work`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
+
+        assertThat(manager.isUnavailable).isTrue()
+
+        // No further config request and no blob fetch happen for the rest of the session.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { blobFetcher.prefetch(any()) }
+    }
+
+    @Test
+    fun `a retryable error does not disable the endpoint`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        assertThat(manager.isUnavailable).isFalse()
+
+        // The endpoint is still usable, so a subsequent refresh fires.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `clearCache does not re-enable an endpoint disabled by a 4xx`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
+
+        // Identity change: the disable survives (it is an endpoint/app-level fact, not per-user).
+        manager.clearCache()
+
+        assertThat(manager.isUnavailable).isTrue()
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -503,7 +561,10 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        onError.invoke(PurchasesError(PurchasesErrorCode.UnknownError, "boom"))
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownError, "boom"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
 
         verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }


### PR DESCRIPTION
Disables the `/v1/config` remote config endpoint for the rest of the session when the backend returns a 4xx, so no further config requests or blob fetches are made until the app restarts. The disabled state is exposed via `RemoteConfigManager.isUnavailable`.

Android equivalent of https://github.com/RevenueCat/purchases-ios/pull/7118


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the SDK hits `/v1/config` and prefetches blobs for an entire session after client errors; behavior is intentional but affects remote-config-dependent features until restart.
> 
> **Overview**
> Remote config failures now carry an explicit **retry vs disable** signal from `Backend.getRemoteConfig`, aligned with workflows/offerings-style error handling.
> 
> **Backend** classifies errors as `SHOULD_RETRY` (transport, 5xx, bad parse on 2xx) or `SHOULD_DISABLE` (4xx client refusal) and passes that on the `onError` callback via new `GetRemoteConfigErrorHandlingBehavior`.
> 
> **RemoteConfigManager** sets a session-scoped kill-switch on `SHOULD_DISABLE`, exposes **`isUnavailable`**, and skips further `/v1/config` refreshes (and thus blob prefetch) until app restart. **`clearCache()`** does not clear the disable flag—treated as app/endpoint-level, not per-user.
> 
> Unit and integration tests cover 4xx/5xx behavior, retry after transient errors, and disable surviving identity changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cfe71a8e57a5db6f72abdb5413dded1620dfa08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->