### PR TITLE
perf(remote-config): run /v1/config on a dedicated dispatcher to overlap getOfferings

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -160,6 +160,13 @@ internal class PurchasesFactory(
                 createEventsExecutor(),
                 runningIntegrationTests = runningIntegrationTests,
             )
+            // `/v1/config` gets its own thread so it overlaps `getOfferings` instead of serializing behind it
+            // on the backend dispatcher. Kept separate even when the app supplied its own `service`, since
+            // sharing that executor would re-serialize the two requests.
+            val remoteConfigDispatcher = Dispatcher(
+                createRemoteConfigExecutor(),
+                runningIntegrationTests = runningIntegrationTests,
+            )
 
             var diagnosticsFileHelper: DiagnosticsFileHelper? = null
             var diagnosticsHelper: DiagnosticsHelper? = null
@@ -208,6 +215,7 @@ internal class PurchasesFactory(
                 eventsDispatcher,
                 httpClient,
                 backendHelper,
+                remoteConfigDispatcher,
             )
             val coilImageDownloader = CoilImageDownloader(application)
             val fileRepository = DefaultFileRepository(application)
@@ -557,6 +565,12 @@ internal class PurchasesFactory(
 
     private fun createEventsExecutor(): ExecutorService {
         return Executors.newSingleThreadScheduledExecutor(LowPriorityThreadFactory("revenuecat-events-thread"))
+    }
+
+    // Scheduled so the dispatcher can apply the background jitter (Delay.DEFAULT) getRemoteConfig uses.
+    // Normal priority: it sits on the getOfferings critical path, unlike the low-priority events executor.
+    private fun createRemoteConfigExecutor(): ExecutorService {
+        return Executors.newSingleThreadScheduledExecutor()
     }
 
     private class LowPriorityThreadFactory(private val threadName: String) : ThreadFactory {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -567,8 +567,6 @@ internal class PurchasesFactory(
         return Executors.newSingleThreadScheduledExecutor(LowPriorityThreadFactory("revenuecat-events-thread"))
     }
 
-    // Scheduled so the dispatcher can apply the background jitter (Delay.DEFAULT) getRemoteConfig uses.
-    // Normal priority: it sits on the getOfferings critical path, unlike the low-priority events executor.
     private fun createRemoteConfigExecutor(): ExecutorService {
         return Executors.newSingleThreadScheduledExecutor()
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -146,9 +146,6 @@ internal class Backend(
     private val eventsDispatcher: Dispatcher,
     private val httpClient: HTTPClient,
     private val backendHelper: BackendHelper,
-    // Remote config (`/v1/config`) runs on its own dispatcher so it can overlap `getOfferings` instead of
-    // serializing behind it on the shared backend [dispatcher]. Defaults to [dispatcher] so callers that
-    // don't override it (tests) keep the previous single-threaded behavior.
     private val remoteConfigDispatcher: Dispatcher = dispatcher,
 ) {
     companion object {
@@ -226,7 +223,6 @@ internal class Backend(
 
     fun close() {
         this.dispatcher.close()
-        // No-op double shutdown when it defaults to [dispatcher]; closes the dedicated thread otherwise.
         this.remoteConfigDispatcher.close()
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -146,6 +146,10 @@ internal class Backend(
     private val eventsDispatcher: Dispatcher,
     private val httpClient: HTTPClient,
     private val backendHelper: BackendHelper,
+    // Remote config (`/v1/config`) runs on its own dispatcher so it can overlap `getOfferings` instead of
+    // serializing behind it on the shared backend [dispatcher]. Defaults to [dispatcher] so callers that
+    // don't override it (tests) keep the previous single-threaded behavior.
+    private val remoteConfigDispatcher: Dispatcher = dispatcher,
 ) {
     companion object {
         private const val APP_USER_ID = "app_user_id"
@@ -222,6 +226,8 @@ internal class Backend(
 
     fun close() {
         this.dispatcher.close()
+        // No-op double shutdown when it defaults to [dispatcher]; closes the dedicated thread otherwise.
+        this.remoteConfigDispatcher.close()
     }
 
     fun getCustomerInfo(
@@ -1250,7 +1256,7 @@ internal class Backend(
             val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
             remoteConfigCallbacks.addBackgroundAwareCallback(
                 call,
-                dispatcher,
+                remoteConfigDispatcher,
                 cacheKey,
                 onSuccess to onError,
                 delay,
@@ -1336,7 +1342,7 @@ internal class Backend(
             val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
             remoteConfigFallbackCallbacks.addBackgroundAwareCallback(
                 call,
-                dispatcher,
+                remoteConfigDispatcher,
                 cacheKey,
                 onSuccess to onError,
                 delay,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
+import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
 import com.revenuecat.purchases.common.HTTPClient
@@ -112,6 +113,50 @@ class BackendGetRemoteConfigTest {
             .isEqualTo(config)
         assertThat(parsed.contentElements).hasSize(1)
         assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
+    }
+
+    @Test
+    fun `getRemoteConfig is enqueued on the remote config dispatcher, not the main backend dispatcher`() {
+        // The whole point of the dedicated dispatcher is that /v1/config overlaps getOfferings instead of
+        // serializing on the shared backend dispatcher. Prove getRemoteConfig routes to the remote-config
+        // dispatcher (delivers synchronously here) and never touches the main backend dispatcher.
+        var mainDispatcherUsed = false
+        val mainDispatcher = object : Dispatcher(mockk()) {
+            override fun enqueue(command: Runnable, delay: Delay) {
+                mainDispatcherUsed = true
+            }
+        }
+        val isolatedBackend = Backend(
+            appConfig,
+            mainDispatcher,
+            SyncDispatcher(),
+            httpClient,
+            BackendHelper("TEST_API_KEY", SyncDispatcher(), appConfig, httpClient),
+            SyncDispatcher(),
+        )
+
+        val config = "{\"hello\":\"world\"}".toByteArray()
+        val element = "blob-bytes".toByteArray()
+        mockHttpResult(
+            payload = HTTPResult.Payload.RCFormat(buildContainer(config = config, elements = listOf(element))),
+            verificationResult = VerificationResult.VERIFIED,
+        )
+
+        var container: RCContainer? = null
+        isolatedBackend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = testAppUserID,
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { result, _ -> container = result },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+
+        // Delivered synchronously => it ran on the (Sync) remote-config dispatcher.
+        assertThat(container).isNotNull
+        // The main backend dispatcher was never used for the config request.
+        assertThat(mainDispatcherUsed).isFalse
     }
 
     @Test


### PR DESCRIPTION
## Summary

`/v1/config` (remote config) shared the single-threaded backend dispatcher with `/offerings`, so the two requests serialized on one worker thread. The config request (~0.5s) and its `RCContainer.parse` were therefore fully additive to cold `getOfferings` latency, even though the readiness gate already kicks both off concurrently at the orchestrator level.

This routes `getRemoteConfig` / `getRemoteConfigFallback` onto their own dedicated dispatcher (a single-thread scheduled executor) so the request and its container parse **overlap** `/offerings` instead of queuing behind it.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Threading-only change with a default constructor fallback; behavior is unchanged aside from request scheduling and one extra executor to shut down.
> 
> **Overview**
> Remote config (`/v1/config` and fallback) no longer shares the single-threaded **backend** dispatcher with `getOfferings` and other API work. `PurchasesFactory` wires a dedicated `remoteConfigDispatcher` backed by its own single-thread executor, including when the app supplies a custom `ExecutorService`, so config traffic cannot queue behind offerings.
> 
> `Backend` routes `getRemoteConfig` / `getRemoteConfigFallback` through that dispatcher, closes it on teardown, and a new test asserts config requests never enqueue on the main backend dispatcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dc2c253cf596796816a2dd047ad12dac878e851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->