### PR TITLE
fix(events): catch FileNotFoundException in openBufferedReader to prevent TOCTOU crash

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/FileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/FileHelper.kt
@@ -77,12 +77,21 @@ internal class FileHelper(
 
     private fun openBufferedReader(filePath: String, contentBlock: ((BufferedReader) -> Unit)) {
         val file = getFileInFilesDir(filePath)
-        FileInputStream(file).use { fileInputStream ->
-            InputStreamReader(fileInputStream).use { inputStreamReader ->
-                BufferedReader(inputStreamReader).use { bufferedReader ->
-                    contentBlock(bufferedReader)
+        // Guard against a TOCTOU race: callers (e.g. EventsFileHelper.readFile) check
+        // fileIsEmpty() before calling here, but a concurrent flush/rotate can delete
+        // the file between that check and FileInputStream(file), producing an uncaught
+        // FileNotFoundException on the SDK background thread that crashes the process.
+        // Treat a missing file as empty — the same semantics fileIsEmpty() uses.
+        try {
+            FileInputStream(file).use { fileInputStream ->
+                InputStreamReader(fileInputStream).use { inputStreamReader ->
+                    BufferedReader(inputStreamReader).use { bufferedReader ->
+                        contentBlock(bufferedReader)
+                    }
                 }
             }
+        } catch (e: FileNotFoundException) {
+            debugLog { "FileHelper: file not found when trying to read: $filePath. Treating as empty." }
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/FileHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/FileHelperTest.kt
@@ -160,6 +160,18 @@ class FileHelperTest {
         assertThat(receivedValues).isEqualTo(listOf("first line", "second line"))
     }
 
+    @Test
+    fun `readFilePerLines does not throw when file is deleted after fileIsEmpty check (TOCTOU race)`() {
+        // Simulate the race: call readFilePerLines on a path that has never existed (or was
+        // deleted between a fileIsEmpty() check and the open). The block must not be called
+        // and no exception must propagate.
+        val receivedValues = mutableListOf<String>()
+        fileHelper.readFilePerLines("RevenueCat/nonexistent_file.txt") { sequence ->
+            sequence.forEach { receivedValues.add(it) }
+        }
+        assertThat(receivedValues).isEmpty()
+    }
+
     private fun verifyFileDoesNotExist() {
         val file = File(testFolder, testFilePath)
         if (file.exists()) {


### PR DESCRIPTION
## Problem

Fixes #3696.

`EventsFileHelper.readFile` guards with `fileIsEmpty()` before opening the event store file, but `FileHelper.openBufferedReader` then calls `FileInputStream(file)` without re-checking existence. A concurrent flush/rotate that deletes `ad_event_store.jsonl` between `fileIsEmpty()` returning `false` and `FileInputStream(file)` throws an **uncaught `FileNotFoundException`** on the SDK background thread (`PurchasesFactory$LowPriorityThreadFactory`), crashing the app.

From the reporter: this is the **#1 fatal crash** on production builds using AdMob/AppLovin ad trackers, with ~53 crashes / ~52 affected users over 30 days, reproduced on Android 14–16.

Crash stack:
```
Fatal Exception: java.io.FileNotFoundException: .../event_store/ad_event_store.jsonl: open failed: ENOENT
    at FileHelper.openBufferedReader(FileHelper.kt:80)
    at FileHelper.readFilePerLines(FileHelper.kt:39)
    at EventsFileHelper.readFile(EventsFileHelper.kt:61)
    at EventsManager.getStoredEvents(EventsManager.kt:422)
    at EventsManager.flushNextBatch(EventsManager.kt:277)
```

## Fix

Catch `FileNotFoundException` in `openBufferedReader` and treat a missing file as empty — the same semantics `fileIsEmpty()` uses — logging at `DEBUG` level. The same pattern is already used in `removeFirstLinesFromFile` (line 58).

```kotlin
} catch (e: FileNotFoundException) {
    debugLog { "FileHelper: file not found when trying to read: $filePath. Treating as empty." }
}
```

Also adds a regression test that calls `readFilePerLines` on a nonexistent path and asserts no exception propagates and the block receives an empty sequence.

## Testing

- New unit test in `FileHelperTest` covers the missing-file path.
- Existing tests all still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive change in file I/O with empty-file semantics preserved; low blast radius beyond preventing a known production crash path.
> 
> **Overview**
> Fixes a **TOCTOU race** where ad/event store reads could crash the app: callers check `fileIsEmpty()` then `readFilePerLines`, but a concurrent flush/rotate can delete the file before `FileInputStream` opens, yielding an uncaught `FileNotFoundException` on the SDK background thread.
> 
> **`FileHelper.openBufferedReader`** now catches `FileNotFoundException`, logs at debug, and treats a missing file as empty (matching `fileIsEmpty()`), aligning with the existing pattern in `removeFirstLinesFromFile`.
> 
> A **regression test** asserts `readFilePerLines` on a nonexistent path does not throw and leaves the consumer with no lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 801a0b5560d3499d8a4ae57c78c7debc37944fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->