### PR TITLE
fix(paywalls): pre-download Paywalls V2 icons from the full base URL path

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
@@ -73,7 +73,10 @@ internal class PaywallComponentsImagePreDownloader(
                             component.overrides.imageUrisToDownload { it.background.findImageUrisToDownload() }
                     }
                     is IconComponent -> {
-                        setOf(Uri.parse(component.baseUrl).buildUpon().path(component.formats.webp).build())
+                        // Concatenate like IconComponentState.url does. Uri.Builder.path() would replace the
+                        // base URL's path (dropping e.g. /icons), and any mismatch with the render-time URL
+                        // defeats the pre-warm since the image cache is keyed by the exact URL string.
+                        setOf(Uri.parse("${component.baseUrl}/${component.formats.webp}"))
                     }
                     is CarouselComponent -> {
                         // pages are visited by BFS; only extract this component's own background

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
@@ -73,10 +73,16 @@ internal class PaywallComponentsImagePreDownloader(
                             component.overrides.imageUrisToDownload { it.background.findImageUrisToDownload() }
                     }
                     is IconComponent -> {
-                        // Concatenate like IconComponentState.url does. Uri.Builder.path() would replace the
-                        // base URL's path (dropping e.g. /icons), and any mismatch with the render-time URL
-                        // defeats the pre-warm since the image cache is keyed by the exact URL string.
-                        setOf(Uri.parse("${component.baseUrl}/${component.formats.webp}"))
+                        // appendEncodedPath, not path() (which replaces the base URL's path, dropping e.g.
+                        // /icons) nor appendPath (which percent-encodes the segment). The result must match
+                        // the URL IconComponentState builds at render time by raw concatenation, since the
+                        // image cache is keyed by the exact URL string.
+                        setOf(
+                            Uri.parse(component.baseUrl)
+                                .buildUpon()
+                                .appendEncodedPath(component.formats.webp)
+                                .build(),
+                        )
                     }
                     is CarouselComponent -> {
                         // pages are visited by BFS; only extract this component's own background

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
@@ -150,7 +150,7 @@ class OfferingImagePreDownloaderTest {
         val expectedImageDownloads = listOf(
             "https://pawwalls.com/test_stack_light_low_res.webp",
             "https://pawwalls.com/test_stack_dark_low_res.webp",
-            "https://pawwalls.com/test_icon_1.webp",
+            "https://pawwalls.com/icons/test_icon_1.webp",
             "https://pawwalls.com/test_image_light_low_res.webp",
             "https://pawwalls.com/test_image_dark_low_res.webp",
             "https://pawwalls.com/test_image_override_light_low_res.webp",
@@ -168,11 +168,11 @@ class OfferingImagePreDownloaderTest {
             "https://pawwalls.com/test_sticky_footer_override_dark_low_res.webp",
             "https://pawwalls.com/test_sticky_footer_override_2_light_low_res.webp",
             "https://pawwalls.com/test_sticky_footer_override_2_dark_low_res.webp",
-            "https://pawwalls.com/test_icon_2.webp",
+            "https://pawwalls.com/icons/test_icon_2.webp",
             "https://pawwalls.com/test_header_low_res.webp",
-            "https://pawwalls.com/test_icon_5.webp",
-            "https://pawwalls.com/test_icon_3.webp",
-            "https://pawwalls.com/test_icon_4.webp",
+            "https://pawwalls.com/icons/test_icon_5.webp",
+            "https://pawwalls.com/icons/test_icon_3.webp",
+            "https://pawwalls.com/icons/test_icon_4.webp",
         )
 
         preDownloader.preDownloadOfferingImages(createOfferingWithV2Paywall(
@@ -193,7 +193,7 @@ class OfferingImagePreDownloaderTest {
                             color = ColorScheme(light = ColorInfo.Alias(ColorAlias(""))),
                         ),
                         IconComponent(
-                            baseUrl = "https://pawwalls.com",
+                            baseUrl = "https://pawwalls.com/icons",
                             iconName = "test_icon",
                             formats = IconComponent.Formats(
                                 webp = "test_icon_1.webp",
@@ -292,7 +292,7 @@ class OfferingImagePreDownloaderTest {
                                         color = ColorScheme(light = ColorInfo.Alias(ColorAlias(""))),
                                     ),
                                     icon = IconComponent(
-                                        baseUrl = "https://pawwalls.com",
+                                        baseUrl = "https://pawwalls.com/icons",
                                         iconName = "test_icon",
                                         formats = IconComponent.Formats(
                                             webp = "test_icon_3.webp",
@@ -305,7 +305,7 @@ class OfferingImagePreDownloaderTest {
                                         color = ColorScheme(light = ColorInfo.Alias(ColorAlias(""))),
                                     ),
                                     icon = IconComponent(
-                                        baseUrl = "https://pawwalls.com",
+                                        baseUrl = "https://pawwalls.com/icons",
                                         iconName = "test_icon",
                                         formats = IconComponent.Formats(
                                             webp = "test_icon_4.webp",
@@ -330,7 +330,7 @@ class OfferingImagePreDownloaderTest {
                                 color = ColorScheme(light = ColorInfo.Alias(ColorAlias("")))
                             ),
                             IconComponent(
-                                baseUrl = "https://pawwalls.com",
+                                baseUrl = "https://pawwalls.com/icons",
                                 iconName = "test_icon",
                                 formats = IconComponent.Formats(
                                     webp = "test_icon_2.webp",
@@ -373,7 +373,7 @@ class OfferingImagePreDownloaderTest {
                     stack = StackComponent(
                         components = listOf(
                             IconComponent(
-                                baseUrl = "https://pawwalls.com",
+                                baseUrl = "https://pawwalls.com/icons",
                                 iconName = "test_icon",
                                 formats = IconComponent.Formats(
                                     webp = "test_icon_5.webp",


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids — none needed: iOS appends correctly (`PaywallV2CacheWarming.swift` uses `appendingPathComponent`), and hybrids inherit this fix through `purchases-android`.

### Motivation
Resolves #3712

`PaywallComponentsImagePreDownloader` builds `IconComponent` pre-download URLs with `Uri.Builder.path()`, which **replaces** the base URL's path instead of appending to it. Icon `base_url`s are served as `https://icons.pawwalls.com/icons`, so the `/icons` segment was silently dropped and every pre-download request hit `https://icons.pawwalls.com/<name>.webp` → S3/CloudFront 403, on every offerings fetch, for every Android user whose paywall contains icon components (reported as fleet-wide APM noise in New Relic, see the linked issue and [community thread](https://community.revenuecat.com/questions/6407)).

The paywall still rendered correctly because `IconComponentState.url` concatenates correctly — which also means the pre-warm has been silently useless since it shipped in 8.12.0 (#2143): icons were always fetched cold at render time.

### Description
- Build the icon URL by concatenation, exactly like `IconComponentState.url` does. Matching the render-path construction is the actual requirement here (not just producing a *valid* URL): the pre-warm only helps if it populates the image cache under the **same URL string** the render path requests.
- Updated the `OfferingImagePreDownloaderTest` icon fixtures to use a base URL with a path segment (`https://pawwalls.com/icons`), matching how icon `base_url`s are served in production. The previous fixtures used a pathless base (`https://pawwalls.com`), for which *replace* and *append* coincidentally produce the same URL — which is why the existing test never caught this.

Intentionally untouched:
- The two `Uri.Builder.path()` usages on the Paywalls **V1** path (`OfferingImagePreDownloader`, `TemplateConfigurationFactory`): V1 `asset_base_url` has no path segment, and the V1 render + pre-download paths use the same construction, so they agree with each other today.
- Icon `overrides` are not pre-warmed (only the base icon), unlike image/stack overrides — pre-existing gap, left out of scope to keep this a pure bug fix.

**Testing**: updated tests fail on `main` (`paywalls V2 - if images, it downloads all of them` captures `…/test_icon_1.webp` without the `/icons` segment) and pass with this change (`:purchases:testDefaultsBc8DebugUnitTest`). `detektAll` clean. Also verified against production CDN: `curl https://icons.pawwalls.com/check.webp` → 403, `curl https://icons.pawwalls.com/icons/check.webp` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow URL-construction fix in best-effort image pre-warming; no auth, purchase, or data-model changes.
> 
> **Overview**
> Fixes Paywalls V2 icon **pre-download** URLs so they include the full `baseUrl` path (e.g. `/icons`) instead of dropping it.
> 
> `PaywallComponentsImagePreDownloader` now builds icon URIs with `appendEncodedPath` on the parsed base URL, aligning with how `IconComponentState` concatenates at render time so Coil warms the **same cache key** the UI requests. Previously `Uri.Builder.path()` replaced the base path, causing 403s on offerings fetch while paywalls still rendered from cold loads.
> 
> Unit test fixtures now use `https://pawwalls.com/icons` as the icon `baseUrl` and assert `…/icons/test_icon_*.webp` so the bug is covered (pathless bases masked the mismatch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ec1d564338a9b75b4ee004a4396ad4dbf6439c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->