### PR TITLE
Handle button sheet destination without an inline sheet

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
@@ -94,11 +94,11 @@ public class ButtonComponent(
         @Serializable
         @Immutable
         public data class Sheet(
-            @get:JvmSynthetic public val id: String,
-            @get:JvmSynthetic public val name: String?,
-            @get:JvmSynthetic public val stack: StackComponent,
-            @get:JvmSynthetic @SerialName("background_blur") public val backgroundBlur: Boolean,
-            @get:JvmSynthetic public val size: Size?,
+            @get:JvmSynthetic public val id: String = "",
+            @get:JvmSynthetic public val name: String? = null,
+            @get:JvmSynthetic public val stack: StackComponent? = null,
+            @get:JvmSynthetic @SerialName("background_blur") public val backgroundBlur: Boolean = false,
+            @get:JvmSynthetic public val size: Size? = null,
         ) : Destination
     }
 
@@ -256,10 +256,7 @@ private class ActionSurrogate(
                         )
                     }
 
-                    DestinationSurrogate.sheet -> {
-                        checkNotNull(sheet) { "`sheet` cannot be null when `destination` is `sheet`." }
-                        sheet
-                    }
+                    DestinationSurrogate.sheet -> sheet ?: Destination.Sheet()
 
                     DestinationSurrogate.unknown -> Destination.Unknown
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
@@ -229,40 +229,34 @@ private class ActionSurrogate(
             ActionTypeSurrogate.navigate_back -> Action.NavigateBack
             ActionTypeSurrogate.workflow -> Action.WorkflowTrigger
             ActionTypeSurrogate.close_workflow -> Action.CloseWorkflow
-            ActionTypeSurrogate.navigate_to -> Action.NavigateTo(
-                destination = when (destination) {
-                    DestinationSurrogate.customer_center -> Destination.CustomerCenter
-                    DestinationSurrogate.privacy_policy -> {
-                        checkNotNull(url) { "`url` cannot be null when `destination` is `privacy_policy`." }
-                        Destination.PrivacyPolicy(
-                            urlLid = url.url_lid,
-                            method = url.method,
-                        )
-                    }
+            ActionTypeSurrogate.navigate_to -> Action.NavigateTo(destination = toDestination())
+        }
 
-                    DestinationSurrogate.terms -> {
-                        checkNotNull(url) { "`url` cannot be null when `destination` is `terms`." }
-                        Destination.Terms(
-                            urlLid = url.url_lid,
-                            method = url.method,
-                        )
-                    }
+    private fun toDestination(): Destination =
+        when (destination) {
+            DestinationSurrogate.customer_center -> Destination.CustomerCenter
+            DestinationSurrogate.privacy_policy -> {
+                checkNotNull(url) { "`url` cannot be null when `destination` is `privacy_policy`." }
+                Destination.PrivacyPolicy(urlLid = url.url_lid, method = url.method)
+            }
 
-                    DestinationSurrogate.url -> {
-                        checkNotNull(url) { "`url` cannot be null when `destination` is `url`." }
-                        Destination.Url(
-                            urlLid = url.url_lid,
-                            method = url.method,
-                        )
-                    }
+            DestinationSurrogate.terms -> {
+                checkNotNull(url) { "`url` cannot be null when `destination` is `terms`." }
+                Destination.Terms(urlLid = url.url_lid, method = url.method)
+            }
 
-                    DestinationSurrogate.sheet -> sheet ?: Destination.Sheet()
+            DestinationSurrogate.url -> {
+                checkNotNull(url) { "`url` cannot be null when `destination` is `url`." }
+                Destination.Url(urlLid = url.url_lid, method = url.method)
+            }
 
-                    DestinationSurrogate.unknown -> Destination.Unknown
+            // The inline sheet is optional; a missing one is a valid (inert) sheet destination
+            // rather than a decode failure, matching the web SDK.
+            DestinationSurrogate.sheet -> sheet ?: Destination.Sheet()
 
-                    null -> error("`destination` cannot be null when `action` is `navigate_to`.")
-                },
-            )
+            DestinationSurrogate.unknown -> Destination.Unknown
+
+            null -> error("`destination` cannot be null when `action` is `navigate_to`.")
         }
 }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
@@ -440,6 +440,32 @@ internal class ButtonComponentTests {
                     ),
                 ),
                 arrayOf(
+                    "navigate_to - sheet without inline sheet",
+                    Args(
+                        json = """
+                        {
+                          "type": "button",
+                          "action": {
+                            "type": "navigate_to",
+                            "destination": "sheet"
+                          },
+                          "stack": {
+                            "type": "stack",
+                            "components": []
+                          }
+                        }
+                        """.trimIndent(),
+                        // A missing inline sheet must decode (not throw) as a content-less sheet
+                        // destination, so the button still renders. Rendering treats it as a no-op tap.
+                        expected = ButtonComponent(
+                            action = ButtonComponent.Action.NavigateTo(
+                                destination = ButtonComponent.Destination.Sheet(),
+                            ),
+                            stack = StackComponent(components = emptyList()),
+                        ),
+                    ),
+                ),
+                arrayOf(
                     "navigate_to - unknown",
                     Args(
                         json = """

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
@@ -24,6 +24,7 @@ internal fun ButtonComponentStyle.Action.componentInteraction(localeUrl: String?
         is ButtonComponentStyle.Action.WebProductSelection,
         is ButtonComponentStyle.Action.CustomWebCheckout,
         is ButtonComponentStyle.Action.WorkflowTrigger,
+        is ButtonComponentStyle.Action.NoOp,
         -> null
     }
 
@@ -54,5 +55,6 @@ internal fun ButtonComponentStyle.Action.isPurchaseRelated(): Boolean =
         is ButtonComponentStyle.Action.NavigateTo,
         is ButtonComponentStyle.Action.WorkflowTrigger,
         is ButtonComponentStyle.Action.CloseWorkflow,
+        is ButtonComponentStyle.Action.NoOp,
         -> false
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
@@ -58,6 +58,7 @@ internal class ButtonComponentState(
             is ButtonComponentStyle.Action.NavigateBack -> PaywallAction.External.NavigateBack
             is ButtonComponentStyle.Action.CloseWorkflow -> PaywallAction.External.CloseWorkflow
             is ButtonComponentStyle.Action.NavigateTo -> toPaywallAction(localeId)
+            is ButtonComponentStyle.Action.NoOp -> null
 
             is ButtonComponentStyle.Action.PurchasePackage ->
                 PaywallAction.External.PurchasePackage(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
@@ -29,6 +29,7 @@ internal data class ButtonComponentStyle(
         object NavigateBack : Action
         object WorkflowTrigger : Action
         object CloseWorkflow : Action
+        object NoOp : Action
 
         @get:JvmSynthetic
         val description: String

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -830,10 +830,14 @@ internal class StyleFactory(
                 destination.method,
                 componentInteractionValue = "navigate_to_url",
             )
-            is ButtonComponent.Destination.Sheet ->
-                // A content-less sheet is handled as a no-op before we get here, so `stack` is non-null;
-                // the elvis is only to satisfy the type system.
-                destination.stack?.let { rawStack ->
+            is ButtonComponent.Destination.Sheet -> {
+                val rawStack = destination.stack
+                if (rawStack == null) {
+                    // Unreachable: a content-less sheet is mapped to NoOp before reaching here. Log in
+                    // case that invariant ever breaks, and hide the button rather than crash.
+                    Logger.e("Sheet destination reached convertDestination without a stack.")
+                    Result.Success(null)
+                } else {
                     createStackComponentStyle(rawStack)
                         .map { it.applyBottomWindowInsetsIfNecessary(shouldApply = true) }
                         .map { it.applyHorizontalWindowInsetsIfNecessary(shouldApply = true) }
@@ -846,7 +850,8 @@ internal class StyleFactory(
                                 size = destination.size,
                             )
                         }
-                } ?: Result.Success(null)
+                }
+            }
             // Returning null here, which will result in this button being hidden.
             is ButtonComponent.Destination.Unknown,
             -> Result.Success(null)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -726,8 +726,16 @@ internal class StyleFactory(
         return when (action) {
             is ButtonComponent.Action.NavigateBack -> Result.Success(ButtonComponentStyle.Action.NavigateBack)
             is ButtonComponent.Action.RestorePurchases -> Result.Success(ButtonComponentStyle.Action.RestorePurchases)
-            is ButtonComponent.Action.NavigateTo -> convertDestination(action.destination)
-                .map { destination -> destination?.let { ButtonComponentStyle.Action.NavigateTo(it) } }
+            is ButtonComponent.Action.NavigateTo -> {
+                val destination = action.destination
+                // A sheet destination with no inline content: render the button, no-op on tap (web parity).
+                if (destination is ButtonComponent.Destination.Sheet && destination.stack == null) {
+                    Result.Success(ButtonComponentStyle.Action.NoOp)
+                } else {
+                    convertDestination(destination)
+                        .map { converted -> converted?.let { ButtonComponentStyle.Action.NavigateTo(it) } }
+                }
+            }
             is ButtonComponent.Action.WorkflowTrigger -> Result.Success(ButtonComponentStyle.Action.WorkflowTrigger)
             is ButtonComponent.Action.CloseWorkflow -> Result.Success(ButtonComponentStyle.Action.CloseWorkflow)
             // Returning null here, which will result in this button being hidden.
@@ -823,18 +831,22 @@ internal class StyleFactory(
                 componentInteractionValue = "navigate_to_url",
             )
             is ButtonComponent.Destination.Sheet ->
-                createStackComponentStyle(destination.stack)
-                    .map { it.applyBottomWindowInsetsIfNecessary(shouldApply = true) }
-                    .map { it.applyHorizontalWindowInsetsIfNecessary(shouldApply = true) }
-                    .map { stackComponentStyle ->
-                        ButtonComponentStyle.Action.NavigateTo.Destination.Sheet(
-                            id = destination.id,
-                            name = destination.name,
-                            stack = stackComponentStyle,
-                            backgroundBlur = destination.backgroundBlur,
-                            size = destination.size,
-                        )
-                    }
+                // A content-less sheet is handled as a no-op before we get here, so `stack` is non-null;
+                // the elvis is only to satisfy the type system.
+                destination.stack?.let { rawStack ->
+                    createStackComponentStyle(rawStack)
+                        .map { it.applyBottomWindowInsetsIfNecessary(shouldApply = true) }
+                        .map { it.applyHorizontalWindowInsetsIfNecessary(shouldApply = true) }
+                        .map { stackComponentStyle ->
+                            ButtonComponentStyle.Action.NavigateTo.Destination.Sheet(
+                                id = destination.id,
+                                name = destination.name,
+                                stack = stackComponentStyle,
+                                backgroundBlur = destination.backgroundBlur,
+                                size = destination.size,
+                            )
+                        }
+                } ?: Result.Success(null)
             // Returning null here, which will result in this button being hidden.
             is ButtonComponent.Destination.Unknown,
             -> Result.Success(null)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -478,7 +478,7 @@ internal fun PaywallComponent.containsUnsupportedCondition(): Boolean = when (th
     is ButtonComponent -> stack.containsUnsupportedCondition() ||
         (action as? ButtonComponent.Action.NavigateTo)?.destination.let { destination ->
             when (destination) {
-                is ButtonComponent.Destination.Sheet -> destination.stack.containsUnsupportedCondition()
+                is ButtonComponent.Destination.Sheet -> destination.stack?.containsUnsupportedCondition() ?: false
                 is ButtonComponent.Destination.CustomerCenter,
                 is ButtonComponent.Destination.PrivacyPolicy,
                 is ButtonComponent.Destination.Terms,


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

## Motivation

While working on bringing Astra to our iOS app, I hit a draft paywall that refused to parse on iOS but rendered fine on the web dashboard, the same applies on Android as well.

A `navigate_to` action with `destination: "sheet"` can arrive without an inline `sheet` object (the backend types it as optional and drops null fields). The `ActionSerializer` required it via `checkNotNull(sheet)`, so a missing sheet
threw `IllegalStateException`. Because that runs during deserialization, one bad button took down the whole paywall parse. 
The web SDK types it as `sheet?: SheetProps | null` and renders a missing sheet as a button with a no-op tap.

## Description

This aligns Android with the web contract:

- `ButtonComponent.Destination.Sheet` fields are now optional (`stack` nullable,  `id` defaulted), so a content-less sheet is representable, and the deserializer  maps a missing sheet to an empty `Sheet` instead of `checkNotNull`-throwing.
- A `navigate_to`/`sheet` destination with no `stack` maps to a new `ButtonComponentStyle.Action.NoOp` in `StyleFactory`, the button renders but its tap does nothing, rather than being routed to `Unknown` (which hides the
  button). Sheets with content are unchanged.
- `NoOp` is handled across the action `when`s (`toPaywallAction` -> null tap, interaction mapping, purchase-related check), and `OfferingToStateMapper`  handles the now-nullable sheet stack.

Added a deserialization test covering a `sheet` destination with no inline `sheet` (decodes to an empty `Sheet` instead of throwing).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized paywall JSON/UI behavior change for an edge-case button action; no purchase, auth, or billing flow changes.
> 
> **Overview**
> Fixes **whole-paywall parse failures** when a button uses `navigate_to` with `destination: "sheet"` but the optional inline `sheet` object is absent (payloads that already work on web).
> 
> **Deserialization:** `Destination.Sheet` now allows a nullable `stack` and defaults on other fields; `ActionSerializer` maps a missing inline sheet to an empty `Sheet()` instead of throwing during decode.
> 
> **Rendering:** `StyleFactory` turns sheet destinations with no `stack` into a new **`NoOp`** button action so the control still shows but taps do nothing (web parity). `NoOp` is wired through paywall action mapping, interaction analytics, and unsupported-condition walks; sheet destinations with content are unchanged.
> 
> Adds a unit test that `destination: "sheet"` without an inline `sheet` decodes successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915f625f86b6c125d931a1884173e20d3be32858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->