### PR TITLE
Drop `ENABLE_REMOTE_CONFIG`, and gate the config layer on useWorkflows

### DIFF
--- a/local.properties.example
+++ b/local.properties.example
@@ -74,11 +74,3 @@
 ## Debug flags
 ## ──────────────────────────────────────────────
 #ENABLE_EXTRA_REQUEST_LOGGING=true
-
-## ──────────────────────────────────────────────
-## Enable Remote Config (test-only)
-## When true, the SDK instantiates the /v1/config manager and refreshes it on app
-## foreground (staleness-gated). The response is not consumed yet; this only exercises
-## the request/parse/persist path from test apps ahead of the production wiring.
-## ──────────────────────────────────────────────
-#ENABLE_REMOTE_CONFIG=true

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -50,12 +50,6 @@ android {
             value = (localProperties["ENABLE_EXTRA_REQUEST_LOGGING"] as? String ?: "false"),
         )
 
-        buildConfigField(
-            type = "boolean",
-            name = "ENABLE_REMOTE_CONFIG",
-            value = (localProperties["ENABLE_REMOTE_CONFIG"] as? String ?: "false"),
-        )
-
         packagingOptions.resources.excludes.addAll(
             listOf("META-INF/LICENSE.md", "META-INF/LICENSE-notice.md"),
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.UserManagerCompat
-import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
@@ -269,11 +268,9 @@ internal class PurchasesFactory(
             val workflowsCache = if (appConfig.useWorkflows) WorkflowsCache(deviceCache = cache) else null
 
             // useWorkflows implies the config layer: workflows are served from `/v1/config`, so the manager
-            // must exist whenever workflows are on, not only when the standalone flag is set. Neither flag
-            // applies to the customEntitlementComputation flavor, which doesn't serve paywalls this way.
-            val remoteConfigManager = if (
-                (BuildConfig.ENABLE_REMOTE_CONFIG || appConfig.useWorkflows) && !appConfig.customEntitlementComputation
-            ) {
+            // must exist whenever workflows are on. Not applicable to the customEntitlementComputation flavor,
+            // which doesn't serve paywalls this way.
+            val remoteConfigManager = if (appConfig.useWorkflows && !appConfig.customEntitlementComputation) {
                 RemoteConfigManager(
                     backend = backend,
                     diskCache = RemoteConfigDiskCache(contextForStorage),


### PR DESCRIPTION
Workflows are the only consumer of `/v1/config` right now, and turning them on already implies needing the config layer, so there's no reason to keep a separate `ENABLE_REMOTE_CONFIG` build flag in sync by hand.

Drops the flag (`buildConfigField` + `local.properties.example` entry) and gates `RemoteConfigManager` on `useWorkflows` alone. Still off in the `customEntitlementComputation` flavor, same as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small wiring change with no auth or payment logic; the only behavioral shift is dropping the unused standalone remote-config flag when workflows are off.
> 
> **Overview**
> Removes the standalone **`ENABLE_REMOTE_CONFIG`** debug/build path so the `/v1/config` stack is no longer toggled separately from workflows.
> 
> **`RemoteConfigManager`** is now created only when **`appConfig.useWorkflows`** is on (still skipped for **`customEntitlementComputation`**). The **`BuildConfig.ENABLE_REMOTE_CONFIG`** field, **`local.properties.example`** entry, and related **`PurchasesFactory`** import are deleted.
> 
> Apps that previously turned on remote config via the build flag without **`useWorkflows`** will no longer instantiate the config layer; that path was test-only and workflows are the sole consumer today.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 245ca3908223258a1d7bb096a04cbd691040c3aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->