### PR TITLE
feat(paywalls): align web_view with the cross-platform contract (PWENG-98)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
@@ -27,13 +27,17 @@ public abstract class PaywallWebViewValue internal constructor() {
 
     /**
      * A numeric value (integer or decimal). Stored as a [Double].
+     *
+     * Non-finite values (`NaN`, infinities) cannot be represented in JSON and serialize as JSON
+     * `null` when sent into the web view. Equality follows [Double.equals] semantics (consistent
+     * with [hashCode]): `NaN` equals `NaN`, and `-0.0` does not equal `0.0`.
      */
     public class Number(public val value: kotlin.Double) : PaywallWebViewValue() {
         public constructor(value: kotlin.Int) : this(value.toDouble())
         public constructor(value: kotlin.Long) : this(value.toDouble())
         public constructor(value: kotlin.Float) : this(value.toDouble())
 
-        override fun equals(other: Any?): kotlin.Boolean = other is Number && value == other.value
+        override fun equals(other: Any?): kotlin.Boolean = other is Number && value.equals(other.value)
         override fun hashCode(): Int = value.hashCode()
         override fun toString(): kotlin.String = "PaywallWebViewValue.Number(value=$value)"
     }
@@ -115,12 +119,17 @@ public abstract class PaywallWebViewValue internal constructor() {
 /**
  * Converts this value into a representation accepted by [JSONObject]/[JSONArray] when serializing a
  * message to send into the web view. Whole numbers are emitted as integers (e.g. `100`, not `100.0`).
+ * Non-finite numbers serialize as JSON `null`: JSON cannot represent them, `org.json`'s `put` throws
+ * for them, and one bad number must never destroy an otherwise-valid outbound message.
  */
 internal fun PaywallWebViewValue.toJsonRepresentation(): Any = when (this) {
     is PaywallWebViewValue.String -> value
     is PaywallWebViewValue.Boolean -> value
-    is PaywallWebViewValue.Number ->
-        if (value % 1.0 == 0.0 && !value.isInfinite()) value.toLong() else value
+    is PaywallWebViewValue.Number -> when {
+        !value.isFinite() -> JSONObject.NULL
+        value % 1.0 == 0.0 -> value.toLong()
+        else -> value
+    }
     is PaywallWebViewValue.Object -> JSONObject().apply {
         value.forEach { (key, child) -> put(key, child.toJsonRepresentation()) }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -17,8 +17,11 @@ internal data class WebViewComponentStyle(
      */
     val componentId: String? = null,
     /**
-     * The schema-declared `protocol_version`. The backend always sends this field (required, strictly 1).
-     * When absent in legacy configs it is treated as 1. Content-Security-Policy is always applied.
+     * The schema-declared `protocol_version`, decoded and preserved for future use. NOT the host's
+     * capability: the bridge always advertises [WebViewEnvelope.DEFAULT_PROTOCOL_VERSION][
+     * com.revenuecat.purchases.ui.revenuecatui.components.webview.WebViewEnvelope.DEFAULT_PROTOCOL_VERSION]
+     * (the single version this SDK build implements) during the handshake, regardless of this value.
+     * Content-Security-Policy is always applied.
      */
     val protocolVersion: Int? = null,
     val fallbackStackComponentStyle: StackComponentStyle? = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -88,7 +88,6 @@ internal fun WebViewComponentView(
                             expectedUrl = resolvedUrl,
                             locale = locale,
                             messageHandler = messageHandler,
-                            protocolVersion = style.protocolVersion ?: WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
                             sizeToContentWidth = sizeToContentWidth,
                             sizeToContentHeight = sizeToContentHeight,
                             onContentResize = { widthCssPx, heightCssPx ->
@@ -99,6 +98,7 @@ internal fun WebViewComponentView(
                     }
                     bridgeHolder.bridge = bridge
                     configure(
+                        expectedOrigin = resolvedUrl.toOriginOrNull(),
                         onMainFrameLoadFailed = { loadFailed = true },
                     )
                     loadUrl(resolvedUrl)
@@ -122,18 +122,27 @@ internal fun WebViewComponentView(
     }
 }
 
-private fun webViewEffectiveSize(
+/**
+ * Placeholder sizes for a `fit` axis until the content reports its size over the bridge — a
+ * WebView has no meaningful intrinsic size, so `fit` would otherwise collapse. 100 (height)
+ * matches the iOS implementation; 300 (width) matches the web implementation's
+ * `FIT_FALLBACK_SIZE_PX`.
+ */
+internal const val FIT_PLACEHOLDER_HEIGHT: UInt = 100u
+internal const val FIT_PLACEHOLDER_WIDTH: UInt = 300u
+
+internal fun webViewEffectiveSize(
     declaredSize: Size,
     contentWidthCssPx: Int,
     contentHeightCssPx: Int,
 ): Size {
-    val width = when (val declaredWidth = declaredSize.width) {
-        is Fit -> if (contentWidthCssPx > 0) Fixed(contentWidthCssPx.toUInt()) else declaredWidth
-        else -> declaredWidth
+    val width = when (declaredSize.width) {
+        is Fit -> Fixed(if (contentWidthCssPx > 0) contentWidthCssPx.toUInt() else FIT_PLACEHOLDER_WIDTH)
+        else -> declaredSize.width
     }
-    val height = when (val declaredHeight = declaredSize.height) {
-        is Fit -> if (contentHeightCssPx > 0) Fixed(contentHeightCssPx.toUInt()) else declaredHeight
-        else -> declaredHeight
+    val height = when (declaredSize.height) {
+        is Fit -> Fixed(if (contentHeightCssPx > 0) contentHeightCssPx.toUInt() else FIT_PLACEHOLDER_HEIGHT)
+        else -> declaredSize.height
     }
     return Size(width = width, height = height)
 }
@@ -144,6 +153,7 @@ private class WebViewBridgeHolder {
 }
 
 private fun WebView.configure(
+    expectedOrigin: String?,
     onMainFrameLoadFailed: () -> Unit,
 ) {
     setBackgroundColor(Color.TRANSPARENT)
@@ -170,7 +180,11 @@ private fun WebView.configure(
         }
 
         override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-            return request.url.scheme != HTTPS_SCHEME
+            return shouldBlockWebViewNavigation(
+                url = request.url?.toString(),
+                isMainFrame = request.isForMainFrame,
+                expectedOrigin = expectedOrigin,
+            )
         }
 
         override fun onReceivedError(
@@ -195,5 +209,4 @@ private fun WebView.configure(
     }
 }
 
-private const val HTTPS_SCHEME = "https"
 private const val HTTP_ERROR_STATUS_MIN = 400

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -46,8 +46,22 @@ internal object WebViewEnvelope {
         val error: String?,
     )
 
+    /**
+     * Coarse structural depth budget for a whole inbound frame: the envelope object itself plus a
+     * payload tree of at most [WebViewMessageParser.MAX_NESTING_DEPTH] levels. The precise per-tree
+     * limit is still enforced during [PaywallWebViewValue][
+     * com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue] conversion; this scan exists only
+     * to stop hostile input before recursion happens.
+     */
+    private val MAX_FRAME_DEPTH: Int = WebViewMessageParser.MAX_NESTING_DEPTH + 1
+
     @Suppress("ReturnCount", "CyclomaticComplexMethod")
     fun parse(rawJson: String): Parsed? {
+        // Enforce the nesting budget BEFORE org.json parses: JSONTokener recurses per nesting
+        // level, and tens of thousands of levels fit inside the 64 KiB frame limit, so a hostile
+        // deeply-nested frame could otherwise overflow the stack before any post-parse check runs.
+        if (exceedsMaxDepth(rawJson)) return null
+
         val json = try {
             JSONObject(rawJson)
         } catch (@Suppress("SwallowedException") _: org.json.JSONException) {
@@ -88,6 +102,40 @@ internal object WebViewEnvelope {
             payload = payload,
             error = error,
         )
+    }
+
+    /**
+     * Non-recursive scan of the raw JSON characters, tracking `{`/`[` nesting outside string
+     * literals (honoring `\` escapes). Returns `true` when the depth exceeds [MAX_FRAME_DEPTH].
+     */
+    @Suppress("LoopWithTooManyJumpStatements")
+    fun exceedsMaxDepth(rawJson: String): Boolean {
+        var depth = 0
+        var inString = false
+        var escaped = false
+
+        for (char in rawJson) {
+            if (inString) {
+                when {
+                    escaped -> escaped = false
+                    char == '\\' -> escaped = true
+                    char == '"' -> inString = false
+                }
+                continue
+            }
+
+            when (char) {
+                '"' -> inString = true
+                '{', '[' -> {
+                    depth += 1
+                    if (depth > MAX_FRAME_DEPTH) return true
+                }
+                '}', ']' -> depth -= 1
+                else -> Unit
+            }
+        }
+
+        return false
     }
 
     @Suppress("LongParameterList")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -49,7 +49,6 @@ internal class WebViewJavaScriptBridge(
     expectedUrl: String,
     locale: String,
     messageHandler: PaywallWebViewMessageHandler?,
-    protocolVersion: Int = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
     private val sizeToContentWidth: Boolean = false,
     private val sizeToContentHeight: Boolean = false,
     private val onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
@@ -58,7 +57,12 @@ internal class WebViewJavaScriptBridge(
 
     private val webViewRef = WeakReference(webView)
     private val expectedOrigin: String? = expectedUrl.toOriginOrNull()
-    private val protocolVersion: Int = protocolVersion
+
+    // The single protocol version this SDK build implements. Deliberately NOT the schema's
+    // `protocol_version`: the envelope version is the wire+SDK major the CONTENT speaks, and the
+    // host must never accept a handshake for a version it cannot service, even if a future schema
+    // declares one.
+    private val protocolVersion: Int = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION
 
     // Refreshed from the latest paywall state on every recomposition via update().
     @Volatile private var locale: String = locale
@@ -68,6 +72,10 @@ internal class WebViewJavaScriptBridge(
     @Volatile private var released: Boolean = false
 
     @Volatile private var channelOpen: Boolean = false
+
+    // Last content sizes applied per fit axis (main thread only), for the resize apply-threshold.
+    private var lastAppliedWidthCssPx: Int? = null
+    private var lastAppliedHeightCssPx: Int? = null
 
     /**
      * Registers the native interface on the WebView. Call once, when the WebView is created.
@@ -152,7 +160,7 @@ internal class WebViewJavaScriptBridge(
                     )
                     return
                 }
-                handleAppFrame(json)
+                handleAppFrame(envelope)
             }
             else -> Unit
         }
@@ -205,17 +213,24 @@ internal class WebViewJavaScriptBridge(
 
     @MainThread
     @Suppress("ReturnCount")
-    private fun handleAppFrame(rawJson: String) {
+    private fun handleAppFrame(envelope: WebViewEnvelope.Parsed) {
         if (!channelOpen) return
 
-        val transport = WebViewEnvelope.parse(rawJson) ?: return
-        if (transport.kind == WebViewEnvelope.KIND_MESSAGE && transport.type == WebViewMessageType.RESIZE) {
-            handleResize(transport)
+        // Any transport `request` without a correlation `id` is undeliverable — drop it before
+        // any handling, matching iOS and the web host.
+        if (envelope.kind == WebViewEnvelope.KIND_REQUEST && envelope.id == null) {
+            Logger.w("Dropping inbound web view message: transport request is missing 'id'.")
+            return
+        }
+
+        // `resize` is SDK-internal regardless of kind; it never reaches the app handler.
+        if (envelope.type == WebViewMessageType.RESIZE) {
+            handleResize(envelope)
             return
         }
 
         val parsed = WebViewMessageParser.parse(
-            rawJson = rawJson,
+            envelope = envelope,
             expectedComponentId = componentId,
         ) ?: return
 
@@ -247,9 +262,34 @@ internal class WebViewJavaScriptBridge(
     private fun handleResize(envelope: WebViewEnvelope.Parsed) {
         if (envelope.componentId != componentId) return
         val payload = envelope.payload ?: return
-        val width = payload.optInt("width").takeIf { payload.has("width") }
-        val height = payload.optInt("height").takeIf { payload.has("height") }
-        onContentResize(width, height)
+
+        val width = applyResize(
+            reported = payload.resizeDimension("width").takeIf { sizeToContentWidth },
+            lastApplied = lastAppliedWidthCssPx,
+        )?.also { lastAppliedWidthCssPx = it }
+        val height = applyResize(
+            reported = payload.resizeDimension("height").takeIf { sizeToContentHeight },
+            lastApplied = lastAppliedHeightCssPx,
+        )?.also { lastAppliedHeightCssPx = it }
+
+        if (width != null || height != null) {
+            onContentResize(width, height)
+        }
+    }
+
+    /**
+     * Returns the value to apply for one axis, or `null` when there is nothing new to apply:
+     * missing/invalid report, non-fit axis, or a change smaller than [RESIZE_APPLY_THRESHOLD_CSS_PX]
+     * against the last applied value (guards report/apply feedback loops — HTML content's reported
+     * width often just echoes the imposed viewport width).
+     */
+    @Suppress("ReturnCount")
+    private fun applyResize(reported: Int?, lastApplied: Int?): Int? {
+        if (reported == null) return null
+        if (lastApplied != null && kotlin.math.abs(reported - lastApplied) < RESIZE_APPLY_THRESHOLD_CSS_PX) {
+            return null
+        }
+        return reported
     }
 
     override fun postVariables(componentId: String, variables: Map<String, PaywallWebViewValue>) {
@@ -344,6 +384,21 @@ internal class WebViewJavaScriptBridge(
             WebViewEnvelope.KIND_REJECT,
         )
 
+        /** Cap a content-reported dimension so a buggy/hostile bundle can't blow up layout. */
+        private const val MAX_RESIZE_CSS_PX = 10_000.0
+
+        /** Minimum per-axis change (CSS px) before a new report is applied. */
+        private const val RESIZE_APPLY_THRESHOLD_CSS_PX = 1
+
+        /** A validated, clamped resize dimension, or `null` when absent, non-finite, or not positive. */
+        @Suppress("ReturnCount")
+        fun JSONObject.resizeDimension(key: String): Int? {
+            if (!has(key)) return null
+            val value = optDouble(key)
+            if (!value.isFinite() || value <= 0) return null
+            return value.coerceAtMost(MAX_RESIZE_CSS_PX).toInt()
+        }
+
         /**
          * JSON is a subset of JS object-literal syntax, but the U+2028/U+2029 separators are valid in
          * JSON strings yet terminate JS statements. Escape them so the payload is safe to embed.
@@ -375,4 +430,24 @@ internal fun String.toOriginOrNull(): String? {
         else -> ":$effectivePort"
     }
     return "$scheme://$host$portSuffix"
+}
+
+/**
+ * Navigation policy for `web_view` content, applied from `shouldOverrideUrlLoading`:
+ *
+ * - Any non-HTTPS navigation is blocked (any frame).
+ * - Main-frame navigation is additionally restricted to the resolved component URL's origin
+ *   (same-origin different-path navigation stays allowed). This makes cross-origin message races
+ *   structurally impossible; the bridge's per-message origin check remains as defense in depth.
+ * - Cross-origin sub-frame loads are left to the Content-Security-Policy.
+ */
+@Suppress("ReturnCount")
+internal fun shouldBlockWebViewNavigation(
+    url: String?,
+    isMainFrame: Boolean,
+    expectedOrigin: String?,
+): Boolean {
+    val origin = url?.toOriginOrNull() ?: return true
+    if (!origin.startsWith("https://")) return true
+    return isMainFrame && origin != expectedOrigin
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParser.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParser.kt
@@ -42,6 +42,14 @@ internal object WebViewMessageParser {
             return null
         }
 
+        return parse(envelope, expectedComponentId)
+    }
+
+    /**
+     * Parses an already-validated transport envelope (size/structure checks done by the caller)
+     * into a typed app message. Avoids re-parsing the raw JSON a second time.
+     */
+    fun parse(envelope: WebViewEnvelope.Parsed, expectedComponentId: String): ParsedAppMessage? {
         return when (envelope.kind) {
             WebViewEnvelope.KIND_MESSAGE,
             WebViewEnvelope.KIND_REQUEST,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValueTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValueTest.kt
@@ -49,12 +49,40 @@ internal class PaywallWebViewValueTest {
     }
 
     @Test
-    fun `toJsonRepresentation keeps non-finite numbers as doubles`() {
-        // Infinity/NaN are not whole numbers, so they must not be collapsed to Long.
+    fun `toJsonRepresentation serializes non-finite numbers as JSON null`() {
+        // JSON cannot represent NaN/infinity and org.json's put() throws for them; one bad number
+        // must never destroy an otherwise-valid outbound message.
         assertThat(PaywallWebViewValue.Number(Double.POSITIVE_INFINITY).toJsonRepresentation())
-            .isEqualTo(Double.POSITIVE_INFINITY)
+            .isEqualTo(JSONObject.NULL)
+        assertThat(PaywallWebViewValue.Number(Double.NEGATIVE_INFINITY).toJsonRepresentation())
+            .isEqualTo(JSONObject.NULL)
         assertThat(PaywallWebViewValue.Number(Double.NaN).toJsonRepresentation())
-            .isEqualTo(Double.NaN)
+            .isEqualTo(JSONObject.NULL)
+    }
+
+    @Test
+    fun `a map containing non-finite numbers serializes without throwing`() {
+        val json = mapOf(
+            "bad" to PaywallWebViewValue.Number(Double.NaN),
+            "good" to PaywallWebViewValue.String("kept"),
+        ).toJsonObject()
+
+        assertThat(json.isNull("bad")).isTrue()
+        assertThat(json.getString("good")).isEqualTo("kept")
+    }
+
+    @Test
+    fun `number equality and hashCode are mutually consistent for edge values`() {
+        // Double.equals semantics: NaN equals NaN; -0.0 does not equal 0.0. Both agree with hashCode.
+        val nan1 = PaywallWebViewValue.Number(Double.NaN)
+        val nan2 = PaywallWebViewValue.Number(Double.NaN)
+        assertThat(nan1).isEqualTo(nan2)
+        assertThat(nan1.hashCode()).isEqualTo(nan2.hashCode())
+
+        val negativeZero = PaywallWebViewValue.Number(-0.0)
+        val positiveZero = PaywallWebViewValue.Number(0.0)
+        assertThat(negativeZero).isNotEqualTo(positiveZero)
+        assertThat(negativeZero.hashCode()).isNotEqualTo(positiveZero.hashCode())
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
@@ -1,0 +1,47 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class WebViewEffectiveSizeTest {
+
+    @Test
+    fun `fit axes use placeholders until the content reports a size`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fit, height = Fit),
+            contentWidthCssPx = 0,
+            contentHeightCssPx = 0,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(FIT_PLACEHOLDER_WIDTH))
+        assertThat(size.height).isEqualTo(Fixed(FIT_PLACEHOLDER_HEIGHT))
+    }
+
+    @Test
+    fun `fit axes use the reported content size once available`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fit, height = Fit),
+            contentWidthCssPx = 320,
+            contentHeightCssPx = 480,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(320u))
+        assertThat(size.height).isEqualTo(Fixed(480u))
+    }
+
+    @Test
+    fun `non-fit axes ignore reported content sizes`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fill, height = Fixed(200u)),
+            contentWidthCssPx = 320,
+            contentHeightCssPx = 480,
+        )
+
+        assertThat(size.width).isEqualTo(Fill)
+        assertThat(size.height).isEqualTo(Fixed(200u))
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -492,6 +492,8 @@ internal class WebViewJavaScriptBridgeTest {
         var reportedHeight: Int? = null
         val bridge = bridge(
             handler = null,
+            sizeToContentWidth = true,
+            sizeToContentHeight = true,
             onContentResize = { widthCssPx, heightCssPx ->
                 reportedWidth = widthCssPx
                 reportedHeight = heightCssPx
@@ -508,6 +510,124 @@ internal class WebViewJavaScriptBridgeTest {
 
         assertThat(reportedWidth).isEqualTo(320)
         assertThat(reportedHeight).isEqualTo(480)
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `resize ignores non-fit axes`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = false,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":400,"height":500}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(null to 500)
+    }
+
+    @Test
+    fun `resize clamps oversized values and drops invalid values per axis`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = true,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        connect(bridge)
+        // Invalid width (negative) with a valid, oversized height: height still applies, clamped.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":-1,"height":99999}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(null to 10_000)
+    }
+
+    @Test
+    fun `resize applies a per-axis change threshold`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = true,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":200,"height":300}"""),
+        )
+        // Same values re-reported: below the 1px threshold on both axes, no callback at all.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":200,"height":300}"""),
+        )
+        // One axis changes: only that axis is delivered.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":200,"height":301}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(200 to 300, null to 301)
+    }
+
+    @Test
+    fun `handles resize sent as a transport request without forwarding to the app handler`() {
+        var reportedHeight: Int? = null
+        val bridge = bridge(
+            sizeToContentHeight = true,
+            onContentResize = { _, heightCssPx -> reportedHeight = heightCssPx },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.RESIZE,
+                payload = """{"height":250}""",
+                kind = WebViewEnvelope.KIND_REQUEST,
+                id = "resize-1",
+            ),
+        )
+        idleMainLooper()
+
+        assertThat(reportedHeight).isEqualTo(250)
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `drops any transport request without an id`() {
+        val bridge = bridge()
+        connect(bridge)
+
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.STEP_LOADED, kind = WebViewEnvelope.KIND_REQUEST),
+        )
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.REQUEST_VARIABLES, kind = WebViewEnvelope.KIND_REQUEST),
+        )
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+        // No auto-reply was sent for the id-less variables request.
+        assertThat(shadowWebView.lastEvaluatedJavascript).doesNotContain("rc:variables")
+    }
+
+    @Test
+    fun `rejects hostile deeply nested frames without crashing`() {
+        val bridge = bridge()
+        connect(bridge)
+
+        val depth = 30_000
+        val nested = "[".repeat(depth) + "]".repeat(depth)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.STEP_COMPLETE, payload = """{"responses":{"deep":$nested}}"""),
+        )
+        idleMainLooper()
+
         assertThat(received).isEmpty()
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParserTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParserTest.kt
@@ -247,6 +247,38 @@ internal class WebViewMessageParserTest {
     }
 
     @Test
+    fun `accepts frame depth 17 before recursive parsing`() {
+        val depth = WebViewMessageParser.MAX_NESTING_DEPTH + 1
+
+        assertThat(WebViewEnvelope.exceedsMaxDepth(nestedArray(depth))).isFalse()
+    }
+
+    @Test
+    fun `rejects frame depth 18 before recursive parsing`() {
+        val depth = WebViewMessageParser.MAX_NESTING_DEPTH + 2
+
+        assertThat(WebViewEnvelope.exceedsMaxDepth(nestedArray(depth))).isTrue()
+    }
+
+    @Test
+    fun `rejects a hostile deeply nested frame before recursive parsing`() {
+        // ~30k nesting levels fit inside the 64 KiB frame limit; the pre-parse structural scan
+        // must reject this before org.json's recursive tokenizer ever runs (stack-overflow guard).
+        val depth = 30_000
+        val nested = "[".repeat(depth) + "]".repeat(depth)
+
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"deep":$nested}}""",
+            ),
+        )
+
+        assertThat(parsed).isNull()
+    }
+
+    @Test
     fun `ignores handshake frames`() {
         assertThat(
             parse(
@@ -258,6 +290,8 @@ internal class WebViewMessageParserTest {
     }
 
     private fun parse(raw: String) = WebViewMessageParser.parse(raw, expectedComponentId = componentId)
+
+    private fun nestedArray(depth: Int): String = "[".repeat(depth) + "0" + "]".repeat(depth)
 
     private fun envelope(
         kind: String,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewNavigationPolicyTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewNavigationPolicyTest.kt
@@ -1,0 +1,70 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+// Robolectric is required because the navigation-policy helper parses origins via android.net.Uri.
+@RunWith(RobolectricTestRunner::class)
+class WebViewNavigationPolicyTest {
+
+    @Test
+    fun `allows same-origin main-frame navigation on a different path`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://assets.example.com/promo/step-two.html",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `blocks cross-origin main-frame navigation even over https`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://evil.example.org/phish.html",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `blocks non-https navigation in any frame`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "http://assets.example.com/promo/index.html",
+                isMainFrame = false,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "custom://assets.example.com/",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `allows cross-origin https sub-frame loads`() {
+        // Sub-frame content is governed by the Content-Security-Policy, not the navigation policy.
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://other.example.com/frame.html",
+                isMainFrame = false,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `blocks unparseable main-frame navigation targets`() {
+        assertThat(
+            shouldBlockWebViewNavigation(url = null, isMainFrame = true, expectedOrigin = "https://a.example"),
+        ).isTrue()
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the Paywalls V2 `web_view` implementation with the agreed cross-platform wire and layout contract. This PR is intentionally one contract-alignment commit on top of `alexrepty/paywalls-web-view-messaging`.

### Retained contract alignment

- Uses host protocol version `1` as an SDK capability, independently of the schema's `protocol_version`.
- Scans raw JSON structure before `JSONObject` parsing and enforces the iOS-aligned whole-frame nesting budget of 17 levels, preventing recursive parser exhaustion.
- Hardens resize handling with per-axis fit gating, a 10,000 CSS px clamp, a 1 px apply threshold, kind-agnostic `resize` interception, and early rejection of request frames without IDs.
- Uses fit placeholders of 100 px height and 300 px width until the first content resize report.
- Serializes non-finite `PaywallWebViewValue.Number` values as JSON `null` and aligns `equals`/`hashCode` with `Double` semantics.
- Blocks cross-origin main-frame navigation while retaining Android's intentionally stricter HTTPS requirement for every frame.
- Reuses the already parsed transport envelope instead of parsing app frames twice.
- Adds targeted Detekt suppressions for guard-style validation code and corrects tests for the authorized 17-level frame budget.

### Coverage

Unit coverage exercises protocol negotiation, structural-depth rejection, resize limits and thresholds, fit placeholders, navigation policy, non-finite serialization, and equality/hash behavior.

Counterpart iOS implementation: RevenueCat/purchases-ios branch `cursor/web-view-rebuild-plan-6dd6` (`WebViewSession.swift`, `WebViewEnvelope.swift`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87e2cece-102f-444d-82f1-ea99ab683e00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87e2cece-102f-444d-82f1-ea99ab683e00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>