### PR TITLE
Fix ui_config font/color decoding bug

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.remoteconfig
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
@@ -419,13 +420,15 @@ internal class RemoteConfigManager(
     /**
      * The resolved blob payload for `itemKey` in [topic], parsed from JSON into [T], or `null` when the item
      * is unknown, has no `blob_ref`, its blob can't be resolved, or its bytes don't deserialize into [T]. [T]
-     * must be a concrete `@Serializable` type; parsing uses the shared [JsonProvider.defaultJson]. For non-JSON
-     * payloads use the `transform` overload, which also documents the resolution and waiting rules.
+     * must be a concrete `@Serializable` type; parsing uses [JsonTools.json] (not [JsonProvider.defaultJson],
+     * whose `classDiscriminator` is overridden for [com.revenuecat.purchases.common.events.BackendEvent] and
+     * would break any topic payload relying on the default `type` discriminator, e.g. paywall components). For
+     * non-JSON payloads use the `transform` overload, which also documents the resolution and waiting rules.
      */
     suspend inline fun <reified T> blobData(topic: RemoteConfigTopic, itemKey: String): T? =
         blobData(topic, itemKey) { bytes ->
             try {
-                JsonProvider.defaultJson.decodeFromString<T>(bytes.decodeToString())
+                JsonTools.json.decodeFromString<T>(bytes.decodeToString())
             } catch (e: SerializationException) {
                 errorLog(e) { "Failed to parse remote config blob for item '$itemKey' as JSON." }
                 null
@@ -468,7 +471,8 @@ internal class RemoteConfigManager(
      * resolved, the call returns `null` (a partial object is never produced) and warn-logs the missing keys.
      * It also returns `null` if any resolved blob isn't valid JSON, or the merged object doesn't deserialize
      * into [T]. Duplicate keys are de-duplicated; an empty [itemKeys] returns `null` without any read; [T] must
-     * be a concrete `@Serializable` type and parsing uses [JsonProvider.defaultJson].
+     * be a concrete `@Serializable` type and parsing uses [JsonTools.json] (see [blobData] for why not
+     * [JsonProvider.defaultJson]).
      *
      * Each item resolves through the same path as the single-key [blobData] (see its KDoc for the `blob_ref`,
      * on-demand fetch, and waiting rules) — this only fans them out. The fan-out is safe: a shared in-flight
@@ -479,7 +483,7 @@ internal class RemoteConfigManager(
     suspend inline fun <reified T> mergeItemsBlobData(topic: RemoteConfigTopic, itemKeys: Collection<String>): T? =
         mergeItemsBlobData(topic, itemKeys) { merged ->
             try {
-                JsonProvider.defaultJson.decodeFromJsonElement<T>(merged)
+                JsonTools.json.decodeFromJsonElement<T>(merged)
             } catch (e: SerializationException) {
                 errorLog(e) { "Failed to decode merged remote config blobs from topic '${topic.wireName}' as JSON." }
                 null

--- a/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.common.uiconfig
 
+import com.revenuecat.purchases.FontAlias
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.UiConfig
@@ -8,6 +9,7 @@ import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationKey
+import com.revenuecat.purchases.paywalls.components.properties.FontStyle
 import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -87,6 +89,51 @@ internal class UiConfigProviderTest {
         assertThat(uiConfig.customVariables).containsKey("user_name")
         assertThat(uiConfig.customVariables["user_name"]?.type).isEqualTo("string")
         assertThat(uiConfig.customVariables["user_name"]?.defaultValue).isEqualTo("Friend")
+    }
+
+    @Test
+    fun `getUiConfig decodes a font whose discriminator uses the real backend key`() = runTest {
+        // Regression test: the backend sends FontInfo's sealed-type discriminator under "type" (as in this
+        // real payload shape). The merge decode must use a Json instance that resolves that key correctly
+        // (JsonTools.json), not JsonProvider.defaultJson, whose classDiscriminator is overridden to
+        // "discriminator" for BackendEvent and would silently drop the font instead of decoding it.
+        stubMergedRead(
+            buildJsonObject {
+                putJsonObject("app") {
+                    put("colors", buildJsonObject {})
+                    putJsonObject("fonts") {
+                        putJsonObject("primary") {
+                            putJsonObject("android") {
+                                put("type", "name")
+                                put("value", "CinzelDecorative-Bold")
+                                put("url", "https://fonts.pawwalls.com/1195295_cb0a3b55_5b882c667007133983d5.ttf")
+                                put("hash", "a388d4f6e855b334da95b975bb30bf4d")
+                                put("family", "Cinzel Decorative")
+                                put("weight", 700)
+                                put("style", "normal")
+                            }
+                        }
+                    }
+                }
+                put("localizations", buildJsonObject {})
+                put("variable_config", buildJsonObject {})
+                put("custom_variables", buildJsonObject {})
+            },
+        )
+
+        val uiConfig = provider.getUiConfig()
+
+        assertThat(uiConfig.app.fonts).containsKey(FontAlias("primary"))
+        assertThat(uiConfig.app.fonts[FontAlias("primary")]?.android).isEqualTo(
+            UiConfig.AppConfig.FontsConfig.FontInfo.Name(
+                value = "CinzelDecorative-Bold",
+                url = "https://fonts.pawwalls.com/1195295_cb0a3b55_5b882c667007133983d5.ttf",
+                hash = "a388d4f6e855b334da95b975bb30bf4d",
+                family = "Cinzel Decorative",
+                weight = 700,
+                style = FontStyle.NORMAL,
+            ),
+        )
     }
 
     @Test


### PR DESCRIPTION
`RemoteConfigManager` decoded merged `ui_config` blobs with `JsonProvider.defaultJson`, whose `classDiscriminator` is overridden to `"discriminator"` for `BackendEvent`. Fonts and colors send their discriminator as `"type"`, so any paywall using custom fonts or colors silently fell back to a default (fontless/colorless) `UiConfig` instead of decoding correctly. 

This PR switches both `blobData`/`mergeItemsBlobData` to `JsonTools.json`, the instance the legacy offerings-embedded `ui_config` path already uses correctly, and adds a regression test that decodes a real font payload through the actual merge path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes JSON decoding for all remote-config blob merges (including ui_config); wrong Json instance would affect every paywall using custom fonts/colors, but the fix is narrowly scoped and covered by a regression test.
> 
> **Overview**
> Fixes **silent loss of custom paywall fonts and colors** when `ui_config` is loaded from remote config merges: `RemoteConfigManager` now decodes single-blob and merged-blob JSON with **`JsonTools.json`** instead of **`JsonProvider.defaultJson`**.
> 
> `defaultJson` sets `classDiscriminator` to `"discriminator"` for `BackendEvent`, but backend payloads (e.g. `FontInfo`) use **`"type"`** as the polymorphic key—so fonts/colors failed to deserialize and callers often saw a default, empty-looking `UiConfig`.
> 
> KDoc on `blobData` / `mergeItemsBlobData` documents why the shared default instance must not be used here (aligned with the legacy offerings `ui_config` path). A **regression test** in `UiConfigProviderTest` asserts a real-shaped font payload decodes through the merge path into `UiConfig.AppConfig.FontsConfig.FontInfo.Name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce939376586b824defb4d6a1ba0d3bc74f053f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->