### PR TITLE
[PW-870] Support transparent overlapping sticky footers

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -208,6 +208,12 @@ internal fun PaywallComponentsScaffold(
  * heights in the same pass. The header is placed at the top and the footer pinned to the bottom, both
  * drawn on top of the main content.
  *
+ * Only the heights of the overlays this layout owns are written to [state]: [state.headerHeightPx]
+ * [PaywallState.Loaded.Components.headerHeightPx] only when [hasHeader], and [state.footerHeightPx]
+ * [PaywallState.Loaded.Components.footerHeightPx] only when [hasFooter]. This lets a nested
+ * OverlayLayout (workflow steps render one inside the scaffold's, sharing the same state) avoid
+ * clobbering a height already set by the outer layout.
+ *
  * Children (in emission order): index 0 = main scrollable content, then the optional header overlay
  * (present when [hasHeader]), then the optional footer overlay (present when [hasFooter]).
  */
@@ -234,8 +240,13 @@ internal fun OverlayLayout(
         // Store overlay heights so child Modifier.layout blocks can read them in this same pass.
         // Header: both hero (ZLayer reads it) and non-hero (headerTopPadding reads it) cases need this.
         // Footer: footerBottomPadding reads it to reserve bottom clearance.
-        state.headerHeightPx = headerPlaceable?.height ?: 0
-        state.footerHeightPx = footerPlaceable?.height ?: 0
+        //
+        // Only publish the height of an overlay this layout actually owns. A nested OverlayLayout
+        // (workflow steps render one inside the scaffold's, sharing the same state) must not clobber a
+        // height set by the outer layout: e.g. an inner layout with hasHeader = false wiping
+        // headerHeightPx to 0 would collapse the step's header clearance.
+        if (hasHeader) state.headerHeightPx = headerPlaceable?.height ?: 0
+        if (hasFooter) state.footerHeightPx = footerPlaceable?.height ?: 0
 
         // Measure main content. Its inner Modifier.layout blocks can now read the stored heights.
         val mainPlaceable = measurables[0].measure(constraints)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -5,7 +5,6 @@ package com.revenuecat.purchases.ui.revenuecatui.components
 
 import android.content.res.Configuration
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
@@ -137,6 +136,9 @@ internal fun LoadedPaywallComponents(
                     }
                     .conditional(state.header != null && !state.mainStackHasHeroImage) {
                         headerTopPadding(state)
+                    }
+                    .conditional(state.stickyFooter != null) {
+                        footerBottomPadding(state)
                     },
             )
         }
@@ -166,55 +168,82 @@ internal fun PaywallComponentsScaffold(
         modifier = background?.let { modifier.background(it) } ?: modifier,
     ) {
         WithOptionalBackgroundOverlay(state, background = background) {
-            Column {
-                HeaderOverlayLayout(
+            if (footerContent != null) {
+                // Overlapping footer: main content fills the whole area and the footer is pinned to the
+                // bottom, drawn on top. Main content reserves bottom clearance equal to the footer height
+                // (see footerBottomPadding), so an opaque footer looks identical to the old stacked layout
+                // while a transparent footer lets content draw behind it.
+                OverlayLayout(
                     state = state,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.fillMaxSize(),
+                    hasHeader = headerContent != null,
+                    hasFooter = true,
+                ) {
+                    // Child 0: caller-supplied main content.
+                    mainContent()
+                    // Child 1 (optional): fixed header overlay.
+                    headerContent?.invoke()
+                    // Child 2: sticky footer overlay, pinned to the bottom.
+                    footerContent.invoke()
+                }
+            } else {
+                OverlayLayout(
+                    state = state,
+                    modifier = Modifier.fillMaxSize(),
+                    hasHeader = headerContent != null,
                 ) {
                     // Child 0: caller-supplied main content.
                     mainContent()
                     // Child 1 (optional): fixed header overlay.
                     headerContent?.invoke()
                 }
-                footerContent?.invoke()
             }
         }
     }
 }
 
 /**
- * Custom Layout that measures the fixed header overlay first, stores its pixel height in [state],
- * then measures the main content.
+ * Custom Layout that measures the fixed header and footer overlays first, stores their pixel heights
+ * in [state], then measures the main content so its inner [Modifier.layout] blocks can read those
+ * heights in the same pass. The header is placed at the top and the footer pinned to the bottom, both
+ * drawn on top of the main content.
  *
- * Children: index 0 = main scrollable content, index 1 (optional) = header overlay.
+ * Children (in emission order): index 0 = main scrollable content, then the optional header overlay
+ * (present when [hasHeader]), then the optional footer overlay (present when [hasFooter]).
  */
 @Composable
-internal fun HeaderOverlayLayout(
+internal fun OverlayLayout(
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
+    hasHeader: Boolean = false,
+    hasFooter: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     Layout(
         content = content,
         modifier = modifier,
     ) { measurables, constraints ->
-        // Measure header first (child 1) to get its height before the main content is measured.
-        val headerPlaceable = if (measurables.size > 1) {
-            measurables[1].measure(constraints.copy(minHeight = 0))
-        } else {
-            null
-        }
+        // Measure the overlays first to get their heights before the main content is measured.
+        // Emission order after main content (index 0) is: header (if any), then footer (if any).
+        val headerMeasurable = if (hasHeader) measurables[1] else null
+        val footerMeasurable = if (hasFooter) measurables[if (hasHeader) 2 else 1] else null
 
-        // Store header height so child Modifier.layout blocks can read it in this same pass.
-        // Both hero (ZLayer reads it) and non-hero (headerTopPadding reads it) cases need this.
+        val headerPlaceable = headerMeasurable?.measure(constraints.copy(minHeight = 0))
+        val footerPlaceable = footerMeasurable?.measure(constraints.copy(minHeight = 0))
+
+        // Store overlay heights so child Modifier.layout blocks can read them in this same pass.
+        // Header: both hero (ZLayer reads it) and non-hero (headerTopPadding reads it) cases need this.
+        // Footer: footerBottomPadding reads it to reserve bottom clearance.
         state.headerHeightPx = headerPlaceable?.height ?: 0
+        state.footerHeightPx = footerPlaceable?.height ?: 0
 
-        // Measure main content. Its inner Modifier.layout blocks can now read state.headerHeightPx.
+        // Measure main content. Its inner Modifier.layout blocks can now read the stored heights.
         val mainPlaceable = measurables[0].measure(constraints)
 
         layout(constraints.maxWidth, constraints.maxHeight) {
             mainPlaceable.placeRelative(0, 0)
             headerPlaceable?.placeRelative(0, 0)
+            footerPlaceable?.placeRelative(0, constraints.maxHeight - footerPlaceable.height)
         }
     }
 }
@@ -222,7 +251,7 @@ internal fun HeaderOverlayLayout(
 /**
  * Adds top padding equal to the header's measured height in pixels. The value is read during the
  * layout phase from [state.headerHeightPx][PaywallState.Loaded.Components.headerHeightPx], which
- * is set by [HeaderOverlayLayout] earlier in the same layout pass.
+ * is set by [OverlayLayout] earlier in the same layout pass.
  */
 internal fun Modifier.headerTopPadding(state: PaywallState.Loaded.Components): Modifier =
     this.layout { measurable, constraints ->
@@ -230,6 +259,22 @@ internal fun Modifier.headerTopPadding(state: PaywallState.Loaded.Components): M
         val placeable = measurable.measure(constraints.offset(vertical = -topPad))
         layout(placeable.width, placeable.height + topPad) {
             placeable.placeRelative(0, topPad)
+        }
+    }
+
+/**
+ * Reserves bottom clearance equal to the sticky footer's measured height in pixels, so the last piece
+ * of main content can scroll clear of a footer that content otherwise draws behind. The value is read
+ * during the layout phase from [state.footerHeightPx][PaywallState.Loaded.Components.footerHeightPx],
+ * which is set by [OverlayLayout] earlier in the same layout pass.
+ */
+internal fun Modifier.footerBottomPadding(state: PaywallState.Loaded.Components): Modifier =
+    this.layout { measurable, constraints ->
+        val bottomPad = state.footerHeightPx
+        val placeable = measurable.measure(constraints.offset(vertical = -bottomPad))
+        layout(placeable.width, placeable.height + bottomPad) {
+            // Content placed at the top; the extra space is reserved at the bottom, behind the footer.
+            placeable.placeRelative(0, 0)
         }
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponentsPreviews.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponentsPreviews.kt
@@ -1213,3 +1213,219 @@ private fun LoadedPaywallComponents_Preview_TransparentFooter() {
         modifier = Modifier.fillMaxSize(),
     )
 }
+
+/**
+ * A small, vertically centered body with a sticky footer. The body must center within the space
+ * *above* the footer (matching the pre-overlap behavior), not the whole screen.
+ */
+@Suppress("LongMethod", "MagicNumber")
+@Preview(name = "CenteredBodyFooter", showSystemUi = true)
+@Composable
+private fun LoadedPaywallComponents_Preview_CenteredBodyFooter() {
+    val textColor = ColorScheme(light = ColorInfo.Hex(Color(0xFF272727).toArgb()))
+    val backgroundColor = ColorScheme(light = ColorInfo.Hex(Color(0xFFFDFDFD).toArgb()))
+    val footerColor = ColorScheme(light = ColorInfo.Hex(Color(0x99057C5B).toArgb()))
+    val ctaTextColor = ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))
+    val ctaBackgroundColor = ColorScheme(light = ColorInfo.Hex(Color(0xFF0A3D2E).toArgb()))
+
+    val data = PaywallComponentsData(
+        id = "preview_centered_body_footer",
+        templateName = "template",
+        assetBaseURL = URL("https://assets.pawwalls.com"),
+        componentsConfig = ComponentsConfig(
+            base = PaywallComponentsConfig(
+                stack = StackComponent(
+                    components = listOf(
+                        TextComponent(
+                            text = LocalizationKey("title"),
+                            color = textColor,
+                            fontWeight = FontWeight.BOLD,
+                            fontSize = 28,
+                            horizontalAlignment = CENTER,
+                            size = Size(width = Fill, height = Fit),
+                            margin = Padding(top = 0.0, bottom = 12.0, leading = 32.0, trailing = 32.0),
+                        ),
+                        TextComponent(
+                            text = LocalizationKey("subtitle"),
+                            color = textColor,
+                            horizontalAlignment = CENTER,
+                            size = Size(width = Fill, height = Fit),
+                            margin = Padding(top = 0.0, bottom = 0.0, leading = 32.0, trailing = 32.0),
+                        ),
+                    ),
+                    dimension = Vertical(alignment = CENTER, distribution = FlexDistribution.CENTER),
+                    size = Size(width = Fill, height = Fill),
+                ),
+                background = Background.Color(backgroundColor),
+                stickyFooter = StickyFooterComponent(
+                    stack = StackComponent(
+                        components = listOf(
+                            StackComponent(
+                                components = listOf(
+                                    TextComponent(
+                                        text = LocalizationKey("cta"),
+                                        color = ctaTextColor,
+                                        fontWeight = FontWeight.BOLD,
+                                    ),
+                                ),
+                                dimension = ZLayer(alignment = TwoDimensionalAlignment.CENTER),
+                                size = Size(width = Fill, height = Fit),
+                                backgroundColor = ctaBackgroundColor,
+                                padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                                shape = Shape.Pill,
+                            ),
+                        ),
+                        dimension = Vertical(alignment = CENTER, distribution = START),
+                        size = Size(width = Fill, height = Fit),
+                        backgroundColor = footerColor,
+                        padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                    ),
+                ),
+            ),
+        ),
+        componentsLocalizations = mapOf(
+            LocaleId("en_US") to mapOf(
+                LocalizationKey("title") to LocalizationData.Text("Centered body"),
+                LocalizationKey("subtitle") to LocalizationData.Text("This should be centered above the footer"),
+                LocalizationKey("cta") to LocalizationData.Text("Continue"),
+            ),
+        ),
+        defaultLocaleIdentifier = LocaleId("en_US"),
+    )
+    val offering = Offering(
+        identifier = "centered_body_footer",
+        serverDescription = "Centered body with footer",
+        metadata = emptyMap(),
+        availablePackages = listOf(TestData.Packages.monthly),
+        paywallComponents = Offering.PaywallComponents(previewUiConfig(), data),
+    )
+    val validated = offering.validatePaywallComponentsDataOrNullForPreviews()?.getOrThrow()!!
+    val state = offering.toComponentsPaywallState(
+        validationResult = validated,
+        storefrontCountryCode = "US",
+        dateProvider = { Date(MILLIS_2025_01_25) },
+        purchases = MockPurchasesType(),
+    )
+
+    LoadedPaywallComponents(
+        state = state,
+        clickHandler = { },
+        modifier = Modifier.fillMaxSize(),
+    )
+}
+
+/**
+ * A sticky footer taller than half the screen. Content occupies the reduced region above it and the
+ * footer fills the rest without clipping the layout.
+ */
+@Suppress("LongMethod", "MagicNumber")
+@Preview(name = "LargeFooter", showSystemUi = true)
+@Composable
+private fun LoadedPaywallComponents_Preview_LargeFooter() {
+    val textColor = ColorScheme(light = ColorInfo.Hex(Color(0xFF272727).toArgb()))
+    val backgroundColor = ColorScheme(light = ColorInfo.Hex(Color(0xFFFDFDFD).toArgb()))
+    val footerColor = ColorScheme(light = ColorInfo.Hex(Color(0xFF057C5B).toArgb()))
+    val ctaTextColor = ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))
+    val ctaBackgroundColor = ColorScheme(light = ColorInfo.Hex(Color(0xFF0A3D2E).toArgb()))
+
+    val footerRows = (1..8).map { index ->
+        TextComponent(
+            text = LocalizationKey("footer-line-$index"),
+            color = ctaTextColor,
+            horizontalAlignment = CENTER,
+            size = Size(width = Fill, height = Fit),
+            margin = Padding(top = 6.0, bottom = 6.0, leading = 0.0, trailing = 0.0),
+        )
+    }
+
+    val data = PaywallComponentsData(
+        id = "preview_large_footer",
+        templateName = "template",
+        assetBaseURL = URL("https://assets.pawwalls.com"),
+        componentsConfig = ComponentsConfig(
+            base = PaywallComponentsConfig(
+                stack = StackComponent(
+                    components = listOf(
+                        TextComponent(
+                            text = LocalizationKey("title"),
+                            color = textColor,
+                            fontWeight = FontWeight.BOLD,
+                            fontSize = 28,
+                            horizontalAlignment = LEADING,
+                            size = Size(width = Fill, height = Fit),
+                            margin = Padding(top = 0.0, bottom = 12.0, leading = 0.0, trailing = 0.0),
+                        ),
+                        TextComponent(
+                            text = LocalizationKey("subtitle"),
+                            color = textColor,
+                            horizontalAlignment = LEADING,
+                            size = Size(width = Fill, height = Fit),
+                        ),
+                    ),
+                    dimension = Vertical(alignment = LEADING, distribution = START),
+                    size = Size(width = Fill, height = Fill),
+                    padding = Padding(top = 32.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                ),
+                background = Background.Color(backgroundColor),
+                stickyFooter = StickyFooterComponent(
+                    stack = StackComponent(
+                        components = footerRows + StackComponent(
+                            components = listOf(
+                                TextComponent(
+                                    text = LocalizationKey("cta"),
+                                    color = ctaTextColor,
+                                    fontWeight = FontWeight.BOLD,
+                                ),
+                            ),
+                            dimension = ZLayer(alignment = TwoDimensionalAlignment.CENTER),
+                            size = Size(width = Fill, height = Fit),
+                            backgroundColor = ctaBackgroundColor,
+                            padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                            margin = Padding(top = 16.0, bottom = 0.0, leading = 0.0, trailing = 0.0),
+                            shape = Shape.Pill,
+                        ),
+                        dimension = Vertical(alignment = CENTER, distribution = FlexDistribution.CENTER),
+                        // Fixed height guarantees the footer is taller than half of a phone screen.
+                        size = Size(width = Fill, height = Fixed(520u)),
+                        backgroundColor = footerColor,
+                        padding = Padding(top = 24.0, bottom = 24.0, leading = 32.0, trailing = 32.0),
+                    ),
+                ),
+            ),
+        ),
+        componentsLocalizations = mapOf(
+            LocaleId("en_US") to (
+                mapOf(
+                    LocalizationKey("title") to LocalizationData.Text("Big footer"),
+                    LocalizationKey("subtitle") to LocalizationData.Text(
+                        "The footer below is taller than half the screen.",
+                    ),
+                    LocalizationKey("cta") to LocalizationData.Text("Continue"),
+                ) + (1..8).associate { index ->
+                    LocalizationKey("footer-line-$index") to LocalizationData.Text("Footer line $index")
+                }
+                ),
+        ),
+        defaultLocaleIdentifier = LocaleId("en_US"),
+    )
+    val offering = Offering(
+        identifier = "large_footer",
+        serverDescription = "Footer taller than half the screen",
+        metadata = emptyMap(),
+        availablePackages = listOf(TestData.Packages.monthly),
+        paywallComponents = Offering.PaywallComponents(previewUiConfig(), data),
+    )
+    val validated = offering.validatePaywallComponentsDataOrNullForPreviews()?.getOrThrow()!!
+    val state = offering.toComponentsPaywallState(
+        validationResult = validated,
+        storefrontCountryCode = "US",
+        dateProvider = { Date(MILLIS_2025_01_25) },
+        purchases = MockPurchasesType(),
+    )
+
+    LoadedPaywallComponents(
+        state = state,
+        clickHandler = { },
+        modifier = Modifier.fillMaxSize(),
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponentsPreviews.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponentsPreviews.kt
@@ -2,6 +2,7 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -1090,4 +1091,125 @@ private fun LoadedPaywallComponents_Preview_HeaderNestedStackWithImage() {
             modifier = Modifier.fillMaxSize(),
         )
     }
+}
+
+/**
+ * Exercises an overlapping, semi-transparent sticky footer over a long scrollable body. The footer is
+ * pinned to the bottom and drawn on top of the content; because its background is translucent, the
+ * body (and the paywall background) show through it, and the content reserves bottom clearance equal to
+ * the footer height so the last row can scroll clear of the footer.
+ */
+@Suppress("LongMethod", "MagicNumber")
+@Preview(name = "TransparentFooter - Light", showSystemUi = true)
+@Preview(name = "TransparentFooter - Dark", showSystemUi = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun LoadedPaywallComponents_Preview_TransparentFooter() {
+    val textColor = ColorScheme(
+        light = ColorInfo.Hex(Color(0xFF272727).toArgb()),
+        dark = ColorInfo.Hex(Color(0xFFFDFDFD).toArgb()),
+    )
+    val backgroundColor = ColorScheme(
+        light = ColorInfo.Hex(Color(0xFFFDFDFD).toArgb()),
+        dark = ColorInfo.Hex(Color(0xFF121212).toArgb()),
+    )
+    // Semi-transparent, tinted footer background so the scrolled content is clearly visible THROUGH
+    // the footer (a distinct tint over the content behind it), demonstrating the overlap.
+    val translucentFooterColor = ColorScheme(
+        light = ColorInfo.Hex(Color(0x99057C5B).toArgb()),
+        dark = ColorInfo.Hex(Color(0x99057C5B).toArgb()),
+    )
+    val ctaTextColor = ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))
+    val ctaBackgroundColor = ColorScheme(light = ColorInfo.Hex(Color(0xFF057C5B).toArgb()))
+
+    val featureRows = (1..25).map { index ->
+        TextComponent(
+            text = LocalizationKey("feature-$index"),
+            color = textColor,
+            horizontalAlignment = LEADING,
+            size = Size(width = Fill, height = Fit),
+            margin = Padding(top = 8.0, bottom = 8.0, leading = 0.0, trailing = 0.0),
+        )
+    }
+
+    val data = PaywallComponentsData(
+        id = "preview_transparent_footer",
+        templateName = "template",
+        assetBaseURL = URL("https://assets.pawwalls.com"),
+        componentsConfig = ComponentsConfig(
+            base = PaywallComponentsConfig(
+                stack = StackComponent(
+                    components = listOf(
+                        TextComponent(
+                            text = LocalizationKey("title"),
+                            color = textColor,
+                            fontWeight = FontWeight.BOLD,
+                            fontSize = 28,
+                            horizontalAlignment = LEADING,
+                            size = Size(width = Fill, height = Fit),
+                            margin = Padding(top = 0.0, bottom = 24.0, leading = 0.0, trailing = 0.0),
+                        ),
+                    ) + featureRows,
+                    dimension = Vertical(alignment = LEADING, distribution = START),
+                    size = Size(width = Fill, height = Fill),
+                    padding = Padding(top = 32.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                ),
+                background = Background.Color(backgroundColor),
+                stickyFooter = StickyFooterComponent(
+                    stack = StackComponent(
+                        components = listOf(
+                            StackComponent(
+                                components = listOf(
+                                    TextComponent(
+                                        text = LocalizationKey("cta"),
+                                        color = ctaTextColor,
+                                        fontWeight = FontWeight.BOLD,
+                                    ),
+                                ),
+                                dimension = ZLayer(alignment = TwoDimensionalAlignment.CENTER),
+                                size = Size(width = Fill, height = Fit),
+                                backgroundColor = ctaBackgroundColor,
+                                padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                                shape = Shape.Pill,
+                            ),
+                        ),
+                        dimension = Vertical(alignment = CENTER, distribution = START),
+                        size = Size(width = Fill, height = Fit),
+                        backgroundColor = translucentFooterColor,
+                        padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                    ),
+                ),
+            ),
+        ),
+        componentsLocalizations = mapOf(
+            LocaleId("en_US") to (
+                mapOf(
+                    LocalizationKey("title") to LocalizationData.Text("Unlock everything"),
+                    LocalizationKey("cta") to LocalizationData.Text("Continue"),
+                ) + (1..25).associate { index ->
+                    LocalizationKey("feature-$index") to LocalizationData.Text("✓ Premium feature number $index")
+                }
+                ),
+        ),
+        defaultLocaleIdentifier = LocaleId("en_US"),
+    )
+    val offering = Offering(
+        identifier = "transparent_footer",
+        serverDescription = "Transparent overlapping footer",
+        metadata = emptyMap(),
+        availablePackages = listOf(TestData.Packages.monthly),
+        paywallComponents = Offering.PaywallComponents(previewUiConfig(), data),
+    )
+    val validated = offering.validatePaywallComponentsDataOrNullForPreviews()?.getOrThrow()!!
+    val state = offering.toComponentsPaywallState(
+        validationResult = validated,
+        storefrontCountryCode = "US",
+        dateProvider = { Date(MILLIS_2025_01_25) },
+        purchases = MockPurchasesType(),
+    )
+
+    LoadedPaywallComponents(
+        state = state,
+        clickHandler = { },
+        modifier = Modifier.fillMaxSize(),
+    )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -5,7 +5,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.components
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
@@ -85,10 +84,10 @@ internal fun LoadedWorkflowPaywall(
     }
 
     // When the header is LEAVING (fading out over an incoming step that has no header), routing it
-    // through HeaderOverlayLayout would write its measured height into currentState.headerHeightPx.
+    // through OverlayLayout would write its measured height into currentState.headerHeightPx.
     // The incoming step would then use that height as its hero ZLayer top inset instead of the
     // status-bar fallback. To avoid this, LEAVING headers are rendered as a Box overlay inside the
-    // mainContent lambda — outside HeaderOverlayLayout — so currentState.headerHeightPx stays 0.
+    // mainContent lambda — outside OverlayLayout — so currentState.headerHeightPx stays 0.
     val isLeavingHeader = headerPresentation.role == WorkflowHeaderTransitionRole.LEAVING
     val headerComposable: (@Composable () -> Unit)? = headerState.header?.let { headerStyle ->
         {
@@ -200,7 +199,7 @@ private fun WorkflowStepsContent(
 
 /**
  * Renders one workflow step's body and footer as a self-contained sliding surface.
- * The header is rendered outside this surface (either via the scaffold's HeaderOverlayLayout or,
+ * The header is rendered outside this surface (either via the scaffold's OverlayLayout or,
  * when LEAVING, as a Box overlay in the main content — see [LoadedWorkflowPaywall]).
  * Off-screen (parked) steps still receive a click handler, but it short-circuits because they are
  * translated off-screen and can't receive touches.
@@ -238,20 +237,29 @@ private fun WorkflowStepContent(
             background = background,
             modifier = Modifier.fillMaxSize(),
         ) {
-            Column(modifier = Modifier.fillMaxSize()) {
+            // The header for a workflow step is rendered by the scaffold, so hasHeader is false here.
+            // A sticky footer, when present, overlays the bottom on top of the full-height content and
+            // reserves clearance via footerBottomPadding (see PaywallComponentsScaffold).
+            OverlayLayout(
+                state = stepState,
+                modifier = Modifier.fillMaxSize(),
+                hasFooter = stepState.stickyFooter != null,
+            ) {
                 ComponentView(
                     style = stepState.stack,
                     state = stepState,
                     onClick = onClick,
                     componentInteractionTracker = tracker,
                     modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth()
+                        .fillMaxSize()
                         .conditional(shouldWrapMainContentInVerticalScroll) {
                             verticalScroll(mainScrollState)
                         }
                         .conditional(stepState.header != null && !stepState.mainStackHasHeroImage) {
                             headerTopPadding(stepState)
+                        }
+                        .conditional(stepState.stickyFooter != null) {
+                            footerBottomPadding(stepState)
                         },
                 )
                 stepState.stickyFooter?.let { footerStyle ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -297,6 +297,15 @@ internal sealed interface PaywallState {
             var headerHeightPx: Int = 0
                 @JvmSynthetic internal set
 
+            /**
+             * The measured height of the sticky-footer overlay in pixels. Set during the layout phase by
+             * the custom Layout in [LoadedPaywallComponents], so main content can reserve bottom clearance
+             * (via [Modifier.footerBottomPadding]) in the same pass, without recomposition.
+             */
+            @get:JvmSynthetic
+            var footerHeightPx: Int = 0
+                @JvmSynthetic internal set
+
             var actionInProgress by mutableStateOf(false)
                 private set
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/OverlappingFooterSnapshotTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/OverlappingFooterSnapshotTest.kt
@@ -1,0 +1,176 @@
+package com.revenuecat.purchases.ui.revenuecatui.snapshottests
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
+import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.LocalizationData
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.Dimension.Vertical
+import com.revenuecat.purchases.paywalls.components.properties.Dimension.ZLayer
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution.START
+import com.revenuecat.purchases.paywalls.components.properties.FontWeight
+import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment.CENTER
+import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment.LEADING
+import com.revenuecat.purchases.paywalls.components.properties.Padding
+import com.revenuecat.purchases.paywalls.components.properties.Shape
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.TwoDimensionalAlignment
+import com.revenuecat.purchases.ui.revenuecatui.components.LoadedPaywallComponents
+import com.revenuecat.purchases.ui.revenuecatui.components.MILLIS_2025_01_25
+import com.revenuecat.purchases.ui.revenuecatui.components.previewUiConfig
+import com.revenuecat.purchases.ui.revenuecatui.components.validatePaywallComponentsDataOrNullForPreviews
+import com.revenuecat.purchases.ui.revenuecatui.data.MockPurchasesType
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.net.URL
+import java.util.Date
+
+/**
+ * Verifies that a semi-transparent sticky footer overlaps the scrollable main content: the footer is
+ * pinned to the bottom and drawn on top, the body shows through it, and the content reserves bottom
+ * clearance equal to the footer height.
+ */
+@OptIn(InternalRevenueCatAPI::class)
+@RunWith(Parameterized::class)
+internal class OverlappingFooterSnapshotTest(testConfig: TestConfig) : BasePaparazziTest(testConfig) {
+
+    @Test
+    fun transparentFooterOverlapsScrollableContent() {
+        screenshotTest {
+            OverlappingFooterPaywall()
+        }
+    }
+
+    @Suppress("LongMethod")
+    @Composable
+    private fun OverlappingFooterPaywall() {
+        val textColor = ColorScheme(
+            light = ColorInfo.Hex(Color(0xFF272727).toArgb()),
+            dark = ColorInfo.Hex(Color(0xFFFDFDFD).toArgb()),
+        )
+        val backgroundColor = ColorScheme(
+            light = ColorInfo.Hex(Color(0xFFFDFDFD).toArgb()),
+            dark = ColorInfo.Hex(Color(0xFF121212).toArgb()),
+        )
+        // Semi-transparent, tinted footer background so the scrolled content is clearly visible THROUGH
+        // the footer (a distinct tint over the content behind it), demonstrating the overlap.
+        val translucentFooterColor = ColorScheme(
+            light = ColorInfo.Hex(Color(0x99057C5B).toArgb()),
+            dark = ColorInfo.Hex(Color(0x99057C5B).toArgb()),
+        )
+        val ctaTextColor = ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))
+        val ctaBackgroundColor = ColorScheme(light = ColorInfo.Hex(Color(0xFF057C5B).toArgb()))
+
+        val featureRows = (1..25).map { index ->
+            TextComponent(
+                text = LocalizationKey("feature-$index"),
+                color = textColor,
+                horizontalAlignment = LEADING,
+                size = Size(width = Fill, height = Fit),
+                margin = Padding(top = 8.0, bottom = 8.0, leading = 0.0, trailing = 0.0),
+            )
+        }
+
+        val data = PaywallComponentsData(
+            id = "snapshot_transparent_footer",
+            templateName = "template",
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(
+                        components = listOf(
+                            TextComponent(
+                                text = LocalizationKey("title"),
+                                color = textColor,
+                                fontWeight = FontWeight.BOLD,
+                                fontSize = 28,
+                                horizontalAlignment = LEADING,
+                                size = Size(width = Fill, height = Fit),
+                                margin = Padding(top = 0.0, bottom = 24.0, leading = 0.0, trailing = 0.0),
+                            ),
+                        ) + featureRows,
+                        dimension = Vertical(alignment = LEADING, distribution = START),
+                        size = Size(width = Fill, height = Fill),
+                        padding = Padding(top = 32.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                    ),
+                    background = Background.Color(backgroundColor),
+                    stickyFooter = StickyFooterComponent(
+                        stack = StackComponent(
+                            components = listOf(
+                                StackComponent(
+                                    components = listOf(
+                                        TextComponent(
+                                            text = LocalizationKey("cta"),
+                                            color = ctaTextColor,
+                                            fontWeight = FontWeight.BOLD,
+                                        ),
+                                    ),
+                                    dimension = ZLayer(alignment = TwoDimensionalAlignment.CENTER),
+                                    size = Size(width = Fill, height = Fit),
+                                    backgroundColor = ctaBackgroundColor,
+                                    padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                                    shape = Shape.Pill,
+                                ),
+                            ),
+                            dimension = Vertical(alignment = CENTER, distribution = START),
+                            size = Size(width = Fill, height = Fit),
+                            backgroundColor = translucentFooterColor,
+                            padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                        ),
+                    ),
+                ),
+            ),
+            componentsLocalizations = mapOf(
+                LocaleId("en_US") to (
+                    mapOf(
+                        LocalizationKey("title") to LocalizationData.Text("Unlock everything"),
+                        LocalizationKey("cta") to LocalizationData.Text("Continue"),
+                    ) + (1..25).associate { index ->
+                        LocalizationKey("feature-$index") to LocalizationData.Text("✓ Premium feature number $index")
+                    }
+                    ),
+            ),
+            defaultLocaleIdentifier = LocaleId("en_US"),
+        )
+        val offering = Offering(
+            identifier = "transparent_footer",
+            serverDescription = "Transparent overlapping footer",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly),
+            paywallComponents = Offering.PaywallComponents(previewUiConfig(), data),
+        )
+        val validated = offering.validatePaywallComponentsDataOrNullForPreviews()?.getOrThrow()!!
+        val state = offering.toComponentsPaywallState(
+            validationResult = validated,
+            storefrontCountryCode = "US",
+            dateProvider = { Date(MILLIS_2025_01_25) },
+            purchases = MockPurchasesType(),
+        )
+
+        LoadedPaywallComponents(
+            state = state,
+            clickHandler = { },
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/OverlappingFooterSnapshotTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/OverlappingFooterSnapshotTest.kt
@@ -21,6 +21,7 @@ import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.paywalls.components.properties.Dimension.Vertical
 import com.revenuecat.purchases.paywalls.components.properties.Dimension.ZLayer
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
 import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution.START
 import com.revenuecat.purchases.paywalls.components.properties.FontWeight
 import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment.CENTER
@@ -30,6 +31,7 @@ import com.revenuecat.purchases.paywalls.components.properties.Shape
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.paywalls.components.properties.TwoDimensionalAlignment
 import com.revenuecat.purchases.ui.revenuecatui.components.LoadedPaywallComponents
 import com.revenuecat.purchases.ui.revenuecatui.components.MILLIS_2025_01_25
@@ -46,9 +48,10 @@ import java.net.URL
 import java.util.Date
 
 /**
- * Verifies that a semi-transparent sticky footer overlaps the scrollable main content: the footer is
- * pinned to the bottom and drawn on top, the body shows through it, and the content reserves bottom
- * clearance equal to the footer height.
+ * Snapshots covering the overlapping sticky footer layout:
+ * - a transparent footer over long scrollable content (content shows through / scrolls behind it),
+ * - a small body that must center in the space *above* the footer (not the whole screen),
+ * - an oversized footer taller than half the screen.
  */
 @OptIn(InternalRevenueCatAPI::class)
 @RunWith(Parameterized::class)
@@ -56,31 +59,25 @@ internal class OverlappingFooterSnapshotTest(testConfig: TestConfig) : BasePapar
 
     @Test
     fun transparentFooterOverlapsScrollableContent() {
-        screenshotTest {
-            OverlappingFooterPaywall()
-        }
+        screenshotTest { TransparentFooterPaywall() }
     }
 
-    @Suppress("LongMethod")
-    @Composable
-    private fun OverlappingFooterPaywall() {
-        val textColor = ColorScheme(
-            light = ColorInfo.Hex(Color(0xFF272727).toArgb()),
-            dark = ColorInfo.Hex(Color(0xFFFDFDFD).toArgb()),
-        )
-        val backgroundColor = ColorScheme(
-            light = ColorInfo.Hex(Color(0xFFFDFDFD).toArgb()),
-            dark = ColorInfo.Hex(Color(0xFF121212).toArgb()),
-        )
-        // Semi-transparent, tinted footer background so the scrolled content is clearly visible THROUGH
-        // the footer (a distinct tint over the content behind it), demonstrating the overlap.
-        val translucentFooterColor = ColorScheme(
-            light = ColorInfo.Hex(Color(0x99057C5B).toArgb()),
-            dark = ColorInfo.Hex(Color(0x99057C5B).toArgb()),
-        )
-        val ctaTextColor = ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))
-        val ctaBackgroundColor = ColorScheme(light = ColorInfo.Hex(Color(0xFF057C5B).toArgb()))
+    @Test
+    fun smallBodyCentersAboveFooter() {
+        screenshotTest { SmallCenteredBodyPaywall() }
+    }
 
+    @Test
+    fun largeFooterTallerThanHalfScreen() {
+        screenshotTest { LargeFooterPaywall() }
+    }
+
+    /**
+     * Long scrollable body with a semi-transparent, tinted footer. The content is visible THROUGH the
+     * footer and scrolls behind it, while reserving footer-height bottom clearance.
+     */
+    @Composable
+    private fun TransparentFooterPaywall() {
         val featureRows = (1..25).map { index ->
             TextComponent(
                 text = LocalizationKey("feature-$index"),
@@ -91,70 +88,165 @@ internal class OverlappingFooterSnapshotTest(testConfig: TestConfig) : BasePapar
             )
         }
 
+        ComponentPaywall(
+            rootStack = StackComponent(
+                components = listOf(
+                    TextComponent(
+                        text = LocalizationKey("title"),
+                        color = textColor,
+                        fontWeight = FontWeight.BOLD,
+                        fontSize = 28,
+                        horizontalAlignment = LEADING,
+                        size = Size(width = Fill, height = Fit),
+                        margin = Padding(top = 0.0, bottom = 24.0, leading = 0.0, trailing = 0.0),
+                    ),
+                ) + featureRows,
+                dimension = Vertical(alignment = LEADING, distribution = START),
+                size = Size(width = Fill, height = Fill),
+                padding = Padding(top = 32.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+            ),
+            footerStack = ctaFooterStack(backgroundColor = translucentFooterColor),
+            localizations = mapOf(
+                LocalizationKey("title") to LocalizationData.Text("Unlock everything"),
+                LocalizationKey("cta") to LocalizationData.Text("Continue"),
+            ) + (1..25).associate { index ->
+                LocalizationKey("feature-$index") to LocalizationData.Text("✓ Premium feature number $index")
+            },
+        )
+    }
+
+    /**
+     * A small body vertically centered. It must center within the space above the footer, matching the
+     * pre-overlap behavior (footer-height clearance is reserved at the bottom).
+     */
+    @Composable
+    private fun SmallCenteredBodyPaywall() {
+        ComponentPaywall(
+            rootStack = StackComponent(
+                components = listOf(
+                    TextComponent(
+                        text = LocalizationKey("title"),
+                        color = textColor,
+                        fontWeight = FontWeight.BOLD,
+                        fontSize = 28,
+                        horizontalAlignment = CENTER,
+                        size = Size(width = Fill, height = Fit),
+                        margin = Padding(top = 0.0, bottom = 12.0, leading = 32.0, trailing = 32.0),
+                    ),
+                    TextComponent(
+                        text = LocalizationKey("subtitle"),
+                        color = textColor,
+                        horizontalAlignment = CENTER,
+                        size = Size(width = Fill, height = Fit),
+                        margin = Padding(top = 0.0, bottom = 0.0, leading = 32.0, trailing = 32.0),
+                    ),
+                ),
+                dimension = Vertical(alignment = CENTER, distribution = FlexDistribution.CENTER),
+                size = Size(width = Fill, height = Fill),
+            ),
+            footerStack = ctaFooterStack(backgroundColor = translucentFooterColor),
+            localizations = mapOf(
+                LocalizationKey("title") to LocalizationData.Text("Centered body"),
+                LocalizationKey("subtitle") to LocalizationData.Text("This should be centered above the footer"),
+                LocalizationKey("cta") to LocalizationData.Text("Continue"),
+            ),
+        )
+    }
+
+    /**
+     * A footer taller than half the screen. Content occupies the reduced region above it; the footer
+     * fills the rest without clipping the layout.
+     */
+    @Composable
+    private fun LargeFooterPaywall() {
+        val footerRows = (1..8).map { index ->
+            TextComponent(
+                text = LocalizationKey("footer-line-$index"),
+                color = ctaTextColor,
+                horizontalAlignment = CENTER,
+                size = Size(width = Fill, height = Fit),
+                margin = Padding(top = 6.0, bottom = 6.0, leading = 0.0, trailing = 0.0),
+            )
+        }
+
+        ComponentPaywall(
+            rootStack = StackComponent(
+                components = listOf(
+                    TextComponent(
+                        text = LocalizationKey("title"),
+                        color = textColor,
+                        fontWeight = FontWeight.BOLD,
+                        fontSize = 28,
+                        horizontalAlignment = LEADING,
+                        size = Size(width = Fill, height = Fit),
+                        margin = Padding(top = 0.0, bottom = 12.0, leading = 0.0, trailing = 0.0),
+                    ),
+                    TextComponent(
+                        text = LocalizationKey("subtitle"),
+                        color = textColor,
+                        horizontalAlignment = LEADING,
+                        size = Size(width = Fill, height = Fit),
+                    ),
+                ),
+                dimension = Vertical(alignment = LEADING, distribution = START),
+                size = Size(width = Fill, height = Fill),
+                padding = Padding(top = 32.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+            ),
+            footerStack = StackComponent(
+                components = footerRows + StackComponent(
+                    components = listOf(
+                        TextComponent(
+                            text = LocalizationKey("cta"),
+                            color = ctaTextColor,
+                            fontWeight = FontWeight.BOLD,
+                        ),
+                    ),
+                    dimension = ZLayer(alignment = TwoDimensionalAlignment.CENTER),
+                    size = Size(width = Fill, height = Fit),
+                    backgroundColor = ctaBackgroundColor,
+                    padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                    margin = Padding(top = 16.0, bottom = 0.0, leading = 0.0, trailing = 0.0),
+                    shape = Shape.Pill,
+                ),
+                dimension = Vertical(alignment = CENTER, distribution = FlexDistribution.CENTER),
+                // Fixed height guarantees the footer is taller than half of a phone screen.
+                size = Size(width = Fill, height = Fixed(520u)),
+                backgroundColor = solidFooterColor,
+                padding = Padding(top = 24.0, bottom = 24.0, leading = 32.0, trailing = 32.0),
+            ),
+            localizations = mapOf(
+                LocalizationKey("title") to LocalizationData.Text("Big footer"),
+                LocalizationKey("subtitle") to LocalizationData.Text("The footer below is taller than half the screen."),
+                LocalizationKey("cta") to LocalizationData.Text("Continue"),
+            ) + (1..8).associate { index ->
+                LocalizationKey("footer-line-$index") to LocalizationData.Text("Footer line $index")
+            },
+        )
+    }
+
+    @Composable
+    private fun ComponentPaywall(
+        rootStack: StackComponent,
+        footerStack: StackComponent,
+        localizations: Map<LocalizationKey, LocalizationData>,
+    ) {
         val data = PaywallComponentsData(
-            id = "snapshot_transparent_footer",
+            id = "snapshot_overlapping_footer",
             templateName = "template",
             assetBaseURL = URL("https://assets.pawwalls.com"),
             componentsConfig = ComponentsConfig(
                 base = PaywallComponentsConfig(
-                    stack = StackComponent(
-                        components = listOf(
-                            TextComponent(
-                                text = LocalizationKey("title"),
-                                color = textColor,
-                                fontWeight = FontWeight.BOLD,
-                                fontSize = 28,
-                                horizontalAlignment = LEADING,
-                                size = Size(width = Fill, height = Fit),
-                                margin = Padding(top = 0.0, bottom = 24.0, leading = 0.0, trailing = 0.0),
-                            ),
-                        ) + featureRows,
-                        dimension = Vertical(alignment = LEADING, distribution = START),
-                        size = Size(width = Fill, height = Fill),
-                        padding = Padding(top = 32.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
-                    ),
+                    stack = rootStack,
                     background = Background.Color(backgroundColor),
-                    stickyFooter = StickyFooterComponent(
-                        stack = StackComponent(
-                            components = listOf(
-                                StackComponent(
-                                    components = listOf(
-                                        TextComponent(
-                                            text = LocalizationKey("cta"),
-                                            color = ctaTextColor,
-                                            fontWeight = FontWeight.BOLD,
-                                        ),
-                                    ),
-                                    dimension = ZLayer(alignment = TwoDimensionalAlignment.CENTER),
-                                    size = Size(width = Fill, height = Fit),
-                                    backgroundColor = ctaBackgroundColor,
-                                    padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
-                                    shape = Shape.Pill,
-                                ),
-                            ),
-                            dimension = Vertical(alignment = CENTER, distribution = START),
-                            size = Size(width = Fill, height = Fit),
-                            backgroundColor = translucentFooterColor,
-                            padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
-                        ),
-                    ),
+                    stickyFooter = StickyFooterComponent(stack = footerStack),
                 ),
             ),
-            componentsLocalizations = mapOf(
-                LocaleId("en_US") to (
-                    mapOf(
-                        LocalizationKey("title") to LocalizationData.Text("Unlock everything"),
-                        LocalizationKey("cta") to LocalizationData.Text("Continue"),
-                    ) + (1..25).associate { index ->
-                        LocalizationKey("feature-$index") to LocalizationData.Text("✓ Premium feature number $index")
-                    }
-                    ),
-            ),
+            componentsLocalizations = mapOf(LocaleId("en_US") to localizations),
             defaultLocaleIdentifier = LocaleId("en_US"),
         )
         val offering = Offering(
-            identifier = "transparent_footer",
-            serverDescription = "Transparent overlapping footer",
+            identifier = "overlapping_footer",
+            serverDescription = "Overlapping footer",
             metadata = emptyMap(),
             availablePackages = listOf(TestData.Packages.monthly),
             paywallComponents = Offering.PaywallComponents(previewUiConfig(), data),
@@ -172,5 +264,52 @@ internal class OverlappingFooterSnapshotTest(testConfig: TestConfig) : BasePapar
             clickHandler = { },
             modifier = Modifier.fillMaxSize(),
         )
+    }
+
+    private fun ctaFooterStack(backgroundColor: ColorScheme): StackComponent =
+        StackComponent(
+            components = listOf(
+                StackComponent(
+                    components = listOf(
+                        TextComponent(
+                            text = LocalizationKey("cta"),
+                            color = ctaTextColor,
+                            fontWeight = FontWeight.BOLD,
+                        ),
+                    ),
+                    dimension = ZLayer(alignment = TwoDimensionalAlignment.CENTER),
+                    size = Size(width = Fill, height = Fit),
+                    backgroundColor = ctaBackgroundColor,
+                    padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+                    shape = Shape.Pill,
+                ),
+            ),
+            dimension = Vertical(alignment = CENTER, distribution = START),
+            size = Size(width = Fill, height = Fit),
+            backgroundColor = backgroundColor,
+            padding = Padding(top = 16.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+        )
+
+    private companion object {
+        val textColor = ColorScheme(
+            light = ColorInfo.Hex(Color(0xFF272727).toArgb()),
+            dark = ColorInfo.Hex(Color(0xFFFDFDFD).toArgb()),
+        )
+        val backgroundColor = ColorScheme(
+            light = ColorInfo.Hex(Color(0xFFFDFDFD).toArgb()),
+            dark = ColorInfo.Hex(Color(0xFF121212).toArgb()),
+        )
+
+        // Semi-transparent, tinted footer background so the content behind it is clearly visible.
+        val translucentFooterColor = ColorScheme(
+            light = ColorInfo.Hex(Color(0x99057C5B).toArgb()),
+            dark = ColorInfo.Hex(Color(0x99057C5B).toArgb()),
+        )
+        val solidFooterColor = ColorScheme(
+            light = ColorInfo.Hex(Color(0xFF057C5B).toArgb()),
+            dark = ColorInfo.Hex(Color(0xFF057C5B).toArgb()),
+        )
+        val ctaTextColor = ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))
+        val ctaBackgroundColor = ColorScheme(light = ColorInfo.Hex(Color(0xFF0A3D2E).toArgb()))
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/OverlappingFooterSnapshotTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/OverlappingFooterSnapshotTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.paywalls.components.HeaderComponent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
@@ -34,11 +35,15 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fi
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.paywalls.components.properties.TwoDimensionalAlignment
 import com.revenuecat.purchases.ui.revenuecatui.components.LoadedPaywallComponents
+import com.revenuecat.purchases.ui.revenuecatui.components.LoadedWorkflowPaywall
 import com.revenuecat.purchases.ui.revenuecatui.components.MILLIS_2025_01_25
 import com.revenuecat.purchases.ui.revenuecatui.components.previewUiConfig
 import com.revenuecat.purchases.ui.revenuecatui.components.validatePaywallComponentsDataOrNullForPreviews
 import com.revenuecat.purchases.ui.revenuecatui.data.MockPurchasesType
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
 import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
 import org.junit.Test
@@ -70,6 +75,11 @@ internal class OverlappingFooterSnapshotTest(testConfig: TestConfig) : BasePapar
     @Test
     fun largeFooterTallerThanHalfScreen() {
         screenshotTest { LargeFooterPaywall() }
+    }
+
+    @Test
+    fun workflowStepWithHeaderAndFooterReservesHeaderClearance() {
+        screenshotTest { WorkflowHeaderFooterPaywall() }
     }
 
     /**
@@ -224,12 +234,101 @@ internal class OverlappingFooterSnapshotTest(testConfig: TestConfig) : BasePapar
         )
     }
 
+    /**
+     * A workflow step that has BOTH a (non-hero) header and a sticky footer. The step renders its own
+     * OverlayLayout nested inside the scaffold's, sharing the same state. Regression guard: the inner
+     * layout must not wipe the header height, so the body keeps its header clearance (title sits below
+     * the header bar, not under it) while still reserving footer clearance at the bottom.
+     */
+    @Composable
+    private fun WorkflowHeaderFooterPaywall() {
+        val featureRows = (1..20).map { index ->
+            TextComponent(
+                text = LocalizationKey("feature-$index"),
+                color = textColor,
+                horizontalAlignment = LEADING,
+                size = Size(width = Fill, height = Fit),
+                margin = Padding(top = 8.0, bottom = 8.0, leading = 0.0, trailing = 0.0),
+            )
+        }
+
+        val state = buildComponentsState(
+            rootStack = StackComponent(
+                components = listOf(
+                    TextComponent(
+                        text = LocalizationKey("title"),
+                        color = textColor,
+                        fontWeight = FontWeight.BOLD,
+                        fontSize = 28,
+                        horizontalAlignment = LEADING,
+                        size = Size(width = Fill, height = Fit),
+                        margin = Padding(top = 0.0, bottom = 24.0, leading = 0.0, trailing = 0.0),
+                    ),
+                ) + featureRows,
+                dimension = Vertical(alignment = LEADING, distribution = START),
+                size = Size(width = Fill, height = Fill),
+                padding = Padding(top = 32.0, bottom = 16.0, leading = 32.0, trailing = 32.0),
+            ),
+            footerStack = ctaFooterStack(backgroundColor = translucentFooterColor),
+            header = HeaderComponent(
+                stack = StackComponent(
+                    components = listOf(
+                        TextComponent(
+                            text = LocalizationKey("header"),
+                            color = ctaTextColor,
+                            fontWeight = FontWeight.BOLD,
+                            fontSize = 20,
+                            horizontalAlignment = CENTER,
+                            size = Size(width = Fill, height = Fit),
+                        ),
+                    ),
+                    dimension = Vertical(alignment = CENTER, distribution = FlexDistribution.CENTER),
+                    size = Size(width = Fill, height = Fit),
+                    backgroundColor = solidFooterColor,
+                    padding = Padding(top = 24.0, bottom = 24.0, leading = 16.0, trailing = 16.0),
+                ),
+            ),
+            localizations = mapOf(
+                LocalizationKey("header") to LocalizationData.Text("Header"),
+                LocalizationKey("title") to LocalizationData.Text("Unlock everything"),
+                LocalizationKey("cta") to LocalizationData.Text("Continue"),
+            ) + (1..20).associate { index ->
+                LocalizationKey("feature-$index") to LocalizationData.Text("✓ Premium feature number $index")
+            },
+        )
+
+        LoadedWorkflowPaywall(
+            workflowState = WorkflowPaywallUiState(
+                currentStepId = "step",
+                stepStates = mapOf("step" to state),
+            ),
+            onTransitionComplete = { },
+            clickHandler = { },
+            componentInteractionTracker = PaywallComponentInteractionTracker { _ -> },
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+
     @Composable
     private fun ComponentPaywall(
         rootStack: StackComponent,
         footerStack: StackComponent,
         localizations: Map<LocalizationKey, LocalizationData>,
     ) {
+        LoadedPaywallComponents(
+            state = buildComponentsState(rootStack = rootStack, footerStack = footerStack, localizations = localizations),
+            clickHandler = { },
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+
+    @Composable
+    private fun buildComponentsState(
+        rootStack: StackComponent,
+        footerStack: StackComponent,
+        localizations: Map<LocalizationKey, LocalizationData>,
+        header: HeaderComponent? = null,
+    ): PaywallState.Loaded.Components {
         val data = PaywallComponentsData(
             id = "snapshot_overlapping_footer",
             templateName = "template",
@@ -239,6 +338,7 @@ internal class OverlappingFooterSnapshotTest(testConfig: TestConfig) : BasePapar
                     stack = rootStack,
                     background = Background.Color(backgroundColor),
                     stickyFooter = StickyFooterComponent(stack = footerStack),
+                    header = header,
                 ),
             ),
             componentsLocalizations = mapOf(LocaleId("en_US") to localizations),
@@ -252,17 +352,11 @@ internal class OverlappingFooterSnapshotTest(testConfig: TestConfig) : BasePapar
             paywallComponents = Offering.PaywallComponents(previewUiConfig(), data),
         )
         val validated = offering.validatePaywallComponentsDataOrNullForPreviews()?.getOrThrow()!!
-        val state = offering.toComponentsPaywallState(
+        return offering.toComponentsPaywallState(
             validationResult = validated,
             storefrontCountryCode = "US",
             dateProvider = { Date(MILLIS_2025_01_25) },
             purchases = MockPurchasesType(),
-        )
-
-        LoadedPaywallComponents(
-            state = state,
-            clickHandler = { },
-            modifier = Modifier.fillMaxSize(),
         )
     }
 


### PR DESCRIPTION
## Intention

Support Paywalls V2 sticky footers with transparent backgrounds, where the main content draws **behind** the footer.

Previously the footer was stacked below the main content (they never overlapped), so an opaque bar was the only possible look. Now the footer overlays the bottom of the content: transparent footers let the content and paywall background show through, while opaque footers stay visually identical to before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Layout behavior changes for all paywalls with sticky footers and nested workflow overlays; regressions would show as wrong scroll clearance, centering, or header overlap, but coverage is snapshot-heavy and opaque footers are intended to stay visually equivalent.
> 
> **Overview**
> Paywalls V2 **sticky footers** no longer sit in a vertical stack under the body. When a footer is present, main content fills the screen and the footer is **pinned and drawn on top** at the bottom, so translucent backgrounds let scrollable content show through.
> 
> **`HeaderOverlayLayout`** is generalized to **`OverlayLayout`**, which can measure and overlay both header and footer, writing **`footerHeightPx`** on paywall state (alongside existing **`headerHeightPx`**). Heights are only updated for overlays that layout owns (`hasHeader` / `hasFooter`), so nested workflow **`OverlayLayout`** instances do not zero out the outer header height. Main content uses new **`footerBottomPadding`** so the last items can scroll clear of the footer; opaque footers should still match the old stacked look.
> 
> **Workflow** steps use the same overlay footer model inside **`WorkflowStepContent`**. Previews and **`OverlappingFooterSnapshotTest`** cover transparent scroll overlap, centered body above the footer, large footers, and header+footer workflow regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 525c0b3a420e2f76a208f9a85f491e45408c2c73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->