### PR TITLE
fix(remote-config): require UI config for workflows

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -629,7 +629,12 @@ internal class PurchasesOrchestrator(
             }
             throw PurchasesException(PurchasesError(PurchasesErrorCode.ConfigurationError, message))
         }
-        return provider.getUiConfig()
+        return provider.getUiConfig() ?: throw PurchasesException(
+            PurchasesError(
+                PurchasesErrorCode.UnknownError,
+                "UI config is unavailable.",
+            ),
+        )
     }
 
     fun getProducts(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
@@ -14,17 +14,18 @@ import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
  * exactly, so the merged object decodes straight into [UiConfig] — including the property-level localizations
  * serializer that skips unknown variable localization keys.
  *
- * The merge is all-or-nothing: if any part is missing, unresolvable, or the merged object doesn't decode, the
- * whole config falls back to a default [UiConfig] rather than a partially-populated one.
+ * The merge is all-or-nothing: if any part is missing, unresolvable, or the merged object doesn't decode, no
+ * [UiConfig] is returned. Callers that need UI config to render should fail instead of using a partial/default
+ * configuration.
  */
 @OptIn(InternalRevenueCatAPI::class)
 internal class UiConfigProvider(
     private val manager: RemoteConfigManager,
 ) {
 
-    suspend fun getUiConfig(): UiConfig =
+    suspend fun getUiConfig(): UiConfig? =
         manager.mergeItemsBlobData<UiConfig>(
             RemoteConfigTopic.UiConfig,
             listOf("app", "localizations", "variable_config", "custom_variables"),
-        ) ?: UiConfig()
+        )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -63,6 +63,24 @@ internal class WorkflowManager(
                     ),
                 )
                 else -> {
+                    val uiConfig = try {
+                        uiConfigProvider.getUiConfig()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                        errorLog(e) { "Failed to load ui_config for workflow '$workflowId'." }
+                        null
+                    }
+                    if (uiConfig == null) {
+                        onError(
+                            PurchasesError(
+                                PurchasesErrorCode.UnknownError,
+                                "Workflow '$workflowId' resolved, but its UI config is unavailable.",
+                            ),
+                        )
+                        return@launch
+                    }
+
                     // Warm the workflow's images and ui_config fonts in parallel with delivery, like the old
                     // fetch path did on resolve; a prewarm failure must never fail the read itself. The fonts
                     // now come from the ui_config topic rather than a uiConfig embedded in the workflow body.
@@ -70,7 +88,7 @@ internal class WorkflowManager(
                         runCatching {
                             workflowAssetPreDownloader.preDownloadWorkflowAssets(
                                 result,
-                                uiConfigProvider.getUiConfig(),
+                                uiConfig,
                             )
                         }.onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
                     }
@@ -96,9 +114,9 @@ internal class WorkflowManager(
      *
      * Both steps are best-effort: a failure to ready either one is swallowed (logged) and never propagates,
      * so [onComplete] always runs and `getOfferings` can never be stranded waiting on it — if config data
-     * couldn't be readied, the render path fetches it on demand or falls back. The only thing that skips
-     * [onComplete] is coroutine cancellation (teardown / identity change), which must not fire a spurious
-     * success. A failure in one step also does not cancel the other.
+     * couldn't be readied, the render path fetches it on demand and reports an error if it is still unavailable.
+     * The only thing that skips [onComplete] is coroutine cancellation (teardown / identity change), which must not
+     * fire a spurious success. A failure in one step also does not cancel the other.
      *
      * It is not a `suspend` function: it launches the wait on [scope] and calls back, so a callback-based
      * caller can gate on it without owning a coroutine scope.
@@ -107,7 +125,7 @@ internal class WorkflowManager(
         scope.launch {
             coroutineScope {
                 launch { awaitBestEffort("workflows topic") { workflowsConfigProvider.awaitReady() } }
-                launch { awaitBestEffort("ui_config") { uiConfigProvider.getUiConfig() } }
+                launch { awaitBestEffort("ui_config") { checkNotNull(uiConfigProvider.getUiConfig()) } }
             }
             onComplete()
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -2924,6 +2924,16 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
+    fun `getUiConfig throws UnknownError when the provider returns null`() {
+        coEvery { mockUiConfigProvider.getUiConfig() } returns null
+
+        assertThatExceptionOfType(PurchasesException::class.java)
+            .isThrownBy { runBlocking { purchases.purchasesOrchestrator.getUiConfig() } }
+            .extracting { it.code }
+            .isEqualTo(PurchasesErrorCode.UnknownError)
+    }
+
+    @Test
     fun `getUiConfig propagates a provider failure to the caller without wrapping it`() {
         val failure = RuntimeException("boom")
         coEvery { mockUiConfigProvider.getUiConfig() } throws failure

--- a/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
@@ -83,12 +83,13 @@ internal class UiConfigProviderTest {
 
         assertThat(requestedKeys.captured)
             .containsExactly("app", "localizations", "variable_config", "custom_variables")
-        assertThat(uiConfig.localizations)
+        val resolvedUiConfig = requireNotNull(uiConfig)
+        assertThat(resolvedUiConfig.localizations)
             .isEqualTo(mapOf(LocaleId("en_US") to mapOf(VariableLocalizationKey.DAY to "Day")))
-        assertThat(uiConfig.variableConfig.variableCompatibilityMap).isEqualTo(mapOf("old_var" to "new_var"))
-        assertThat(uiConfig.customVariables).containsKey("user_name")
-        assertThat(uiConfig.customVariables["user_name"]?.type).isEqualTo("string")
-        assertThat(uiConfig.customVariables["user_name"]?.defaultValue).isEqualTo("Friend")
+        assertThat(resolvedUiConfig.variableConfig.variableCompatibilityMap).isEqualTo(mapOf("old_var" to "new_var"))
+        assertThat(resolvedUiConfig.customVariables).containsKey("user_name")
+        assertThat(resolvedUiConfig.customVariables["user_name"]?.type).isEqualTo("string")
+        assertThat(resolvedUiConfig.customVariables["user_name"]?.defaultValue).isEqualTo("Friend")
     }
 
     @Test
@@ -121,7 +122,7 @@ internal class UiConfigProviderTest {
             },
         )
 
-        val uiConfig = provider.getUiConfig()
+        val uiConfig = requireNotNull(provider.getUiConfig())
 
         assertThat(uiConfig.app.fonts).containsKey(FontAlias("primary"))
         assertThat(uiConfig.app.fonts[FontAlias("primary")]?.android).isEqualTo(
@@ -137,23 +138,22 @@ internal class UiConfigProviderTest {
     }
 
     @Test
-    fun `getUiConfig returns an all-defaults UiConfig when the merged read returns null`() = runTest {
+    fun `getUiConfig returns null when the merged read returns null`() = runTest {
         // mergeItemsBlobData is all-or-nothing: any unresolvable part nulls the whole merge, so the provider
-        // falls back to a fully-default UiConfig rather than a partially-populated one.
+        // returns no UiConfig rather than a partially-populated or default one.
         coEvery {
             manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
         } returns null
 
         val uiConfig = provider.getUiConfig()
 
-        assertThat(uiConfig).isEqualTo(UiConfig())
+        assertThat(uiConfig).isNull()
     }
 
     @Test
-    fun `getUiConfig returns an all-defaults UiConfig when the merged object doesn't decode`() = runTest {
+    fun `getUiConfig returns null when the merged object doesn't decode`() = runTest {
         // A localizations part that isn't the expected locale->map shape makes the whole merged object
-        // undecodable; the reified mergeItemsBlobData swallows that to null instead of throwing out of the
-        // provider, so the caller gets a default UiConfig.
+        // undecodable; the reified mergeItemsBlobData swallows that to null instead of throwing out of the provider.
         stubMergedRead(
             buildJsonObject {
                 put("app", buildJsonObject {})
@@ -165,7 +165,7 @@ internal class UiConfigProviderTest {
 
         val uiConfig = provider.getUiConfig()
 
-        assertThat(uiConfig).isEqualTo(UiConfig())
+        assertThat(uiConfig).isNull()
     }
 
     // The provider calls the reified mergeItemsBlobData overload, which compiles down to the transform

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -14,6 +14,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -118,6 +119,67 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflow calls onError when ui_config is unavailable`() {
+        val expectedResult = mockk<PublishedWorkflow>(relaxed = true)
+        coEvery { mockProvider.workflowIdForOfferingId("wf_1") } returns null
+        coEvery { mockProvider.getWorkflow("wf_1") } returns expectedResult
+        coEvery { mockUiConfigProvider.getUiConfig() } returns null
+
+        var error: PurchasesError? = null
+        workflowManager.getWorkflow(
+            workflowOrOfferingId = "wf_1",
+            onSuccess = { fail("expected error") },
+            onError = { error = it },
+        )
+        testScope.testScheduler.advanceUntilIdle()
+
+        assertThat(error).isNotNull
+        assertThat(error!!.code).isEqualTo(PurchasesErrorCode.UnknownError)
+        assertThat(error!!.underlyingErrorMessage).contains("UI config is unavailable")
+        verify(exactly = 0) { mockAssetPreDownloader.preDownloadWorkflowAssets(any(), any()) }
+    }
+
+    @Test
+    fun `getWorkflow calls onError when ui_config loading fails`() {
+        val expectedResult = mockk<PublishedWorkflow>(relaxed = true)
+        coEvery { mockProvider.workflowIdForOfferingId("wf_1") } returns null
+        coEvery { mockProvider.getWorkflow("wf_1") } returns expectedResult
+        coEvery { mockUiConfigProvider.getUiConfig() } throws RuntimeException("boom")
+
+        var error: PurchasesError? = null
+        workflowManager.getWorkflow(
+            workflowOrOfferingId = "wf_1",
+            onSuccess = { fail("expected error") },
+            onError = { error = it },
+        )
+        testScope.testScheduler.advanceUntilIdle()
+
+        assertThat(error).isNotNull
+        assertThat(error!!.code).isEqualTo(PurchasesErrorCode.UnknownError)
+        assertThat(error!!.underlyingErrorMessage).contains("UI config is unavailable")
+        verify(exactly = 0) { mockAssetPreDownloader.preDownloadWorkflowAssets(any(), any()) }
+    }
+
+    @Test
+    fun `getWorkflow does not call back when ui_config loading is cancelled`() {
+        val expectedResult = mockk<PublishedWorkflow>(relaxed = true)
+        coEvery { mockProvider.workflowIdForOfferingId("wf_1") } returns null
+        coEvery { mockProvider.getWorkflow("wf_1") } returns expectedResult
+        coEvery { mockUiConfigProvider.getUiConfig() } throws CancellationException("cancelled")
+
+        var calledBack = false
+        workflowManager.getWorkflow(
+            workflowOrOfferingId = "wf_1",
+            onSuccess = { calledBack = true },
+            onError = { calledBack = true },
+        )
+        testScope.testScheduler.advanceUntilIdle()
+
+        assertThat(calledBack).isFalse()
+        verify(exactly = 0) { mockAssetPreDownloader.preDownloadWorkflowAssets(any(), any()) }
+    }
+
+    @Test
     fun `getWorkflow pre-downloads the workflow's assets with the ui_config on success`() {
         val expectedResult = mockk<PublishedWorkflow>(relaxed = true)
         coEvery { mockProvider.workflowIdForOfferingId("wf_1") } returns null
@@ -197,6 +259,20 @@ class WorkflowManagerTest {
         val mockProvider = mockk<WorkflowsConfigProvider>()
         coEvery { mockProvider.awaitReady() } just Runs
         coEvery { mockUiConfigProvider.getUiConfig() } throws RuntimeException("boom")
+        val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
+
+        var completed = false
+        manager.onPaywallConfigReady { completed = true }
+        testScope.testScheduler.advanceUntilIdle()
+
+        assertThat(completed).isTrue()
+    }
+
+    @Test
+    fun `onPaywallConfigReady still completes when ui_config is unavailable`() {
+        val mockProvider = mockk<WorkflowsConfigProvider>()
+        coEvery { mockProvider.awaitReady() } just Runs
+        coEvery { mockUiConfigProvider.getUiConfig() } returns null
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
 
         var completed = false


### PR DESCRIPTION
## Description

iOS requires the `UIConfig` to be successfully loaded in order for workflows to be presented. Android was more flexible here in the sense that it used to fall back to an empty `UIConfig`. However this could potentially greatly alter the look / feel / workings of workflows that we've decided that it indeed should be required.

This PR ensures the `UIConfig` is available, or throws an `PurchasesErrorCode.UnknownError` with message ` "UI config is unavailable."`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall/workflow presentation behavior: missing or broken remote UI config now fails workflow fetch instead of rendering with defaults, which may surface new errors in production but avoids incorrect paywall styling.
> 
> **Overview**
> Aligns Android with iOS by treating remote **UI config** as mandatory for workflows instead of silently using an empty default when merge/decode fails.
> 
> **`UiConfigProvider`** now returns `null` when the four-part `ui_config` merge is missing or invalid; it no longer substitutes `UiConfig()`. **`PurchasesOrchestrator.getUiConfig`** throws `PurchasesErrorCode.UnknownError` with `"UI config is unavailable."` when the provider returns null. **`WorkflowManager.getWorkflow`** loads UI config after resolving the workflow and calls **`onError`** (without asset prewarm) if config is null or load throws; **`CancellationException`** still propagates with no callback. The **`getOfferings`** readiness gate (`onPaywallConfigReady`) stays best-effort so offerings are not blocked, but docs note the render path must error if config is still missing at presentation time.
> 
> Tests cover null provider results, workflow errors, cancellation, and unchanged gate completion when UI config is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52cd759249e0c2b24d160c8bc59c32fbb9b0e20d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->