### PR TITLE
Add `WorkflowsConfigProvider`

### DIFF
--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallOptionsAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallOptionsAPI.kt
@@ -2,7 +2,7 @@ package com.revenuecat.apitester.kotlin.revenuecatui
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -37,7 +37,7 @@ private class PaywallOptionsAPI {
     @OptIn(InternalRevenueCatAPI::class)
     private fun checkInjectedWorkflow(
         builder: PaywallOptions.Builder,
-        workflow: WorkflowDataResult,
+        workflow: PublishedWorkflow,
         offering: Offering?,
     ) {
         val configured: PaywallOptions.Builder = builder.injectedWorkflow(workflow, offering)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -22,7 +22,7 @@ import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.warnLog
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.deeplinks.DeepLinkParser
 import com.revenuecat.purchases.interfaces.Callback
@@ -417,7 +417,7 @@ public class Purchases internal constructor(
     @Throws(PurchasesException::class)
     public suspend fun awaitGetWorkflow(
         workflowId: String,
-    ): WorkflowDataResult = suspendCoroutine { continuation ->
+    ): PublishedWorkflow = suspendCoroutine { continuation ->
         purchasesOrchestrator.getWorkflow(
             workflowId = workflowId,
             onSuccess = continuation::resume,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -53,7 +53,7 @@ import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeK
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.common.warnLog
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.deeplinks.WebPurchaseRedemptionHelper
@@ -578,7 +578,7 @@ internal class PurchasesOrchestrator(
 
     fun getWorkflow(
         workflowId: String,
-        onSuccess: (WorkflowDataResult) -> Unit,
+        onSuccess: (PublishedWorkflow) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
         // Deliver every outcome through dispatch so the callback always lands on the main thread,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowDetailResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowDetailResolver.kt
@@ -29,9 +29,6 @@ internal class WorkflowDetailResolver(
                 WorkflowJsonParser.parsePublishedWorkflow(json)
             }
         }
-        return WorkflowDataResult(
-            workflow = workflow,
-            enrolledVariants = response.enrolledVariants,
-        )
+        return WorkflowDataResult(workflow = workflow)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowDetailResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowDetailResolver.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.common.verification.SignatureVerificationExcepti
 import com.revenuecat.purchases.models.Checksum
 
 /**
- * Resolves a [WorkflowDetailResponse] envelope into a [WorkflowDataResult]
+ * Resolves a [WorkflowDetailResponse] envelope into a [PublishedWorkflow]
  * by handling inline data or CDN fetching + checksum validation.
  */
 internal class WorkflowDetailResolver(
@@ -15,7 +15,7 @@ internal class WorkflowDetailResolver(
 ) {
 
     @Throws(IllegalStateException::class, SignatureVerificationException::class)
-    suspend fun resolve(response: WorkflowDetailResponse): WorkflowDataResult {
+    suspend fun resolve(response: WorkflowDetailResponse): PublishedWorkflow {
         val workflow = when (response.action) {
             WorkflowResponseAction.INLINE -> {
                 response.data
@@ -29,6 +29,6 @@ internal class WorkflowDetailResolver(
                 WorkflowJsonParser.parsePublishedWorkflow(json)
             }
         }
-        return WorkflowDataResult(workflow = workflow)
+        return workflow
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -67,7 +67,7 @@ internal class WorkflowManager(
         appUserID: String,
         workflowOrOfferingId: String,
         appInBackground: Boolean,
-        onSuccess: (WorkflowDataResult) -> Unit,
+        onSuccess: (PublishedWorkflow) -> Unit,
         onError: (PurchasesError) -> Unit,
         callbackDispatcher: Dispatcher? = null,
         persistEnvelopeOnResolve: Boolean = false,
@@ -145,7 +145,7 @@ internal class WorkflowManager(
         callbackDispatcher: Dispatcher?,
         persistEnvelopeOnResolve: Boolean,
         offeringIdToRecordOnResolve: String?,
-        onSuccess: (WorkflowDataResult) -> Unit,
+        onSuccess: (PublishedWorkflow) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
         val onSuccessHandler: (WorkflowDetailResponse) -> Unit = { response ->
@@ -163,7 +163,7 @@ internal class WorkflowManager(
                 }
                 cacheResolvedWorkflow(result, response, persistEnvelopeOnResolve, offeringIdToRecordOnResolve)
                 scope.launch {
-                    runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result.workflow) }
+                    runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result) }
                         .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
                 }
                 onSuccess(result)
@@ -216,12 +216,12 @@ internal class WorkflowManager(
      * the next render refetches.
      */
     private fun cacheResolvedWorkflow(
-        result: WorkflowDataResult,
+        result: PublishedWorkflow,
         response: WorkflowDetailResponse,
         persistEnvelopeOnResolve: Boolean,
         offeringIdToRecordOnResolve: String?,
     ) {
-        val resolvedWorkflowId = result.workflow.id
+        val resolvedWorkflowId = result.id
         if (resolvedWorkflowId.isEmpty()) {
             errorLog { "Workflow resolved with an empty id; serving it without caching." }
             return
@@ -251,7 +251,7 @@ internal class WorkflowManager(
     private suspend fun resolveDiskFallback(
         workflowId: String,
         networkError: PurchasesError,
-        onSuccess: (WorkflowDataResult) -> Unit,
+        onSuccess: (PublishedWorkflow) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
         val envelope = workflowsCache.cachedWorkflowDetailEnvelopeFromDisk(workflowId)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -164,11 +164,6 @@ public data class WorkflowExitOffer(
     val stepId: String,
 )
 
-@InternalRevenueCatAPI
-public data class WorkflowDataResult(
-    val workflow: PublishedWorkflow,
-)
-
 @Serializable
 internal enum class WorkflowResponseAction {
     @SerialName("inline")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -167,7 +167,6 @@ public data class WorkflowExitOffer(
 @InternalRevenueCatAPI
 public data class WorkflowDataResult(
     val workflow: PublishedWorkflow,
-    val enrolledVariants: Map<String, String>?,
 )
 
 @Serializable
@@ -185,8 +184,6 @@ internal data class WorkflowDetailResponse(
     val data: PublishedWorkflow? = null,
     val url: String? = null,
     val hash: String? = null,
-    @SerialName("enrolled_variants")
-    val enrolledVariants: Map<String, String>? = null,
 )
 
 @Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 
 /**
- * In-memory cache for all workflow data: the resolved per-workflow [WorkflowDataResult]s and the
+ * In-memory cache for all workflow data: the resolved per-workflow [PublishedWorkflow]s and the
  * workflows list (plus its derived offeringId → workflowId map). It is the single owner of this
  * state so that clearing it on identity transitions wipes everything at once, mirroring how
  * [com.revenuecat.purchases.common.offerings.OfferingsCache] owns the in-memory offerings cache.
@@ -39,7 +39,7 @@ internal class WorkflowsCache(
     private val deviceCache: DeviceCache,
     private val dateProvider: DateProvider = DefaultDateProvider(),
 ) {
-    private val cachedWorkflows = mutableMapOf<String, InMemoryCachedObject<WorkflowDataResult>>()
+    private val cachedWorkflows = mutableMapOf<String, InMemoryCachedObject<PublishedWorkflow>>()
     private val workflowsListCachedObject = InMemoryCachedObject<WorkflowsListResponse>(dateProvider = dateProvider)
 
     @Volatile
@@ -48,7 +48,7 @@ internal class WorkflowsCache(
     // region Workflow detail cache
 
     @Synchronized
-    fun cachedWorkflow(workflowId: String): WorkflowDataResult? =
+    fun cachedWorkflow(workflowId: String): PublishedWorkflow? =
         cachedWorkflows[workflowId]?.cachedInstance
 
     @Synchronized
@@ -56,7 +56,7 @@ internal class WorkflowsCache(
         cachedWorkflows[workflowId]?.lastUpdatedAt?.isCacheStale(appInBackground, dateProvider) ?: true
 
     @Synchronized
-    fun cacheWorkflow(workflowId: String, result: WorkflowDataResult) {
+    fun cacheWorkflow(workflowId: String, result: PublishedWorkflow) {
         val cached = cachedWorkflows.getOrPut(workflowId) { InMemoryCachedObject(dateProvider = dateProvider) }
         cached.cacheInstance(result)
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -50,9 +50,7 @@ internal class WorkflowsConfigProvider(
         return try {
             val workflow = WorkflowJsonParser.parsePublishedWorkflow(body.decodeToString())
             debugLog { "Parsed workflow '$workflowId' (${workflow.steps.size} step(s))" }
-            // enrolled_variants is out of scope for this spike; it does not fit the topic-dedup model and is
-            // being designed separately.
-            WorkflowDataResult(workflow = workflow, enrolledVariants = null)
+            WorkflowDataResult(workflow = workflow)
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             errorLog(e) { "Failed to parse workflow '$workflowId' body." }
             null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -39,10 +39,10 @@ internal class WorkflowsConfigProvider(
     }
 
     /**
-     * Resolves [workflowId] into a [WorkflowDataResult], or `null` when the item is unknown, its body can be
+     * Resolves [workflowId] into a [PublishedWorkflow], or `null` when the item is unknown, its body can be
      * neither read nor downloaded, or the body fails to parse.
      */
-    suspend fun getWorkflow(workflowId: String): WorkflowDataResult? {
+    suspend fun getWorkflow(workflowId: String): PublishedWorkflow? {
         val body = manager.blobData(RemoteConfigTopic.Workflows, workflowId) { it } ?: run {
             errorLog { "Workflow '$workflowId' is unavailable from remote config." }
             return null
@@ -50,7 +50,7 @@ internal class WorkflowsConfigProvider(
         return try {
             val workflow = WorkflowJsonParser.parsePublishedWorkflow(body.decodeToString())
             debugLog { "Parsed workflow '$workflowId' (${workflow.steps.size} step(s))" }
-            WorkflowDataResult(workflow = workflow)
+            workflow
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             errorLog(e) { "Failed to parse workflow '$workflowId' body." }
             null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -1,0 +1,78 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.workflows
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * The topic-specific front door for workflows — the config-endpoint replacement for `WorkflowManager`'s read
+ * path. It knows only the `workflows` topic, that an item's `offering_identifier` lives in its inline
+ * content, and how to parse a [PublishedWorkflow]. Everything else — reading metadata, waiting on an in-flight
+ * sync, resolving inline vs `blob_ref`, downloading and reading the body — it delegates to [RemoteConfigManager]
+ * through `topic()` / `blobData()`. It never sees the blob store, the fetcher, or the disk cache.
+ */
+internal class WorkflowsConfigProvider(
+    private val manager: RemoteConfigManager,
+) {
+
+    suspend fun workflowIdForOfferingId(offeringId: String): String? {
+        val topic = manager.topic(RemoteConfigTopic.Workflows)
+        debugLog { "workflows topic ${if (topic == null) "is absent" else "has ${topic.size} item(s)"}" }
+        val workflowId = topic
+            ?.entries
+            ?.firstOrNull { (_, item) -> item.metadata.stringOrNull(KEY_OFFERING_IDENTIFIER) == offeringId }
+            ?.key
+        debugLog {
+            if (workflowId != null) {
+                "Resolved offering '$offeringId' to workflow '$workflowId'"
+            } else {
+                "No workflow found for offering '$offeringId'"
+            }
+        }
+        return workflowId
+    }
+
+    /**
+     * Resolves [workflowId] into a [WorkflowDataResult], or `null` when the item is unknown, its body can be
+     * neither read nor downloaded, or the body fails to parse.
+     */
+    suspend fun getWorkflow(workflowId: String): WorkflowDataResult? {
+        val body = manager.blobData(RemoteConfigTopic.Workflows, workflowId) { it } ?: run {
+            errorLog { "Workflow '$workflowId' is unavailable from remote config." }
+            return null
+        }
+        return try {
+            val workflow = WorkflowJsonParser.parsePublishedWorkflow(body.decodeToString())
+            debugLog { "Parsed workflow '$workflowId' (${workflow.steps.size} step(s))" }
+            // enrolled_variants is out of scope for this spike; it does not fit the topic-dedup model and is
+            // being designed separately.
+            WorkflowDataResult(workflow = workflow, enrolledVariants = null)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            errorLog(e) { "Failed to parse workflow '$workflowId' body." }
+            null
+        }
+    }
+
+    /**
+     * Forces the `workflows` topic to be synced (or confirms it already is), discarding the result. Used by
+     * [WorkflowManager.awaitWorkflowsReady] so `OfferingsManager` can gate its `onSuccess` callback on
+     * workflow data being ready, the way it used to gate on the old `getWorkflowsList` fetch — cheap on a warm
+     * cache since [RemoteConfigManager.topic] returns immediately once a topic is committed.
+     */
+    suspend fun awaitReady() {
+        manager.topic(RemoteConfigTopic.Workflows)
+    }
+
+    private companion object {
+        private const val KEY_OFFERING_IDENTIFIER = "offering_identifier"
+
+        private fun JsonObject.stringOrNull(key: String): String? =
+            (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import com.revenuecat.purchases.common.verboseLog
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
@@ -23,12 +24,12 @@ internal class WorkflowsConfigProvider(
 
     suspend fun workflowIdForOfferingId(offeringId: String): String? {
         val topic = manager.topic(RemoteConfigTopic.Workflows)
-        debugLog { "workflows topic ${if (topic == null) "is absent" else "has ${topic.size} item(s)"}" }
+        verboseLog { "workflows topic ${if (topic == null) "is absent" else "has ${topic.size} item(s)"}" }
         val workflowId = topic
             ?.entries
             ?.firstOrNull { (_, item) -> item.metadata.stringOrNull(KEY_OFFERING_IDENTIFIER) == offeringId }
             ?.key
-        debugLog {
+        verboseLog {
             if (workflowId != null) {
                 "Resolved offering '$offeringId' to workflow '$workflowId'"
             } else {

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -2841,7 +2841,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     @OptIn(InternalRevenueCatAPI::class)
     @Test
     fun `getWorkflow delivers the manager success result to the caller`() {
-        val expected = WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+        val expected = WorkflowDataResult(workflow = mockk())
         val successSlot = slot<(WorkflowDataResult) -> Unit>()
         every {
             mockWorkflowManager.getWorkflow(

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -11,7 +11,7 @@ import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.ReplaceProductInfo
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
 import com.revenuecat.purchases.google.toInAppStoreProduct
 import com.revenuecat.purchases.google.toStoreProduct
@@ -2841,8 +2841,8 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     @OptIn(InternalRevenueCatAPI::class)
     @Test
     fun `getWorkflow delivers the manager success result to the caller`() {
-        val expected = WorkflowDataResult(workflow = mockk())
-        val successSlot = slot<(WorkflowDataResult) -> Unit>()
+        val expected = mockk<PublishedWorkflow>()
+        val successSlot = slot<(PublishedWorkflow) -> Unit>()
         every {
             mockWorkflowManager.getWorkflow(
                 appUserID = appUserId,
@@ -2854,7 +2854,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             )
         } answers { successSlot.captured(expected) }
 
-        var received: WorkflowDataResult? = null
+        var received: PublishedWorkflow? = null
         var receivedError: PurchasesError? = null
         purchases.purchasesOrchestrator.getWorkflow(
             workflowId = "wf_1",
@@ -2882,7 +2882,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             )
         } answers { errorSlot.captured(expectedError) }
 
-        var received: WorkflowDataResult? = null
+        var received: PublishedWorkflow? = null
         var receivedError: PurchasesError? = null
         purchases.purchasesOrchestrator.getWorkflow(
             workflowId = "wf_1",
@@ -2899,7 +2899,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     fun `getWorkflow returns ConfigurationError and never calls manager when uiPreviewMode is true`() {
         buildPurchases(anonymous = true, uiPreviewMode = true)
 
-        var received: WorkflowDataResult? = null
+        var received: PublishedWorkflow? = null
         var receivedError: PurchasesError? = null
         purchases.purchasesOrchestrator.getWorkflow(
             workflowId = "wf_1",

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
@@ -125,7 +125,6 @@ class BackendWorkflowsTest {
                 assertThat(response.data).isNotNull
                 assertThat(response.data!!.id).isEqualTo("wf_1")
                 assertThat(response.data!!.initialStepId).isEqualTo("step_1")
-                assertThat(response.enrolledVariants).isNull()
                 success = true
             },
             onError = { e, _ -> fail("unexpected error $e") },
@@ -163,7 +162,6 @@ class BackendWorkflowsTest {
                 assertThat(response.action).isEqualTo(WorkflowResponseAction.USE_CDN)
                 assertThat(response.url).isEqualTo("https://cdn.example.com/wf.json")
                 assertThat(response.hash).isEqualTo("abc123")
-                assertThat(response.enrolledVariants).isEqualTo(mapOf("exp_1" to "variant_a"))
                 assertThat(response.data).isNull()
                 success = true
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowDetailResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowDetailResolverTest.kt
@@ -57,7 +57,7 @@ class WorkflowDetailResolverTest {
             data = inlineWorkflow(),
         )
         val result = resolver.resolve(response)
-        assertThat(result.workflow.id).isEqualTo("wf_1")
+        assertThat(result.id).isEqualTo("wf_1")
     }
 
     @Test
@@ -82,7 +82,7 @@ class WorkflowDetailResolverTest {
             url = "https://cdn.example.com/wf.json",
         )
         val result = resolver.resolve(response)
-        assertThat(result.workflow.id).isEqualTo("wf_1")
+        assertThat(result.id).isEqualTo("wf_1")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowDetailResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowDetailResolverTest.kt
@@ -58,19 +58,6 @@ class WorkflowDetailResolverTest {
         )
         val result = resolver.resolve(response)
         assertThat(result.workflow.id).isEqualTo("wf_1")
-        assertThat(result.enrolledVariants).isNull()
-    }
-
-    @Test
-    fun `inline with enrolled_variants passes them through`() = runTest {
-        val resolver = createResolver()
-        val response = WorkflowDetailResponse(
-            action = WorkflowResponseAction.INLINE,
-            data = inlineWorkflow(),
-            enrolledVariants = mapOf("exp_1" to "variant_a"),
-        )
-        val result = resolver.resolve(response)
-        assertThat(result.enrolledVariants).isEqualTo(mapOf("exp_1" to "variant_a"))
     }
 
     @Test
@@ -96,18 +83,6 @@ class WorkflowDetailResolverTest {
         )
         val result = resolver.resolve(response)
         assertThat(result.workflow.id).isEqualTo("wf_1")
-    }
-
-    @Test
-    fun `use_cdn with enrolled_variants passes them through`() = runTest {
-        val resolver = createResolver { _, _ -> minimalWorkflowJson }
-        val response = WorkflowDetailResponse(
-            action = WorkflowResponseAction.USE_CDN,
-            url = "https://cdn.example.com/wf.json",
-            enrolledVariants = mapOf("x" to "y"),
-        )
-        val result = resolver.resolve(response)
-        assertThat(result.enrolledVariants).isEqualTo(mapOf("x" to "y"))
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -79,9 +79,7 @@ class WorkflowManagerTest {
             action = WorkflowResponseAction.INLINE,
             data = mockk(relaxed = true),
         )
-        val expectedResult = WorkflowDataResult(
-            workflow = response.data!!,
-        )
+        val expectedResult = response.data!!
         coEvery { mockResolver.resolve(response) } returns expectedResult
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
@@ -97,7 +95,7 @@ class WorkflowManagerTest {
             successSlot.captured(response)
         }
 
-        var result: WorkflowDataResult? = null
+        var result: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -106,7 +104,7 @@ class WorkflowManagerTest {
             onError = { fail("unexpected error $it") },
         )
         assertThat(result).isEqualTo(expectedResult)
-        verify(exactly = 1) { mockAssetPreDownloader.preDownloadWorkflowAssets(expectedResult.workflow) }
+        verify(exactly = 1) { mockAssetPreDownloader.preDownloadWorkflowAssets(expectedResult) }
     }
 
     @Test
@@ -224,7 +222,7 @@ class WorkflowManagerTest {
         }
 
         var error: PurchasesError? = null
-        var result: WorkflowDataResult? = null
+        var result: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -242,9 +240,7 @@ class WorkflowManagerTest {
             action = WorkflowResponseAction.INLINE,
             data = mockk(relaxed = true),
         )
-        val expectedResult = WorkflowDataResult(
-            workflow = response.data!!,
-        )
+        val expectedResult = response.data!!
         coEvery { mockResolver.resolve(response) } returns expectedResult
         every {
             mockAssetPreDownloader.preDownloadWorkflowAssets(any())
@@ -263,7 +259,7 @@ class WorkflowManagerTest {
             successSlot.captured(response)
         }
 
-        var result: WorkflowDataResult? = null
+        var result: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -316,7 +312,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf_1.json",
             hash = "h",
         )
-        val expectedResult = WorkflowDataResult(workflow = workflowMock())
+        val expectedResult = workflowMock()
         coEvery { mockResolver.resolve(envelope) } returns expectedResult
 
         // Disk holds one envelope for wf_1
@@ -339,7 +335,7 @@ class WorkflowManagerTest {
             )
         }
 
-        var successResult: WorkflowDataResult? = null
+        var successResult: PublishedWorkflow? = null
         var errorCalled = false
         workflowManager.getWorkflow(
             appUserID = "user_1",
@@ -372,7 +368,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf.json",
             hash = "h",
         )
-        val recovered = WorkflowDataResult(workflow = workflowMock(workflowId))
+        val recovered = workflowMock(workflowId)
         coEvery { mockResolver.resolve(envelope) } returns recovered
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"$workflowId":{"action":"use_cdn","url":"https://cdn/wf.json","hash":"h"}}"""
@@ -393,7 +389,7 @@ class WorkflowManagerTest {
             )
         }
 
-        var served: WorkflowDataResult? = null
+        var served: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = offeringId,
@@ -415,7 +411,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf.json",
             hash = "h",
         )
-        val recovered = WorkflowDataResult(workflow = workflowMock(resolvedWorkflowId))
+        val recovered = workflowMock(resolvedWorkflowId)
         coEvery { mockResolver.resolve(envelope) } returns recovered
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"$requestedWorkflowId":{"action":"use_cdn","url":"https://cdn/wf.json","hash":"h"}}"""
@@ -571,7 +567,7 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow caches result on success`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val expectedResult = WorkflowDataResult(workflow = response.data!!)
+        val expectedResult = response.data!!
         coEvery { mockResolver.resolve(response) } returns expectedResult
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
@@ -599,7 +595,7 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow returns cached result without calling backend when cache is fresh`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val expectedResult = WorkflowDataResult(workflow = response.data!!)
+        val expectedResult = response.data!!
         coEvery { mockResolver.resolve(response) } returns expectedResult
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
@@ -623,7 +619,7 @@ class WorkflowManagerTest {
         )
 
         // Second call within TTL should hit the cache and skip the backend.
-        var secondResult: WorkflowDataResult? = null
+        var secondResult: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -647,8 +643,8 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow refreshes in the background and still re-fetches when cache is stale`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val firstResult = WorkflowDataResult(workflow = response.data!!)
-        val secondResult = WorkflowDataResult(workflow = response.data!!)
+        val firstResult = response.data!!
+        val secondResult = response.data!!
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -675,7 +671,7 @@ class WorkflowManagerTest {
         // Second call past the 5-minute foreground TTL serves the stale value and refetches.
         every { mockDateProvider.now } returns Date(6L * 60 * 1000)
         coEvery { mockResolver.resolve(response) } returns secondResult
-        var served: WorkflowDataResult? = null
+        var served: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -700,8 +696,8 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow stale hit serves the cached value and refreshes the cache in the background`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val staleResult = WorkflowDataResult(workflow = response.data!!)
-        val refreshedResult = WorkflowDataResult(workflow = response.data!!)
+        val staleResult = response.data!!
+        val refreshedResult = response.data!!
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -729,7 +725,7 @@ class WorkflowManagerTest {
         every { mockDateProvider.now } returns Date(6L * 60 * 1000)
         coEvery { mockResolver.resolve(response) } returns refreshedResult
 
-        var served: WorkflowDataResult? = null
+        var served: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -756,7 +752,7 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow stale hit does not surface a failing background refresh to the caller`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val staleResult = WorkflowDataResult(workflow = response.data!!)
+        val staleResult = response.data!!
         coEvery { mockResolver.resolve(response) } returns staleResult
 
         // First backend call succeeds (populates the cache); the second fails (background refresh).
@@ -795,7 +791,7 @@ class WorkflowManagerTest {
 
         // Stale call whose background refresh fails: caller still gets the stale value, no error.
         every { mockDateProvider.now } returns Date(6L * 60 * 1000)
-        var served: WorkflowDataResult? = null
+        var served: PublishedWorkflow? = null
         var erroredWith: PurchasesError? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
@@ -816,7 +812,7 @@ class WorkflowManagerTest {
         // older prefetched envelope over a newer on-demand value) is bounded and self-healing, closed
         // by the on-demand envelope persistence + LRU follow-up.
         val inlineResponse = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val staleResult = WorkflowDataResult(workflow = inlineResponse.data!!)
+        val staleResult = inlineResponse.data!!
         coEvery { mockResolver.resolve(inlineResponse) } returns staleResult
 
         // A distinct value persisted on disk, which the failed refresh should recover and re-pin.
@@ -825,7 +821,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf_1.json",
             hash = "h",
         )
-        val diskResult = WorkflowDataResult(workflow = workflowMock())
+        val diskResult = workflowMock()
         coEvery { mockResolver.resolve(diskEnvelope) } returns diskResult
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
@@ -866,7 +862,7 @@ class WorkflowManagerTest {
 
         // Stale call at t=6min: serves stale immediately, the background refresh then fails.
         every { mockDateProvider.now } returns Date(6L * 60 * 1000)
-        var served: WorkflowDataResult? = null
+        var served: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -882,7 +878,7 @@ class WorkflowManagerTest {
         assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isFalse
 
         // Consequence: the next render serves the recovered disk value with no further backend call.
-        var servedAgain: WorkflowDataResult? = null
+        var servedAgain: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -905,8 +901,8 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow with staleWhileRevalidate false blocks on the refetch instead of serving stale`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val staleResult = WorkflowDataResult(workflow = response.data!!)
-        val refreshedResult = WorkflowDataResult(workflow = response.data!!)
+        val staleResult = response.data!!
+        val refreshedResult = response.data!!
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -933,7 +929,7 @@ class WorkflowManagerTest {
         // Stale call with SWR disabled: must deliver the freshly-fetched value, not the stale one.
         every { mockDateProvider.now } returns Date(6L * 60 * 1000)
         coEvery { mockResolver.resolve(response) } returns refreshedResult
-        var served: WorkflowDataResult? = null
+        var served: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -959,7 +955,7 @@ class WorkflowManagerTest {
         val mockWorkflow = mockk<PublishedWorkflow>()
         every { mockWorkflow.id } returns realWorkflowId
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockWorkflow)
-        val expectedResult = WorkflowDataResult(workflow = mockWorkflow)
+        val expectedResult = mockWorkflow
         coEvery { mockResolver.resolve(response) } returns expectedResult
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
@@ -991,7 +987,7 @@ class WorkflowManagerTest {
         // does). getWorkflow resolves it through the recorded mapping to realWorkflowId and serves the
         // cached entry — no second backend call. The cache was stamped at Date(0) and mockDateProvider.now
         // is Date(0), so 0 - 0 = 0 < 5min → fresh.
-        var secondResult: WorkflowDataResult? = null
+        var secondResult: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = offeringId,
@@ -1018,14 +1014,14 @@ class WorkflowManagerTest {
         // ask must resolve through the map and hit the cached entry instead of firing a fresh fetch.
         val offeringId = "my-offering"
         val workflowId = "wfl-real-id"
-        val prefetched = WorkflowDataResult(workflow = mockk(relaxed = true))
+        val prefetched = mockk<PublishedWorkflow>(relaxed = true)
         workflowsCache.cacheWorkflowsListInMemory(
             WorkflowsListResponse(workflows = emptyList()),
             mapOf(offeringId to workflowId),
         )
         workflowsCache.cacheWorkflow(workflowId, prefetched)
 
-        var served: WorkflowDataResult? = null
+        var served: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = offeringId,
@@ -1055,7 +1051,7 @@ class WorkflowManagerTest {
             data = workflowMock(resolvedWorkflowId),
         )
         coEvery { mockResolver.resolve(response) } returns
-            WorkflowDataResult(workflow = response.data!!)
+            response.data!!
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -1109,7 +1105,7 @@ class WorkflowManagerTest {
         val mockWorkflow = mockk<PublishedWorkflow>()
         every { mockWorkflow.id } returns ""
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockWorkflow)
-        val expectedResult = WorkflowDataResult(workflow = mockWorkflow)
+        val expectedResult = mockWorkflow
         coEvery { mockResolver.resolve(response) } returns expectedResult
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
@@ -1123,7 +1119,7 @@ class WorkflowManagerTest {
             )
         } answers { successSlot.captured(response) }
 
-        var served: WorkflowDataResult? = null
+        var served: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = offeringId,
@@ -1214,7 +1210,7 @@ class WorkflowManagerTest {
         )
         val envelope = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk(relaxed = true))
         coEvery { mockResolver.resolve(envelope) } returns
-            WorkflowDataResult(workflow = envelope.data!!)
+            envelope.data!!
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any())
         } answers {
@@ -1265,7 +1261,7 @@ class WorkflowManagerTest {
             ),
         )
         val envelope = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val expectedResult = WorkflowDataResult(workflow = envelope.data!!)
+        val expectedResult = envelope.data!!
         coEvery { mockResolver.resolve(envelope) } returns expectedResult
         every {
             mockBackend.getWorkflow(
@@ -1314,7 +1310,7 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false, forceRefresh = true)
 
         // getWorkflow should return the cached result without a new backend call.
-        var result: WorkflowDataResult? = null
+        var result: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -1953,7 +1949,7 @@ class WorkflowManagerTest {
             hash = "h",
         )
         coEvery { mockResolver.resolve(envelope) } returns
-            WorkflowDataResult(workflow = workflowMock())
+            workflowMock()
 
         val listResponse = WorkflowsListResponse(
             workflows = listOf(
@@ -1989,7 +1985,7 @@ class WorkflowManagerTest {
     fun `prefetch persists the envelope even when the workflow is already cached but stale`() {
         // Seed the detail cache at t=0 so the workflow is present but will be stale at prefetch time.
         every { mockDateProvider.now } returns Date(0)
-        workflowsCache.cacheWorkflow("wf_1", WorkflowDataResult(workflow = mockk(relaxed = true)))
+        workflowsCache.cacheWorkflow("wf_1", mockk<PublishedWorkflow>(relaxed = true))
 
         // Advance past the 5-minute TTL: the prefetch now sees a stale-but-present cache entry.
         // With SWR disabled on the prefetch path it must still do a real fetch and persist, not serve stale.
@@ -2001,7 +1997,7 @@ class WorkflowManagerTest {
             hash = "h",
         )
         coEvery { mockResolver.resolve(envelope) } returns
-            WorkflowDataResult(workflow = workflowMock())
+            workflowMock()
 
         val listResponse = WorkflowsListResponse(
             workflows = listOf(
@@ -2048,7 +2044,7 @@ class WorkflowManagerTest {
     fun `on-demand getWorkflow does not persist the envelope`() {
         val envelope = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk(relaxed = true))
         coEvery { mockResolver.resolve(envelope) } returns
-            WorkflowDataResult(workflow = envelope.data!!)
+            envelope.data!!
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -2115,7 +2111,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf_1.json",
             hash = "h",
         )
-        val resolved = WorkflowDataResult(workflow = workflowMock())
+        val resolved = workflowMock()
         coEvery { mockResolver.resolve(envelope) } returns resolved
         // Persisting blows up at the DeviceCache layer.
         every { mockDeviceCache.cacheWorkflowDetailEnvelopes(any()) } throws IOException("disk full")
@@ -2172,7 +2168,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf_1.json",
             hash = "h",
         )
-        val diskResult = WorkflowDataResult(workflow = workflowMock())
+        val diskResult = workflowMock()
         coEvery { mockResolver.resolve(diskEnvelope) } returns diskResult
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
@@ -2224,7 +2220,7 @@ class WorkflowManagerTest {
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
 
-        val restored = WorkflowDataResult(workflow = mockk(relaxed = true))
+        val restored = mockk<PublishedWorkflow>(relaxed = true)
         coEvery {
             mockResolver.resolve(
                 WorkflowDetailResponse(action = WorkflowResponseAction.USE_CDN, url = "https://cdn/wf_1.json", hash = "h"),
@@ -2234,7 +2230,7 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
         assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_1")
-        var result: WorkflowDataResult? = null
+        var result: PublishedWorkflow? = null
         workflowManager.getWorkflow(
             appUserID = "user_1",
             workflowOrOfferingId = "wf_1",
@@ -2258,7 +2254,7 @@ class WorkflowManagerTest {
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"wf_ok":{"action":"use_cdn","url":"u_ok","hash":"h"},"wf_bad":{"action":"use_cdn","url":"u_bad","hash":"h"}}"""
 
-        val okResult = WorkflowDataResult(workflow = mockk(relaxed = true))
+        val okResult = mockk<PublishedWorkflow>(relaxed = true)
         coEvery {
             mockResolver.resolve(WorkflowDetailResponse(action = WorkflowResponseAction.USE_CDN, url = "u_ok", hash = "h"))
         } returns okResult

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -81,7 +81,6 @@ class WorkflowManagerTest {
         )
         val expectedResult = WorkflowDataResult(
             workflow = response.data!!,
-            enrolledVariants = null,
         )
         coEvery { mockResolver.resolve(response) } returns expectedResult
 
@@ -245,7 +244,6 @@ class WorkflowManagerTest {
         )
         val expectedResult = WorkflowDataResult(
             workflow = response.data!!,
-            enrolledVariants = null,
         )
         coEvery { mockResolver.resolve(response) } returns expectedResult
         every {
@@ -318,7 +316,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf_1.json",
             hash = "h",
         )
-        val expectedResult = WorkflowDataResult(workflow = workflowMock(), enrolledVariants = null)
+        val expectedResult = WorkflowDataResult(workflow = workflowMock())
         coEvery { mockResolver.resolve(envelope) } returns expectedResult
 
         // Disk holds one envelope for wf_1
@@ -374,7 +372,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf.json",
             hash = "h",
         )
-        val recovered = WorkflowDataResult(workflow = workflowMock(workflowId), enrolledVariants = null)
+        val recovered = WorkflowDataResult(workflow = workflowMock(workflowId))
         coEvery { mockResolver.resolve(envelope) } returns recovered
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"$workflowId":{"action":"use_cdn","url":"https://cdn/wf.json","hash":"h"}}"""
@@ -417,7 +415,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf.json",
             hash = "h",
         )
-        val recovered = WorkflowDataResult(workflow = workflowMock(resolvedWorkflowId), enrolledVariants = null)
+        val recovered = WorkflowDataResult(workflow = workflowMock(resolvedWorkflowId))
         coEvery { mockResolver.resolve(envelope) } returns recovered
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"$requestedWorkflowId":{"action":"use_cdn","url":"https://cdn/wf.json","hash":"h"}}"""
@@ -573,7 +571,7 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow caches result on success`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val expectedResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        val expectedResult = WorkflowDataResult(workflow = response.data!!)
         coEvery { mockResolver.resolve(response) } returns expectedResult
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
@@ -601,7 +599,7 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow returns cached result without calling backend when cache is fresh`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val expectedResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        val expectedResult = WorkflowDataResult(workflow = response.data!!)
         coEvery { mockResolver.resolve(response) } returns expectedResult
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
@@ -649,8 +647,8 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow refreshes in the background and still re-fetches when cache is stale`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val firstResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
-        val secondResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        val firstResult = WorkflowDataResult(workflow = response.data!!)
+        val secondResult = WorkflowDataResult(workflow = response.data!!)
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -702,8 +700,8 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow stale hit serves the cached value and refreshes the cache in the background`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
-        val refreshedResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        val staleResult = WorkflowDataResult(workflow = response.data!!)
+        val refreshedResult = WorkflowDataResult(workflow = response.data!!)
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -758,7 +756,7 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow stale hit does not surface a failing background refresh to the caller`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        val staleResult = WorkflowDataResult(workflow = response.data!!)
         coEvery { mockResolver.resolve(response) } returns staleResult
 
         // First backend call succeeds (populates the cache); the second fails (background refresh).
@@ -818,7 +816,7 @@ class WorkflowManagerTest {
         // older prefetched envelope over a newer on-demand value) is bounded and self-healing, closed
         // by the on-demand envelope persistence + LRU follow-up.
         val inlineResponse = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val staleResult = WorkflowDataResult(workflow = inlineResponse.data!!, enrolledVariants = null)
+        val staleResult = WorkflowDataResult(workflow = inlineResponse.data!!)
         coEvery { mockResolver.resolve(inlineResponse) } returns staleResult
 
         // A distinct value persisted on disk, which the failed refresh should recover and re-pin.
@@ -827,7 +825,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf_1.json",
             hash = "h",
         )
-        val diskResult = WorkflowDataResult(workflow = workflowMock(), enrolledVariants = null)
+        val diskResult = WorkflowDataResult(workflow = workflowMock())
         coEvery { mockResolver.resolve(diskEnvelope) } returns diskResult
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
@@ -907,8 +905,8 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflow with staleWhileRevalidate false blocks on the refetch instead of serving stale`() {
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val staleResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
-        val refreshedResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        val staleResult = WorkflowDataResult(workflow = response.data!!)
+        val refreshedResult = WorkflowDataResult(workflow = response.data!!)
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -961,7 +959,7 @@ class WorkflowManagerTest {
         val mockWorkflow = mockk<PublishedWorkflow>()
         every { mockWorkflow.id } returns realWorkflowId
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockWorkflow)
-        val expectedResult = WorkflowDataResult(workflow = mockWorkflow, enrolledVariants = null)
+        val expectedResult = WorkflowDataResult(workflow = mockWorkflow)
         coEvery { mockResolver.resolve(response) } returns expectedResult
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
@@ -1020,7 +1018,7 @@ class WorkflowManagerTest {
         // ask must resolve through the map and hit the cached entry instead of firing a fresh fetch.
         val offeringId = "my-offering"
         val workflowId = "wfl-real-id"
-        val prefetched = WorkflowDataResult(workflow = mockk(relaxed = true), enrolledVariants = null)
+        val prefetched = WorkflowDataResult(workflow = mockk(relaxed = true))
         workflowsCache.cacheWorkflowsListInMemory(
             WorkflowsListResponse(workflows = emptyList()),
             mapOf(offeringId to workflowId),
@@ -1057,7 +1055,7 @@ class WorkflowManagerTest {
             data = workflowMock(resolvedWorkflowId),
         )
         coEvery { mockResolver.resolve(response) } returns
-            WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+            WorkflowDataResult(workflow = response.data!!)
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -1111,7 +1109,7 @@ class WorkflowManagerTest {
         val mockWorkflow = mockk<PublishedWorkflow>()
         every { mockWorkflow.id } returns ""
         val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockWorkflow)
-        val expectedResult = WorkflowDataResult(workflow = mockWorkflow, enrolledVariants = null)
+        val expectedResult = WorkflowDataResult(workflow = mockWorkflow)
         coEvery { mockResolver.resolve(response) } returns expectedResult
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
@@ -1216,7 +1214,7 @@ class WorkflowManagerTest {
         )
         val envelope = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk(relaxed = true))
         coEvery { mockResolver.resolve(envelope) } returns
-            WorkflowDataResult(workflow = envelope.data!!, enrolledVariants = null)
+            WorkflowDataResult(workflow = envelope.data!!)
         every {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any())
         } answers {
@@ -1267,7 +1265,7 @@ class WorkflowManagerTest {
             ),
         )
         val envelope = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = workflowMock())
-        val expectedResult = WorkflowDataResult(workflow = envelope.data!!, enrolledVariants = null)
+        val expectedResult = WorkflowDataResult(workflow = envelope.data!!)
         coEvery { mockResolver.resolve(envelope) } returns expectedResult
         every {
             mockBackend.getWorkflow(
@@ -1955,7 +1953,7 @@ class WorkflowManagerTest {
             hash = "h",
         )
         coEvery { mockResolver.resolve(envelope) } returns
-            WorkflowDataResult(workflow = workflowMock(), enrolledVariants = null)
+            WorkflowDataResult(workflow = workflowMock())
 
         val listResponse = WorkflowsListResponse(
             workflows = listOf(
@@ -1991,7 +1989,7 @@ class WorkflowManagerTest {
     fun `prefetch persists the envelope even when the workflow is already cached but stale`() {
         // Seed the detail cache at t=0 so the workflow is present but will be stale at prefetch time.
         every { mockDateProvider.now } returns Date(0)
-        workflowsCache.cacheWorkflow("wf_1", WorkflowDataResult(workflow = mockk(relaxed = true), enrolledVariants = null))
+        workflowsCache.cacheWorkflow("wf_1", WorkflowDataResult(workflow = mockk(relaxed = true)))
 
         // Advance past the 5-minute TTL: the prefetch now sees a stale-but-present cache entry.
         // With SWR disabled on the prefetch path it must still do a real fetch and persist, not serve stale.
@@ -2003,7 +2001,7 @@ class WorkflowManagerTest {
             hash = "h",
         )
         coEvery { mockResolver.resolve(envelope) } returns
-            WorkflowDataResult(workflow = workflowMock(), enrolledVariants = null)
+            WorkflowDataResult(workflow = workflowMock())
 
         val listResponse = WorkflowsListResponse(
             workflows = listOf(
@@ -2050,7 +2048,7 @@ class WorkflowManagerTest {
     fun `on-demand getWorkflow does not persist the envelope`() {
         val envelope = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk(relaxed = true))
         coEvery { mockResolver.resolve(envelope) } returns
-            WorkflowDataResult(workflow = envelope.data!!, enrolledVariants = null)
+            WorkflowDataResult(workflow = envelope.data!!)
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -2117,7 +2115,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf_1.json",
             hash = "h",
         )
-        val resolved = WorkflowDataResult(workflow = workflowMock(), enrolledVariants = null)
+        val resolved = WorkflowDataResult(workflow = workflowMock())
         coEvery { mockResolver.resolve(envelope) } returns resolved
         // Persisting blows up at the DeviceCache layer.
         every { mockDeviceCache.cacheWorkflowDetailEnvelopes(any()) } throws IOException("disk full")
@@ -2174,7 +2172,7 @@ class WorkflowManagerTest {
             url = "https://cdn/wf_1.json",
             hash = "h",
         )
-        val diskResult = WorkflowDataResult(workflow = workflowMock(), enrolledVariants = null)
+        val diskResult = WorkflowDataResult(workflow = workflowMock())
         coEvery { mockResolver.resolve(diskEnvelope) } returns diskResult
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
@@ -2226,7 +2224,7 @@ class WorkflowManagerTest {
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"wf_1":{"action":"use_cdn","url":"https://cdn/wf_1.json","hash":"h"}}"""
 
-        val restored = WorkflowDataResult(workflow = mockk(relaxed = true), enrolledVariants = mapOf("e" to "v"))
+        val restored = WorkflowDataResult(workflow = mockk(relaxed = true))
         coEvery {
             mockResolver.resolve(
                 WorkflowDetailResponse(action = WorkflowResponseAction.USE_CDN, url = "https://cdn/wf_1.json", hash = "h"),
@@ -2260,7 +2258,7 @@ class WorkflowManagerTest {
         every { mockDeviceCache.getWorkflowDetailEnvelopesCache() } returns
             """{"wf_ok":{"action":"use_cdn","url":"u_ok","hash":"h"},"wf_bad":{"action":"use_cdn","url":"u_bad","hash":"h"}}"""
 
-        val okResult = WorkflowDataResult(workflow = mockk(relaxed = true), enrolledVariants = null)
+        val okResult = WorkflowDataResult(workflow = mockk(relaxed = true))
         coEvery {
             mockResolver.resolve(WorkflowDetailResponse(action = WorkflowResponseAction.USE_CDN, url = "u_ok", hash = "h"))
         } returns okResult

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -245,7 +245,6 @@ class WorkflowsCacheTest {
             action = WorkflowResponseAction.USE_CDN,
             url = url,
             hash = hash,
-            enrolledVariants = mapOf("exp" to "variant_a"),
         )
 
     @Test
@@ -283,8 +282,8 @@ class WorkflowsCacheTest {
         val envelopes = workflowsCache.cachedWorkflowDetailEnvelopesFromDisk()
 
         assertThat(envelopes).containsKey("wf_1")
+        // The persisted payload includes enrolled_variants (written by an older SDK); it parses and is ignored.
         assertThat(envelopes!!.getValue("wf_1").url).isEqualTo("https://cdn/x.json")
-        assertThat(envelopes.getValue("wf_1").enrolledVariants).isEqualTo(mapOf("e" to "v"))
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -50,7 +50,7 @@ class WorkflowsCacheTest {
 
     @Test
     fun `cachedWorkflow returns cached value after cacheWorkflow`() {
-        val result = mockk<WorkflowDataResult>()
+        val result = mockk<PublishedWorkflow>()
         workflowsCache.cacheWorkflow("wf_1", result)
         assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(result)
     }
@@ -374,8 +374,8 @@ class WorkflowsCacheTest {
 
     @Test
     fun `different workflowIds are cached independently`() {
-        val first = mockk<WorkflowDataResult>()
-        val second = mockk<WorkflowDataResult>()
+        val first = mockk<PublishedWorkflow>()
+        val second = mockk<PublishedWorkflow>()
         workflowsCache.cacheWorkflow("wf_1", first)
         currentDate = currentDate.add(6.minutes)
         workflowsCache.cacheWorkflow("wf_2", second)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -123,8 +123,6 @@ class WorkflowsConfigIntegrationTest {
         val result = provider.getWorkflow("wf-1")
         assertThat(result).isNotNull
         assertThat(result!!.workflow.id).isEqualTo("wf-1")
-        // enrolled_variants is intentionally out of scope for the config-topic path (see WorkflowsConfigProvider).
-        assertThat(result.enrolledVariants).isNull()
         // The body arrived inline, so neither prefetch nor the read touches the downloader.
         assertThat(downloadCount).isZero()
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -122,7 +122,7 @@ class WorkflowsConfigIntegrationTest {
         assertThat(provider.workflowIdForOfferingId("premium_annual")).isEqualTo("wf-1")
         val result = provider.getWorkflow("wf-1")
         assertThat(result).isNotNull
-        assertThat(result!!.workflow.id).isEqualTo("wf-1")
+        assertThat(result!!.id).isEqualTo("wf-1")
         // The body arrived inline, so neither prefetch nor the read touches the downloader.
         assertThat(downloadCount).isZero()
     }
@@ -175,7 +175,7 @@ class WorkflowsConfigIntegrationTest {
         // First read misses the blob store and pulls the body on demand.
         val result = provider.getWorkflow("wf-1")
         assertThat(result).isNotNull
-        assertThat(result!!.workflow.id).isEqualTo("wf-1")
+        assertThat(result!!.id).isEqualTo("wf-1")
         assertThat(downloadCount).isEqualTo(1)
 
         // A second read is served from the store — no further download.

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -1,0 +1,263 @@
+package com.revenuecat.purchases.common.workflows
+
+import android.util.Base64
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.networking.RCContainer
+import com.revenuecat.purchases.common.networking.RCElement
+import com.revenuecat.purchases.common.remoteconfig.PersistedRemoteConfigurationState
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobFetcher
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSource
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceHandle
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceProvider
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import com.revenuecat.purchases.utils.UrlConnection
+import com.revenuecat.purchases.utils.UrlConnectionFactory
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.ByteArrayInputStream
+import java.net.HttpURLConnection
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+
+/**
+ * End-to-end: drives a fake `/v1/config` sync through the **real** [RemoteConfigManager] (the single read
+ * front door via `topic()`/`body()`, and the owner of the generic best-effort prefetch) + [RemoteConfigBlobStore]
+ * + [RemoteConfigBlobFetcher] + [WorkflowsConfigProvider]. Only the backend transport and the blob HTTP download
+ * are faked; the disk cache is a stateful in-memory stand-in so reads see exactly what the sync committed.
+ */
+@OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class WorkflowsConfigIntegrationTest {
+
+    private lateinit var backend: Backend
+    private lateinit var diskCache: RemoteConfigDiskCache
+    private lateinit var blobStore: RemoteConfigBlobStore
+    private lateinit var provider: WorkflowsConfigProvider
+    private lateinit var manager: RemoteConfigManager
+
+    private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
+
+    /** Stateful stand-in for the persisted config file: write stashes, read returns the latest. */
+    private var persistedState: PersistedRemoteConfigurationState? = null
+
+    /** Stand-in for the blob downloader: ref -> bytes the fake HTTP layer serves to the fetcher. */
+    private val downloads = mutableMapOf<String, ByteArray>()
+    private var downloadCount = 0
+
+    // One scheduler for the manager's scope AND its ioDispatcher, so reads and the sync's persist all run
+    // eagerly inline under runTest(testDispatcher).
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = CoroutineScope(testDispatcher)
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        backend = mockk()
+        diskCache = mockk()
+        every { diskCache.read() } answers { persistedState }
+        every { diskCache.write(any()) } answers { persistedState = firstArg(); true }
+        blobStore = RemoteConfigBlobStore(context)
+        blobStore.retainOnly(emptySet()) // start from a clean blob dir between runs
+        val fetcher = RemoteConfigBlobFetcher(
+            blobStore = blobStore,
+            sourceProvider = FakeBlobSourceProvider,
+            urlConnectionFactory = fakeUrlConnectionFactory(),
+            scope = testScope,
+        )
+        manager = RemoteConfigManager(
+            backend,
+            diskCache,
+            blobStore,
+            blobFetcher = fetcher,
+            scope = testScope,
+            ioDispatcher = testDispatcher,
+        )
+        provider = WorkflowsConfigProvider(manager)
+
+        every {
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any())
+        } answers {
+            onSuccess = arg(5)
+        }
+    }
+
+    @Test
+    fun `a prefetched inline workflow is served without any download`() = runTest(testDispatcher) {
+        val workflowJson = JsonTools.json.encodeToString(PublishedWorkflow.serializer(), minimalWorkflow("wf-1"))
+        val config = """
+            {
+              "domain": "app",
+              "manifest": "v1.workflows:etag1",
+              "active_topics": ["workflows"],
+              "prefetch_blobs": ["$INLINE_REF"],
+              "topics": {
+                "workflows": {
+                  "wf-1": { "blob_ref": "$INLINE_REF", "offering_identifier": "premium_annual", "prefetch": true }
+                }
+              }
+            }
+        """.trimIndent()
+
+        sync(config, INLINE_REF to workflowJson)
+
+        assertThat(provider.workflowIdForOfferingId("premium_annual")).isEqualTo("wf-1")
+        val result = provider.getWorkflow("wf-1")
+        assertThat(result).isNotNull
+        assertThat(result!!.workflow.id).isEqualTo("wf-1")
+        // enrolled_variants is intentionally out of scope for the config-topic path (see WorkflowsConfigProvider).
+        assertThat(result.enrolledVariants).isNull()
+        // The body arrived inline, so neither prefetch nor the read touches the downloader.
+        assertThat(downloadCount).isZero()
+    }
+
+    @Test
+    fun `a prefetch-marked workflow is downloaded during the sync, before any read`() = runTest(testDispatcher) {
+        val workflowJson = JsonTools.json.encodeToString(PublishedWorkflow.serializer(), minimalWorkflow("wf-1"))
+        val ref = refOf(workflowJson.toByteArray())
+        downloads[ref] = workflowJson.toByteArray()
+        val config = """
+            {
+              "domain": "app",
+              "manifest": "v1.workflows:etag1",
+              "active_topics": ["workflows"],
+              "topics": {
+                "workflows": { "wf-1": { "blob_ref": "$ref", "prefetch": true } }
+              }
+            }
+        """.trimIndent()
+
+        sync(config) // no inline blob; the manager prefetches it during the sync
+
+        assertThat(blobStore.contains(ref)).isTrue()
+        assertThat(downloadCount).isEqualTo(1)
+        // The read is then served from disk — the shared fetcher does not download again.
+        assertThat(provider.getWorkflow("wf-1")).isNotNull
+        assertThat(downloadCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `a non-prefetched workflow commits metadata and downloads its body on demand`() = runTest(testDispatcher) {
+        val workflowJson = JsonTools.json.encodeToString(PublishedWorkflow.serializer(), minimalWorkflow("wf-1"))
+        val ref = refOf(workflowJson.toByteArray())
+        downloads[ref] = workflowJson.toByteArray()
+        val config = """
+            {
+              "domain": "app",
+              "manifest": "v1.workflows:etag1",
+              "active_topics": ["workflows"],
+              "topics": {
+                "workflows": { "wf-1": { "blob_ref": "$ref", "offering_identifier": "premium_annual" } }
+              }
+            }
+        """.trimIndent()
+
+        sync(config) // not inlined, not prefetched: only the metadata commits during the sync
+        assertThat(downloadCount).isZero()
+        assertThat(manager.topic(RemoteConfigTopic.Workflows)?.containsKey("wf-1")).isTrue()
+
+        // First read misses the blob store and pulls the body on demand.
+        val result = provider.getWorkflow("wf-1")
+        assertThat(result).isNotNull
+        assertThat(result!!.workflow.id).isEqualTo("wf-1")
+        assertThat(downloadCount).isEqualTo(1)
+
+        // A second read is served from the store — no further download.
+        assertThat(provider.getWorkflow("wf-1")).isNotNull
+        assertThat(downloadCount).isEqualTo(1)
+    }
+
+    private fun sync(configJson: String, vararg blobs: Pair<String, String>) {
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = "user-1")
+        onSuccess.invoke(containerWith(configJson, *blobs), VerificationResult.VERIFIED)
+    }
+
+    private fun minimalWorkflow(id: String) = PublishedWorkflow(
+        id = id,
+        displayName = "Workflow $id",
+        initialStepId = "step-1",
+        steps = emptyMap(),
+        screens = emptyMap(),
+        // Still required pre-switch; the config-endpoint bodies stop shipping it once serving moves over.
+        uiConfig = UiConfig(),
+    )
+
+    private fun containerWith(configJson: String, vararg blobs: Pair<String, String>): RCContainer {
+        val configElement = mockk<RCElement>()
+        every { configElement.decode() } returns ByteBuffer.wrap(configJson.toByteArray())
+        val elements = blobs.associate { (ref, json) ->
+            val element = mockk<RCElement>()
+            val bytes = ByteBuffer.wrap(json.toByteArray())
+            every { element.decode() } returns bytes
+            every { element.matchesChecksum(any()) } returns true
+            ref to element
+        }
+        val container = mockk<RCContainer>()
+        every { container.config } returns configElement
+        every { container.elements } returns elements
+        return container
+    }
+
+    private fun fakeUrlConnectionFactory() = object : UrlConnectionFactory {
+        override fun createConnection(url: String, requestMethod: String): UrlConnection {
+            val ref = url.substringAfterLast("/")
+            val bytes = downloads[ref]
+            if (bytes != null) {
+                downloadCount++
+            }
+            return object : UrlConnection {
+                override val responseCode: Int = if (bytes == null) {
+                    HttpURLConnection.HTTP_NOT_FOUND
+                } else {
+                    HttpURLConnection.HTTP_OK
+                }
+                override val inputStream = ByteArrayInputStream(bytes ?: byteArrayOf())
+                override fun disconnect() = Unit
+            }
+        }
+    }
+
+    private companion object {
+        private val FakeBlobSourceProvider = object : RemoteConfigSourceProvider {
+            override fun getCurrent(purpose: RemoteConfigSourceHandle.Purpose): RemoteConfigSourceHandle =
+                RemoteConfigSourceHandle(
+                    purpose = purpose,
+                    source = RemoteConfigSource(url = "https://blob.test/{blob_ref}", priority = 1, weight = 1),
+                    token = 0,
+                )
+
+            override fun reportUnhealthy(handle: RemoteConfigSourceHandle) = Unit
+
+            override fun restart(purpose: RemoteConfigSourceHandle.Purpose) = Unit
+
+            override fun restartIfExhausted(purpose: RemoteConfigSourceHandle.Purpose): Boolean = false
+        }
+
+        // A valid content-address ref for the inline path (the store checks shape, not hash, on write).
+        private const val INLINE_REF = "abcdefghijklmnopqrstuvwxyz012345"
+
+        /** `base64url-nopad(sha256(bytes)[0 until 24])` — the ref the workflow body hashes to. */
+        private fun refOf(bytes: ByteArray): String {
+            val digest = MessageDigest.getInstance("SHA-256").digest(bytes).copyOf(24)
+            return Base64.encodeToString(digest, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+        }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.UiConfig
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 import dev.drewhamilton.poko.Poko
@@ -60,7 +60,7 @@ public class PaywallOptions internal constructor(
      * `{{ $custom.key }}` placeholders in the paywall configuration.
      */
     public val customVariables: Map<String, CustomVariableValue> = emptyMap(),
-    internal val injectedWorkflow: WorkflowDataResult? = null,
+    internal val injectedWorkflow: PublishedWorkflow? = null,
     internal val injectedWorkflowUiConfig: UiConfig = UiConfig(),
 ) {
     public companion object {
@@ -122,7 +122,7 @@ public class PaywallOptions internal constructor(
         dismissRequest: () -> Unit = this.dismissRequest,
         dismissRequestWithExitOffering: ((Offering?, PaywallResult?) -> Unit)? = this.dismissRequestWithExitOffering,
         customVariables: Map<String, CustomVariableValue> = this.customVariables,
-        injectedWorkflow: WorkflowDataResult? = this.injectedWorkflow,
+        injectedWorkflow: PublishedWorkflow? = this.injectedWorkflow,
         injectedWorkflowUiConfig: UiConfig = this.injectedWorkflowUiConfig,
     ): PaywallOptions = PaywallOptions(
         offeringSelection = offeringSelection,
@@ -150,7 +150,7 @@ public class PaywallOptions internal constructor(
         internal var mode: PaywallMode = PaywallMode.default
         internal var dismissRequestWithExitOffering: ((Offering?, PaywallResult?) -> Unit)? = null
         internal var customVariables: Map<String, CustomVariableValue> = emptyMap()
-        internal var injectedWorkflow: WorkflowDataResult? = null
+        internal var injectedWorkflow: PublishedWorkflow? = null
         internal var injectedWorkflowUiConfig: UiConfig = UiConfig()
 
         public fun setOffering(offering: Offering?): Builder = apply {
@@ -226,7 +226,7 @@ public class PaywallOptions internal constructor(
          */
         @InternalRevenueCatAPI
         public fun injectedWorkflow(
-            workflow: WorkflowDataResult,
+            workflow: PublishedWorkflow,
             offering: Offering?,
             uiConfig: UiConfig = UiConfig(),
         ): Builder = apply {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -9,7 +9,7 @@ import com.revenuecat.purchases.PurchaseResult
 import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.events.FeatureEvent
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
@@ -62,7 +62,7 @@ internal class MockPurchasesType(
         // No-op for mock - return success to simulate success
         return CreateSupportTicketResult(success = true)
     }
-    override suspend fun awaitGetWorkflow(workflowId: String): WorkflowDataResult {
+    override suspend fun awaitGetWorkflow(workflowId: String): PublishedWorkflow {
         throw NotImplementedError("Mock implementation for previews only")
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -24,7 +24,6 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
 import com.revenuecat.purchases.common.workflows.WorkflowScreenType
 import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
@@ -204,7 +203,7 @@ internal class PaywallViewModelImpl(
     private var paywallPresentationData: PaywallEvent.Data? = null
 
     private var workflowNavigator: WorkflowNavigator? = null
-    private var currentWorkflowResult: WorkflowDataResult? = null
+    private var currentWorkflow: PublishedWorkflow? = null
     private var currentWorkflowUiConfig: UiConfig = UiConfig()
     private var currentWorkflowOfferings: Offerings? = null
     private var currentWorkflowPresentedOfferingContext: PresentedOfferingContext? = null
@@ -365,7 +364,7 @@ internal class PaywallViewModelImpl(
         preWarmJob?.cancel()
         preWarmJob = null
         workflowNavigator = null
-        currentWorkflowResult = null
+        currentWorkflow = null
         currentWorkflowOfferings = null
         currentWorkflowPresentedOfferingContext = null
         currentWorkflowStepTracksPaywallEvents = true
@@ -439,7 +438,7 @@ internal class PaywallViewModelImpl(
 
     @Suppress("ReturnCount")
     override fun trackPaywallImpressionIfNeeded() {
-        val isWorkflowPresentation = currentWorkflowResult != null
+        val isWorkflowPresentation = currentWorkflow != null
         if (isWorkflowPresentation && !currentWorkflowStepTracksPaywallEvents) {
             paywallPresentationData = null
             return
@@ -488,7 +487,7 @@ internal class PaywallViewModelImpl(
     override fun trackComponentInteraction(data: PaywallComponentInteractionData) {
         val eventData = paywallPresentationData
         if (eventData == null) {
-            if (currentWorkflowResult != null && !currentWorkflowStepTracksPaywallEvents) return
+            if (currentWorkflow != null && !currentWorkflowStepTracksPaywallEvents) return
             Logger.e("Paywall event data is null, not tracking paywall component interaction")
             return
         }
@@ -855,11 +854,11 @@ internal class PaywallViewModelImpl(
         // converted to a workflow.
         val workflowIdentifier = purchases.workflowIdForOfferingId(offering.identifier) ?: offering.identifier
         coroutineScope {
-            val fetchResultDeferred = async { purchases.awaitGetWorkflow(workflowIdentifier) }
+            val workflowDeferred = async { purchases.awaitGetWorkflow(workflowIdentifier) }
             val uiConfigDeferred = async { purchases.awaitGetUiConfig() }
             val offeringsDeferred = async { preloadedOfferings ?: purchases.awaitOfferings() }
             startWorkflowPresentation(
-                fetchResultDeferred.await(),
+                workflowDeferred.await(),
                 uiConfigDeferred.await(),
                 offeringsDeferred.await(),
                 offering.presentedOfferingContext,
@@ -925,23 +924,22 @@ internal class PaywallViewModelImpl(
     }
 
     internal fun startWorkflowPresentationFromResult(
-        fetchResult: WorkflowDataResult,
+        workflow: PublishedWorkflow,
         offerings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,
         uiConfig: UiConfig = UiConfig(),
     ) {
         cancelStateUpdate()
-        startWorkflowPresentation(fetchResult, uiConfig, offerings, presentedOfferingContext)
+        startWorkflowPresentation(workflow, uiConfig, offerings, presentedOfferingContext)
     }
 
     @Suppress("ReturnCount")
     private fun startWorkflowPresentation(
-        fetchResult: WorkflowDataResult,
+        workflow: PublishedWorkflow,
         uiConfig: UiConfig,
         offerings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,
     ) {
-        val workflow = fetchResult.workflow
         val initialStep = workflow.steps[workflow.initialStepId]
         if (initialStep == null) {
             updateExitOfferData(ExitOfferData.Unavailable())
@@ -952,10 +950,10 @@ internal class PaywallViewModelImpl(
         }
 
         // Close the lifecycle of any step the user was already on before starting a new presentation.
-        // Uses the old currentWorkflowResult and _workflowState before either is mutated below.
+        // Uses the old currentWorkflow and _workflowState before either is mutated below.
         trackCurrentWorkflowStepCompleted()
 
-        currentWorkflowResult = fetchResult
+        currentWorkflow = workflow
         currentWorkflowUiConfig = uiConfig
         currentWorkflowOfferings = offerings
         currentWorkflowPresentedOfferingContext = presentedOfferingContext
@@ -992,11 +990,11 @@ internal class PaywallViewModelImpl(
      */
     @Suppress("ReturnCount")
     private fun rebuildWorkflowStepStates() {
-        val result = currentWorkflowResult ?: return
+        val workflow = currentWorkflow ?: return
         val offerings = currentWorkflowOfferings ?: return
         val currentStep = workflowNavigator?.currentStep ?: return
         buildWorkflowStates(
-            workflow = result.workflow,
+            workflow = workflow,
             uiConfig = currentWorkflowUiConfig,
             offerings = offerings,
             presentedOfferingContext = currentWorkflowPresentedOfferingContext,
@@ -1182,10 +1180,10 @@ internal class PaywallViewModelImpl(
     @Suppress("ReturnCount")
     override fun handleWorkflowAction(componentId: String, triggerType: WorkflowTriggerType) {
         val navigator = workflowNavigator ?: return
-        val result = currentWorkflowResult ?: return
+        val workflow = currentWorkflow ?: return
         val offerings = currentWorkflowOfferings ?: return
         val candidate = navigator.peekTriggerStep(componentId, triggerType) ?: return
-        validateStep(candidate, result.workflow, offerings)?.let { error ->
+        validateStep(candidate, workflow, offerings)?.let { error ->
             Logger.e("Cannot navigate to step '${candidate.id}': $error")
             return
         }
@@ -1199,7 +1197,7 @@ internal class PaywallViewModelImpl(
         }
         buildStateFromStep(
             newStep,
-            result.workflow,
+            workflow,
             currentWorkflowUiConfig,
             offerings,
             currentWorkflowPresentedOfferingContext,
@@ -1217,10 +1215,10 @@ internal class PaywallViewModelImpl(
     override fun handleBackNavigation(): Boolean {
         val navigator = workflowNavigator ?: return false
         if (!navigator.canNavigateBack) return false
-        val result = currentWorkflowResult ?: return false
+        val workflow = currentWorkflow ?: return false
         val offerings = currentWorkflowOfferings ?: return false
         val candidate = navigator.peekBackStep ?: return false
-        validateStep(candidate, result.workflow, offerings)?.let { error ->
+        validateStep(candidate, workflow, offerings)?.let { error ->
             Logger.e("Cannot navigate back to step '${candidate.id}': $error")
             return false
         }
@@ -1233,7 +1231,7 @@ internal class PaywallViewModelImpl(
         }
         buildStateFromStep(
             newStep,
-            result.workflow,
+            workflow,
             currentWorkflowUiConfig,
             offerings,
             currentWorkflowPresentedOfferingContext,
@@ -1272,8 +1270,7 @@ internal class PaywallViewModelImpl(
         fromStepId: String?,
         entryReason: WorkflowStepEntryReason,
     ) {
-        val workflowResult = currentWorkflowResult ?: return
-        val workflow = workflowResult.workflow
+        val workflow = currentWorkflow ?: return
         purchases.track(
             WorkflowEvent.StepStarted(
                 creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
@@ -1289,8 +1286,7 @@ internal class PaywallViewModelImpl(
     }
 
     private fun trackWorkflowStepCompleted(step: WorkflowStep, toStepId: String?) {
-        val workflowResult = currentWorkflowResult ?: return
-        val workflow = workflowResult.workflow
+        val workflow = currentWorkflow ?: return
         purchases.track(
             WorkflowEvent.StepCompleted(
                 creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
@@ -1312,7 +1308,7 @@ internal class PaywallViewModelImpl(
     private val currentWorkflowStep: WorkflowStep?
         get() {
             val stepId = _workflowState.value?.currentStepId ?: return null
-            return currentWorkflowResult?.workflow?.steps?.get(stepId)
+            return currentWorkflow?.steps?.get(stepId)
         }
 
     /**
@@ -1336,9 +1332,8 @@ internal class PaywallViewModelImpl(
      * workflow was not completed (no purchase).
      */
     private fun trackCurrentWorkflowAbandoned() {
-        val workflowResult = currentWorkflowResult ?: return
+        val workflow = currentWorkflow ?: return
         val step = currentWorkflowStep ?: return
-        val workflow = workflowResult.workflow
         purchases.track(
             WorkflowEvent.Close(
                 creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
@@ -1533,7 +1528,7 @@ internal class PaywallViewModelImpl(
 
     @Suppress("ReturnCount")
     private fun createEventData(): PaywallEvent.Data? {
-        val workflowId = currentWorkflowResult?.workflow?.id
+        val workflowId = currentWorkflow?.id
         val stepId = _workflowState.value?.currentStepId
         return when (val currentState = state.value) {
             is PaywallState.Loaded.Legacy -> currentState.createEventData(workflowId, stepId)
@@ -1654,7 +1649,7 @@ internal class PaywallViewModelImpl(
         )
 
     private fun PaywallEvent.Data.withCurrentWorkflowMetadata(): PaywallEvent.Data {
-        val workflowId = currentWorkflowResult?.workflow?.id
+        val workflowId = currentWorkflow?.id
         val stepId = _workflowState.value?.currentStepId
         return if (this.workflowId == workflowId && this.stepId == stepId) {
             this

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -21,7 +21,7 @@ import com.revenuecat.purchases.awaitPurchase
 import com.revenuecat.purchases.awaitRestore
 import com.revenuecat.purchases.awaitSyncPurchases
 import com.revenuecat.purchases.common.events.FeatureEvent
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
@@ -68,7 +68,7 @@ internal interface PurchasesType {
     suspend fun awaitCreateSupportTicket(email: String, description: String): CreateSupportTicketResult
 
     @Throws(PurchasesException::class)
-    suspend fun awaitGetWorkflow(workflowId: String): WorkflowDataResult
+    suspend fun awaitGetWorkflow(workflowId: String): PublishedWorkflow
 
     @Throws(PurchasesException::class)
     suspend fun awaitGetUiConfig(): UiConfig
@@ -146,7 +146,7 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
     }
 
     @Throws(PurchasesException::class)
-    override suspend fun awaitGetWorkflow(workflowId: String): WorkflowDataResult {
+    override suspend fun awaitGetWorkflow(workflowId: String): PublishedWorkflow {
         return purchases.awaitGetWorkflow(workflowId)
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -9,7 +9,7 @@ import com.revenuecat.purchases.PurchaseResult
 import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.events.FeatureEvent
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
@@ -59,7 +59,7 @@ internal class MockPurchasesType(
         // No-op for mock - return success to simulate success
         return CreateSupportTicketResult(success = true)
     }
-    override suspend fun awaitGetWorkflow(workflowId: String): WorkflowDataResult {
+    override suspend fun awaitGetWorkflow(workflowId: String): PublishedWorkflow {
         throw NotImplementedError("Mock implementation")
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -37,7 +37,6 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
 import com.revenuecat.purchases.common.workflows.WorkflowScreen
 import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.common.workflows.WorkflowTrigger
@@ -1428,7 +1427,7 @@ class PaywallViewModelTest {
             uiConfig = UiConfig(),
         )
         every { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns "wfl-test"
-        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns WorkflowDataResult(workflow)
+        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns workflow
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
@@ -1487,7 +1486,7 @@ class PaywallViewModelTest {
             uiConfig = UiConfig(),
         )
         every { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns "wfl-test"
-        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns WorkflowDataResult(workflow)
+        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns workflow
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
@@ -3078,7 +3077,7 @@ class PaywallViewModelTest {
             purchases,
             PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
                 .setListener(listener)
-                .injectedWorkflow(WorkflowDataResult(workflow), defaultOffering, UiConfig())
+                .injectedWorkflow(workflow, defaultOffering, UiConfig())
                 .build(),
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
@@ -3159,7 +3158,7 @@ class PaywallViewModelTest {
             screens = mapOf("screen-1" to workflowScreen),
             uiConfig = UiConfig(),
         )
-        coEvery { purchases.awaitGetWorkflow(workflowId) } returns WorkflowDataResult(workflow)
+        coEvery { purchases.awaitGetWorkflow(workflowId) } returns workflow
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
@@ -3209,7 +3208,7 @@ class PaywallViewModelTest {
             screens = mapOf("screen-1" to workflowScreen),
             uiConfig = UiConfig(),
         )
-        coEvery { purchases.awaitGetWorkflow(offeringWithWPL.identifier) } returns WorkflowDataResult(workflow)
+        coEvery { purchases.awaitGetWorkflow(offeringWithWPL.identifier) } returns workflow
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -1428,7 +1428,7 @@ class PaywallViewModelTest {
             uiConfig = UiConfig(),
         )
         every { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns "wfl-test"
-        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns WorkflowDataResult(workflow, null)
+        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns WorkflowDataResult(workflow)
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
@@ -1487,7 +1487,7 @@ class PaywallViewModelTest {
             uiConfig = UiConfig(),
         )
         every { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns "wfl-test"
-        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns WorkflowDataResult(workflow, null)
+        coEvery { purchases.awaitGetWorkflow("wfl-test") } returns WorkflowDataResult(workflow)
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
@@ -3078,7 +3078,7 @@ class PaywallViewModelTest {
             purchases,
             PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
                 .setListener(listener)
-                .injectedWorkflow(WorkflowDataResult(workflow, null), defaultOffering, UiConfig())
+                .injectedWorkflow(WorkflowDataResult(workflow), defaultOffering, UiConfig())
                 .build(),
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
@@ -3159,7 +3159,7 @@ class PaywallViewModelTest {
             screens = mapOf("screen-1" to workflowScreen),
             uiConfig = UiConfig(),
         )
-        coEvery { purchases.awaitGetWorkflow(workflowId) } returns WorkflowDataResult(workflow, null)
+        coEvery { purchases.awaitGetWorkflow(workflowId) } returns WorkflowDataResult(workflow)
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
@@ -3209,7 +3209,7 @@ class PaywallViewModelTest {
             screens = mapOf("screen-1" to workflowScreen),
             uiConfig = UiConfig(),
         )
-        coEvery { purchases.awaitGetWorkflow(offeringWithWPL.identifier) } returns WorkflowDataResult(workflow, null)
+        coEvery { purchases.awaitGetWorkflow(offeringWithWPL.identifier) } returns WorkflowDataResult(workflow)
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -193,7 +193,7 @@ class PaywallViewModelWorkflowTest {
             webCheckoutURL = null,
         )
         val offerings = Offerings(offering, mapOf(offeringId to offering))
-        return WorkflowDataResult(workflow = wfl, enrolledVariants = null) to offerings
+        return WorkflowDataResult(workflow = wfl) to offerings
     }
 
     private fun screenTypeMetadata(vararg types: String): JsonObject =
@@ -244,7 +244,7 @@ class PaywallViewModelWorkflowTest {
             webCheckoutURL = null,
         )
         val offerings = Offerings(offering, mapOf(offeringId to offering))
-        return WorkflowDataResult(workflow = wfl, enrolledVariants = null) to offerings
+        return WorkflowDataResult(workflow = wfl) to offerings
     }
 
     // Workflow rendering no longer reads `workflow.uiConfig`: startWorkflowPresentationFromResult now takes it
@@ -263,7 +263,7 @@ class PaywallViewModelWorkflowTest {
         metadata = emptyMap(),
         singleStepFallbackId = "step-1",
     )
-    private val fetchResult = WorkflowDataResult(workflow = workflow, enrolledVariants = null)
+    private val fetchResult = WorkflowDataResult(workflow = workflow)
 
     private val testOffering = Offering(
         identifier = offeringId,
@@ -316,7 +316,6 @@ class PaywallViewModelWorkflowTest {
     )
     private val fetchResultWithExitOffer = WorkflowDataResult(
         workflow = workflowWithExitOffer,
-        enrolledVariants = null,
     )
 
     private val singleStep = WorkflowStep(
@@ -339,7 +338,6 @@ class PaywallViewModelWorkflowTest {
     )
     private val singleStepFetchResultWithExitOffer = WorkflowDataResult(
         workflow = singleStepWorkflowWithExitOffer,
-        enrolledVariants = null,
     )
 
     // Exit offer is on step-1's screen, not step-2's (the terminal step). Without
@@ -359,7 +357,6 @@ class PaywallViewModelWorkflowTest {
     )
     private val fetchResultWithFallback = WorkflowDataResult(
         workflow = workflowWithFallbackPointingToFirstStep,
-        enrolledVariants = null,
     )
 
     // An offering with no packages — validateStep passes but calculateState returns PaywallState.Error.
@@ -440,7 +437,7 @@ class PaywallViewModelWorkflowTest {
         uiConfig = UiConfig(),
         metadata = emptyMap(),
     )
-    private val fetchResultFailingInitial = WorkflowDataResult(workflow = workflowFailingInitial, enrolledVariants = null)
+    private val fetchResultFailingInitial = WorkflowDataResult(workflow = workflowFailingInitial)
 
     private val workflowToError = PublishedWorkflow(
         id = "wfl-to-error",
@@ -451,7 +448,7 @@ class PaywallViewModelWorkflowTest {
         uiConfig = UiConfig(),
         metadata = emptyMap(),
     )
-    private val fetchResultToError = WorkflowDataResult(workflow = workflowToError, enrolledVariants = null)
+    private val fetchResultToError = WorkflowDataResult(workflow = workflowToError)
 
 
     @Before
@@ -835,7 +832,7 @@ class PaywallViewModelWorkflowTest {
             webCheckoutURL = null,
         )
         val threeStepOfferings = Offerings(threeStepOffering, mapOf(threeStepOfferingId to threeStepOffering))
-        val wflResult = WorkflowDataResult(workflow = threeStepWorkflow, enrolledVariants = null)
+        val wflResult = WorkflowDataResult(workflow = threeStepWorkflow)
 
         val vm = createVm()
         vm.startWorkflowPresentationFromResult(wflResult, threeStepOfferings, null, uiConfig)
@@ -1155,7 +1152,7 @@ class PaywallViewModelWorkflowTest {
 
         val vm = createVm()
         vm.startWorkflowPresentationFromResult(
-            WorkflowDataResult(workflowWithFailingInitialAndSuccessfulFallback, enrolledVariants = null),
+            WorkflowDataResult(workflowWithFailingInitialAndSuccessfulFallback),
             testOfferingsWithEmpty,
             null,
             uiConfig,
@@ -1737,7 +1734,6 @@ class PaywallViewModelWorkflowTest {
                 singleStepFallbackId = "step-1",
                 steps = sharedScreenSteps,
             ),
-            enrolledVariants = null,
         )
         val step2Result = WorkflowDataResult(
             workflow = workflow.copy(
@@ -1745,7 +1741,6 @@ class PaywallViewModelWorkflowTest {
                 singleStepFallbackId = "step-2",
                 steps = sharedScreenSteps,
             ),
-            enrolledVariants = null,
         )
 
         vm.startWorkflowPresentationFromResult(step1Result, testOfferings, null, uiConfig)
@@ -1788,7 +1783,6 @@ class PaywallViewModelWorkflowTest {
                 singleStepFallbackId = "step-1",
                 steps = sharedScreenSteps,
             ),
-            enrolledVariants = null,
         )
         val step2Result = WorkflowDataResult(
             workflow = workflow.copy(
@@ -1796,7 +1790,6 @@ class PaywallViewModelWorkflowTest {
                 singleStepFallbackId = "step-2",
                 steps = sharedScreenSteps,
             ),
-            enrolledVariants = null,
         )
 
         vm.startWorkflowPresentationFromResult(step1Result, testOfferings, null, uiConfig)
@@ -1992,7 +1985,6 @@ class PaywallViewModelWorkflowTest {
                 screens = mapOf(screenId1 to makeScreen(screenId1)),
                 singleStepFallbackId = "step-only",
             ),
-            enrolledVariants = null,
         )
     }
 
@@ -2070,7 +2062,6 @@ class PaywallViewModelWorkflowTest {
         // non-fallback initial step.
         val untaggedMultiStep = WorkflowDataResult(
             workflow = workflow.copy(singleStepFallbackId = "step-2"),
-            enrolledVariants = null,
         )
         vm.startWorkflowPresentationFromResult(untaggedMultiStep, testOfferings, null, uiConfig)
         vm.trackPaywallImpressionIfNeeded()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -21,7 +21,6 @@ import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.paywalls.components.PackageComponent
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
-import com.revenuecat.purchases.common.workflows.WorkflowDataResult
 import com.revenuecat.purchases.common.workflows.WorkflowScreen
 import com.revenuecat.purchases.common.workflows.WorkflowScreenType
 import com.revenuecat.purchases.common.workflows.WorkflowStep
@@ -178,7 +177,7 @@ class PaywallViewModelWorkflowTest {
         ),
     )
 
-    private fun makeTwoPackageWorkflow(): Pair<WorkflowDataResult, Offerings> {
+    private fun makeTwoPackageWorkflow(): Pair<PublishedWorkflow, Offerings> {
         val screen1 = makeScreen(screenId1).copy(componentsConfig = twoPackageComponentsConfig)
         val screen2 = makeScreen(screenId2).copy(componentsConfig = twoPackageComponentsConfig)
         val wfl = workflow.copy(
@@ -193,13 +192,13 @@ class PaywallViewModelWorkflowTest {
             webCheckoutURL = null,
         )
         val offerings = Offerings(offering, mapOf(offeringId to offering))
-        return WorkflowDataResult(workflow = wfl) to offerings
+        return wfl to offerings
     }
 
     private fun screenTypeMetadata(vararg types: String): JsonObject =
         JsonObject(mapOf(WorkflowScreenType.METADATA_KEY to JsonArray(types.map { JsonPrimitive(it) })))
 
-    private fun makeContextPackageWorkflow(): Pair<WorkflowDataResult, Offerings> {
+    private fun makeContextPackageWorkflow(): Pair<PublishedWorkflow, Offerings> {
         val earlyScreen = makeScreen(screenId1).copy(componentsConfig = noPackagesComponentsConfig)
         val terminalScreen = makeScreen(screenId2).copy(componentsConfig = twoPackageComponentsConfig)
 
@@ -244,7 +243,7 @@ class PaywallViewModelWorkflowTest {
             webCheckoutURL = null,
         )
         val offerings = Offerings(offering, mapOf(offeringId to offering))
-        return WorkflowDataResult(workflow = wfl) to offerings
+        return wfl to offerings
     }
 
     // Workflow rendering no longer reads `workflow.uiConfig`: startWorkflowPresentationFromResult now takes it
@@ -263,7 +262,7 @@ class PaywallViewModelWorkflowTest {
         metadata = emptyMap(),
         singleStepFallbackId = "step-1",
     )
-    private val fetchResult = WorkflowDataResult(workflow = workflow)
+    private val fetchResult = workflow
 
     private val testOffering = Offering(
         identifier = offeringId,
@@ -314,9 +313,7 @@ class PaywallViewModelWorkflowTest {
         metadata = emptyMap(),
         singleStepFallbackId = "step-2",
     )
-    private val fetchResultWithExitOffer = WorkflowDataResult(
-        workflow = workflowWithExitOffer,
-    )
+    private val fetchResultWithExitOffer = workflowWithExitOffer
 
     private val singleStep = WorkflowStep(
         id = "step-only",
@@ -336,9 +333,7 @@ class PaywallViewModelWorkflowTest {
         metadata = emptyMap(),
         singleStepFallbackId = "step-only",
     )
-    private val singleStepFetchResultWithExitOffer = WorkflowDataResult(
-        workflow = singleStepWorkflowWithExitOffer,
-    )
+    private val singleStepFetchResultWithExitOffer = singleStepWorkflowWithExitOffer
 
     // Exit offer is on step-1's screen, not step-2's (the terminal step). Without
     // single_step_fallback_id, the traversal would land on step-2 and miss the exit offer.
@@ -355,9 +350,7 @@ class PaywallViewModelWorkflowTest {
         metadata = emptyMap(),
         singleStepFallbackId = "step-1",
     )
-    private val fetchResultWithFallback = WorkflowDataResult(
-        workflow = workflowWithFallbackPointingToFirstStep,
-    )
+    private val fetchResultWithFallback = workflowWithFallbackPointingToFirstStep
 
     // An offering with no packages — validateStep passes but calculateState returns PaywallState.Error.
     private val emptyOfferingId = "empty_offering"
@@ -437,7 +430,7 @@ class PaywallViewModelWorkflowTest {
         uiConfig = UiConfig(),
         metadata = emptyMap(),
     )
-    private val fetchResultFailingInitial = WorkflowDataResult(workflow = workflowFailingInitial)
+    private val fetchResultFailingInitial = workflowFailingInitial
 
     private val workflowToError = PublishedWorkflow(
         id = "wfl-to-error",
@@ -448,7 +441,7 @@ class PaywallViewModelWorkflowTest {
         uiConfig = UiConfig(),
         metadata = emptyMap(),
     )
-    private val fetchResultToError = WorkflowDataResult(workflow = workflowToError)
+    private val fetchResultToError = workflowToError
 
 
     @Before
@@ -832,7 +825,7 @@ class PaywallViewModelWorkflowTest {
             webCheckoutURL = null,
         )
         val threeStepOfferings = Offerings(threeStepOffering, mapOf(threeStepOfferingId to threeStepOffering))
-        val wflResult = WorkflowDataResult(workflow = threeStepWorkflow)
+        val wflResult = threeStepWorkflow
 
         val vm = createVm()
         vm.startWorkflowPresentationFromResult(wflResult, threeStepOfferings, null, uiConfig)
@@ -890,9 +883,7 @@ class PaywallViewModelWorkflowTest {
     @Test
     fun `singleStepFallbackId pointing to missing step produces no context and does not crash`() {
         val (result, offerings) = makeContextPackageWorkflow()
-        val brokenResult = result.copy(
-            workflow = result.workflow.copy(singleStepFallbackId = "non-existent-step"),
-        )
+        val brokenResult = result.copy(singleStepFallbackId = "non-existent-step")
         val vm = createVm()
 
         vm.startWorkflowPresentationFromResult(brokenResult, offerings, null, uiConfig)
@@ -908,9 +899,7 @@ class PaywallViewModelWorkflowTest {
         // so the pre-computation guard skips re-building the step. The step's own selection
         // (ownSelection) must still win over the self-referential defaultPackageInfo.
         val (twoPackageResult, twoPackageOfferings) = makeTwoPackageWorkflow()
-        val singleFallbackResult = twoPackageResult.copy(
-            workflow = twoPackageResult.workflow.copy(singleStepFallbackId = "step-1"),
-        )
+        val singleFallbackResult = twoPackageResult.copy(singleStepFallbackId = "step-1")
         val vm = createVm()
 
         vm.startWorkflowPresentationFromResult(singleFallbackResult, twoPackageOfferings, null, uiConfig)
@@ -1152,7 +1141,7 @@ class PaywallViewModelWorkflowTest {
 
         val vm = createVm()
         vm.startWorkflowPresentationFromResult(
-            WorkflowDataResult(workflowWithFailingInitialAndSuccessfulFallback),
+            workflowWithFailingInitialAndSuccessfulFallback,
             testOfferingsWithEmpty,
             null,
             uiConfig,
@@ -1707,7 +1696,7 @@ class PaywallViewModelWorkflowTest {
         val impressions = captured.filterIsInstance<PaywallEvent>()
             .filter { it.type == PaywallEventType.IMPRESSION }
         assertThat(impressions).isNotEmpty()
-        assertThat(impressions.first().data.workflowId).isEqualTo(fetchResult.workflow.id)
+        assertThat(impressions.first().data.workflowId).isEqualTo(fetchResult.id)
     }
 
     @Test
@@ -1728,20 +1717,16 @@ class PaywallViewModelWorkflowTest {
             "step-1" to step1.copy(screenId = screenId2),
             "step-2" to step2.copy(screenId = screenId2),
         )
-        val step1Result = WorkflowDataResult(
-            workflow = workflow.copy(
+        val step1Result = workflow.copy(
                 initialStepId = "step-1",
                 singleStepFallbackId = "step-1",
                 steps = sharedScreenSteps,
-            ),
-        )
-        val step2Result = WorkflowDataResult(
-            workflow = workflow.copy(
+            )
+        val step2Result = workflow.copy(
                 initialStepId = "step-2",
                 singleStepFallbackId = "step-2",
                 steps = sharedScreenSteps,
-            ),
-        )
+            )
 
         vm.startWorkflowPresentationFromResult(step1Result, testOfferings, null, uiConfig)
         vm.trackPaywallImpressionIfNeeded()
@@ -1759,7 +1744,7 @@ class PaywallViewModelWorkflowTest {
 
         val purchaseInitiated = captured.filterIsInstance<PaywallEvent>()
             .single { it.type == PaywallEventType.PURCHASE_INITIATED }
-        assertThat(purchaseInitiated.data.workflowId).isEqualTo(step2Result.workflow.id)
+        assertThat(purchaseInitiated.data.workflowId).isEqualTo(step2Result.id)
         assertThat(purchaseInitiated.data.stepId).isEqualTo("step-2")
     }
 
@@ -1777,20 +1762,16 @@ class PaywallViewModelWorkflowTest {
             "step-1" to step1.copy(screenId = screenId2),
             "step-2" to step2.copy(screenId = screenId2),
         )
-        val step1Result = WorkflowDataResult(
-            workflow = workflow.copy(
+        val step1Result = workflow.copy(
                 initialStepId = "step-1",
                 singleStepFallbackId = "step-1",
                 steps = sharedScreenSteps,
-            ),
-        )
-        val step2Result = WorkflowDataResult(
-            workflow = workflow.copy(
+            )
+        val step2Result = workflow.copy(
                 initialStepId = "step-2",
                 singleStepFallbackId = "step-2",
                 steps = sharedScreenSteps,
-            ),
-        )
+            )
 
         vm.startWorkflowPresentationFromResult(step1Result, testOfferings, null, uiConfig)
         vm.trackPaywallImpressionIfNeeded()
@@ -1808,7 +1789,7 @@ class PaywallViewModelWorkflowTest {
 
         val exitOffer = captured.filterIsInstance<PaywallEvent>()
             .single { it.type == PaywallEventType.EXIT_OFFER }
-        assertThat(exitOffer.data.workflowId).isEqualTo(step2Result.workflow.id)
+        assertThat(exitOffer.data.workflowId).isEqualTo(step2Result.id)
         assertThat(exitOffer.data.stepId).isEqualTo("step-2")
     }
 
@@ -1969,7 +1950,7 @@ class PaywallViewModelWorkflowTest {
 
     // region screen_type paywall-event gating
 
-    private fun singleStepScreenTypeWorkflow(metadata: JsonObject?): WorkflowDataResult {
+    private fun singleStepScreenTypeWorkflow(metadata: JsonObject?): PublishedWorkflow {
         val step = WorkflowStep(
             id = "step-only",
             type = "screen",
@@ -1978,13 +1959,11 @@ class PaywallViewModelWorkflowTest {
             triggerActions = emptyMap(),
             metadata = metadata,
         )
-        return WorkflowDataResult(
-            workflow = workflow.copy(
-                initialStepId = "step-only",
-                steps = mapOf("step-only" to step),
-                screens = mapOf(screenId1 to makeScreen(screenId1)),
-                singleStepFallbackId = "step-only",
-            ),
+        return workflow.copy(
+            initialStepId = "step-only",
+            steps = mapOf("step-only" to step),
+            screens = mapOf(screenId1 to makeScreen(screenId1)),
+            singleStepFallbackId = "step-only",
         )
     }
 
@@ -2060,9 +2039,7 @@ class PaywallViewModelWorkflowTest {
         val vm = createVm()
         // Base workflow steps carry no screen_type; point the fallback at step-2 so step-1 is a
         // non-fallback initial step.
-        val untaggedMultiStep = WorkflowDataResult(
-            workflow = workflow.copy(singleStepFallbackId = "step-2"),
-        )
+        val untaggedMultiStep = workflow.copy(singleStepFallbackId = "step-2")
         vm.startWorkflowPresentationFromResult(untaggedMultiStep, testOfferings, null, uiConfig)
         vm.trackPaywallImpressionIfNeeded()
 


### PR DESCRIPTION
Adds `WorkflowsConfigProvider`. It resolves an offering id to its workflow id from topic metadata, and reads workflow bodies through `RemoteConfigManager`.

Nothing calls it yet. The next PR points `WorkflowManager` at it and drops the per-workflow backend fetch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the internal workflow API shape and removes enrolled-variants from the detail envelope, which could affect experiment attribution if anything still relied on it; the new config provider is additive but targets the same paywall/workflow load path that a follow-up PR will switch to.
> 
> **Overview**
> Introduces **`WorkflowsConfigProvider`** as the remote-config read path for workflows: it maps an offering id to a workflow id via topic metadata, loads and parses workflow bodies through **`RemoteConfigManager`**, and exposes **`awaitReady()`** so offerings can wait on the workflows topic. An integration test drives a fake `/v1/config` sync through the real manager, blob store, and provider.
> 
> In parallel, the workflow fetch surface is **flattened**: **`WorkflowDataResult`** is removed and **`awaitGetWorkflow`**, **`WorkflowManager`**, caches, and **`WorkflowDetailResolver`** now deal in **`PublishedWorkflow`** only. **`enrolled_variants`** is dropped from **`WorkflowDetailResponse`** and is no longer surfaced to callers.
> 
> **RevenueCat UI** (`PaywallOptions`, **`PaywallViewModel`**, **`PurchasesType`**) and API testers are updated to use **`PublishedWorkflow`** for injected/fetched workflows instead of the old wrapper type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404e96ae6049618a68fa528073a39f5b62cf4deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->