### PR TITLE
fix(remote-config): Remote-config fixes/improvements

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.remoteconfig
 
 import android.content.Context
+import androidx.core.util.AtomicFile
 import com.revenuecat.purchases.common.errorLog
 import java.io.File
 import java.io.IOException
@@ -47,31 +48,33 @@ internal class RemoteConfigBlobStore(
         }
     }
 
-    /** Returns whether the blob was actually persisted; IO failures are logged, swallowed, and reported as `false`. */
+    /**
+     * Returns whether the blob was actually persisted; IO failures are logged, swallowed, and reported as `false`.
+     *
+     * Writes are crash-safe via [AtomicFile] (mirroring [RemoteConfigDiskCache]): the bytes go to a `<ref>.new`
+     * side file that is synced and renamed over the target only on success, so the blob file itself is never
+     * partial. An interrupted write leaves only the `.new` orphan, whose name is not a valid ref — it is
+     * invisible to the index scan and pruned by [retainOnly].
+     */
     fun write(ref: String, data: ByteBuffer): Boolean {
         val target = blobFile(ref)
         if (target == null) {
             errorLog { "Refusing to write remote config blob with malformed ref '$ref'." }
             return false
         }
-        val parent = blobsDir()
         return try {
-            if (!parent.exists()) {
-                parent.mkdirs()
-            }
             val view = data.duplicate()
             val bytes = ByteArray(view.remaining())
             view.get(bytes)
-            val tempFile = File.createTempFile("rc_blob_", ".tmp", parent)
+            // startWrite creates the blobs directory when missing.
+            val atomicFile = AtomicFile(target)
+            val out = atomicFile.startWrite()
             try {
-                tempFile.writeBytes(bytes)
-                if (!tempFile.renameTo(target)) {
-                    tempFile.copyTo(target, overwrite = true)
-                }
-            } finally {
-                if (tempFile.exists()) {
-                    tempFile.delete()
-                }
+                out.write(bytes)
+                atomicFile.finishWrite(out)
+            } catch (e: IOException) {
+                atomicFile.failWrite(out)
+                throw e
             }
             synchronized(lock) { loadedRefs().add(ref) }
             true
@@ -86,8 +89,9 @@ internal class RemoteConfigBlobStore(
 
     /**
      * Deletes every cached blob whose ref is not in [refs]. Scans the directory (not just the in-memory index)
-     * so orphans the index never tracks are pruned too: leftover `rc_blob_*.tmp` files from a write interrupted
-     * by a process kill, and any invalid-named file. Runs once per sync, so the scan is not on a hot path.
+     * so orphans the index never tracks are pruned too: leftover `<ref>.new` side files from an [AtomicFile]
+     * write interrupted by a process kill, and any invalid-named file. Runs once per sync, so the scan is not
+     * on a hot path.
      */
     fun retainOnly(refs: Set<String>) {
         val parent = blobsDir()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -34,12 +34,6 @@ internal data class PersistedRemoteConfigurationState(
  * Persists [PersistedRemoteConfigurationState] to `noBackupFilesDir/RevenueCat/remote_config/`
  * (excluded from backups as a regenerable cache). Writes are atomic and crash-safe via [AtomicFile];
  * a missing or corrupt file reads back as `null`.
- *
- * The last read or written state is kept as an in-memory snapshot, so the file is parsed at most once:
- * reads on the hot path (every `topic()`/`blobData()` call, every blob-source lookup during a download)
- * answer from memory, and the shared object identity also lets the source provider's lazily-computed
- * [ConfigTopic.contentHash] be reused instead of recomputed per read. The cache is the file's sole
- * accessor, so the snapshot stays authoritative; [write]/[clear] keep it in sync.
  */
 internal class RemoteConfigDiskCache(
     private val applicationContext: Context,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -34,13 +34,44 @@ internal data class PersistedRemoteConfigurationState(
  * Persists [PersistedRemoteConfigurationState] to `noBackupFilesDir/RevenueCat/remote_config/`
  * (excluded from backups as a regenerable cache). Writes are atomic and crash-safe via [AtomicFile];
  * a missing or corrupt file reads back as `null`.
+ *
+ * The last read or written state is kept as an in-memory snapshot, so the file is parsed at most once:
+ * reads on the hot path (every `topic()`/`blobData()` call, every blob-source lookup during a download)
+ * answer from memory, and the shared object identity also lets the source provider's lazily-computed
+ * [ConfigTopic.contentHash] be reused instead of recomputed per read. The cache is the file's sole
+ * accessor, so the snapshot stays authoritative; [write]/[clear] keep it in sync.
  */
 internal class RemoteConfigDiskCache(
     private val applicationContext: Context,
 ) {
     private val json = JsonProvider.defaultJson
+    private val lock = Any()
 
-    fun read(): PersistedRemoteConfigurationState? {
+    // In-memory snapshot of the persisted state. `snapshotLoaded` distinguishes "not read yet" from
+    // "read: nothing usable on disk (null)", so a missing/corrupt file is not re-read on every call.
+    private var snapshot: PersistedRemoteConfigurationState? = null
+    private var snapshotLoaded = false
+
+    fun read(): PersistedRemoteConfigurationState? = synchronized(lock) {
+        if (!snapshotLoaded) {
+            snapshot = readFromDisk()
+            snapshotLoaded = true
+        }
+        snapshot
+    }
+
+    /** Returns `true` once the state is durably persisted, `false` if serialization or IO failed. */
+    fun write(config: PersistedRemoteConfigurationState): Boolean = synchronized(lock) {
+        writeToDisk(config).also { persisted ->
+            if (persisted) {
+                // Only mirror a durable write; on failure the previous state is still what is on disk.
+                snapshot = config
+                snapshotLoaded = true
+            }
+        }
+    }
+
+    private fun readFromDisk(): PersistedRemoteConfigurationState? {
         val target = targetFile()
         if (!target.exists()) return null
         val atomicFile = AtomicFile(target)
@@ -58,8 +89,7 @@ internal class RemoteConfigDiskCache(
         }
     }
 
-    /** Returns `true` once the state is durably persisted, `false` if serialization or IO failed. */
-    fun write(config: PersistedRemoteConfigurationState): Boolean {
+    private fun writeToDisk(config: PersistedRemoteConfigurationState): Boolean {
         return try {
             val target = targetFile()
             target.parentFile?.let { parent ->
@@ -95,10 +125,14 @@ internal class RemoteConfigDiskCache(
      * change to keep configuration from bleeding across users.
      */
     fun clear() {
-        try {
-            AtomicFile(targetFile()).delete()
-        } catch (e: SecurityException) {
-            errorLog(e) { "Failed to clear remote config from disk." }
+        synchronized(lock) {
+            snapshot = null
+            snapshotLoaded = true
+            try {
+                AtomicFile(targetFile()).delete()
+            } catch (e: SecurityException) {
+                errorLog(e) { "Failed to clear remote config from disk." }
+            }
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -43,11 +43,10 @@ import java.util.concurrent.atomic.AtomicInteger
  * from the response's [RemoteConfiguration.activeTopics]. The manager is topic-agnostic: it never interprets item
  * shapes or branches on topic name — consumer topics are read lazily by providers through the manager.
  *
- * A refresh's disk work runs on [scope]: the pre-request reads (persisted state + cached blob refs) and the
- * `200` path's parse/commit/blob pass, so callers never touch disk on their own thread and the launch lets
- * [clearCache] cancel in-flight work. Blob prefetch runs on the fetcher's own worker pool (not [scope]).
- * Identity changes call [clearCache], which bumps an epoch so a late `/v1/config` response (its HTTP request
- * cannot be socket-cancelled) is dropped instead of persisting over the freshly wiped cache.
+ * The `200` path runs on [scope]: persistence is synchronous, but the launch lets [clearCache] cancel the
+ * in-flight parse/persist. Blob prefetch runs on the fetcher's own worker pool (not [scope]). Identity changes
+ * call [clearCache], which bumps an epoch so a late `/v1/config` response (its HTTP request cannot be
+ * socket-cancelled) is dropped instead of persisting over the freshly wiped cache.
  *
  * Overlapping refreshes are deduped: only one [refreshRemoteConfig] runs at a time. A call made while one is
  * already in flight is skipped (the backend collapses concurrent requests but still fires every callback, which
@@ -82,11 +81,9 @@ internal class RemoteConfigManager(
     // socket-cancelled), so an old user's response can never persist over the wiped cache.
     private val epoch = AtomicInteger(0)
 
-    // Serializes a sync's "re-check epoch + commit" against clearCache()'s "bump epoch + wipe". commitConfig()
-    // is synchronous, so cancellation can't interrupt it; this lock makes the two critical sections atomic so a
-    // late commit either runs fully before the wipe or sees the bumped epoch and skips — the configuration is
-    // never written after the wipe. The best-effort blob pass deliberately runs outside this lock (see
-    // handleContainer), so an identity change is never blocked behind blob IO.
+    // Serializes a sync's "re-check epoch + persist" against clearCache()'s "bump epoch + wipe". persist() is
+    // synchronous, so cancellation can't interrupt it; this lock makes the two critical sections atomic so a
+    // late persist either runs fully before the wipe or sees the bumped epoch and skips — never writes after it.
     private val cacheLock = Any()
 
     @Volatile
@@ -137,75 +134,49 @@ internal class RemoteConfigManager(
             requestEpoch = epoch.get()
             refreshCompletion = CompletableDeferred()
         }
-        // The pre-request disk reads (persisted state + cached blob refs, which may scan the blobs directory)
-        // run on the manager's scope so callers — e.g. an identity change on the main thread — never touch
-        // disk. The guard and completion were acquired synchronously above, so a concurrent read can already
-        // await this refresh.
-        scope.launch {
-            // Cleared (identity change) before this ran: the guard was already handed back by clearCache().
-            if (epoch.get() != requestEpoch) return@launch
-            val persisted = diskCache.read()
-            val storedBlobs = blobStore.cachedRefs()
-            logRefreshStart(persisted, appInBackground)
-            backend.getRemoteConfig(
-                appInBackground = appInBackground,
-                appUserID = appUserID,
-                domain = persisted?.domain ?: DEFAULT_DOMAIN,
-                // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
-                manifest = persisted?.manifest,
-                // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
-                prefetchedBlobs = persisted?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
-                onSuccess = { container, _ ->
-                    if (epoch.get() != requestEpoch) {
-                        // The cache was cleared (identity change) after this request started. Drop the stale
-                        // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
-                        return@getRemoteConfig
+        val persisted = diskCache.read()
+        val storedBlobs = blobStore.cachedRefs()
+        logRefreshStart(persisted, appInBackground)
+        backend.getRemoteConfig(
+            appInBackground = appInBackground,
+            appUserID = appUserID,
+            domain = persisted?.domain ?: DEFAULT_DOMAIN,
+            // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
+            manifest = persisted?.manifest,
+            // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
+            prefetchedBlobs = persisted?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
+            onSuccess = { container, _ ->
+                if (epoch.get() != requestEpoch) {
+                    // The cache was cleared (identity change) after this request started. Drop the stale
+                    // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
+                    return@getRemoteConfig
+                }
+                if (container == null) {
+                    handleNotModified(requestEpoch)
+                    return@getRemoteConfig
+                }
+                scope.launch {
+                    try {
+                        val response = RemoteConfiguration.parse(container.config.decode())
+                        synchronized(cacheLock) {
+                            if (epoch.get() != requestEpoch) return@launch
+                            persist(previous = persisted, response = response, container = container)
+                        }
+                    } catch (e: SerializationException) {
+                        errorLog(e) {
+                            "Failed to parse remote config response. Keeping the cached configuration."
+                        }
+                    } catch (e: RCContainerFormatException) {
+                        errorLog(e) {
+                            "Failed to decode remote config response. Keeping the cached configuration."
+                        }
+                    } finally {
+                        releaseGuardIfOwned(requestEpoch)
                     }
-                    if (container == null) {
-                        handleNotModified(requestEpoch)
-                        return@getRemoteConfig
-                    }
-                    scope.launch {
-                        handleContainer(requestEpoch, persisted, container)
-                    }
-                },
-                onError = { error, behavior -> handleRefreshError(requestEpoch, error, behavior) },
-            )
-        }
-    }
-
-    /**
-     * The `200` path: parses the container's config element, commits it under [cacheLock], then runs the
-     * best-effort blob sync **outside** the lock so an identity change ([clearCache]) is never blocked behind
-     * blob IO. Only the commit needs atomicity with the epoch check; a stale blob written past a concurrent
-     * wipe is inert (content-addressed and unreferenced by the new config) and pruned by the next sync's
-     * retain pass.
-     */
-    private fun handleContainer(
-        requestEpoch: Int,
-        persisted: PersistedRemoteConfigurationState?,
-        container: RCContainer,
-    ) {
-        try {
-            val response = RemoteConfiguration.parse(container.config.decode())
-            val commit = synchronized(cacheLock) {
-                if (epoch.get() != requestEpoch) return
-                commitConfig(previous = persisted, response = response)
-            }
-            if (commit != null && epoch.get() == requestEpoch) {
-                syncBlobs(container, response, commit)
-            }
-        } catch (e: SerializationException) {
-            errorLog(e) {
-                "Failed to parse remote config response. Keeping the cached configuration."
-            }
-        } catch (e: RCContainerFormatException) {
-            errorLog(e) {
-                "Failed to decode remote config response. Keeping the cached configuration."
-            }
-        } finally {
-            releaseGuardIfOwned(requestEpoch)
-        }
+                }
+            },
+            onError = { error, behavior -> handleRefreshError(requestEpoch, error, behavior) },
+        )
     }
 
     /** Handles a `204 Not Modified`: nothing changed, so keep the cache and just advance the refresh bookkeeping. */
@@ -443,23 +414,11 @@ internal class RemoteConfigManager(
         }
     }
 
-    /** What a committed sync leaves for the out-of-lock blob pass: the merged index + the wanted blob refs. */
-    private class CommittedSync(
-        val mergedTopics: Map<String, ConfigTopic>,
-        val blobRefsToKeep: Set<String>,
-    )
-
-    /**
-     * Persists the configuration — the full topic index (incl. each item's inline content) plus the manifest
-     * the server diffs against is the source of truth, and persisting it IS the entire commit (the manifest
-     * advances unconditionally). Returns what the blob pass needs, or `null` when the write failed (the
-     * previous state stands and the next sync replays it). Callers must hold [cacheLock]; only the commit
-     * needs that atomicity, so this deliberately does no blob IO.
-     */
-    private fun commitConfig(
+    private fun persist(
         previous: PersistedRemoteConfigurationState?,
         response: RemoteConfiguration,
-    ): CommittedSync? {
+        container: RCContainer,
+    ) {
         debugLog {
             val changed = response.topics.entries.joinToString { (name, topic) ->
                 "$name -> items=${topic.keys}"
@@ -476,6 +435,10 @@ internal class RemoteConfigManager(
         // Blobs the current config still wants: the prefetch set plus any active-topic blob ref.
         val blobRefsToKeep = response.prefetchBlobs.toSet() + mergedTopics.toTopicBlobRefs().values.flatten()
 
+        // Persist the configuration first: the full topic index (incl. each item's inline content) plus the
+        // manifest the server diffs against is the source of truth, and persisting it IS the entire commit (the
+        // manifest advances unconditionally). Inline blobs are recoverable over the network, so only touch the
+        // blob store once the state is durably committed — a failed persist never orphans or evicts blobs.
         val persisted = diskCache.write(
             PersistedRemoteConfigurationState(
                 domain = response.domain,
@@ -486,28 +449,18 @@ internal class RemoteConfigManager(
             ),
         )
 
-        return if (persisted) {
+        if (persisted) {
             lastRefreshedAt = dateProvider.now
             debugLog {
                 "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +
                     "${blobRefsToKeep.size} blobs wanted)."
             }
-            CommittedSync(mergedTopics, blobRefsToKeep)
+            extractInlineBlobs(container, blobRefsToKeep)
+            blobStore.retainOnly(blobRefsToKeep)
+            prefetchBlobs(response, mergedTopics)
         } else {
             errorLog { "Skipping remote config blob sync: failed to persist the configuration." }
-            null
         }
-    }
-
-    /**
-     * The best-effort blob pass after a committed sync: extract the inlined blobs the config still wants,
-     * prune the rest, and prefetch what is missing. Inline blobs are recoverable over the network, so this
-     * only runs once the state is durably committed — a failed persist never orphans or evicts blobs.
-     */
-    private fun syncBlobs(container: RCContainer, response: RemoteConfiguration, commit: CommittedSync) {
-        extractInlineBlobs(container, commit.blobRefsToKeep)
-        blobStore.retainOnly(commit.blobRefsToKeep)
-        prefetchBlobs(response, commit.mergedTopics)
     }
 
     /**
@@ -515,7 +468,7 @@ internal class RemoteConfigManager(
      * [RemoteConfiguration.prefetchBlobs] plus any item flagged `prefetch`. Re-arms the blob source provider
      * first **only if a prior cycle exhausted its sources** (otherwise failover progress is kept, so a
      * known-bad higher-priority source isn't re-tried every sync), then hands the not-yet-cached refs to the
-     * fetcher's LOW-priority queue. Runs on the manager's IO scope (inside [syncBlobs]), so it never blocks the
+     * fetcher's LOW-priority queue. Runs on the manager's IO scope (inside [persist]), so it never blocks the
      * main thread; a failed download is tolerated (re-fetched next sync / on demand).
      */
     private fun prefetchBlobs(response: RemoteConfiguration, mergedTopics: Map<String, ConfigTopic>) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -43,10 +43,11 @@ import java.util.concurrent.atomic.AtomicInteger
  * from the response's [RemoteConfiguration.activeTopics]. The manager is topic-agnostic: it never interprets item
  * shapes or branches on topic name — consumer topics are read lazily by providers through the manager.
  *
- * The `200` path runs on [scope]: persistence is synchronous, but the launch lets [clearCache] cancel the
- * in-flight parse/persist. Blob prefetch runs on the fetcher's own worker pool (not [scope]). Identity changes
- * call [clearCache], which bumps an epoch so a late `/v1/config` response (its HTTP request cannot be
- * socket-cancelled) is dropped instead of persisting over the freshly wiped cache.
+ * A refresh's disk work runs on [scope]: the pre-request reads (persisted state + cached blob refs) and the
+ * `200` path's parse/commit/blob pass, so callers never touch disk on their own thread and the launch lets
+ * [clearCache] cancel in-flight work. Blob prefetch runs on the fetcher's own worker pool (not [scope]).
+ * Identity changes call [clearCache], which bumps an epoch so a late `/v1/config` response (its HTTP request
+ * cannot be socket-cancelled) is dropped instead of persisting over the freshly wiped cache.
  *
  * Overlapping refreshes are deduped: only one [refreshRemoteConfig] runs at a time. A call made while one is
  * already in flight is skipped (the backend collapses concurrent requests but still fires every callback, which
@@ -81,9 +82,11 @@ internal class RemoteConfigManager(
     // socket-cancelled), so an old user's response can never persist over the wiped cache.
     private val epoch = AtomicInteger(0)
 
-    // Serializes a sync's "re-check epoch + persist" against clearCache()'s "bump epoch + wipe". persist() is
-    // synchronous, so cancellation can't interrupt it; this lock makes the two critical sections atomic so a
-    // late persist either runs fully before the wipe or sees the bumped epoch and skips — never writes after it.
+    // Serializes a sync's "re-check epoch + commit" against clearCache()'s "bump epoch + wipe". commitConfig()
+    // is synchronous, so cancellation can't interrupt it; this lock makes the two critical sections atomic so a
+    // late commit either runs fully before the wipe or sees the bumped epoch and skips — the configuration is
+    // never written after the wipe. The best-effort blob pass deliberately runs outside this lock (see
+    // handleContainer), so an identity change is never blocked behind blob IO.
     private val cacheLock = Any()
 
     @Volatile
@@ -134,49 +137,75 @@ internal class RemoteConfigManager(
             requestEpoch = epoch.get()
             refreshCompletion = CompletableDeferred()
         }
-        val persisted = diskCache.read()
-        val storedBlobs = blobStore.cachedRefs()
-        logRefreshStart(persisted, appInBackground)
-        backend.getRemoteConfig(
-            appInBackground = appInBackground,
-            appUserID = appUserID,
-            domain = persisted?.domain ?: DEFAULT_DOMAIN,
-            // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
-            manifest = persisted?.manifest,
-            // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
-            prefetchedBlobs = persisted?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
-            onSuccess = { container, _ ->
-                if (epoch.get() != requestEpoch) {
-                    // The cache was cleared (identity change) after this request started. Drop the stale
-                    // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
-                    return@getRemoteConfig
-                }
-                if (container == null) {
-                    handleNotModified(requestEpoch)
-                    return@getRemoteConfig
-                }
-                scope.launch {
-                    try {
-                        val response = RemoteConfiguration.parse(container.config.decode())
-                        synchronized(cacheLock) {
-                            if (epoch.get() != requestEpoch) return@launch
-                            persist(previous = persisted, response = response, container = container)
-                        }
-                    } catch (e: SerializationException) {
-                        errorLog(e) {
-                            "Failed to parse remote config response. Keeping the cached configuration."
-                        }
-                    } catch (e: RCContainerFormatException) {
-                        errorLog(e) {
-                            "Failed to decode remote config response. Keeping the cached configuration."
-                        }
-                    } finally {
-                        releaseGuardIfOwned(requestEpoch)
+        // The pre-request disk reads (persisted state + cached blob refs, which may scan the blobs directory)
+        // run on the manager's scope so callers — e.g. an identity change on the main thread — never touch
+        // disk. The guard and completion were acquired synchronously above, so a concurrent read can already
+        // await this refresh.
+        scope.launch {
+            // Cleared (identity change) before this ran: the guard was already handed back by clearCache().
+            if (epoch.get() != requestEpoch) return@launch
+            val persisted = diskCache.read()
+            val storedBlobs = blobStore.cachedRefs()
+            logRefreshStart(persisted, appInBackground)
+            backend.getRemoteConfig(
+                appInBackground = appInBackground,
+                appUserID = appUserID,
+                domain = persisted?.domain ?: DEFAULT_DOMAIN,
+                // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
+                manifest = persisted?.manifest,
+                // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
+                prefetchedBlobs = persisted?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
+                onSuccess = { container, _ ->
+                    if (epoch.get() != requestEpoch) {
+                        // The cache was cleared (identity change) after this request started. Drop the stale
+                        // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
+                        return@getRemoteConfig
                     }
-                }
-            },
-            onError = { error, behavior -> handleRefreshError(requestEpoch, error, behavior) },
-        )
+                    if (container == null) {
+                        handleNotModified(requestEpoch)
+                        return@getRemoteConfig
+                    }
+                    scope.launch {
+                        handleContainer(requestEpoch, persisted, container)
+                    }
+                },
+                onError = { error, behavior -> handleRefreshError(requestEpoch, error, behavior) },
+            )
+        }
+    }
+
+    /**
+     * The `200` path: parses the container's config element, commits it under [cacheLock], then runs the
+     * best-effort blob sync **outside** the lock so an identity change ([clearCache]) is never blocked behind
+     * blob IO. Only the commit needs atomicity with the epoch check; a stale blob written past a concurrent
+     * wipe is inert (content-addressed and unreferenced by the new config) and pruned by the next sync's
+     * retain pass.
+     */
+    private fun handleContainer(
+        requestEpoch: Int,
+        persisted: PersistedRemoteConfigurationState?,
+        container: RCContainer,
+    ) {
+        try {
+            val response = RemoteConfiguration.parse(container.config.decode())
+            val commit = synchronized(cacheLock) {
+                if (epoch.get() != requestEpoch) return
+                commitConfig(previous = persisted, response = response)
+            }
+            if (commit != null && epoch.get() == requestEpoch) {
+                syncBlobs(container, response, commit)
+            }
+        } catch (e: SerializationException) {
+            errorLog(e) {
+                "Failed to parse remote config response. Keeping the cached configuration."
+            }
+        } catch (e: RCContainerFormatException) {
+            errorLog(e) {
+                "Failed to decode remote config response. Keeping the cached configuration."
+            }
+        } finally {
+            releaseGuardIfOwned(requestEpoch)
+        }
     }
 
     /** Handles a `204 Not Modified`: nothing changed, so keep the cache and just advance the refresh bookkeeping. */
@@ -414,11 +443,23 @@ internal class RemoteConfigManager(
         }
     }
 
-    private fun persist(
+    /** What a committed sync leaves for the out-of-lock blob pass: the merged index + the wanted blob refs. */
+    private class CommittedSync(
+        val mergedTopics: Map<String, ConfigTopic>,
+        val blobRefsToKeep: Set<String>,
+    )
+
+    /**
+     * Persists the configuration — the full topic index (incl. each item's inline content) plus the manifest
+     * the server diffs against is the source of truth, and persisting it IS the entire commit (the manifest
+     * advances unconditionally). Returns what the blob pass needs, or `null` when the write failed (the
+     * previous state stands and the next sync replays it). Callers must hold [cacheLock]; only the commit
+     * needs that atomicity, so this deliberately does no blob IO.
+     */
+    private fun commitConfig(
         previous: PersistedRemoteConfigurationState?,
         response: RemoteConfiguration,
-        container: RCContainer,
-    ) {
+    ): CommittedSync? {
         debugLog {
             val changed = response.topics.entries.joinToString { (name, topic) ->
                 "$name -> items=${topic.keys}"
@@ -435,10 +476,6 @@ internal class RemoteConfigManager(
         // Blobs the current config still wants: the prefetch set plus any active-topic blob ref.
         val blobRefsToKeep = response.prefetchBlobs.toSet() + mergedTopics.toTopicBlobRefs().values.flatten()
 
-        // Persist the configuration first: the full topic index (incl. each item's inline content) plus the
-        // manifest the server diffs against is the source of truth, and persisting it IS the entire commit (the
-        // manifest advances unconditionally). Inline blobs are recoverable over the network, so only touch the
-        // blob store once the state is durably committed — a failed persist never orphans or evicts blobs.
         val persisted = diskCache.write(
             PersistedRemoteConfigurationState(
                 domain = response.domain,
@@ -449,18 +486,28 @@ internal class RemoteConfigManager(
             ),
         )
 
-        if (persisted) {
+        return if (persisted) {
             lastRefreshedAt = dateProvider.now
             debugLog {
                 "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +
                     "${blobRefsToKeep.size} blobs wanted)."
             }
-            extractInlineBlobs(container, blobRefsToKeep)
-            blobStore.retainOnly(blobRefsToKeep)
-            prefetchBlobs(response, mergedTopics)
+            CommittedSync(mergedTopics, blobRefsToKeep)
         } else {
             errorLog { "Skipping remote config blob sync: failed to persist the configuration." }
+            null
         }
+    }
+
+    /**
+     * The best-effort blob pass after a committed sync: extract the inlined blobs the config still wants,
+     * prune the rest, and prefetch what is missing. Inline blobs are recoverable over the network, so this
+     * only runs once the state is durably committed — a failed persist never orphans or evicts blobs.
+     */
+    private fun syncBlobs(container: RCContainer, response: RemoteConfiguration, commit: CommittedSync) {
+        extractInlineBlobs(container, commit.blobRefsToKeep)
+        blobStore.retainOnly(commit.blobRefsToKeep)
+        prefetchBlobs(response, commit.mergedTopics)
     }
 
     /**
@@ -468,7 +515,7 @@ internal class RemoteConfigManager(
      * [RemoteConfiguration.prefetchBlobs] plus any item flagged `prefetch`. Re-arms the blob source provider
      * first **only if a prior cycle exhausted its sources** (otherwise failover progress is kept, so a
      * known-bad higher-priority source isn't re-tried every sync), then hands the not-yet-cached refs to the
-     * fetcher's LOW-priority queue. Runs on the manager's IO scope (inside [persist]), so it never blocks the
+     * fetcher's LOW-priority queue. Runs on the manager's IO scope (inside [syncBlobs]), so it never blocks the
      * main thread; a failed download is tolerated (re-fetched next sync / on demand).
      */
     private fun prefetchBlobs(response: RemoteConfiguration, mergedTopics: Map<String, ConfigTopic>) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
@@ -156,8 +156,6 @@ internal object ConfigItemSerializer : KSerializer<RemoteConfiguration.ConfigIte
     override fun deserialize(decoder: Decoder): RemoteConfiguration.ConfigItem {
         val jsonDecoder = decoder as? JsonDecoder
             ?: throw SerializationException("ConfigItem can only be deserialized from JSON.")
-        // Throw SerializationException (not the ISE of the .jsonObject accessor) so a malformed item is a
-        // recoverable parse failure to callers catching serialization errors, never an uncaught crash.
         val element = jsonDecoder.decodeJsonElement()
         val obj = element as? JsonObject
             ?: throw SerializationException("ConfigItem must be a JSON object, but was: $element.")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfiguration.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.common.JsonProvider
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -16,7 +17,6 @@ import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.jsonObject
 import java.nio.ByteBuffer
 import java.security.MessageDigest
 
@@ -155,8 +155,12 @@ internal object ConfigItemSerializer : KSerializer<RemoteConfiguration.ConfigIte
 
     override fun deserialize(decoder: Decoder): RemoteConfiguration.ConfigItem {
         val jsonDecoder = decoder as? JsonDecoder
-            ?: error("ConfigItem can only be deserialized from JSON.")
-        val obj = jsonDecoder.decodeJsonElement().jsonObject
+            ?: throw SerializationException("ConfigItem can only be deserialized from JSON.")
+        // Throw SerializationException (not the ISE of the .jsonObject accessor) so a malformed item is a
+        // recoverable parse failure to callers catching serialization errors, never an uncaught crash.
+        val element = jsonDecoder.decodeJsonElement()
+        val obj = element as? JsonObject
+            ?: throw SerializationException("ConfigItem must be a JSON object, but was: $element.")
         val blobRef = (obj[BLOB_REF_KEY] as? JsonPrimitive)?.takeIf { it.isString }?.content
         val prefetch = (obj[PREFETCH_KEY] as? JsonPrimitive)?.booleanOrNull ?: false
         val metadata = JsonObject(obj.filterKeys { it != BLOB_REF_KEY && it != PREFETCH_KEY })
@@ -165,7 +169,7 @@ internal object ConfigItemSerializer : KSerializer<RemoteConfiguration.ConfigIte
 
     override fun serialize(encoder: Encoder, value: RemoteConfiguration.ConfigItem) {
         val jsonEncoder = encoder as? JsonEncoder
-            ?: error("ConfigItem can only be serialized to JSON.")
+            ?: throw SerializationException("ConfigItem can only be serialized to JSON.")
         val merged = buildMap<String, JsonElement> {
             putAll(value.metadata)
             value.blobRef?.let { put(BLOB_REF_KEY, JsonPrimitive(it)) }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -2955,6 +2955,28 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         }
     }
 
+    @Test
+    fun `syncAttributesAndOfferingsIfNeeded does not refresh remote config when rate limited`() {
+        every {
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserId, captureLambda())
+        } answers { lambda<() -> Unit>().captured.invoke() }
+        every {
+            mockOfferingsManager.getOfferings(appUserId, false, any(), any(), any())
+        } just Runs
+
+        val callback = object : SyncAttributesAndOfferingsCallback {
+            override fun onSuccess(offerings: Offerings) {}
+            override fun onError(error: PurchasesError) {}
+        }
+        // The rate limiter allows 5 calls per minute; the 6th takes the rate-limited early-return branch,
+        // which serves cached offerings and must not force a remote config refresh.
+        repeat(6) { purchases.purchasesOrchestrator.syncAttributesAndOfferingsIfNeeded(callback) }
+
+        verify(exactly = 5) {
+            mockRemoteConfigManager.refreshRemoteConfig(false, appUserId)
+        }
+    }
+
     // endregion
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStoreTest.kt
@@ -123,19 +123,39 @@ class RemoteConfigBlobStoreTest {
     }
 
     @Test
-    fun `retainOnly prunes orphan temp files and invalid-named files the index never tracks`() {
+    fun `retainOnly prunes orphan side files and invalid-named files the index never tracks`() {
         blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
-        // Simulate a temp file left by a write interrupted mid-flight, plus a stray invalid-named file.
+        // Simulate the AtomicFile side file left by a write interrupted mid-flight, plus a stray
+        // invalid-named file.
         val blobsDir = File(File(testFolder, "RevenueCat"), "blobs")
-        val orphanTemp = File(blobsDir, "rc_blob_orphan.tmp").apply { writeBytes(byteArrayOf(9)) }
+        val orphanSideFile = File(blobsDir, "$refB.new").apply { writeBytes(byteArrayOf(9)) }
         val invalidNamed = File(blobsDir, "not-a-valid-ref").apply { writeBytes(byteArrayOf(9)) }
 
         blobStore.retainOnly(setOf(refA))
 
-        assertThat(orphanTemp.exists()).isFalse
+        assertThat(orphanSideFile.exists()).isFalse
         assertThat(invalidNamed.exists()).isFalse
         assertThat(blobStore.contains(refA)).isTrue
         assertThat(blobStore.cachedRefs()).containsExactly(refA)
+    }
+
+    @Test
+    fun `a write interrupted mid-flight leaves no readable blob`() {
+        // An interrupted AtomicFile write leaves only the `<ref>.new` side file: the blob file itself is
+        // renamed into place only on a successful finish, so it can never exist half-written.
+        val blobsDir = File(File(testFolder, "RevenueCat"), "blobs").apply { mkdirs() }
+        File(blobsDir, "$refA.new").writeBytes(byteArrayOf(1, 2))
+
+        // Neither the store nor a fresh instance's disk scan sees the interrupted write as a cached blob.
+        assertThat(blobStore.contains(refA)).isFalse
+        assertThat(blobStore.read(refA)).isNull()
+        val reopened = RemoteConfigBlobStore(applicationContext)
+        assertThat(reopened.contains(refA)).isFalse
+        assertThat(reopened.cachedRefs()).isEmpty()
+
+        // A retry completes normally, replacing the leftover side file.
+        assertThat(blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(3, 4)))).isTrue
+        assertThat(blobStore.read(refA)).isEqualTo(byteArrayOf(3, 4))
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
@@ -69,6 +69,38 @@ class RemoteConfigDiskCacheTest {
     }
 
     @Test
+    fun `read serves the in-memory snapshot without re-reading the file`() {
+        val config = PersistedRemoteConfigurationState(domain = "app", manifest = "v1.0.")
+        diskCache.write(config)
+
+        // Remove the backing file: a read must still answer from the snapshot, proving no file re-read.
+        File(File(File(testFolder, "RevenueCat"), "remote_config"), "remote_config.json").delete()
+
+        assertThat(diskCache.read()).isEqualTo(config)
+    }
+
+    @Test
+    fun `a fresh instance reads the state from disk`() {
+        val config = PersistedRemoteConfigurationState(domain = "app", manifest = "v1.0.")
+        diskCache.write(config)
+
+        // A new instance has no snapshot, so this proves the write actually reached the file.
+        assertThat(RemoteConfigDiskCache(applicationContext).read()).isEqualTo(config)
+    }
+
+    @Test
+    fun `read caches a miss so the file is not re-checked every call`() {
+        assertThat(diskCache.read()).isNull()
+
+        // A file appearing behind the cache's back is not picked up: the cache is the file's sole writer,
+        // and the cached miss stands until a write() or clear() through this instance.
+        RemoteConfigDiskCache(applicationContext)
+            .write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.0."))
+
+        assertThat(diskCache.read()).isNull()
+    }
+
+    @Test
     fun `write returns true on a successful persist`() {
         val persisted = diskCache.write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.0."))
 
@@ -160,6 +192,35 @@ class RemoteConfigDiskCacheTest {
         diskCache.clear()
 
         assertThat(diskCache.read()).isNull()
+    }
+
+    @Test
+    fun `read tolerates unknown keys in the persisted file for forward-compatibility`() {
+        // A file written by a future SDK version may carry extra fields; they must not fail the read.
+        val file = File(File(File(testFolder, "RevenueCat"), "remote_config"), "remote_config.json")
+        file.parentFile!!.mkdirs()
+        // The persisted format uses the Kotlin property names (e.g. `activeTopics`), unlike the wire format.
+        // language=json
+        file.writeText(
+            """
+            {
+              "domain": "app",
+              "manifest": "v1.0.",
+              "activeTopics": ["sources"],
+              "future_field": { "nested": true },
+              "topics": { "sources": { "api": { "url": "https://api.revenuecat.com", "future_key": 1 } } }
+            }
+            """.trimIndent(),
+        )
+
+        val read = diskCache.read()
+
+        assertThat(read).isNotNull
+        assertThat(read!!.domain).isEqualTo("app")
+        assertThat(read.manifest).isEqualTo("v1.0.")
+        assertThat(read.activeTopics).containsExactly("sources")
+        // Unknown item keys survive as metadata (the ConfigItem serializer keeps non-reserved keys).
+        assertThat(read.topics.getValue("sources").getValue("api").metadata).containsKey("future_key")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -41,7 +40,6 @@ import org.robolectric.annotation.Config
 import java.nio.ByteBuffer
 import java.util.Date
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
@@ -747,80 +745,6 @@ class RemoteConfigManagerTest {
         assertThat(clearEntered.count).isZero()
         verify(exactly = 1) { diskCache.write(any()) }
         verify(exactly = 1) { diskCache.clear() }
-    }
-
-    @Test
-    fun `clearCache is not blocked behind the post-commit blob pass`() {
-        every { diskCache.read() } returns null
-        val response = """
-            {
-              "domain": "app",
-              "manifest": "v1.200.sources:etag2",
-              "active_topics": ["sources"],
-              "topics": { "sources": { "default": { "blob_ref": "newBlob" } } }
-            }
-        """.trimIndent()
-
-        val retainEntered = CountDownLatch(1)
-        val releaseRetain = CountDownLatch(1)
-        val clearEntered = CountDownLatch(1)
-        // The blob pass runs after the commit, outside cacheLock; park inside it to race clearCache.
-        every { blobStore.retainOnly(any()) } answers {
-            retainEntered.countDown()
-            check(releaseRetain.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "retainOnly was not released in time" }
-        }
-        every { diskCache.clear() } answers { clearEntered.countDown() }
-
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        val persistThread = thread { onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED) }
-        check(retainEntered.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "sync did not reach retainOnly" }
-
-        // Identity change mid-blob-pass: the commit already released cacheLock, so the wipe runs immediately
-        // instead of waiting for the (potentially long) blob IO to finish.
-        val clearThread = thread { manager.clearCache() }
-        assertThat(clearEntered.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue()
-
-        releaseRetain.countDown()
-        persistThread.join(TimeUnit.SECONDS.toMillis(WAIT_SECONDS))
-        clearThread.join(TimeUnit.SECONDS.toMillis(WAIT_SECONDS))
-
-        verify(exactly = 1) { diskCache.write(any()) }
-        verify(exactly = 1) { diskCache.clear() }
-    }
-
-    @Test
-    fun `refreshRemoteConfig reads disk on the manager scope, not the caller thread`() {
-        val ioThreadName = "rc-manager-io"
-        val ioScope = CoroutineScope(
-            Executors.newSingleThreadExecutor { runnable -> Thread(runnable, ioThreadName) }
-                .asCoroutineDispatcher(),
-        )
-        var readThreadName: String? = null
-        every { diskCache.read() } answers {
-            readThreadName = Thread.currentThread().name
-            null
-        }
-        val requestIssued = CountDownLatch(1)
-        every {
-            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any())
-        } answers { requestIssued.countDown() }
-        val manager = RemoteConfigManager(
-            backend,
-            diskCache,
-            blobStore,
-            dateProvider = dateProvider,
-            scope = ioScope,
-            sourceProvider = sourceProvider,
-            blobFetcher = blobFetcher,
-        )
-
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-
-        // The pre-request disk reads hop to the manager scope: an identity change on the main thread must
-        // never do file IO. The request is still issued (from that scope).
-        check(requestIssued.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "request was not issued in time" }
-        // Coroutine debug mode may append " @coroutine#N" to the carrier thread's name.
-        assertThat(readThreadName).startsWith(ioThreadName)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -19,8 +19,14 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlin.concurrent.thread
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -35,7 +41,9 @@ import org.robolectric.annotation.Config
 import java.nio.ByteBuffer
 import java.util.Date
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 @OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -155,6 +163,23 @@ class RemoteConfigManagerTest {
 
         // Identity change wipes the cache and the in-memory marker, so the next user refreshes immediately.
         manager.clearCache()
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a failed refresh does not stamp the refresh time, so the next staleness check retries`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        // Same clock: the failure left lastRefreshedAt unset, so the staleness check retries immediately
+        // instead of sitting out the window with no data.
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
 
         verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
@@ -610,6 +635,32 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `a non-object topic item leaves the cache untouched and releases the guard, without crashing`() {
+        every { diskCache.read() } returns null
+
+        // Well-formed JSON whose topic item is a primitive: the custom item serializer must surface this as a
+        // SerializationException the manager catches, not an uncaught error that would crash the app.
+        val config = """
+            {
+              "domain": "app",
+              "manifest": "manifest-1",
+              "active_topics": ["sources"],
+              "topics": { "sources": { "api": "not-an-object" } }
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onSuccess.invoke(containerWithConfig(config), VerificationResult.VERIFIED)
+
+        // The parse failure is caught: nothing is persisted and the cache is left intact.
+        verify(exactly = 0) { diskCache.write(any()) }
+
+        // The guard was released in the finally block, so a subsequent refresh is allowed to start.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `a config element that fails to decode leaves the cache untouched and releases the guard`() {
         every { diskCache.read() } returns null
 
@@ -696,6 +747,80 @@ class RemoteConfigManagerTest {
         assertThat(clearEntered.count).isZero()
         verify(exactly = 1) { diskCache.write(any()) }
         verify(exactly = 1) { diskCache.clear() }
+    }
+
+    @Test
+    fun `clearCache is not blocked behind the post-commit blob pass`() {
+        every { diskCache.read() } returns null
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.sources:etag2",
+              "active_topics": ["sources"],
+              "topics": { "sources": { "default": { "blob_ref": "newBlob" } } }
+            }
+        """.trimIndent()
+
+        val retainEntered = CountDownLatch(1)
+        val releaseRetain = CountDownLatch(1)
+        val clearEntered = CountDownLatch(1)
+        // The blob pass runs after the commit, outside cacheLock; park inside it to race clearCache.
+        every { blobStore.retainOnly(any()) } answers {
+            retainEntered.countDown()
+            check(releaseRetain.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "retainOnly was not released in time" }
+        }
+        every { diskCache.clear() } answers { clearEntered.countDown() }
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        val persistThread = thread { onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED) }
+        check(retainEntered.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "sync did not reach retainOnly" }
+
+        // Identity change mid-blob-pass: the commit already released cacheLock, so the wipe runs immediately
+        // instead of waiting for the (potentially long) blob IO to finish.
+        val clearThread = thread { manager.clearCache() }
+        assertThat(clearEntered.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue()
+
+        releaseRetain.countDown()
+        persistThread.join(TimeUnit.SECONDS.toMillis(WAIT_SECONDS))
+        clearThread.join(TimeUnit.SECONDS.toMillis(WAIT_SECONDS))
+
+        verify(exactly = 1) { diskCache.write(any()) }
+        verify(exactly = 1) { diskCache.clear() }
+    }
+
+    @Test
+    fun `refreshRemoteConfig reads disk on the manager scope, not the caller thread`() {
+        val ioThreadName = "rc-manager-io"
+        val ioScope = CoroutineScope(
+            Executors.newSingleThreadExecutor { runnable -> Thread(runnable, ioThreadName) }
+                .asCoroutineDispatcher(),
+        )
+        var readThreadName: String? = null
+        every { diskCache.read() } answers {
+            readThreadName = Thread.currentThread().name
+            null
+        }
+        val requestIssued = CountDownLatch(1)
+        every {
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any())
+        } answers { requestIssued.countDown() }
+        val manager = RemoteConfigManager(
+            backend,
+            diskCache,
+            blobStore,
+            dateProvider = dateProvider,
+            scope = ioScope,
+            sourceProvider = sourceProvider,
+            blobFetcher = blobFetcher,
+        )
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        // The pre-request disk reads hop to the manager scope: an identity change on the main thread must
+        // never do file IO. The request is still issued (from that scope).
+        check(requestIssued.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "request was not issued in time" }
+        // Coroutine debug mode may append " @coroutine#N" to the carrier thread's name.
+        assertThat(readThreadName).startsWith(ioThreadName)
     }
 
     @Test
@@ -1121,6 +1246,72 @@ class RemoteConfigManagerTest {
         assertThat(result).isNull()
     }
 
+    @Test
+    fun `concurrent reads with interleaved refreshes and cache clears all complete`() {
+        // language=json
+        val stressResponse = """
+            {
+              "domain": "app",
+              "manifest": "m-stress",
+              "active_topics": ["sources"],
+              "topics": { "sources": { "api": { "url": "https://api.revenuecat.com" } } }
+            }
+        """.trimIndent()
+        // A tiny thread-safe fake of the persisted state, so commits and wipes interleave like the real cache.
+        val state = AtomicReference<PersistedRemoteConfigurationState?>(null)
+        every { diskCache.read() } answers { state.get() }
+        every { diskCache.write(any()) } answers { state.set(firstArg()); true }
+        every { diskCache.clear() } answers { state.set(null) }
+        every { blobStore.cachedRefs() } returns emptySet()
+        every {
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any())
+        } answers {
+            arg<(RCContainer?, VerificationResult) -> Unit>(5)
+                .invoke(containerWithConfig(stressResponse), VerificationResult.VERIFIED)
+        }
+        val manager = RemoteConfigManager(
+            backend,
+            diskCache,
+            blobStore,
+            dateProvider = dateProvider,
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+            ioDispatcher = Dispatchers.IO,
+            sourceProvider = sourceProvider,
+            blobFetcher = blobFetcher,
+            appUserIDProvider = { TEST_APP_USER_ID },
+        )
+
+        val clearer = thread { repeat(STRESS_ITERATIONS) { manager.clearCache() } }
+        val refresher = thread {
+            repeat(STRESS_ITERATIONS) {
+                manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+            }
+        }
+        // Cold readers constantly wait on (or self-trigger) refreshes; the epoch/guard/completion machinery
+        // must never strand one on a hung await, even with clearCache racing every step.
+        runBlocking {
+            withTimeout(TimeUnit.SECONDS.toMillis(STRESS_TIMEOUT_SECONDS)) {
+                List(STRESS_READERS) {
+                    launch(Dispatchers.IO) {
+                        repeat(STRESS_ITERATIONS) { manager.topic(RemoteConfigTopic.Sources) }
+                    }
+                }.joinAll()
+            }
+        }
+        clearer.join(TimeUnit.SECONDS.toMillis(WAIT_SECONDS))
+        refresher.join(TimeUnit.SECONDS.toMillis(WAIT_SECONDS))
+        assertThat(clearer.isAlive).isFalse()
+        assertThat(refresher.isAlive).isFalse()
+
+        // The manager is still functional after the churn: a read self-primes and serves the committed topic.
+        runBlocking {
+            val topic = withTimeout(TimeUnit.SECONDS.toMillis(STRESS_TIMEOUT_SECONDS)) {
+                manager.topic(RemoteConfigTopic.Sources)
+            }
+            assertThat(topic).isNotNull
+        }
+    }
+
     // A manager whose read methods run on this test's scheduler, so suspend reads are deterministic.
     private fun TestScope.readManager(appUserIDProvider: () -> String? = { null }): RemoteConfigManager {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
@@ -1191,6 +1382,9 @@ class RemoteConfigManagerTest {
         private const val STALE_FOREGROUND_AGE_MILLIS = 6 * 60 * 1000L
         private const val WAIT_SECONDS = 5L
         private const val BLOCKED_MILLIS = 200L
+        private const val STRESS_ITERATIONS = 50
+        private const val STRESS_READERS = 8
+        private const val STRESS_TIMEOUT_SECONDS = 30L
         private const val REF_VALID = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"
         private const val REF_TAMPERED = "IIIIJJJJKKKKLLLLMMMMNNNNOOOOPPPP"
         private const val REF_UNWANTED = "QQQQRRRRSSSSTTTTUUUUVVVVWWWWXXXX"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigurationTest.kt
@@ -248,6 +248,25 @@ class RemoteConfigurationTest {
     }
 
     @Test
+    fun `fails to parse a non-object topic item with a SerializationException, not an uncaught error`() {
+        // A topic item must be a JSON object. The custom ConfigItemSerializer must surface anything else as
+        // a SerializationException (a recoverable parse failure to the manager), never the IllegalStateException
+        // the .jsonObject accessor throws, which would escape the manager's catch and crash the app.
+        // language=json
+        val payload = """
+            {
+              "domain": "app",
+              "manifest": "v1.1710002100.sources:etag1",
+              "active_topics": ["sources"],
+              "topics": { "sources": { "api": "not-an-object" } }
+            }
+        """
+
+        assertThatThrownBy { RemoteConfiguration.parse(payload.trimIndent().toByteArray()) }
+            .isInstanceOf(SerializationException::class.java)
+    }
+
+    @Test
     fun `fails to parse when a field has the wrong type`() {
         // manifest must be a string, not an object.
         // language=json


### PR DESCRIPTION
Hardening fixes from a review pass over the remote-config stack.

### Changes

- **Malformed topic item no longer crashes the app**: `ConfigItemSerializer` throws `SerializationException` (instead of the `.jsonObject` accessor's `IllegalStateException`, which escaped the manager's catch) for a non-object item, making it a recoverable parse failure.
- **Crash-safe blob writes**: `RemoteConfigBlobStore` writes via `AtomicFile` (same scheme as the disk cache), so a process kill can never leave a partial blob file under a valid ref.
- **In-memory snapshot in `RemoteConfigDiskCache`**: hot-path reads (`topic()`/`blobData()`, blob-source lookups per download) stop re-reading + re-parsing the file and recomputing `contentHash` on every call.

### Tests

- Non-object topic item: parse fails with `SerializationException`; manager keeps the cache, releases the guard, no crash.
- Interrupted blob write leaves no readable blob; the `.new` orphan is pruned by `retainOnly`.
- Disk-cache snapshot is served without file re-reads and dropped on `clear()`; fresh instances still read from disk.
- A failed refresh does not stamp the staleness window (next check retries); the rate-limited `syncAttributesAndOfferings` branch does not force a refresh.
- Persisted-file forward-compat: unknown keys are tolerated.
- Concurrency stress: 8 readers × 50 iterations racing `clearCache` + refreshes all complete, manager stays functional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect on-disk config/blob caching and config parse error handling on a hot SDK path; behavior is defensive and well-covered by tests, but incorrect snapshot or atomic-write semantics could cause stale config or missed updates.
> 
> **Overview**
> Hardens the remote-config persistence and parsing stack so bad payloads and crashes are handled safely, and hot-path disk access is cheaper.
> 
> **`ConfigItemSerializer`** now throws **`SerializationException`** when a topic item is not a JSON object (instead of **`IllegalStateException`** from **`.jsonObject`**), so **`RemoteConfigManager`** can treat malformed config as a recoverable parse failure without crashing.
> 
> **`RemoteConfigBlobStore`** switches blob persistence to **`AtomicFile`** (same pattern as the disk cache), so a killed process cannot leave a partial file under a valid ref; **`retainOnly`** docs/tests now cover **`<ref>.new`** orphans instead of **`rc_blob_*.tmp`**.
> 
> **`RemoteConfigDiskCache`** adds a synchronized in-memory snapshot: **`read()`** loads from disk once (including caching a miss), **`write()`** updates the snapshot only after a durable write, and **`clear()`** resets the snapshot before deleting the file.
> 
> Tests cover interrupted blob writes, snapshot behavior, forward-compatible persisted JSON, failed refresh / rate-limited sync not over-refreshing, non-object topic items, and a concurrency stress run over **`clearCache`** + refreshes + **`topic()`** reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0319791878019eb2b255daae5188e004c0a6549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->