### PR TITLE
Fall back to the offerings paywall when the workflow fetch fails

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -815,6 +815,11 @@ internal class PaywallViewModelImpl(
                 // paywall /offerings already delivered so the app still shows something; rethrow
                 // (→ PaywallState.Error) only when there is nothing to fall back to.
                 if (selectedOffering.paywallComponents == null) throw e
+                // A prior render on this ViewModel may have been a successful workflow, leaving
+                // _workflowState non-null. InternalPaywall renders the workflow UI whenever workflowState
+                // is non-null, so without clearing it the stale workflow would mask the offerings fallback
+                // we're about to set via updatePaywallState.
+                clearWorkflowState()
                 Logger.w(
                     "Paywalls: Failed to fetch workflow for offering '${selectedOffering.identifier}' " +
                         "(${e.message}). Falling back to the offerings-provided paywall.",

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -800,14 +800,26 @@ internal class PaywallViewModelImpl(
         val resolvedOfferingSelection = resolveOfferingSelection(offeringSelection)
         val selectedOffering = resolvedOfferingSelection.selectedOffering
 
-        // When workflows are enabled, every non-legacy paywall is served through the /workflows
-        // endpoint. `offering.paywall == null` is the durable marker of a non-legacy (workflow)
+        // When workflows are enabled, every non-legacy paywall is served through the workflows
+        // path. `offering.paywall == null` is the durable marker of a non-legacy (workflow)
         // paywall: a legacy v1 paywall always carries `offering.paywall`, and that field stays
         // even after `paywallComponents` is removed and all V2 paywalls move to workflows. We
         // deliberately do NOT gate on `paywallComponents`, which is going away.
         if (useWorkflowsEndpoint && selectedOffering != null && selectedOffering.paywall == null) {
-            presentWorkflow(selectedOffering, resolvedOfferingSelection.offeringsForExitOfferLookup)
-            return
+            try {
+                presentWorkflow(selectedOffering, resolvedOfferingSelection.offeringsForExitOfferLookup)
+                return
+            } catch (e: PurchasesException) {
+                // The workflow could not be served — the config endpoint is disabled for the session
+                // (4xx kill switch), unreachable, or the offering has no workflow yet. Degrade to the
+                // paywall /offerings already delivered so the app still shows something; rethrow
+                // (→ PaywallState.Error) only when there is nothing to fall back to.
+                if (selectedOffering.paywallComponents == null) throw e
+                Logger.w(
+                    "Paywalls: Failed to fetch workflow for offering '${selectedOffering.identifier}' " +
+                        "(${e.message}). Falling back to the offerings-provided paywall.",
+                )
+            }
         }
 
         val exitOfferingId = selectedOffering?.paywallComponents?.data?.exitOffers?.dismiss?.offeringId

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -3222,6 +3222,64 @@ class PaywallViewModelTest {
         coVerify(exactly = 1) { purchases.awaitGetWorkflow(offeringWithWPL.identifier) }
     }
 
+    @Test
+    fun `when useWorkflows is true and the workflow fetch fails, falls back to the offerings-provided paywall`() {
+        // The config endpoint may be disabled for the session (4xx kill switch) or unreachable, or the
+        // offering may have no workflow yet. The offering still carries the paywall /offerings delivered,
+        // so the paywall renders through the regular components path instead of erroring.
+        coEvery { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns null
+        coEvery { purchases.awaitGetWorkflow(offeringWithWPL.identifier) } throws PurchasesException(
+            PurchasesError(PurchasesErrorCode.UnknownError, "Workflow is unavailable from remote config."),
+        )
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offeringWithWPL)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+        coVerify(exactly = 1) { purchases.awaitGetWorkflow(offeringWithWPL.identifier) }
+    }
+
+    @Test
+    fun `when useWorkflows is true and the workflow fetch fails with no fallback paywall, surfaces the error`() {
+        val offeringWithoutPaywallData = Offering(
+            identifier = "offering-no-paywall-data",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly),
+            paywallComponents = null,
+            webCheckoutURL = null,
+        )
+        coEvery { purchases.workflowIdForOfferingId(offeringWithoutPaywallData.identifier) } returns null
+        coEvery { purchases.awaitGetWorkflow(offeringWithoutPaywallData.identifier) } throws PurchasesException(
+            PurchasesError(PurchasesErrorCode.UnknownError, "Workflow is unavailable from remote config."),
+        )
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offeringWithoutPaywallData)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.state.value).isInstanceOf(PaywallState.Error::class.java)
+    }
+
     private fun create(
         offering: Offering? = null,
         customPurchaseLogic: PaywallPurchaseLogic? = null,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -3280,6 +3280,79 @@ class PaywallViewModelTest {
         assertThat(model.state.value).isInstanceOf(PaywallState.Error::class.java)
     }
 
+    @Test
+    fun `when a prior workflow succeeded, a later fallback clears the stale workflow state`() {
+        // A prior successful workflow leaves _workflowState non-null. When a later presentation on the
+        // same ViewModel falls back to the offerings paywall, that stale workflow state must be cleared —
+        // InternalPaywall renders the workflow UI whenever workflowState != null, so otherwise the old
+        // workflow would keep showing instead of the fallback components.
+        val workflowScreen = WorkflowScreen(
+            templateName = "template",
+            revision = 0,
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(components = listOf(TestData.Components.monthlyPackageComponent)),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    stickyFooter = null,
+                ),
+            ),
+            componentsLocalizations = localizations,
+            defaultLocaleIdentifier = defaultLocaleIdentifier,
+            offeringIdentifier = defaultOffering.identifier,
+        )
+        val workflow = PublishedWorkflow(
+            id = "wfl-test",
+            displayName = "Test Workflow",
+            initialStepId = "step-1",
+            steps = mapOf("step-1" to WorkflowStep(id = "step-1", type = "screen", screenId = "screen-1")),
+            screens = mapOf("screen-1" to workflowScreen),
+        )
+        coEvery { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns "wfl-test"
+        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns workflow
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offeringWithWPL)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        // The workflow loaded — this is the state InternalPaywall would render.
+        assertThat(model.workflowState.value).isNotNull()
+
+        // Re-present a different offering whose workflow can't be served but that carries a fallback paywall.
+        val fallbackOffering = Offering(
+            identifier = "offering-fallback",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly),
+            paywallComponents = Offering.PaywallComponents(UiConfig(), emptyPaywallComponentsData),
+            webCheckoutURL = null,
+        )
+        coEvery { purchases.workflowIdForOfferingId(fallbackOffering.identifier) } returns null
+        coEvery { purchases.awaitGetWorkflow(fallbackOffering.identifier) } throws PurchasesException(
+            PurchasesError(PurchasesErrorCode.UnknownError, "Workflow is unavailable from remote config."),
+        )
+
+        model.updateOptions(
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(fallbackOffering)
+                .build(),
+        )
+
+        // Fallback rendered as components AND the stale workflow state was cleared.
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+        assertThat(model.workflowState.value).isNull()
+    }
+
     private fun create(
         offering: Offering? = null,
         customPurchaseLogic: PaywallPurchaseLogic? = null,


### PR DESCRIPTION
The config endpoint can be disabled for the session after a 4xx, be unreachable, or simply have no workflow for the offering yet. In all of those cases the offering still carries the paywall `/offerings` delivered, so render that through the regular components path instead of surfacing `PaywallState.Error`.

Stacked on #3716.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which paywall surface users see when the workflow endpoint fails; behavior is guarded by fallback data checks and covered by new ViewModel tests.
> 
> **Overview**
> When workflows are enabled but **`presentWorkflow`** throws (config kill switch, network, or no workflow yet), **`PaywallViewModel`** no longer always surfaces **`PaywallState.Error`**. If the offering still has **`paywallComponents`** from `/offerings`, it logs a warning, **clears stale `workflowState`** (so a prior successful workflow does not mask the fallback), and continues through the normal components path via **`updatePaywallState`**. If there is no fallback paywall data, the exception is rethrown and behavior stays an error.
> 
> Tests cover successful fallback, error with no **`paywallComponents`**, and clearing **`workflowState`** when re-presenting an offering after a workflow had already loaded on the same ViewModel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c97035174175034677d05b8705087305dada4ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->