### PR TITLE
refactor(remote-config): Clarify prefetch remote-config blobs in the server-provided order

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -733,12 +733,12 @@ internal class RemoteConfigManager(
      */
     private fun prefetchBlobs(response: RemoteConfiguration, mergedTopics: Map<String, ConfigTopic>) {
         sourceProvider.restartIfExhausted(RemoteConfigSourceHandle.Purpose.BLOB)
-        val refs = buildSet {
+        val refs = buildList {
             addAll(response.prefetchBlobs)
             mergedTopics.values.forEach { topic ->
                 topic.values.forEach { item -> if (item.prefetch) item.blobRef?.let(::add) }
             }
-        }
+        }.distinct()
         val toPrefetch = refs.filterNot { blobStore.contains(it) }
         verboseLog { "Prefetching ${toPrefetch.size} remote config blob(s)." }
         blobFetcher.prefetch(toPrefetch)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -285,6 +285,22 @@ class RemoteConfigBlobFetcherTest {
     }
 
     @Test
+    fun `prefetch downloads blobs in the given list order`() = runTest {
+        val started = CopyOnWriteArrayList<String>()
+        recordStartedConnections(started)
+        val fetcherScope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val fetcher = RemoteConfigBlobFetcher(blobStore, provider(blobSource(TEMPLATE)), urlConnectionFactory, fetcherScope)
+
+        // Deliberately unsorted: the LOW queue must attempt the refs in exactly the order they were handed over.
+        val refs = listOf("e", "a", "d", "b", "c").map { refOf("blob-$it".toByteArray()) }
+        fetcher.prefetch(refs)
+        advanceUntilIdle()
+
+        assertThat(started).containsExactly(*refs.toTypedArray())
+        fetcherScope.cancel()
+    }
+
+    @Test
     fun `an on-demand request boosts and joins a blob already queued for prefetch`() = runTest {
         val started = CopyOnWriteArrayList<String>()
         recordStartedConnections(started)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -447,6 +447,34 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `prefetch preserves the server prefetch_blobs order, then item prefetch refs, deduped`() {
+        every { diskCache.read() } returns null
+        // prefetch_blobs deliberately not sorted: the SDK must warm them in the exact order the server sent.
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.workflows:etag2",
+              "active_topics": ["workflows"],
+              "prefetch_blobs": ["$REF_TAMPERED", "$REF_VALID", "$REF_UNWANTED"],
+              "topics": {
+                "workflows": {
+                  "wf1": { "blob_ref": "$REF_VALID", "prefetch": true },
+                  "wf2": { "blob_ref": "$REF_EXTRA", "prefetch": true }
+                }
+              }
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        val prefetched = slot<List<String>>()
+        verify(exactly = 1) { blobFetcher.prefetch(capture(prefetched)) }
+        // Server order first (as-is), then the only new item ref; REF_VALID is deduped to its first position.
+        assertThat(prefetched.captured).containsExactly(REF_TAMPERED, REF_VALID, REF_UNWANTED, REF_EXTRA)
+    }
+
+    @Test
     fun `a 200 response does not prefetch blobs already cached`() {
         every { diskCache.read() } returns null
         every { blobStore.contains(REF_VALID) } returns true
@@ -1917,5 +1945,6 @@ class RemoteConfigManagerTest {
         private const val REF_VALID = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"
         private const val REF_TAMPERED = "IIIIJJJJKKKKLLLLMMMMNNNNOOOOPPPP"
         private const val REF_UNWANTED = "QQQQRRRRSSSSTTTTUUUUVVVVWWWWXXXX"
+        private const val REF_EXTRA = "11112222333344445555666677778888"
     }
 }


### PR DESCRIPTION
Prefetch non-inlined prefetch blobs in the order the backend returns them in `prefetch_blobs`. This is already the case right now but it's more incidental (LinkedHashSet preserves order but List is a better type to represent this). Also added tests to preserve this behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small type/refactor in prefetch assembly plus unit tests; no auth, persistence, or API surface changes beyond prefetch scheduling order being explicit and covered.
> 
> **Overview**
> Remote config blob prefetch now builds an **ordered** `List` (server `prefetch_blobs` first, then topic items with `prefetch: true`) and **dedupes** while keeping the first occurrence—replacing a `Set` where order was only incidental.
> 
> New tests lock in that **`RemoteConfigBlobFetcher`** runs LOW-priority prefetch in list order and that **`RemoteConfigManager`** passes refs to `blobFetcher.prefetch` in server order, then item refs, with duplicates collapsed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0419c982d336a9ab231a0402047965cd7d442e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->