### PR TITLE
fix(remote-config): use a dedicated fallback endpoint

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -28,6 +28,7 @@ import com.revenuecat.purchases.common.networking.RewardVerificationResponse
 import com.revenuecat.purchases.common.networking.WebBillingProductsResponse
 import com.revenuecat.purchases.common.networking.buildPostReceiptResponse
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterRoot
@@ -109,6 +110,11 @@ internal typealias RewardVerificationResultCallback =
 
 internal typealias RemoteConfigCallback = Pair<
     (RCContainer?, VerificationResult) -> Unit,
+    (PurchasesError, errorHandlingBehavior: GetRemoteConfigErrorHandlingBehavior) -> Unit,
+    >
+
+internal typealias RemoteConfigFallbackCallback = Pair<
+    (RemoteConfiguration) -> Unit,
     (PurchasesError, errorHandlingBehavior: GetRemoteConfigErrorHandlingBehavior) -> Unit,
     >
 
@@ -209,6 +215,10 @@ internal class Backend(
     @get:Synchronized @set:Synchronized
     @Volatile var remoteConfigCallbacks =
         mutableMapOf<BackgroundAwareCallbackCacheKey, MutableList<RemoteConfigCallback>>()
+
+    @get:Synchronized @set:Synchronized
+    @Volatile var remoteConfigFallbackCallbacks =
+        mutableMapOf<BackgroundAwareCallbackCacheKey, MutableList<RemoteConfigFallbackCallback>>()
 
     fun close() {
         this.dispatcher.close()
@@ -1162,7 +1172,6 @@ internal class Backend(
         val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path, appUserID), appInBackground)
 
         val baseURL = appConfig.baseURL
-        val fallbackBaseURLs = appConfig.fallbackBaseURLs
         // The manifest is an opaque token replayed verbatim; omitted on the first run when there is none.
         val body = buildMap<String, Any?> {
             put(APP_USER_ID, appUserID)
@@ -1178,7 +1187,6 @@ internal class Backend(
                     body = body,
                     postFieldsToSign = null,
                     backendHelper.authenticationHeaders,
-                    fallbackBaseURLs = fallbackBaseURLs,
                 )
             }
 
@@ -1241,6 +1249,89 @@ internal class Backend(
         synchronized(this@Backend) {
             val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
             remoteConfigCallbacks.addBackgroundAwareCallback(
+                call,
+                dispatcher,
+                cacheKey,
+                onSuccess to onError,
+                delay,
+            )
+        }
+    }
+
+    fun getRemoteConfigFallback(
+        appInBackground: Boolean,
+        domain: String,
+        onSuccess: (RemoteConfiguration) -> Unit,
+        onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit,
+    ) {
+        val fallbackURL = appConfig.fallbackBaseURLs.firstOrNull()
+        if (fallbackURL == null) {
+            onError(
+                PurchasesError(
+                    PurchasesErrorCode.UnknownError,
+                    "No fallback base URL configured for remote config.",
+                ).also { errorLog(it) },
+                GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+            )
+            return
+        }
+        val endpoint = Endpoint.GetRemoteConfigFallback(domain)
+        val cacheKey = BackgroundAwareCallbackCacheKey(listOf(endpoint.getPath()), appInBackground)
+
+        val call = object : Dispatcher.AsyncCall() {
+            override fun call(): HTTPResult {
+                return httpClient.performRequest(
+                    fallbackURL,
+                    endpoint,
+                    // A null body makes this a GET (getConnection only switches to POST when a body is present).
+                    body = null,
+                    postFieldsToSign = null,
+                    backendHelper.authenticationHeaders,
+                )
+            }
+
+            override fun onError(error: PurchasesError) {
+                synchronized(this@Backend) {
+                    remoteConfigFallbackCallbacks.remove(cacheKey)
+                }?.forEach { (_, onErrorHandler) ->
+                    // Transport/IO failure: no HTTP status, the endpoint may recover on a future sync.
+                    onErrorHandler(error, GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY)
+                }
+            }
+
+            override fun onCompletion(result: HTTPResult) {
+                synchronized(this@Backend) {
+                    remoteConfigFallbackCallbacks.remove(cacheKey)
+                }?.forEach { (onSuccessHandler, onErrorHandler) ->
+                    if (result.isSuccessful()) {
+                        try {
+                            onSuccessHandler(RemoteConfiguration.parse(result.payloadText.encodeToByteArray()))
+                        } catch (e: SerializationException) {
+                            // A 2xx body that doesn't parse is not a client error; keep retrying.
+                            onErrorHandler(
+                                e.toPurchasesError().also { errorLog(it) },
+                                GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+                            )
+                        }
+                    } else {
+                        // A 4xx means the endpoint intentionally refused: disable it for the session. Any other
+                        // non-success (5xx) may recover, so keep retrying.
+                        val isClientError = !RCHTTPStatusCodes.isSuccessful(result.responseCode) &&
+                            !RCHTTPStatusCodes.isServerError(result.responseCode)
+                        val behavior = if (isClientError) {
+                            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE
+                        } else {
+                            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY
+                        }
+                        onErrorHandler(result.toPurchasesError().also { errorLog(it) }, behavior)
+                    }
+                }
+            }
+        }
+
+        synchronized(this@Backend) {
+            val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
+            remoteConfigFallbackCallbacks.addBackgroundAwareCallback(
                 call,
                 dispatcher,
                 cacheKey,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -114,7 +114,7 @@ internal typealias RemoteConfigCallback = Pair<
     >
 
 internal typealias RemoteConfigFallbackCallback = Pair<
-    (RemoteConfiguration) -> Unit,
+    (RemoteConfiguration, VerificationResult) -> Unit,
     (PurchasesError, errorHandlingBehavior: GetRemoteConfigErrorHandlingBehavior) -> Unit,
     >
 
@@ -1261,7 +1261,7 @@ internal class Backend(
     fun getRemoteConfigFallback(
         appInBackground: Boolean,
         domain: String,
-        onSuccess: (RemoteConfiguration) -> Unit,
+        onSuccess: (RemoteConfiguration, VerificationResult) -> Unit,
         onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit,
     ) {
         val fallbackURL = appConfig.fallbackBaseURLs.firstOrNull()
@@ -1305,7 +1305,10 @@ internal class Backend(
                 }?.forEach { (onSuccessHandler, onErrorHandler) ->
                     if (result.isSuccessful()) {
                         try {
-                            onSuccessHandler(RemoteConfiguration.parse(result.payloadText.encodeToByteArray()))
+                            onSuccessHandler(
+                                RemoteConfiguration.parse(result.payloadText.encodeToByteArray()),
+                                result.verificationResult,
+                            )
                         } catch (e: SerializationException) {
                             // A 2xx body that doesn't parse is not a client error; keep retrying.
                             onErrorHandler(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -81,13 +81,22 @@ internal sealed class Endpoint(
     data class GetRemoteConfig(val domain: String) : Endpoint(
         pathTemplate = "/v1/config/%s",
         name = "remote_config",
-        fallbackPath = "/v1/config/%s",
     ) {
-        override fun getPath(useFallback: Boolean): String {
-            val template = if (useFallback && fallbackPath != null) fallbackPath else pathTemplate
-            return template.format(Uri.encode(domain))
-        }
+        override fun getPath(useFallback: Boolean) = pathTemplate.format(Uri.encode(domain))
         override val expectsRCFormatResponse: Boolean = true
+    }
+
+    /**
+     * Fallback for [GetRemoteConfig] served from a fallback base URL. Unlike the main endpoint, it is a plain
+     * `GET` returning `application/json` (no `x-rc-format`, no inlined blobs, no request body), and its response
+     * is signature-verified **without** a nonce (mirroring [GetOfferings]). The domain layer chooses this
+     * endpoint explicitly; it does not participate in the generic HTTPClient URL-fallback mechanism.
+     */
+    data class GetRemoteConfigFallback(val domain: String) : Endpoint(
+        pathTemplate = "/v1/config/%s",
+        name = "remote_config_fallback",
+    ) {
+        override fun getPath(useFallback: Boolean) = pathTemplate.format(Uri.encode(domain))
     }
     object PostCreateSupportTicket : Endpoint(
         "/v1/customercenter/support/create-ticket",
@@ -137,6 +146,7 @@ internal sealed class Endpoint(
             is GetVirtualCurrencies,
             is GetRewardVerification,
             is GetRemoteConfig,
+            is GetRemoteConfigFallback,
             ->
                 true
             is GetAmazonReceipt,
@@ -172,6 +182,7 @@ internal sealed class Endpoint(
             PostCreateSupportTicket,
             is WebBillingGetProducts,
             is AliasUsers,
+            is GetRemoteConfigFallback,
             ->
                 false
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -199,6 +199,66 @@ internal class RemoteConfigManager(
                     }
                 }
             },
+            onError = { error, behavior ->
+                handleMainRefreshError(requestEpoch, appInBackground, persisted, error, behavior)
+            },
+        )
+    }
+
+    /**
+     * Handles a failure of the **main** `/v1/config` request. Prefers cached data over the fallback: only when
+     * the request fails with a retryable error AND nothing is persisted yet (cold start) is the fallback
+     * endpoint tried. Any cached config wins (keep it), and a 4xx (`SHOULD_DISABLE`) still disables the endpoint
+     * without a fallback.
+     */
+    private fun handleMainRefreshError(
+        requestEpoch: Int,
+        appInBackground: Boolean,
+        persisted: PersistedRemoteConfigurationState?,
+        error: PurchasesError,
+        behavior: GetRemoteConfigErrorHandlingBehavior,
+    ) {
+        if (behavior == GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY && persisted == null) {
+            fetchFromFallback(requestEpoch, appInBackground, previous = persisted)
+        } else {
+            handleRefreshError(requestEpoch, error, behavior)
+        }
+    }
+
+    /**
+     * The cold-start fallback: the main `/v1/config` request failed with a retryable error and no config is
+     * cached, so fetch the plain-JSON [RemoteConfiguration] from the fallback endpoint and commit it. The
+     * in-flight guard captured by the originating [refreshRemoteConfig] is **kept held** across this call — the
+     * fallback continues that same sync/epoch and releases the guard at its own terminal points (success
+     * `finally` / `onError`). Does nothing if the epoch changed meanwhile (an identity change already reset the
+     * guard via [clearCache]).
+     */
+    private fun fetchFromFallback(
+        requestEpoch: Int,
+        appInBackground: Boolean,
+        previous: PersistedRemoteConfigurationState?,
+    ) {
+        if (epoch.get() != requestEpoch) return
+        verboseLog { "Main remote config request failed with no cached config; trying the fallback endpoint." }
+        backend.getRemoteConfigFallback(
+            appInBackground = appInBackground,
+            domain = previous?.domain ?: DEFAULT_DOMAIN,
+            onSuccess = { response ->
+                if (epoch.get() != requestEpoch) {
+                    // Identity changed after the fallback started; clearCache() reset the guard. Drop the result.
+                    return@getRemoteConfigFallback
+                }
+                scope.launch {
+                    try {
+                        synchronized(cacheLock) {
+                            if (epoch.get() != requestEpoch) return@launch
+                            persist(previous = previous, response = response, container = null)
+                        }
+                    } finally {
+                        releaseGuardIfOwned(requestEpoch)
+                    }
+                }
+            },
             onError = { error, behavior -> handleRefreshError(requestEpoch, error, behavior) },
         )
     }
@@ -593,7 +653,9 @@ internal class RemoteConfigManager(
     private fun persist(
         previous: PersistedRemoteConfigurationState?,
         response: RemoteConfiguration,
-        container: RCContainer,
+        // Null on the fallback path (plain-JSON response with no inlined blob elements to extract); the wanted
+        // blobs are then fetched over the network by prefetchBlobs instead.
+        container: RCContainer?,
     ) {
         debugLog {
             val changed = response.topics.entries.joinToString { (name, topic) ->
@@ -631,7 +693,7 @@ internal class RemoteConfigManager(
                 "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +
                     "${blobRefsToKeep.size} blobs wanted)."
             }
-            extractInlineBlobs(container, blobRefsToKeep)
+            container?.let { extractInlineBlobs(it, blobRefsToKeep) }
             blobStore.retainOnly(blobRefsToKeep)
             prefetchBlobs(response, mergedTopics)
         } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -160,66 +160,86 @@ internal class RemoteConfigManager(
         }
         val persisted = diskCache.read()
         val storedBlobs = blobStore.cachedRefs()
+        val domain = persisted?.domain ?: DEFAULT_DOMAIN
         logRefreshStart(persisted, appInBackground)
         backend.getRemoteConfig(
             appInBackground = appInBackground,
             appUserID = requestAppUserID,
-            domain = persisted?.domain ?: DEFAULT_DOMAIN,
+            domain = domain,
             // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
             manifest = persisted?.manifest,
             // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
             prefetchedBlobs = persisted?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
-            onSuccess = { container, _ ->
-                if (epoch.get() != requestEpoch) {
-                    // The cache was cleared (identity change) after this request started. Drop the stale
-                    // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
-                    return@getRemoteConfig
-                }
-                if (container == null) {
-                    handleNotModified(requestEpoch)
-                    return@getRemoteConfig
-                }
-                scope.launch {
-                    try {
-                        val response = RemoteConfiguration.parse(container.config.decode())
-                        synchronized(cacheLock) {
-                            if (epoch.get() != requestEpoch) return@launch
-                            persist(previous = persisted, response = response, container = container)
-                        }
-                    } catch (e: SerializationException) {
-                        errorLog(e) {
-                            "Failed to parse remote config response. Keeping the cached configuration."
-                        }
-                    } catch (e: RCContainerFormatException) {
-                        errorLog(e) {
-                            "Failed to decode remote config response. Keeping the cached configuration."
-                        }
-                    } finally {
-                        releaseGuardIfOwned(requestEpoch)
-                    }
-                }
-            },
+            onSuccess = { container, _ -> handleMainRefreshSuccess(requestEpoch, persisted, container) },
             onError = { error, behavior ->
-                handleMainRefreshError(requestEpoch, appInBackground, persisted, error, behavior)
+                handleMainRefreshError(
+                    requestEpoch,
+                    appInBackground,
+                    domain,
+                    hasCachedConfig = persisted != null,
+                    error,
+                    behavior,
+                )
             },
         )
     }
 
     /**
+     * Handles a successful **main** `/v1/config` response: a `204` keeps the cache (bookkeeping only), a `200`
+     * parses the config element and commits it (on [scope] so [clearCache] can cancel the parse/persist). Drops
+     * the result if the epoch changed meanwhile (an identity change already reset the guard via [clearCache]).
+     */
+    private fun handleMainRefreshSuccess(
+        requestEpoch: Int,
+        persisted: PersistedRemoteConfigurationState?,
+        container: RCContainer?,
+    ) {
+        if (epoch.get() != requestEpoch) {
+            // The cache was cleared (identity change) after this request started. Drop the stale
+            // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
+            return
+        }
+        if (container == null) {
+            handleNotModified(requestEpoch)
+            return
+        }
+        scope.launch {
+            try {
+                val response = RemoteConfiguration.parse(container.config.decode())
+                synchronized(cacheLock) {
+                    if (epoch.get() != requestEpoch) return@launch
+                    persist(previous = persisted, response = response, container = container)
+                }
+            } catch (e: SerializationException) {
+                errorLog(e) {
+                    "Failed to parse remote config response. Keeping the cached configuration."
+                }
+            } catch (e: RCContainerFormatException) {
+                errorLog(e) {
+                    "Failed to decode remote config response. Keeping the cached configuration."
+                }
+            } finally {
+                releaseGuardIfOwned(requestEpoch)
+            }
+        }
+    }
+
+    /**
      * Handles a failure of the **main** `/v1/config` request. Prefers cached data over the fallback: only when
-     * the request fails with a retryable error AND nothing is persisted yet (cold start) is the fallback
-     * endpoint tried. Any cached config wins (keep it), and a 4xx (`SHOULD_DISABLE`) still disables the endpoint
-     * without a fallback.
+     * the request fails with a retryable error AND nothing is cached yet (cold start) is the fallback endpoint
+     * tried, using the same [domain] the main request used. Any cached config wins (keep it), and a 4xx
+     * (`SHOULD_DISABLE`) still disables the endpoint without a fallback.
      */
     private fun handleMainRefreshError(
         requestEpoch: Int,
         appInBackground: Boolean,
-        persisted: PersistedRemoteConfigurationState?,
+        domain: String,
+        hasCachedConfig: Boolean,
         error: PurchasesError,
         behavior: GetRemoteConfigErrorHandlingBehavior,
     ) {
-        if (behavior == GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY && persisted == null) {
-            fetchFromFallback(requestEpoch, appInBackground, previous = persisted)
+        if (behavior == GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY && !hasCachedConfig) {
+            fetchFromFallback(requestEpoch, appInBackground, domain)
         } else {
             handleRefreshError(requestEpoch, error, behavior)
         }
@@ -227,22 +247,23 @@ internal class RemoteConfigManager(
 
     /**
      * The cold-start fallback: the main `/v1/config` request failed with a retryable error and no config is
-     * cached, so fetch the plain-JSON [RemoteConfiguration] from the fallback endpoint and commit it. The
-     * in-flight guard captured by the originating [refreshRemoteConfig] is **kept held** across this call — the
-     * fallback continues that same sync/epoch and releases the guard at its own terminal points (success
-     * `finally` / `onError`). Does nothing if the epoch changed meanwhile (an identity change already reset the
-     * guard via [clearCache]).
+     * cached, so fetch the plain-JSON [RemoteConfiguration] from the fallback endpoint (for the same [domain] the
+     * main request used) and commit it. There is never persisted state on this path, so the commit passes
+     * `previous = null`. The in-flight guard captured by the originating [refreshRemoteConfig] is **kept held**
+     * across this call — the fallback continues that same sync/epoch and releases the guard at its own terminal
+     * points (success `finally` / `onError`). Does nothing if the epoch changed meanwhile (an identity change
+     * already reset the guard via [clearCache]).
      */
     private fun fetchFromFallback(
         requestEpoch: Int,
         appInBackground: Boolean,
-        previous: PersistedRemoteConfigurationState?,
+        domain: String,
     ) {
         if (epoch.get() != requestEpoch) return
         verboseLog { "Main remote config request failed with no cached config; trying the fallback endpoint." }
         backend.getRemoteConfigFallback(
             appInBackground = appInBackground,
-            domain = previous?.domain ?: DEFAULT_DOMAIN,
+            domain = domain,
             onSuccess = { response, _ ->
                 if (epoch.get() != requestEpoch) {
                     // Identity changed after the fallback started; clearCache() reset the guard. Drop the result.
@@ -252,7 +273,8 @@ internal class RemoteConfigManager(
                     try {
                         synchronized(cacheLock) {
                             if (epoch.get() != requestEpoch) return@launch
-                            persist(previous = previous, response = response, container = null)
+                            // No persisted state exists on the fallback path (it only runs on a cold start).
+                            persist(previous = null, response = response, container = null)
                         }
                     } finally {
                         releaseGuardIfOwned(requestEpoch)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -243,7 +243,7 @@ internal class RemoteConfigManager(
         backend.getRemoteConfigFallback(
             appInBackground = appInBackground,
             domain = previous?.domain ?: DEFAULT_DOMAIN,
-            onSuccess = { response ->
+            onSuccess = { response, _ ->
                 if (epoch.get() != requestEpoch) {
                     // Identity changed after the fallback started; clearCache() reset the guard. Drop the result.
                     return@getRemoteConfigFallback

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/GoldenFileRecorder.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/GoldenFileRecorder.kt
@@ -108,6 +108,7 @@ class GoldenFileRecorder(
             "Via",
             "X-Signature",
             "X-Revenuecat-Etag",
+            "X-RC-Last-Refresh-Time",
             "Last-Modified",
             "CF-Ray",
             "x-envoy-upstream-service-time",

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.backend_integration_tests
 import android.content.Context
 import com.revenuecat.purchases.ForceServerErrorStrategy
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobFetcher
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
@@ -45,7 +46,7 @@ internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegr
 
     @Test
     fun `can fetch remote config from the fallback endpoint`() {
-        val (error, config) = fetchRemoteConfigFallback()
+        val (error, config, _) = fetchRemoteConfigFallback()
 
         assertThat(error).isNull()
         val remoteConfiguration = requireNotNull(config) { "Expected a fallback config response." }
@@ -69,12 +70,14 @@ internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegr
     fun `verifies the fallback response without a nonce when verification is enforced`() {
         setupTest(SignatureVerificationMode.Enforced())
 
-        val (error, config) = fetchRemoteConfigFallback()
+        val (error, config, verification) = fetchRemoteConfigFallback()
 
         // Under enforcement a failed verification surfaces as an error, so a null error already implies the
-        // response verified (statically, without a nonce). Assert the signing call happened explicitly too.
+        // response verified (statically, without a nonce). Assert the exposed verification result and the
+        // signing call explicitly too.
         assertThat(error).isNull()
         assertThat(config).isNotNull
+        assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
         assertSigningPerformed()
     }
 
@@ -90,8 +93,8 @@ internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegr
             sharedPreferencesEditor
         }
 
-        val (firstError, firstConfig) = fetchRemoteConfigFallback()
-        val (secondError, secondConfig) = fetchRemoteConfigFallback()
+        val (firstError, firstConfig, _) = fetchRemoteConfigFallback()
+        val (secondError, secondConfig, _) = fetchRemoteConfigFallback()
 
         assertThat(firstError).isNull()
         assertThat(secondError).isNull()
@@ -125,20 +128,22 @@ internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegr
     }
 
     /**
-     * Performs a single fallback request and blocks until it completes, returning the error (or `null`) and the
-     * parsed [RemoteConfiguration] (or `null` on error).
+     * Performs a single fallback request and blocks until it completes, returning the error (or `null`), the
+     * parsed [RemoteConfiguration] (or `null` on error), and the [VerificationResult] (or `null` on error).
      */
-    private fun fetchRemoteConfigFallback(): Pair<PurchasesError?, RemoteConfiguration?> {
+    private fun fetchRemoteConfigFallback(): Triple<PurchasesError?, RemoteConfiguration?, VerificationResult?> {
         every { appConfig.isDebugBuild } returns false
 
         var error: PurchasesError? = null
         var config: RemoteConfiguration? = null
+        var verification: VerificationResult? = null
         ensureBlockFinishes { latch ->
             backend.getRemoteConfigFallback(
                 appInBackground = false,
                 domain = "app",
-                onSuccess = {
-                    config = it
+                onSuccess = { result, verificationResult ->
+                    config = result
+                    verification = verificationResult
                     latch.countDown()
                 },
                 onError = { purchasesError, _ ->
@@ -147,7 +152,7 @@ internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegr
                 },
             )
         }
-        return error to config
+        return Triple(error, config, verification)
     }
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
@@ -1,0 +1,154 @@
+package com.revenuecat.purchases.backend_integration_tests
+
+import android.content.Context
+import com.revenuecat.purchases.ForceServerErrorStrategy
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobFetcher
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.After
+import org.junit.Ignore
+import org.junit.Test
+import java.io.File
+
+/**
+ * Exercises the remote-config fallback endpoint against the real fallback host
+ * (`https://api-production.8-lives-cat.io/`). Unlike the main endpoint this is a plain `GET` returning an
+ * `application/json` [RemoteConfiguration] body (no `x-rc-format`, no inlined blobs, no request body, no nonce).
+ *
+ * [forceServerErrorStrategy] is [ForceServerErrorStrategy.failExceptFallbackUrls]: the direct-endpoint tests
+ * call the fallback host (which is never faked) so they hit the real endpoint, and the manager-flow test relies
+ * on the main `api.revenuecat.com` request being forced to a `5xx` so the domain layer routes to the fallback.
+ *
+ * TODO: Ignored until the backend deploys the fallback config endpoint. As of writing, `GET /v1/config/{domain}`
+ * on the fallback host returns `404 Object Not Found` (the sibling `/v1/offerings` and
+ * `/v1/product_entitlement_mapping` fallbacks return `200`, so the host and auth are fine — the config snapshot
+ * just isn't served yet). Re-enable once it is live. The SDK logic is fully covered by the unit tests in
+ * `BackendGetRemoteConfigTest` and `RemoteConfigManagerTest`.
+ */
+@Ignore("Backend fallback config endpoint (GET /v1/config/{domain}) not deployed yet; returns 404.")
+internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegrationTest() {
+    override fun apiKey() = Constants.apiKey
+    override val forceServerErrorStrategy: ForceServerErrorStrategy = ForceServerErrorStrategy.failExceptFallbackUrls
+
+    private val testFolder = "temp_production_remote_config_fallback_integration_test_folder"
+
+    private lateinit var remoteConfigBlobStore: RemoteConfigBlobStore
+
+    @After
+    fun tearDownRemoteConfigStorage() {
+        File(testFolder).deleteRecursively()
+    }
+
+    @Test
+    fun `can fetch remote config from the fallback endpoint`() {
+        val (error, config) = fetchRemoteConfigFallback()
+
+        assertThat(error).isNull()
+        val remoteConfiguration = requireNotNull(config) { "Expected a fallback config response." }
+        assertThat(remoteConfiguration.domain).isEqualTo("app")
+        assertThat(remoteConfiguration.manifest).isNotEmpty()
+        assertThat(remoteConfiguration.activeTopics).contains("sources", "ui_config", "workflows")
+
+        verify(exactly = 1) {
+            // The fallback endpoint is a plain-JSON GET, so its response is ETag-cached under the fallback URL,
+            // confirming the exact host + path we hit.
+            sharedPreferencesEditor.putString(
+                "https://api-production.8-lives-cat.io/v1/config/app",
+                any(),
+            )
+        }
+        // The fallback response is not signed with a nonce; with verification disabled no verification runs.
+        assertSigningNotPerformed()
+    }
+
+    @Test
+    fun `verifies the fallback response without a nonce when verification is enforced`() {
+        setupTest(SignatureVerificationMode.Enforced())
+
+        val (error, config) = fetchRemoteConfigFallback()
+
+        // Under enforcement a failed verification surfaces as an error, so a null error already implies the
+        // response verified (statically, without a nonce). Assert the signing call happened explicitly too.
+        assertThat(error).isNull()
+        assertThat(config).isNotNull
+        assertSigningPerformed()
+    }
+
+    @Test
+    fun `domain layer falls back to the fallback endpoint when the main request fails with no cached config`() {
+        every { appConfig.isDebugBuild } returns false
+        val manager = buildRemoteConfigManager()
+
+        // A cold read with an empty cache triggers an on-demand sync: the main /v1/config request is forced to a
+        // 5xx (failExceptFallbackUrls), so the domain layer routes to the fallback endpoint, whose plain-JSON
+        // config it parses and commits — making the topic readable.
+        val sources = runBlocking { manager.topic(RemoteConfigTopic.Sources) }
+
+        assertThat(sources).withFailMessage { "Expected the sources topic to be committed from the fallback." }
+            .isNotNull
+        assertThat(sources).isNotEmpty
+    }
+
+    /**
+     * Performs a single fallback request and blocks until it completes, returning the error (or `null`) and the
+     * parsed [RemoteConfiguration] (or `null` on error).
+     */
+    private fun fetchRemoteConfigFallback(): Pair<PurchasesError?, RemoteConfiguration?> {
+        every { appConfig.isDebugBuild } returns false
+
+        var error: PurchasesError? = null
+        var config: RemoteConfiguration? = null
+        ensureBlockFinishes { latch ->
+            backend.getRemoteConfigFallback(
+                appInBackground = false,
+                domain = "app",
+                onSuccess = {
+                    config = it
+                    latch.countDown()
+                },
+                onError = { purchasesError, _ ->
+                    error = purchasesError
+                    latch.countDown()
+                },
+            )
+        }
+        return error to config
+    }
+
+    /**
+     * Builds a [RemoteConfigManager] wired to the real [backend] and backed by the real [RemoteConfigDiskCache] +
+     * [RemoteConfigBlobStore] on a fresh temp folder (empty cache → cold start). The blob fetcher's network layer
+     * is mocked out (the fallback response carries no inlined blobs, and topic reads need no blob), so only the
+     * fetch -> persist -> disk -> read path is exercised.
+     */
+    private fun buildRemoteConfigManager(): RemoteConfigManager {
+        val context = mockk<Context>()
+        every { context.noBackupFilesDir } returns File(testFolder).apply { mkdirs() }
+        remoteConfigBlobStore = RemoteConfigBlobStore(context)
+        val blobFetcher = mockk<RemoteConfigBlobFetcher>(relaxed = true)
+        coEvery { blobFetcher.ensureDownloaded(any<String>()) } answers { remoteConfigBlobStore.contains(firstArg()) }
+        return RemoteConfigManager(
+            backend = backend,
+            diskCache = RemoteConfigDiskCache(context),
+            blobStore = remoteConfigBlobStore,
+            blobFetcher = blobFetcher,
+            appUserIDProvider = { REMOTE_CONFIG_USER },
+        )
+    }
+
+    private companion object {
+        private const val REMOTE_CONFIG_USER = "integrationTestRemoteConfigFallbackUser"
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
@@ -79,6 +79,37 @@ internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegr
     }
 
     @Test
+    fun `a second fallback request is served from the ETag cache`() {
+        every { appConfig.isDebugBuild } returns false
+        // The base prefs mock does not persist, so back it with a real map: otherwise the stored ETag is never
+        // read back and the second request could not send `X-RevenueCat-ETag`.
+        val prefsBacking = mutableMapOf<String, String?>()
+        every { sharedPreferences.getString(any(), any()) } answers { prefsBacking[firstArg()] ?: secondArg() as String? }
+        every { sharedPreferencesEditor.putString(any(), any()) } answers {
+            prefsBacking[firstArg()] = secondArg()
+            sharedPreferencesEditor
+        }
+
+        val (firstError, firstConfig) = fetchRemoteConfigFallback()
+        val (secondError, secondConfig) = fetchRemoteConfigFallback()
+
+        assertThat(firstError).isNull()
+        assertThat(secondError).isNull()
+        // The cached response is returned verbatim, so the second config equals the first.
+        assertThat(secondConfig).isEqualTo(firstConfig)
+
+        // The first `200` is stored under the fallback URL; the second request sends the stored ETag, the server
+        // replies `304 Not Modified`, and the SDK serves the cached result. A `304` is not re-stored, so exactly
+        // one write to the fallback URL key proves the ETag round-trip happened (a plain re-fetch would store twice).
+        verify(exactly = 1) {
+            sharedPreferencesEditor.putString(
+                "https://api-production.8-lives-cat.io/v1/config/app",
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun `domain layer falls back to the fallback endpoint when the main request fails with no cached config`() {
         every { appConfig.isDebugBuild } returns false
         val manager = buildRemoteConfigManager()

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.After
-import org.junit.Ignore
 import org.junit.Test
 import java.io.File
 
@@ -30,14 +29,7 @@ import java.io.File
  * [forceServerErrorStrategy] is [ForceServerErrorStrategy.failExceptFallbackUrls]: the direct-endpoint tests
  * call the fallback host (which is never faked) so they hit the real endpoint, and the manager-flow test relies
  * on the main `api.revenuecat.com` request being forced to a `5xx` so the domain layer routes to the fallback.
- *
- * TODO: Ignored until the backend deploys the fallback config endpoint. As of writing, `GET /v1/config/{domain}`
- * on the fallback host returns `404 Object Not Found` (the sibling `/v1/offerings` and
- * `/v1/product_entitlement_mapping` fallbacks return `200`, so the host and auth are fine — the config snapshot
- * just isn't served yet). Re-enable once it is live. The SDK logic is fully covered by the unit tests in
- * `BackendGetRemoteConfigTest` and `RemoteConfigManagerTest`.
  */
-@Ignore("Backend fallback config endpoint (GET /v1/config/{domain}) not deployed yet; returns 404.")
 internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegrationTest() {
     override fun apiKey() = Constants.apiKey
     override val forceServerErrorStrategy: ForceServerErrorStrategy = ForceServerErrorStrategy.failExceptFallbackUrls

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -14,6 +14,7 @@ import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -36,6 +37,7 @@ import kotlin.time.Duration.Companion.seconds
 class BackendGetRemoteConfigTest {
 
     private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
+    private val mockFallbackURL = URL("http://mock-fallback-test.revenuecat.com/")
 
     private val testDomain = "app"
     private val testAppUserID = "test-app-user-id"
@@ -382,6 +384,136 @@ class BackendGetRemoteConfigTest {
             )
         }
     }
+
+    // region Fallback endpoint
+
+    @Test
+    fun `getRemoteConfigFallback parses a JSON RemoteConfiguration body`() {
+        every { appConfig.fallbackBaseURLs } returns listOf(mockFallbackURL)
+        mockHttpResult(
+            payload = HTTPResult.Payload.Text(
+                """
+                {
+                  "domain": "app",
+                  "manifest": "v1.fallback.sources:etag",
+                  "active_topics": ["sources"],
+                  "topics": { "sources": { "default": { "blob_ref": "someBlob" } } }
+                }
+                """.trimIndent(),
+            ),
+            verificationResult = VerificationResult.VERIFIED,
+        )
+
+        var config: RemoteConfiguration? = null
+        backend.getRemoteConfigFallback(
+            appInBackground = false,
+            domain = testDomain,
+            onSuccess = { config = it },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+
+        assertThat(config).isNotNull
+        assertThat(config!!.domain).isEqualTo("app")
+        assertThat(config!!.manifest).isEqualTo("v1.fallback.sources:etag")
+        assertThat(config!!.activeTopics).containsExactly("sources")
+        assertThat(config!!.topics["sources"]!!["default"]!!.blobRef).isEqualTo("someBlob")
+    }
+
+    @Test
+    fun `getRemoteConfigFallback sends a GET with no body to the fallback base URL`() {
+        every { appConfig.fallbackBaseURLs } returns listOf(mockFallbackURL)
+        mockHttpResult(payload = HTTPResult.Payload.Text("""{"domain":"app","manifest":"m"}"""))
+
+        backend.getRemoteConfigFallback(
+            appInBackground = false,
+            domain = testDomain,
+            onSuccess = { },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+
+        verify(exactly = 1) {
+            httpClient.performRequest(
+                mockFallbackURL,
+                Endpoint.GetRemoteConfigFallback(testDomain),
+                // A null body is what makes this a GET.
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `getRemoteConfigFallback errors as retryable when no fallback base URL is configured`() {
+        every { appConfig.fallbackBaseURLs } returns emptyList()
+
+        var obtainedBehavior: GetRemoteConfigErrorHandlingBehavior? = null
+        backend.getRemoteConfigFallback(
+            appInBackground = false,
+            domain = testDomain,
+            onSuccess = { fail("Expected error. Got success") },
+            onError = { _, behavior -> obtainedBehavior = behavior },
+        )
+
+        assertThat(obtainedBehavior).isEqualTo(GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY)
+        verify(exactly = 0) {
+            httpClient.performRequest(any(), any(), any(), any(), any(), fallbackBaseURLs = any())
+        }
+    }
+
+    @Test
+    fun `getRemoteConfigFallback surfaces malformed JSON as retryable`() {
+        every { appConfig.fallbackBaseURLs } returns listOf(mockFallbackURL)
+        mockHttpResult(payload = HTTPResult.Payload.Text("{ not valid json"))
+
+        var obtainedError: PurchasesError? = null
+        var obtainedBehavior: GetRemoteConfigErrorHandlingBehavior? = null
+        backend.getRemoteConfigFallback(
+            appInBackground = false,
+            domain = testDomain,
+            onSuccess = { fail("Expected error. Got success") },
+            onError = { error, behavior ->
+                obtainedError = error
+                obtainedBehavior = behavior
+            },
+        )
+
+        assertThat(obtainedError).isNotNull
+        assertThat(obtainedBehavior).isEqualTo(GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY)
+    }
+
+    @Test
+    fun `getRemoteConfigFallback marks a 5xx as retryable and a 4xx as should-disable`() {
+        every { appConfig.fallbackBaseURLs } returns listOf(mockFallbackURL)
+
+        mockHttpResult(
+            responseCode = RCHTTPStatusCodes.ERROR,
+            payload = HTTPResult.Payload.Text("""{"code": 7000, "message": "internal error"}"""),
+        )
+        var serverErrorBehavior: GetRemoteConfigErrorHandlingBehavior? = null
+        backend.getRemoteConfigFallback(
+            appInBackground = false,
+            domain = testDomain,
+            onSuccess = { fail("Expected error. Got success") },
+            onError = { _, behavior -> serverErrorBehavior = behavior },
+        )
+        assertThat(serverErrorBehavior).isEqualTo(GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY)
+
+        mockHttpResult(
+            responseCode = RCHTTPStatusCodes.BAD_REQUEST,
+            payload = HTTPResult.Payload.Text("""{"code": 7000, "message": "bad request"}"""),
+        )
+        var clientErrorBehavior: GetRemoteConfigErrorHandlingBehavior? = null
+        backend.getRemoteConfigFallback(
+            appInBackground = false,
+            domain = testDomain,
+            onSuccess = { fail("Expected error. Got success") },
+            onError = { _, behavior -> clientErrorBehavior = behavior },
+        )
+        assertThat(clientErrorBehavior).isEqualTo(GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE)
+    }
+
+    // endregion Fallback endpoint
 
     private fun mockNoContentRequest(bodySlot: MutableList<Map<String, Any?>?>) {
         every {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -405,10 +405,14 @@ class BackendGetRemoteConfigTest {
         )
 
         var config: RemoteConfiguration? = null
+        var verification: VerificationResult? = null
         backend.getRemoteConfigFallback(
             appInBackground = false,
             domain = testDomain,
-            onSuccess = { config = it },
+            onSuccess = { result, verificationResult ->
+                config = result
+                verification = verificationResult
+            },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
@@ -417,6 +421,8 @@ class BackendGetRemoteConfigTest {
         assertThat(config!!.manifest).isEqualTo("v1.fallback.sources:etag")
         assertThat(config!!.activeTopics).containsExactly("sources")
         assertThat(config!!.topics["sources"]!!["default"]!!.blobRef).isEqualTo("someBlob")
+        // The verification result is exposed the same way as the main endpoint.
+        assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
     }
 
     @Test
@@ -427,7 +433,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfigFallback(
             appInBackground = false,
             domain = testDomain,
-            onSuccess = { },
+            onSuccess = { _, _ -> },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
@@ -451,7 +457,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfigFallback(
             appInBackground = false,
             domain = testDomain,
-            onSuccess = { fail("Expected error. Got success") },
+            onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { _, behavior -> obtainedBehavior = behavior },
         )
 
@@ -471,7 +477,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfigFallback(
             appInBackground = false,
             domain = testDomain,
-            onSuccess = { fail("Expected error. Got success") },
+            onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error, behavior ->
                 obtainedError = error
                 obtainedBehavior = behavior
@@ -494,7 +500,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfigFallback(
             appInBackground = false,
             domain = testDomain,
-            onSuccess = { fail("Expected error. Got success") },
+            onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { _, behavior -> serverErrorBehavior = behavior },
         )
         assertThat(serverErrorBehavior).isEqualTo(GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY)
@@ -507,7 +513,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfigFallback(
             appInBackground = false,
             domain = testDomain,
-            onSuccess = { fail("Expected error. Got success") },
+            onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { _, behavior -> clientErrorBehavior = behavior },
         )
         assertThat(clientErrorBehavior).isEqualTo(GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -25,6 +25,7 @@ class EndpointTest {
         Endpoint.GetRewardVerification("test-user-id", "client-transaction-id"),
         Endpoint.AliasUsers("test-user-id"),
         Endpoint.GetRemoteConfig("app"),
+        Endpoint.GetRemoteConfigFallback("app"),
     )
 
     @Test
@@ -160,23 +161,34 @@ class EndpointTest {
     }
 
     @Test
-    fun `GetRemoteConfig supports fallback base URLs`() {
+    fun `GetRemoteConfig does not support fallback base URLs`() {
         val endpoint = Endpoint.GetRemoteConfig("app")
-        assertThat(endpoint.supportsFallbackBaseURLs).isTrue
+        assertThat(endpoint.supportsFallbackBaseURLs).isFalse
     }
 
     @Test
-    fun `GetRemoteConfig fallback path is correct`() {
+    fun `GetRemoteConfig expects an RC Container Format response`() {
         val endpoint = Endpoint.GetRemoteConfig("app")
-        val expectedPath = "/v1/config/app"
-        assertThat(endpoint.getPath(useFallback = true)).isEqualTo(expectedPath)
+        assertThat(endpoint.expectsRCFormatResponse).isTrue
     }
 
     @Test
-    fun `GetRemoteConfig encodes the domain in the fallback path`() {
-        val endpoint = Endpoint.GetRemoteConfig("my domain")
+    fun `GetRemoteConfigFallback encodes the domain in the path`() {
+        val endpoint = Endpoint.GetRemoteConfigFallback("my domain")
         val expectedPath = "/v1/config/my%20domain"
-        assertThat(endpoint.getPath(useFallback = true)).isEqualTo(expectedPath)
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `GetRemoteConfigFallback does not support fallback base URLs`() {
+        val endpoint = Endpoint.GetRemoteConfigFallback("app")
+        assertThat(endpoint.supportsFallbackBaseURLs).isFalse
+    }
+
+    @Test
+    fun `GetRemoteConfigFallback does not expect an RC Container Format response`() {
+        val endpoint = Endpoint.GetRemoteConfigFallback("app")
+        assertThat(endpoint.expectsRCFormatResponse).isFalse
     }
 
     @Test
@@ -197,6 +209,7 @@ class EndpointTest {
             Endpoint.GetVirtualCurrencies(userId = "test-user-id"),
             Endpoint.GetRewardVerification("test-user-id", "client-transaction-id"),
             Endpoint.GetRemoteConfig("app"),
+            Endpoint.GetRemoteConfigFallback("app"),
         )
         for (endpoint in expectedSupportsValidationEndpoints) {
             assertThat(endpoint.supportsSignatureVerification)
@@ -262,6 +275,7 @@ class EndpointTest {
             Endpoint.PostEvents,
             Endpoint.WebBillingGetProducts("test-user-id", setOf("product1", "product2")),
             Endpoint.AliasUsers("test-user-id"),
+            Endpoint.GetRemoteConfigFallback("app"),
         )
         for (endpoint in expectedEndpoints) {
             assertThat(endpoint.needsNonceToPerformSigning)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -73,6 +73,9 @@ class RemoteConfigManagerTest {
     private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
     private lateinit var onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit
 
+    private lateinit var onFallbackSuccess: (RemoteConfiguration) -> Unit
+    private lateinit var onFallbackError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit
+
     @Before
     fun setup() {
         backend = mockk()
@@ -102,6 +105,13 @@ class RemoteConfigManagerTest {
             capturedPrefetchedBlobs = arg(4)
             onSuccess = arg(5)
             onError = arg(6)
+        }
+
+        every {
+            backend.getRemoteConfigFallback(any(), any(), any(), any())
+        } answers {
+            onFallbackSuccess = arg(2)
+            onFallbackError = arg(3)
         }
     }
 
@@ -170,7 +180,9 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `a failed refresh does not stamp the refresh time, so the next staleness check retries`() {
-        every { diskCache.read() } returns null
+        // A warm cache: a retryable error settles the refresh directly (no cold-start fallback), so this
+        // exercises the "failure doesn't stamp the time" bookkeeping in isolation.
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onError.invoke(
@@ -681,7 +693,8 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `a retryable error does not disable the endpoint`() {
-        every { diskCache.read() } returns null
+        // Warm cache: a retryable error settles directly (no cold-start fallback), so a subsequent refresh fires.
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onError.invoke(
@@ -695,6 +708,140 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
     }
+
+    // region Fallback endpoint
+
+    @Test
+    fun `a cold-start retryable error fetches from the fallback endpoint and commits its config`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        // No cached config: the retryable main error routes to the fallback endpoint for the same domain.
+        verify(exactly = 1) { backend.getRemoteConfigFallback(any(), "app", any(), any()) }
+
+        // The fallback returns a plain-JSON RemoteConfiguration, which the manager persists as the commit.
+        onFallbackSuccess.invoke(
+            remoteConfiguration(
+                """
+                {
+                  "domain": "app",
+                  "manifest": "v1.fallback.sources:etag",
+                  "active_topics": ["sources"],
+                  "prefetch_blobs": ["newBlob"],
+                  "topics": { "sources": { "default": { "blob_ref": "newBlob" } } }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        val written = slot<PersistedRemoteConfigurationState>()
+        verify(exactly = 1) { diskCache.write(capture(written)) }
+        assertThat(written.captured.manifest).isEqualTo("v1.fallback.sources:etag")
+        assertThat(written.captured.activeTopics).containsExactly("sources")
+        assertThat(written.captured.topics["sources"]!!["default"]!!.blobRef).isEqualTo("newBlob")
+    }
+
+    @Test
+    fun `a fallback commit prefetches wanted blobs over the network with no inline extraction`() {
+        every { diskCache.read() } returns null
+        every { blobStore.contains(any()) } returns false
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        onFallbackSuccess.invoke(
+            remoteConfiguration(
+                """
+                {
+                  "domain": "app",
+                  "manifest": "v1.fallback.sources:etag",
+                  "active_topics": ["sources"],
+                  "prefetch_blobs": ["newBlob"],
+                  "topics": { "sources": { "default": { "blob_ref": "newBlob" } } }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        // The fallback body carries no inlined elements, so no inline blob is written; the wanted blob is
+        // instead fetched over the network.
+        verify(exactly = 0) { blobStore.write(any(), any()) }
+        verify(exactly = 1) { blobFetcher.prefetch(match { it.contains("newBlob") }) }
+    }
+
+    @Test
+    fun `the fallback is not attempted when a retryable error occurs with cached data`() {
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        // Cached data wins: no fallback request, and the cache is left untouched.
+        verify(exactly = 0) { backend.getRemoteConfigFallback(any(), any(), any(), any()) }
+        verify(exactly = 0) { diskCache.write(any()) }
+    }
+
+    @Test
+    fun `a 4xx does not attempt the fallback`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
+
+        verify(exactly = 0) { backend.getRemoteConfigFallback(any(), any(), any(), any()) }
+        assertThat(manager.isDisabled).isTrue()
+    }
+
+    @Test
+    fun `a failing fallback releases the guard so a later refresh retries`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        onFallbackError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "still down"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        // The fallback settled the sync, so a later refresh is allowed to fire again.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a 4xx from the fallback disables the endpoint`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        onFallbackError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
+
+        assertThat(manager.isDisabled).isTrue()
+    }
+
+    // endregion Fallback endpoint
 
     @Test
     fun `clearCache does not re-enable an endpoint disabled by a 4xx`() {
@@ -738,7 +885,8 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `a new refresh is allowed after an error settles the in-flight one`() {
-        every { diskCache.read() } returns null
+        // Warm cache: the error settles the in-flight refresh directly (no cold-start fallback continuation).
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
         onError.invoke(
@@ -1592,7 +1740,14 @@ class RemoteConfigManagerTest {
         }
         assertThat(read.isActive).isTrue()
 
+        // Cold start (empty cache): the retryable main error continues into the fallback, so the read stays
+        // parked until the fallback also settles. A failing fallback then releases the guard and unblocks it.
         onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownError, "boom"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        assertThat(read.isActive).isTrue()
+        onFallbackError.invoke(
             PurchasesError(PurchasesErrorCode.UnknownError, "boom"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
         )
@@ -1707,6 +1862,10 @@ class RemoteConfigManagerTest {
         every { element.matchesChecksum(any()) } returns checksumValid
         return element
     }
+
+    /** Parses a plain-JSON [RemoteConfiguration] the way the fallback endpoint delivers it (no RC container). */
+    private fun remoteConfiguration(json: String): RemoteConfiguration =
+        RemoteConfiguration.parse(json.toByteArray())
 
     private fun containerWithConfig(json: String, elements: Map<String, RCElement> = emptyMap()): RCContainer {
         val element = mockk<RCElement>()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -73,7 +73,7 @@ class RemoteConfigManagerTest {
     private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
     private lateinit var onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit
 
-    private lateinit var onFallbackSuccess: (RemoteConfiguration) -> Unit
+    private lateinit var onFallbackSuccess: (RemoteConfiguration, VerificationResult) -> Unit
     private lateinit var onFallbackError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit
 
     @Before
@@ -737,6 +737,7 @@ class RemoteConfigManagerTest {
                 }
                 """.trimIndent(),
             ),
+            VerificationResult.VERIFIED,
         )
 
         val written = slot<PersistedRemoteConfigurationState>()
@@ -768,6 +769,7 @@ class RemoteConfigManagerTest {
                 }
                 """.trimIndent(),
             ),
+            VerificationResult.VERIFIED,
         )
 
         // The fallback body carries no inlined elements, so no inline blob is written; the wanted blob is

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/request_001.json
@@ -1,0 +1,22 @@
+{
+  "url": "https:\/\/api-production.8-lives-cat.io\/v1\/config\/app",
+  "method": "GET",
+  "headers": {
+    "Content-Type": "application\/json",
+    "X-Billing-Client-Sdk-Version": "8.3.0",
+    "X-Client-Bundle-ID": "com.revenuecat.purchases.backend_tests",
+    "X-Client-Locale": "en-US",
+    "X-Client-Version": "test-version-name",
+    "X-Is-Backgrounded": "false",
+    "X-Is-Debug-Build": "false",
+    "X-Kotlin-Version": "2.0.21",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "android",
+    "X-Platform-Brand": "robolectric",
+    "X-Platform-Device": "robolectric",
+    "X-Platform-Flavor": "test-flavor",
+    "X-Platform-Version": "36",
+    "X-Preferred-Locales": "en_US"
+  },
+  "body": null
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/request_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/request_002.json
@@ -16,8 +16,7 @@
     "X-Platform-Device": "robolectric",
     "X-Platform-Flavor": "test-flavor",
     "X-Platform-Version": "36",
-    "X-Preferred-Locales": "en_US",
-    "X-RC-Last-Refresh-Time": "1783679388012"
+    "X-Preferred-Locales": "en_US"
   },
   "body": null
 }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/request_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/request_002.json
@@ -1,0 +1,23 @@
+{
+  "url": "https:\/\/api-production.8-lives-cat.io\/v1\/config\/app",
+  "method": "GET",
+  "headers": {
+    "Content-Type": "application\/json",
+    "X-Billing-Client-Sdk-Version": "8.3.0",
+    "X-Client-Bundle-ID": "com.revenuecat.purchases.backend_tests",
+    "X-Client-Locale": "en-US",
+    "X-Client-Version": "test-version-name",
+    "X-Is-Backgrounded": "false",
+    "X-Is-Debug-Build": "false",
+    "X-Kotlin-Version": "2.0.21",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "android",
+    "X-Platform-Brand": "robolectric",
+    "X-Platform-Device": "robolectric",
+    "X-Platform-Flavor": "test-flavor",
+    "X-Platform-Version": "36",
+    "X-Preferred-Locales": "en_US",
+    "X-RC-Last-Refresh-Time": "1783679388012"
+  },
+  "body": null
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/response_001.json
@@ -1,0 +1,71 @@
+{
+  "statusCode": 200,
+  "headers": {
+    "Connection": "keep-alive",
+    "Content-Length": "1002",
+    "Server": "cloudflare"
+  },
+  "body": {
+    "active_topics": [
+      "sources",
+      "ui_config",
+      "workflows"
+    ],
+    "domain": "app",
+    "manifest": "TEST_STATIC_VALUE",
+    "prefetch_blobs": [
+      "xSPsPoI1UfONQ_9Rr2y1-obBx6ODzUbB"
+    ],
+    "topics": {
+      "sources": {
+        "api": {
+          "sources": [
+            {
+              "id": "primary",
+              "url": "https:\/\/api.revenuecat.com\/",
+              "priority": 0,
+              "weight": 100
+            }
+          ]
+        },
+        "blob": {
+          "sources": [
+            {
+              "id": "primary",
+              "url_format": "https:\/\/config.revenuecat-static.com\/XG8lxnuicyUpwT-t\/{blob_ref}",
+              "priority": 0,
+              "weight": 100
+            },
+            {
+              "id": "source_1",
+              "url_format": "https:\/\/config.revenuecat-static.net\/XG8lxnuicyUpwT-t\/{blob_ref}",
+              "priority": 1,
+              "weight": 100
+            }
+          ]
+        }
+      },
+      "ui_config": {
+        "app": {
+          "blob_ref": "Ewnl-09gwxiodIR5CRhrhFzGFZmV6-1i"
+        },
+        "localizations": {
+          "blob_ref": "JewnfTkEoy4-m-Z6PTP01zML1fpVPwp7"
+        },
+        "variable_config": {
+          "blob_ref": "xXyp4pHaDNzyBOTRgrLJCxjuBSG21a1p"
+        },
+        "custom_variables": {
+          "blob_ref": "RBNvo1WzZ4oRRq0W9-hknpT7T8If536D"
+        }
+      },
+      "workflows": {
+        "wf6201bae5e8254982": {
+          "blob_ref": "xSPsPoI1UfONQ_9Rr2y1-obBx6ODzUbB",
+          "prefetch": true,
+          "offering_identifier": "default"
+        }
+      }
+    }
+  }
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/response_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/response_002.json
@@ -1,0 +1,8 @@
+{
+  "statusCode": 304,
+  "headers": {
+    "Connection": "keep-alive",
+    "Server": "cloudflare"
+  },
+  "body": null
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/can fetch remote config from the fallback endpoint/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/can fetch remote config from the fallback endpoint/request_001.json
@@ -1,0 +1,22 @@
+{
+  "url": "https:\/\/api-production.8-lives-cat.io\/v1\/config\/app",
+  "method": "GET",
+  "headers": {
+    "Content-Type": "application\/json",
+    "X-Billing-Client-Sdk-Version": "8.3.0",
+    "X-Client-Bundle-ID": "com.revenuecat.purchases.backend_tests",
+    "X-Client-Locale": "en-US",
+    "X-Client-Version": "test-version-name",
+    "X-Is-Backgrounded": "false",
+    "X-Is-Debug-Build": "false",
+    "X-Kotlin-Version": "2.0.21",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "android",
+    "X-Platform-Brand": "robolectric",
+    "X-Platform-Device": "robolectric",
+    "X-Platform-Flavor": "test-flavor",
+    "X-Platform-Version": "36",
+    "X-Preferred-Locales": "en_US"
+  },
+  "body": null
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/can fetch remote config from the fallback endpoint/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/can fetch remote config from the fallback endpoint/response_001.json
@@ -1,0 +1,71 @@
+{
+  "statusCode": 200,
+  "headers": {
+    "Connection": "keep-alive",
+    "Content-Length": "1002",
+    "Server": "cloudflare"
+  },
+  "body": {
+    "active_topics": [
+      "sources",
+      "ui_config",
+      "workflows"
+    ],
+    "domain": "app",
+    "manifest": "TEST_STATIC_VALUE",
+    "prefetch_blobs": [
+      "xSPsPoI1UfONQ_9Rr2y1-obBx6ODzUbB"
+    ],
+    "topics": {
+      "sources": {
+        "api": {
+          "sources": [
+            {
+              "id": "primary",
+              "url": "https:\/\/api.revenuecat.com\/",
+              "priority": 0,
+              "weight": 100
+            }
+          ]
+        },
+        "blob": {
+          "sources": [
+            {
+              "id": "primary",
+              "url_format": "https:\/\/config.revenuecat-static.com\/XG8lxnuicyUpwT-t\/{blob_ref}",
+              "priority": 0,
+              "weight": 100
+            },
+            {
+              "id": "source_1",
+              "url_format": "https:\/\/config.revenuecat-static.net\/XG8lxnuicyUpwT-t\/{blob_ref}",
+              "priority": 1,
+              "weight": 100
+            }
+          ]
+        }
+      },
+      "ui_config": {
+        "app": {
+          "blob_ref": "Ewnl-09gwxiodIR5CRhrhFzGFZmV6-1i"
+        },
+        "localizations": {
+          "blob_ref": "JewnfTkEoy4-m-Z6PTP01zML1fpVPwp7"
+        },
+        "variable_config": {
+          "blob_ref": "xXyp4pHaDNzyBOTRgrLJCxjuBSG21a1p"
+        },
+        "custom_variables": {
+          "blob_ref": "RBNvo1WzZ4oRRq0W9-hknpT7T8If536D"
+        }
+      },
+      "workflows": {
+        "wf6201bae5e8254982": {
+          "blob_ref": "xSPsPoI1UfONQ_9Rr2y1-obBx6ODzUbB",
+          "prefetch": true,
+          "offering_identifier": "default"
+        }
+      }
+    }
+  }
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/request_001.json
@@ -1,0 +1,27 @@
+{
+  "url": "https:\/\/api.revenuecat.com\/v1\/config\/app",
+  "method": "POST",
+  "headers": {
+    "Accept": "application\/x-rc-format",
+    "Accept-RC-Element-Encoding": "gzip",
+    "Content-Type": "application\/json",
+    "X-Billing-Client-Sdk-Version": "8.3.0",
+    "X-Client-Bundle-ID": "com.revenuecat.purchases.backend_tests",
+    "X-Client-Locale": "en-US",
+    "X-Client-Version": "test-version-name",
+    "X-Is-Backgrounded": "false",
+    "X-Is-Debug-Build": "false",
+    "X-Kotlin-Version": "2.0.21",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "android",
+    "X-Platform-Brand": "robolectric",
+    "X-Platform-Device": "robolectric",
+    "X-Platform-Flavor": "test-flavor",
+    "X-Platform-Version": "36",
+    "X-Preferred-Locales": "en_US"
+  },
+  "body": {
+    "app_user_id": "integrationTestRemoteConfigFallbackUser",
+    "prefetched_blobs": []
+  }
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/request_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/request_002.json
@@ -1,0 +1,22 @@
+{
+  "url": "https:\/\/api-production.8-lives-cat.io\/v1\/config\/app",
+  "method": "GET",
+  "headers": {
+    "Content-Type": "application\/json",
+    "X-Billing-Client-Sdk-Version": "8.3.0",
+    "X-Client-Bundle-ID": "com.revenuecat.purchases.backend_tests",
+    "X-Client-Locale": "en-US",
+    "X-Client-Version": "test-version-name",
+    "X-Is-Backgrounded": "false",
+    "X-Is-Debug-Build": "false",
+    "X-Kotlin-Version": "2.0.21",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "android",
+    "X-Platform-Brand": "robolectric",
+    "X-Platform-Device": "robolectric",
+    "X-Platform-Flavor": "test-flavor",
+    "X-Platform-Version": "36",
+    "X-Preferred-Locales": "en_US"
+  },
+  "body": null
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/response_001.json
@@ -1,0 +1,10 @@
+{
+  "statusCode": 502,
+  "headers": {
+    "Connection": "keep-alive",
+    "Content-Length": "960",
+    "Content-Type": "text\/html",
+    "Server": "CloudFront"
+  },
+  "body": null
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/response_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/response_002.json
@@ -1,0 +1,71 @@
+{
+  "statusCode": 200,
+  "headers": {
+    "Connection": "keep-alive",
+    "Content-Length": "1002",
+    "Server": "cloudflare"
+  },
+  "body": {
+    "active_topics": [
+      "sources",
+      "ui_config",
+      "workflows"
+    ],
+    "domain": "app",
+    "manifest": "TEST_STATIC_VALUE",
+    "prefetch_blobs": [
+      "xSPsPoI1UfONQ_9Rr2y1-obBx6ODzUbB"
+    ],
+    "topics": {
+      "sources": {
+        "api": {
+          "sources": [
+            {
+              "id": "primary",
+              "url": "https:\/\/api.revenuecat.com\/",
+              "priority": 0,
+              "weight": 100
+            }
+          ]
+        },
+        "blob": {
+          "sources": [
+            {
+              "id": "primary",
+              "url_format": "https:\/\/config.revenuecat-static.com\/XG8lxnuicyUpwT-t\/{blob_ref}",
+              "priority": 0,
+              "weight": 100
+            },
+            {
+              "id": "source_1",
+              "url_format": "https:\/\/config.revenuecat-static.net\/XG8lxnuicyUpwT-t\/{blob_ref}",
+              "priority": 1,
+              "weight": 100
+            }
+          ]
+        }
+      },
+      "ui_config": {
+        "app": {
+          "blob_ref": "Ewnl-09gwxiodIR5CRhrhFzGFZmV6-1i"
+        },
+        "localizations": {
+          "blob_ref": "JewnfTkEoy4-m-Z6PTP01zML1fpVPwp7"
+        },
+        "variable_config": {
+          "blob_ref": "xXyp4pHaDNzyBOTRgrLJCxjuBSG21a1p"
+        },
+        "custom_variables": {
+          "blob_ref": "RBNvo1WzZ4oRRq0W9-hknpT7T8If536D"
+        }
+      },
+      "workflows": {
+        "wf6201bae5e8254982": {
+          "blob_ref": "xSPsPoI1UfONQ_9Rr2y1-obBx6ODzUbB",
+          "prefetch": true,
+          "offering_identifier": "default"
+        }
+      }
+    }
+  }
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/verifies the fallback response without a nonce when verification is enforced/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/verifies the fallback response without a nonce when verification is enforced/request_001.json
@@ -1,0 +1,22 @@
+{
+  "url": "https:\/\/api-production.8-lives-cat.io\/v1\/config\/app",
+  "method": "GET",
+  "headers": {
+    "Content-Type": "application\/json",
+    "X-Billing-Client-Sdk-Version": "8.3.0",
+    "X-Client-Bundle-ID": "com.revenuecat.purchases.backend_tests",
+    "X-Client-Locale": "en-US",
+    "X-Client-Version": "test-version-name",
+    "X-Is-Backgrounded": "false",
+    "X-Is-Debug-Build": "false",
+    "X-Kotlin-Version": "2.0.21",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "android",
+    "X-Platform-Brand": "robolectric",
+    "X-Platform-Device": "robolectric",
+    "X-Platform-Flavor": "test-flavor",
+    "X-Platform-Version": "36",
+    "X-Preferred-Locales": "en_US"
+  },
+  "body": null
+}

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/verifies the fallback response without a nonce when verification is enforced/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/verifies the fallback response without a nonce when verification is enforced/response_001.json
@@ -1,0 +1,71 @@
+{
+  "statusCode": 200,
+  "headers": {
+    "Connection": "keep-alive",
+    "Content-Length": "1002",
+    "Server": "cloudflare"
+  },
+  "body": {
+    "active_topics": [
+      "sources",
+      "ui_config",
+      "workflows"
+    ],
+    "domain": "app",
+    "manifest": "TEST_STATIC_VALUE",
+    "prefetch_blobs": [
+      "xSPsPoI1UfONQ_9Rr2y1-obBx6ODzUbB"
+    ],
+    "topics": {
+      "sources": {
+        "api": {
+          "sources": [
+            {
+              "id": "primary",
+              "url": "https:\/\/api.revenuecat.com\/",
+              "priority": 0,
+              "weight": 100
+            }
+          ]
+        },
+        "blob": {
+          "sources": [
+            {
+              "id": "primary",
+              "url_format": "https:\/\/config.revenuecat-static.com\/XG8lxnuicyUpwT-t\/{blob_ref}",
+              "priority": 0,
+              "weight": 100
+            },
+            {
+              "id": "source_1",
+              "url_format": "https:\/\/config.revenuecat-static.net\/XG8lxnuicyUpwT-t\/{blob_ref}",
+              "priority": 1,
+              "weight": 100
+            }
+          ]
+        }
+      },
+      "ui_config": {
+        "app": {
+          "blob_ref": "Ewnl-09gwxiodIR5CRhrhFzGFZmV6-1i"
+        },
+        "localizations": {
+          "blob_ref": "JewnfTkEoy4-m-Z6PTP01zML1fpVPwp7"
+        },
+        "variable_config": {
+          "blob_ref": "xXyp4pHaDNzyBOTRgrLJCxjuBSG21a1p"
+        },
+        "custom_variables": {
+          "blob_ref": "RBNvo1WzZ4oRRq0W9-hknpT7T8If536D"
+        }
+      },
+      "workflows": {
+        "wf6201bae5e8254982": {
+          "blob_ref": "xSPsPoI1UfONQ_9Rr2y1-obBx6ODzUbB",
+          "prefetch": true,
+          "offering_identifier": "default"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The config endpoint fallback wasn't really working in the previous format, since it has some differences from the main endpoint. For example:
- It's a GET, not a POST
- Uses application/json, not x-rc-format
- No inline items
- No `nonce` for signing

Since it was quite different, we split the fallback to a completely separate endpoint. This will only be hit if there is nothing in cache, preferring cache over the fallback values.

Also added some integration tests for this

Android equivalent of https://github.com/RevenueCat/purchases-ios/pull/7182


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cold-start remote config networking and commit behavior (no inlined blobs on fallback), but scope is limited to empty-cache retry paths and is covered by integration and unit tests.
> 
> **Overview**
> Remote config no longer relies on the generic HTTP client URL fallback for `/v1/config`. The main **`GetRemoteConfig`** call always hits the primary base URL only (no `fallbackBaseURLs` on that request), and a separate **`GetRemoteConfigFallback`** endpoint handles recovery.
> 
> **Dedicated fallback path:** **`Backend.getRemoteConfigFallback`** issues a **GET** to the first configured fallback host, parses plain **`application/json`** into **`RemoteConfiguration`** (not RC container format), and verifies signatures **without a nonce** (like offerings). **`RemoteConfigManager`** only uses this on **cold start**: when the main POST fails with a retryable error **and** there is **no cached config**. If anything is already cached, that data is kept and the fallback is skipped; **4xx** still disables the endpoint without trying fallback.
> 
> **Persistence:** Fallback commits pass **`container = null`**, so inlined blobs are not extracted from the response; wanted blobs are fetched via **`prefetchBlobs`** / the blob fetcher instead.
> 
> Unit, manager, endpoint, and production integration tests (including ETag caching on the fallback host) cover the new flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cad78ce91e4218a56169d1650a48c5a8845262b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->