### PR TITLE
fix(paywalls): don't let image backgrounds affect layout size

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Background.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Background.kt
@@ -57,9 +57,7 @@ internal fun Modifier.background(
                 .drawImageBehind(
                     painter = background.painter,
                     contentScale = background.contentScale,
-                    // Center the image so that when it's scaled to cover (Crop/fill) and overflows the
-                    // container, it's cropped equally on all sides and the middle stays visible.
-                    alignment = Alignment.Center,
+                    alignment = Alignment.TopCenter,
                 )
         is BackgroundStyle.Video ->
             // Video backgrounds are handled specially - they need to be rendered
@@ -69,7 +67,7 @@ internal fun Modifier.background(
 
 /**
  * Draws [painter] behind the content, scaled by [contentScale] and positioned by [alignment] within
- * the node's already-measured bounds, then draws the content on top. Unlike [Modifier.paint] this is
+ * the node's already-measured bounds, then draws the content on top. Unlike `Modifier.paint` this is
  * a pure draw modifier: it never contributes to layout, so the background can never resize the
  * element it decorates. The drawing logic mirrors `PainterModifier.draw`; clipping to the desired
  * shape is expected to be applied by the caller (see [background]).

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Background.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Background.kt
@@ -8,11 +8,19 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.paint
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.times
+import androidx.compose.ui.unit.IntSize
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
+import kotlin.math.roundToInt
 
 @JvmSynthetic
 @Stable
@@ -34,17 +42,74 @@ internal fun Modifier.background(
     when (background) {
         is BackgroundStyle.Color -> this.background(color = background.color, shape = shape)
         is BackgroundStyle.Image ->
-            // The image is applied here via paint(). Color overlays (if present) are rendered
-            // separately in WithOptionalBackgroundOverlay to ensure the overlay covers the full
-            // container, not just the image bounds. This matches the web builder behavior.
+            // The image is applied here as a draw-only background. Color overlays (if present) are
+            // rendered separately in WithOptionalBackgroundOverlay to ensure the overlay covers the
+            // full container, not just the image bounds. This matches the web builder behavior.
+            //
+            // We intentionally do NOT use Modifier.paint(): that modifier participates in layout and
+            // imposes a size on the container (it sizes to the painter's scaled intrinsic size, or,
+            // with sizeToIntrinsics = false and bounded constraints, expands to fill the max). A
+            // background must never change the size of the element it decorates, exactly like a color
+            // background. Otherwise a wrap-content (Fit) sticky footer with an image background would
+            // measure taller than its content, over-reserving scroll clearance and letting the main
+            // content scroll off-screen behind a transparent footer.
             this.clip(shape)
-                .paint(
+                .drawImageBehind(
                     painter = background.painter,
                     contentScale = background.contentScale,
-                    alignment = Alignment.TopCenter,
+                    // Center the image so that when it's scaled to cover (Crop/fill) and overflows the
+                    // container, it's cropped equally on all sides and the middle stays visible.
+                    alignment = Alignment.Center,
                 )
         is BackgroundStyle.Video ->
             // Video backgrounds are handled specially - they need to be rendered
             // in a Box behind the content, so we do nothing here
             this
+    }
+
+/**
+ * Draws [painter] behind the content, scaled by [contentScale] and positioned by [alignment] within
+ * the node's already-measured bounds, then draws the content on top. Unlike [Modifier.paint] this is
+ * a pure draw modifier: it never contributes to layout, so the background can never resize the
+ * element it decorates. The drawing logic mirrors `PainterModifier.draw`; clipping to the desired
+ * shape is expected to be applied by the caller (see [background]).
+ */
+private fun Modifier.drawImageBehind(
+    painter: Painter,
+    contentScale: ContentScale,
+    alignment: Alignment,
+): Modifier =
+    this.drawWithContent {
+        val intrinsicSize = painter.intrinsicSize
+        val srcWidth = if (intrinsicSize.isSpecified && intrinsicSize.width.isFinite()) {
+            intrinsicSize.width
+        } else {
+            size.width
+        }
+        val srcHeight = if (intrinsicSize.isSpecified && intrinsicSize.height.isFinite()) {
+            intrinsicSize.height
+        } else {
+            size.height
+        }
+        val srcSize = Size(srcWidth, srcHeight)
+
+        val scaledSize = if (size.width != 0f && size.height != 0f) {
+            srcSize * contentScale.computeScaleFactor(srcSize, size)
+        } else {
+            Size.Zero
+        }
+
+        val alignedPosition = alignment.align(
+            IntSize(scaledSize.width.roundToInt(), scaledSize.height.roundToInt()),
+            IntSize(size.width.roundToInt(), size.height.roundToInt()),
+            layoutDirection,
+        )
+
+        translate(alignedPosition.x.toFloat(), alignedPosition.y.toFloat()) {
+            with(painter) {
+                draw(size = scaledSize)
+            }
+        }
+
+        drawContent()
     }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/OverlappingFooterLayoutTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/OverlappingFooterLayoutTests.kt
@@ -1,0 +1,92 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression tests for the overlapping sticky-footer layout. The footer is drawn on top of the
+ * full-height scrollable content, which reserves bottom clearance equal to the footer's measured
+ * height ([Modifier.footerBottomPadding]) so the last content item can scroll clear of the footer.
+ *
+ * The root invariant guarded here: a background (image or color) must NOT change the size of the
+ * element it decorates. An image background applied via [Modifier.background] previously used
+ * `paint(sizeToIntrinsics = true)`, so the painter's intrinsic size (scaled by its contentScale
+ * against the incoming constraints) inflated the container. For a sticky footer that meant it
+ * measured taller than its content, over-reserving clearance and letting the main content scroll
+ * entirely off-screen behind a transparent footer.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class OverlappingFooterLayoutTests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /**
+     * A painter with a large intrinsic size, standing in for a loaded image background (e.g. the
+     * reported 512x512 footer image). If the intrinsic size leaks into layout, the decorated element
+     * grows far beyond its content.
+     */
+    private val largeIntrinsicPainter = object : Painter() {
+        override val intrinsicSize: Size = Size(512f, 512f)
+        override fun DrawScope.onDraw() = Unit
+    }
+
+    @Test
+    fun `image background does not affect measured size`(): Unit =
+        with(composeTestRule) {
+            setContent {
+                Row {
+                    // Baseline: a color background never affects size.
+                    Box(
+                        modifier = Modifier
+                            .testTag("color")
+                            .background(BackgroundStyle.Color(ColorStyle.Solid(Color.Green))),
+                    ) {
+                        Box(modifier = Modifier.size(width = 80.dp, height = 40.dp))
+                    }
+                    // An image background must behave identically: draw behind, never resize.
+                    Box(
+                        modifier = Modifier
+                            .testTag("image")
+                            .background(
+                                BackgroundStyle.Image(
+                                    painter = largeIntrinsicPainter,
+                                    contentScale = ContentScale.Crop,
+                                    colorOverlay = null,
+                                ),
+                            ),
+                    ) {
+                        Box(modifier = Modifier.size(width = 80.dp, height = 40.dp))
+                    }
+                }
+            }
+            waitForIdle()
+
+            val colorSize = onNodeWithTag("color").fetchSemanticsNode().size
+            val imageSize = onNodeWithTag("image").fetchSemanticsNode().size
+
+            // The image-backed box measures to its content, exactly like the color-backed box. Before
+            // the fix it ballooned toward the painter's (Crop-scaled) 512px intrinsic height.
+            assertThat(imageSize.height).isEqualTo(colorSize.height)
+            assertThat(imageSize.width).isEqualTo(colorSize.width)
+        }
+}


### PR DESCRIPTION
## Motivation

Right now, image backgrounds can potentially affect the sizing of components in a paywall which is counter-intuitive and doesn't follow the behavior we have in the dashboard. 

This changes that so the image is indeed only drawn as background, without affecting the size of the components.

Note, this does mean some existing paywalls may change their looks in android, though it should be much closer to the dashboard after this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Visual layout for existing paywalls with image backgrounds may shift on Android (closer to dashboard), though behavior is intentional; change is localized to Compose background drawing with a targeted test.
> 
> **Overview**
> Image paywall backgrounds are now **draw-only**: `BackgroundStyle.Image` no longer uses `Modifier.paint()` (which could inflate measured size from the painter’s intrinsic dimensions) and instead uses a new **`drawImageBehind`** helper built on `drawWithContent`, scaling and aligning the painter within the node’s existing bounds like color backgrounds.
> 
> This fixes overlapping sticky footers that previously measured too tall when a large image background was applied, over-reserving bottom scroll clearance and hiding main content behind the footer. **Color overlays** still render separately in `WithOptionalBackgroundOverlay` unchanged.
> 
> Adds **`OverlappingFooterLayoutTests`** to assert image-backed boxes match color-backed boxes when content is fixed size (512×512 intrinsic painter regression).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc4e92e8560b7917ce0f665e941d8cc3a7891e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->