### PR TITLE
refactor(remote-config): Add `mergeItemsBlobData` to `RemoteConfigManager`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -19,8 +19,10 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
@@ -370,6 +372,56 @@ internal class RemoteConfigManager(
         transform: (ByteArray) -> T?,
     ): T? = withContext(ioDispatcher) {
         resolveBlobBytes(topic, itemKey)?.let(transform)
+    }
+
+    /**
+     * The resolved blob payloads for [itemKeys] in [topic], each parsed from JSON into [T], keyed by item key.
+     * The batch counterpart of the single-key reified overload: every requested key is present in the result,
+     * mapping to `null` when that item is unknown, has no `blob_ref`, its blob can't be resolved, or its bytes
+     * don't deserialize into [T]. Duplicate keys collapse to one entry; an empty [itemKeys] returns an empty
+     * map. [T] must be a concrete `@Serializable` type; parsing uses the shared [JsonProvider.defaultJson]. For
+     * non-JSON payloads use the `transform` batch overload, which documents the resolution and waiting rules.
+     */
+    suspend inline fun <reified T> blobData(topic: RemoteConfigTopic, itemKeys: Collection<String>): Map<String, T?> =
+        blobData(topic, itemKeys) { bytes ->
+            try {
+                JsonProvider.defaultJson.decodeFromString<T>(bytes.decodeToString())
+            } catch (e: SerializationException) {
+                errorLog(e) { "Failed to parse remote config blob as JSON." }
+                null
+            }
+        }
+
+    /**
+     * Resolves the blob payload bytes for each key in [itemKeys] within [topic] **concurrently** and maps each
+     * through [transform], keyed by item key. The batch counterpart of the single-key `transform` overload:
+     * every requested key is present in the result, mapping to `null` when that item is unknown or its blob
+     * can't be resolved. Duplicate keys collapse to one entry; an empty [itemKeys] returns an empty map.
+     *
+     * Each key resolves through the same path as the single-key overload (see its KDoc for the `blob_ref`,
+     * on-demand fetch, and waiting rules), so the per-item semantics are identical — this only fans them out.
+     * The fan-out is safe: a shared in-flight `/v1/config` refresh is deduped across all keys, and the blob
+     * fetcher dedupes concurrent downloads of the same ref. When the endpoint is [isDisabled] (the 4xx session
+     * kill-switch) every key resolves to `null` without any read. Runs on [ioDispatcher].
+     */
+    suspend fun <T> blobData(
+        topic: RemoteConfigTopic,
+        itemKeys: Collection<String>,
+        transform: (ByteArray) -> T?,
+    ): Map<String, T?> = withContext(ioDispatcher) {
+        coroutineScope {
+            itemKeys.distinct()
+                .associateWith { key -> async { resolveBlobBytes(topic, key)?.let(transform) } }
+                .mapValues { (_, deferred) -> deferred.await() }
+        }.also { resolved ->
+            val unresolved = resolved.filterValues { it == null }.keys
+            if (unresolved.isNotEmpty()) {
+                warnLog {
+                    "Could not resolve remote config blob(s) for ${unresolved.size} of ${resolved.size} " +
+                        "requested item(s) in topic '${topic.wireName}': $unresolved."
+                }
+            }
+        }
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -387,14 +387,14 @@ internal class RemoteConfigManager(
      * This is **all-or-nothing**: if any requested item is unknown, has no `blob_ref`, or its blob can't be
      * resolved, the call returns `null` (a partial object is never produced) and warn-logs the missing keys.
      * It also returns `null` if any resolved blob isn't valid JSON, or the merged object doesn't deserialize
-     * into [T]. Duplicate keys are de-duplicated; [T] must be a concrete `@Serializable` type and parsing uses
-     * [JsonProvider.defaultJson].
+     * into [T]. Duplicate keys are de-duplicated; an empty [itemKeys] returns `null` without any read; [T] must
+     * be a concrete `@Serializable` type and parsing uses [JsonProvider.defaultJson].
      *
      * Each item resolves through the same path as the single-key [blobData] (see its KDoc for the `blob_ref`,
      * on-demand fetch, and waiting rules) — this only fans them out. The fan-out is safe: a shared in-flight
      * `/v1/config` refresh is deduped across all keys, and the blob fetcher dedupes concurrent downloads of the
      * same ref. When the endpoint is [isDisabled] (the 4xx session kill-switch) the call returns `null`
-     * immediately without any read (including for an empty [itemKeys]). Runs on [ioDispatcher].
+     * immediately without any read. Runs on [ioDispatcher].
      */
     suspend inline fun <reified T> mergeItemsBlobData(topic: RemoteConfigTopic, itemKeys: Collection<String>): T? =
         mergeItemsBlobData(topic, itemKeys) { merged ->
@@ -434,6 +434,10 @@ internal class RemoteConfigManager(
             return null
         }
         val keys = itemKeys.distinct()
+        if (keys.isEmpty()) {
+            verboseLog { "No item keys requested for merged remote config read in topic '${topic.wireName}'." }
+            return null
+        }
         val resolved = coroutineScope {
             keys.associateWith { key -> async { resolveBlobBytes(topic, key) } }
                 .mapValues { (_, deferred) -> deferred.await() }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -378,16 +378,17 @@ internal class RemoteConfigManager(
     }
 
     /**
-     * Resolves the blobs for every key in [itemKeys] within [topic] **concurrently**, merges each (parsed as a
-     * JSON object) into one combined JSON object, and decodes that into a single [T]. Use this when a single
-     * logical object is assembled from data spread across several items in a topic (e.g. item `a` carries
-     * `{"x":...}` and item `b` carries `{"y":...}`, together decoding into `T(x, y)`).
+     * Resolves the blobs for every key in [itemKeys] within [topic] **concurrently**, builds a single JSON
+     * object mapping **each item key to that item's parsed blob JSON**, and decodes it into a single [T]. Use
+     * this to assemble one object from several items in a topic: given items `wf1 -> {"a":...}` and
+     * `wf2 -> {"b":...}`, the merged object is `{"wf1": {"a":...}, "wf2": {"b":...}}`, so [T] declares a field
+     * per item key.
      *
      * This is **all-or-nothing**: if any requested item is unknown, has no `blob_ref`, or its blob can't be
      * resolved, the call returns `null` (a partial object is never produced) and warn-logs the missing keys.
-     * It also returns `null` if any resolved blob isn't valid JSON, isn't a JSON object, or the merged object
-     * doesn't deserialize into [T]. On a key collision the later item in [itemKeys] wins. Duplicate keys are
-     * de-duplicated; [T] must be a concrete `@Serializable` type and parsing uses [JsonProvider.defaultJson].
+     * It also returns `null` if any resolved blob isn't valid JSON, or the merged object doesn't deserialize
+     * into [T]. Duplicate keys are de-duplicated; [T] must be a concrete `@Serializable` type and parsing uses
+     * [JsonProvider.defaultJson].
      *
      * Each item resolves through the same path as the single-key [blobData] (see its KDoc for the `blob_ref`,
      * on-demand fetch, and waiting rules) — this only fans them out. The fan-out is safe: a shared in-flight
@@ -406,10 +407,10 @@ internal class RemoteConfigManager(
     }
 
     /**
-     * Resolves every item in [itemKeys] concurrently and merges each blob (parsed as a JSON object) into one
-     * combined object, or `null` if any item can't be resolved or any resolved blob isn't a JSON object. The
-     * non-inline worker behind [mergeItemsBlobData]; kept non-`private` so the reified `inline` function can
-     * call it. Runs on [ioDispatcher].
+     * Resolves every item in [itemKeys] concurrently and builds a JSON object keyed by item key, each mapping
+     * to that item's parsed blob JSON, or `null` if any item can't be resolved or any resolved blob isn't valid
+     * JSON. The non-inline worker behind [mergeItemsBlobData]; kept non-`private` so the reified `inline`
+     * function can call it. Runs on [ioDispatcher].
      */
     suspend fun mergedBlobObject(topic: RemoteConfigTopic, itemKeys: Collection<String>): JsonObject? =
         withContext(ioDispatcher) {
@@ -434,12 +435,8 @@ internal class RemoteConfigManager(
                     errorLog(e) { "Remote config blob for item '$key' in topic '${topic.wireName}' is not valid JSON." }
                     return@withContext null
                 }
-                if (element !is JsonObject) {
-                    errorLog { "Remote config blob for item '$key' in topic '${topic.wireName}' is not a JSON object." }
-                    return@withContext null
-                }
-                // Later items in itemKeys override earlier ones on a key collision.
-                merged.putAll(element)
+                // Nest each item's blob JSON under its item key.
+                merged[key] = element
             }
             JsonObject(merged)
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -393,8 +393,8 @@ internal class RemoteConfigManager(
      * Each item resolves through the same path as the single-key [blobData] (see its KDoc for the `blob_ref`,
      * on-demand fetch, and waiting rules) — this only fans them out. The fan-out is safe: a shared in-flight
      * `/v1/config` refresh is deduped across all keys, and the blob fetcher dedupes concurrent downloads of the
-     * same ref. When the endpoint is [isDisabled] (the 4xx session kill-switch) every item resolves to `null`,
-     * so the call returns `null` without any read. Runs on [ioDispatcher].
+     * same ref. When the endpoint is [isDisabled] (the 4xx session kill-switch) the call returns `null`
+     * immediately without any read (including for an empty [itemKeys]). Runs on [ioDispatcher].
      */
     suspend inline fun <reified T> mergeItemsBlobData(topic: RemoteConfigTopic, itemKeys: Collection<String>): T? =
         mergeItemsBlobData(topic, itemKeys) { merged ->
@@ -429,6 +429,10 @@ internal class RemoteConfigManager(
      */
     @Suppress("ReturnCount")
     private suspend fun mergedBlobObject(topic: RemoteConfigTopic, itemKeys: Collection<String>): JsonObject? {
+        if (disabled) {
+            verboseLog { "Remote config disabled (4xx); skipping merged read for topic '${topic.wireName}'." }
+            return null
+        }
         val keys = itemKeys.distinct()
         val resolved = coroutineScope {
             keys.associateWith { key -> async { resolveBlobBytes(topic, key) } }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -26,6 +26,9 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -375,54 +378,71 @@ internal class RemoteConfigManager(
     }
 
     /**
-     * The resolved blob payloads for [itemKeys] in [topic], each parsed from JSON into [T], keyed by item key.
-     * The batch counterpart of the single-key reified overload: every requested key is present in the result,
-     * mapping to `null` when that item is unknown, has no `blob_ref`, its blob can't be resolved, or its bytes
-     * don't deserialize into [T]. Duplicate keys collapse to one entry; an empty [itemKeys] returns an empty
-     * map. [T] must be a concrete `@Serializable` type; parsing uses the shared [JsonProvider.defaultJson]. For
-     * non-JSON payloads use the `transform` batch overload, which documents the resolution and waiting rules.
-     */
-    suspend inline fun <reified T> blobData(topic: RemoteConfigTopic, itemKeys: Collection<String>): Map<String, T?> =
-        blobData(topic, itemKeys) { bytes ->
-            try {
-                JsonProvider.defaultJson.decodeFromString<T>(bytes.decodeToString())
-            } catch (e: SerializationException) {
-                errorLog(e) { "Failed to parse remote config blob as JSON." }
-                null
-            }
-        }
-
-    /**
-     * Resolves the blob payload bytes for each key in [itemKeys] within [topic] **concurrently** and maps each
-     * through [transform], keyed by item key. The batch counterpart of the single-key `transform` overload:
-     * every requested key is present in the result, mapping to `null` when that item is unknown or its blob
-     * can't be resolved. Duplicate keys collapse to one entry; an empty [itemKeys] returns an empty map.
+     * Resolves the blobs for every key in [itemKeys] within [topic] **concurrently**, merges each (parsed as a
+     * JSON object) into one combined JSON object, and decodes that into a single [T]. Use this when a single
+     * logical object is assembled from data spread across several items in a topic (e.g. item `a` carries
+     * `{"x":...}` and item `b` carries `{"y":...}`, together decoding into `T(x, y)`).
      *
-     * Each key resolves through the same path as the single-key overload (see its KDoc for the `blob_ref`,
-     * on-demand fetch, and waiting rules), so the per-item semantics are identical — this only fans them out.
-     * The fan-out is safe: a shared in-flight `/v1/config` refresh is deduped across all keys, and the blob
-     * fetcher dedupes concurrent downloads of the same ref. When the endpoint is [isDisabled] (the 4xx session
-     * kill-switch) every key resolves to `null` without any read. Runs on [ioDispatcher].
+     * This is **all-or-nothing**: if any requested item is unknown, has no `blob_ref`, or its blob can't be
+     * resolved, the call returns `null` (a partial object is never produced) and warn-logs the missing keys.
+     * It also returns `null` if any resolved blob isn't valid JSON, isn't a JSON object, or the merged object
+     * doesn't deserialize into [T]. On a key collision the later item in [itemKeys] wins. Duplicate keys are
+     * de-duplicated; [T] must be a concrete `@Serializable` type and parsing uses [JsonProvider.defaultJson].
+     *
+     * Each item resolves through the same path as the single-key [blobData] (see its KDoc for the `blob_ref`,
+     * on-demand fetch, and waiting rules) — this only fans them out. The fan-out is safe: a shared in-flight
+     * `/v1/config` refresh is deduped across all keys, and the blob fetcher dedupes concurrent downloads of the
+     * same ref. When the endpoint is [isDisabled] (the 4xx session kill-switch) every item resolves to `null`,
+     * so the call returns `null` without any read. Runs on [ioDispatcher].
      */
-    suspend fun <T> blobData(
-        topic: RemoteConfigTopic,
-        itemKeys: Collection<String>,
-        transform: (ByteArray) -> T?,
-    ): Map<String, T?> = withContext(ioDispatcher) {
-        coroutineScope {
-            itemKeys.distinct()
-                .associateWith { key -> async { resolveBlobBytes(topic, key)?.let(transform) } }
-                .mapValues { (_, deferred) -> deferred.await() }
-        }.also { resolved ->
-            val unresolved = resolved.filterValues { it == null }.keys
-            if (unresolved.isNotEmpty()) {
-                warnLog {
-                    "Could not resolve remote config blob(s) for ${unresolved.size} of ${resolved.size} " +
-                        "requested item(s) in topic '${topic.wireName}': $unresolved."
-                }
-            }
+    suspend inline fun <reified T> mergeItemsBlobData(topic: RemoteConfigTopic, itemKeys: Collection<String>): T? {
+        val merged = mergedBlobObject(topic, itemKeys) ?: return null
+        return try {
+            JsonProvider.defaultJson.decodeFromJsonElement<T>(merged)
+        } catch (e: SerializationException) {
+            errorLog(e) { "Failed to decode merged remote config blobs from topic '${topic.wireName}' as JSON." }
+            null
         }
     }
+
+    /**
+     * Resolves every item in [itemKeys] concurrently and merges each blob (parsed as a JSON object) into one
+     * combined object, or `null` if any item can't be resolved or any resolved blob isn't a JSON object. The
+     * non-inline worker behind [mergeItemsBlobData]; kept non-`private` so the reified `inline` function can
+     * call it. Runs on [ioDispatcher].
+     */
+    suspend fun mergedBlobObject(topic: RemoteConfigTopic, itemKeys: Collection<String>): JsonObject? =
+        withContext(ioDispatcher) {
+            val keys = itemKeys.distinct()
+            val resolved = coroutineScope {
+                keys.associateWith { key -> async { resolveBlobBytes(topic, key) } }
+                    .mapValues { (_, deferred) -> deferred.await() }
+            }
+            val missing = resolved.filterValues { it == null }.keys
+            if (missing.isNotEmpty()) {
+                warnLog {
+                    "Could not resolve remote config blob(s) for ${missing.size} of ${resolved.size} " +
+                        "requested item(s) in topic '${topic.wireName}': $missing. Returning null."
+                }
+                return@withContext null
+            }
+            val merged = LinkedHashMap<String, JsonElement>()
+            for (key in keys) {
+                val element = try {
+                    JsonProvider.defaultJson.parseToJsonElement(resolved.getValue(key)!!.decodeToString())
+                } catch (e: SerializationException) {
+                    errorLog(e) { "Remote config blob for item '$key' in topic '${topic.wireName}' is not valid JSON." }
+                    return@withContext null
+                }
+                if (element !is JsonObject) {
+                    errorLog { "Remote config blob for item '$key' in topic '${topic.wireName}' is not a JSON object." }
+                    return@withContext null
+                }
+                // Later items in itemKeys override earlier ones on a key collision.
+                merged.putAll(element)
+            }
+            JsonObject(merged)
+        }
 
     /**
      * Resolves an item's referenced-blob bytes, or `null` when the endpoint is [isDisabled], the item is

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -396,50 +396,65 @@ internal class RemoteConfigManager(
      * same ref. When the endpoint is [isDisabled] (the 4xx session kill-switch) every item resolves to `null`,
      * so the call returns `null` without any read. Runs on [ioDispatcher].
      */
-    suspend inline fun <reified T> mergeItemsBlobData(topic: RemoteConfigTopic, itemKeys: Collection<String>): T? {
-        val merged = mergedBlobObject(topic, itemKeys) ?: return null
-        return try {
-            JsonProvider.defaultJson.decodeFromJsonElement<T>(merged)
-        } catch (e: SerializationException) {
-            errorLog(e) { "Failed to decode merged remote config blobs from topic '${topic.wireName}' as JSON." }
-            null
+    suspend inline fun <reified T> mergeItemsBlobData(topic: RemoteConfigTopic, itemKeys: Collection<String>): T? =
+        mergeItemsBlobData(topic, itemKeys) { merged ->
+            try {
+                JsonProvider.defaultJson.decodeFromJsonElement<T>(merged)
+            } catch (e: SerializationException) {
+                errorLog(e) { "Failed to decode merged remote config blobs from topic '${topic.wireName}' as JSON." }
+                null
+            }
         }
+
+    /**
+     * Resolves + merges the [itemKeys] blobs (see the reified [mergeItemsBlobData] for the merge shape and rules)
+     * and maps the resulting keyed JSON object through [transform] — resolution, merge, and [transform] all run
+     * on [ioDispatcher] so JSON decoding never runs on the caller's thread. Returns `null` when the merged
+     * object can't be built (any item unresolvable or non-JSON). The non-inline worker behind the reified
+     * overload; kept non-`private` so the `inline` function can call it.
+     */
+    suspend fun <T> mergeItemsBlobData(
+        topic: RemoteConfigTopic,
+        itemKeys: Collection<String>,
+        transform: (JsonObject) -> T?,
+    ): T? = withContext(ioDispatcher) {
+        mergedBlobObject(topic, itemKeys)?.let(transform)
     }
 
     /**
      * Resolves every item in [itemKeys] concurrently and builds a JSON object keyed by item key, each mapping
      * to that item's parsed blob JSON, or `null` if any item can't be resolved or any resolved blob isn't valid
-     * JSON. The non-inline worker behind [mergeItemsBlobData]; kept non-`private` so the reified `inline`
-     * function can call it. Runs on [ioDispatcher].
+     * JSON. Assumes it is already running on [ioDispatcher] (its only caller wraps it), so it doesn't switch
+     * context itself.
      */
-    suspend fun mergedBlobObject(topic: RemoteConfigTopic, itemKeys: Collection<String>): JsonObject? =
-        withContext(ioDispatcher) {
-            val keys = itemKeys.distinct()
-            val resolved = coroutineScope {
-                keys.associateWith { key -> async { resolveBlobBytes(topic, key) } }
-                    .mapValues { (_, deferred) -> deferred.await() }
-            }
-            val missing = resolved.filterValues { it == null }.keys
-            if (missing.isNotEmpty()) {
-                warnLog {
-                    "Could not resolve remote config blob(s) for ${missing.size} of ${resolved.size} " +
-                        "requested item(s) in topic '${topic.wireName}': $missing. Returning null."
-                }
-                return@withContext null
-            }
-            val merged = LinkedHashMap<String, JsonElement>()
-            for (key in keys) {
-                val element = try {
-                    JsonProvider.defaultJson.parseToJsonElement(resolved.getValue(key)!!.decodeToString())
-                } catch (e: SerializationException) {
-                    errorLog(e) { "Remote config blob for item '$key' in topic '${topic.wireName}' is not valid JSON." }
-                    return@withContext null
-                }
-                // Nest each item's blob JSON under its item key.
-                merged[key] = element
-            }
-            JsonObject(merged)
+    @Suppress("ReturnCount")
+    private suspend fun mergedBlobObject(topic: RemoteConfigTopic, itemKeys: Collection<String>): JsonObject? {
+        val keys = itemKeys.distinct()
+        val resolved = coroutineScope {
+            keys.associateWith { key -> async { resolveBlobBytes(topic, key) } }
+                .mapValues { (_, deferred) -> deferred.await() }
         }
+        val missing = resolved.filterValues { it == null }.keys
+        if (missing.isNotEmpty()) {
+            warnLog {
+                "Could not resolve remote config blob(s) for ${missing.size} of ${resolved.size} " +
+                    "requested item(s) in topic '${topic.wireName}': $missing. Returning null."
+            }
+            return null
+        }
+        val merged = LinkedHashMap<String, JsonElement>()
+        for (key in keys) {
+            val element = try {
+                JsonProvider.defaultJson.parseToJsonElement(resolved.getValue(key)!!.decodeToString())
+            } catch (e: SerializationException) {
+                errorLog(e) { "Remote config blob for item '$key' in topic '${topic.wireName}' is not valid JSON." }
+                return null
+            }
+            // Nest each item's blob JSON under its item key.
+            merged[key] = element
+        }
+        return JsonObject(merged)
+    }
 
     /**
      * Resolves an item's referenced-blob bytes, or `null` when the endpoint is [isDisabled], the item is

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -1146,6 +1146,77 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `mergeItemsBlobData returns null when a resolved blob is not valid JSON`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(
+                    mapOf(
+                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
+                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+                    ),
+                ),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
+        every { blobStore.read(REF_VALID) } returns """{"value":"x"}""".toByteArray()
+        // wf2's blob is not parseable JSON, so the whole merge fails.
+        every { blobStore.read(REF_TAMPERED) } returns "not json".toByteArray()
+
+        val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `mergeItemsBlobData returns null when the merged object does not deserialize into T`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(
+                    mapOf(
+                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
+                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+                    ),
+                ),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
+        // Both blobs are valid JSON, but wf2 is missing Section's required "value" field, so the merged
+        // {"wf1": {"value":"x"}, "wf2": {"nope":true}} can't decode into MergedBlob.
+        every { blobStore.read(REF_VALID) } returns """{"value":"x"}""".toByteArray()
+        every { blobStore.read(REF_TAMPERED) } returns """{"nope":true}""".toByteArray()
+
+        val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `mergeItemsBlobData returns null for an empty key list without touching the network`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(
+                    mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID)),
+                ),
+            ),
+        )
+
+        // Even though OptionalBlob would decode from an empty object, an empty key list is a no-op → null.
+        val result = readManager().mergeItemsBlobData<OptionalBlob>(RemoteConfigTopic.Workflows, emptyList())
+
+        assertThat(result).isNull()
+        coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `mergeItemsBlobData warns and returns null when one or more items cannot be resolved`() {
         every { diskCache.read() } returns persisted(
             manifest = "m",

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -1095,7 +1095,7 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `batch blobData resolves multiple blob-backed items keyed by item key`() = runTest {
+    fun `mergeItemsBlobData merges multiple items' JSON objects and decodes into a single object`() = runTest {
         every { diskCache.read() } returns persisted(
             manifest = "m",
             activeTopics = listOf("workflows"),
@@ -1110,18 +1110,66 @@ class RemoteConfigManagerTest {
         )
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
         coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
-        every { blobStore.read(REF_VALID) } returns byteArrayOf(4, 2)
-        every { blobStore.read(REF_TAMPERED) } returns byteArrayOf(7)
+        // Each item contributes part of the object; merged they form the full MergedBlob.
+        every { blobStore.read(REF_VALID) } returns """{"a":"x"}""".toByteArray()
+        every { blobStore.read(REF_TAMPERED) } returns """{"b":"y"}""".toByteArray()
 
-        val result = readManager().blobData(RemoteConfigTopic.Workflows, listOf("wf1", "wf2")) { it }
+        val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
 
-        assertThat(result.keys).containsExactlyInAnyOrder("wf1", "wf2")
-        assertThat(result["wf1"]).isEqualTo(byteArrayOf(4, 2))
-        assertThat(result["wf2"]).isEqualTo(byteArrayOf(7))
+        assertThat(result).isEqualTo(MergedBlob(a = "x", b = "y"))
     }
 
     @Test
-    fun `batch blobData keeps null entries for unresolvable items alongside resolved ones`() = runTest {
+    fun `mergeItemsBlobData lets a later item override an earlier item on a key collision`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(
+                    mapOf(
+                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
+                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+                    ),
+                ),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
+        every { blobStore.read(REF_VALID) } returns """{"a":"first","b":"y"}""".toByteArray()
+        every { blobStore.read(REF_TAMPERED) } returns """{"a":"second"}""".toByteArray()
+
+        // wf2 comes after wf1, so its "a" wins.
+        val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
+
+        assertThat(result).isEqualTo(MergedBlob(a = "second", b = "y"))
+    }
+
+    @Test
+    fun `mergeItemsBlobData returns null when an item's blob cannot be fetched`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(
+                    mapOf(
+                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
+                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+                    ),
+                ),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns false
+        every { blobStore.read(REF_VALID) } returns """{"a":"x"}""".toByteArray()
+
+        // All-or-nothing: one unresolved item nulls out the whole call, even though wf1 resolved.
+        val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `mergeItemsBlobData returns null for an item without a blob ref`() = runTest {
         val metadata = buildJsonObject { put("offering_id", "offer_123") }
         every { diskCache.read() } returns persisted(
             manifest = "m",
@@ -1130,31 +1178,22 @@ class RemoteConfigManagerTest {
                 "workflows" to ConfigTopic(
                     mapOf(
                         "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
-                        // Fetch fails for this one.
-                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
                         // No blob ref: inline-only, no payload.
-                        "wf3" to RemoteConfiguration.ConfigItem(metadata = metadata),
+                        "wf2" to RemoteConfiguration.ConfigItem(metadata = metadata),
                     ),
                 ),
             ),
         )
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
-        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns false
-        every { blobStore.read(REF_VALID) } returns byteArrayOf(1)
+        every { blobStore.read(REF_VALID) } returns """{"a":"x"}""".toByteArray()
 
-        val result = readManager().blobData(
-            RemoteConfigTopic.Workflows,
-            listOf("wf1", "wf2", "wf3"),
-        ) { it }
+        val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
 
-        assertThat(result.keys).containsExactlyInAnyOrder("wf1", "wf2", "wf3")
-        assertThat(result["wf1"]).isEqualTo(byteArrayOf(1))
-        assertThat(result["wf2"]).isNull()
-        assertThat(result["wf3"]).isNull()
+        assertThat(result).isNull()
     }
 
     @Test
-    fun `batch blobData warns when one or more items cannot be resolved`() {
+    fun `mergeItemsBlobData warns and returns null when one or more items cannot be resolved`() {
         every { diskCache.read() } returns persisted(
             manifest = "m",
             activeTopics = listOf("workflows"),
@@ -1169,20 +1208,20 @@ class RemoteConfigManagerTest {
         )
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
         coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns false
-        every { blobStore.read(REF_VALID) } returns byteArrayOf(1)
+        every { blobStore.read(REF_VALID) } returns """{"a":"x"}""".toByteArray()
 
         assertWarnLog(
             "Could not resolve remote config blob(s) for 1 of 2 requested item(s) in " +
-                "topic 'workflows': [wf2].",
+                "topic 'workflows': [wf2]. Returning null.",
         ) {
             runTest {
-                readManager().blobData(RemoteConfigTopic.Workflows, listOf("wf1", "wf2")) { it }
+                readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
             }
         }
     }
 
     @Test
-    fun `reified batch blobData deserializes each present blob`() = runTest {
+    fun `mergeItemsBlobData returns null once the endpoint is disabled without touching the network`() = runTest {
         every { diskCache.read() } returns persisted(
             manifest = "m",
             activeTopics = listOf("workflows"),
@@ -1195,73 +1234,36 @@ class RemoteConfigManagerTest {
                 ),
             ),
         )
-        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
-        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
-        every { blobStore.read(REF_VALID) } returns """{"id":"wf-1"}""".toByteArray()
-        every { blobStore.read(REF_TAMPERED) } returns """{"id":"wf-2"}""".toByteArray()
+        val manager = readManager()
+        // A 4xx disables the endpoint for the session.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
 
-        val result = readManager().blobData<TestBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
+        val result = manager.mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
 
-        assertThat(result).isEqualTo(mapOf("wf1" to TestBlob(id = "wf-1"), "wf2" to TestBlob(id = "wf-2")))
+        assertThat(result).isNull()
+        coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
     }
 
     @Test
-    fun `batch blobData returns all-null entries once the endpoint is disabled without touching the network`() =
-        runTest {
-            every { diskCache.read() } returns persisted(
-                manifest = "m",
-                activeTopics = listOf("workflows"),
-                topics = mapOf(
-                    "workflows" to ConfigTopic(
-                        mapOf(
-                            "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
-                            "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
-                        ),
-                    ),
-                ),
-            )
-            val manager = readManager()
-            // A 4xx disables the endpoint for the session.
-            manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-            onError.invoke(
-                PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
-                GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
-            )
-
-            val result = manager.blobData(RemoteConfigTopic.Workflows, listOf("wf1", "wf2")) { it }
-
-            assertThat(result.keys).containsExactlyInAnyOrder("wf1", "wf2")
-            assertThat(result.values).containsOnlyNulls()
-            coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
-        }
-
-    @Test
-    fun `batch blobData returns an empty map for empty item keys without triggering a sync`() = runTest {
-        every { diskCache.read() } returns null
-
-        val result = readManager(appUserIDProvider = { TEST_APP_USER_ID })
-            .blobData(RemoteConfigTopic.Workflows, emptyList()) { it }
-
-        assertThat(result).isEmpty()
-        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
-    }
-
-    @Test
-    fun `batch blobData triggers a single shared sync for multiple uncached items`() = runTest {
+    fun `mergeItemsBlobData triggers a single shared sync for multiple uncached items then decodes`() = runTest {
         var state: PersistedRemoteConfigurationState? = null
         every { diskCache.read() } answers { state }
         every { diskCache.write(any()) } answers { state = firstArg(); true }
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
         coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
-        every { blobStore.read(REF_VALID) } returns byteArrayOf(4, 2)
-        every { blobStore.read(REF_TAMPERED) } returns byteArrayOf(7)
+        every { blobStore.read(REF_VALID) } returns """{"a":"x"}""".toByteArray()
+        every { blobStore.read(REF_TAMPERED) } returns """{"b":"y"}""".toByteArray()
         val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
 
-        // Nothing cached and nothing in flight: the batch read fans out, but the concurrent per-key waits
+        // Nothing cached and nothing in flight: the read fans out, but the concurrent per-item waits
         // collapse onto a single shared on-demand sync.
-        var result: Map<String, ByteArray?> = emptyMap()
+        var result: MergedBlob? = null
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
-            result = manager.blobData(RemoteConfigTopic.Workflows, listOf("wf1", "wf2")) { it }
+            result = manager.mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
         }
         verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
         assertThat(read.isActive).isTrue()
@@ -1282,8 +1284,7 @@ class RemoteConfigManagerTest {
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         assertThat(read.isCompleted).isTrue()
-        assertThat(result["wf1"]).isEqualTo(byteArrayOf(4, 2))
-        assertThat(result["wf2"]).isEqualTo(byteArrayOf(7))
+        assertThat(result).isEqualTo(MergedBlob(a = "x", b = "y"))
     }
 
     @Test
@@ -1490,6 +1491,10 @@ class RemoteConfigManagerTest {
 
     @Serializable
     private data class TestBlob(val id: String)
+
+    // A single object assembled from data spread across multiple items in a topic.
+    @Serializable
+    private data class MergedBlob(val a: String, val b: String)
 
     private companion object {
         private const val TEST_APP_USER_ID = "test-app-user-id"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -1095,54 +1095,31 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `mergeItemsBlobData merges multiple items' JSON objects and decodes into a single object`() = runTest {
-        every { diskCache.read() } returns persisted(
-            manifest = "m",
-            activeTopics = listOf("workflows"),
-            topics = mapOf(
-                "workflows" to ConfigTopic(
-                    mapOf(
-                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
-                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+    fun `mergeItemsBlobData nests each item's blob JSON under its item key and decodes into a single object`() =
+        runTest {
+            every { diskCache.read() } returns persisted(
+                manifest = "m",
+                activeTopics = listOf("workflows"),
+                topics = mapOf(
+                    "workflows" to ConfigTopic(
+                        mapOf(
+                            "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
+                            "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+                        ),
                     ),
                 ),
-            ),
-        )
-        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
-        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
-        // Each item contributes part of the object; merged they form the full MergedBlob.
-        every { blobStore.read(REF_VALID) } returns """{"a":"x"}""".toByteArray()
-        every { blobStore.read(REF_TAMPERED) } returns """{"b":"y"}""".toByteArray()
+            )
+            coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+            coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
+            // Merged into {"wf1": {"value":"x"}, "wf2": {"value":"y"}}, keyed by item key.
+            every { blobStore.read(REF_VALID) } returns """{"value":"x"}""".toByteArray()
+            every { blobStore.read(REF_TAMPERED) } returns """{"value":"y"}""".toByteArray()
 
-        val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
+            val result = readManager()
+                .mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
 
-        assertThat(result).isEqualTo(MergedBlob(a = "x", b = "y"))
-    }
-
-    @Test
-    fun `mergeItemsBlobData lets a later item override an earlier item on a key collision`() = runTest {
-        every { diskCache.read() } returns persisted(
-            manifest = "m",
-            activeTopics = listOf("workflows"),
-            topics = mapOf(
-                "workflows" to ConfigTopic(
-                    mapOf(
-                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
-                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
-                    ),
-                ),
-            ),
-        )
-        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
-        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
-        every { blobStore.read(REF_VALID) } returns """{"a":"first","b":"y"}""".toByteArray()
-        every { blobStore.read(REF_TAMPERED) } returns """{"a":"second"}""".toByteArray()
-
-        // wf2 comes after wf1, so its "a" wins.
-        val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
-
-        assertThat(result).isEqualTo(MergedBlob(a = "second", b = "y"))
-    }
+            assertThat(result).isEqualTo(MergedBlob(wf1 = Section("x"), wf2 = Section("y")))
+        }
 
     @Test
     fun `mergeItemsBlobData returns null when an item's blob cannot be fetched`() = runTest {
@@ -1160,7 +1137,7 @@ class RemoteConfigManagerTest {
         )
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
         coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns false
-        every { blobStore.read(REF_VALID) } returns """{"a":"x"}""".toByteArray()
+        every { blobStore.read(REF_VALID) } returns """{"value":"x"}""".toByteArray()
 
         // All-or-nothing: one unresolved item nulls out the whole call, even though wf1 resolved.
         val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
@@ -1185,7 +1162,7 @@ class RemoteConfigManagerTest {
             ),
         )
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
-        every { blobStore.read(REF_VALID) } returns """{"a":"x"}""".toByteArray()
+        every { blobStore.read(REF_VALID) } returns """{"value":"x"}""".toByteArray()
 
         val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
 
@@ -1208,7 +1185,7 @@ class RemoteConfigManagerTest {
         )
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
         coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns false
-        every { blobStore.read(REF_VALID) } returns """{"a":"x"}""".toByteArray()
+        every { blobStore.read(REF_VALID) } returns """{"value":"x"}""".toByteArray()
 
         assertWarnLog(
             "Could not resolve remote config blob(s) for 1 of 2 requested item(s) in " +
@@ -1255,8 +1232,8 @@ class RemoteConfigManagerTest {
         every { diskCache.write(any()) } answers { state = firstArg(); true }
         coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
         coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
-        every { blobStore.read(REF_VALID) } returns """{"a":"x"}""".toByteArray()
-        every { blobStore.read(REF_TAMPERED) } returns """{"b":"y"}""".toByteArray()
+        every { blobStore.read(REF_VALID) } returns """{"value":"x"}""".toByteArray()
+        every { blobStore.read(REF_TAMPERED) } returns """{"value":"y"}""".toByteArray()
         val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
 
         // Nothing cached and nothing in flight: the read fans out, but the concurrent per-item waits
@@ -1284,7 +1261,7 @@ class RemoteConfigManagerTest {
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         assertThat(read.isCompleted).isTrue()
-        assertThat(result).isEqualTo(MergedBlob(a = "x", b = "y"))
+        assertThat(result).isEqualTo(MergedBlob(wf1 = Section("x"), wf2 = Section("y")))
     }
 
     @Test
@@ -1492,9 +1469,13 @@ class RemoteConfigManagerTest {
     @Serializable
     private data class TestBlob(val id: String)
 
-    // A single object assembled from data spread across multiple items in a topic.
+    // A single object assembled from several items in a topic, keyed by item key: each item's blob JSON is
+    // nested under a field named after its item key.
     @Serializable
-    private data class MergedBlob(val a: String, val b: String)
+    private data class Section(val value: String)
+
+    @Serializable
+    private data class MergedBlob(val wf1: Section, val wf2: Section)
 
     private companion object {
         private const val TEST_APP_USER_ID = "test-app-user-id"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -1226,6 +1226,24 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `mergeItemsBlobData returns null for an empty key list once the endpoint is disabled`() = runTest {
+        every { diskCache.read() } returns null
+        val manager = readManager()
+        // A 4xx disables the endpoint for the session.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
+
+        // Without the disabled short-circuit an empty key list would build an empty object and decode to a
+        // non-null OptionalBlob (all fields optional); the kill-switch must take precedence and return null.
+        val result = manager.mergeItemsBlobData<OptionalBlob>(RemoteConfigTopic.Workflows, emptyList())
+
+        assertThat(result).isNull()
+    }
+
+    @Test
     fun `mergeItemsBlobData triggers a single shared sync for multiple uncached items then decodes`() = runTest {
         var state: PersistedRemoteConfigurationState? = null
         every { diskCache.read() } answers { state }
@@ -1476,6 +1494,11 @@ class RemoteConfigManagerTest {
 
     @Serializable
     private data class MergedBlob(val wf1: Section, val wf2: Section)
+
+    // All fields optional, so it decodes from an empty JSON object to a non-null instance — used to prove the
+    // disabled kill-switch short-circuits before an empty key list would build and decode an empty object.
+    @Serializable
+    private data class OptionalBlob(val a: String? = null)
 
     private companion object {
         private const val TEST_APP_USER_ID = "test-app-user-id"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.assertWarnLog
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
@@ -1091,6 +1092,198 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
 
         assertThat(manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isEqualTo(byteArrayOf(9))
+    }
+
+    @Test
+    fun `batch blobData resolves multiple blob-backed items keyed by item key`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(
+                    mapOf(
+                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
+                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+                    ),
+                ),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
+        every { blobStore.read(REF_VALID) } returns byteArrayOf(4, 2)
+        every { blobStore.read(REF_TAMPERED) } returns byteArrayOf(7)
+
+        val result = readManager().blobData(RemoteConfigTopic.Workflows, listOf("wf1", "wf2")) { it }
+
+        assertThat(result.keys).containsExactlyInAnyOrder("wf1", "wf2")
+        assertThat(result["wf1"]).isEqualTo(byteArrayOf(4, 2))
+        assertThat(result["wf2"]).isEqualTo(byteArrayOf(7))
+    }
+
+    @Test
+    fun `batch blobData keeps null entries for unresolvable items alongside resolved ones`() = runTest {
+        val metadata = buildJsonObject { put("offering_id", "offer_123") }
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(
+                    mapOf(
+                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
+                        // Fetch fails for this one.
+                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+                        // No blob ref: inline-only, no payload.
+                        "wf3" to RemoteConfiguration.ConfigItem(metadata = metadata),
+                    ),
+                ),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns false
+        every { blobStore.read(REF_VALID) } returns byteArrayOf(1)
+
+        val result = readManager().blobData(
+            RemoteConfigTopic.Workflows,
+            listOf("wf1", "wf2", "wf3"),
+        ) { it }
+
+        assertThat(result.keys).containsExactlyInAnyOrder("wf1", "wf2", "wf3")
+        assertThat(result["wf1"]).isEqualTo(byteArrayOf(1))
+        assertThat(result["wf2"]).isNull()
+        assertThat(result["wf3"]).isNull()
+    }
+
+    @Test
+    fun `batch blobData warns when one or more items cannot be resolved`() {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(
+                    mapOf(
+                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
+                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+                    ),
+                ),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns false
+        every { blobStore.read(REF_VALID) } returns byteArrayOf(1)
+
+        assertWarnLog(
+            "Could not resolve remote config blob(s) for 1 of 2 requested item(s) in " +
+                "topic 'workflows': [wf2].",
+        ) {
+            runTest {
+                readManager().blobData(RemoteConfigTopic.Workflows, listOf("wf1", "wf2")) { it }
+            }
+        }
+    }
+
+    @Test
+    fun `reified batch blobData deserializes each present blob`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("workflows"),
+            topics = mapOf(
+                "workflows" to ConfigTopic(
+                    mapOf(
+                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
+                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+                    ),
+                ),
+            ),
+        )
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
+        every { blobStore.read(REF_VALID) } returns """{"id":"wf-1"}""".toByteArray()
+        every { blobStore.read(REF_TAMPERED) } returns """{"id":"wf-2"}""".toByteArray()
+
+        val result = readManager().blobData<TestBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
+
+        assertThat(result).isEqualTo(mapOf("wf1" to TestBlob(id = "wf-1"), "wf2" to TestBlob(id = "wf-2")))
+    }
+
+    @Test
+    fun `batch blobData returns all-null entries once the endpoint is disabled without touching the network`() =
+        runTest {
+            every { diskCache.read() } returns persisted(
+                manifest = "m",
+                activeTopics = listOf("workflows"),
+                topics = mapOf(
+                    "workflows" to ConfigTopic(
+                        mapOf(
+                            "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
+                            "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
+                        ),
+                    ),
+                ),
+            )
+            val manager = readManager()
+            // A 4xx disables the endpoint for the session.
+            manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+            onError.invoke(
+                PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+                GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+            )
+
+            val result = manager.blobData(RemoteConfigTopic.Workflows, listOf("wf1", "wf2")) { it }
+
+            assertThat(result.keys).containsExactlyInAnyOrder("wf1", "wf2")
+            assertThat(result.values).containsOnlyNulls()
+            coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
+        }
+
+    @Test
+    fun `batch blobData returns an empty map for empty item keys without triggering a sync`() = runTest {
+        every { diskCache.read() } returns null
+
+        val result = readManager(appUserIDProvider = { TEST_APP_USER_ID })
+            .blobData(RemoteConfigTopic.Workflows, emptyList()) { it }
+
+        assertThat(result).isEmpty()
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `batch blobData triggers a single shared sync for multiple uncached items`() = runTest {
+        var state: PersistedRemoteConfigurationState? = null
+        every { diskCache.read() } answers { state }
+        every { diskCache.write(any()) } answers { state = firstArg(); true }
+        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
+        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns true
+        every { blobStore.read(REF_VALID) } returns byteArrayOf(4, 2)
+        every { blobStore.read(REF_TAMPERED) } returns byteArrayOf(7)
+        val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
+
+        // Nothing cached and nothing in flight: the batch read fans out, but the concurrent per-key waits
+        // collapse onto a single shared on-demand sync.
+        var result: Map<String, ByteArray?> = emptyMap()
+        val read = launch(UnconfinedTestDispatcher(testScheduler)) {
+            result = manager.blobData(RemoteConfigTopic.Workflows, listOf("wf1", "wf2")) { it }
+        }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        assertThat(read.isActive).isTrue()
+
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.workflows:etag",
+              "active_topics": ["workflows"],
+              "topics": {
+                "workflows": {
+                  "wf1": { "blob_ref": "$REF_VALID" },
+                  "wf2": { "blob_ref": "$REF_TAMPERED" }
+                }
+              }
+            }
+        """.trimIndent()
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        assertThat(read.isCompleted).isTrue()
+        assertThat(result["wf1"]).isEqualTo(byteArrayOf(4, 2))
+        assertThat(result["wf2"]).isEqualTo(byteArrayOf(7))
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -18,7 +18,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import kotlin.concurrent.thread
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -26,10 +25,10 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -43,6 +42,7 @@ import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
 
 @OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -1120,30 +1120,6 @@ class RemoteConfigManagerTest {
 
             assertThat(result).isEqualTo(MergedBlob(wf1 = Section("x"), wf2 = Section("y")))
         }
-
-    @Test
-    fun `mergeItemsBlobData returns null when an item's blob cannot be fetched`() = runTest {
-        every { diskCache.read() } returns persisted(
-            manifest = "m",
-            activeTopics = listOf("workflows"),
-            topics = mapOf(
-                "workflows" to ConfigTopic(
-                    mapOf(
-                        "wf1" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID),
-                        "wf2" to RemoteConfiguration.ConfigItem(blobRef = REF_TAMPERED),
-                    ),
-                ),
-            ),
-        )
-        coEvery { blobFetcher.ensureDownloaded(REF_VALID) } returns true
-        coEvery { blobFetcher.ensureDownloaded(REF_TAMPERED) } returns false
-        every { blobStore.read(REF_VALID) } returns """{"value":"x"}""".toByteArray()
-
-        // All-or-nothing: one unresolved item nulls out the whole call, even though wf1 resolved.
-        val result = readManager().mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
-
-        assertThat(result).isNull()
-    }
 
     @Test
     fun `mergeItemsBlobData returns null for an item without a blob ref`() = runTest {


### PR DESCRIPTION
## Why

Sometimes a single logical object in a remote-config topic needs data spread across multiple items. Previously a consumer would have to fetch each item's blob one by one. This adds `mergeItemsBlobData`, which fetches the requested items' blobs in parallel, merges them into one JSON object, and decodes it into a single `T`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-side API on remote config that reuses existing blob resolution and sync behavior; no changes to persist/sync commit paths.
> 
> **Overview**
> Adds **`mergeItemsBlobData`** on `RemoteConfigManager` so callers can load several topic items in one shot instead of repeated **`blobData`** calls.
> 
> The API resolves each requested item’s blob **in parallel** (same rules as **`blobData`**: on-demand sync, blob fetch deduping), nests each blob’s JSON under its **item key** (e.g. `{"wf1":{...},"wf2":{...}}`), then decodes into a single `@Serializable` type—or returns **`null`** with logging when anything is missing, non-JSON, or fails deserialization (**all-or-nothing**). Empty key lists and the existing 4xx **disabled** kill-switch also yield **`null`** without I/O.
> 
> Tests cover the happy path, failure modes, disabled endpoint behavior, and a single shared on-demand `/v1/config` sync when multiple uncached items are merged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ee12925e519e814f68a30b8bb69144c0f4d928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->