### PR TITLE
Coalesce `onPaywallConfigReady` so `getOfferings` readiness runs once

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -10,8 +10,10 @@ import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -35,6 +37,15 @@ internal class WorkflowManager(
     private val workflowAssetPreDownloader: WorkflowAssetPreDownloader,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
+
+    // Guards [inFlightReadiness] so that concurrent calls to [onPaywallConfigReady] see the same
+    // Deferred and don't start a second round of readiness work while one is already in flight.
+    private val readinessLock = Any()
+
+    // The single in-flight readiness check started on [scope]. Null when no check is in progress.
+    // Written only under [readinessLock]; read under the lock to decide whether to reuse or start.
+    @Volatile
+    private var inFlightReadiness: Deferred<Unit>? = null
 
     fun close() {
         scope.cancel()
@@ -118,15 +129,34 @@ internal class WorkflowManager(
      * The only thing that skips [onComplete] is coroutine cancellation (teardown / identity change), which must not
      * fire a spurious success. A failure in one step also does not cancel the other.
      *
+     * Overlapping calls are coalesced: if a readiness check is already in flight when this is called, the
+     * new caller awaits the same [Deferred] instead of starting a second one, so the underlying work (topic
+     * sync + ui_config fetch) runs only once per overlapping burst. Sequential calls after the in-flight
+     * check completes may start a fresh one; by then blobs are cached so the cost is negligible.
+     *
      * It is not a `suspend` function: it launches the wait on [scope] and calls back, so a callback-based
      * caller can gate on it without owning a coroutine scope.
      */
     fun onPaywallConfigReady(onComplete: () -> Unit) {
-        scope.launch {
-            coroutineScope {
-                launch { awaitBestEffort("workflows topic") { workflowsConfigProvider.awaitReady() } }
-                launch { awaitBestEffort("ui_config") { checkNotNull(uiConfigProvider.getUiConfig()) } }
+        val readiness: Deferred<Unit> = synchronized(readinessLock) {
+            inFlightReadiness ?: scope.async<Unit> {
+                coroutineScope {
+                    launch { awaitBestEffort("workflows topic") { workflowsConfigProvider.awaitReady() } }
+                    launch { awaitBestEffort("ui_config") { checkNotNull(uiConfigProvider.getUiConfig()) } }
+                }
+            }.also { deferred ->
+                inFlightReadiness = deferred
+                deferred.invokeOnCompletion {
+                    synchronized(readinessLock) {
+                        if (inFlightReadiness === deferred) {
+                            inFlightReadiness = null
+                        }
+                    }
+                }
             }
+        }
+        scope.launch {
+            readiness.await()
             onComplete()
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -15,6 +15,9 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -295,5 +298,49 @@ class WorkflowManagerTest {
         assertThat(completed).isTrue()
         // A failure to ready one step must not cancel the other.
         coVerify(exactly = 1) { mockUiConfigProvider.getUiConfig() }
+    }
+
+    @Test
+    fun `onPaywallConfigReady coalesces overlapping calls so readiness work runs only once and both callbacks fire`() {
+        val gate = CompletableDeferred<Unit>()
+        val mockProvider = mockk<WorkflowsConfigProvider>()
+        coEvery { mockProvider.awaitReady() } coAnswers { gate.await() }
+        val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
+
+        var completed1 = false
+        var completed2 = false
+        manager.onPaywallConfigReady { completed1 = true }
+        manager.onPaywallConfigReady { completed2 = true }
+
+        // Readiness work is still suspended inside the gate; neither callback should have fired yet.
+        assertThat(completed1).isFalse()
+        assertThat(completed2).isFalse()
+
+        gate.complete(Unit)
+        testScope.testScheduler.advanceUntilIdle()
+
+        assertThat(completed1).isTrue()
+        assertThat(completed2).isTrue()
+        // The underlying work must have run exactly once despite two concurrent callers.
+        coVerify(exactly = 1) { mockProvider.awaitReady() }
+        coVerify(exactly = 1) { mockUiConfigProvider.getUiConfig() }
+    }
+
+    @Test
+    fun `onPaywallConfigReady does not invoke onComplete when the manager is closed before readiness completes`() {
+        val gate = CompletableDeferred<Unit>()
+        // Use a dedicated scope so closing the manager doesn't cancel the shared testScope.
+        val managerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val mockProvider = mockk<WorkflowsConfigProvider>()
+        coEvery { mockProvider.awaitReady() } coAnswers { gate.await() }
+        val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = managerScope)
+
+        var completed = false
+        manager.onPaywallConfigReady { completed = true }
+
+        // Cancel scope (simulates teardown / identity change) while readiness is still suspended.
+        manager.close()
+
+        assertThat(completed).isFalse()
     }
 }


### PR DESCRIPTION
`getOfferings` does not dispatch success until `WorkflowManager.onPaywallConfigReady` completes. That gate resolves the workflows topic and `ui_config` before returning. If it is invoked more than once like by `getOfferings` and `configure()` it will redundantly call the config manager more than once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized concurrency change to the paywall readiness gate with matching unit tests; behavior for single callers and best-effort failures stays the same.
> 
> **Overview**
> **Overlapping `onPaywallConfigReady` calls now share one in-flight readiness pass** instead of each starting its own workflows-topic sync and `ui_config` fetch. That matters because `OfferingsManager` gates `getOfferings` success on this hook, and concurrent callers (e.g. configure plus get offerings) used to duplicate config work.
> 
> `WorkflowManager` keeps a single `Deferred` under a lock, reuses it while readiness is running, and clears it when that work finishes. Each caller still gets its own `onComplete` after awaiting the shared deferred. Docs note that sequential calls after completion may start a fresh check, which should be cheap once caches are warm.
> 
> Tests cover coalescing (one `awaitReady` / one `getUiConfig`, both callbacks fire) and **no `onComplete` when `close()` cancels the scope** before readiness completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f2a041b8d6fd4413f04e518277b4fb5a997abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->