### PR TITLE
fix(remote-config): don't sync a cold read for the previous user on identity change

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -279,7 +279,8 @@ internal class PurchasesFactory(
                     backend = backend,
                     diskCache = RemoteConfigDiskCache(contextForStorage),
                     blobStore = RemoteConfigBlobStore(contextForStorage),
-                    // Lets a cold on-demand read self-trigger a sync for the current user (see blobData()).
+                    // Bootstrap source for a cold on-demand read's self-triggered sync (see blobData()); after
+                    // the first identity change the manager syncs for the user clearCache() binds instead.
                     appUserIDProvider = { cache.getCachedAppUserID() },
                 )
             } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -132,16 +132,24 @@ internal class RemoteConfigManager(
             return
         }
         val requestEpoch: Int
+        val requestAppUserID: String
         // Acquire the in-flight guard and capture the epoch together under the lock that also guards
         // clearCache()'s epoch bump + guard release. Otherwise an identity change could slip its bump
         // between getAndSet(true) and epoch.get(), stranding this request with a stale epoch: its
         // callbacks would drop on the mismatch and never release the guard, freezing all future syncs.
+        // The user is snapshotted here too, so the (user, epoch) pair the request carries is consistent:
+        // any clearCache() that would change the user also bumps the epoch under this same lock, so it
+        // either lands fully before this capture (we see its new user) or after (the epoch mismatch drops
+        // our response) — never a stale user paired with the post-clear epoch. currentAppUserID (bound by
+        // clearCache) wins; the passed appUserID is only the pre-first-identity-change bootstrap fallback.
+        // Read only in-memory state under the lock — never appUserIDProvider(), which can re-enter clearCache().
         synchronized(cacheLock) {
             if (isRefreshing.getAndSet(true)) {
                 debugLog { "Remote config refresh already in progress. Skipping." }
                 return
             }
             requestEpoch = epoch.get()
+            requestAppUserID = currentAppUserID ?: appUserID
             refreshCompletion = CompletableDeferred()
         }
         val persisted = diskCache.read()
@@ -149,7 +157,7 @@ internal class RemoteConfigManager(
         logRefreshStart(persisted, appInBackground)
         backend.getRemoteConfig(
             appInBackground = appInBackground,
-            appUserID = appUserID,
+            appUserID = requestAppUserID,
             domain = persisted?.domain ?: DEFAULT_DOMAIN,
             // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
             manifest = persisted?.manifest,
@@ -285,9 +293,10 @@ internal class RemoteConfigManager(
      *   user is known yet, in which case it gives up without a network call.
      *
      * The on-demand sync is issued as foreground (`appInBackground = false`): a read is blocking on the result,
-     * so it wants the un-jittered, prompt request. It syncs for the identity [clearCache] bound (falling back to
-     * [appUserIDProvider] only before the first identity change), never the potentially-stale provider value, so
-     * a read racing an identity change can never fetch and persist the previous user's config.
+     * so it wants the un-jittered, prompt request. The user it syncs for is snapshotted atomically with the
+     * epoch inside [refreshRemoteConfig] (the identity [clearCache] bound wins); the value resolved here is only
+     * the pre-first-identity-change bootstrap and the "is any user known" gate, so a read racing an identity
+     * change can never fetch and persist the previous user's config.
      */
     private suspend fun awaitConfigForRead() {
         if (awaitInFlightRefresh()) {
@@ -295,7 +304,8 @@ internal class RemoteConfigManager(
             return
         }
         // Nothing in flight: trigger a sync on demand, unless the endpoint is disabled or no user is known yet.
-        // Prefer the identity clearCache() bound (see [currentAppUserID]); the provider is only the bootstrap.
+        // This value is only the bootstrap fallback + the "user known" gate; refreshRemoteConfig re-resolves the
+        // effective user under the lock (preferring the clearCache-bound [currentAppUserID]) when it runs.
         val appUserID = (currentAppUserID ?: appUserIDProvider())?.takeIf { it.isNotBlank() }
         if (!disabled && appUserID != null) {
             verboseLog { "Cold remote config read triggering an on-demand sync." }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -46,7 +46,10 @@ import java.util.concurrent.atomic.AtomicInteger
  * The `200` path runs on [scope]: persistence is synchronous, but the launch lets [clearCache] cancel the
  * in-flight parse/persist. Blob prefetch runs on the fetcher's own worker pool (not [scope]). Identity changes
  * call [clearCache], which bumps an epoch so a late `/v1/config` response (its HTTP request cannot be
- * socket-cancelled) is dropped instead of persisting over the freshly wiped cache.
+ * socket-cancelled) is dropped instead of persisting over the freshly wiped cache. [clearCache] also rebinds
+ * the current app user atomically with that bump, so a cold on-demand read triggered right after an identity
+ * change never fetches for the previous user (the cached app user ID the [appUserIDProvider] reads can still
+ * lag the change for a window).
  *
  * Overlapping refreshes are deduped: only one [refreshRemoteConfig] runs at a time. A call made while one is
  * already in flight is skipped (the backend collapses concurrent requests but still fires every callback, which
@@ -88,6 +91,13 @@ internal class RemoteConfigManager(
 
     @Volatile
     private var lastRefreshedAt: Date? = null
+
+    // The app user a cold on-demand read should sync for, rebound by clearCache() under [cacheLock] atomically
+    // with the epoch bump, so it can never lag the identity change the way [appUserIDProvider] (backed by the
+    // device cache) can. Null until the first identity change; awaitConfigForRead() falls back to the provider
+    // for that pre-first-change bootstrap window, where it is accurate and no transition is racing.
+    @Volatile
+    private var currentAppUserID: String? = null
 
     // Completion signal for the single in-flight refresh, so a read that finds no cached data can wait for the
     // refresh already in progress instead of failing. Created under [cacheLock] when a refresh starts, completed
@@ -215,12 +225,18 @@ internal class RemoteConfigManager(
     }
 
     /**
-     * Wipes the cache on an identity change so configuration never bleeds across users (offerings-parity).
+     * Wipes the cache on an identity change so configuration never bleeds across users (offerings-parity), and
+     * rebinds [currentAppUserID] to [appUserID] atomically with the epoch bump. Binding the new identity here —
+     * rather than reading it back through [appUserIDProvider] — closes the window where a cold on-demand read
+     * could sync for the previous user: the device-cache-backed provider can still return the old user until the
+     * caller finishes caching the new one, but the epoch is already bumped, so that stale-user response would not
+     * be dropped and would repopulate the freshly wiped cache for the wrong user.
      */
-    fun clearCache() {
+    fun clearCache(appUserID: String) {
         scope.coroutineContext.cancelChildren()
         synchronized(cacheLock) {
             epoch.incrementAndGet()
+            currentAppUserID = appUserID
             isRefreshing.set(false)
             lastRefreshedAt = null
             completeRefresh()
@@ -269,7 +285,9 @@ internal class RemoteConfigManager(
      *   user is known yet, in which case it gives up without a network call.
      *
      * The on-demand sync is issued as foreground (`appInBackground = false`): a read is blocking on the result,
-     * so it wants the un-jittered, prompt request.
+     * so it wants the un-jittered, prompt request. It syncs for the identity [clearCache] bound (falling back to
+     * [appUserIDProvider] only before the first identity change), never the potentially-stale provider value, so
+     * a read racing an identity change can never fetch and persist the previous user's config.
      */
     private suspend fun awaitConfigForRead() {
         if (awaitInFlightRefresh()) {
@@ -277,7 +295,8 @@ internal class RemoteConfigManager(
             return
         }
         // Nothing in flight: trigger a sync on demand, unless the endpoint is disabled or no user is known yet.
-        val appUserID = appUserIDProvider()?.takeIf { it.isNotBlank() }
+        // Prefer the identity clearCache() bound (see [currentAppUserID]); the provider is only the bootstrap.
+        val appUserID = (currentAppUserID ?: appUserIDProvider())?.takeIf { it.isNotBlank() }
         if (!disabled && appUserID != null) {
             verboseLog { "Cold remote config read triggering an on-demand sync." }
             refreshRemoteConfig(appInBackground = false, appUserID = appUserID)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -107,7 +107,7 @@ internal class IdentityManager(
                         }
                         offeringsCache.clearCache()
                         workflowsCache?.clearCache()
-                        remoteConfigManager?.clearCache()
+                        remoteConfigManager?.clearCache(newAppUserID)
                         deviceCache.clearCustomerInfoCache(newAppUserID)
                         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     }
@@ -161,7 +161,7 @@ internal class IdentityManager(
                         deviceCache.clearCachesForAppUserID(oldAppUserID)
                         offeringsCache.clearCache()
                         workflowsCache?.clearCache()
-                        remoteConfigManager?.clearCache()
+                        remoteConfigManager?.clearCache(newAppUserID)
                         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
 
                         deviceCache.cacheAppUserID(newAppUserID)
@@ -265,7 +265,7 @@ internal class IdentityManager(
         deviceCache.clearCachesForAppUserID(currentAppUserID)
         offeringsCache.clearCache()
         workflowsCache?.clearCache()
-        remoteConfigManager?.clearCache()
+        remoteConfigManager?.clearCache(newUserID)
         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(currentAppUserID)
         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
         deviceCache.cacheAppUserID(newUserID)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -847,6 +847,34 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `on-demand sync uses the bound user even if identity changes between resolving it and capturing the epoch`() =
+        runTest {
+            // The tightest form of the race: the identity change lands *after* the read resolves its (stale)
+            // user but *before* refreshRemoteConfig captures the epoch. Simulated by a provider that clears the
+            // cache for the new user and then returns the old one. Because refreshRemoteConfig snapshots the user
+            // together with the epoch under the lock, the request must carry the newly bound user, not the stale
+            // provider value — otherwise the old user's response would persist under the post-clear epoch.
+            every { diskCache.read() } returns null
+
+            lateinit var manager: RemoteConfigManager
+            manager = readManager(
+                appUserIDProvider = {
+                    manager.clearCache("new-user")
+                    "old-user"
+                },
+            )
+
+            val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+                manager.topic(RemoteConfigTopic.Workflows)
+            }
+            verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+            assertThat(capturedAppUserID).isEqualTo("new-user")
+
+            onSuccess.invoke(null, VerificationResult.VERIFIED)
+            assertThat(read.isCompleted).isTrue()
+        }
+
+    @Test
     fun `an on-demand sync before any identity change syncs for the bootstrap provider user`() = runTest {
         // No clearCache() yet, so no identity is bound: the cold read falls back to the provider (the device
         // cache), which is accurate in this pre-first-change window since no transition is racing.

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -160,7 +160,7 @@ class RemoteConfigManagerTest {
         onSuccess.invoke(null, VerificationResult.VERIFIED)
 
         // Identity change wipes the cache and the in-memory marker, so the next user refreshes immediately.
-        manager.clearCache()
+        manager.clearCache(TEST_APP_USER_ID)
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
 
         verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
@@ -579,7 +579,7 @@ class RemoteConfigManagerTest {
         )
 
         // Identity change: the disable survives (it is an endpoint/app-level fact, not per-user).
-        manager.clearCache()
+        manager.clearCache(TEST_APP_USER_ID)
 
         assertThat(manager.isDisabled).isTrue()
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
@@ -675,7 +675,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `clearCache wipes the disk cache, blob store and resolved sources`() {
-        manager.clearCache()
+        manager.clearCache(TEST_APP_USER_ID)
 
         verify(exactly = 1) { diskCache.clear() }
         verify(exactly = 1) { blobStore.clear() }
@@ -696,7 +696,7 @@ class RemoteConfigManagerTest {
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         // Identity change wipes the cache before the in-flight request settles.
-        manager.clearCache()
+        manager.clearCache(TEST_APP_USER_ID)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         // The stale response is dropped (epoch guard): nothing is written over the wiped cache.
@@ -732,7 +732,7 @@ class RemoteConfigManagerTest {
         check(writeEntered.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "persist did not reach diskCache.write" }
 
         // Identity change mid-persist: clearCache must block on the lock persist is holding.
-        val clearThread = thread { manager.clearCache() }
+        val clearThread = thread { manager.clearCache(TEST_APP_USER_ID) }
 
         // While persist holds the lock, the wipe cannot run — the stale config can't be cleared out from under it.
         assertThat(clearEntered.await(BLOCKED_MILLIS, TimeUnit.MILLISECONDS)).isFalse()
@@ -759,7 +759,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.clearCache()
+        manager.clearCache(TEST_APP_USER_ID)
         // A brand-new sync (e.g. for the new user) proceeds normally: the guard was released by clearCache.
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
@@ -821,6 +821,46 @@ class RemoteConfigManagerTest {
 
         assertThat(read.isCompleted).isTrue()
         assertThat(result).containsKey("wf1")
+    }
+
+    @Test
+    fun `an on-demand sync after clearCache uses the newly bound user, not the lagging provider`() = runTest {
+        // The device-cache-backed provider can still return the previous user for a window after an identity
+        // change (the caller caches the new ID only after wiping remote config), but clearCache() binds the new
+        // user atomically with the epoch bump. The on-demand sync this cold read triggers must therefore fetch
+        // for the new user — otherwise it would repopulate the freshly wiped cache with the previous user's
+        // config and bleed it across identities.
+        every { diskCache.read() } returns null
+        val manager = readManager(appUserIDProvider = { "old-user" })
+
+        manager.clearCache("new-user")
+
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            manager.topic(RemoteConfigTopic.Workflows)
+        }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        assertThat(capturedAppUserID).isEqualTo("new-user")
+
+        // Settle the triggered sync so the parked read completes cleanly.
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        assertThat(read.isCompleted).isTrue()
+    }
+
+    @Test
+    fun `an on-demand sync before any identity change syncs for the bootstrap provider user`() = runTest {
+        // No clearCache() yet, so no identity is bound: the cold read falls back to the provider (the device
+        // cache), which is accurate in this pre-first-change window since no transition is racing.
+        every { diskCache.read() } returns null
+        val manager = readManager(appUserIDProvider = { "bootstrap-user" })
+
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            manager.topic(RemoteConfigTopic.Workflows)
+        }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        assertThat(capturedAppUserID).isEqualTo("bootstrap-user")
+
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        assertThat(read.isCompleted).isTrue()
     }
 
     @Test
@@ -1106,7 +1146,7 @@ class RemoteConfigManagerTest {
         assertThat(read.isActive).isTrue()
 
         // Identity change unblocks the waiter, which re-reads the now-wiped cache and gives up.
-        manager.clearCache()
+        manager.clearCache(TEST_APP_USER_ID)
 
         assertThat(read.isCompleted).isTrue()
         assertThat(result).isNull()
@@ -1205,7 +1245,7 @@ class RemoteConfigManagerTest {
             appUserIDProvider = { TEST_APP_USER_ID },
         )
 
-        val clearer = thread { repeat(STRESS_ITERATIONS) { manager.clearCache() } }
+        val clearer = thread { repeat(STRESS_ITERATIONS) { manager.clearCache(TEST_APP_USER_ID) } }
         val refresher = thread {
             repeat(STRESS_ITERATIONS) {
                 manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -82,7 +82,7 @@ class IdentityManagerTests {
             every { clearCache() } just Runs
         }
         mockRemoteConfigManager = mockk<RemoteConfigManager>().apply {
-            every { clearCache() } just Runs
+            every { clearCache(any()) } just Runs
         }
 
         mockBackend = mockk<Backend>().apply {
@@ -256,7 +256,7 @@ class IdentityManagerTests {
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
         verify(exactly = 1) { mockWorkflowsCache.clearCache() }
-        verify(exactly = 1) { mockRemoteConfigManager.clearCache() }
+        verify(exactly = 1) { mockRemoteConfigManager.clearCache(newAppUserID) }
     }
 
     @Test
@@ -412,7 +412,8 @@ class IdentityManagerTests {
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
         verify(exactly = 1) { mockWorkflowsCache.clearCache() }
-        verify(exactly = 1) { mockRemoteConfigManager.clearCache() }
+        // logOut resets to a freshly generated anonymous ID, so match any user.
+        verify(exactly = 1) { mockRemoteConfigManager.clearCache(any()) }
     }
 
     @Test
@@ -638,7 +639,7 @@ class IdentityManagerTests {
         verify(exactly = 1) { mockDeviceCache.clearCachesForAppUserID(oldAppUserID) }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
         verify(exactly = 1) { mockWorkflowsCache.clearCache() }
-        verify(exactly = 1) { mockRemoteConfigManager.clearCache() }
+        verify(exactly = 1) { mockRemoteConfigManager.clearCache(newAppUserID) }
         verify(exactly = 1) {
             mockSubscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
         }
@@ -771,7 +772,7 @@ class IdentityManagerTests {
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
         verify(exactly = 1) { mockWorkflowsCache.clearCache() }
-        verify(exactly = 1) { mockRemoteConfigManager.clearCache() }
+        verify(exactly = 1) { mockRemoteConfigManager.clearCache(newAppUserId) }
         verify(exactly = 1) { mockDeviceCache.clearCustomerInfoCache(newAppUserId) }
         verify(exactly = 1) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }
@@ -811,7 +812,7 @@ class IdentityManagerTests {
         }
         verify(exactly = 0) { mockOfferingsCache.clearCache() }
         verify(exactly = 0) { mockWorkflowsCache.clearCache() }
-        verify(exactly = 0) { mockRemoteConfigManager.clearCache() }
+        verify(exactly = 0) { mockRemoteConfigManager.clearCache(any()) }
         verify(exactly = 0) { mockDeviceCache.clearCustomerInfoCache(newAppUserId) }
         verify(exactly = 0) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }


### PR DESCRIPTION
## Why

On an identity change, `IdentityManager` wiped remote config before caching the new app user ID. A cold `topic()`/`blobData()` read racing that change could trigger an on-demand sync for the **previous** user and, because that request starts after the cache is wiped, persist the wrong user's config into the new user's freshly-wiped cache and return it. This violates the offerings-parity invariant `clearCache()` exists to protect (config must never bleed across users).

The path is currently latent (the `topic()`/`blobData()` facade has no production callers yet), but it's a landmine for the first consumer.

## Fix

`clearCache()` now binds the incoming app user to the drop-epoch atomically, and cold on-demand reads sync for that bound identity rather than the potentially-stale cached ID.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches identity-sensitive remote config sync and locking around `/v1/config`; wrong user binding would leak config across users, but the change is narrowly scoped with targeted race tests.
> 
> **Overview**
> Fixes a race where **remote config could bleed across users** after login, alias, switch, or logout. Identity flows wipe remote config before the device cache always reflects the new app user ID, so a cold `topic()` / `blobData()` read could trigger `/v1/config` for the **previous** user and persist that response into the wiped cache.
> 
> **`RemoteConfigManager.clearCache`** now takes the new `appUserID` and sets **`currentAppUserID`** in the same critical section as the identity **epoch** bump. **`refreshRemoteConfig`** snapshots **`requestAppUserID`** with the epoch under `cacheLock` (`currentAppUserID` wins; the caller’s ID is only a pre–first-identity-change bootstrap). Cold reads still use `appUserIDProvider` only until the first `clearCache`.
> 
> **`IdentityManager`** passes the target user into `remoteConfigManager?.clearCache(...)` on alias, login, switch, and logout. Tests cover the lagging-provider and mid-read identity-change cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53840787f10eaeb63018baf8d785344cc9ffa671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->