### PR TITLE
fix(remote-config): throttle failed refresh attempts

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * Orchestrates a single `/v1/config` sync: replays the persisted opaque manifest, then on `204` keeps the cache
@@ -803,7 +803,7 @@ internal class RemoteConfigManager(
 
     private companion object {
         private const val DEFAULT_DOMAIN = "app"
-        private val REFRESH_ATTEMPT_COOLDOWN = 30.seconds
+        private val REFRESH_ATTEMPT_COOLDOWN = 1.minutes
     }
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -33,6 +33,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Orchestrates a single `/v1/config` sync: replays the persisted opaque manifest, then on `204` keeps the cache
@@ -98,6 +99,9 @@ internal class RemoteConfigManager(
     @Volatile
     private var lastRefreshedAt: Date? = null
 
+    @Volatile
+    private var lastRefreshAttemptAt: Date? = null
+
     // The app user a cold on-demand read should sync for, rebound by clearCache() under [cacheLock] atomically
     // with the epoch bump, so it can never lag the identity change the way [appUserIDProvider] (backed by the
     // device cache) can. Null until the first identity change; awaitConfigForRead() falls back to the provider
@@ -128,7 +132,7 @@ internal class RemoteConfigManager(
 
     fun refreshRemoteConfigIfStale(appInBackground: Boolean, appUserID: String) {
         if (lastRefreshedAt.isCacheStale(appInBackground, dateProvider)) {
-            refreshRemoteConfig(appInBackground, appUserID)
+            refreshRemoteConfigIfAttemptCooldownElapsed(appInBackground, appUserID)
         }
     }
 
@@ -182,6 +186,17 @@ internal class RemoteConfigManager(
                 )
             },
         )
+    }
+
+    private fun refreshRemoteConfigIfAttemptCooldownElapsed(appInBackground: Boolean, appUserID: String) {
+        val now = dateProvider.now
+        val lastAttempt = lastRefreshAttemptAt
+        if (lastAttempt == null || now.time - lastAttempt.time >= REFRESH_ATTEMPT_COOLDOWN.inWholeMilliseconds) {
+            lastRefreshAttemptAt = now
+            refreshRemoteConfig(appInBackground, appUserID)
+        } else {
+            debugLog { "Remote config refresh was attempted recently. Skipping stale-gated refresh." }
+        }
     }
 
     /**
@@ -291,6 +306,7 @@ internal class RemoteConfigManager(
         synchronized(cacheLock) {
             if (epoch.get() == requestEpoch) {
                 lastRefreshedAt = dateProvider.now
+                lastRefreshAttemptAt = null
                 isRefreshing.set(false)
                 completeRefresh()
             }
@@ -335,6 +351,7 @@ internal class RemoteConfigManager(
             currentAppUserID = appUserID
             isRefreshing.set(false)
             lastRefreshedAt = null
+            lastRefreshAttemptAt = null
             completeRefresh()
             // Intentionally NOT resetting `disabled`: a 4xx is an endpoint/app-level fact that outlives an
             // identity change. It clears only on app restart.
@@ -397,7 +414,7 @@ internal class RemoteConfigManager(
         val appUserID = (currentAppUserID ?: appUserIDProvider())?.takeIf { it.isNotBlank() }
         if (!disabled && appUserID != null) {
             verboseLog { "Cold remote config read triggering an on-demand sync." }
-            refreshRemoteConfig(appInBackground = false, appUserID = appUserID)
+            refreshRemoteConfigIfAttemptCooldownElapsed(appInBackground = false, appUserID = appUserID)
             // Join whatever is now in flight — the sync we just triggered, or one a concurrent caller started.
             awaitInFlightRefresh()
         } else {
@@ -711,6 +728,7 @@ internal class RemoteConfigManager(
 
         if (persisted) {
             lastRefreshedAt = dateProvider.now
+            lastRefreshAttemptAt = null
             debugLog {
                 "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +
                     "${blobRefsToKeep.size} blobs wanted)."
@@ -770,6 +788,7 @@ internal class RemoteConfigManager(
 
     private companion object {
         private const val DEFAULT_DOMAIN = "app"
+        private val REFRESH_ATTEMPT_COOLDOWN = 30.seconds
     }
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -132,17 +132,21 @@ internal class RemoteConfigManager(
 
     fun refreshRemoteConfigIfStale(appInBackground: Boolean, appUserID: String) {
         if (lastRefreshedAt.isCacheStale(appInBackground, dateProvider)) {
-            refreshRemoteConfigIfAttemptCooldownElapsed(appInBackground, appUserID)
+            refreshRemoteConfig(appInBackground, appUserID, staleGated = true)
         }
     }
 
     fun refreshRemoteConfig(appInBackground: Boolean, appUserID: String) {
+        refreshRemoteConfig(appInBackground, appUserID, staleGated = false)
+    }
+
+    private fun refreshRemoteConfig(appInBackground: Boolean, appUserID: String, staleGated: Boolean) {
         if (disabled) {
             debugLog { "Remote config is disabled for this session (4xx). Skipping refresh." }
             return
         }
-        val requestEpoch: Int
-        val requestAppUserID: String
+        var requestEpoch = 0
+        var requestAppUserID = appUserID
         // Acquire the in-flight guard and capture the epoch together under the lock that also guards
         // clearCache()'s epoch bump + guard release. Otherwise an identity change could slip its bump
         // between getAndSet(true) and epoch.get(), stranding this request with a stale epoch: its
@@ -153,14 +157,31 @@ internal class RemoteConfigManager(
         // our response) — never a stale user paired with the post-clear epoch. currentAppUserID (bound by
         // clearCache) wins; the passed appUserID is only the pre-first-identity-change bootstrap fallback.
         // Read only in-memory state under the lock — never appUserIDProvider(), which can re-enter clearCache().
-        synchronized(cacheLock) {
-            if (isRefreshing.getAndSet(true)) {
-                debugLog { "Remote config refresh already in progress. Skipping." }
-                return
+        val shouldRefresh = synchronized(cacheLock) {
+            val now = dateProvider.now
+            when {
+                isRefreshing.get() -> {
+                    debugLog { "Remote config refresh already in progress. Skipping." }
+                    false
+                }
+                staleGated && !isRefreshAttemptCooldownElapsed(now) -> {
+                    debugLog { "Remote config refresh was attempted recently. Skipping stale-gated refresh." }
+                    false
+                }
+                else -> {
+                    if (staleGated) {
+                        lastRefreshAttemptAt = now
+                    }
+                    isRefreshing.set(true)
+                    requestEpoch = epoch.get()
+                    requestAppUserID = currentAppUserID ?: appUserID
+                    refreshCompletion = CompletableDeferred()
+                    true
+                }
             }
-            requestEpoch = epoch.get()
-            requestAppUserID = currentAppUserID ?: appUserID
-            refreshCompletion = CompletableDeferred()
+        }
+        if (!shouldRefresh) {
+            return
         }
         val persisted = diskCache.read()
         val storedBlobs = blobStore.cachedRefs()
@@ -188,15 +209,9 @@ internal class RemoteConfigManager(
         )
     }
 
-    private fun refreshRemoteConfigIfAttemptCooldownElapsed(appInBackground: Boolean, appUserID: String) {
-        val now = dateProvider.now
+    private fun isRefreshAttemptCooldownElapsed(now: Date): Boolean {
         val lastAttempt = lastRefreshAttemptAt
-        if (lastAttempt == null || now.time - lastAttempt.time >= REFRESH_ATTEMPT_COOLDOWN.inWholeMilliseconds) {
-            lastRefreshAttemptAt = now
-            refreshRemoteConfig(appInBackground, appUserID)
-        } else {
-            debugLog { "Remote config refresh was attempted recently. Skipping stale-gated refresh." }
-        }
+        return lastAttempt == null || now.time - lastAttempt.time >= REFRESH_ATTEMPT_COOLDOWN.inWholeMilliseconds
     }
 
     /**
@@ -414,7 +429,7 @@ internal class RemoteConfigManager(
         val appUserID = (currentAppUserID ?: appUserIDProvider())?.takeIf { it.isNotBlank() }
         if (!disabled && appUserID != null) {
             verboseLog { "Cold remote config read triggering an on-demand sync." }
-            refreshRemoteConfigIfAttemptCooldownElapsed(appInBackground = false, appUserID = appUserID)
+            refreshRemoteConfig(appInBackground = false, appUserID = appUserID, staleGated = true)
             // Join whatever is now in flight — the sync we just triggered, or one a concurrent caller started.
             awaitInFlightRefresh()
         } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
 import com.revenuecat.purchases.common.JsonProvider
+import com.revenuecat.purchases.common.between
 import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
@@ -33,6 +34,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 /**
@@ -211,7 +213,7 @@ internal class RemoteConfigManager(
 
     private fun isRefreshAttemptCooldownElapsed(now: Date): Boolean {
         val lastAttempt = lastRefreshAttemptAt
-        return lastAttempt == null || now.time - lastAttempt.time >= REFRESH_ATTEMPT_COOLDOWN.inWholeMilliseconds
+        return lastAttempt == null || Duration.between(lastAttempt, now) >= REFRESH_ATTEMPT_COOLDOWN
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -321,7 +321,6 @@ internal class RemoteConfigManager(
         synchronized(cacheLock) {
             if (epoch.get() == requestEpoch) {
                 lastRefreshedAt = dateProvider.now
-                lastRefreshAttemptAt = null
                 isRefreshing.set(false)
                 completeRefresh()
             }
@@ -743,7 +742,6 @@ internal class RemoteConfigManager(
 
         if (persisted) {
             lastRefreshedAt = dateProvider.now
-            lastRefreshAttemptAt = null
             debugLog {
                 "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +
                     "${blobRefsToKeep.size} blobs wanted)."

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -179,9 +179,46 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `a failed refresh does not stamp the refresh time, so the next staleness check retries`() {
+    fun `clearCache clears the failed attempt cooldown`() {
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
+
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        manager.clearCache(TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a failed refresh does not stamp the refresh time, but stale-gated retries are throttled`() {
         // A warm cache: a retryable error settles the refresh directly (no cold-start fallback), so this
         // exercises the "failure doesn't stamp the time" bookkeeping in isolation.
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
+
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        // Same clock: the failure left lastRefreshedAt unset, but the recent attempt keeps stale-gated refreshes
+        // from retrying on every caller.
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+
+        currentTimeMillis += REFRESH_ATTEMPT_COOLDOWN_MILLIS + 1
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `explicit refresh retries immediately after a retryable failure`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
@@ -190,9 +227,7 @@ class RemoteConfigManagerTest {
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
         )
 
-        // Same clock: the failure left lastRefreshedAt unset, so the staleness check retries immediately
-        // instead of sitting out the window with no data.
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
 
         verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
     }
@@ -855,6 +890,28 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `a failing fallback is throttled for stale-gated retries`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        onFallbackError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "still down"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+
+        currentTimeMillis += REFRESH_ATTEMPT_COOLDOWN_MILLIS + 1
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `a 4xx from the fallback disables the endpoint`() {
         every { diskCache.read() } returns null
 
@@ -1127,6 +1184,44 @@ class RemoteConfigManagerTest {
 
         assertThat(read.isCompleted).isTrue()
         assertThat(result).containsKey("wf1")
+    }
+
+    @Test
+    fun `topic-triggered syncs are throttled after a retryable failure`() = runTest {
+        every { diskCache.read() } returns persisted(
+            manifest = "m",
+            activeTopics = listOf("sources"),
+            topics = mapOf(
+                "sources" to ConfigTopic(mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = REF_VALID))),
+            ),
+        )
+        val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
+
+        var firstResult: ConfigTopic? = ConfigTopic(emptyMap())
+        val firstRead = launch(UnconfinedTestDispatcher(testScheduler)) {
+            firstResult = manager.topic(RemoteConfigTopic.Workflows)
+        }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        assertThat(firstRead.isCompleted).isTrue()
+        assertThat(firstResult).isNull()
+
+        assertThat(manager.topic(RemoteConfigTopic.Workflows)).isNull()
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+
+        currentTimeMillis += REFRESH_ATTEMPT_COOLDOWN_MILLIS + 1
+        val retryRead = launch(UnconfinedTestDispatcher(testScheduler)) {
+            manager.topic(RemoteConfigTopic.Workflows)
+        }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        assertThat(retryRead.isCompleted).isTrue()
     }
 
     @Test
@@ -1937,6 +2032,7 @@ class RemoteConfigManagerTest {
 
         // Older than the 5-minute foreground staleness window (see Date?.isCacheStale).
         private const val STALE_FOREGROUND_AGE_MILLIS = 6 * 60 * 1000L
+        private const val REFRESH_ATTEMPT_COOLDOWN_MILLIS = 30_000L
         private const val WAIT_SECONDS = 5L
         private const val BLOCKED_MILLIS = 200L
         private const val STRESS_ITERATIONS = 50

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -2048,7 +2048,7 @@ class RemoteConfigManagerTest {
 
         // Older than the 5-minute foreground staleness window (see Date?.isCacheStale).
         private const val STALE_FOREGROUND_AGE_MILLIS = 6 * 60 * 1000L
-        private const val REFRESH_ATTEMPT_COOLDOWN_MILLIS = 30_000L
+        private const val REFRESH_ATTEMPT_COOLDOWN_MILLIS = 60_000L
         private const val WAIT_SECONDS = 5L
         private const val BLOCKED_MILLIS = 200L
         private const val STRESS_ITERATIONS = 50

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -218,6 +218,22 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `a skipped stale-gated refresh while already in flight does not start the cooldown`() {
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `explicit refresh retries immediately after a retryable failure`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -179,7 +179,7 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `clearCache clears the failed attempt cooldown`() {
+    fun `clearCache clears the refresh attempt cooldown`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)


### PR DESCRIPTION
Android equivalent of https://github.com/RevenueCat/purchases-ios/pull/7191

## Motivation

When locally cached remote-config data is available, a failed request to the remote config endpoint does not fall back. However it also does not update the local cache (which makes sense). However this results in it also bypassing the staleness check, causing every subsequent request to be sent to the backend right away.

Now that we're refreshing the remote config state when fetching offerings, any call to `getOfferings()` (or any app-foreground) will make another call to the remote config API as long as it's degraded.

## Changes
This PR adds the `lastRefreshAttemptAt` and will only allow a new request to be sent after the `rereshAttemptCooldownInSeconds` has passed, which I set to `30s` for now (up for discussion)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes refresh scheduling for a core sync path used by offerings and topic reads; mis-tuned cooldown or gating could delay recovery after outages, though explicit refresh and cache clear remain escape hatches.
> 
> **Overview**
> Stops **retry storms** when `/v1/config` fails but local config is still usable: failed syncs never update `lastRefreshedAt`, so every stale check (e.g. offerings / foreground) could hit the API again immediately.
> 
> **`RemoteConfigManager`** now tracks **`lastRefreshAttemptAt`** and routes refreshes through a **`staleGated`** flag. **`refreshRemoteConfigIfStale`**, cold reads (`awaitConfigForRead`), and topic-triggered on-demand syncs use stale-gated mode and are **skipped** until **`REFRESH_ATTEMPT_COOLDOWN` (1 minute)** elapses after the last started attempt. **`refreshRemoteConfig()`** (explicit) **ignores** that cooldown so callers can retry right away. The cooldown is recorded only when a stale-gated refresh **actually starts** (not when one is skipped because another is in flight). **`clearCache`** clears the attempt timestamp so a new user can sync immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40de1c66ceaab972eeaadaa9883b0e9d589d05af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->