### PR TITLE
ci: Bump sdks-common-config orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ aliases:
 version: 2.1
 orbs:
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@4.1.0
+  revenuecat: revenuecat/sdks-common-config@4.3.1
   codecov: codecov/codecov@3.2.4
 
 parameters:


### PR DESCRIPTION
### Description
Bumps version of the shared orb to get the latest fixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single orb version bump in CI config; behavior may shift slightly via upstream orb changes but no application or security code is touched.
> 
> **Overview**
> Updates the CircleCI **`revenuecat/sdks-common-config`** orb from **4.1.0** to **4.3.1** in `.circleci/config.yml` so pipelines pick up the latest shared SDK CI fixes.
> 
> No job definitions or workflow structure change—only the orb version pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c89e64f741e422c0aebd7a9413e1d16a20bd87b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->