### PR TITLE
refactor(remote-config): add RemoteConfigManager read facade (topic/body)

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -279,7 +279,7 @@ internal class PurchasesFactory(
                     backend = backend,
                     diskCache = RemoteConfigDiskCache(contextForStorage),
                     blobStore = RemoteConfigBlobStore(contextForStorage),
-                    // Lets a cold on-demand read self-trigger a sync for the current user (see body()).
+                    // Lets a cold on-demand read self-trigger a sync for the current user (see blobData()).
                     appUserIDProvider = { cache.getCachedAppUserID() },
                 )
             } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -279,6 +279,8 @@ internal class PurchasesFactory(
                     backend = backend,
                     diskCache = RemoteConfigDiskCache(contextForStorage),
                     blobStore = RemoteConfigBlobStore(contextForStorage),
+                    // Lets a cold on-demand read self-trigger a sync for the current user (see body()).
+                    appUserIDProvider = { cache.getCachedAppUserID() },
                 )
             } else {
                 null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -431,6 +431,7 @@ internal class PurchasesOrchestrator(
         }
 
         subscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserID) {
+            remoteConfigManager?.refreshRemoteConfig(state.appInBackground, appUserID)
             getOfferings(receiveOfferingsCallback, fetchCurrent = true)
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -67,18 +67,12 @@ internal class RemoteConfigManager(
     private val blobStore: RemoteConfigBlobStore,
     private val dateProvider: DateProvider = DefaultDateProvider(),
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
-    // The manager owns the threading for its reads: disk-touching read methods hop to this dispatcher, so
-    // callers never read disk on their own thread. Injectable so tests can run reads deterministically.
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-    // The single read seam over the persisted item index: shared by the read facade (topic()/body()) and the
-    // source provider. Synchronous + metadata-only (no blob, no wait); the manager adds the IO hop / wait.
     private val topicStore: RemoteConfigTopicStore =
-        RemoteConfigTopicStore { diskCache.read()?.topics?.get(it) },
+        RemoteConfigTopicStore { diskCache.read()?.topics?.get(it.wireName) },
     private val sourceProvider: RemoteConfigSourceProvider =
         DefaultRemoteConfigSourceProvider(topicStore),
     private val blobFetcher: RemoteConfigBlobFetcher = RemoteConfigBlobFetcher(blobStore, sourceProvider),
-    // The current app user id, used only to self-trigger a sync on a cold read (see [body]). A blank/null result
-    // means "no user yet", so no sync is triggered. Defaults to none so tests never self-trigger unless they opt in.
     private val appUserIDProvider: () -> String? = { null },
 ) {
     private val isRefreshing = AtomicBoolean(false)
@@ -217,7 +211,6 @@ internal class RemoteConfigManager(
             epoch.incrementAndGet()
             isRefreshing.set(false)
             lastRefreshedAt = null
-            // Unblock any read waiting on the refresh we just superseded; it re-reads the now-wiped cache.
             completeRefresh()
             // Intentionally NOT resetting `unavailable`: a 4xx is an endpoint/app-level fact that outlives an
             // identity change. It clears only on app restart.
@@ -247,11 +240,6 @@ internal class RemoteConfigManager(
         owned
     }
 
-    /**
-     * Unblocks any read waiting on the in-flight refresh and clears the handle. Completes (never cancels) so a
-     * waiting [body] resumes and re-reads the committed state rather than throwing. Must be called while holding
-     * [cacheLock] — every call site (terminal refresh points and [clearCache]) already does.
-     */
     private fun completeRefresh() {
         refreshCompletion?.complete(Unit)
         refreshCompletion = null
@@ -267,7 +255,7 @@ internal class RemoteConfigManager(
      * The on-demand sync is issued as foreground (`appInBackground = false`): a read is blocking on the result,
      * so it wants the un-jittered, prompt request.
      */
-    suspend fun awaitConfigForRead() {
+    private suspend fun awaitConfigForRead() {
         if (awaitInFlightRefresh()) return
         // Nothing in flight: trigger a sync on demand, unless the endpoint is disabled or no user is known yet.
         val appUserID = appUserIDProvider()?.takeIf { it.isNotBlank() }
@@ -291,18 +279,18 @@ internal class RemoteConfigManager(
 
     /**
      * A topic's persisted item index (metadata only — inline `content` + `blob_ref`, no blob bytes), or `null`
-     * when the topic is unknown / nothing is cached. Does not wait for an in-flight refresh; use [body] for a
-     * resolved payload that waits and resolves blobs. Reads disk on [ioDispatcher].
+     * when nothing is cached for [topic]. Does not wait for an in-flight refresh; use [body] for a resolved
+     * payload that waits and resolves blobs. Reads disk on [ioDispatcher].
      */
-    suspend fun topic(name: String): ConfigTopic? = withContext(ioDispatcher) {
-        topicStore.topic(name)
+    suspend fun topic(topic: RemoteConfigTopic): ConfigTopic? = withContext(ioDispatcher) {
+        topicStore.topic(topic)
     }
 
     /**
-     * The resolved payload bytes for `itemKey` in `topicName`, or `null` when the item is unknown or its blob
-     * can't be resolved. Owns the inline-vs-`blob_ref` rule: an item with no `blob_ref` returns its inline
-     * `content` bytes; otherwise the referenced blob is resolved on demand (HIGH priority, joining any in-flight
-     * prefetch of the same ref) and read back.
+     * The resolved payload bytes for `itemKey` in [topic], or `null` when the item is unknown or its blob can't
+     * be resolved. Owns the inline-vs-`blob_ref` rule: an item with no `blob_ref` returns its inline `content`
+     * bytes; otherwise the referenced blob is resolved on demand (HIGH priority, joining any in-flight prefetch
+     * of the same ref) and read back.
      *
      * When the item isn't committed yet, [awaitConfigForRead] first waits for a refresh in progress — or triggers
      * one on demand — and then re-reads before giving up, so a read during the initial sync (or before any sync)
@@ -312,11 +300,11 @@ internal class RemoteConfigManager(
      * Short-circuits the network when the endpoint is [isUnavailable] (the 4xx session kill-switch): inline
      * content is still returned, but no on-demand config/blob fetch is attempted. Runs on [ioDispatcher].
      */
-    suspend fun body(topicName: String, itemKey: String): ByteArray? = withContext(ioDispatcher) {
-        val item = topicStore.topic(topicName)?.get(itemKey)
+    suspend fun body(topic: RemoteConfigTopic, itemKey: String): ByteArray? = withContext(ioDispatcher) {
+        val item = topicStore.topic(topic)?.get(itemKey)
             ?: run {
                 awaitConfigForRead()
-                topicStore.topic(topicName)?.get(itemKey)
+                topicStore.topic(topic)?.get(itemKey)
             }
             ?: return@withContext null
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.JsonObject
 import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -52,10 +51,10 @@ import java.util.concurrent.atomic.AtomicInteger
  * would otherwise parse and persist the same response more than once).
  *
  * Consumers read through the facade: [topic] for a topic's committed item index (metadata only, no wait) and
- * [body] for a resolved item payload (inline content or an on-demand blob). Both run on [ioDispatcher] so
- * callers never touch disk on their own thread. When [body] finds no committed data it calls [awaitConfigForRead]
+ * [blobData] for a resolved item's blob payload (fetched on demand). Both run on [ioDispatcher] so callers
+ * never touch disk on their own thread. When [blobData] finds no committed data it calls [awaitConfigForRead]
  * rather than failing — waiting for a refresh in progress, or triggering one on demand when none is (a cold read
- * fetches its own data) — unless the endpoint is [isUnavailable] or no app user is known yet.
+ * fetches its own data) — unless the endpoint is [isDisabled] or no app user is known yet.
  */
 @OptIn(InternalRevenueCatAPI::class)
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -100,14 +99,14 @@ internal class RemoteConfigManager(
     // persist — no blob fetch happens either. Memory-only: an app restart re-enables the endpoint. Intentionally
     // NOT reset by clearCache() (a 4xx is an endpoint/app-level fact, not per-user).
     @Volatile
-    private var unavailable = false
+    private var disabled = false
 
     /**
      * Whether `/v1/config` has been disabled for this session after a 4xx client error. Consumers can read this
      * to know the remote config endpoint is not being used. Resets only on app restart.
      */
-    val isUnavailable: Boolean
-        get() = unavailable
+    val isDisabled: Boolean
+        get() = disabled
 
     fun refreshRemoteConfigIfStale(appInBackground: Boolean, appUserID: String) {
         if (lastRefreshedAt.isCacheStale(appInBackground, dateProvider)) {
@@ -116,8 +115,8 @@ internal class RemoteConfigManager(
     }
 
     fun refreshRemoteConfig(appInBackground: Boolean, appUserID: String) {
-        if (unavailable) {
-            debugLog { "Remote config is unavailable for this session (4xx). Skipping refresh." }
+        if (disabled) {
+            debugLog { "Remote config is disabled for this session (4xx). Skipping refresh." }
             return
         }
         val requestEpoch: Int
@@ -193,7 +192,7 @@ internal class RemoteConfigManager(
             // A 4xx: disable the endpoint for the rest of the session. This is an endpoint-level fact, so set it
             // regardless of epoch ownership (a late response for an old identity is still a valid signal that the
             // endpoint refuses this app's requests).
-            unavailable = true
+            disabled = true
         }
         if (releaseGuardIfOwned(requestEpoch)) {
             errorLog(error)
@@ -210,7 +209,7 @@ internal class RemoteConfigManager(
             isRefreshing.set(false)
             lastRefreshedAt = null
             completeRefresh()
-            // Intentionally NOT resetting `unavailable`: a 4xx is an endpoint/app-level fact that outlives an
+            // Intentionally NOT resetting `disabled`: a 4xx is an endpoint/app-level fact that outlives an
             // identity change. It clears only on app restart.
             diskCache.clear()
             blobStore.clear()
@@ -247,7 +246,7 @@ internal class RemoteConfigManager(
      * Makes a best effort to have the configuration loaded before a read that found no cached data gives up:
      * - a refresh already in progress → wait for it (a read during the initial sync sees its result);
      * - otherwise trigger a sync on demand and wait for it, so a cold read fetches its own data instead of
-     *   returning `null` — **unless** the endpoint is [isUnavailable] (the 4xx session kill-switch) or no app
+     *   returning `null` — **unless** the endpoint is [isDisabled] (the 4xx session kill-switch) or no app
      *   user is known yet, in which case it gives up without a network call.
      *
      * The on-demand sync is issued as foreground (`appInBackground = false`): a read is blocking on the result,
@@ -257,7 +256,7 @@ internal class RemoteConfigManager(
         if (awaitInFlightRefresh()) return
         // Nothing in flight: trigger a sync on demand, unless the endpoint is disabled or no user is known yet.
         val appUserID = appUserIDProvider()?.takeIf { it.isNotBlank() }
-        if (!unavailable && appUserID != null) {
+        if (!disabled && appUserID != null) {
             refreshRemoteConfig(appInBackground = false, appUserID = appUserID)
             // Join whatever is now in flight — the sync we just triggered, or one a concurrent caller started.
             awaitInFlightRefresh()
@@ -276,45 +275,79 @@ internal class RemoteConfigManager(
     }
 
     /**
-     * A topic's persisted item index (metadata only — inline `content` + `blob_ref`, no blob bytes), or `null`
-     * when nothing is cached for [topic]. Does not wait for an in-flight refresh; use [body] for a resolved
-     * payload that waits and resolves blobs. Reads disk on [ioDispatcher].
+     * A topic's persisted item index (metadata only — inline `metadata` + `blob_ref`, no blob bytes), or `null`
+     * when nothing is cached for [topic] or the endpoint is [isDisabled] (the 4xx session kill-switch). Does not
+     * wait for an in-flight refresh; use [blobData] for a resolved payload that waits and resolves blobs. Reads
+     * disk on [ioDispatcher].
      */
     suspend fun topic(topic: RemoteConfigTopic): ConfigTopic? = withContext(ioDispatcher) {
+        if (disabled) return@withContext null
         topicStore.topic(topic)
     }
 
     /**
-     * The resolved payload bytes for `itemKey` in [topic], or `null` when the item is unknown or its blob can't
-     * be resolved. Owns the inline-vs-`blob_ref` rule: an item with no `blob_ref` returns its inline `content`
-     * bytes; otherwise the referenced blob is resolved on demand (HIGH priority, joining any in-flight prefetch
-     * of the same ref) and read back.
-     *
-     * When the item isn't committed yet, [awaitConfigForRead] first waits for a refresh in progress — or triggers
-     * one on demand — and then re-reads before giving up, so a read during the initial sync (or before any sync)
-     * returns fresh data instead of `null`. A committed item returns immediately, never delayed by an unrelated
-     * in-flight refresh.
-     *
-     * Short-circuits the network when the endpoint is [isUnavailable] (the 4xx session kill-switch): inline
-     * content is still returned, but no on-demand config/blob fetch is attempted. Runs on [ioDispatcher].
+     * The resolved blob payload for `itemKey` in [topic], parsed from JSON into [T], or `null` when the item
+     * is unknown, has no `blob_ref`, its blob can't be resolved, or its bytes don't deserialize into [T]. [T]
+     * must be a concrete `@Serializable` type; parsing uses the shared [JsonProvider.defaultJson]. For non-JSON
+     * payloads use the `transform` overload, which also documents the resolution and waiting rules.
      */
-    suspend fun body(topic: RemoteConfigTopic, itemKey: String): ByteArray? = withContext(ioDispatcher) {
-        val item = topicStore.topic(topic)?.get(itemKey)
-            ?: run {
-                awaitConfigForRead()
-                topicStore.topic(topic)?.get(itemKey)
+    suspend inline fun <reified T> blobData(topic: RemoteConfigTopic, itemKey: String): T? =
+        blobData(topic, itemKey) { bytes ->
+            try {
+                JsonProvider.defaultJson.decodeFromString<T>(bytes.decodeToString())
+            } catch (e: SerializationException) {
+                errorLog(e) { "Failed to parse remote config blob for item '$itemKey' as JSON." }
+                null
             }
-            ?: return@withContext null
+        }
 
-        val ref = item.blobRef
-            ?: return@withContext JsonProvider.defaultJson
-                .encodeToString(JsonObject.serializer(), item.content)
-                .encodeToByteArray()
+    /**
+     * Resolves the blob payload bytes for `itemKey` in [topic] and maps them through [transform], or `null`
+     * when the item is unknown or its blob can't be resolved. Use this for non-JSON blobs the caller parses
+     * itself; the reified overload is the JSON convenience built on top of it.
+     *
+     * Owns the `blob_ref` rule: an item with **no** `blob_ref` resolves to `null` (its inline metadata is
+     * exposed only through [topic], never as a payload); otherwise the referenced blob is resolved on demand
+     * (HIGH priority, joining any in-flight prefetch of the same ref) and read back.
+     *
+     * When the item isn't committed yet, [awaitConfigForRead] first waits for a refresh in progress — or
+     * triggers one on demand — and then re-reads before giving up, so a read during the initial sync (or
+     * before any sync) returns fresh data instead of `null`. A committed item returns immediately, never
+     * delayed by an unrelated in-flight refresh.
+     *
+     * Returns `null` without any read when the endpoint is [isDisabled] (the 4xx session kill-switch). Runs on
+     * [ioDispatcher].
+     */
+    suspend fun <T> blobData(
+        topic: RemoteConfigTopic,
+        itemKey: String,
+        transform: (ByteArray) -> T?,
+    ): T? = withContext(ioDispatcher) {
+        resolveBlobBytes(topic, itemKey)?.let(transform)
+    }
 
-        // Blob-backed but the endpoint is disabled for the session: skip the on-demand network fetch.
-        if (unavailable) return@withContext null
+    /**
+     * Resolves an item's referenced-blob bytes, or `null` when the endpoint is [isDisabled], the item is
+     * unknown, or it has no `blob_ref`.
+     */
+    private suspend fun resolveBlobBytes(topic: RemoteConfigTopic, itemKey: String): ByteArray? {
+        if (disabled) return null
+        val ref = committedItem(topic, itemKey)?.blobRef
+        return when {
+            ref == null -> null
+            blobFetcher.ensureDownloaded(ref) -> blobStore.read(ref)
+            else -> null
+        }
+    }
 
-        if (blobFetcher.ensureDownloaded(ref)) blobStore.read(ref) else null
+    /**
+     * The committed item for `itemKey` in [topic], awaiting an in-flight or on-demand refresh once when it
+     * isn't cached yet (see [awaitConfigForRead]), or `null` when it still isn't found.
+     */
+    private suspend fun committedItem(topic: RemoteConfigTopic, itemKey: String): RemoteConfiguration.ConfigItem? {
+        topicStore.topic(topic)?.get(itemKey)?.let { return it }
+        awaitConfigForRead()
+        return topicStore.topic(topic)?.get(itemKey)
     }
 
     private fun persist(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -58,8 +58,6 @@ import java.util.concurrent.atomic.AtomicInteger
  * fetches its own data) — unless the endpoint is [isUnavailable] or no app user is known yet.
  */
 @OptIn(InternalRevenueCatAPI::class)
-// TooManyFunctions: the sync lifecycle and the read facade (topic/body + wait) both live here by design — the
-// manager is the single seam consumer topics read through (see class KDoc).
 @Suppress("LongParameterList", "TooManyFunctions")
 internal class RemoteConfigManager(
     private val backend: Backend,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -219,6 +219,10 @@ internal class RemoteConfigManager(
 
     fun close() {
         scope.cancel()
+        synchronized(cacheLock) {
+            isRefreshing.set(false)
+            completeRefresh()
+        }
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -50,11 +50,11 @@ import java.util.concurrent.atomic.AtomicInteger
  * already in flight is skipped (the backend collapses concurrent requests but still fires every callback, which
  * would otherwise parse and persist the same response more than once).
  *
- * Consumers read through the facade: [topic] for a topic's committed item index (metadata only, no wait) and
- * [blobData] for a resolved item's blob payload (fetched on demand). Both run on [ioDispatcher] so callers
- * never touch disk on their own thread. When [blobData] finds no committed data it calls [awaitConfigForRead]
- * rather than failing — waiting for a refresh in progress, or triggering one on demand when none is (a cold read
- * fetches its own data) — unless the endpoint is [isDisabled] or no app user is known yet.
+ * Consumers read through the facade: [topic] for a topic's committed item index (metadata only) and [blobData]
+ * for a resolved item's blob payload (fetched on demand). Both run on [ioDispatcher] so callers never touch disk
+ * on their own thread. When either read finds no committed data it calls [awaitConfigForRead] rather than
+ * failing — waiting for a refresh in progress, or triggering one on demand when none is (a cold read fetches its
+ * own data) — unless the endpoint is [isDisabled] or no app user is known yet.
  */
 @OptIn(InternalRevenueCatAPI::class)
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -276,12 +276,19 @@ internal class RemoteConfigManager(
 
     /**
      * A topic's persisted item index (metadata only — inline `metadata` + `blob_ref`, no blob bytes), or `null`
-     * when nothing is cached for [topic] or the endpoint is [isDisabled] (the 4xx session kill-switch). Does not
-     * wait for an in-flight refresh; use [blobData] for a resolved payload that waits and resolves blobs. Reads
-     * disk on [ioDispatcher].
+     * when nothing is cached for [topic] even after a refresh, or when the endpoint is [isDisabled] (the 4xx
+     * session kill-switch).
+     *
+     * When the topic isn't committed yet, [awaitConfigForRead] first waits for a refresh in progress — or
+     * triggers one on demand — and then re-reads before giving up, so a read during the initial sync (or before
+     * any sync) returns fresh data instead of `null`, mirroring [blobData]. A committed topic returns
+     * immediately, never delayed by an unrelated in-flight refresh. Use [blobData] for a resolved item payload
+     * that also resolves the referenced blob. Reads disk on [ioDispatcher].
      */
     suspend fun topic(topic: RemoteConfigTopic): ConfigTopic? = withContext(ioDispatcher) {
         if (disabled) return@withContext null
+        topicStore.topic(topic)?.let { return@withContext it }
+        awaitConfigForRead()
         topicStore.topic(topic)
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -6,18 +6,23 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
+import com.revenuecat.purchases.common.JsonProvider
 import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerFormatException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonObject
 import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -45,18 +50,36 @@ import java.util.concurrent.atomic.AtomicInteger
  * Overlapping refreshes are deduped: only one [refreshRemoteConfig] runs at a time. A call made while one is
  * already in flight is skipped (the backend collapses concurrent requests but still fires every callback, which
  * would otherwise parse and persist the same response more than once).
+ *
+ * Consumers read through the facade: [topic] for a topic's committed item index (metadata only, no wait) and
+ * [body] for a resolved item payload (inline content or an on-demand blob). Both run on [ioDispatcher] so
+ * callers never touch disk on their own thread. When [body] finds no committed data it calls [awaitConfigForRead]
+ * rather than failing — waiting for a refresh in progress, or triggering one on demand when none is (a cold read
+ * fetches its own data) — unless the endpoint is [isUnavailable] or no app user is known yet.
  */
 @OptIn(InternalRevenueCatAPI::class)
-@Suppress("LongParameterList")
+// TooManyFunctions: the sync lifecycle and the read facade (topic/body + wait) both live here by design — the
+// manager is the single seam consumer topics read through (see class KDoc).
+@Suppress("LongParameterList", "TooManyFunctions")
 internal class RemoteConfigManager(
     private val backend: Backend,
     private val diskCache: RemoteConfigDiskCache,
     private val blobStore: RemoteConfigBlobStore,
     private val dateProvider: DateProvider = DefaultDateProvider(),
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    // The manager owns the threading for its reads: disk-touching read methods hop to this dispatcher, so
+    // callers never read disk on their own thread. Injectable so tests can run reads deterministically.
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    // The single read seam over the persisted item index: shared by the read facade (topic()/body()) and the
+    // source provider. Synchronous + metadata-only (no blob, no wait); the manager adds the IO hop / wait.
+    private val topicStore: RemoteConfigTopicStore =
+        RemoteConfigTopicStore { diskCache.read()?.topics?.get(it) },
     private val sourceProvider: RemoteConfigSourceProvider =
-        DefaultRemoteConfigSourceProvider({ diskCache.read()?.topics?.get(it) }),
+        DefaultRemoteConfigSourceProvider(topicStore),
     private val blobFetcher: RemoteConfigBlobFetcher = RemoteConfigBlobFetcher(blobStore, sourceProvider),
+    // The current app user id, used only to self-trigger a sync on a cold read (see [body]). A blank/null result
+    // means "no user yet", so no sync is triggered. Defaults to none so tests never self-trigger unless they opt in.
+    private val appUserIDProvider: () -> String? = { null },
 ) {
     private val isRefreshing = AtomicBoolean(false)
 
@@ -72,6 +95,13 @@ internal class RemoteConfigManager(
 
     @Volatile
     private var lastRefreshedAt: Date? = null
+
+    // Completion signal for the single in-flight refresh, so a read that finds no cached data can wait for the
+    // refresh already in progress instead of failing. Created under [cacheLock] when a refresh starts, completed
+    // (never cancelled, so waiting reads never throw) at every terminal point and by clearCache(); null when no
+    // refresh is in flight. isRefreshing keeps its skip semantics; this only adds an awaitable handle.
+    @Volatile
+    private var refreshCompletion: CompletableDeferred<Unit>? = null
 
     // Session-scoped kill-switch. Set when `/v1/config` returns a 4xx (the endpoint intentionally refused the
     // request). While set, no config request is issued and — since blob prefetch only runs after a successful
@@ -109,6 +139,7 @@ internal class RemoteConfigManager(
                 return
             }
             requestEpoch = epoch.get()
+            refreshCompletion = CompletableDeferred()
         }
         val persisted = diskCache.read()
         val storedBlobs = blobStore.cachedRefs()
@@ -132,6 +163,7 @@ internal class RemoteConfigManager(
                         if (epoch.get() == requestEpoch) {
                             lastRefreshedAt = dateProvider.now
                             isRefreshing.set(false)
+                            completeRefresh()
                         }
                     }
                     return@getRemoteConfig
@@ -185,6 +217,8 @@ internal class RemoteConfigManager(
             epoch.incrementAndGet()
             isRefreshing.set(false)
             lastRefreshedAt = null
+            // Unblock any read waiting on the refresh we just superseded; it re-reads the now-wiped cache.
+            completeRefresh()
             // Intentionally NOT resetting `unavailable`: a 4xx is an endpoint/app-level fact that outlives an
             // identity change. It clears only on app restart.
             diskCache.clear()
@@ -206,8 +240,95 @@ internal class RemoteConfigManager(
      */
     private fun releaseGuardIfOwned(requestEpoch: Int): Boolean = synchronized(cacheLock) {
         val owned = epoch.get() == requestEpoch
-        if (owned) isRefreshing.set(false)
+        if (owned) {
+            isRefreshing.set(false)
+            completeRefresh()
+        }
         owned
+    }
+
+    /**
+     * Unblocks any read waiting on the in-flight refresh and clears the handle. Completes (never cancels) so a
+     * waiting [body] resumes and re-reads the committed state rather than throwing. Must be called while holding
+     * [cacheLock] — every call site (terminal refresh points and [clearCache]) already does.
+     */
+    private fun completeRefresh() {
+        refreshCompletion?.complete(Unit)
+        refreshCompletion = null
+    }
+
+    /**
+     * Makes a best effort to have the configuration loaded before a read that found no cached data gives up:
+     * - a refresh already in progress → wait for it (a read during the initial sync sees its result);
+     * - otherwise trigger a sync on demand and wait for it, so a cold read fetches its own data instead of
+     *   returning `null` — **unless** the endpoint is [isUnavailable] (the 4xx session kill-switch) or no app
+     *   user is known yet, in which case it gives up without a network call.
+     *
+     * The on-demand sync is issued as foreground (`appInBackground = false`): a read is blocking on the result,
+     * so it wants the un-jittered, prompt request.
+     */
+    suspend fun awaitConfigForRead() {
+        if (awaitInFlightRefresh()) return
+        // Nothing in flight: trigger a sync on demand, unless the endpoint is disabled or no user is known yet.
+        val appUserID = appUserIDProvider()?.takeIf { it.isNotBlank() }
+        if (!unavailable && appUserID != null) {
+            refreshRemoteConfig(appInBackground = false, appUserID = appUserID)
+            // Join whatever is now in flight — the sync we just triggered, or one a concurrent caller started.
+            awaitInFlightRefresh()
+        }
+    }
+
+    /**
+     * Suspends until the refresh already in progress finishes; returns `true` if there was one to await, `false`
+     * when none was in flight. The handle is captured under [cacheLock] but awaited outside it, so this never
+     * holds the lock across suspension.
+     */
+    private suspend fun awaitInFlightRefresh(): Boolean {
+        val completion = synchronized(cacheLock) { refreshCompletion } ?: return false
+        completion.await()
+        return true
+    }
+
+    /**
+     * A topic's persisted item index (metadata only — inline `content` + `blob_ref`, no blob bytes), or `null`
+     * when the topic is unknown / nothing is cached. Does not wait for an in-flight refresh; use [body] for a
+     * resolved payload that waits and resolves blobs. Reads disk on [ioDispatcher].
+     */
+    suspend fun topic(name: String): ConfigTopic? = withContext(ioDispatcher) {
+        topicStore.topic(name)
+    }
+
+    /**
+     * The resolved payload bytes for `itemKey` in `topicName`, or `null` when the item is unknown or its blob
+     * can't be resolved. Owns the inline-vs-`blob_ref` rule: an item with no `blob_ref` returns its inline
+     * `content` bytes; otherwise the referenced blob is resolved on demand (HIGH priority, joining any in-flight
+     * prefetch of the same ref) and read back.
+     *
+     * When the item isn't committed yet, [awaitConfigForRead] first waits for a refresh in progress — or triggers
+     * one on demand — and then re-reads before giving up, so a read during the initial sync (or before any sync)
+     * returns fresh data instead of `null`. A committed item returns immediately, never delayed by an unrelated
+     * in-flight refresh.
+     *
+     * Short-circuits the network when the endpoint is [isUnavailable] (the 4xx session kill-switch): inline
+     * content is still returned, but no on-demand config/blob fetch is attempted. Runs on [ioDispatcher].
+     */
+    suspend fun body(topicName: String, itemKey: String): ByteArray? = withContext(ioDispatcher) {
+        val item = topicStore.topic(topicName)?.get(itemKey)
+            ?: run {
+                awaitConfigForRead()
+                topicStore.topic(topicName)?.get(itemKey)
+            }
+            ?: return@withContext null
+
+        val ref = item.blobRef
+            ?: return@withContext JsonProvider.defaultJson
+                .encodeToString(JsonObject.serializer(), item.content)
+                .encodeToByteArray()
+
+        // Blob-backed but the endpoint is disabled for the session: skip the on-demand network fetch.
+        if (unavailable) return@withContext null
+
+        if (blobFetcher.ensureDownloaded(ref)) blobStore.read(ref) else null
     }
 
     private fun persist(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
@@ -214,7 +214,7 @@ internal class DefaultRemoteConfigSourceProvider(
          * entry's url from [urlKey] (`url` for api, `url_format` for blob). Malformed entries are skipped.
          */
         fun parseSources(topic: ConfigTopic?, itemKey: String, urlKey: String): List<RemoteConfigSource> {
-            val entries = topic?.get(itemKey)?.content?.get(SOURCES_KEY) as? JsonArray ?: return emptyList()
+            val entries = topic?.get(itemKey)?.metadata?.get(SOURCES_KEY) as? JsonArray ?: return emptyList()
             return entries.mapNotNull { element ->
                 val obj = element as? JsonObject ?: return@mapNotNull null
                 val url = obj.string(urlKey) ?: return@mapNotNull null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
@@ -152,7 +152,7 @@ internal class DefaultRemoteConfigSourceProvider(
      * a rebuild happened. Callers must hold [lock].
      */
     private fun rebuildIfChanged(): Boolean {
-        val topic = topicStore.topic(SOURCES_TOPIC)
+        val topic = topicStore.topic(RemoteConfigTopic.Sources)
         if (topic?.contentHash == builtHash) return false
         rebuild(topic)
         return true
@@ -179,7 +179,6 @@ internal class DefaultRemoteConfigSourceProvider(
     }
 
     private companion object {
-        private const val SOURCES_TOPIC = "sources"
         private const val API_ITEM = "api"
         private const val BLOB_ITEM = "blob"
         private const val SOURCES_KEY = "sources"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigTopic.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigTopic.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+/**
+ * The remote-config topics the SDK can read through [RemoteConfigManager]. Restricting reads to this closed set
+ * keeps consumers from requesting arbitrary (or misspelled) topic names.
+ *
+ * [wireName] is the key the backend uses in the response's `active_topics` and `topics` map, and the key under
+ * which the item index is persisted — the manager maps a [RemoteConfigTopic] to it when reading. The sync/persist
+ * path itself stays topic-agnostic (string-keyed), so unknown server topics are still stored and forwarded.
+ */
+internal enum class RemoteConfigTopic(val wireName: String) {
+    Workflows("workflows"),
+    UiConfig("ui_config"),
+    Sources("sources"),
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigTopicStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigTopicStore.kt
@@ -2,6 +2,9 @@ package com.revenuecat.purchases.common.remoteconfig
 
 /** Read-only access to a topic's persisted item index (metadata only — no blob bytes, no waiting). */
 internal fun interface RemoteConfigTopicStore {
-    /** The saved items for [name], or `null` when the topic is unknown / nothing has been persisted yet. */
-    fun topic(name: String): ConfigTopic?
+    /**
+     * The saved items for [topic], or `null` when nothing has been persisted for it yet. Implementations map the
+     * [RemoteConfigTopic] to its [RemoteConfigTopic.wireName] to look it up in the string-keyed disk cache.
+     */
+    fun topic(topic: RemoteConfigTopic): ConfigTopic?
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
@@ -55,17 +55,15 @@ internal data class RemoteConfiguration(
     /**
      * A single item within a topic. An item is arbitrary, topic-specific JSON; [blobRef] and [prefetch] are
      * the only reserved conventions the SDK interprets, and every other key is preserved verbatim in
-     * [content].
+     * [metadata].
      *
-     * An item's payload arrives one of two ways, chosen by the server per response:
-     * - **inline**: [blobRef] is `null` and the payload is the topic-specific JSON in [content]
-     *   (e.g. a `sources` `api`/`blob` descriptor, or an inline `product_entitlement_mapping` entry).
-     * - **by reference**: [blobRef] is set and the payload lives in an external blob to fetch/read by that
-     *   ref; [content] then holds only whatever extra inline keys (if any) accompanied the reference.
+     * An item's payload lives in an external blob addressed by [blobRef]; [metadata] holds any inline keys
+     * (other than the reserved [blobRef]/[prefetch]) that accompanied the item. Reads go through
+     * `RemoteConfigManager.blobData`, which resolves the referenced blob and returns `null` when [blobRef] is
+     * absent — inline [metadata] is exposed only as the topic's item index, never as a payload.
      *
-     * Topic handlers resolve the payload as `blobRef?.let { read+parse blob } ?: content`, so both modes work
-     * for any topic. Unknown reserved keys are not a concern: anything that is not [blobRef]/[prefetch] is
-     * kept in [content], keeping the SDK forward-compatible.
+     * Unknown reserved keys are not a concern: anything that is not [blobRef]/[prefetch] is kept in
+     * [metadata], keeping the SDK forward-compatible.
      */
     @Serializable(with = ConfigItemSerializer::class)
     internal data class ConfigItem(
@@ -73,8 +71,8 @@ internal data class RemoteConfiguration(
         val blobRef: String? = null,
         /** When `true`, the SDK should proactively cache this item's blob. */
         val prefetch: Boolean = false,
-        /** The topic-specific item content (all keys except the reserved [blobRef]/[prefetch]). */
-        val content: JsonObject = JsonObject(emptyMap()),
+        /** The topic-specific item metadata (all keys except the reserved [blobRef]/[prefetch]). */
+        val metadata: JsonObject = JsonObject(emptyMap()),
     )
 
     companion object {
@@ -146,7 +144,7 @@ internal object ConfigTopicSerializer : KSerializer<ConfigTopic> {
 
 /**
  * Serializes [RemoteConfiguration.ConfigItem] as a flat JSON object: the reserved keys `blob_ref`/`prefetch`
- * plus every key of [RemoteConfiguration.ConfigItem.content], so arbitrary inline item content survives a
+ * plus every key of [RemoteConfiguration.ConfigItem.metadata], so arbitrary inline item metadata survives a
  * parse -> persist -> parse round-trip.
  */
 internal object ConfigItemSerializer : KSerializer<RemoteConfiguration.ConfigItem> {
@@ -161,15 +159,15 @@ internal object ConfigItemSerializer : KSerializer<RemoteConfiguration.ConfigIte
         val obj = jsonDecoder.decodeJsonElement().jsonObject
         val blobRef = (obj[BLOB_REF_KEY] as? JsonPrimitive)?.takeIf { it.isString }?.content
         val prefetch = (obj[PREFETCH_KEY] as? JsonPrimitive)?.booleanOrNull ?: false
-        val content = JsonObject(obj.filterKeys { it != BLOB_REF_KEY && it != PREFETCH_KEY })
-        return RemoteConfiguration.ConfigItem(blobRef = blobRef, prefetch = prefetch, content = content)
+        val metadata = JsonObject(obj.filterKeys { it != BLOB_REF_KEY && it != PREFETCH_KEY })
+        return RemoteConfiguration.ConfigItem(blobRef = blobRef, prefetch = prefetch, metadata = metadata)
     }
 
     override fun serialize(encoder: Encoder, value: RemoteConfiguration.ConfigItem) {
         val jsonEncoder = encoder as? JsonEncoder
             ?: error("ConfigItem can only be serialized to JSON.")
         val merged = buildMap<String, JsonElement> {
-            putAll(value.content)
+            putAll(value.metadata)
             value.blobRef?.let { put(BLOB_REF_KEY, JsonPrimitive(it)) }
             if (value.prefetch) put(PREFETCH_KEY, JsonPrimitive(true))
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.google.toInAppStoreProduct
 import com.revenuecat.purchases.google.toStoreProduct
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
+import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback
 import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
 import com.revenuecat.purchases.models.Period
@@ -2930,6 +2931,27 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         purchases.purchasesOrchestrator.onAppForegrounded()
         verify(exactly = 1) {
             mockPostPendingTransactionsHelper.syncPendingPurchaseQueue(any(), any())
+        }
+    }
+
+    @Test
+    fun `syncAttributesAndOfferingsIfNeeded refreshes remote config`() {
+        every {
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserId, captureLambda())
+        } answers { lambda<() -> Unit>().captured.invoke() }
+        every {
+            mockOfferingsManager.getOfferings(appUserId, false, any(), any(), fetchCurrent = true)
+        } just Runs
+
+        purchases.purchasesOrchestrator.syncAttributesAndOfferingsIfNeeded(
+            object : SyncAttributesAndOfferingsCallback {
+                override fun onSuccess(offerings: Offerings) {}
+                override fun onError(error: PurchasesError) {}
+            },
+        )
+
+        verify(exactly = 1) {
+            mockRemoteConfigManager.refreshRemoteConfig(false, appUserId)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -1,20 +1,42 @@
 package com.revenuecat.purchases.backend_integration_tests
 
+import android.content.Context
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.JsonProvider
 import com.revenuecat.purchases.common.networking.RCContainer
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobFetcher
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
+import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.jsonObject
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Test
+import java.io.File
+import kotlin.time.Duration.Companion.seconds
 
 internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTest() {
     override fun apiKey() = Constants.apiKey
+
+    private val testFolder = "temp_production_remote_config_integration_test_folder"
+
+    private lateinit var remoteConfigBlobStore: RemoteConfigBlobStore
+
+    @After
+    fun tearDownRemoteConfigStorage() {
+        File(testFolder).deleteRecursively()
+    }
 
     @Test
     fun `can fetch remote config`() {
@@ -81,6 +103,42 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         val decodedBytes = ByteArray(decodedView.remaining()).also { decodedView.get(it) }
         val json = JsonProvider.defaultJson.parseToJsonElement(decodedBytes.decodeToString())
         assertThat(json.jsonObject).isNotEmpty()
+    }
+
+    @Test
+    fun `fetches, persists and reads an inlined workflows blob back through the manager facade`() {
+        setupTest(SignatureVerificationMode.Informational())
+        every { appConfig.isDebugBuild } returns false
+        val manager = buildRemoteConfigManager()
+
+        // A cold read finds nothing cached, so through the facade it triggers a real /v1/config fetch, persists
+        // the whole config to disk (extracting inline blobs into the blob store), and only then resolves. The
+        // sources "api" item is a stable inline item, so this both drives the end-to-end fetch -> persist and
+        // returns non-null, leaving every active topic committed on disk for the reads below.
+        val sourcesBody = runBlocking {
+            withTimeout(FETCH_TIMEOUT) { manager.body(RemoteConfigTopic.Sources, "api") }
+        }
+        assertThat(sourcesBody).isNotNull
+
+        // topic(): the workflows item index is now served from the real on-disk cache through the facade.
+        val workflows = requireNotNull(runBlocking { manager.topic(RemoteConfigTopic.Workflows) }) {
+            "Expected a workflows topic after the sync."
+        }
+
+        // Pick a workflows item whose blob the backend inlined and the manager extracted to disk during persist.
+        val (itemKey, ref) = requireNotNull(
+            workflows.entries.firstNotNullOfOrNull { (key, item) ->
+                item.blobRef?.takeIf { remoteConfigBlobStore.contains(it) }?.let { key to it }
+            },
+        ) { "Expected a workflows item with an inlined blob stored on disk." }
+
+        // body(): resolves the blob-backed item off disk through the facade (no network: it is already cached).
+        val body = runBlocking { manager.body(RemoteConfigTopic.Workflows, itemKey) }
+        assertThat(body).isNotNull
+        assertThat(body).isEqualTo(remoteConfigBlobStore.read(ref))
+        // The bytes are real, structured content (a non-empty JSON object), not garbage.
+        val json = JsonProvider.defaultJson.parseToJsonElement(body!!.decodeToString()).jsonObject
+        assertThat(json).isNotEmpty()
     }
 
     @Test
@@ -165,5 +223,34 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
             )
         }
         return Triple(error, container, verification)
+    }
+
+    /**
+     * Builds a [RemoteConfigManager] wired to the real [backend] and backed by the real [RemoteConfigDiskCache] +
+     * [RemoteConfigBlobStore] on a temp folder, so a read exercises the full fetch -> persist -> disk -> read path.
+     *
+     * Only the blob fetcher's network layer is kept out: it is unit-tested elsewhere, and these reads only touch a
+     * blob the real backend inlined and the manager extracted to disk, so [RemoteConfigBlobFetcher.ensureDownloaded]
+     * resolves from the store (its real short-circuit for an already-cached ref) with no CDN call, and prefetch is
+     * a no-op.
+     */
+    private fun buildRemoteConfigManager(): RemoteConfigManager {
+        val context = mockk<Context>()
+        every { context.noBackupFilesDir } returns File(testFolder).apply { mkdirs() }
+        remoteConfigBlobStore = RemoteConfigBlobStore(context)
+        val blobFetcher = mockk<RemoteConfigBlobFetcher>(relaxed = true)
+        coEvery { blobFetcher.ensureDownloaded(any<String>()) } answers { remoteConfigBlobStore.contains(firstArg()) }
+        return RemoteConfigManager(
+            backend = backend,
+            diskCache = RemoteConfigDiskCache(context),
+            blobStore = remoteConfigBlobStore,
+            blobFetcher = blobFetcher,
+            appUserIDProvider = { REMOTE_CONFIG_USER },
+        )
+    }
+
+    private companion object {
+        private const val REMOTE_CONFIG_USER = "integrationTestRemoteConfigUser"
+        private val FETCH_TIMEOUT = 15.seconds
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -113,12 +113,11 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
 
         // A cold read finds nothing cached, so through the facade it triggers a real /v1/config fetch, persists
         // the whole config to disk (extracting inline blobs into the blob store), and only then resolves. The
-        // sources "api" item is a stable inline item, so this both drives the end-to-end fetch -> persist and
-        // returns non-null, leaving every active topic committed on disk for the reads below.
-        val sourcesBody = runBlocking {
-            withTimeout(FETCH_TIMEOUT) { manager.body(RemoteConfigTopic.Sources, "api") }
+        // sources "api" item has no blob_ref, so it resolves to null, but the read still drives the end-to-end
+        // fetch -> persist, leaving every active topic committed on disk for the reads below.
+        runBlocking {
+            withTimeout(FETCH_TIMEOUT) { manager.blobData(RemoteConfigTopic.Sources, "api") { it } }
         }
-        assertThat(sourcesBody).isNotNull
 
         // topic(): the workflows item index is now served from the real on-disk cache through the facade.
         val workflows = requireNotNull(runBlocking { manager.topic(RemoteConfigTopic.Workflows) }) {
@@ -132,8 +131,8 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
             },
         ) { "Expected a workflows item with an inlined blob stored on disk." }
 
-        // body(): resolves the blob-backed item off disk through the facade (no network: it is already cached).
-        val body = runBlocking { manager.body(RemoteConfigTopic.Workflows, itemKey) }
+        // blobData(): resolves the blob-backed item off disk through the facade (no network: it is already cached).
+        val body = runBlocking { manager.blobData(RemoteConfigTopic.Workflows, itemKey) { it } }
         assertThat(body).isNotNull
         assertThat(body).isEqualTo(remoteConfigBlobStore.read(ref))
         // The bytes are real, structured content (a non-empty JSON object), not garbage.

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -17,6 +17,8 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.jsonObject
@@ -139,6 +141,51 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         val json = JsonProvider.defaultJson.parseToJsonElement(body!!.decodeToString()).jsonObject
         assertThat(json).isNotEmpty()
     }
+
+    @Test
+    fun `reads and deserializes a workflows blob into a typed value through the facade`() {
+        setupTest(SignatureVerificationMode.Informational())
+        every { appConfig.isDebugBuild } returns false
+        val manager = buildRemoteConfigManager()
+
+        // A cold read drives the real /v1/config fetch -> persist, committing every active topic (and its
+        // inlined blobs) to disk. topic() does not itself wait for a refresh, so this priming read is what
+        // makes the workflows index below available off disk.
+        runBlocking {
+            withTimeout(FETCH_TIMEOUT) { manager.blobData(RemoteConfigTopic.Sources, "api") { it } }
+        }
+
+        val workflows = requireNotNull(runBlocking { manager.topic(RemoteConfigTopic.Workflows) }) {
+            "Expected a workflows topic after the sync."
+        }
+
+        // Pick a workflows item whose blob the backend inlined and the manager extracted to disk during persist.
+        val itemKey = requireNotNull(
+            workflows.entries.firstNotNullOfOrNull { (key, item) ->
+                key.takeIf { item.blobRef?.let(remoteConfigBlobStore::contains) == true }
+            },
+        ) { "Expected a workflows item with an inlined blob stored on disk." }
+
+        // The reified facade resolves the blob off disk and deserializes it into a concrete @Serializable type.
+        // We use a minimal test-only type (not the full PublishedWorkflow) because the shared defaultJson used by
+        // the reified overload can't decode the full workflow's polymorphic component tree, and these lazy paywall
+        // workflows carry no ui_config; a small subset over the stable top-level fields exercises the typed path.
+        val workflow = runBlocking { manager.blobData<TestWorkflowBlob>(RemoteConfigTopic.Workflows, itemKey) }
+
+        assertThat(workflow).isNotNull
+        assertThat(workflow!!.id).isNotEmpty()
+        assertThat(workflow.displayName).isNotEmpty()
+        assertThat(workflow.initialStepId).isNotEmpty()
+    }
+
+    // A minimal projection of a workflows blob's stable top-level fields, used only to exercise the reified
+    // blobData<T> deserialization path. Extra keys (screens, steps, metadata, ...) are ignored by defaultJson.
+    @Serializable
+    private data class TestWorkflowBlob(
+        val id: String,
+        @SerialName("display_name") val displayName: String,
+        @SerialName("initial_step_id") val initialStepId: String,
+    )
 
     @Test
     fun `replaying the manifest returns no content`() {

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -16,7 +16,6 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.MapSerializer
@@ -26,7 +25,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Test
 import java.io.File
-import kotlin.time.Duration.Companion.seconds
 
 internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTest() {
     override fun apiKey() = Constants.apiKey
@@ -113,15 +111,6 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         every { appConfig.isDebugBuild } returns false
         val manager = buildRemoteConfigManager()
 
-        // A cold read finds nothing cached, so through the facade it triggers a real /v1/config fetch, persists
-        // the whole config to disk (extracting inline blobs into the blob store), and only then resolves. The
-        // sources "api" item has no blob_ref, so it resolves to null, but the read still drives the end-to-end
-        // fetch -> persist, leaving every active topic committed on disk for the reads below.
-        runBlocking {
-            withTimeout(FETCH_TIMEOUT) { manager.blobData(RemoteConfigTopic.Sources, "api") { it } }
-        }
-
-        // topic(): the workflows item index is now served from the real on-disk cache through the facade.
         val workflows = requireNotNull(runBlocking { manager.topic(RemoteConfigTopic.Workflows) }) {
             "Expected a workflows topic after the sync."
         }
@@ -147,13 +136,6 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         setupTest(SignatureVerificationMode.Informational())
         every { appConfig.isDebugBuild } returns false
         val manager = buildRemoteConfigManager()
-
-        // A cold read drives the real /v1/config fetch -> persist, committing every active topic (and its
-        // inlined blobs) to disk. topic() does not itself wait for a refresh, so this priming read is what
-        // makes the workflows index below available off disk.
-        runBlocking {
-            withTimeout(FETCH_TIMEOUT) { manager.blobData(RemoteConfigTopic.Sources, "api") { it } }
-        }
 
         val workflows = requireNotNull(runBlocking { manager.topic(RemoteConfigTopic.Workflows) }) {
             "Expected a workflows topic after the sync."
@@ -297,6 +279,5 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
 
     private companion object {
         private const val REMOTE_CONFIG_USER = "integrationTestRemoteConfigUser"
-        private val FETCH_TIMEOUT = 15.seconds
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -384,7 +384,7 @@ class RemoteConfigBlobFetcherTest {
     private fun sourcesTopic(blob: List<RemoteConfigSource>): ConfigTopic = ConfigTopic(
         mapOf(
             "blob" to RemoteConfiguration.ConfigItem(
-                content = buildJsonObject {
+                metadata = buildJsonObject {
                     putJsonArray("sources") {
                         blob.forEach { s ->
                             addJsonObject {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -442,7 +442,8 @@ class RemoteConfigBlobFetcherTest {
     }
 
     private class FakeTopicStore(private val sources: ConfigTopic?) : RemoteConfigTopicStore {
-        override fun topic(name: String): ConfigTopic? = if (name == "sources") sources else null
+        override fun topic(topic: RemoteConfigTopic): ConfigTopic? =
+            if (topic == RemoteConfigTopic.Sources) sources else null
     }
 
     /** Deterministic randomizer for weighted source selection: always returns the first candidate. */

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
@@ -85,7 +85,7 @@ class RemoteConfigDiskCacheTest {
                 "sources" to ConfigTopic(
                     mapOf(
                         "api" to RemoteConfiguration.ConfigItem(
-                            content = buildJsonObject { put("url", "https://api.revenuecat.com") },
+                            metadata = buildJsonObject { put("url", "https://api.revenuecat.com") },
                         ),
                     ),
                 ),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
@@ -6,7 +6,6 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
-import com.revenuecat.purchases.common.JsonProvider
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerTestData
 import com.revenuecat.purchases.common.networking.RCContentEncoding
@@ -16,7 +15,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.serialization.json.JsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -113,8 +111,8 @@ class RemoteConfigManagerIntegrationTest {
         assertThat(persisted.prefetchBlobs).containsExactly(ref)
         assertThat(persisted.topics).containsOnlyKeys("workflows")
         assertThat(persisted.topics["workflows"]!!.values.mapNotNull { it.blobRef }).containsExactly(ref)
-        // The full config is the source of truth: the item's inline content is persisted too, not just its ref.
-        assertThat(persisted.topics["workflows"]!!["wf1234"]!!.content).containsKey("offering_identifier")
+        // The full config is the source of truth: the item's inline metadata is persisted too, not just its ref.
+        assertThat(persisted.topics["workflows"]!!["wf1234"]!!.metadata).containsKey("offering_identifier")
         assertThat(blobStore.contains(ref)).isTrue
         assertThat(blobStore.read(ref)).isEqualTo(blob)
     }
@@ -272,8 +270,8 @@ class RemoteConfigManagerIntegrationTest {
     }
 
     @Test
-    fun `a synced inline item is readable through the topic and body facade`() {
-        // An inline-only item: its payload lives in the config's inline content, persisted to disk, no blob.
+    fun `a synced inline item exposes its metadata via topic but resolves to no blob payload`() {
+        // An inline-only item: its metadata is persisted to disk, but it carries no blob_ref.
         val config = workflowsConfig(items = mapOf("wf1234" to null))
 
         sync(container(config))
@@ -281,15 +279,11 @@ class RemoteConfigManagerIntegrationTest {
         // topic(): the committed item index is served from the real disk cache through the facade.
         val topic = runBlocking { manager.topic(RemoteConfigTopic.Workflows) }
         assertThat(topic).isNotNull
-        assertThat(topic!!["wf1234"]!!.content).containsKey("offering_identifier")
+        assertThat(topic!!["wf1234"]!!.metadata).containsKey("offering_identifier")
 
-        // body(): an item with no blob_ref returns its inline content bytes (JsonObject -> UTF-8) off disk,
-        // never touching the blob fetcher/store.
-        val body = runBlocking { manager.body(RemoteConfigTopic.Workflows, "wf1234") }
-        val expected = JsonProvider.defaultJson
-            .encodeToString(JsonObject.serializer(), topic["wf1234"]!!.content)
-            .encodeToByteArray()
-        assertThat(body).isEqualTo(expected)
+        // blobData(): an item with no blob_ref has no payload, so it resolves to null off disk.
+        val body = runBlocking { manager.blobData(RemoteConfigTopic.Workflows, "wf1234") { it } }
+        assertThat(body).isNull()
     }
 
     /** Builds a workflows-topic config. Each item maps an item key to its `blob_ref`, or `null` for inline-only. */

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.JsonProvider
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerTestData
 import com.revenuecat.purchases.common.networking.RCContentEncoding
@@ -13,7 +14,9 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.serialization.json.JsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -266,6 +269,27 @@ class RemoteConfigManagerIntegrationTest {
         assertThat(topics["workflows"]!!["wf1234"]!!.blobRef).isNull()
         assertThat(topics["workflows"]!!.values.mapNotNull { it.blobRef }).isEmpty()
         assertThat(blobStore.cachedRefs()).isEmpty()
+    }
+
+    @Test
+    fun `a synced inline item is readable through the topic and body facade`() {
+        // An inline-only item: its payload lives in the config's inline content, persisted to disk, no blob.
+        val config = workflowsConfig(items = mapOf("wf1234" to null))
+
+        sync(container(config))
+
+        // topic(): the committed item index is served from the real disk cache through the facade.
+        val topic = runBlocking { manager.topic(RemoteConfigTopic.Workflows) }
+        assertThat(topic).isNotNull
+        assertThat(topic!!["wf1234"]!!.content).containsKey("offering_identifier")
+
+        // body(): an item with no blob_ref returns its inline content bytes (JsonObject -> UTF-8) off disk,
+        // never touching the blob fetcher/store.
+        val body = runBlocking { manager.body(RemoteConfigTopic.Workflows, "wf1234") }
+        val expected = JsonProvider.defaultJson
+            .encodeToString(JsonObject.serializer(), topic["wf1234"]!!.content)
+            .encodeToByteArray()
+        assertThat(body).isEqualTo(expected)
     }
 
     /** Builds a workflows-topic config. Each item maps an item key to its `blob_ref`, or `null` for inline-only. */

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat
@@ -798,6 +799,26 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `reified blobData fetches the blob on demand then deserializes it, like the transform overload`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID))),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        every { blobStore.read(REF_VALID) } returns """{"id":"wf-1"}""".toByteArray()
+
+        // The reified overload delegates to the transform overload, so it resolves the blob the same way:
+        // fetch on demand (waiting for the download) and read it back, then decode the bytes as JSON.
+        val result = readManager().blobData<TestBlob>(RemoteConfigTopic.Workflows, "wf1")
+
+        assertThat(result).isEqualTo(TestBlob(id = "wf-1"))
+        coVerify(exactly = 1) { blobFetcher.ensureDownloaded(REF_VALID) }
+    }
+
+    @Test
     fun `blobData returns null for a blob-backed item that cannot be fetched`() = runTest {
         every { diskCache.read() } returns persisted(
             manifest = "m",
@@ -1058,6 +1079,9 @@ class RemoteConfigManagerTest {
         every { container.elements } returns emptyMap()
         return container
     }
+
+    @Serializable
+    private data class TestBlob(val id: String)
 
     private companion object {
         private const val TEST_APP_USER_ID = "test-app-user-id"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -736,10 +736,91 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `topic returns null when nothing is cached`() = runTest {
+    fun `topic returns null without triggering a sync when nothing is cached and no app user is known`() = runTest {
         every { diskCache.read() } returns null
 
-        assertThat(readManager().topic(RemoteConfigTopic.Sources)).isNull()
+        assertThat(readManager(appUserIDProvider = { null }).topic(RemoteConfigTopic.Sources)).isNull()
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `topic triggers a sync for an uncached topic when none is in flight and returns the committed index`() = runTest {
+        var state: PersistedRemoteConfigurationState? = null
+        every { diskCache.read() } answers { state }
+        every { diskCache.write(any()) } answers { state = firstArg(); true }
+        val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
+
+        // Nothing is in flight and nothing is cached: the read triggers its own sync and waits for it.
+        var result: ConfigTopic? = null
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            result = manager.topic(RemoteConfigTopic.Workflows)
+        }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        // The on-demand sync is issued as foreground for the current user.
+        assertThat(capturedAppUserID).isEqualTo(TEST_APP_USER_ID)
+        assertThat(read.isActive).isTrue()
+
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.workflows:etag",
+              "active_topics": ["workflows"],
+              "topics": { "workflows": { "wf1": { "blob_ref": "$REF_VALID" } } }
+            }
+        """.trimIndent()
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        assertThat(read.isCompleted).isTrue()
+        assertThat(result).containsKey("wf1")
+    }
+
+    @Test
+    fun `topic waits for an in-flight refresh and returns the freshly committed index`() = runTest {
+        var state: PersistedRemoteConfigurationState? = null
+        every { diskCache.read() } answers { state }
+        every { diskCache.write(any()) } answers { state = firstArg(); true }
+        val manager = readManager()
+
+        // A refresh is in flight: the backend stub captures the callbacks without settling them yet.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        // The topic is not committed yet, so the read parks on the in-flight refresh.
+        var result: ConfigTopic? = null
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            result = manager.topic(RemoteConfigTopic.Workflows)
+        }
+        assertThat(read.isActive).isTrue()
+
+        // Settle the refresh with a 200 that commits the topic.
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.workflows:etag",
+              "active_topics": ["workflows"],
+              "topics": { "workflows": { "wf1": { "blob_ref": "$REF_VALID" } } }
+            }
+        """.trimIndent()
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        assertThat(read.isCompleted).isTrue()
+        assertThat(result).containsKey("wf1")
+    }
+
+    @Test
+    fun `topic returns a committed topic without waiting even while a refresh is in flight`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID))),
+            ),
+        )
+        val manager = readManager()
+
+        // A refresh is in flight and never settles; a committed read must not block on it (else this hangs).
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        assertThat(manager.topic(RemoteConfigTopic.Workflows)).containsKey("wf1")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -711,15 +711,34 @@ class RemoteConfigManagerTest {
         )
         val manager = readManager()
 
-        assertThat(manager.topic("sources")).containsKey("default")
-        assertThat(manager.topic("workflows")).isNull()
+        assertThat(manager.topic(RemoteConfigTopic.Sources)).containsKey("default")
+        assertThat(manager.topic(RemoteConfigTopic.Workflows)).isNull()
     }
 
     @Test
     fun `topic returns null when nothing is cached`() = runTest {
         every { diskCache.read() } returns null
 
-        assertThat(readManager().topic("sources")).isNull()
+        assertThat(readManager().topic(RemoteConfigTopic.Sources)).isNull()
+    }
+
+    @Test
+    fun `topic maps each enum value to its wire name`() = runTest {
+        // Persisted (and served) under the backend wire names; reads go through the typed enum.
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows", "ui_config", "sources"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(mapOf("wf" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID))),
+                "ui_config" to ConfigTopic(mapOf("ui" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED))),
+                "sources" to ConfigTopic(mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = REF_UNWANTED))),
+            ),
+        )
+        val manager = readManager()
+
+        assertThat(manager.topic(RemoteConfigTopic.Workflows)).containsKey("wf")
+        assertThat(manager.topic(RemoteConfigTopic.UiConfig)).containsKey("ui")
+        assertThat(manager.topic(RemoteConfigTopic.Sources)).containsKey("default")
     }
 
     @Test
@@ -733,7 +752,7 @@ class RemoteConfigManagerTest {
             ),
         )
 
-        val result = readManager().body("workflows", "wf1")
+        val result = readManager().body(RemoteConfigTopic.Workflows, "wf1")
 
         val expected = JsonProvider.defaultJson.encodeToString(JsonObject.serializer(), content).encodeToByteArray()
         assertThat(result).isEqualTo(expected)
@@ -754,7 +773,7 @@ class RemoteConfigManagerTest {
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
         every { blobStore.read(REF_VALID) } returns byteArrayOf(4, 2)
 
-        val result = readManager().body("workflows", "wf1")
+        val result = readManager().body(RemoteConfigTopic.Workflows, "wf1")
 
         assertThat(result).isEqualTo(byteArrayOf(4, 2))
         coVerify(exactly = 1) { blobFetcher.ensureDownloaded(REF_VALID) }
@@ -771,7 +790,7 @@ class RemoteConfigManagerTest {
         )
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns false
 
-        assertThat(readManager().body("workflows", "wf1")).isNull()
+        assertThat(readManager().body(RemoteConfigTopic.Workflows, "wf1")).isNull()
         verify(exactly = 0) { blobStore.read(any()) }
     }
 
@@ -792,7 +811,7 @@ class RemoteConfigManagerTest {
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
         )
 
-        assertThat(manager.body("workflows", "wf1")).isNull()
+        assertThat(manager.body(RemoteConfigTopic.Workflows, "wf1")).isNull()
         coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
     }
 
@@ -806,7 +825,7 @@ class RemoteConfigManagerTest {
         // Nothing is in flight and nothing is cached: the read triggers its own sync and waits for it.
         var result: ByteArray? = null
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.body("workflows", "wf1")
+            result = manager.body(RemoteConfigTopic.Workflows, "wf1")
         }
         verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
         // The on-demand sync is issued as foreground for the current user.
@@ -832,7 +851,7 @@ class RemoteConfigManagerTest {
     fun `body returns null without triggering a sync when no app user is known`() = runTest {
         every { diskCache.read() } returns null
 
-        assertThat(readManager(appUserIDProvider = { null }).body("workflows", "wf1")).isNull()
+        assertThat(readManager(appUserIDProvider = { null }).body(RemoteConfigTopic.Workflows, "wf1")).isNull()
         verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
     }
 
@@ -847,7 +866,7 @@ class RemoteConfigManagerTest {
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
         )
 
-        assertThat(manager.body("workflows", "wf1")).isNull()
+        assertThat(manager.body(RemoteConfigTopic.Workflows, "wf1")).isNull()
         verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
     }
 
@@ -864,7 +883,7 @@ class RemoteConfigManagerTest {
         // The item is not committed yet, so the read parks on the in-flight refresh.
         var result: ByteArray? = null
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.body("workflows", "wf1")
+            result = manager.body(RemoteConfigTopic.Workflows, "wf1")
         }
         assertThat(read.isActive).isTrue()
 
@@ -900,7 +919,7 @@ class RemoteConfigManagerTest {
         // A refresh is in flight and never settles; a committed read must not block on it (else this hangs).
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
 
-        assertThat(manager.body("workflows", "wf1")).isEqualTo(byteArrayOf(9))
+        assertThat(manager.body(RemoteConfigTopic.Workflows, "wf1")).isEqualTo(byteArrayOf(9))
     }
 
     @Test
@@ -911,7 +930,7 @@ class RemoteConfigManagerTest {
 
         var result: ByteArray? = byteArrayOf(1)
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.body("workflows", "wf1")
+            result = manager.body(RemoteConfigTopic.Workflows, "wf1")
         }
         assertThat(read.isActive).isTrue()
 
@@ -930,7 +949,7 @@ class RemoteConfigManagerTest {
 
         var result: ByteArray? = byteArrayOf(1)
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.body("workflows", "wf1")
+            result = manager.body(RemoteConfigTopic.Workflows, "wf1")
         }
         assertThat(read.isActive).isTrue()
 
@@ -948,7 +967,7 @@ class RemoteConfigManagerTest {
 
         var result: ByteArray? = byteArrayOf(1)
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.body("workflows", "wf1")
+            result = manager.body(RemoteConfigTopic.Workflows, "wf1")
         }
         assertThat(read.isActive).isTrue()
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -1064,6 +1064,25 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `close unblocks a body waiting on an in-flight refresh`() = runTest {
+        every { diskCache.read() } returns null
+        val manager = readManager()
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        var result: ByteArray? = byteArrayOf(1)
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            result = manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }
+        }
+        assertThat(read.isActive).isTrue()
+
+        // SDK teardown unblocks the waiter, which re-reads the still-empty cache and gives up.
+        manager.close()
+
+        assertThat(read.isCompleted).isTrue()
+        assertThat(result).isNull()
+    }
+
+    @Test
     fun `a 204 unblocks a body waiting on an in-flight refresh`() = runTest {
         every { diskCache.read() } returns null
         val manager = readManager()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -8,7 +8,6 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
-import com.revenuecat.purchases.common.JsonProvider
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerFormatException
 import com.revenuecat.purchases.common.networking.RCElement
@@ -25,7 +24,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat
@@ -499,13 +497,34 @@ class RemoteConfigManagerTest {
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
         )
 
-        assertThat(manager.isUnavailable).isTrue()
+        assertThat(manager.isDisabled).isTrue()
 
         // No further config request and no blob fetch happen for the rest of the session.
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
         verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
         verify(exactly = 0) { blobFetcher.prefetch(any()) }
+    }
+
+    @Test
+    fun `topic returns null once the endpoint is disabled even when data is cached`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID))),
+            ),
+        )
+        val manager = readManager()
+        // A 4xx disables the endpoint for the session.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
+
+        // Even though the topic is cached, a disabled endpoint yields no reads.
+        assertThat(manager.topic(RemoteConfigTopic.Workflows)).isNull()
     }
 
     @Test
@@ -518,7 +537,7 @@ class RemoteConfigManagerTest {
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
         )
 
-        assertThat(manager.isUnavailable).isFalse()
+        assertThat(manager.isDisabled).isFalse()
 
         // The endpoint is still usable, so a subsequent refresh fires.
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
@@ -538,7 +557,7 @@ class RemoteConfigManagerTest {
         // Identity change: the disable survives (it is an endpoint/app-level fact, not per-user).
         manager.clearCache()
 
-        assertThat(manager.isUnavailable).isTrue()
+        assertThat(manager.isDisabled).isTrue()
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
         verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
     }
@@ -742,27 +761,26 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `body returns the inline content bytes for an item without a blob ref`() = runTest {
-        val content = buildJsonObject { put("offering_id", "offer_123") }
+    fun `blobData returns null for an item without a blob ref`() = runTest {
+        val metadata = buildJsonObject { put("offering_id", "offer_123") }
         every { diskCache.read() } returns persisted(
             manifest = "m",
             activeTopics = listOf("workflows"),
             topics = mapOf(
-                "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(content = content))),
+                "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(metadata = metadata))),
             ),
         )
 
-        val result = readManager().body(RemoteConfigTopic.Workflows, "wf1")
+        val result = readManager().blobData(RemoteConfigTopic.Workflows, "wf1") { it }
 
-        val expected = JsonProvider.defaultJson.encodeToString(JsonObject.serializer(), content).encodeToByteArray()
-        assertThat(result).isEqualTo(expected)
-        // Inline content is resolved without touching the network or the blob store.
+        // An item with no blob ref has no payload: neither the network nor the blob store is touched.
+        assertThat(result).isNull()
         coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
         verify(exactly = 0) { blobStore.read(any()) }
     }
 
     @Test
-    fun `body resolves a blob-backed item by fetching on demand then reading the blob`() = runTest {
+    fun `blobData resolves a blob-backed item by fetching on demand then reading the blob`() = runTest {
         every { diskCache.read() } returns persisted(
             manifest = "m",
             activeTopics = listOf("workflows"),
@@ -773,14 +791,14 @@ class RemoteConfigManagerTest {
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
         every { blobStore.read(REF_VALID) } returns byteArrayOf(4, 2)
 
-        val result = readManager().body(RemoteConfigTopic.Workflows, "wf1")
+        val result = readManager().blobData(RemoteConfigTopic.Workflows, "wf1") { it }
 
         assertThat(result).isEqualTo(byteArrayOf(4, 2))
         coVerify(exactly = 1) { blobFetcher.ensureDownloaded(REF_VALID) }
     }
 
     @Test
-    fun `body returns null for a blob-backed item that cannot be fetched`() = runTest {
+    fun `blobData returns null for a blob-backed item that cannot be fetched`() = runTest {
         every { diskCache.read() } returns persisted(
             manifest = "m",
             activeTopics = listOf("workflows"),
@@ -790,12 +808,12 @@ class RemoteConfigManagerTest {
         )
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns false
 
-        assertThat(readManager().body(RemoteConfigTopic.Workflows, "wf1")).isNull()
+        assertThat(readManager().blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isNull()
         verify(exactly = 0) { blobStore.read(any()) }
     }
 
     @Test
-    fun `body skips the network for a blob-backed item once the endpoint is unavailable`() = runTest {
+    fun `blobData skips the network for a blob-backed item once the endpoint is disabled`() = runTest {
         every { diskCache.read() } returns persisted(
             manifest = "m",
             activeTopics = listOf("workflows"),
@@ -811,21 +829,23 @@ class RemoteConfigManagerTest {
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
         )
 
-        assertThat(manager.body(RemoteConfigTopic.Workflows, "wf1")).isNull()
+        assertThat(manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isNull()
         coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
     }
 
     @Test
-    fun `body triggers a sync for an uncached item when none is in flight and returns the committed data`() = runTest {
+    fun `blobData triggers a sync for an uncached item when none is in flight and returns the committed data`() = runTest {
         var state: PersistedRemoteConfigurationState? = null
         every { diskCache.read() } answers { state }
         every { diskCache.write(any()) } answers { state = firstArg(); true }
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        every { blobStore.read(REF_VALID) } returns byteArrayOf(4, 2)
         val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
 
         // Nothing is in flight and nothing is cached: the read triggers its own sync and waits for it.
         var result: ByteArray? = null
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.body(RemoteConfigTopic.Workflows, "wf1")
+            result = manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }
         }
         verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
         // The on-demand sync is issued as foreground for the current user.
@@ -837,26 +857,25 @@ class RemoteConfigManagerTest {
               "domain": "app",
               "manifest": "v1.200.workflows:etag",
               "active_topics": ["workflows"],
-              "topics": { "workflows": { "wf1": { "offering_id": "offer_123" } } }
+              "topics": { "workflows": { "wf1": { "blob_ref": "$REF_VALID" } } }
             }
         """.trimIndent()
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         assertThat(read.isCompleted).isTrue()
-        assertThat(result).isNotNull()
-        assertThat(result!!.decodeToString()).contains("offer_123")
+        assertThat(result).isEqualTo(byteArrayOf(4, 2))
     }
 
     @Test
-    fun `body returns null without triggering a sync when no app user is known`() = runTest {
+    fun `blobData returns null without triggering a sync when no app user is known`() = runTest {
         every { diskCache.read() } returns null
 
-        assertThat(readManager(appUserIDProvider = { null }).body(RemoteConfigTopic.Workflows, "wf1")).isNull()
+        assertThat(readManager(appUserIDProvider = { null }).blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isNull()
         verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
-    fun `body does not trigger a sync for an uncached item once the endpoint is unavailable`() = runTest {
+    fun `blobData does not trigger a sync for an uncached item once the endpoint is disabled`() = runTest {
         every { diskCache.read() } returns null
         val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
         // A 4xx disables the endpoint for the session (this is the only config request that should ever fire).
@@ -866,15 +885,17 @@ class RemoteConfigManagerTest {
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
         )
 
-        assertThat(manager.body(RemoteConfigTopic.Workflows, "wf1")).isNull()
+        assertThat(manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isNull()
         verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
-    fun `body waits for an in-flight refresh and returns the freshly committed data`() = runTest {
+    fun `blobData waits for an in-flight refresh and returns the freshly committed data`() = runTest {
         var state: PersistedRemoteConfigurationState? = null
         every { diskCache.read() } answers { state }
         every { diskCache.write(any()) } answers { state = firstArg(); true }
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        every { blobStore.read(REF_VALID) } returns byteArrayOf(4, 2)
         val manager = readManager()
 
         // A refresh is in flight: the backend stub captures the callbacks without settling them yet.
@@ -883,7 +904,7 @@ class RemoteConfigManagerTest {
         // The item is not committed yet, so the read parks on the in-flight refresh.
         var result: ByteArray? = null
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.body(RemoteConfigTopic.Workflows, "wf1")
+            result = manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }
         }
         assertThat(read.isActive).isTrue()
 
@@ -893,18 +914,17 @@ class RemoteConfigManagerTest {
               "domain": "app",
               "manifest": "v1.200.workflows:etag",
               "active_topics": ["workflows"],
-              "topics": { "workflows": { "wf1": { "offering_id": "offer_123" } } }
+              "topics": { "workflows": { "wf1": { "blob_ref": "$REF_VALID" } } }
             }
         """.trimIndent()
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         assertThat(read.isCompleted).isTrue()
-        assertThat(result).isNotNull()
-        assertThat(result!!.decodeToString()).contains("offer_123")
+        assertThat(result).isEqualTo(byteArrayOf(4, 2))
     }
 
     @Test
-    fun `body returns a committed item without waiting even while a refresh is in flight`() = runTest {
+    fun `blobData returns a committed item without waiting even while a refresh is in flight`() = runTest {
         every { diskCache.read() } returns persisted(
             manifest = "m",
             activeTopics = listOf("workflows"),
@@ -919,7 +939,7 @@ class RemoteConfigManagerTest {
         // A refresh is in flight and never settles; a committed read must not block on it (else this hangs).
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
 
-        assertThat(manager.body(RemoteConfigTopic.Workflows, "wf1")).isEqualTo(byteArrayOf(9))
+        assertThat(manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isEqualTo(byteArrayOf(9))
     }
 
     @Test
@@ -930,7 +950,7 @@ class RemoteConfigManagerTest {
 
         var result: ByteArray? = byteArrayOf(1)
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.body(RemoteConfigTopic.Workflows, "wf1")
+            result = manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }
         }
         assertThat(read.isActive).isTrue()
 
@@ -949,7 +969,7 @@ class RemoteConfigManagerTest {
 
         var result: ByteArray? = byteArrayOf(1)
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.body(RemoteConfigTopic.Workflows, "wf1")
+            result = manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }
         }
         assertThat(read.isActive).isTrue()
 
@@ -967,7 +987,7 @@ class RemoteConfigManagerTest {
 
         var result: ByteArray? = byteArrayOf(1)
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.body(RemoteConfigTopic.Workflows, "wf1")
+            result = manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }
         }
         assertThat(read.isActive).isTrue()
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -8,9 +8,12 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
+import com.revenuecat.purchases.common.JsonProvider
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerFormatException
 import com.revenuecat.purchases.common.networking.RCElement
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -18,7 +21,13 @@ import io.mockk.verify
 import kotlin.concurrent.thread
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -688,6 +697,287 @@ class RemoteConfigManagerTest {
 
         verify(exactly = 1) { diskCache.write(any()) }
     }
+
+    // region Phase 6 read facade (topic / body) + wait-for-in-flight
+
+    @Test
+    fun `topic returns the committed item index and null for an unknown topic`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("sources"),
+            topics = mapOf(
+                "sources" to ConfigTopic(mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID))),
+            ),
+        )
+        val manager = readManager()
+
+        assertThat(manager.topic("sources")).containsKey("default")
+        assertThat(manager.topic("workflows")).isNull()
+    }
+
+    @Test
+    fun `topic returns null when nothing is cached`() = runTest {
+        every { diskCache.read() } returns null
+
+        assertThat(readManager().topic("sources")).isNull()
+    }
+
+    @Test
+    fun `body returns the inline content bytes for an item without a blob ref`() = runTest {
+        val content = buildJsonObject { put("offering_id", "offer_123") }
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(content = content))),
+            ),
+        )
+
+        val result = readManager().body("workflows", "wf1")
+
+        val expected = JsonProvider.defaultJson.encodeToString(JsonObject.serializer(), content).encodeToByteArray()
+        assertThat(result).isEqualTo(expected)
+        // Inline content is resolved without touching the network or the blob store.
+        coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
+        verify(exactly = 0) { blobStore.read(any()) }
+    }
+
+    @Test
+    fun `body resolves a blob-backed item by fetching on demand then reading the blob`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID))),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        every { blobStore.read(REF_VALID) } returns byteArrayOf(4, 2)
+
+        val result = readManager().body("workflows", "wf1")
+
+        assertThat(result).isEqualTo(byteArrayOf(4, 2))
+        coVerify(exactly = 1) { blobFetcher.ensureDownloaded(REF_VALID) }
+    }
+
+    @Test
+    fun `body returns null for a blob-backed item that cannot be fetched`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID))),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns false
+
+        assertThat(readManager().body("workflows", "wf1")).isNull()
+        verify(exactly = 0) { blobStore.read(any()) }
+    }
+
+    @Test
+    fun `body skips the network for a blob-backed item once the endpoint is unavailable`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID))),
+            ),
+        )
+        val manager = readManager()
+        // A 4xx disables the endpoint for the session.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
+
+        assertThat(manager.body("workflows", "wf1")).isNull()
+        coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
+    }
+
+    @Test
+    fun `body triggers a sync for an uncached item when none is in flight and returns the committed data`() = runTest {
+        var state: PersistedRemoteConfigurationState? = null
+        every { diskCache.read() } answers { state }
+        every { diskCache.write(any()) } answers { state = firstArg(); true }
+        val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
+
+        // Nothing is in flight and nothing is cached: the read triggers its own sync and waits for it.
+        var result: ByteArray? = null
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            result = manager.body("workflows", "wf1")
+        }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        // The on-demand sync is issued as foreground for the current user.
+        assertThat(capturedAppUserID).isEqualTo(TEST_APP_USER_ID)
+        assertThat(read.isActive).isTrue()
+
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.workflows:etag",
+              "active_topics": ["workflows"],
+              "topics": { "workflows": { "wf1": { "offering_id": "offer_123" } } }
+            }
+        """.trimIndent()
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        assertThat(read.isCompleted).isTrue()
+        assertThat(result).isNotNull()
+        assertThat(result!!.decodeToString()).contains("offer_123")
+    }
+
+    @Test
+    fun `body returns null without triggering a sync when no app user is known`() = runTest {
+        every { diskCache.read() } returns null
+
+        assertThat(readManager(appUserIDProvider = { null }).body("workflows", "wf1")).isNull()
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `body does not trigger a sync for an uncached item once the endpoint is unavailable`() = runTest {
+        every { diskCache.read() } returns null
+        val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
+        // A 4xx disables the endpoint for the session (this is the only config request that should ever fire).
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
+
+        assertThat(manager.body("workflows", "wf1")).isNull()
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `body waits for an in-flight refresh and returns the freshly committed data`() = runTest {
+        var state: PersistedRemoteConfigurationState? = null
+        every { diskCache.read() } answers { state }
+        every { diskCache.write(any()) } answers { state = firstArg(); true }
+        val manager = readManager()
+
+        // A refresh is in flight: the backend stub captures the callbacks without settling them yet.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        // The item is not committed yet, so the read parks on the in-flight refresh.
+        var result: ByteArray? = null
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            result = manager.body("workflows", "wf1")
+        }
+        assertThat(read.isActive).isTrue()
+
+        // Settle the refresh with a 200 that commits the item.
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.workflows:etag",
+              "active_topics": ["workflows"],
+              "topics": { "workflows": { "wf1": { "offering_id": "offer_123" } } }
+            }
+        """.trimIndent()
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        assertThat(read.isCompleted).isTrue()
+        assertThat(result).isNotNull()
+        assertThat(result!!.decodeToString()).contains("offer_123")
+    }
+
+    @Test
+    fun `body returns a committed item without waiting even while a refresh is in flight`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID))),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        every { blobStore.read(REF_VALID) } returns byteArrayOf(9)
+        val manager = readManager()
+
+        // A refresh is in flight and never settles; a committed read must not block on it (else this hangs).
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        assertThat(manager.body("workflows", "wf1")).isEqualTo(byteArrayOf(9))
+    }
+
+    @Test
+    fun `clearCache unblocks a body waiting on an in-flight refresh`() = runTest {
+        every { diskCache.read() } returns null
+        val manager = readManager()
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        var result: ByteArray? = byteArrayOf(1)
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            result = manager.body("workflows", "wf1")
+        }
+        assertThat(read.isActive).isTrue()
+
+        // Identity change unblocks the waiter, which re-reads the now-wiped cache and gives up.
+        manager.clearCache()
+
+        assertThat(read.isCompleted).isTrue()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `a 204 unblocks a body waiting on an in-flight refresh`() = runTest {
+        every { diskCache.read() } returns null
+        val manager = readManager()
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        var result: ByteArray? = byteArrayOf(1)
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            result = manager.body("workflows", "wf1")
+        }
+        assertThat(read.isActive).isTrue()
+
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+
+        assertThat(read.isCompleted).isTrue()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `an error unblocks a body waiting on an in-flight refresh`() = runTest {
+        every { diskCache.read() } returns null
+        val manager = readManager()
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        var result: ByteArray? = byteArrayOf(1)
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            result = manager.body("workflows", "wf1")
+        }
+        assertThat(read.isActive).isTrue()
+
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownError, "boom"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        assertThat(read.isCompleted).isTrue()
+        assertThat(result).isNull()
+    }
+
+    // A manager whose read methods run on this test's scheduler, so suspend reads are deterministic.
+    private fun TestScope.readManager(appUserIDProvider: () -> String? = { null }): RemoteConfigManager {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        return RemoteConfigManager(
+            backend,
+            diskCache,
+            blobStore,
+            dateProvider = dateProvider,
+            scope = CoroutineScope(dispatcher),
+            ioDispatcher = dispatcher,
+            sourceProvider = sourceProvider,
+            blobFetcher = blobFetcher,
+            appUserIDProvider = appUserIDProvider,
+        )
+    }
+
+    // endregion
 
     private fun persisted(
         manifest: String,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProviderTest.kt
@@ -516,7 +516,8 @@ class RemoteConfigSourceProviderTest {
     }
 
     private class FakeTopicStore(var sources: ConfigTopic?) : RemoteConfigTopicStore {
-        override fun topic(name: String): ConfigTopic? = if (name == "sources") sources else null
+        override fun topic(topic: RemoteConfigTopic): ConfigTopic? =
+            if (topic == RemoteConfigTopic.Sources) sources else null
     }
 
     private fun runConcurrently(iterations: Int, block: () -> Unit) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProviderTest.kt
@@ -500,7 +500,7 @@ class RemoteConfigSourceProviderTest {
     /** Builds a `sources` ConfigTopic matching the backend shape: api entries use `url`, blob use `url_format`. */
     private fun sourcesTopic(api: List<RemoteConfigSource>, blob: List<RemoteConfigSource>): ConfigTopic {
         fun item(sources: List<RemoteConfigSource>, urlKey: String) = RemoteConfiguration.ConfigItem(
-            content = buildJsonObject {
+            metadata = buildJsonObject {
                 putJsonArray("sources") {
                     sources.forEach { s ->
                         addJsonObject {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigurationTest.kt
@@ -135,11 +135,11 @@ class RemoteConfigurationTest {
         val item = response.topics.getValue("sources").getValue("blob")
         assertThat(item.blobRef).isEqualTo("sourcesBlob")
         assertThat(item.prefetch).isTrue
-        // Non-reserved keys are kept in content (not dropped).
-        assertThat(item.content["future_field"]?.jsonPrimitive?.content).isEqualTo("kept")
-        // Reserved keys are not duplicated into content.
-        assertThat(item.content).doesNotContainKey("blob_ref")
-        assertThat(item.content).doesNotContainKey("prefetch")
+        // Non-reserved keys are kept in metadata (not dropped).
+        assertThat(item.metadata["future_field"]?.jsonPrimitive?.content).isEqualTo("kept")
+        // Reserved keys are not duplicated into metadata.
+        assertThat(item.metadata).doesNotContainKey("blob_ref")
+        assertThat(item.metadata).doesNotContainKey("prefetch")
     }
 
     @Test
@@ -163,10 +163,10 @@ class RemoteConfigurationTest {
         val item = response.topics.getValue("sources").getValue("api")
         assertThat(item.blobRef).isNull()
         assertThat(item.prefetch).isFalse
-        assertThat(item.content["id"]?.jsonPrimitive?.content).isEqualTo("primary")
-        assertThat(item.content["url"]?.jsonPrimitive?.content).isEqualTo("https://api.revenuecat.com")
-        assertThat(item.content["priority"]?.jsonPrimitive?.int).isEqualTo(100)
-        assertThat(item.content["weight"]?.jsonPrimitive?.int).isEqualTo(100)
+        assertThat(item.metadata["id"]?.jsonPrimitive?.content).isEqualTo("primary")
+        assertThat(item.metadata["url"]?.jsonPrimitive?.content).isEqualTo("https://api.revenuecat.com")
+        assertThat(item.metadata["priority"]?.jsonPrimitive?.int).isEqualTo(100)
+        assertThat(item.metadata["weight"]?.jsonPrimitive?.int).isEqualTo(100)
     }
 
     @Test

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/request_001.json
@@ -1,0 +1,27 @@
+{
+  "url": "https:\/\/api.revenuecat.com\/v1\/config\/app",
+  "method": "POST",
+  "headers": {
+    "Accept": "application\/x-rc-format",
+    "Accept-RC-Element-Encoding": "gzip",
+    "Content-Type": "application\/json",
+    "X-Billing-Client-Sdk-Version": "8.3.0",
+    "X-Client-Bundle-ID": "com.revenuecat.purchases.backend_tests",
+    "X-Client-Locale": "en-US",
+    "X-Client-Version": "test-version-name",
+    "X-Is-Backgrounded": "false",
+    "X-Is-Debug-Build": "false",
+    "X-Kotlin-Version": "2.0.21",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "android",
+    "X-Platform-Brand": "robolectric",
+    "X-Platform-Device": "robolectric",
+    "X-Platform-Flavor": "test-flavor",
+    "X-Platform-Version": "36",
+    "X-Preferred-Locales": "en_US"
+  },
+  "body": {
+    "app_user_id": "integrationTestRemoteConfigUser",
+    "prefetched_blobs": []
+  }
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/response_001.json
@@ -1,0 +1,10 @@
+{
+  "statusCode": 200,
+  "headers": {
+    "Connection": "keep-alive",
+    "Content-Length": "3448",
+    "Content-Type": "application\/x-rc-format",
+    "server": "envoy"
+  },
+  "body": null
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/response_001.json
@@ -2,7 +2,7 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3448",
+    "Content-Length": "3704",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/request_001.json
@@ -1,0 +1,27 @@
+{
+  "url": "https:\/\/api.revenuecat.com\/v1\/config\/app",
+  "method": "POST",
+  "headers": {
+    "Accept": "application\/x-rc-format",
+    "Accept-RC-Element-Encoding": "gzip",
+    "Content-Type": "application\/json",
+    "X-Billing-Client-Sdk-Version": "8.3.0",
+    "X-Client-Bundle-ID": "com.revenuecat.purchases.backend_tests",
+    "X-Client-Locale": "en-US",
+    "X-Client-Version": "test-version-name",
+    "X-Is-Backgrounded": "false",
+    "X-Is-Debug-Build": "false",
+    "X-Kotlin-Version": "2.0.21",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "android",
+    "X-Platform-Brand": "robolectric",
+    "X-Platform-Device": "robolectric",
+    "X-Platform-Flavor": "test-flavor",
+    "X-Platform-Version": "36",
+    "X-Preferred-Locales": "en_US"
+  },
+  "body": {
+    "app_user_id": "integrationTestRemoteConfigUser",
+    "prefetched_blobs": []
+  }
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/response_001.json
@@ -1,0 +1,10 @@
+{
+  "statusCode": 200,
+  "headers": {
+    "Connection": "keep-alive",
+    "Content-Length": "3704",
+    "Content-Type": "application\/x-rc-format",
+    "server": "envoy"
+  },
+  "body": null
+}


### PR DESCRIPTION
Adds a read API to `RemoteConfigManager` so consumers can read remote-config data:

- `topic(name)` — a topic's committed metadata.
- `blobData(topicName, itemKey)` — a resolved item payload (its inline content, or its blob).

On a cache miss, a read resolves from an in-progress or on-demand sync instead of returning empty.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New suspend read paths can block on network and trigger on-demand `/v1/config` syncs; behavior is complex but heavily tested and gated on identity/disable state.
> 
> **Overview**
> Adds a **suspend read API** on `RemoteConfigManager`: `topic(RemoteConfigTopic)` for committed item metadata, and `blobData` (transform + JSON reified) for blob-backed payloads. Reads run on IO, respect the session **4xx kill-switch** (`isUnavailable` → `isDisabled`), and on a cache miss **wait for an in-flight sync or trigger a foreground on-demand refresh** when an app user ID is available (wired from `PurchasesFactory` via `appUserIDProvider`).
> 
> Introduces **`RemoteConfigTopic`** and threads it through `RemoteConfigTopicStore` / source parsing. Renames config item inline fields **`content` → `metadata`** and documents that payloads without `blob_ref` are index-only (`blobData` returns null).
> 
> `syncAttributesAndOfferingsIfNeeded` now calls **`refreshRemoteConfig`** before fetching offerings. Refresh completion is signaled with **`CompletableDeferred`** so blocked readers unblock on 204, errors, `clearCache`, and `close`. Unit, integration, and production golden tests cover the facade and waiting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3f74fbf745f3a2862b9917d76ecd270565a0a6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->