### PR TITLE
Document why host failover ignores device-connectivity errors

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -218,6 +218,12 @@ internal class HTTPClient(
                 requestResult = HTTPTimeoutManager.RequestResult.TIMEOUT_ON_MAIN_BACKEND_FOR_FALLBACK_SUPPORTED_ENDPOINT
                 callResult = performRequestToFallbackURL()
             } else if (canUseFallback()) {
+                // Unlike iOS, we keep failing over on every connection-level IOException here, including ones
+                // that may be caused by the device being offline. iOS suppresses the host switch on device
+                // connectivity errors, but Android has no equivalent signal at this layer: a device with no
+                // connectivity and a host whose DNS fails both surface as UnknownHostException, and telling
+                // them apart requires a ConnectivityManager check (ACCESS_NETWORK_STATE), which the SDK does
+                // not currently have. Gating this reliably is deferred to a follow-up; see the PR description.
                 callResult = performRequestToFallbackURL()
             } else {
                 throw e

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -223,7 +223,7 @@ internal class HTTPClient(
                 // connectivity errors, but Android has no equivalent signal at this layer: a device with no
                 // connectivity and a host whose DNS fails both surface as UnknownHostException, and telling
                 // them apart requires a ConnectivityManager check (ACCESS_NETWORK_STATE), which the SDK does
-                // not currently have. Gating this reliably is deferred to a follow-up; see the PR description.
+                // not currently have.
                 callResult = performRequestToFallbackURL()
             } else {
                 throw e


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
iOS counterpart (RevenueCat/purchases-ios#7176) stops switching hosts when the device is offline. Android can't do the same reliably yet, and this documents why.

### Description
- Android keeps failing over on every connection-level `IOException`; behavior is unchanged (no new tests).
- A device with no connectivity and a host whose DNS fails both surface as `UnknownHostException`, so they can't be told apart at this layer without a `ConnectivityManager` check (`ACCESS_NETWORK_STATE`), which the SDK doesn't have.
- Adds a code comment recording this limitation and the divergence from iOS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only; no networking or failover logic changes.
> 
> **Overview**
> **Documentation-only change** in `HTTPClient.performRequest`: a comment above the generic `IOException` → fallback path explains why Android still retries alternate hosts on every connection-level failure, including cases that may be “device offline,” while iOS can skip failover for connectivity errors.
> 
> The comment records a **platform divergence**: offline and bad-DNS both often appear as `UnknownHostException` at this layer, and distinguishing them would need `ConnectivityManager` / `ACCESS_NETWORK_STATE`, which the SDK does not use today. **Runtime behavior is unchanged**—no logic or tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61ce62b83386068838f06d108cc8b8812937127c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->