### PR TITLE
feat(paywalls): web_view component (PWENG-98)

### DIFF
--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallDialogOptionsAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallDialogOptionsAPI.kt
@@ -24,6 +24,7 @@ private class PaywallDialogOptionsAPI {
             .setListener(listener)
             .setShouldDisplayDismissButton(true)
             .setFontProvider(fontProvider)
+            .setWebViewMessageHandler(null)
             .build()
         val shouldDisplayBlock2 = options.shouldDisplayBlock
         val offering2: Offering? = options.offering

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ testLibraries = "1.6.1"
 tink = "1.8.0"
 viewmodelCompose = "2.4.0"
 window = "1.1.0"
+webkit = "1.12.1"
 junit = "1.2.1"
 uiautomator = "2.3.0"
 benchmarkMacroJunit4 = "1.3.4"
@@ -85,6 +86,7 @@ androidx-browser = { module = "androidx.browser:browser", version.ref = "browser
 androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidxCardView" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidxConstraintLayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
+androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "webkit" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreference" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
 androidx-legacy-core-ui = { module = "androidx.legacy:legacy-support-core-ui", version.ref = "legacyCoreUi" }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
@@ -57,6 +57,7 @@ internal class PaywallComponentSerializer : KSerializer<PaywallComponent> {
             "tabs" -> jsonDecoder.json.decodeFromJsonElement<TabsComponent>(json)
             "video" -> jsonDecoder.json.decodeFromJsonElement<VideoComponent>(json)
             "countdown" -> jsonDecoder.json.decodeFromJsonElement<CountdownComponent>(json)
+            "web_view" -> jsonDecoder.json.decodeFromJsonElement<WebViewComponent>(json)
             "fallback_header" -> FallbackHeaderComponent
             else -> json["fallback"]
                 ?.let { it as? JsonObject }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -1,0 +1,41 @@
+package com.revenuecat.purchases.paywalls.components
+
+import androidx.compose.runtime.Immutable
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A Paywalls V2 component that renders generic hosted web content (a web bundle entrypoint) inside a
+ * web view.
+ *
+ * Only [protocolVersion] `1` is currently supported. Isolation from external sources is expected from
+ * the Content-Security-Policy served by the backend with the web content; the bundle must be fully
+ * self-contained.
+ */
+@InternalRevenueCatAPI
+@Poko
+@Serializable
+@SerialName("web_view")
+@Immutable
+public class WebViewComponent(
+    @get:JvmSynthetic
+    public val url: String,
+    @get:JvmSynthetic
+    public val id: String? = null,
+    @get:JvmSynthetic
+    public val name: String? = null,
+    @get:JvmSynthetic
+    public val visible: Boolean? = null,
+    @SerialName("protocol_version")
+    @get:JvmSynthetic
+    public val protocolVersion: Int? = null,
+    @get:JvmSynthetic
+    public val size: Size = Size(width = Fill, height = SizeConstraint.Fit),
+    @get:JvmSynthetic
+    public val fallback: StackComponent? = null,
+) : PaywallComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -36,6 +36,4 @@ public class WebViewComponent(
     public val protocolVersion: Int? = null,
     @get:JvmSynthetic
     public val size: Size = Size(width = Fill, height = SizeConstraint.Fit),
-    @get:JvmSynthetic
-    public val fallback: StackComponent? = null,
 ) : PaywallComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentFilterExtension.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentFilterExtension.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 
 /**
  * Returns all PaywallComponent that satisfy the predicate.
@@ -74,6 +75,7 @@ internal fun PaywallComponent.filter(predicate: (PaywallComponent) -> Boolean): 
             is ImageComponent,
             is IconComponent,
             is TextComponent,
+            is WebViewComponent,
             -> {
                 // These don't have child components.
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
@@ -115,6 +116,7 @@ internal class PaywallComponentsImagePreDownloader(
                     is TabControlToggleComponent,
                     is TextComponent,
                     is TimelineComponent,
+                    is WebViewComponent,
                     -> emptySet()
                 }
             }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -1,0 +1,133 @@
+package com.revenuecat.purchases.paywalls.components
+
+import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.utils.filter
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class WebViewComponentTests {
+
+    @Language("json")
+    private val fullJson = """
+        {
+          "id": "promo_web_view",
+          "type": "web_view",
+          "protocol_version": 1,
+          "url": "https://assets.pawwalls.com/web_bundles/123/index.html",
+          "size": {
+            "width": { "type": "fill" },
+            "height": { "type": "fit" }
+          },
+          "visible": true,
+          "name": "Promo web component",
+          "fallback": {
+            "type": "stack",
+            "components": []
+          }
+        }
+        """
+
+    @Test
+    fun `deserializes full Khepri schema`() {
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(fullJson)
+
+        assertThat(actual).isInstanceOf(WebViewComponent::class.java)
+        val webView = actual as WebViewComponent
+
+        assertThat(webView.id).isEqualTo("promo_web_view")
+        assertThat(webView.name).isEqualTo("Promo web component")
+        assertThat(webView.visible).isTrue()
+        assertThat(webView.protocolVersion).isEqualTo(1)
+        assertThat(webView.url).isEqualTo("https://assets.pawwalls.com/web_bundles/123/index.html")
+        assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit))
+        assertThat(webView.fallback).isNotNull
+        assertThat(webView.fallback?.components).isEmpty()
+    }
+
+    @Test
+    fun `ignores capabilities declared by the schema`() {
+        // Isolation from external sources is expected from the server-provided CSP, so any
+        // schema-declared capabilities are decoded-and-ignored rather than failing to parse.
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "capabilities": {
+                "network_access": { "allowed_domains": ["api.segment.io"] },
+                "camera": true,
+                "microphone": true,
+                "clipboard_write": true,
+                "clipboard_read": true,
+                "geolocation": true
+              }
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
+
+        assertEquals(
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            actual,
+        )
+    }
+
+    @Test
+    fun `deserializes template url correctly`() {
+        @Language("json")
+        val templateJson = """
+            {
+              "type": "web_view",
+              "protocol_version": 1,
+              "url": "https://paywalls.revenuecat.com/{{ custom.animal }}.html"
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(templateJson)
+
+        assertEquals(
+            WebViewComponent(
+                url = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
+                protocolVersion = 1,
+            ),
+            actual,
+        )
+    }
+
+    @Test
+    fun `deserializes minimal shape with defaults for missing optional fields`() {
+        // Older/partial configs may omit protocol_version and size. These should still
+        // decode without crashing, using defaults.
+        @Language("json")
+        val minimalJson = """
+            {
+              "type": "web_view",
+              "url": "https://paywalls.revenuecat.com/index.html"
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(minimalJson)
+
+        assertEquals(
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            actual,
+        )
+        val webView = actual as WebViewComponent
+        assertThat(webView.protocolVersion).isNull()
+        assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit))
+    }
+
+    @Test
+    fun `filter treats web_view as a leaf component`() {
+        // web_view has no child components, so filtering a tree should return only the component itself.
+        val webView = WebViewComponent(url = "https://paywalls.revenuecat.com/index.html")
+
+        val matches = webView.filter { it is WebViewComponent }
+
+        assertThat(matches).containsExactly(webView)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -23,11 +23,7 @@ class WebViewComponentTests {
             "height": { "type": "fit" }
           },
           "visible": true,
-          "name": "Promo web component",
-          "fallback": {
-            "type": "stack",
-            "components": []
-          }
+          "name": "Promo web component"
         }
         """
 
@@ -44,8 +40,30 @@ class WebViewComponentTests {
         assertThat(webView.protocolVersion).isEqualTo(1)
         assertThat(webView.url).isEqualTo("https://assets.pawwalls.com/web_bundles/123/index.html")
         assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit))
-        assertThat(webView.fallback).isNotNull
-        assertThat(webView.fallback?.components).isEmpty()
+    }
+
+    @Test
+    fun `ignores schema fallback field`() {
+        // web_view intentionally has no native fallback stack; older/dashboard payloads that
+        // still include `fallback` must decode without error (unknown keys are ignored).
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "fallback": {
+                "type": "stack",
+                "components": []
+              }
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
+
+        assertEquals(
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            actual,
+        )
     }
 
     @Test

--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -44,6 +44,7 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic? getPurchaseLogic();
     method public kotlin.jvm.functions.Function1<com.revenuecat.purchases.CustomerInfo,java.lang.Boolean>? getShouldDisplayBlock();
     method public boolean getShouldDisplayDismissButton();
+    method public com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler? getWebViewMessageHandler();
     property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue> customVariables;
     property public final kotlin.jvm.functions.Function0<kotlin.Unit>? dismissRequest;
     property public final com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider? fontProvider;
@@ -52,6 +53,8 @@ package com.revenuecat.purchases.ui.revenuecatui {
     property public final com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic? purchaseLogic;
     property public final kotlin.jvm.functions.Function1<com.revenuecat.purchases.CustomerInfo,java.lang.Boolean>? shouldDisplayBlock;
     property public final boolean shouldDisplayDismissButton;
+    property public final com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler? webViewMessageHandler;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions.Companion Companion;
   }
 
   public static final class PaywallDialogOptions.Builder {
@@ -66,6 +69,10 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions.Builder setRequiredEntitlementIdentifier(String? requiredEntitlementIdentifier);
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions.Builder setShouldDisplayBlock(kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.CustomerInfo,java.lang.Boolean>? shouldDisplayBlock);
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions.Builder setShouldDisplayDismissButton(boolean shouldDisplayDismissButton);
+    method public com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions.Builder setWebViewMessageHandler(com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler? handler);
+  }
+
+  public static final class PaywallDialogOptions.Companion {
   }
 
   public final class PaywallFooterKt {
@@ -96,11 +103,13 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider? getFontProvider();
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallListener? getListener();
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic? getPurchaseLogic();
+    method public com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler? getWebViewMessageHandler();
     property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue> customVariables;
     property public final kotlin.jvm.functions.Function0<kotlin.Unit> dismissRequest;
     property public final com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider? fontProvider;
     property public final com.revenuecat.purchases.ui.revenuecatui.PaywallListener? listener;
     property public final com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic? purchaseLogic;
+    property public final com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler? webViewMessageHandler;
     field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallOptions.Companion Companion;
   }
 
@@ -113,6 +122,7 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallOptions.Builder setOffering(com.revenuecat.purchases.Offering? offering);
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallOptions.Builder setPurchaseLogic(com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic? purchaseLogic);
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallOptions.Builder setShouldDisplayDismissButton(boolean shouldDisplayDismissButton);
+    method public com.revenuecat.purchases.ui.revenuecatui.PaywallOptions.Builder setWebViewMessageHandler(com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler? handler);
   }
 
   public static final class PaywallOptions.Companion {
@@ -148,6 +158,67 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public abstract void performPurchaseWithCompletion(android.app.Activity activity, com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogicParams params, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult,kotlin.Unit> completion);
     method public final suspend Object? performRestore(com.revenuecat.purchases.CustomerInfo customerInfo, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult>);
     method public abstract void performRestoreWithCompletion(com.revenuecat.purchases.CustomerInfo customerInfo, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult,kotlin.Unit> completion);
+  }
+
+  public interface PaywallWebViewController {
+    method public void postMessage(String componentId, String type, java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> variables);
+    method public void postVariables(String componentId, java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> variables);
+  }
+
+  @dev.drewhamilton.poko.Poko public final class PaywallWebViewMessage {
+    ctor public PaywallWebViewMessage(String componentId, String type, optional java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? responses, optional String? error);
+    method public String getComponentId();
+    method public String? getError();
+    method public java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? getResponses();
+    method public String getType();
+    property public final String componentId;
+    property public final String? error;
+    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? responses;
+    property public final String type;
+  }
+
+  public fun interface PaywallWebViewMessageHandler {
+    method public void onMessage(com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessage message, com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController controller);
+  }
+
+  public abstract class PaywallWebViewValue {
+  }
+
+  public static final class PaywallWebViewValue.Array extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Array(java.util.List<? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value);
+    method public java.util.List<com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> getValue();
+    property public final java.util.List<com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value;
+  }
+
+  public static final class PaywallWebViewValue.Boolean extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Boolean(boolean value);
+    method public boolean getValue();
+    property public final boolean value;
+  }
+
+  public static final class PaywallWebViewValue.Null extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue.Null INSTANCE;
+  }
+
+  public static final class PaywallWebViewValue.Number extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Number(double value);
+    ctor public PaywallWebViewValue.Number(float value);
+    ctor public PaywallWebViewValue.Number(int value);
+    ctor public PaywallWebViewValue.Number(long value);
+    method public double getValue();
+    property public final double value;
+  }
+
+  public static final class PaywallWebViewValue.Object extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Object(java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value);
+    method public java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> getValue();
+    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value;
+  }
+
+  public static final class PaywallWebViewValue.String extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.String(String value);
+    method public String getValue();
+    property public final String value;
   }
 
   @Deprecated public interface PurchaseLogic extends com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic {

--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -54,7 +54,6 @@ package com.revenuecat.purchases.ui.revenuecatui {
     property public final kotlin.jvm.functions.Function1<com.revenuecat.purchases.CustomerInfo,java.lang.Boolean>? shouldDisplayBlock;
     property public final boolean shouldDisplayDismissButton;
     property public final com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler? webViewMessageHandler;
-    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions.Companion Companion;
   }
 
   public static final class PaywallDialogOptions.Builder {
@@ -70,9 +69,6 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions.Builder setShouldDisplayBlock(kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.CustomerInfo,java.lang.Boolean>? shouldDisplayBlock);
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions.Builder setShouldDisplayDismissButton(boolean shouldDisplayDismissButton);
     method public com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions.Builder setWebViewMessageHandler(com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler? handler);
-  }
-
-  public static final class PaywallDialogOptions.Companion {
   }
 
   public final class PaywallFooterKt {

--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -99,6 +99,7 @@ dependencies {
     implementation(libs.compose.ui.google.fonts)
 
     implementation(libs.androidx.core)
+    implementation(libs.androidx.webkit)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -132,5 +132,6 @@ private fun buildPaywallOptions(
         .setPurchaseLogic(paywallDialogOptions.purchaseLogic)
         .setDismissRequestWithExitOffering(dismissRequestWithExitOffering)
         .setCustomVariables(paywallDialogOptions.customVariables)
+        .setWebViewMessageHandler(paywallDialogOptions.webViewMessageHandler)
         .build()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -43,7 +43,7 @@ public class PaywallDialogOptions internal constructor(
         webViewMessageHandler = builder.webViewMessageHandler,
     )
 
-    public companion object {
+    private companion object {
         private const val hashMultiplier = 31
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -22,6 +22,10 @@ public class PaywallDialogOptions internal constructor(
      * `{{ $custom.key }}` placeholders in the paywall configuration.
      */
     public val customVariables: Map<String, CustomVariableValue> = emptyMap(),
+    /**
+     * Handler for messages sent by Paywalls V2 `web_view` components. See [PaywallWebViewMessageHandler].
+     */
+    public val webViewMessageHandler: PaywallWebViewMessageHandler? = null,
 ) {
 
     internal val offeringSelection: OfferingSelection
@@ -36,8 +40,40 @@ public class PaywallDialogOptions internal constructor(
         listener = builder.listener,
         purchaseLogic = builder.purchaseLogic,
         customVariables = builder.customVariables,
+        webViewMessageHandler = builder.webViewMessageHandler,
     )
 
+    public companion object {
+        private const val hashMultiplier = 31
+    }
+
+    // webViewMessageHandler is included in equals but excluded from hashCode (like PaywallOptions).
+    override fun hashCode(): Int {
+        var result = shouldDisplayDismissButton.hashCode()
+        result = hashMultiplier * result + customVariables.hashCode()
+        result = hashMultiplier * result + (offering?.identifier?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PaywallDialogOptions) return false
+
+        return when {
+            this.shouldDisplayBlock != other.shouldDisplayBlock -> false
+            this.dismissRequest != other.dismissRequest -> false
+            this.offering != other.offering -> false
+            this.shouldDisplayDismissButton != other.shouldDisplayDismissButton -> false
+            this.fontProvider != other.fontProvider -> false
+            this.listener != other.listener -> false
+            this.purchaseLogic != other.purchaseLogic -> false
+            this.customVariables != other.customVariables -> false
+            this.webViewMessageHandler != other.webViewMessageHandler -> false
+            else -> true
+        }
+    }
+
+    @Suppress("TooManyFunctions")
     public class Builder {
         internal var shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null
         internal var dismissRequest: (() -> Unit)? = null
@@ -47,6 +83,7 @@ public class PaywallDialogOptions internal constructor(
         internal var listener: PaywallListener? = null
         internal var purchaseLogic: PaywallPurchaseLogic? = null
         internal var customVariables: Map<String, CustomVariableValue> = emptyMap()
+        internal var webViewMessageHandler: PaywallWebViewMessageHandler? = null
 
         /**
          * Allows to configure whether to display the paywall dialog depending on operations on the CustomerInfo
@@ -104,6 +141,15 @@ public class PaywallDialogOptions internal constructor(
          */
         public fun setCustomVariables(variables: Map<String, CustomVariableValue>): Builder = apply {
             this.customVariables = variables
+        }
+
+        /**
+         * Sets a handler for messages sent by Paywalls V2 `web_view` components. The handler receives
+         * validated messages (such as `rc:step-complete`, `rc:request-variables`, and `rc:error`) on
+         * the main thread, along with a [PaywallWebViewController] for replying to the web view.
+         */
+        public fun setWebViewMessageHandler(handler: PaywallWebViewMessageHandler?): Builder = apply {
+            this.webViewMessageHandler = handler
         }
 
         public fun build(): PaywallDialogOptions {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -60,6 +60,11 @@ public class PaywallOptions internal constructor(
      * `{{ $custom.key }}` placeholders in the paywall configuration.
      */
     public val customVariables: Map<String, CustomVariableValue> = emptyMap(),
+    /**
+     * Handler for messages sent by Paywalls V2 `web_view` components. Lets app code receive validated
+     * messages and reply to them. See [PaywallWebViewMessageHandler].
+     */
+    public val webViewMessageHandler: PaywallWebViewMessageHandler? = null,
     internal val injectedWorkflow: PublishedWorkflow? = null,
     internal val injectedWorkflowUiConfig: UiConfig = emptyUiConfig(),
 ) {
@@ -77,6 +82,7 @@ public class PaywallOptions internal constructor(
         dismissRequest = builder.dismissRequest,
         dismissRequestWithExitOffering = builder.dismissRequestWithExitOffering,
         customVariables = builder.customVariables,
+        webViewMessageHandler = builder.webViewMessageHandler,
         injectedWorkflow = builder.injectedWorkflow,
         injectedWorkflowUiConfig = builder.injectedWorkflowUiConfig,
     )
@@ -106,6 +112,7 @@ public class PaywallOptions internal constructor(
             this.purchaseLogic != other.purchaseLogic -> false
             this.mode != other.mode -> false
             this.customVariables != other.customVariables -> false
+            this.webViewMessageHandler != other.webViewMessageHandler -> false
             this.injectedWorkflow != other.injectedWorkflow -> false
             this.injectedWorkflowUiConfig != other.injectedWorkflowUiConfig -> false
             else -> this.dismissRequest == other.dismissRequest
@@ -122,6 +129,7 @@ public class PaywallOptions internal constructor(
         dismissRequest: () -> Unit = this.dismissRequest,
         dismissRequestWithExitOffering: ((Offering?, PaywallResult?) -> Unit)? = this.dismissRequestWithExitOffering,
         customVariables: Map<String, CustomVariableValue> = this.customVariables,
+        webViewMessageHandler: PaywallWebViewMessageHandler? = this.webViewMessageHandler,
         injectedWorkflow: PublishedWorkflow? = this.injectedWorkflow,
         injectedWorkflowUiConfig: UiConfig = this.injectedWorkflowUiConfig,
     ): PaywallOptions = PaywallOptions(
@@ -134,6 +142,7 @@ public class PaywallOptions internal constructor(
         dismissRequest = dismissRequest,
         dismissRequestWithExitOffering = dismissRequestWithExitOffering,
         customVariables = customVariables,
+        webViewMessageHandler = webViewMessageHandler,
         injectedWorkflow = injectedWorkflow,
         injectedWorkflowUiConfig = injectedWorkflowUiConfig,
     )
@@ -150,6 +159,7 @@ public class PaywallOptions internal constructor(
         internal var mode: PaywallMode = PaywallMode.default
         internal var dismissRequestWithExitOffering: ((Offering?, PaywallResult?) -> Unit)? = null
         internal var customVariables: Map<String, CustomVariableValue> = emptyMap()
+        internal var webViewMessageHandler: PaywallWebViewMessageHandler? = null
         internal var injectedWorkflow: PublishedWorkflow? = null
         internal var injectedWorkflowUiConfig: UiConfig = emptyUiConfig()
 
@@ -211,6 +221,19 @@ public class PaywallOptions internal constructor(
          */
         public fun setCustomVariables(variables: Map<String, CustomVariableValue>): Builder = apply {
             this.customVariables = CustomVariableKeyValidator.validateAndFilter(variables)
+        }
+
+        /**
+         * Sets a handler for messages sent by Paywalls V2 `web_view` components. The handler receives
+         * validated messages (such as `rc:step-complete`, `rc:request-variables`, and `rc:error`) on
+         * the main thread, along with a [PaywallWebViewController] for replying to the web view.
+         *
+         * Bidirectional messaging is always enabled for `web_view` components; this handler is how the
+         * app observes and responds to those messages. The SDK does not automatically dismiss the
+         * paywall or trigger a purchase in response to any message.
+         */
+        public fun setWebViewMessageHandler(handler: PaywallWebViewMessageHandler?): Builder = apply {
+            this.webViewMessageHandler = handler
         }
 
         /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewMessage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewMessage.kt
@@ -1,0 +1,93 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import dev.drewhamilton.poko.Poko
+
+/**
+ * A validated message received from a Paywalls V2 `web_view` component.
+ *
+ * Messages follow the RevenueCat web view postMessage envelope. Known [type]s include:
+ * - `rc:step-loaded`
+ * - `rc:step-complete` (carries [responses])
+ * - `rc:request-variables`
+ * - `rc:error` (carries [error])
+ *
+ * @property componentId The canonical component id (the `web_view.id` from the paywall schema). This
+ * matches the id API consumers see in the paywall configuration.
+ * @property type The message type, e.g. `rc:step-complete`.
+ * @property responses The structured responses for a `rc:step-complete` message, if any.
+ * @property error The error description for a `rc:error` message, if any.
+ */
+@Poko
+public class PaywallWebViewMessage(
+    public val componentId: String,
+    public val type: String,
+    public val responses: Map<String, PaywallWebViewValue>? = null,
+    public val error: String? = null,
+)
+
+/**
+ * Lets app code send messages back into a Paywalls V2 `web_view` component, for example in response to
+ * a `rc:request-variables` message.
+ *
+ * Outgoing messages preserve the RevenueCat web view postMessage envelope and are validated before
+ * being delivered to the web view.
+ */
+public interface PaywallWebViewController {
+
+    /**
+     * Sends a `rc:variables` message into the web view targeting [componentId]. The SDK already replies
+     * with SDK-managed variables (such as `locale`); use this to provide additional values. The flat
+     * [variables] map is sent as the transport envelope's `payload` field (not nested under a
+     * `variables` key). Reserved SDK-managed top-level keys cannot be overwritten; provide
+     * app-specific values under `custom`.
+     */
+    public fun postVariables(
+        componentId: String,
+        variables: Map<String, PaywallWebViewValue>,
+    )
+
+    /**
+     * Sends a message of the given [type] into the web view targeting [componentId]. The flat
+     * [variables] map is sent as the transport envelope's `payload` field (not nested under a
+     * `variables` key). Use [postVariables] for the common `rc:variables` case.
+     */
+    public fun postMessage(
+        componentId: String,
+        type: String,
+        variables: Map<String, PaywallWebViewValue>,
+    )
+}
+
+/**
+ * Receives validated messages from Paywalls V2 `web_view` components.
+ *
+ * Set this on [PaywallOptions.Builder.setWebViewMessageHandler]. The handler is always invoked on the
+ * main thread. The app decides what to do with each message: the SDK does not automatically dismiss the
+ * paywall or trigger a purchase in response to `rc:step-complete`.
+ *
+ * ### Usage
+ * ```kotlin
+ * PaywallOptions.Builder { /* dismiss */ }
+ *     .setWebViewMessageHandler { message, controller ->
+ *         when (message.type) {
+ *             "rc:request-variables" -> controller.postVariables(
+ *                 componentId = message.componentId,
+ *                 variables = mapOf(
+ *                     "custom" to PaywallWebViewValue.Object(
+ *                         mapOf("app_segment" to PaywallWebViewValue.String("high_intent")),
+ *                     ),
+ *                 ),
+ *             )
+ *             "rc:step-complete" -> { /* read message.responses, navigate, log analytics, etc. */ }
+ *             "rc:error" -> { /* log message.error */ }
+ *         }
+ *     }
+ *     .build()
+ * ```
+ */
+public fun interface PaywallWebViewMessageHandler {
+    public fun onMessage(
+        message: PaywallWebViewMessage,
+        controller: PaywallWebViewController,
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
@@ -1,0 +1,144 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A JSON-compatible value used in messages exchanged with a Paywalls V2 `web_view` component.
+ *
+ * Only JSON-like values are supported: [String], [Number], [Boolean], [Object], [Array] and [Null].
+ * Functions, binary blobs, dates, and platform-specific objects are intentionally not representable.
+ *
+ * @see PaywallWebViewMessage
+ * @see PaywallWebViewController
+ */
+// Modeled as an abstract class with a closed set of subtypes (mirroring [CustomVariableValue]) rather
+// than a sealed class, to stay binary-compatible as public API.
+public abstract class PaywallWebViewValue internal constructor() {
+
+    /**
+     * A string value.
+     */
+    public class String(public val value: kotlin.String) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is String && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.String(value=$value)"
+    }
+
+    /**
+     * A numeric value (integer or decimal). Stored as a [Double].
+     *
+     * Non-finite values (`NaN`, infinities) cannot be represented in JSON and serialize as JSON
+     * `null` when sent into the web view. Equality follows [Double.equals] semantics (consistent
+     * with [hashCode]): `NaN` equals `NaN`, and `-0.0` does not equal `0.0`.
+     */
+    public class Number(public val value: kotlin.Double) : PaywallWebViewValue() {
+        public constructor(value: kotlin.Int) : this(value.toDouble())
+        public constructor(value: kotlin.Long) : this(value.toDouble())
+        public constructor(value: kotlin.Float) : this(value.toDouble())
+
+        override fun equals(other: Any?): kotlin.Boolean = other is Number && value.equals(other.value)
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Number(value=$value)"
+    }
+
+    /**
+     * A boolean value.
+     */
+    public class Boolean(public val value: kotlin.Boolean) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Boolean && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Boolean(value=$value)"
+    }
+
+    /**
+     * A JSON object: a map of string keys to [PaywallWebViewValue]s.
+     */
+    public class Object(public val value: Map<kotlin.String, PaywallWebViewValue>) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Object && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Object(value=$value)"
+    }
+
+    /**
+     * A JSON array: an ordered list of [PaywallWebViewValue]s.
+     */
+    public class Array(public val value: List<PaywallWebViewValue>) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Array && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Array(value=$value)"
+    }
+
+    /**
+     * A JSON `null` value.
+     */
+    public object Null : PaywallWebViewValue() {
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Null"
+    }
+
+    internal companion object {
+        /**
+         * Converts an `org.json` value (or Kotlin primitive) into a [PaywallWebViewValue], rejecting
+         * anything that is not JSON-compatible or that exceeds [remainingDepth] levels of nesting.
+         *
+         * @return the converted value, or `null` if the value is not JSON-compatible or too deeply nested.
+         */
+        @Suppress("ReturnCount", "CyclomaticComplexMethod")
+        fun fromJson(value: Any?, remainingDepth: Int): PaywallWebViewValue? {
+            return when (value) {
+                null, JSONObject.NULL -> Null
+                is kotlin.String -> String(value)
+                is kotlin.Boolean -> Boolean(value)
+                is Int -> Number(value)
+                is Long -> Number(value)
+                is Double -> Number(value)
+                is Float -> Number(value)
+                is JSONObject -> {
+                    if (remainingDepth <= 0) return null
+                    val map = LinkedHashMap<kotlin.String, PaywallWebViewValue>(value.length())
+                    for (key in value.keys()) {
+                        map[key] = fromJson(value.get(key), remainingDepth - 1) ?: return null
+                    }
+                    Object(map)
+                }
+                is JSONArray -> {
+                    if (remainingDepth <= 0) return null
+                    val list = ArrayList<PaywallWebViewValue>(value.length())
+                    for (index in 0 until value.length()) {
+                        list.add(fromJson(value.get(index), remainingDepth - 1) ?: return null)
+                    }
+                    Array(list)
+                }
+                // Numbers stored by org.json as BigDecimal/BigInteger, or any other type, are not supported.
+                else -> (value as? kotlin.Number)?.let { Number(it.toDouble()) }
+            }
+        }
+    }
+}
+
+/**
+ * Converts this value into a representation accepted by [JSONObject]/[JSONArray] when serializing a
+ * message to send into the web view. Whole numbers are emitted as integers (e.g. `100`, not `100.0`).
+ * Non-finite numbers serialize as JSON `null`: JSON cannot represent them, `org.json`'s `put` throws
+ * for them, and one bad number must never destroy an otherwise-valid outbound message.
+ */
+internal fun PaywallWebViewValue.toJsonRepresentation(): Any = when (this) {
+    is PaywallWebViewValue.String -> value
+    is PaywallWebViewValue.Boolean -> value
+    is PaywallWebViewValue.Number -> when {
+        !value.isFinite() -> JSONObject.NULL
+        value % 1.0 == 0.0 -> value.toLong()
+        else -> value
+    }
+    is PaywallWebViewValue.Object -> JSONObject().apply {
+        value.forEach { (key, child) -> put(key, child.toJsonRepresentation()) }
+    }
+    is PaywallWebViewValue.Array -> JSONArray().apply {
+        value.forEach { child -> put(child.toJsonRepresentation()) }
+    }
+    else -> JSONObject.NULL
+}
+
+internal fun Map<String, PaywallWebViewValue>.toJsonObject(): JSONObject = JSONObject().apply {
+    forEach { (key, value) -> put(key, value.toJsonRepresentation()) }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ComponentView.kt
@@ -30,12 +30,14 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.TabsComponentSt
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TimelineComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabControlButtonView
 import com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabControlToggleView
 import com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabsComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.text.TextComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.timeline.TimelineComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.video.VideoComponentView
+import com.revenuecat.purchases.ui.revenuecatui.components.webview.WebViewComponentView
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
 
@@ -73,6 +75,13 @@ internal fun ComponentView(
             modifier = modifier,
         )
     }
+    is WebViewComponentStyle -> WebViewComponentView(
+        style = style,
+        state = state,
+        modifier = modifier,
+        onClick = onClick,
+        componentInteractionTracker = componentInteractionTracker,
+    )
     is ButtonComponentStyle -> ButtonComponentView(
         style = style,
         state = state,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ComponentView.kt
@@ -79,8 +79,6 @@ internal fun ComponentView(
         style = style,
         state = state,
         modifier = modifier,
-        onClick = onClick,
-        componentInteractionTracker = componentInteractionTracker,
     )
     is ButtonComponentStyle -> ButtonComponentView(
         style = style,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -27,6 +27,7 @@ import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
@@ -573,11 +574,26 @@ internal class StyleFactory(
             is TabsComponent -> createTabsComponentStyle(component)
             is VideoComponent -> createVideoComponentStyle(component)
             is FallbackHeaderComponent -> Result.Success(null)
+            is WebViewComponent -> createWebViewComponentStyle(component)
             is CountdownComponent -> createCountdownComponentStyle(
                 component,
             )
         }
     }
+
+    private fun StyleFactoryScope.createWebViewComponentStyle(
+        component: WebViewComponent,
+    ): Result<WebViewComponentStyle, NonEmptyList<PaywallValidationError>> =
+        component.fallback?.let { createStackComponentStyle(it) }.orSuccessfullyNull().map { fallbackStyle ->
+            WebViewComponentStyle(
+                url = component.url,
+                visible = component.visible ?: DEFAULT_VISIBILITY,
+                size = component.size,
+                componentId = component.id,
+                protocolVersion = component.protocolVersion,
+                fallbackStackComponentStyle = fallbackStyle,
+            )
+        }
 
     private fun StyleFactoryScope.createCountdownComponentStyle(
         component: CountdownComponent,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -584,16 +584,15 @@ internal class StyleFactory(
     private fun StyleFactoryScope.createWebViewComponentStyle(
         component: WebViewComponent,
     ): Result<WebViewComponentStyle, NonEmptyList<PaywallValidationError>> =
-        component.fallback?.let { createStackComponentStyle(it) }.orSuccessfullyNull().map { fallbackStyle ->
+        Result.Success(
             WebViewComponentStyle(
                 url = component.url,
                 visible = component.visible ?: DEFAULT_VISIBILITY,
                 size = component.size,
                 componentId = component.id,
                 protocolVersion = component.protocolVersion,
-                fallbackStackComponentStyle = fallbackStyle,
-            )
-        }
+            ),
+        )
 
     private fun StyleFactoryScope.createCountdownComponentStyle(
         component: CountdownComponent,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -23,5 +23,4 @@ internal data class WebViewComponentStyle(
      * (the single version this SDK build implements) during the handshake, regardless of this value.
      */
     val protocolVersion: Int? = null,
-    val fallbackStackComponentStyle: StackComponentStyle? = null,
 ) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -1,0 +1,27 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.style
+
+import androidx.compose.runtime.Immutable
+import com.revenuecat.purchases.paywalls.components.properties.Size
+
+@Immutable
+internal data class WebViewComponentStyle(
+    val url: String,
+    override val visible: Boolean,
+    override val size: Size,
+    /**
+     * The canonical component id from the schema (`web_view.id`), used to scope bidirectional
+     * messages. May be null for legacy/partial configs that omit it, in which case the message bridge
+     * is not installed.
+     */
+    val componentId: String? = null,
+    /**
+     * The schema-declared `protocol_version`, decoded and preserved for future use. NOT the host's
+     * capability: the bridge always advertises [WebViewEnvelope.DEFAULT_PROTOCOL_VERSION][
+     * com.revenuecat.purchases.ui.revenuecatui.components.webview.WebViewEnvelope.DEFAULT_PROTOCOL_VERSION]
+     * (the single version this SDK build implements) during the handshake, regardless of this value.
+     */
+    val protocolVersion: Int? = null,
+    val fallbackStackComponentStyle: StackComponentStyle? = null,
+) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -1,0 +1,77 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.graphics.Bitmap
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+
+/**
+ * [WebViewClient] for Paywalls V2 `web_view` components. Owns navigation policy, main-frame document
+ * lifecycle notifications, and a single terminal failure path shared by URL errors, HTTP errors, and
+ * renderer termination.
+ */
+internal class PaywallWebViewClient(
+    private val expectedOrigin: String?,
+    private val onMainFrameNavigationStarted: (url: String?) -> Unit,
+    private val onMainFrameLoadFailed: () -> Unit,
+) : WebViewClient() {
+
+    @Volatile
+    private var failed: Boolean = false
+
+    private fun markFailed() {
+        if (failed) return
+        failed = true
+        onMainFrameLoadFailed()
+    }
+
+    override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+        super.onPageStarted(view, url, favicon)
+        // onPageStarted is main-frame only and marks a new JavaScript document.
+        onMainFrameNavigationStarted(url)
+    }
+
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        return shouldBlockWebViewNavigation(
+            url = request.url?.toString(),
+            isMainFrame = request.isForMainFrame,
+            expectedOrigin = expectedOrigin,
+        )
+    }
+
+    override fun onReceivedError(
+        view: WebView,
+        request: WebResourceRequest,
+        error: WebResourceError,
+    ) {
+        if (request.isForMainFrame) {
+            markFailed()
+        }
+    }
+
+    override fun onReceivedHttpError(
+        view: WebView,
+        request: WebResourceRequest,
+        errorResponse: WebResourceResponse,
+    ) {
+        if (request.isForMainFrame && errorResponse.statusCode >= HTTP_ERROR_STATUS_MIN) {
+            markFailed()
+        }
+    }
+
+    override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
+        markFailed()
+        // Returning true tells the platform we handled the dead renderer; the dead WebView must not
+        // be reused. Composition removes it via the failure path + AndroidView.onRelease.
+        return true
+    }
+
+    private companion object {
+        private const val HTTP_ERROR_STATUS_MIN = 400
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -34,6 +34,16 @@ internal class PaywallWebViewClient(
         super.onPageStarted(view, url, favicon)
         // onPageStarted is main-frame only and marks a new JavaScript document.
         onMainFrameNavigationStarted(url)
+        // shouldOverrideUrlLoading is not called for POST navigations, so re-check the policy
+        // here and kill any main-frame load that slipped through (cross-origin / non-HTTPS).
+        if (shouldBlockWebViewNavigation(
+                url = url,
+                isMainFrame = true,
+                expectedOrigin = expectedOrigin,
+            )
+        ) {
+            view.stopLoading()
+        }
     }
 
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProvider.kt
@@ -1,0 +1,58 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+
+/**
+ * Builds the `variables` payload sent to a `web_view` component in response to `rc:request-variables`.
+ *
+ * Produces a flat map shaped like:
+ * ```json
+ * { "locale": "en-US" }
+ * ```
+ *
+ * Only safe, already-available system context is exposed: the paywall locale. The paywall's
+ * dashboard-defined custom variables are intentionally NOT passed across the bridge in v1. API keys,
+ * email addresses, the Purchases SDK instance, and storage are never included.
+ *
+ * [KEY_LOCALE] is a reserved SDK-managed top-level key: app-provided variables may not overwrite it.
+ */
+internal object PaywallWebViewVariablesProvider {
+
+    const val KEY_LOCALE: String = "locale"
+
+    val reservedKeys: Set<String> = setOf(KEY_LOCALE)
+
+    /**
+     * The SDK-managed system variables exposed to the web view.
+     *
+     * @param locale a BCP-47-ish locale string, e.g. `en-US`.
+     */
+    fun sdkManagedVariables(
+        locale: String,
+    ): Map<String, PaywallWebViewValue> = linkedMapOf(
+        KEY_LOCALE to PaywallWebViewValue.String(locale),
+    )
+
+    /**
+     * Removes reserved SDK-managed top-level keys from app-provided variables so they cannot overwrite
+     * SDK values, logging a warning for any that were dropped.
+     */
+    fun sanitizeAppProvidedVariables(
+        variables: Map<String, PaywallWebViewValue>,
+    ): Map<String, PaywallWebViewValue> {
+        val sanitized = variables.filterKeys { key ->
+            val reserved = key in reservedKeys
+            if (reserved) {
+                Logger.w(
+                    "Ignoring reserved web view variable key '$key'. Reserved SDK-managed keys cannot be " +
+                        "overwritten.",
+                )
+            }
+            !reserved
+        }
+        return sanitized
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -18,12 +18,9 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
-import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
-import com.revenuecat.purchases.ui.revenuecatui.components.stack.StackComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
-import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
 
 @JvmSynthetic
 @Composable
@@ -32,8 +29,6 @@ internal fun WebViewComponentView(
     style: WebViewComponentStyle,
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
-    onClick: suspend (PaywallAction) -> Unit = {},
-    componentInteractionTracker: PaywallComponentInteractionTracker = PaywallComponentInteractionTracker { _ -> },
 ) {
     if (!style.visible) return
 
@@ -74,79 +69,72 @@ internal fun WebViewComponentView(
             )
         }
 
-        val fallbackStyle = style.fallbackStackComponentStyle
         if (loadFailed) {
-            if (fallbackStyle != null) {
-                StackComponentView(
-                    style = fallbackStyle,
-                    state = state,
-                    clickHandler = onClick,
-                    componentInteractionTracker = componentInteractionTracker,
-                    modifier = modifier.size(effectiveSize),
-                )
-            }
-            // No fallback: render nothing rather than retain a dead/unusable WebView.
-        } else {
-            AndroidView(
-                factory = { context ->
-                    WebView(context).apply {
-                        val bridge = componentId?.let { id ->
-                            WebViewJavaScriptBridge(
-                                webView = this,
-                                componentId = id,
-                                expectedUrl = resolvedUrl,
-                                locale = locale,
-                                messageHandler = messageHandler,
-                                sizeToContentWidth = sizeToContentWidth,
-                                sizeToContentHeight = sizeToContentHeight,
-                                onContentResize = { widthCssPx, heightCssPx ->
-                                    widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
-                                    heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
-                                },
-                                onDocumentReset = {
-                                    contentWidthCssPx = 0
-                                    contentHeightCssPx = 0
-                                },
-                                onSecureMessagingUnsupported = {
-                                    if (failureFlag.markFailed()) {
-                                        loadFailed = true
-                                    }
-                                },
-                            ).also { createdBridge -> createdBridge.attach() }
-                        }
-                        bridgeHolder.bridge = bridge
-                        configure(
-                            expectedOrigin = resolvedUrl.toOriginOrNull(),
-                            onMainFrameNavigationStarted = { url ->
-                                bridgeHolder.bridge?.onMainFrameNavigationStarted(url)
+            // Terminal failure: render nothing rather than retain a dead/unusable WebView.
+            // There is intentionally no native fallback stack — apps must use an SDK that
+            // supports web_view.
+            return@key
+        }
+
+        AndroidView(
+            factory = { context ->
+                WebView(context).apply {
+                    val bridge = componentId?.let { id ->
+                        WebViewJavaScriptBridge(
+                            webView = this,
+                            componentId = id,
+                            expectedUrl = resolvedUrl,
+                            locale = locale,
+                            messageHandler = messageHandler,
+                            sizeToContentWidth = sizeToContentWidth,
+                            sizeToContentHeight = sizeToContentHeight,
+                            onContentResize = { widthCssPx, heightCssPx ->
+                                widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
+                                heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
                             },
-                            onMainFrameLoadFailed = {
+                            onDocumentReset = {
+                                contentWidthCssPx = 0
+                                contentHeightCssPx = 0
+                            },
+                            onSecureMessagingUnsupported = {
                                 if (failureFlag.markFailed()) {
                                     loadFailed = true
                                 }
                             },
-                        )
-                        loadUrl(resolvedUrl)
+                        ).also { createdBridge -> createdBridge.attach() }
                     }
-                },
-                update = {
-                    bridgeHolder.bridge?.update(
-                        locale = locale,
-                        messageHandler = messageHandler,
+                    bridgeHolder.bridge = bridge
+                    configure(
+                        expectedOrigin = resolvedUrl.toOriginOrNull(),
+                        onMainFrameNavigationStarted = { url ->
+                            bridgeHolder.bridge?.onMainFrameNavigationStarted(url)
+                        },
+                        onMainFrameLoadFailed = {
+                            if (failureFlag.markFailed()) {
+                                loadFailed = true
+                            }
+                        },
                     )
-                },
-                onRelease = { webView ->
-                    // Only release the bridge that this view installed into this holder.
-                    val bridge = bridgeHolder.bridge
-                    bridgeHolder.bridge = null
-                    bridge?.release()
-                    webView.stopLoading()
-                    webView.webViewClient = WebViewClient()
-                    webView.destroy()
-                },
-                modifier = modifier.size(effectiveSize),
-            )
-        }
+                    loadUrl(resolvedUrl)
+                }
+            },
+            update = {
+                bridgeHolder.bridge?.update(
+                    locale = locale,
+                    messageHandler = messageHandler,
+                )
+            },
+            onRelease = { webView ->
+                // Only release the bridge that this view installed into this holder.
+                val bridge = bridgeHolder.bridge
+                bridgeHolder.bridge = null
+                bridge?.release()
+                webView.stopLoading()
+                webView.webViewClient = WebViewClient()
+                webView.destroy()
+            },
+            modifier = modifier.size(effectiveSize),
+        )
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -1,0 +1,199 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.graphics.Color
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
+import com.revenuecat.purchases.ui.revenuecatui.components.stack.StackComponentView
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
+
+@JvmSynthetic
+@Composable
+@Suppress("LongMethod", "ReturnCount")
+internal fun WebViewComponentView(
+    style: WebViewComponentStyle,
+    state: PaywallState.Loaded.Components,
+    modifier: Modifier = Modifier,
+    onClick: suspend (PaywallAction) -> Unit = {},
+    componentInteractionTracker: PaywallComponentInteractionTracker = PaywallComponentInteractionTracker { _ -> },
+) {
+    if (!style.visible) return
+
+    val resolvedUrl = remember(style.url) {
+        WebViewUrlResolver.resolve(style.url)
+    }
+    if (resolvedUrl == null) return
+
+    val componentId = style.componentId
+    val locale = state.locale.toLanguageTag()
+    val messageHandler = state.webViewMessageHandler
+    val sizeToContentWidth = style.size.width is Fit
+    val sizeToContentHeight = style.size.height is Fit
+
+    var contentWidthCssPx by remember(resolvedUrl) { mutableIntStateOf(0) }
+    var contentHeightCssPx by remember(resolvedUrl) { mutableIntStateOf(0) }
+    var loadFailed by remember(resolvedUrl) { mutableStateOf(false) }
+    val bridgeHolder = remember { WebViewBridgeHolder() }
+
+    val effectiveSize = remember(style.size, contentWidthCssPx, contentHeightCssPx) {
+        webViewEffectiveSize(
+            declaredSize = style.size,
+            contentWidthCssPx = contentWidthCssPx,
+            contentHeightCssPx = contentHeightCssPx,
+        )
+    }
+
+    val fallbackStyle = style.fallbackStackComponentStyle
+    if (loadFailed && fallbackStyle != null) {
+        StackComponentView(
+            style = fallbackStyle,
+            state = state,
+            clickHandler = onClick,
+            componentInteractionTracker = componentInteractionTracker,
+            modifier = modifier.size(effectiveSize),
+        )
+        return
+    }
+
+    key(resolvedUrl) {
+        AndroidView(
+            factory = { context ->
+                WebView(context).apply {
+                    val bridge = componentId?.let { id ->
+                        WebViewJavaScriptBridge(
+                            webView = this,
+                            componentId = id,
+                            expectedUrl = resolvedUrl,
+                            locale = locale,
+                            messageHandler = messageHandler,
+                            sizeToContentWidth = sizeToContentWidth,
+                            sizeToContentHeight = sizeToContentHeight,
+                            onContentResize = { widthCssPx, heightCssPx ->
+                                widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
+                                heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
+                            },
+                        ).also { createdBridge -> createdBridge.attach() }
+                    }
+                    bridgeHolder.bridge = bridge
+                    configure(
+                        expectedOrigin = resolvedUrl.toOriginOrNull(),
+                        onMainFrameLoadFailed = { loadFailed = true },
+                    )
+                    loadUrl(resolvedUrl)
+                }
+            },
+            update = {
+                bridgeHolder.bridge?.update(
+                    locale = locale,
+                    messageHandler = messageHandler,
+                )
+            },
+            onRelease = { webView ->
+                bridgeHolder.bridge?.release()
+                bridgeHolder.bridge = null
+                webView.stopLoading()
+                webView.webViewClient = WebViewClient()
+                webView.destroy()
+            },
+            modifier = modifier.size(effectiveSize),
+        )
+    }
+}
+
+/**
+ * Placeholder sizes for a `fit` axis until the content reports its size over the bridge — a
+ * WebView has no meaningful intrinsic size, so `fit` would otherwise collapse. 100 (height)
+ * matches the iOS implementation; 300 (width) matches the web implementation's
+ * `FIT_FALLBACK_SIZE_PX`.
+ */
+internal const val FIT_PLACEHOLDER_HEIGHT: UInt = 100u
+internal const val FIT_PLACEHOLDER_WIDTH: UInt = 300u
+
+internal fun webViewEffectiveSize(
+    declaredSize: Size,
+    contentWidthCssPx: Int,
+    contentHeightCssPx: Int,
+): Size {
+    val width = when (declaredSize.width) {
+        is Fit -> Fixed(if (contentWidthCssPx > 0) contentWidthCssPx.toUInt() else FIT_PLACEHOLDER_WIDTH)
+        else -> declaredSize.width
+    }
+    val height = when (declaredSize.height) {
+        is Fit -> Fixed(if (contentHeightCssPx > 0) contentHeightCssPx.toUInt() else FIT_PLACEHOLDER_HEIGHT)
+        else -> declaredSize.height
+    }
+    return Size(width = width, height = height)
+}
+
+/** Mutable holder for the per-WebView bridge instance, shared across factory/update/onRelease. */
+private class WebViewBridgeHolder {
+    var bridge: WebViewJavaScriptBridge? = null
+}
+
+private fun WebView.configure(
+    expectedOrigin: String?,
+    onMainFrameLoadFailed: () -> Unit,
+) {
+    setBackgroundColor(Color.TRANSPARENT)
+    isVerticalScrollBarEnabled = false
+    isHorizontalScrollBarEnabled = false
+    settings.allowContentAccess = false
+    settings.allowFileAccess = false
+    settings.cacheMode = WebSettings.LOAD_DEFAULT
+    settings.domStorageEnabled = true
+    settings.javaScriptEnabled = true
+    settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+    settings.setGeolocationEnabled(false)
+    webViewClient = object : WebViewClient() {
+        override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+            return shouldBlockWebViewNavigation(
+                url = request.url?.toString(),
+                isMainFrame = request.isForMainFrame,
+                expectedOrigin = expectedOrigin,
+            )
+        }
+
+        override fun onReceivedError(
+            view: WebView,
+            request: WebResourceRequest,
+            error: WebResourceError,
+        ) {
+            if (request.isForMainFrame) {
+                onMainFrameLoadFailed()
+            }
+        }
+
+        override fun onReceivedHttpError(
+            view: WebView,
+            request: WebResourceRequest,
+            errorResponse: WebResourceResponse,
+        ) {
+            if (request.isForMainFrame && errorResponse.statusCode >= HTTP_ERROR_STATUS_MIN) {
+                onMainFrameLoadFailed()
+            }
+        }
+    }
+}
+
+private const val HTTP_ERROR_STATUS_MIN = 400

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -69,72 +69,70 @@ internal fun WebViewComponentView(
             )
         }
 
-        if (loadFailed) {
-            // Terminal failure: render nothing rather than retain a dead/unusable WebView.
-            // There is intentionally no native fallback stack — apps must use an SDK that
-            // supports web_view.
-            return@key
-        }
-
-        AndroidView(
-            factory = { context ->
-                WebView(context).apply {
-                    val bridge = componentId?.let { id ->
-                        WebViewJavaScriptBridge(
-                            webView = this,
-                            componentId = id,
-                            expectedUrl = resolvedUrl,
-                            locale = locale,
-                            messageHandler = messageHandler,
-                            sizeToContentWidth = sizeToContentWidth,
-                            sizeToContentHeight = sizeToContentHeight,
-                            onContentResize = { widthCssPx, heightCssPx ->
-                                widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
-                                heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
+        if (!loadFailed) {
+            AndroidView(
+                factory = { context ->
+                    WebView(context).apply {
+                        val bridge = componentId?.let { id ->
+                            WebViewJavaScriptBridge(
+                                webView = this,
+                                componentId = id,
+                                expectedUrl = resolvedUrl,
+                                locale = locale,
+                                messageHandler = messageHandler,
+                                sizeToContentWidth = sizeToContentWidth,
+                                sizeToContentHeight = sizeToContentHeight,
+                                onContentResize = { widthCssPx, heightCssPx ->
+                                    widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
+                                    heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
+                                },
+                                onDocumentReset = {
+                                    contentWidthCssPx = 0
+                                    contentHeightCssPx = 0
+                                },
+                                onSecureMessagingUnsupported = {
+                                    if (failureFlag.markFailed()) {
+                                        loadFailed = true
+                                    }
+                                },
+                            ).also { createdBridge -> createdBridge.attach() }
+                        }
+                        bridgeHolder.bridge = bridge
+                        configure(
+                            expectedOrigin = resolvedUrl.toOriginOrNull(),
+                            onMainFrameNavigationStarted = { url ->
+                                bridgeHolder.bridge?.onMainFrameNavigationStarted(url)
                             },
-                            onDocumentReset = {
-                                contentWidthCssPx = 0
-                                contentHeightCssPx = 0
-                            },
-                            onSecureMessagingUnsupported = {
+                            onMainFrameLoadFailed = {
                                 if (failureFlag.markFailed()) {
                                     loadFailed = true
                                 }
                             },
-                        ).also { createdBridge -> createdBridge.attach() }
+                        )
+                        loadUrl(resolvedUrl)
                     }
-                    bridgeHolder.bridge = bridge
-                    configure(
-                        expectedOrigin = resolvedUrl.toOriginOrNull(),
-                        onMainFrameNavigationStarted = { url ->
-                            bridgeHolder.bridge?.onMainFrameNavigationStarted(url)
-                        },
-                        onMainFrameLoadFailed = {
-                            if (failureFlag.markFailed()) {
-                                loadFailed = true
-                            }
-                        },
+                },
+                update = {
+                    bridgeHolder.bridge?.update(
+                        locale = locale,
+                        messageHandler = messageHandler,
                     )
-                    loadUrl(resolvedUrl)
-                }
-            },
-            update = {
-                bridgeHolder.bridge?.update(
-                    locale = locale,
-                    messageHandler = messageHandler,
-                )
-            },
-            onRelease = { webView ->
-                // Only release the bridge that this view installed into this holder.
-                val bridge = bridgeHolder.bridge
-                bridgeHolder.bridge = null
-                bridge?.release()
-                webView.stopLoading()
-                webView.webViewClient = WebViewClient()
-                webView.destroy()
-            },
-            modifier = modifier.size(effectiveSize),
-        )
+                },
+                onRelease = { webView ->
+                    // Only release the bridge that this view installed into this holder.
+                    val bridge = bridgeHolder.bridge
+                    bridgeHolder.bridge = null
+                    bridge?.release()
+                    webView.stopLoading()
+                    webView.webViewClient = WebViewClient()
+                    webView.destroy()
+                },
+                modifier = modifier.size(effectiveSize),
+            )
+        }
+        // Terminal failure: render nothing rather than retain a dead/unusable WebView.
+        // There is intentionally no native fallback stack — apps must use an SDK that
+        // supports web_view.
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -3,9 +3,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.graphics.Color
-import android.webkit.WebResourceError
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -51,73 +48,105 @@ internal fun WebViewComponentView(
     val sizeToContentWidth = style.size.width is Fit
     val sizeToContentHeight = style.size.height is Fit
 
-    var contentWidthCssPx by remember(resolvedUrl) { mutableIntStateOf(0) }
-    var contentHeightCssPx by remember(resolvedUrl) { mutableIntStateOf(0) }
-    var loadFailed by remember(resolvedUrl) { mutableStateOf(false) }
-    val bridgeHolder = remember { WebViewBridgeHolder() }
+    val identity = WebViewIdentity(
+        resolvedUrl = resolvedUrl,
+        componentId = componentId,
+        sizeToContentWidth = sizeToContentWidth,
+        sizeToContentHeight = sizeToContentHeight,
+    )
 
-    val effectiveSize = remember(style.size, contentWidthCssPx, contentHeightCssPx) {
-        webViewEffectiveSize(
-            declaredSize = style.size,
-            contentWidthCssPx = contentWidthCssPx,
-            contentHeightCssPx = contentHeightCssPx,
-        )
-    }
+    // Identity-scoped state: when any immutable bridge field changes, Compose disposes the previous
+    // key subtree (WebView + bridge + measured sizes + failure flag) and creates a fresh one.
+    key(identity) {
+        var contentWidthCssPx by remember { mutableIntStateOf(0) }
+        var contentHeightCssPx by remember { mutableIntStateOf(0) }
+        var loadFailed by remember { mutableStateOf(false) }
+        // Holder is remembered inside the identity key so an old AndroidView.onRelease can only
+        // clear/release the bridge that belonged to that specific view instance.
+        val bridgeHolder = remember { WebViewBridgeHolder() }
+        val failureFlag = remember { LoadFailureFlag() }
 
-    val fallbackStyle = style.fallbackStackComponentStyle
-    if (loadFailed && fallbackStyle != null) {
-        StackComponentView(
-            style = fallbackStyle,
-            state = state,
-            clickHandler = onClick,
-            componentInteractionTracker = componentInteractionTracker,
-            modifier = modifier.size(effectiveSize),
-        )
-        return
-    }
+        val effectiveSize = remember(style.size, contentWidthCssPx, contentHeightCssPx) {
+            webViewEffectiveSize(
+                declaredSize = style.size,
+                contentWidthCssPx = contentWidthCssPx,
+                contentHeightCssPx = contentHeightCssPx,
+            )
+        }
 
-    key(resolvedUrl) {
-        AndroidView(
-            factory = { context ->
-                WebView(context).apply {
-                    val bridge = componentId?.let { id ->
-                        WebViewJavaScriptBridge(
-                            webView = this,
-                            componentId = id,
-                            expectedUrl = resolvedUrl,
-                            locale = locale,
-                            messageHandler = messageHandler,
-                            sizeToContentWidth = sizeToContentWidth,
-                            sizeToContentHeight = sizeToContentHeight,
-                            onContentResize = { widthCssPx, heightCssPx ->
-                                widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
-                                heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
-                            },
-                        ).also { createdBridge -> createdBridge.attach() }
-                    }
-                    bridgeHolder.bridge = bridge
-                    configure(
-                        expectedOrigin = resolvedUrl.toOriginOrNull(),
-                        onMainFrameLoadFailed = { loadFailed = true },
-                    )
-                    loadUrl(resolvedUrl)
-                }
-            },
-            update = {
-                bridgeHolder.bridge?.update(
-                    locale = locale,
-                    messageHandler = messageHandler,
+        val fallbackStyle = style.fallbackStackComponentStyle
+        if (loadFailed) {
+            if (fallbackStyle != null) {
+                StackComponentView(
+                    style = fallbackStyle,
+                    state = state,
+                    clickHandler = onClick,
+                    componentInteractionTracker = componentInteractionTracker,
+                    modifier = modifier.size(effectiveSize),
                 )
-            },
-            onRelease = { webView ->
-                bridgeHolder.bridge?.release()
-                bridgeHolder.bridge = null
-                webView.stopLoading()
-                webView.webViewClient = WebViewClient()
-                webView.destroy()
-            },
-            modifier = modifier.size(effectiveSize),
-        )
+            }
+            // No fallback: render nothing rather than retain a dead/unusable WebView.
+        } else {
+            AndroidView(
+                factory = { context ->
+                    WebView(context).apply {
+                        val bridge = componentId?.let { id ->
+                            WebViewJavaScriptBridge(
+                                webView = this,
+                                componentId = id,
+                                expectedUrl = resolvedUrl,
+                                locale = locale,
+                                messageHandler = messageHandler,
+                                sizeToContentWidth = sizeToContentWidth,
+                                sizeToContentHeight = sizeToContentHeight,
+                                onContentResize = { widthCssPx, heightCssPx ->
+                                    widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
+                                    heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
+                                },
+                                onDocumentReset = {
+                                    contentWidthCssPx = 0
+                                    contentHeightCssPx = 0
+                                },
+                                onSecureMessagingUnsupported = {
+                                    if (failureFlag.markFailed()) {
+                                        loadFailed = true
+                                    }
+                                },
+                            ).also { createdBridge -> createdBridge.attach() }
+                        }
+                        bridgeHolder.bridge = bridge
+                        configure(
+                            expectedOrigin = resolvedUrl.toOriginOrNull(),
+                            onMainFrameNavigationStarted = { url ->
+                                bridgeHolder.bridge?.onMainFrameNavigationStarted(url)
+                            },
+                            onMainFrameLoadFailed = {
+                                if (failureFlag.markFailed()) {
+                                    loadFailed = true
+                                }
+                            },
+                        )
+                        loadUrl(resolvedUrl)
+                    }
+                },
+                update = {
+                    bridgeHolder.bridge?.update(
+                        locale = locale,
+                        messageHandler = messageHandler,
+                    )
+                },
+                onRelease = { webView ->
+                    // Only release the bridge that this view installed into this holder.
+                    val bridge = bridgeHolder.bridge
+                    bridgeHolder.bridge = null
+                    bridge?.release()
+                    webView.stopLoading()
+                    webView.webViewClient = WebViewClient()
+                    webView.destroy()
+                },
+                modifier = modifier.size(effectiveSize),
+            )
+        }
     }
 }
 
@@ -147,12 +176,24 @@ internal fun webViewEffectiveSize(
 }
 
 /** Mutable holder for the per-WebView bridge instance, shared across factory/update/onRelease. */
-private class WebViewBridgeHolder {
+internal class WebViewBridgeHolder {
     var bridge: WebViewJavaScriptBridge? = null
+}
+
+/** Idempotent failure latch shared by URL/HTTP/renderer/secure-messaging failure paths. */
+internal class LoadFailureFlag {
+    private var failed: Boolean = false
+
+    fun markFailed(): Boolean {
+        if (failed) return false
+        failed = true
+        return true
+    }
 }
 
 private fun WebView.configure(
     expectedOrigin: String?,
+    onMainFrameNavigationStarted: (url: String?) -> Unit,
     onMainFrameLoadFailed: () -> Unit,
 ) {
     setBackgroundColor(Color.TRANSPARENT)
@@ -165,35 +206,9 @@ private fun WebView.configure(
     settings.javaScriptEnabled = true
     settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
     settings.setGeolocationEnabled(false)
-    webViewClient = object : WebViewClient() {
-        override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-            return shouldBlockWebViewNavigation(
-                url = request.url?.toString(),
-                isMainFrame = request.isForMainFrame,
-                expectedOrigin = expectedOrigin,
-            )
-        }
-
-        override fun onReceivedError(
-            view: WebView,
-            request: WebResourceRequest,
-            error: WebResourceError,
-        ) {
-            if (request.isForMainFrame) {
-                onMainFrameLoadFailed()
-            }
-        }
-
-        override fun onReceivedHttpError(
-            view: WebView,
-            request: WebResourceRequest,
-            errorResponse: WebResourceResponse,
-        ) {
-            if (request.isForMainFrame && errorResponse.statusCode >= HTTP_ERROR_STATUS_MIN) {
-                onMainFrameLoadFailed()
-            }
-        }
-    }
+    webViewClient = PaywallWebViewClient(
+        expectedOrigin = expectedOrigin,
+        onMainFrameNavigationStarted = onMainFrameNavigationStarted,
+        onMainFrameLoadFailed = onMainFrameLoadFailed,
+    )
 }
-
-private const val HTTP_ERROR_STATUS_MIN = 400

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -1,0 +1,160 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.json.JSONObject
+
+/**
+ * Wire-format envelopes for the `workflow-web-components-sdk` transport layer.
+ *
+ * Matches [RevenueCat/workflow-web-components-sdk](https://github.com/RevenueCat/workflow-web-components-sdk):
+ * channel `rc-web-components`, handshake kinds `connect` / `init` / `reject`, and app frames
+ * `message` / `request` / `response` / `error`.
+ */
+internal object WebViewEnvelope {
+
+    const val CHANNEL: String = "rc-web-components"
+    const val NATIVE_OBJECT_NAME: String = "rcWebComponents"
+    const val RECEIVE_FUNCTION: String = "__rcWebComponentsReceive"
+    const val DEFAULT_PROTOCOL_VERSION: Int = 1
+
+    const val KIND_CONNECT: String = "connect"
+    const val KIND_INIT: String = "init"
+    const val KIND_REJECT: String = "reject"
+    const val KIND_MESSAGE: String = "message"
+    const val KIND_REQUEST: String = "request"
+    const val KIND_RESPONSE: String = "response"
+    const val KIND_ERROR: String = "error"
+
+    private val ENVELOPE_KINDS: Set<String> = setOf(
+        KIND_CONNECT,
+        KIND_INIT,
+        KIND_REJECT,
+        KIND_MESSAGE,
+        KIND_REQUEST,
+        KIND_RESPONSE,
+        KIND_ERROR,
+    )
+
+    internal data class Parsed(
+        val kind: String,
+        val protocolVersion: Int,
+        val componentId: String,
+        val type: String?,
+        val id: String?,
+        val payload: JSONObject?,
+        val error: String?,
+    )
+
+    /**
+     * Coarse structural depth budget for a whole inbound frame: the envelope object itself plus a
+     * payload tree of at most [WebViewMessageParser.MAX_NESTING_DEPTH] levels. The precise per-tree
+     * limit is still enforced during [PaywallWebViewValue][
+     * com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue] conversion; this scan exists only
+     * to stop hostile input before recursion happens.
+     */
+    private val MAX_FRAME_DEPTH: Int = WebViewMessageParser.MAX_NESTING_DEPTH + 1
+
+    @Suppress("ReturnCount", "CyclomaticComplexMethod")
+    fun parse(rawJson: String): Parsed? {
+        // Enforce the nesting budget BEFORE org.json parses: JSONTokener recurses per nesting
+        // level, and tens of thousands of levels fit inside the 64 KiB frame limit, so a hostile
+        // deeply-nested frame could otherwise overflow the stack before any post-parse check runs.
+        if (exceedsMaxDepth(rawJson)) return null
+
+        val json = try {
+            JSONObject(rawJson)
+        } catch (@Suppress("SwallowedException") _: org.json.JSONException) {
+            return null
+        }
+
+        if (json.opt(WebViewMessageField.CHANNEL) != CHANNEL) return null
+
+        val protocolVersion = json.opt(WebViewMessageField.PROTOCOL_VERSION)
+        if (protocolVersion !is Number || !protocolVersion.toDouble().isFinite()) return null
+
+        val kind = json.opt(WebViewMessageField.KIND) as? String
+        if (kind == null || kind !in ENVELOPE_KINDS) return null
+
+        val componentId = json.opt(WebViewMessageField.COMPONENT_ID) as? String ?: return null
+
+        val type = json.opt(WebViewMessageField.TYPE) as? String
+        if (json.has(WebViewMessageField.TYPE) && type == null) return null
+
+        val id = json.opt(WebViewMessageField.ID) as? String
+        if (json.has(WebViewMessageField.ID) && id == null) return null
+
+        val error = json.opt(WebViewMessageField.ERROR) as? String
+        if (json.has(WebViewMessageField.ERROR) && error == null) return null
+
+        val payload = when (val payloadValue = json.opt(WebViewMessageField.PAYLOAD)) {
+            null, JSONObject.NULL -> null
+            is JSONObject -> payloadValue
+            else -> return null
+        }
+
+        return Parsed(
+            kind = kind,
+            protocolVersion = protocolVersion.toInt(),
+            componentId = componentId,
+            type = type,
+            id = id,
+            payload = payload,
+            error = error,
+        )
+    }
+
+    /**
+     * Non-recursive scan of the raw JSON characters, tracking `{`/`[` nesting outside string
+     * literals (honoring `\` escapes). Returns `true` when the depth exceeds [MAX_FRAME_DEPTH].
+     */
+    @Suppress("LoopWithTooManyJumpStatements")
+    fun exceedsMaxDepth(rawJson: String): Boolean {
+        var depth = 0
+        var inString = false
+        var escaped = false
+
+        for (char in rawJson) {
+            if (inString) {
+                when {
+                    escaped -> escaped = false
+                    char == '\\' -> escaped = true
+                    char == '"' -> inString = false
+                }
+                continue
+            }
+
+            when (char) {
+                '"' -> inString = true
+                '{', '[' -> {
+                    depth += 1
+                    if (depth > MAX_FRAME_DEPTH) return true
+                }
+                '}', ']' -> depth -= 1
+                else -> Unit
+            }
+        }
+
+        return false
+    }
+
+    @Suppress("LongParameterList")
+    fun build(
+        kind: String,
+        protocolVersion: Int,
+        componentId: String,
+        type: String? = null,
+        id: String? = null,
+        payload: JSONObject? = null,
+        error: String? = null,
+    ): JSONObject = JSONObject().apply {
+        put(WebViewMessageField.CHANNEL, CHANNEL)
+        put(WebViewMessageField.PROTOCOL_VERSION, protocolVersion)
+        put(WebViewMessageField.KIND, kind)
+        put(WebViewMessageField.COMPONENT_ID, componentId)
+        type?.let { put(WebViewMessageField.TYPE, it) }
+        id?.let { put(WebViewMessageField.ID, it) }
+        payload?.let { put(WebViewMessageField.PAYLOAD, it) }
+        error?.let { put(WebViewMessageField.ERROR, it) }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -10,6 +10,10 @@ import org.json.JSONObject
  * Matches [RevenueCat/workflow-web-components-sdk](https://github.com/RevenueCat/workflow-web-components-sdk):
  * channel `rc-web-components`, handshake kinds `connect` / `init` / `reject`, and app frames
  * `message` / `request` / `response` / `error`.
+ *
+ * On Android the host installs `rcWebComponents` via `WebViewCompat.addWebMessageListener` so inbound
+ * frames carry a platform `sourceOrigin` / `isMainFrame`. The content still calls
+ * `rcWebComponents.postMessage(jsonString)`.
  */
 internal object WebViewEnvelope {
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentity.kt
@@ -1,0 +1,15 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+/**
+ * Immutable configuration that identifies a rendered `web_view` instance. When any field changes the
+ * Compose tree must dispose the previous [android.webkit.WebView] / bridge and create a new pair —
+ * locale and message handler are deliberately excluded so they can update in place.
+ */
+internal data class WebViewIdentity(
+    val resolvedUrl: String,
+    val componentId: String?,
+    val sizeToContentWidth: Boolean,
+    val sizeToContentHeight: Boolean,
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -5,9 +5,10 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
-import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import androidx.annotation.MainThread
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController
 import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
 import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
@@ -23,24 +24,22 @@ import java.util.Locale
  *
  * ## Transport
  * Implements the native Android host contract from `workflow-web-components-sdk`:
- * - JS → native: `window.rcWebComponents.postMessage(jsonString)` via [addJavascriptInterface]
+ * - JS → native: `rcWebComponents.postMessage(jsonString)` via [WebViewCompat.addWebMessageListener]
  * - native → JS: `window.__rcWebComponentsReceive(data)` via [WebView.evaluateJavascript]
  * - Wire format: `{ channel: "rc-web-components", kind, protocol_version, component_id, … }`
  *
- * The content SDK (`window.RC`) auto-detects Android when [NATIVE_OBJECT_NAME] is present and runs
- * the same connect/init handshake as on web. No document-start shim is injected.
+ * Inbound frames are validated against the message listener's `sourceOrigin` and `isMainFrame` —
+ * the WebView's top-level URL alone is not sufficient (same-origin subframes and navigation races).
  *
- * Because `addJavascriptInterface` provides no platform origin scoping, the bridge enforces the origin
- * itself: before delivering any inbound or outbound message it verifies the WebView's current URL still
- * has the same origin (scheme + host + port) as the resolved component URL, rejecting messages received
- * after navigation to an unexpected origin. Origin is always re-checked on the main thread at delivery
- * time.
+ * ## Document lifecycle
+ * Each main-frame navigation creates a new JavaScript document that must re-handshake. Call
+ * [onMainFrameNavigationStarted] from `WebViewClient.onPageStarted` so a fresh `connect` is accepted
+ * and outbound work queued for a previous document generation is dropped.
  *
  * ## Lifecycle & threading
  * The bridge holds only a [WeakReference] to the [WebView] (no Activity/Context), and stops delivering
- * messages once [release] is called. Inbound JavaScript callbacks arrive on a binder thread and are
- * hopped onto the main thread; app callbacks and all WebView interactions happen on the main thread.
- * Outbound [WebView.evaluateJavascript] calls queued before [release] are dropped when they run.
+ * messages once [release] is called. Inbound callbacks are hopped onto the main thread; app callbacks
+ * and all WebView interactions happen on the main thread.
  */
 @Suppress("LongParameterList", "TooManyFunctions")
 internal class WebViewJavaScriptBridge(
@@ -52,7 +51,23 @@ internal class WebViewJavaScriptBridge(
     private val sizeToContentWidth: Boolean = false,
     private val sizeToContentHeight: Boolean = false,
     private val onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
+    private val onDocumentReset: () -> Unit = {},
+    private val onSecureMessagingUnsupported: () -> Unit = {},
     private val mainHandler: Handler = Handler(Looper.getMainLooper()),
+    private val isWebMessageListenerSupported: () -> Boolean = {
+        WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+    },
+    private val installWebMessageListener: (
+        WebView,
+        String,
+        Set<String>,
+        WebViewCompat.WebMessageListener,
+    ) -> Unit = { view, jsObjectName, allowedOrigins, listener ->
+        WebViewCompat.addWebMessageListener(view, jsObjectName, allowedOrigins, listener)
+    },
+    private val uninstallWebMessageListener: (WebView, String) -> Unit = { view, jsObjectName ->
+        WebViewCompat.removeWebMessageListener(view, jsObjectName)
+    },
 ) : PaywallWebViewController {
 
     private val webViewRef = WeakReference(webView)
@@ -73,16 +88,50 @@ internal class WebViewJavaScriptBridge(
 
     @Volatile private var channelOpen: Boolean = false
 
+    @Volatile private var messageListenerInstalled: Boolean = false
+
+    /**
+     * Incremented on every main-frame document start. Outbound [WebView.evaluateJavascript] work
+     * captures the generation at enqueue time and is dropped if a newer document has started.
+     */
+    private var documentGeneration: Int = 0
+
     // Last content sizes applied per fit axis (main thread only), for the resize apply-threshold.
     private var lastAppliedWidthCssPx: Int? = null
     private var lastAppliedHeightCssPx: Int? = null
 
+    private val webMessageListener = WebViewCompat.WebMessageListener { _, message, sourceOrigin, isMainFrame, _ ->
+        val data = message.data ?: return@WebMessageListener
+        mainHandler.post {
+            if (released) return@post
+            handleInboundMessage(
+                json = data,
+                sourceOrigin = sourceOrigin,
+                isMainFrame = isMainFrame,
+            )
+        }
+    }
+
     /**
-     * Registers the native interface on the WebView. Call once, when the WebView is created.
+     * Registers the secure message listener on the WebView. Call once, when the WebView is created.
+     * If [WebViewFeature.WEB_MESSAGE_LISTENER] is unavailable, invokes [onSecureMessagingUnsupported]
+     * so the host can take the terminal failure/fallback path.
      */
     @MainThread
     fun attach() {
-        webViewRef.get()?.addJavascriptInterface(this, WebViewEnvelope.NATIVE_OBJECT_NAME)
+        val webView = webViewRef.get() ?: return
+        val origin = expectedOrigin
+        if (origin == null || !isWebMessageListenerSupported()) {
+            onSecureMessagingUnsupported()
+            return
+        }
+        installWebMessageListener(
+            webView,
+            WebViewEnvelope.NATIVE_OBJECT_NAME,
+            setOf(origin),
+            webMessageListener,
+        )
+        messageListenerInstalled = true
     }
 
     /**
@@ -98,6 +147,22 @@ internal class WebViewJavaScriptBridge(
     }
 
     /**
+     * Marks the start of a new main-frame JavaScript document (initial load, same-origin
+     * navigation, or reload). Resets the handshake and fit/resize threshold state so the new
+     * document can `connect` again.
+     */
+    @MainThread
+    @Suppress("UnusedParameter")
+    fun onMainFrameNavigationStarted(url: String?) {
+        if (released) return
+        documentGeneration += 1
+        channelOpen = false
+        lastAppliedWidthCssPx = null
+        lastAppliedHeightCssPx = null
+        onDocumentReset()
+    }
+
+    /**
      * Stops the bridge. After this call no further inbound messages are delivered and no outbound
      * messages are sent. Call from `AndroidView`'s onRelease block.
      */
@@ -105,26 +170,33 @@ internal class WebViewJavaScriptBridge(
     fun release() {
         released = true
         channelOpen = false
-        webViewRef.get()?.removeJavascriptInterface(WebViewEnvelope.NATIVE_OBJECT_NAME)
-    }
-
-    /**
-     * Entry point for `window.rcWebComponents.postMessage`. Invoked on a binder thread; we hop to the
-     * main thread before touching the WebView or validating the message.
-     */
-    @JavascriptInterface
-    fun postMessage(json: String) {
-        mainHandler.post {
-            if (released) return@post
-            handleInboundMessage(json)
+        val webView = webViewRef.get()
+        if (messageListenerInstalled && webView != null) {
+            uninstallWebMessageListener(webView, WebViewEnvelope.NATIVE_OBJECT_NAME)
+            messageListenerInstalled = false
         }
     }
 
+    /**
+     * Processes an inbound transport frame. Production traffic arrives via [webMessageListener];
+     * tests call this directly with an explicit [sourceOrigin] and [isMainFrame].
+     */
     @MainThread
     @Suppress("ReturnCount")
-    private fun handleInboundMessage(json: String) {
+    internal fun handleInboundMessage(
+        json: String,
+        sourceOrigin: Uri?,
+        isMainFrame: Boolean,
+    ) {
         if (released) return
-        val webView = webViewRef.get() ?: return
+
+        if (!isSourceTrusted(sourceOrigin = sourceOrigin, isMainFrame = isMainFrame)) {
+            Logger.w(
+                "Dropping inbound web view message: source origin is not the resolved component " +
+                    "origin or the frame is not the main frame.",
+            )
+            return
+        }
 
         if (json.toByteArray(Charsets.UTF_8).size > WebViewMessageParser.MAX_PAYLOAD_BYTES) {
             Logger.w(
@@ -140,29 +212,37 @@ internal class WebViewJavaScriptBridge(
         }
 
         when (envelope.kind) {
-            WebViewEnvelope.KIND_CONNECT -> {
-                if (!isOriginTrusted(webView, allowBeforeNavigation = true)) {
-                    Logger.w(
-                        "Dropping inbound web view connect: current origin does not match the " +
-                            "resolved component origin.",
-                    )
-                    return
-                }
-                handleConnect(envelope)
-            }
+            WebViewEnvelope.KIND_CONNECT -> handleConnect(envelope)
             WebViewEnvelope.KIND_MESSAGE,
             WebViewEnvelope.KIND_REQUEST,
-            -> {
-                if (!isOriginTrusted(webView, allowBeforeNavigation = false)) {
-                    Logger.w(
-                        "Dropping inbound web view message: current origin does not match the " +
-                            "resolved component origin.",
-                    )
-                    return
-                }
-                handleAppFrame(envelope)
-            }
+            -> handleAppFrame(envelope)
             else -> Unit
+        }
+    }
+
+    /**
+     * Test helper: posts [json] onto the main thread as a trusted main-frame message from
+     * [expectedOrigin], mirroring the WebMessageListener hop.
+     */
+    internal fun postMessage(json: String) {
+        val originUri = expectedOrigin?.let { Uri.parse(it) }
+        mainHandler.post {
+            if (released) return@post
+            handleInboundMessage(json = json, sourceOrigin = originUri, isMainFrame = true)
+        }
+    }
+
+    /**
+     * Test helper for explicit origin / main-frame combinations.
+     */
+    internal fun postMessage(
+        json: String,
+        sourceOrigin: Uri?,
+        isMainFrame: Boolean,
+    ) {
+        mainHandler.post {
+            if (released) return@post
+            handleInboundMessage(json = json, sourceOrigin = sourceOrigin, isMainFrame = isMainFrame)
         }
     }
 
@@ -329,14 +409,19 @@ internal class WebViewJavaScriptBridge(
     }
 
     private fun deliverEnvelope(envelope: JSONObject) {
+        val generationAtEnqueue = documentGeneration
         runOnMainThread {
             if (released) return@runOnMainThread
+            if (generationAtEnqueue != documentGeneration) return@runOnMainThread
             val webView = webViewRef.get() ?: return@runOnMainThread
             val kind = envelope.optString(WebViewMessageField.KIND)
             val allowBeforeNavigation = kind in HANDSHAKE_OUTBOUND_KINDS
-            if (!isOriginTrusted(webView, allowBeforeNavigation = allowBeforeNavigation)) {
+            // Defense in depth: drop outbound work if the top-level URL left the expected origin
+            // (e.g. after a policy hole). Inbound validation uses sourceOrigin separately.
+            if (!isCurrentUrlTrusted(webView, allowBeforeNavigation = allowBeforeNavigation)) {
                 Logger.w(
-                    "Dropping outbound web view message: current origin does not match the resolved component origin.",
+                    "Dropping outbound web view message: current origin does not match the " +
+                        "resolved component origin.",
                 )
                 return@runOnMainThread
             }
@@ -351,13 +436,24 @@ internal class WebViewJavaScriptBridge(
     }
 
     /**
-     * Whether the WebView's current URL still has the same origin (scheme + host + port) as the
-     * resolved component URL. When [allowBeforeNavigation] is true and the WebView has not committed
-     * a URL yet, the expected origin is trusted so the connect/init handshake can complete before
-     * the first navigation.
+     * Whether [sourceOrigin] matches the resolved component origin and the frame is the main frame.
+     * Subframe messages are always rejected — isolation for those is expected from the server CSP.
      */
     @MainThread
-    private fun isOriginTrusted(webView: WebView, allowBeforeNavigation: Boolean): Boolean {
+    @Suppress("ReturnCount")
+    private fun isSourceTrusted(sourceOrigin: Uri?, isMainFrame: Boolean): Boolean {
+        if (!isMainFrame) return false
+        if (expectedOrigin == null) return false
+        val origin = sourceOrigin?.toOriginOrNull() ?: return false
+        return origin == expectedOrigin
+    }
+
+    /**
+     * Whether the WebView's current top-level URL still has the expected origin. Used only as an
+     * outbound defense-in-depth check; inbound traffic is gated by [isSourceTrusted].
+     */
+    @MainThread
+    private fun isCurrentUrlTrusted(webView: WebView, allowBeforeNavigation: Boolean): Boolean {
         if (expectedOrigin == null) return false
         val currentOrigin = webView.url?.toOriginOrNull()
         return when {
@@ -411,14 +507,24 @@ internal class WebViewJavaScriptBridge(
 /**
  * The origin of this URL as `scheme://host[:port]`, or `null` if it lacks a host. Host comparison is
  * case-insensitive. Default ports (443 for https, 80 for http) are omitted.
+ *
+ * Accepts both full URLs and bare origins (as provided by [WebViewCompat.WebMessageListener]).
  */
 @Suppress("ReturnCount", "MagicNumber")
 internal fun String.toOriginOrNull(): String? {
     val uri = Uri.parse(this)
-    val scheme = uri.scheme?.lowercase(Locale.US) ?: return null
-    val host = uri.host?.takeIf { it.isNotBlank() }?.lowercase(Locale.US) ?: return null
+    return uri.toOriginOrNull()
+}
+
+/**
+ * The origin of this [Uri] as `scheme://host[:port]`, or `null` if it lacks a host.
+ */
+@Suppress("ReturnCount", "MagicNumber")
+internal fun Uri.toOriginOrNull(): String? {
+    val scheme = scheme?.lowercase(Locale.US) ?: return null
+    val host = host?.takeIf { it.isNotBlank() }?.lowercase(Locale.US) ?: return null
     val effectivePort = when {
-        uri.port != -1 -> uri.port
+        port != -1 -> port
         scheme == "https" -> 443
         scheme == "http" -> 80
         else -> -1

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -115,7 +115,7 @@ internal class WebViewJavaScriptBridge(
     /**
      * Registers the secure message listener on the WebView. Call once, when the WebView is created.
      * If [WebViewFeature.WEB_MESSAGE_LISTENER] is unavailable, invokes [onSecureMessagingUnsupported]
-     * so the host can take the terminal failure/fallback path.
+     * so the host can take the terminal failure path.
      */
     @MainThread
     fun attach() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -1,0 +1,454 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import androidx.annotation.MainThread
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import com.revenuecat.purchases.ui.revenuecatui.toJsonObject
+import org.json.JSONObject
+import java.lang.ref.WeakReference
+import java.util.Locale
+
+/**
+ * Installs and drives the bidirectional bridge between a Paywalls V2 `web_view` component and native
+ * code. One bridge is created per rendered `web_view`.
+ *
+ * ## Transport
+ * Implements the native Android host contract from `workflow-web-components-sdk`:
+ * - JS → native: `window.rcWebComponents.postMessage(jsonString)` via [addJavascriptInterface]
+ * - native → JS: `window.__rcWebComponentsReceive(data)` via [WebView.evaluateJavascript]
+ * - Wire format: `{ channel: "rc-web-components", kind, protocol_version, component_id, … }`
+ *
+ * The content SDK (`window.RC`) auto-detects Android when [NATIVE_OBJECT_NAME] is present and runs
+ * the same connect/init handshake as on web. No document-start shim is injected.
+ *
+ * Because `addJavascriptInterface` provides no platform origin scoping, the bridge enforces the origin
+ * itself: before delivering any inbound or outbound message it verifies the WebView's current URL still
+ * has the same origin (scheme + host + port) as the resolved component URL, rejecting messages received
+ * after navigation to an unexpected origin. Origin is always re-checked on the main thread at delivery
+ * time.
+ *
+ * ## Lifecycle & threading
+ * The bridge holds only a [WeakReference] to the [WebView] (no Activity/Context), and stops delivering
+ * messages once [release] is called. Inbound JavaScript callbacks arrive on a binder thread and are
+ * hopped onto the main thread; app callbacks and all WebView interactions happen on the main thread.
+ * Outbound [WebView.evaluateJavascript] calls queued before [release] are dropped when they run.
+ */
+@Suppress("LongParameterList", "TooManyFunctions")
+internal class WebViewJavaScriptBridge(
+    webView: WebView,
+    private val componentId: String,
+    expectedUrl: String,
+    locale: String,
+    messageHandler: PaywallWebViewMessageHandler?,
+    private val sizeToContentWidth: Boolean = false,
+    private val sizeToContentHeight: Boolean = false,
+    private val onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
+    private val mainHandler: Handler = Handler(Looper.getMainLooper()),
+) : PaywallWebViewController {
+
+    private val webViewRef = WeakReference(webView)
+    private val expectedOrigin: String? = expectedUrl.toOriginOrNull()
+
+    // The single protocol version this SDK build implements. Deliberately NOT the schema's
+    // `protocol_version`: the envelope version is the wire+SDK major the CONTENT speaks, and the
+    // host must never accept a handshake for a version it cannot service, even if a future schema
+    // declares one.
+    private val protocolVersion: Int = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION
+
+    // Refreshed from the latest paywall state on every recomposition via update().
+    @Volatile private var locale: String = locale
+
+    @Volatile private var messageHandler: PaywallWebViewMessageHandler? = messageHandler
+
+    @Volatile private var released: Boolean = false
+
+    @Volatile private var channelOpen: Boolean = false
+
+    // Last content sizes applied per fit axis (main thread only), for the resize apply-threshold.
+    private var lastAppliedWidthCssPx: Int? = null
+    private var lastAppliedHeightCssPx: Int? = null
+
+    /**
+     * Registers the native interface on the WebView. Call once, when the WebView is created.
+     */
+    @MainThread
+    fun attach() {
+        webViewRef.get()?.addJavascriptInterface(this, WebViewEnvelope.NATIVE_OBJECT_NAME)
+    }
+
+    /**
+     * Refreshes the locale and the app message handler from the latest paywall state. Call from
+     * `AndroidView`'s update block.
+     */
+    fun update(
+        locale: String,
+        messageHandler: PaywallWebViewMessageHandler?,
+    ) {
+        this.locale = locale
+        this.messageHandler = messageHandler
+    }
+
+    /**
+     * Stops the bridge. After this call no further inbound messages are delivered and no outbound
+     * messages are sent. Call from `AndroidView`'s onRelease block.
+     */
+    @MainThread
+    fun release() {
+        released = true
+        channelOpen = false
+        webViewRef.get()?.removeJavascriptInterface(WebViewEnvelope.NATIVE_OBJECT_NAME)
+    }
+
+    /**
+     * Entry point for `window.rcWebComponents.postMessage`. Invoked on a binder thread; we hop to the
+     * main thread before touching the WebView or validating the message.
+     */
+    @JavascriptInterface
+    fun postMessage(json: String) {
+        mainHandler.post {
+            if (released) return@post
+            handleInboundMessage(json)
+        }
+    }
+
+    @MainThread
+    @Suppress("ReturnCount")
+    private fun handleInboundMessage(json: String) {
+        if (released) return
+        val webView = webViewRef.get() ?: return
+
+        if (json.toByteArray(Charsets.UTF_8).size > WebViewMessageParser.MAX_PAYLOAD_BYTES) {
+            Logger.w(
+                "Dropping inbound web view message: payload exceeds " +
+                    "${WebViewMessageParser.MAX_PAYLOAD_BYTES} bytes.",
+            )
+            return
+        }
+
+        val envelope = WebViewEnvelope.parse(json) ?: run {
+            Logger.w("Dropping inbound web view message: not a valid transport envelope.")
+            return
+        }
+
+        when (envelope.kind) {
+            WebViewEnvelope.KIND_CONNECT -> {
+                if (!isOriginTrusted(webView, allowBeforeNavigation = true)) {
+                    Logger.w(
+                        "Dropping inbound web view connect: current origin does not match the " +
+                            "resolved component origin.",
+                    )
+                    return
+                }
+                handleConnect(envelope)
+            }
+            WebViewEnvelope.KIND_MESSAGE,
+            WebViewEnvelope.KIND_REQUEST,
+            -> {
+                if (!isOriginTrusted(webView, allowBeforeNavigation = false)) {
+                    Logger.w(
+                        "Dropping inbound web view message: current origin does not match the " +
+                            "resolved component origin.",
+                    )
+                    return
+                }
+                handleAppFrame(envelope)
+            }
+            else -> Unit
+        }
+    }
+
+    @MainThread
+    private fun handleConnect(envelope: WebViewEnvelope.Parsed) {
+        if (channelOpen || released) return
+
+        if (envelope.protocolVersion != protocolVersion) {
+            deliverEnvelope(
+                WebViewEnvelope.build(
+                    kind = WebViewEnvelope.KIND_REJECT,
+                    protocolVersion = protocolVersion,
+                    componentId = "",
+                    error = "Unsupported protocol_version ${envelope.protocolVersion}; " +
+                        "native host supports $protocolVersion",
+                ),
+            )
+            return
+        }
+
+        channelOpen = true
+        deliverEnvelope(
+            WebViewEnvelope.build(
+                kind = WebViewEnvelope.KIND_INIT,
+                protocolVersion = protocolVersion,
+                componentId = componentId,
+            ),
+        )
+        sendFitIfNeeded()
+    }
+
+    private fun sendFitIfNeeded() {
+        if (!sizeToContentWidth && !sizeToContentHeight) return
+        val payload = JSONObject().apply {
+            if (sizeToContentWidth) put("width", true)
+            if (sizeToContentHeight) put("height", true)
+        }
+        deliverEnvelope(
+            WebViewEnvelope.build(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                protocolVersion = protocolVersion,
+                componentId = componentId,
+                type = WebViewMessageType.FIT,
+                payload = payload,
+            ),
+        )
+    }
+
+    @MainThread
+    @Suppress("ReturnCount")
+    private fun handleAppFrame(envelope: WebViewEnvelope.Parsed) {
+        if (!channelOpen) return
+
+        // Any transport `request` without a correlation `id` is undeliverable — drop it before
+        // any handling, matching iOS and the web host.
+        if (envelope.kind == WebViewEnvelope.KIND_REQUEST && envelope.id == null) {
+            Logger.w("Dropping inbound web view message: transport request is missing 'id'.")
+            return
+        }
+
+        // `resize` is SDK-internal regardless of kind; it never reaches the app handler.
+        if (envelope.type == WebViewMessageType.RESIZE) {
+            handleResize(envelope)
+            return
+        }
+
+        val parsed = WebViewMessageParser.parse(
+            envelope = envelope,
+            expectedComponentId = componentId,
+        ) ?: return
+
+        val message = parsed.message
+
+        if (message.type == WebViewMessageType.REQUEST_VARIABLES) {
+            val variables = PaywallWebViewVariablesProvider.sdkManagedVariables(locale = locale)
+            val requestId = parsed.requestId
+            if (requestId != null) {
+                deliverEnvelope(
+                    WebViewEnvelope.build(
+                        kind = WebViewEnvelope.KIND_RESPONSE,
+                        protocolVersion = protocolVersion,
+                        componentId = componentId,
+                        type = parsed.requestType,
+                        id = requestId,
+                        payload = variables.toJsonObject(),
+                    ),
+                )
+            } else {
+                postVariablesMessage(componentId = componentId, variables = variables)
+            }
+        }
+
+        messageHandler?.onMessage(message, this)
+    }
+
+    @MainThread
+    private fun handleResize(envelope: WebViewEnvelope.Parsed) {
+        if (envelope.componentId != componentId) return
+        val payload = envelope.payload ?: return
+
+        val width = applyResize(
+            reported = payload.resizeDimension("width").takeIf { sizeToContentWidth },
+            lastApplied = lastAppliedWidthCssPx,
+        )?.also { lastAppliedWidthCssPx = it }
+        val height = applyResize(
+            reported = payload.resizeDimension("height").takeIf { sizeToContentHeight },
+            lastApplied = lastAppliedHeightCssPx,
+        )?.also { lastAppliedHeightCssPx = it }
+
+        if (width != null || height != null) {
+            onContentResize(width, height)
+        }
+    }
+
+    /**
+     * Returns the value to apply for one axis, or `null` when there is nothing new to apply:
+     * missing/invalid report, non-fit axis, or a change smaller than [RESIZE_APPLY_THRESHOLD_CSS_PX]
+     * against the last applied value (guards report/apply feedback loops — HTML content's reported
+     * width often just echoes the imposed viewport width).
+     */
+    @Suppress("ReturnCount")
+    private fun applyResize(reported: Int?, lastApplied: Int?): Int? {
+        if (reported == null) return null
+        if (lastApplied != null && kotlin.math.abs(reported - lastApplied) < RESIZE_APPLY_THRESHOLD_CSS_PX) {
+            return null
+        }
+        return reported
+    }
+
+    override fun postVariables(componentId: String, variables: Map<String, PaywallWebViewValue>) {
+        postVariablesMessage(
+            componentId = componentId,
+            variables = PaywallWebViewVariablesProvider.sanitizeAppProvidedVariables(variables),
+        )
+    }
+
+    override fun postMessage(componentId: String, type: String, variables: Map<String, PaywallWebViewValue>) {
+        postAppMessage(
+            componentId = componentId,
+            type = type,
+            payload = variables.toJsonObject(),
+        )
+    }
+
+    private fun postVariablesMessage(componentId: String, variables: Map<String, PaywallWebViewValue>) {
+        postAppMessage(
+            componentId = componentId,
+            type = WebViewMessageType.VARIABLES,
+            payload = variables.toJsonObject(),
+        )
+    }
+
+    private fun postAppMessage(componentId: String, type: String, payload: JSONObject) {
+        if (!channelOpen) return
+        deliverEnvelope(
+            WebViewEnvelope.build(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                protocolVersion = protocolVersion,
+                componentId = componentId,
+                type = type,
+                payload = payload,
+            ),
+        )
+    }
+
+    private fun deliverEnvelope(envelope: JSONObject) {
+        runOnMainThread {
+            if (released) return@runOnMainThread
+            val webView = webViewRef.get() ?: return@runOnMainThread
+            val kind = envelope.optString(WebViewMessageField.KIND)
+            val allowBeforeNavigation = kind in HANDSHAKE_OUTBOUND_KINDS
+            if (!isOriginTrusted(webView, allowBeforeNavigation = allowBeforeNavigation)) {
+                Logger.w(
+                    "Dropping outbound web view message: current origin does not match the resolved component origin.",
+                )
+                return@runOnMainThread
+            }
+            val payload = envelope.toString().escapeForJavaScript()
+            webView.evaluateJavascript(
+                "if (window.${WebViewEnvelope.RECEIVE_FUNCTION}) { " +
+                    "window.${WebViewEnvelope.RECEIVE_FUNCTION}($payload); " +
+                    "}",
+                null,
+            )
+        }
+    }
+
+    /**
+     * Whether the WebView's current URL still has the same origin (scheme + host + port) as the
+     * resolved component URL. When [allowBeforeNavigation] is true and the WebView has not committed
+     * a URL yet, the expected origin is trusted so the connect/init handshake can complete before
+     * the first navigation.
+     */
+    @MainThread
+    private fun isOriginTrusted(webView: WebView, allowBeforeNavigation: Boolean): Boolean {
+        if (expectedOrigin == null) return false
+        val currentOrigin = webView.url?.toOriginOrNull()
+        return when {
+            currentOrigin == null -> allowBeforeNavigation
+            else -> currentOrigin == expectedOrigin
+        }
+    }
+
+    private fun runOnMainThread(block: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            if (released) return
+            block()
+        } else {
+            mainHandler.post {
+                if (released) return@post
+                block()
+            }
+        }
+    }
+
+    private companion object {
+        private val HANDSHAKE_OUTBOUND_KINDS: Set<String> = setOf(
+            WebViewEnvelope.KIND_INIT,
+            WebViewEnvelope.KIND_REJECT,
+        )
+
+        /** Cap a content-reported dimension so a buggy/hostile bundle can't blow up layout. */
+        private const val MAX_RESIZE_CSS_PX = 10_000.0
+
+        /** Minimum per-axis change (CSS px) before a new report is applied. */
+        private const val RESIZE_APPLY_THRESHOLD_CSS_PX = 1
+
+        /** A validated, clamped resize dimension, or `null` when absent, non-finite, or not positive. */
+        @Suppress("ReturnCount")
+        fun JSONObject.resizeDimension(key: String): Int? {
+            if (!has(key)) return null
+            val value = optDouble(key)
+            if (!value.isFinite() || value <= 0) return null
+            return value.coerceAtMost(MAX_RESIZE_CSS_PX).toInt()
+        }
+
+        /**
+         * JSON is a subset of JS object-literal syntax, but the U+2028/U+2029 separators are valid in
+         * JSON strings yet terminate JS statements. Escape them so the payload is safe to embed.
+         */
+        fun String.escapeForJavaScript(): String =
+            replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")
+    }
+}
+
+/**
+ * The origin of this URL as `scheme://host[:port]`, or `null` if it lacks a host. Host comparison is
+ * case-insensitive. Default ports (443 for https, 80 for http) are omitted.
+ */
+@Suppress("ReturnCount", "MagicNumber")
+internal fun String.toOriginOrNull(): String? {
+    val uri = Uri.parse(this)
+    val scheme = uri.scheme?.lowercase(Locale.US) ?: return null
+    val host = uri.host?.takeIf { it.isNotBlank() }?.lowercase(Locale.US) ?: return null
+    val effectivePort = when {
+        uri.port != -1 -> uri.port
+        scheme == "https" -> 443
+        scheme == "http" -> 80
+        else -> -1
+    }
+    val portSuffix = when {
+        effectivePort == -1 -> ""
+        scheme == "https" && effectivePort == 443 -> ""
+        scheme == "http" && effectivePort == 80 -> ""
+        else -> ":$effectivePort"
+    }
+    return "$scheme://$host$portSuffix"
+}
+
+/**
+ * Navigation policy for `web_view` content, applied from `shouldOverrideUrlLoading`:
+ *
+ * - Any non-HTTPS navigation is blocked (any frame).
+ * - Main-frame navigation is additionally restricted to the resolved component URL's origin
+ *   (same-origin different-path navigation stays allowed). This makes cross-origin message races
+ *   structurally impossible; the bridge's per-message origin check remains as defense in depth.
+ * - Cross-origin sub-frame loads are not blocked here; isolation for those is expected from the
+ *   server-provided Content-Security-Policy served with the web content.
+ */
+@Suppress("ReturnCount")
+internal fun shouldBlockWebViewNavigation(
+    url: String?,
+    isMainFrame: Boolean,
+    expectedOrigin: String?,
+): Boolean {
+    val origin = url?.toOriginOrNull() ?: return true
+    if (!origin.startsWith("https://")) return true
+    return isMainFrame && origin != expectedOrigin
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParser.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParser.kt
@@ -1,0 +1,176 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessage
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import org.json.JSONObject
+
+/**
+ * Parses and validates raw JSON strings received from a `web_view` component into typed
+ * [PaywallWebViewMessage]s before they reach app code.
+ *
+ * Payloads use the `workflow-web-components-sdk` transport envelope (`channel`,
+ * `protocol_version`, `kind`, `component_id`, …). App-level messages arrive as `kind`
+ * `message` or `request` with a `type` such as `rc:step-loaded`.
+ *
+ * Returns `null` for handshake frames, transport errors, malformed payloads, wrong
+ * `component_id`, or unknown app message types.
+ */
+internal object WebViewMessageParser {
+
+    const val MAX_PAYLOAD_BYTES: Int = 65_536
+    const val MAX_NESTING_DEPTH: Int = 16
+
+    internal data class ParsedAppMessage(
+        val message: PaywallWebViewMessage,
+        /** Set when the inbound frame is a transport `request` that expects a `response`. */
+        val requestId: String? = null,
+        val requestType: String? = null,
+    )
+
+    @Suppress("ReturnCount")
+    fun parse(rawJson: String, expectedComponentId: String): ParsedAppMessage? {
+        if (rawJson.toByteArray(Charsets.UTF_8).size > MAX_PAYLOAD_BYTES) {
+            Logger.w("Dropping web view message: payload exceeds $MAX_PAYLOAD_BYTES bytes.")
+            return null
+        }
+
+        val envelope = WebViewEnvelope.parse(rawJson) ?: run {
+            Logger.w("Dropping web view message: not a valid transport envelope.")
+            return null
+        }
+
+        return parse(envelope, expectedComponentId)
+    }
+
+    /**
+     * Parses an already-validated transport envelope (size/structure checks done by the caller)
+     * into a typed app message. Avoids re-parsing the raw JSON a second time.
+     */
+    fun parse(envelope: WebViewEnvelope.Parsed, expectedComponentId: String): ParsedAppMessage? {
+        return when (envelope.kind) {
+            WebViewEnvelope.KIND_MESSAGE,
+            WebViewEnvelope.KIND_REQUEST,
+            -> parseAppMessage(envelope, expectedComponentId)
+
+            else -> null
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun parseAppMessage(
+        envelope: WebViewEnvelope.Parsed,
+        expectedComponentId: String,
+    ): ParsedAppMessage? {
+        if (envelope.componentId != expectedComponentId) {
+            Logger.w("Dropping web view message: 'component_id' does not match the rendered web_view.")
+            return null
+        }
+
+        val type = envelope.type?.takeIf { it.isNotEmpty() }
+        if (type == null) {
+            Logger.w("Dropping web view message: missing or non-string 'type'.")
+            return null
+        }
+
+        val message = when (type) {
+            WebViewMessageType.STEP_LOADED,
+            WebViewMessageType.REQUEST_VARIABLES,
+            -> PaywallWebViewMessage(componentId = envelope.componentId, type = type)
+
+            WebViewMessageType.STEP_COMPLETE -> {
+                val responses = parseResponses(envelope.payload) ?: return null
+                PaywallWebViewMessage(
+                    componentId = envelope.componentId,
+                    type = type,
+                    responses = responses.value,
+                )
+            }
+
+            WebViewMessageType.ERROR -> {
+                val error = parseError(envelope) ?: return null
+                PaywallWebViewMessage(componentId = envelope.componentId, type = type, error = error)
+            }
+
+            else -> {
+                Logger.d("Dropping web view message: unknown type '$type'.")
+                return null
+            }
+        }
+
+        val requestId = if (envelope.kind == WebViewEnvelope.KIND_REQUEST) envelope.id else null
+        if (envelope.kind == WebViewEnvelope.KIND_REQUEST && requestId == null) {
+            Logger.w("Dropping web view message: transport request is missing 'id'.")
+            return null
+        }
+
+        return ParsedAppMessage(
+            message = message,
+            requestId = requestId,
+            requestType = type,
+        )
+    }
+
+    private fun parseError(envelope: WebViewEnvelope.Parsed): String? {
+        val payloadError = envelope.payload?.opt(WebViewMessageField.ERROR) as? String
+        val error = payloadError ?: envelope.error
+        if (error == null) {
+            Logger.w("Dropping web view message: 'rc:error' requires a string 'error'.")
+            return null
+        }
+        return error
+    }
+
+    /**
+     * Parses the `responses` object for a `rc:step-complete` message. The responses may live under
+     * `payload.responses` or directly in `payload` when the content sends only response fields.
+     */
+    private class ParsedResponses(val value: Map<String, PaywallWebViewValue>)
+
+    @Suppress("ReturnCount")
+    private fun parseResponses(payload: JSONObject?): ParsedResponses? {
+        if (payload == null || payload.length() == 0) {
+            return ParsedResponses(emptyMap())
+        }
+
+        val responsesJson = when {
+            payload.has(WebViewMessageField.RESPONSES) && !payload.isNull(WebViewMessageField.RESPONSES) ->
+                payload.opt(WebViewMessageField.RESPONSES) as? JSONObject
+
+            payload.keys().asSequence().any { it in STEP_COMPLETE_RESERVED_PAYLOAD_KEYS } -> {
+                Logger.w(
+                    "Dropping web view message: 'rc:step-complete' payload contains transport fields " +
+                        "without a 'responses' object.",
+                )
+                return null
+            }
+
+            else -> payload
+        }
+
+        if (responsesJson == null) {
+            Logger.w("Dropping web view message: 'responses' must be a JSON object.")
+            return null
+        }
+
+        val converted = PaywallWebViewValue.fromJson(responsesJson, MAX_NESTING_DEPTH)
+        if (converted !is PaywallWebViewValue.Object) {
+            Logger.w("Dropping web view message: 'responses' contains non-JSON values or is too deeply nested.")
+            return null
+        }
+        return ParsedResponses(converted.value)
+    }
+
+    private val STEP_COMPLETE_RESERVED_PAYLOAD_KEYS: Set<String> = setOf(
+        WebViewMessageField.CHANNEL,
+        WebViewMessageField.PROTOCOL_VERSION,
+        WebViewMessageField.KIND,
+        WebViewMessageField.TYPE,
+        WebViewMessageField.COMPONENT_ID,
+        WebViewMessageField.ID,
+        WebViewMessageField.ERROR,
+        WebViewMessageField.VARIABLES,
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
@@ -1,0 +1,39 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+/**
+ * Message type identifiers for the RevenueCat `web_view` postMessage protocol (`protocol_version: 1`).
+ * These mirror the shapes used by the web implementation and must not diverge.
+ */
+internal object WebViewMessageType {
+    const val STEP_LOADED = "rc:step-loaded"
+    const val STEP_COMPLETE = "rc:step-complete"
+    const val REQUEST_VARIABLES = "rc:request-variables"
+    const val ERROR = "rc:error"
+    const val VARIABLES = "rc:variables"
+
+    /** Host → content: which axes the native host sizes to the content (`fit`). */
+    const val FIT = "fit"
+
+    /** Content → host: reported content box size in CSS pixels. */
+    const val RESIZE = "resize"
+}
+
+/**
+ * Field names used in the flat message envelope. The envelope is intentionally flat: message-specific
+ * fields such as [RESPONSES], [ERROR] and [VARIABLES] live at the top level rather than under a
+ * generic `payload` key.
+ */
+internal object WebViewMessageField {
+    const val CHANNEL = "channel"
+    const val PROTOCOL_VERSION = "protocol_version"
+    const val KIND = "kind"
+    const val TYPE = "type"
+    const val COMPONENT_ID = "component_id"
+    const val ID = "id"
+    const val PAYLOAD = "payload"
+    const val RESPONSES = "responses"
+    const val ERROR = "error"
+    const val VARIABLES = "variables"
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
@@ -1,0 +1,19 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.net.Uri
+
+internal object WebViewUrlResolver {
+
+    fun resolve(url: String): String? {
+        if (url.contains("{{")) return null
+
+        val uri = Uri.parse(url)
+        return url.takeIf {
+            uri.scheme == HTTPS_SCHEME && !uri.host.isNullOrBlank()
+        }
+    }
+
+    private const val HTTPS_SCHEME = "https"
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.UiConfig.VariableConfig
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.getBestMatch
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toComposeLocale
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toJavaLocale
@@ -85,7 +86,7 @@ internal sealed interface PaywallState {
             }
         }
 
-        @Suppress("LongParameterList")
+        @Suppress("LongParameterList", "TooManyFunctions")
         @Stable
         class Components(
             val stack: ComponentStyle,
@@ -116,6 +117,7 @@ internal sealed interface PaywallState {
              * Default custom variables from the dashboard configuration.
              */
             val defaultCustomVariables: Map<String, CustomVariableValue> = emptyMap(),
+            initialWebViewMessageHandler: PaywallWebViewMessageHandler? = null,
             initialLocaleList: LocaleList = LocaleList.current,
             initialSelectedTabIndex: Int? = null,
             initialSheetState: SimpleSheetState = SimpleSheetState(),
@@ -187,6 +189,17 @@ internal sealed interface PaywallState {
             }
 
             private var localeId by mutableStateOf(initialLocaleList.toLocaleId())
+
+            /**
+             * Optional handler for messages sent by `web_view` components, set via
+             * [com.revenuecat.purchases.ui.revenuecatui.PaywallOptions.Builder.setWebViewMessageHandler].
+             *
+             * Backed by snapshot state and refreshed in place (without rebuilding the paywall state) when
+             * the handler changes on [com.revenuecat.purchases.ui.revenuecatui.PaywallOptions]; see
+             * `PaywallViewModelImpl.updateOptions`.
+             */
+            var webViewMessageHandler by mutableStateOf(initialWebViewMessageHandler)
+                private set
 
             // We find all available device locales with the same country as the storefront country.
             private val availableStorefrontCountryLocalesByLanguage: Map<String, Locale> by lazy {
@@ -340,6 +353,10 @@ internal sealed interface PaywallState {
                 }
 
                 if (actionInProgress != null) this.actionInProgress = actionInProgress
+            }
+
+            fun update(webViewMessageHandler: PaywallWebViewMessageHandler?) {
+                this.webViewMessageHandler = webViewMessageHandler
             }
 
             fun update(selectedPackageUniqueId: String) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -275,9 +275,22 @@ internal class PaywallViewModelImpl(
         val needsUpdateState = this.options.hashCode() != options.hashCode()
         // Some properties not considered for equality (hashCode) may have changed
         // (e.g. the listener may change in some re-renderers)
+        val previousWebViewMessageHandler = this.options.webViewMessageHandler
         this.options = options
         if (needsUpdateState) {
             updateState()
+        } else if (previousWebViewMessageHandler !== options.webViewMessageHandler) {
+            // The web view message handler is excluded from hashCode and is baked into the loaded
+            // Components state, so a handler-only change won't rebuild state. Refresh it in place
+            // (like refreshStateIfLocaleChanged) so web_view components get the latest handler without
+            // re-resolving the offering or resetting selections.
+            val currentState = _state.value
+            if (currentState is PaywallState.Loaded.Components) {
+                currentState.update(webViewMessageHandler = options.webViewMessageHandler)
+                workflowStepStateCache.values.forEach {
+                    it.update(webViewMessageHandler = options.webViewMessageHandler)
+                }
+            }
         }
     }
 
@@ -1186,7 +1199,12 @@ internal class PaywallViewModelImpl(
                 }
                 if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {
                     workflowStepStateCache[stepId] = computed
+                    // Re-stamp the locale and web view message handler from the latest values at insertion
+                    // time: this step's state was computed on the background dispatcher with a snapshot
+                    // taken before any concurrent updateOptions/locale change, and updateOptions only
+                    // refreshes steps already present in the cache when it runs.
                     computed.update(localeList = _lastLocaleList.value.toFrameworkLocaleList())
+                    computed.update(webViewMessageHandler = options.webViewMessageHandler)
                     workflow.singleStepFallbackId
                         ?.let { workflowStepStateCache[it]?.selectedPackageInfo }
                         ?.let { computed.setDefaultPackage(it) }
@@ -1459,6 +1477,7 @@ internal class PaywallViewModelImpl(
                 purchases = purchases,
                 customVariables = options.customVariables,
                 defaultCustomVariables = extractDefaultCustomVariables(offering),
+                webViewMessageHandler = options.webViewMessageHandler,
             )
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -25,6 +25,7 @@ import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.common.LocalizationData
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
@@ -35,6 +36,7 @@ import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.getBestMatch
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.FontSpec
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.determineFontSpecs
@@ -366,6 +368,7 @@ internal fun Offering.toComponentsPaywallState(
     purchases: PurchasesType,
     customVariables: Map<String, CustomVariableValue> = emptyMap(),
     defaultCustomVariables: Map<String, CustomVariableValue> = emptyMap(),
+    webViewMessageHandler: PaywallWebViewMessageHandler? = null,
 ): PaywallState.Loaded.Components {
     val showPricesWithDecimals = storefrontCountryCode?.let {
         !validationResult.zeroDecimalPlaceCountries.contains(it)
@@ -386,6 +389,7 @@ internal fun Offering.toComponentsPaywallState(
         packages = validationResult.packages,
         customVariables = customVariables,
         defaultCustomVariables = defaultCustomVariables,
+        initialWebViewMessageHandler = webViewMessageHandler,
         initialSelectedTabIndex = validationResult.initialSelectedTabIndex,
         mainStackHasHeroImage = validationResult.mainStackHasHeroImage,
         purchases = purchases,
@@ -516,6 +520,7 @@ internal fun PaywallComponent.containsUnsupportedCondition(): Boolean = when (th
     is TabControlToggleComponent -> false
     is TabControlComponent -> false
     is FallbackHeaderComponent -> false
+    is WebViewComponent -> false
 }
 
 @JvmSynthetic

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptionsWebViewHandlerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptionsWebViewHandlerTest.kt
@@ -1,0 +1,42 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class PaywallDialogOptionsWebViewHandlerTest {
+
+    private fun options(handler: PaywallWebViewMessageHandler?): PaywallDialogOptions =
+        PaywallDialogOptions.Builder()
+            .setWebViewMessageHandler(handler)
+            .build()
+
+    @Test
+    fun `builder stores the web view message handler`() {
+        val handler = PaywallWebViewMessageHandler { _, _ -> }
+
+        assertThat(options(handler).webViewMessageHandler).isSameAs(handler)
+    }
+
+    @Test
+    fun `defaults to no web view message handler`() {
+        val options = PaywallDialogOptions.Builder().build()
+
+        assertThat(options.webViewMessageHandler).isNull()
+    }
+
+    @Test
+    fun `options differing only by handler are not equal`() {
+        val handlerA = PaywallWebViewMessageHandler { _, _ -> }
+        val handlerB = PaywallWebViewMessageHandler { _, _ -> }
+
+        assertThat(options(handlerA)).isNotEqualTo(options(handlerB))
+    }
+
+    @Test
+    fun `handler is excluded from hashCode so state updates are not triggered by it alone`() {
+        val handlerA = PaywallWebViewMessageHandler { _, _ -> }
+        val handlerB = PaywallWebViewMessageHandler { _, _ -> }
+
+        assertThat(options(handlerA).hashCode()).isEqualTo(options(handlerB).hashCode())
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptionsWebViewHandlerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptionsWebViewHandlerTest.kt
@@ -1,0 +1,44 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class PaywallOptionsWebViewHandlerTest {
+
+    private fun options(handler: PaywallWebViewMessageHandler?): PaywallOptions =
+        PaywallOptions.Builder(dismissRequest = {})
+            .setWebViewMessageHandler(handler)
+            .build()
+
+    @Test
+    fun `builder stores the web view message handler`() {
+        val handler = PaywallWebViewMessageHandler { _, _ -> }
+
+        assertThat(options(handler).webViewMessageHandler).isSameAs(handler)
+    }
+
+    @Test
+    fun `defaults to no web view message handler`() {
+        val options = PaywallOptions.Builder(dismissRequest = {}).build()
+
+        assertThat(options.webViewMessageHandler).isNull()
+    }
+
+    @Test
+    fun `options differing only by handler are not equal`() {
+        val handlerA = PaywallWebViewMessageHandler { _, _ -> }
+        val handlerB = PaywallWebViewMessageHandler { _, _ -> }
+
+        assertThat(options(handlerA)).isNotEqualTo(options(handlerB))
+    }
+
+    @Test
+    fun `handler is excluded from hashCode so state updates are not triggered by it alone`() {
+        val handlerA = PaywallWebViewMessageHandler { _, _ -> }
+        val handlerB = PaywallWebViewMessageHandler { _, _ -> }
+
+        // hashCode intentionally ignores the handler (like listener) so swapping handlers does not
+        // force a paywall state refresh; see PaywallViewModel.updateOptions.
+        assertThat(options(handlerA).hashCode()).isEqualTo(options(handlerB).hashCode())
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValueTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValueTest.kt
@@ -1,0 +1,113 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+
+internal class PaywallWebViewValueTest {
+
+    @Test
+    fun `fromJson converts primitives`() {
+        assertThat(PaywallWebViewValue.fromJson("hello", 8)).isEqualTo(PaywallWebViewValue.String("hello"))
+        assertThat(PaywallWebViewValue.fromJson(true, 8)).isEqualTo(PaywallWebViewValue.Boolean(true))
+        assertThat(PaywallWebViewValue.fromJson(42, 8)).isEqualTo(PaywallWebViewValue.Number(42))
+        assertThat(PaywallWebViewValue.fromJson(3.5, 8)).isEqualTo(PaywallWebViewValue.Number(3.5))
+        assertThat(PaywallWebViewValue.fromJson(null, 8)).isEqualTo(PaywallWebViewValue.Null)
+        assertThat(PaywallWebViewValue.fromJson(JSONObject.NULL, 8)).isEqualTo(PaywallWebViewValue.Null)
+    }
+
+    @Test
+    fun `fromJson converts nested objects and arrays`() {
+        val json = JSONObject("""{"a":1,"b":["x",false],"c":{"d":null}}""")
+
+        val value = PaywallWebViewValue.fromJson(json, 8)
+
+        assertThat(value).isInstanceOf(PaywallWebViewValue.Object::class.java)
+        val obj = (value as PaywallWebViewValue.Object).value
+        assertThat(obj["a"]).isEqualTo(PaywallWebViewValue.Number(1))
+        assertThat(obj["b"]).isEqualTo(
+            PaywallWebViewValue.Array(listOf(PaywallWebViewValue.String("x"), PaywallWebViewValue.Boolean(false))),
+        )
+        assertThat(obj["c"]).isEqualTo(
+            PaywallWebViewValue.Object(mapOf("d" to PaywallWebViewValue.Null)),
+        )
+    }
+
+    @Test
+    fun `fromJson returns null when too deeply nested`() {
+        val json = JSONObject("""{"a":{"b":{"c":1}}}""")
+
+        // Allow only 2 levels: top object (1) -> a (2) -> b would exceed.
+        assertThat(PaywallWebViewValue.fromJson(json, 2)).isNull()
+    }
+
+    @Test
+    fun `toJsonRepresentation emits whole numbers as integers`() {
+        assertThat(PaywallWebViewValue.Number(100.0).toJsonRepresentation()).isEqualTo(100L)
+        assertThat(PaywallWebViewValue.Number(99.99).toJsonRepresentation()).isEqualTo(99.99)
+    }
+
+    @Test
+    fun `toJsonRepresentation serializes non-finite numbers as JSON null`() {
+        // JSON cannot represent NaN/infinity and org.json's put() throws for them; one bad number
+        // must never destroy an otherwise-valid outbound message.
+        assertThat(PaywallWebViewValue.Number(Double.POSITIVE_INFINITY).toJsonRepresentation())
+            .isEqualTo(JSONObject.NULL)
+        assertThat(PaywallWebViewValue.Number(Double.NEGATIVE_INFINITY).toJsonRepresentation())
+            .isEqualTo(JSONObject.NULL)
+        assertThat(PaywallWebViewValue.Number(Double.NaN).toJsonRepresentation())
+            .isEqualTo(JSONObject.NULL)
+    }
+
+    @Test
+    fun `a map containing non-finite numbers serializes without throwing`() {
+        val json = mapOf(
+            "bad" to PaywallWebViewValue.Number(Double.NaN),
+            "good" to PaywallWebViewValue.String("kept"),
+        ).toJsonObject()
+
+        assertThat(json.isNull("bad")).isTrue()
+        assertThat(json.getString("good")).isEqualTo("kept")
+    }
+
+    @Test
+    fun `number equality and hashCode are mutually consistent for edge values`() {
+        // Double.equals semantics: NaN equals NaN; -0.0 does not equal 0.0. Both agree with hashCode.
+        val nan1 = PaywallWebViewValue.Number(Double.NaN)
+        val nan2 = PaywallWebViewValue.Number(Double.NaN)
+        assertThat(nan1).isEqualTo(nan2)
+        assertThat(nan1.hashCode()).isEqualTo(nan2.hashCode())
+
+        val negativeZero = PaywallWebViewValue.Number(-0.0)
+        val positiveZero = PaywallWebViewValue.Number(0.0)
+        assertThat(negativeZero).isNotEqualTo(positiveZero)
+        assertThat(negativeZero.hashCode()).isNotEqualTo(positiveZero.hashCode())
+    }
+
+    @Test
+    fun `toJsonObject round-trips a map`() {
+        val map = mapOf(
+            "locale" to PaywallWebViewValue.String("en-US"),
+            "custom" to PaywallWebViewValue.Object(
+                mapOf(
+                    "plan" to PaywallWebViewValue.String("annual"),
+                    "count" to PaywallWebViewValue.Number(3),
+                    "flag" to PaywallWebViewValue.Boolean(true),
+                    "list" to PaywallWebViewValue.Array(listOf(PaywallWebViewValue.Number(1))),
+                    "nothing" to PaywallWebViewValue.Null,
+                ),
+            ),
+        )
+
+        val json = map.toJsonObject()
+
+        assertThat(json.getString("locale")).isEqualTo("en-US")
+        val custom = json.getJSONObject("custom")
+        assertThat(custom.getString("plan")).isEqualTo("annual")
+        assertThat(custom.getInt("count")).isEqualTo(3)
+        assertThat(custom.getBoolean("flag")).isTrue()
+        assertThat(custom.get("list")).isInstanceOf(JSONArray::class.java)
+        assertThat(custom.isNull("nothing")).isTrue()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.paywalls.components.TabControlComponent
 import com.revenuecat.purchases.paywalls.components.TabControlToggleComponent
 import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
@@ -116,6 +117,41 @@ class StyleFactoryTests {
             .isEqualTo(localizations.getValue(localeId)[LOCALIZATION_KEY_TEXT_1]!!.value)
         val colorStyle = style.color.light as ColorStyle.Solid
         assertThat(colorStyle.color).isEqualTo(expectedColor)
+    }
+
+    @Test
+    fun `Should create a WebViewComponentStyle for a WebViewComponent`() {
+        val size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit)
+        val component = WebViewComponent(
+            url = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
+            id = "promo_web_view",
+            visible = false,
+            size = size,
+        )
+
+        val result = styleFactory.create(component)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as WebViewComponentStyle
+        assertThat(style.url).isEqualTo("https://paywalls.revenuecat.com/{{ custom.animal }}.html")
+        assertThat(style.visible).isFalse()
+        assertThat(style.size).isEqualTo(size)
+        assertThat(style.componentId).isEqualTo("promo_web_view")
+        assertThat(style.protocolVersion).isNull()
+    }
+
+    @Test
+    fun `Should pass protocolVersion through to the WebViewComponentStyle`() {
+        val component = WebViewComponent(
+            url = "https://paywalls.revenuecat.com/index.html",
+            protocolVersion = 1,
+        )
+
+        val result = styleFactory.create(component)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as WebViewComponentStyle
+        assertThat(style.protocolVersion).isEqualTo(1)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentViewTests.kt
@@ -39,6 +39,7 @@ import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
@@ -1298,7 +1299,8 @@ class TabsComponentViewTests {
                 is IconComponent,
                 is TextComponent,
                 is VideoComponent,
-                    -> {
+                is WebViewComponent,
+                -> {
                     // These don't have child components.
                 }
             }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
@@ -1,0 +1,72 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class PaywallWebViewClientTest {
+
+    private lateinit var webView: WebView
+    private val expectedOrigin = "https://assets.example.com"
+    private val navigations = mutableListOf<String?>()
+    private var failureCount = 0
+
+    private lateinit var client: PaywallWebViewClient
+
+    @Before
+    fun setUp() {
+        webView = WebView(ApplicationProvider.getApplicationContext())
+        navigations.clear()
+        failureCount = 0
+        client = PaywallWebViewClient(
+            expectedOrigin = expectedOrigin,
+            onMainFrameNavigationStarted = { navigations.add(it) },
+            onMainFrameLoadFailed = { failureCount += 1 },
+        )
+    }
+
+    @Test
+    fun `onPageStarted notifies main-frame document start`() {
+        client.onPageStarted(webView, "https://assets.example.com/promo/index.html", null)
+
+        assertThat(navigations).containsExactly("https://assets.example.com/promo/index.html")
+    }
+
+    @Test
+    fun `onRenderProcessGone returns true and activates failure once`() {
+        val detail = mockk<RenderProcessGoneDetail>(relaxed = true)
+
+        val first = client.onRenderProcessGone(webView, detail)
+        val second = client.onRenderProcessGone(webView, detail)
+
+        assertThat(first).isTrue()
+        assertThat(second).isTrue()
+        assertThat(failureCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `main-frame URL and HTTP errors share the terminal failure path`() {
+        val request = mockk<WebResourceRequest>()
+        every { request.isForMainFrame } returns true
+        val error = mockk<WebResourceError>(relaxed = true)
+        val response = mockk<WebResourceResponse>()
+        every { response.statusCode } returns 500
+
+        client.onReceivedError(webView, request, error)
+        client.onReceivedHttpError(webView, request, response)
+        client.onRenderProcessGone(webView, mockk(relaxed = true))
+
+        assertThat(failureCount).isEqualTo(1)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import android.content.Context
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -17,16 +18,26 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 internal class PaywallWebViewClientTest {
 
-    private lateinit var webView: WebView
+    private lateinit var webView: TrackingWebView
     private val expectedOrigin = "https://assets.example.com"
     private val navigations = mutableListOf<String?>()
     private var failureCount = 0
 
     private lateinit var client: PaywallWebViewClient
 
+    private class TrackingWebView(context: Context) : WebView(context) {
+        var stopLoadingCount: Int = 0
+            private set
+
+        override fun stopLoading() {
+            stopLoadingCount += 1
+            super.stopLoading()
+        }
+    }
+
     @Before
     fun setUp() {
-        webView = WebView(ApplicationProvider.getApplicationContext())
+        webView = TrackingWebView(ApplicationProvider.getApplicationContext())
         navigations.clear()
         failureCount = 0
         client = PaywallWebViewClient(
@@ -41,6 +52,32 @@ internal class PaywallWebViewClientTest {
         client.onPageStarted(webView, "https://assets.example.com/promo/index.html", null)
 
         assertThat(navigations).containsExactly("https://assets.example.com/promo/index.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `onPageStarted does not stop same-origin https loads`() {
+        client.onPageStarted(webView, "https://assets.example.com/promo/step-two.html", null)
+
+        assertThat(navigations).containsExactly("https://assets.example.com/promo/step-two.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `onPageStarted stops blocked cross-origin loads that bypass shouldOverrideUrlLoading`() {
+        // POST navigations skip shouldOverrideUrlLoading; onPageStarted is the backstop.
+        client.onPageStarted(webView, "https://evil.example.org/phish.html", null)
+
+        assertThat(navigations).containsExactly("https://evil.example.org/phish.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `onPageStarted stops blocked non-https loads`() {
+        client.onPageStarted(webView, "http://assets.example.com/promo/insecure.html", null)
+
+        assertThat(navigations).containsExactly("http://assets.example.com/promo/insecure.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(1)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProviderTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProviderTest.kt
@@ -1,0 +1,34 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class PaywallWebViewVariablesProviderTest {
+
+    @Test
+    fun `sdkManagedVariables exposes only the locale system variable`() {
+        val variables = PaywallWebViewVariablesProvider.sdkManagedVariables(locale = "en-US")
+
+        // Only the locale system variable is exposed; nothing else is passed across the bridge in v1.
+        assertThat(variables).hasSize(1)
+        assertThat(variables[PaywallWebViewVariablesProvider.KEY_LOCALE])
+            .isEqualTo(PaywallWebViewValue.String("en-US"))
+    }
+
+    @Test
+    fun `sanitizeAppProvidedVariables drops reserved keys`() {
+        val sanitized = PaywallWebViewVariablesProvider.sanitizeAppProvidedVariables(
+            mapOf(
+                "locale" to PaywallWebViewValue.String("zz-ZZ"),
+                "app_segment" to PaywallWebViewValue.String("high_intent"),
+            ),
+        )
+
+        assertThat(sanitized).doesNotContainKey("locale")
+        assertThat(sanitized).containsKey("app_segment")
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
@@ -1,0 +1,47 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class WebViewEffectiveSizeTest {
+
+    @Test
+    fun `fit axes use placeholders until the content reports a size`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fit, height = Fit),
+            contentWidthCssPx = 0,
+            contentHeightCssPx = 0,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(FIT_PLACEHOLDER_WIDTH))
+        assertThat(size.height).isEqualTo(Fixed(FIT_PLACEHOLDER_HEIGHT))
+    }
+
+    @Test
+    fun `fit axes use the reported content size once available`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fit, height = Fit),
+            contentWidthCssPx = 320,
+            contentHeightCssPx = 480,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(320u))
+        assertThat(size.height).isEqualTo(Fixed(480u))
+    }
+
+    @Test
+    fun `non-fit axes ignore reported content sizes`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fill, height = Fixed(200u)),
+            contentWidthCssPx = 320,
+            contentHeightCssPx = 480,
+        )
+
+        assertThat(size.width).isEqualTo(Fill)
+        assertThat(size.height).isEqualTo(Fixed(200u))
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewFailurePathTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewFailurePathTest.kt
@@ -1,0 +1,147 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebView
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class WebViewFailurePathTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `renderer termination shows fallback and destroys the web view`() {
+        var destroyed = false
+        var identity by mutableStateOf("a")
+        var showFallback = false
+
+        composeTestRule.setContent {
+            key(identity) {
+                var loadFailed by remember { mutableStateOf(false) }
+                showFallback = loadFailed
+                if (loadFailed) {
+                    Text("fallback")
+                } else {
+                    val context = LocalContext.current
+                    val holder = remember { WebViewBridgeHolder() }
+                    AndroidView(
+                        factory = {
+                            WebView(context).apply {
+                                val client = PaywallWebViewClient(
+                                    expectedOrigin = "https://assets.example.com",
+                                    onMainFrameNavigationStarted = {},
+                                    onMainFrameLoadFailed = { loadFailed = true },
+                                )
+                                setWebViewClient(client)
+                                // Simulate renderer death immediately after creation.
+                                client.onRenderProcessGone(this, mockk<RenderProcessGoneDetail>(relaxed = true))
+                            }
+                        },
+                        onRelease = { webView ->
+                            holder.bridge?.release()
+                            holder.bridge = null
+                            webView.destroy()
+                            destroyed = true
+                        },
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("fallback").assertIsDisplayed()
+        assertThat(destroyed).isTrue()
+        assertThat(showFallback).isTrue()
+    }
+
+    @Test
+    fun `without fallback the dead android view is removed`() {
+        var webViewPresent = true
+        composeTestRule.setContent {
+            var loadFailed by remember { mutableStateOf(false) }
+            if (loadFailed) {
+                webViewPresent = false
+                Box {}
+            } else {
+                val context = LocalContext.current
+                AndroidView(
+                    factory = {
+                        WebView(context).apply {
+                            val client = PaywallWebViewClient(
+                                expectedOrigin = "https://assets.example.com",
+                                onMainFrameNavigationStarted = {},
+                                onMainFrameLoadFailed = { loadFailed = true },
+                            )
+                            setWebViewClient(client)
+                            client.onRenderProcessGone(this, mockk(relaxed = true))
+                        }
+                    },
+                    onRelease = { it.destroy() },
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertThat(webViewPresent).isFalse()
+    }
+
+    @Test
+    fun `identity change after failure can create a replacement web view`() {
+        val creations = mutableListOf<String>()
+        var identity by mutableStateOf("one")
+        var failNext = true
+
+        composeTestRule.setContent {
+            key(identity) {
+                var loadFailed by remember { mutableStateOf(false) }
+                if (loadFailed) {
+                    Text("failed-$identity")
+                } else {
+                    val context = LocalContext.current
+                    AndroidView(
+                        factory = {
+                            creations.add(identity)
+                            WebView(context).apply {
+                                if (failNext) {
+                                    failNext = false
+                                    val client = PaywallWebViewClient(
+                                        expectedOrigin = "https://assets.example.com",
+                                        onMainFrameNavigationStarted = {},
+                                        onMainFrameLoadFailed = { loadFailed = true },
+                                    )
+                                    setWebViewClient(client)
+                                    client.onRenderProcessGone(this, mockk(relaxed = true))
+                                }
+                            }
+                        },
+                        onRelease = { it.destroy() },
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("failed-one").assertIsDisplayed()
+
+        identity = "two"
+        composeTestRule.waitForIdle()
+
+        assertThat(creations).containsExactly("one", "two")
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewFailurePathTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewFailurePathTest.kt
@@ -2,9 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebView
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -29,59 +27,16 @@ internal class WebViewFailurePathTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun `renderer termination shows fallback and destroys the web view`() {
+    fun `renderer termination removes the dead web view`() {
         var destroyed = false
-        var identity by mutableStateOf("a")
-        var showFallback = false
+        var loadFailedObserved = false
 
-        composeTestRule.setContent {
-            key(identity) {
-                var loadFailed by remember { mutableStateOf(false) }
-                showFallback = loadFailed
-                if (loadFailed) {
-                    Text("fallback")
-                } else {
-                    val context = LocalContext.current
-                    val holder = remember { WebViewBridgeHolder() }
-                    AndroidView(
-                        factory = {
-                            WebView(context).apply {
-                                val client = PaywallWebViewClient(
-                                    expectedOrigin = "https://assets.example.com",
-                                    onMainFrameNavigationStarted = {},
-                                    onMainFrameLoadFailed = { loadFailed = true },
-                                )
-                                setWebViewClient(client)
-                                // Simulate renderer death immediately after creation.
-                                client.onRenderProcessGone(this, mockk<RenderProcessGoneDetail>(relaxed = true))
-                            }
-                        },
-                        onRelease = { webView ->
-                            holder.bridge?.release()
-                            holder.bridge = null
-                            webView.destroy()
-                            destroyed = true
-                        },
-                    )
-                }
-            }
-        }
-        composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("fallback").assertIsDisplayed()
-        assertThat(destroyed).isTrue()
-        assertThat(showFallback).isTrue()
-    }
-
-    @Test
-    fun `without fallback the dead android view is removed`() {
-        var webViewPresent = true
         composeTestRule.setContent {
             var loadFailed by remember { mutableStateOf(false) }
-            if (loadFailed) {
-                webViewPresent = false
-                Box {}
-            } else {
+            loadFailedObserved = loadFailed
+            if (!loadFailed) {
                 val context = LocalContext.current
+                val holder = remember { WebViewBridgeHolder() }
                 AndroidView(
                     factory = {
                         WebView(context).apply {
@@ -91,15 +46,22 @@ internal class WebViewFailurePathTest {
                                 onMainFrameLoadFailed = { loadFailed = true },
                             )
                             setWebViewClient(client)
-                            client.onRenderProcessGone(this, mockk(relaxed = true))
+                            // Simulate renderer death immediately after creation.
+                            client.onRenderProcessGone(this, mockk<RenderProcessGoneDetail>(relaxed = true))
                         }
                     },
-                    onRelease = { it.destroy() },
+                    onRelease = { webView ->
+                        holder.bridge?.release()
+                        holder.bridge = null
+                        webView.destroy()
+                        destroyed = true
+                    },
                 )
             }
         }
         composeTestRule.waitForIdle()
-        assertThat(webViewPresent).isFalse()
+        assertThat(destroyed).isTrue()
+        assertThat(loadFailedObserved).isTrue()
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
@@ -1,0 +1,282 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.webkit.WebView
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class WebViewIdentityTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `identity differs when component id changes`() {
+        val base = WebViewIdentity(
+            resolvedUrl = "https://assets.example.com/a.html",
+            componentId = "one",
+            sizeToContentWidth = false,
+            sizeToContentHeight = true,
+        )
+        val changed = base.copy(componentId = "two")
+
+        assertThat(base).isNotEqualTo(changed)
+    }
+
+    @Test
+    fun `identity differs when fit width or height changes`() {
+        val base = WebViewIdentity(
+            resolvedUrl = "https://assets.example.com/a.html",
+            componentId = "one",
+            sizeToContentWidth = false,
+            sizeToContentHeight = false,
+        )
+
+        assertThat(base).isNotEqualTo(base.copy(sizeToContentWidth = true))
+        assertThat(base).isNotEqualTo(base.copy(sizeToContentHeight = true))
+    }
+
+    @Test
+    fun `same url with different component id recreates the web view and bridge`() {
+        val creations = mutableListOf<String?>()
+        val releases = mutableListOf<String?>()
+        var identity by mutableStateOf(
+            WebViewIdentity(
+                resolvedUrl = "https://assets.example.com/a.html",
+                componentId = "one",
+                sizeToContentWidth = false,
+                sizeToContentHeight = false,
+            ),
+        )
+
+        composeTestRule.setContent {
+            TestWebViewSlot(
+                identity = identity,
+                locale = "en-US",
+                messageHandler = null,
+                onCreated = { creations.add(it) },
+                onReleased = { releases.add(it) },
+            )
+        }
+        composeTestRule.waitForIdle()
+        assertThat(creations).containsExactly("one")
+
+        identity = identity.copy(componentId = "two")
+        composeTestRule.waitForIdle()
+
+        assertThat(releases).containsExactly("one")
+        assertThat(creations).containsExactly("one", "two")
+    }
+
+    @Test
+    fun `fixed-to-fit width and height changes recreate the web view`() {
+        val creations = mutableListOf<WebViewIdentity>()
+        var identity by mutableStateOf(
+            WebViewIdentity(
+                resolvedUrl = "https://assets.example.com/a.html",
+                componentId = "one",
+                sizeToContentWidth = false,
+                sizeToContentHeight = false,
+            ),
+        )
+
+        composeTestRule.setContent {
+            TestWebViewSlot(
+                identity = identity,
+                locale = "en-US",
+                messageHandler = null,
+                onCreated = { creations.add(identity) },
+                onReleased = {},
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        identity = identity.copy(sizeToContentWidth = true)
+        composeTestRule.waitForIdle()
+        identity = identity.copy(sizeToContentHeight = true)
+        composeTestRule.waitForIdle()
+
+        assertThat(creations).hasSize(3)
+        assertThat(creations[1].sizeToContentWidth).isTrue()
+        assertThat(creations[2].sizeToContentHeight).isTrue()
+    }
+
+    @Test
+    fun `locale and handler only updates do not recreate the web view`() {
+        val creations = mutableListOf<Int>()
+        var identity by mutableStateOf(
+            WebViewIdentity(
+                resolvedUrl = "https://assets.example.com/a.html",
+                componentId = "one",
+                sizeToContentWidth = false,
+                sizeToContentHeight = false,
+            ),
+        )
+        var locale by mutableStateOf("en-US")
+        var handler by mutableStateOf<PaywallWebViewMessageHandler?>(null)
+        val updates = mutableListOf<Pair<String, PaywallWebViewMessageHandler?>>()
+
+        composeTestRule.setContent {
+            TestWebViewSlot(
+                identity = identity,
+                locale = locale,
+                messageHandler = handler,
+                onCreated = { creations.add(creations.size) },
+                onReleased = {},
+                onUpdated = { loc, msg -> updates.add(loc to msg) },
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        locale = "fr-FR"
+        composeTestRule.waitForIdle()
+        val newHandler = PaywallWebViewMessageHandler { _, _ -> }
+        handler = newHandler
+        composeTestRule.waitForIdle()
+
+        assertThat(creations).hasSize(1)
+        assertThat(updates.map { it.first }).contains("fr-FR")
+        assertThat(updates.map { it.second }).contains(newHandler)
+    }
+
+    @Test
+    fun `old onRelease cannot release the replacement bridge`() {
+        val releasedBridges = mutableListOf<WebViewJavaScriptBridge>()
+        var identity by mutableStateOf(
+            WebViewIdentity(
+                resolvedUrl = "https://assets.example.com/a.html",
+                componentId = "one",
+                sizeToContentWidth = false,
+                sizeToContentHeight = false,
+            ),
+        )
+        val liveBridges = mutableListOf<WebViewJavaScriptBridge>()
+
+        composeTestRule.setContent {
+            TestWebViewSlot(
+                identity = identity,
+                locale = "en-US",
+                messageHandler = null,
+                onCreated = {},
+                onReleased = {},
+                onBridgeCreated = { liveBridges.add(it) },
+                onBridgeReleased = { releasedBridges.add(it) },
+            )
+        }
+        composeTestRule.waitForIdle()
+        val first = liveBridges.single()
+
+        identity = identity.copy(componentId = "two")
+        composeTestRule.waitForIdle()
+
+        assertThat(releasedBridges).containsExactly(first)
+        assertThat(liveBridges).hasSize(2)
+        assertThat(releasedBridges).doesNotContain(liveBridges.last())
+    }
+
+    @Test
+    fun `measured dimensions start at zero for a new identity`() {
+        val initialSizes = mutableListOf<Pair<Int, Int>>()
+        var identity by mutableStateOf(
+            WebViewIdentity(
+                resolvedUrl = "https://assets.example.com/a.html",
+                componentId = "one",
+                sizeToContentWidth = true,
+                sizeToContentHeight = true,
+            ),
+        )
+
+        composeTestRule.setContent {
+            key(identity) {
+                var contentWidthCssPx by remember { mutableIntStateOf(0) }
+                var contentHeightCssPx by remember { mutableIntStateOf(0) }
+                DisposableEffect(Unit) {
+                    initialSizes.add(contentWidthCssPx to contentHeightCssPx)
+                    contentWidthCssPx = 100
+                    onDispose { }
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertThat(initialSizes).containsExactly(0 to 0)
+
+        identity = identity.copy(componentId = "two")
+        composeTestRule.waitForIdle()
+        assertThat(initialSizes).containsExactly(0 to 0, 0 to 0)
+    }
+}
+
+/**
+ * Mirrors the identity-scoped AndroidView / bridge-holder pattern used by [WebViewComponentView]
+ * so lifecycle guarantees can be asserted without spinning up a full paywall state tree.
+ */
+@Composable
+private fun TestWebViewSlot(
+    identity: WebViewIdentity,
+    locale: String,
+    messageHandler: PaywallWebViewMessageHandler?,
+    onCreated: (String?) -> Unit,
+    onReleased: (String?) -> Unit,
+    onUpdated: (String, PaywallWebViewMessageHandler?) -> Unit = { _, _ -> },
+    onBridgeCreated: (WebViewJavaScriptBridge) -> Unit = {},
+    onBridgeReleased: (WebViewJavaScriptBridge) -> Unit = {},
+) {
+    key(identity) {
+        val bridgeHolder = remember { WebViewBridgeHolder() }
+        val context = LocalContext.current
+        AndroidView(
+            factory = {
+                WebView(context).apply {
+                    val bridge = identity.componentId?.let { id ->
+                        WebViewJavaScriptBridge(
+                            webView = this,
+                            componentId = id,
+                            expectedUrl = identity.resolvedUrl,
+                            locale = locale,
+                            messageHandler = messageHandler,
+                            sizeToContentWidth = identity.sizeToContentWidth,
+                            sizeToContentHeight = identity.sizeToContentHeight,
+                            isWebMessageListenerSupported = { true },
+                            installWebMessageListener = { _, _, _, _ -> },
+                            uninstallWebMessageListener = { _, _ -> },
+                        ).also { created ->
+                            created.attach()
+                            onBridgeCreated(created)
+                        }
+                    }
+                    bridgeHolder.bridge = bridge
+                    onCreated(identity.componentId)
+                }
+            },
+            update = {
+                bridgeHolder.bridge?.update(locale = locale, messageHandler = messageHandler)
+                onUpdated(locale, messageHandler)
+            },
+            onRelease = { webView ->
+                val bridge = bridgeHolder.bridge
+                bridgeHolder.bridge = null
+                if (bridge != null) {
+                    onBridgeReleased(bridge)
+                    bridge.release()
+                }
+                onReleased(identity.componentId)
+                webView.destroy()
+            },
+        )
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -24,12 +24,14 @@ internal class WebViewJavaScriptBridgeTest {
     private lateinit var webView: WebView
     private lateinit var shadowWebView: ShadowWebView
     private val received = mutableListOf<PaywallWebViewMessage>()
+    private val installedListeners = mutableListOf<Boolean>()
 
     @Before
     fun setUp() {
         webView = WebView(ApplicationProvider.getApplicationContext())
         shadowWebView = shadowOf(webView)
         received.clear()
+        installedListeners.clear()
     }
 
     private fun bridge(
@@ -39,6 +41,10 @@ internal class WebViewJavaScriptBridgeTest {
         sizeToContentWidth: Boolean = false,
         sizeToContentHeight: Boolean = false,
         onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
+        onDocumentReset: () -> Unit = {},
+        onSecureMessagingUnsupported: () -> Unit = {},
+        webMessageListenerSupported: Boolean = true,
+        trackInstallState: Boolean = false,
     ): WebViewJavaScriptBridge {
         val bridge = WebViewJavaScriptBridge(
             webView = webView,
@@ -49,6 +55,15 @@ internal class WebViewJavaScriptBridgeTest {
             sizeToContentWidth = sizeToContentWidth,
             sizeToContentHeight = sizeToContentHeight,
             onContentResize = onContentResize,
+            onDocumentReset = onDocumentReset,
+            onSecureMessagingUnsupported = onSecureMessagingUnsupported,
+            isWebMessageListenerSupported = { webMessageListenerSupported },
+            installWebMessageListener = { _, _, _, _ ->
+                if (trackInstallState) installedListeners.add(true)
+            },
+            uninstallWebMessageListener = { _, _ ->
+                if (trackInstallState) installedListeners.add(false)
+            },
         )
         bridge.attach()
         navigateTo?.let { webView.loadUrl(it) }
@@ -270,12 +285,15 @@ internal class WebViewJavaScriptBridgeTest {
     }
 
     @Test
-    fun `re-validates origin at main-thread delivery after navigation race`() {
+    fun `re-validates source origin at main-thread delivery`() {
         val bridge = bridge()
         connect(bridge)
-        webView.loadUrl("https://evil.example.org/phish.html")
         val background = Thread {
-            bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+            bridge.postMessage(
+                json = appMessage(WebViewMessageType.STEP_LOADED),
+                sourceOrigin = android.net.Uri.parse("https://evil.example.org"),
+                isMainFrame = true,
+            )
         }
         background.start()
         background.join()
@@ -288,17 +306,39 @@ internal class WebViewJavaScriptBridgeTest {
     fun `treats host comparison as case insensitive`() {
         val bridge = bridge(navigateTo = "https://Assets.Example.COM/promo/index.html")
         connect(bridge)
-        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        bridge.postMessage(
+            json = appMessage(WebViewMessageType.STEP_LOADED),
+            sourceOrigin = android.net.Uri.parse("https://Assets.Example.COM"),
+            isMainFrame = true,
+        )
         idleMainLooper()
 
         assertThat(received).hasSize(1)
     }
 
     @Test
-    fun `rejects messages after navigation to an unexpected origin`() {
-        val bridge = bridge(navigateTo = "https://evil.example.org/phish.html")
+    fun `rejects messages from an unexpected source origin`() {
+        val bridge = bridge()
         connect(bridge)
-        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        bridge.postMessage(
+            json = appMessage(WebViewMessageType.STEP_LOADED),
+            sourceOrigin = android.net.Uri.parse("https://evil.example.org"),
+            isMainFrame = true,
+        )
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `rejects messages that are not from the main frame`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            json = appMessage(WebViewMessageType.STEP_LOADED),
+            sourceOrigin = android.net.Uri.parse("https://assets.example.com"),
+            isMainFrame = false,
+        )
         idleMainLooper()
 
         assertThat(received).isEmpty()
@@ -459,20 +499,33 @@ internal class WebViewJavaScriptBridgeTest {
     }
 
     @Test
-    fun `attach registers native interface under rcWebComponents`() {
-        bridge()
+    fun `attach installs the web message listener when supported`() {
+        bridge(trackInstallState = true)
 
-        assertThat(shadowWebView.getJavascriptInterface("rcWebComponents")).isNotNull
+        assertThat(installedListeners).containsExactly(true)
     }
 
     @Test
-    fun `release removes the native interface`() {
-        val bridge = bridge()
-        assertThat(shadowWebView.getJavascriptInterface("rcWebComponents")).isNotNull
+    fun `attach reports unsupported secure messaging when the feature is missing`() {
+        var unsupported = false
+        bridge(
+            webMessageListenerSupported = false,
+            onSecureMessagingUnsupported = { unsupported = true },
+            trackInstallState = true,
+        )
+
+        assertThat(unsupported).isTrue()
+        assertThat(installedListeners).isEmpty()
+    }
+
+    @Test
+    fun `release removes the web message listener`() {
+        val bridge = bridge(trackInstallState = true)
+        assertThat(installedListeners).containsExactly(true)
 
         bridge.release()
 
-        assertThat(shadowWebView.getJavascriptInterface("rcWebComponents")).isNull()
+        assertThat(installedListeners).containsExactly(true, false)
     }
 
     @Test
@@ -629,5 +682,150 @@ internal class WebViewJavaScriptBridgeTest {
         idleMainLooper()
 
         assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `initial document connect produces one init`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+    }
+
+    @Test
+    fun `duplicate connect in the same document is ignored`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        val afterFirst = shadowWebView.lastEvaluatedJavascript
+        connect(bridge)
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).isEqualTo(afterFirst)
+    }
+
+    @Test
+    fun `after navigation starts app frames are rejected until reconnect`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `new document connect produces a second init`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+        webView.loadUrl("https://assets.example.com/promo/step-two.html")
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+        assertThat(received).isEmpty()
+
+        connect(bridge)
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+        assertThat(received).hasSize(1)
+    }
+
+    @Test
+    fun `rc fit is resent after reconnect when height is fit`() {
+        val bridge = bridge(sizeToContentHeight = true)
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"type\":\"fit\"")
+
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+        webView.loadUrl("https://assets.example.com/promo/step-two.html")
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"type\":\"fit\"")
+        assertThat(script).contains("\"height\":true")
+    }
+
+    @Test
+    fun `resize threshold state is reset between documents`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"height":300}"""),
+        )
+        idleMainLooper()
+        assertThat(resizes).containsExactly(null to 300)
+
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+        webView.loadUrl("https://assets.example.com/promo/step-two.html")
+        connect(bridge)
+        // Same height as before the document reset — must apply again because threshold state cleared.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"height":300}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(null to 300, null to 300)
+    }
+
+    @Test
+    fun `document reset clears compose content dimensions`() {
+        var resets = 0
+        val bridge = bridge(onDocumentReset = { resets += 1 })
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/reload.html")
+
+        assertThat(resets).isEqualTo(2)
+    }
+
+    @Test
+    fun `queued outbound message from the old document is not delivered after navigation`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        val background = Thread {
+            bridge.postMessage(
+                componentId = componentId,
+                type = "rc:queued",
+                variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+            )
+        }
+        background.start()
+        background.join()
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).doesNotContain("rc:queued")
+    }
+
+    @Test
+    fun `reload follows the same reconnect behavior`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        bridge.onMainFrameNavigationStarted(expectedUrl) // reload
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+        assertThat(received).isEmpty()
+
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -1,0 +1,633 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.os.Looper
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessage
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowWebView
+
+@RunWith(RobolectricTestRunner::class)
+internal class WebViewJavaScriptBridgeTest {
+
+    private val componentId = "promo_web_view"
+    private val expectedUrl = "https://assets.example.com/promo/index.html"
+
+    private lateinit var webView: WebView
+    private lateinit var shadowWebView: ShadowWebView
+    private val received = mutableListOf<PaywallWebViewMessage>()
+
+    @Before
+    fun setUp() {
+        webView = WebView(ApplicationProvider.getApplicationContext())
+        shadowWebView = shadowOf(webView)
+        received.clear()
+    }
+
+    private fun bridge(
+        handler: PaywallWebViewMessageHandler? = PaywallWebViewMessageHandler { message, _ -> received.add(message) },
+        locale: String = "en-US",
+        navigateTo: String? = expectedUrl,
+        sizeToContentWidth: Boolean = false,
+        sizeToContentHeight: Boolean = false,
+        onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
+    ): WebViewJavaScriptBridge {
+        val bridge = WebViewJavaScriptBridge(
+            webView = webView,
+            componentId = componentId,
+            expectedUrl = expectedUrl,
+            locale = locale,
+            messageHandler = handler,
+            sizeToContentWidth = sizeToContentWidth,
+            sizeToContentHeight = sizeToContentHeight,
+            onContentResize = onContentResize,
+        )
+        bridge.attach()
+        navigateTo?.let { webView.loadUrl(it) }
+        return bridge
+    }
+
+    private fun idleMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun connect(bridge: WebViewJavaScriptBridge) {
+        bridge.postMessage(
+            """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"connect","component_id":""}
+            """.trimIndent(),
+        )
+        idleMainLooper()
+    }
+
+    private fun appMessage(
+        type: String,
+        payload: String? = null,
+        kind: String = WebViewEnvelope.KIND_MESSAGE,
+        id: String? = null,
+    ): String {
+        val payloadField = payload?.let { ""","payload":$it""" } ?: ""
+        val idField = id?.let { ""","id":"$it"""" } ?: ""
+        return """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId","type":"$type"$payloadField$idField}
+            """.trimIndent()
+    }
+
+    @Test
+    fun `completes connect handshake with init`() {
+        val bridge = bridge()
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("window.__rcWebComponentsReceive(")
+        assertThat(script).contains("\"kind\":\"init\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+    }
+
+    @Test
+    fun `completes connect handshake before the web view URL is available`() {
+        val bridge = bridge(navigateTo = null)
+        assertThat(webView.url).isNull()
+
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"kind\":\"init\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+    }
+
+    @Test
+    fun `rejects unsupported protocol version`() {
+        val bridge = bridge()
+        bridge.postMessage(
+            """
+            {"channel":"rc-web-components","protocol_version":2,"kind":"connect","component_id":""}
+            """.trimIndent(),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"kind\":\"reject\"")
+        assertThat(script).contains("Unsupported protocol_version 2")
+    }
+
+    @Test
+    fun `delivers valid message after handshake`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+        assertThat(received.single().componentId).isEqualTo("promo_web_view")
+        assertThat(received.single().type).isEqualTo("rc:step-loaded")
+    }
+
+    @Test
+    fun `ignores app messages before handshake`() {
+        bridge().postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `rejects messages for a different component id`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.STEP_LOADED,
+            ).replace(componentId, "other_web_view"),
+        )
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `request-variables auto-sends rc variables with locale only`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
+        idleMainLooper()
+
+        assertThat(received.single().type).isEqualTo("rc:request-variables")
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("window.__rcWebComponentsReceive(")
+        assertThat(script).contains("\"kind\":\"message\"")
+        assertThat(script).contains("\"rc:variables\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+        assertThat(script).contains("\"locale\":\"en-US\"")
+        assertThat(script).doesNotContain("\"custom\"")
+    }
+
+    @Test
+    fun `request-variables transport request also sends response`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.REQUEST_VARIABLES,
+                kind = WebViewEnvelope.KIND_REQUEST,
+                id = "req-1",
+            ),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"kind\":\"response\"")
+        assertThat(script).contains("\"id\":\"req-1\"")
+        assertThat(script).contains("\"locale\":\"en-US\"")
+        assertThat(script).doesNotContain("\"rc:variables\"")
+    }
+
+    @Test
+    fun `app can reply with extra variables through the controller`() {
+        val handler = PaywallWebViewMessageHandler { message, controller ->
+            received.add(message)
+            if (message.type == WebViewMessageType.REQUEST_VARIABLES) {
+                controller.postVariables(
+                    componentId = message.componentId,
+                    variables = mapOf(
+                        "custom" to PaywallWebViewValue.Object(
+                            mapOf("app_segment" to PaywallWebViewValue.String("high_intent")),
+                        ),
+                    ),
+                )
+            }
+        }
+        val bridge = bridge(handler = handler)
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"rc:variables\"")
+        assertThat(script).contains("\"app_segment\":\"high_intent\"")
+    }
+
+    @Test
+    fun `controller postVariables drops reserved keys`() {
+        val controllerHolder = arrayOfNulls<PaywallWebViewController>(1)
+        val handler = PaywallWebViewMessageHandler { _, controller -> controllerHolder[0] = controller }
+        val bridge = bridge(handler = handler)
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        controllerHolder[0]!!.postVariables(
+            componentId = componentId,
+            variables = mapOf(
+                "locale" to PaywallWebViewValue.String("zz-ZZ"),
+                "custom" to PaywallWebViewValue.Object(mapOf("k" to PaywallWebViewValue.String("v"))),
+            ),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).doesNotContain("zz-ZZ")
+        assertThat(script).contains("\"k\":\"v\"")
+    }
+
+    @Test
+    fun `does not deliver messages after release`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.release()
+
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `does not execute queued outbound evaluateJavascript after release`() {
+        val bridge = bridge()
+        connect(bridge)
+        val background = Thread {
+            bridge.postMessage(
+                componentId = componentId,
+                type = "rc:queued",
+                variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+            )
+        }
+        background.start()
+        background.join()
+        bridge.release()
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).doesNotContain("rc:queued")
+    }
+
+    @Test
+    fun `re-validates origin at main-thread delivery after navigation race`() {
+        val bridge = bridge()
+        connect(bridge)
+        webView.loadUrl("https://evil.example.org/phish.html")
+        val background = Thread {
+            bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        }
+        background.start()
+        background.join()
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `treats host comparison as case insensitive`() {
+        val bridge = bridge(navigateTo = "https://Assets.Example.COM/promo/index.html")
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+    }
+
+    @Test
+    fun `rejects messages after navigation to an unexpected origin`() {
+        val bridge = bridge(navigateTo = "https://evil.example.org/phish.html")
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `allows messages from the same origin on a different path`() {
+        val bridge = bridge(navigateTo = "https://assets.example.com/promo/step-two.html")
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+    }
+
+    @Test
+    fun `does not deliver outbound messages after navigation to an unexpected origin`() {
+        val bridge = bridge(navigateTo = "https://evil.example.org/phish.html")
+        connect(bridge)
+        bridge.postMessage(
+            componentId = componentId,
+            type = "rc:custom",
+            variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+        )
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).isNull()
+    }
+
+    @Test
+    fun `treats the default https port as the same origin`() {
+        val bridge = bridge(navigateTo = "https://assets.example.com:443/promo/index.html")
+        connect(bridge)
+        bridge.postMessage(
+            componentId = componentId,
+            type = "rc:custom",
+            variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+        )
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"type\":\"rc:custom\"")
+    }
+
+    @Test
+    fun `delivers rc step-complete responses to the handler without sending an outbound message`() {
+        val bridge = bridge()
+        connect(bridge)
+        val scriptAfterConnect = shadowWebView.lastEvaluatedJavascript
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"selected_plan":"annual","accepted_terms":true}}""",
+            ),
+        )
+        idleMainLooper()
+
+        val message = received.single()
+        assertThat(message.type).isEqualTo("rc:step-complete")
+        assertThat(message.responses?.get("selected_plan")).isEqualTo(PaywallWebViewValue.String("annual"))
+        assertThat(message.responses?.get("accepted_terms")).isEqualTo(PaywallWebViewValue.Boolean(true))
+        assertThat(shadowWebView.lastEvaluatedJavascript).isEqualTo(scriptAfterConnect)
+    }
+
+    @Test
+    fun `delivers rc error to the handler`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.ERROR,
+                payload = """{"error":"Something went wrong"}""",
+            ),
+        )
+        idleMainLooper()
+
+        val message = received.single()
+        assertThat(message.type).isEqualTo("rc:error")
+        assertThat(message.error).isEqualTo("Something went wrong")
+    }
+
+    @Test
+    fun `does not deliver malformed messages to the handler`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage("""not even json""")
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `auto-sends rc variables even when no handler is set`() {
+        val bridge = bridge(handler = null)
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"rc:variables\"")
+        assertThat(script).contains("\"locale\":\"en-US\"")
+    }
+
+    @Test
+    fun `update refreshes the variables sent on a subsequent request`() {
+        val bridge = bridge(locale = "en-US")
+        connect(bridge)
+        bridge.update(
+            locale = "fr-FR",
+            messageHandler = null,
+        )
+
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"locale\":\"fr-FR\"")
+        assertThat(script).doesNotContain("en-US")
+    }
+
+    @Test
+    fun `generic postMessage sends transport envelope with payload`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            componentId = componentId,
+            type = "rc:custom",
+            variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("window.__rcWebComponentsReceive(")
+        assertThat(script).contains("\"kind\":\"message\"")
+        assertThat(script).contains("\"type\":\"rc:custom\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+        assertThat(script).contains("\"payload\":{\"foo\":\"bar\"}")
+    }
+
+    @Test
+    fun `escapes line and paragraph separators in outbound payloads`() {
+        val raw = "a\u2028b\u2029c"
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postVariables(
+            componentId = componentId,
+            variables = mapOf(
+                "custom" to PaywallWebViewValue.Object(mapOf("note" to PaywallWebViewValue.String(raw))),
+            ),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).doesNotContain("\u2028")
+        assertThat(script).doesNotContain("\u2029")
+        assertThat(script).contains("\\u2028")
+        assertThat(script).contains("\\u2029")
+    }
+
+    @Test
+    fun `attach registers native interface under rcWebComponents`() {
+        bridge()
+
+        assertThat(shadowWebView.getJavascriptInterface("rcWebComponents")).isNotNull
+    }
+
+    @Test
+    fun `release removes the native interface`() {
+        val bridge = bridge()
+        assertThat(shadowWebView.getJavascriptInterface("rcWebComponents")).isNotNull
+
+        bridge.release()
+
+        assertThat(shadowWebView.getJavascriptInterface("rcWebComponents")).isNull()
+    }
+
+    @Test
+    fun `sends fit message after init when height is fit`() {
+        val bridge = bridge(sizeToContentHeight = true)
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"type\":\"fit\"")
+        assertThat(script).contains("\"height\":true")
+        assertThat(script).doesNotContain("\"width\":true")
+    }
+
+    @Test
+    fun `reports content resize from inbound resize message`() {
+        var reportedWidth: Int? = null
+        var reportedHeight: Int? = null
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = true,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx ->
+                reportedWidth = widthCssPx
+                reportedHeight = heightCssPx
+            },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.RESIZE,
+                payload = """{"width":320,"height":480}""",
+            ),
+        )
+        idleMainLooper()
+
+        assertThat(reportedWidth).isEqualTo(320)
+        assertThat(reportedHeight).isEqualTo(480)
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `resize ignores non-fit axes`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = false,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":400,"height":500}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(null to 500)
+    }
+
+    @Test
+    fun `resize clamps oversized values and drops invalid values per axis`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = true,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        connect(bridge)
+        // Invalid width (negative) with a valid, oversized height: height still applies, clamped.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":-1,"height":99999}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(null to 10_000)
+    }
+
+    @Test
+    fun `resize applies a per-axis change threshold`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = true,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":200,"height":300}"""),
+        )
+        // Same values re-reported: below the 1px threshold on both axes, no callback at all.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":200,"height":300}"""),
+        )
+        // One axis changes: only that axis is delivered.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":200,"height":301}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(200 to 300, null to 301)
+    }
+
+    @Test
+    fun `handles resize sent as a transport request without forwarding to the app handler`() {
+        var reportedHeight: Int? = null
+        val bridge = bridge(
+            sizeToContentHeight = true,
+            onContentResize = { _, heightCssPx -> reportedHeight = heightCssPx },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.RESIZE,
+                payload = """{"height":250}""",
+                kind = WebViewEnvelope.KIND_REQUEST,
+                id = "resize-1",
+            ),
+        )
+        idleMainLooper()
+
+        assertThat(reportedHeight).isEqualTo(250)
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `drops any transport request without an id`() {
+        val bridge = bridge()
+        connect(bridge)
+
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.STEP_LOADED, kind = WebViewEnvelope.KIND_REQUEST),
+        )
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.REQUEST_VARIABLES, kind = WebViewEnvelope.KIND_REQUEST),
+        )
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+        // No auto-reply was sent for the id-less variables request.
+        assertThat(shadowWebView.lastEvaluatedJavascript).doesNotContain("rc:variables")
+    }
+
+    @Test
+    fun `rejects hostile deeply nested frames without crashing`() {
+        val bridge = bridge()
+        connect(bridge)
+
+        val depth = 30_000
+        val nested = "[".repeat(depth) + "]".repeat(depth)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.STEP_COMPLETE, payload = """{"responses":{"deep":$nested}}"""),
+        )
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParserTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParserTest.kt
@@ -1,0 +1,309 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class WebViewMessageParserTest {
+
+    private val componentId = "promo_web_view"
+
+    @Test
+    fun `parses rc step-loaded`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_LOADED,
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        val message = parsed!!.message
+        assertThat(message.type).isEqualTo("rc:step-loaded")
+        assertThat(message.componentId).isEqualTo("promo_web_view")
+        assertThat(message.responses).isNull()
+        assertThat(message.error).isNull()
+    }
+
+    @Test
+    fun `parses rc step-complete with responses in payload`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"selected_plan":"annual","accepted_terms":true,"count":3}}""",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        val responses = parsed!!.message.responses
+        assertThat(responses).isNotNull
+        assertThat(responses!!["selected_plan"]).isEqualTo(PaywallWebViewValue.String("annual"))
+        assertThat(responses["accepted_terms"]).isEqualTo(PaywallWebViewValue.Boolean(true))
+        assertThat(responses["count"]).isEqualTo(PaywallWebViewValue.Number(3))
+    }
+
+    @Test
+    fun `parses rc step-complete without responses as empty map`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.responses).isEmpty()
+    }
+
+    @Test
+    fun `parses rc request-variables as message`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.REQUEST_VARIABLES,
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.type).isEqualTo("rc:request-variables")
+        assertThat(parsed.requestId).isNull()
+    }
+
+    @Test
+    fun `parses rc request-variables as transport request`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_REQUEST,
+                type = WebViewMessageType.REQUEST_VARIABLES,
+                id = "req-1",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.type).isEqualTo("rc:request-variables")
+        assertThat(parsed.requestId).isEqualTo("req-1")
+    }
+
+    @Test
+    fun `parses rc error from payload`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.ERROR,
+                payload = """{"error":"Boom"}""",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.error).isEqualTo("Boom")
+    }
+
+    @Test
+    fun `rejects message without type`() {
+        assertThat(
+            parse(
+                """{"channel":"rc-web-components","protocol_version":1,"kind":"message","component_id":"promo_web_view"}""",
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with non-string type`() {
+        assertThat(
+            parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"message","component_id":"promo_web_view","type":123}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message without component_id`() {
+        assertThat(
+            parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"message","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with wrong component_id`() {
+        assertThat(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_LOADED,
+                componentId = "other_web_view",
+            ).let(::parse),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects rc step-complete with non-object responses`() {
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = WebViewMessageType.STEP_COMPLETE,
+                    payload = """{"responses":"nope"}""",
+                ),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects rc step-complete payload with transport fields and no responses object`() {
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = WebViewMessageType.STEP_COMPLETE,
+                    payload = """{"type":"rc:step-complete","selected_plan":"annual"}""",
+                ),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects rc error without error string`() {
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = WebViewMessageType.ERROR,
+                ),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `drops unknown message types`() {
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = "rc:something-new",
+                ),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects malformed json`() {
+        assertThat(parse("""not json""")).isNull()
+    }
+
+    @Test
+    fun `rejects non-object json`() {
+        assertThat(parse("""["a","b"]""")).isNull()
+    }
+
+    @Test
+    fun `rejects oversized payload`() {
+        val hugeValue = "x".repeat(WebViewMessageParser.MAX_PAYLOAD_BYTES + 1)
+        val raw = envelope(
+            kind = WebViewEnvelope.KIND_MESSAGE,
+            type = WebViewMessageType.ERROR,
+            payload = """{"error":"$hugeValue"}""",
+        )
+        assertThat(parse(raw)).isNull()
+    }
+
+    @Test
+    fun `rejects excessively nested responses`() {
+        val depth = WebViewMessageParser.MAX_NESTING_DEPTH + 2
+        val opening = "{\"a\":".repeat(depth)
+        val closing = "}".repeat(depth)
+        val nested = opening + "1" + closing
+        val raw = envelope(
+            kind = WebViewEnvelope.KIND_MESSAGE,
+            type = WebViewMessageType.STEP_COMPLETE,
+            payload = """{"responses":$nested}""",
+        )
+        assertThat(parse(raw)).isNull()
+    }
+
+    @Test
+    fun `accepts null and nested json-compatible values in responses`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"maybe":null,"list":[1,"two",false],"obj":{"k":"v"}}}""",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        val responses = parsed!!.message.responses!!
+        assertThat(responses["maybe"]).isEqualTo(PaywallWebViewValue.Null)
+        assertThat(responses["list"]).isInstanceOf(PaywallWebViewValue.Array::class.java)
+        assertThat(responses["obj"]).isInstanceOf(PaywallWebViewValue.Object::class.java)
+    }
+
+    @Test
+    fun `accepts frame depth 17 before recursive parsing`() {
+        val depth = WebViewMessageParser.MAX_NESTING_DEPTH + 1
+
+        assertThat(WebViewEnvelope.exceedsMaxDepth(nestedArray(depth))).isFalse()
+    }
+
+    @Test
+    fun `rejects frame depth 18 before recursive parsing`() {
+        val depth = WebViewMessageParser.MAX_NESTING_DEPTH + 2
+
+        assertThat(WebViewEnvelope.exceedsMaxDepth(nestedArray(depth))).isTrue()
+    }
+
+    @Test
+    fun `rejects a hostile deeply nested frame before recursive parsing`() {
+        // ~30k nesting levels fit inside the 64 KiB frame limit; the pre-parse structural scan
+        // must reject this before org.json's recursive tokenizer ever runs (stack-overflow guard).
+        val depth = 30_000
+        val nested = "[".repeat(depth) + "]".repeat(depth)
+
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"deep":$nested}}""",
+            ),
+        )
+
+        assertThat(parsed).isNull()
+    }
+
+    @Test
+    fun `ignores handshake frames`() {
+        assertThat(
+            parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"connect","component_id":""}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    private fun parse(raw: String) = WebViewMessageParser.parse(raw, expectedComponentId = componentId)
+
+    private fun nestedArray(depth: Int): String = "[".repeat(depth) + "0" + "]".repeat(depth)
+
+    private fun envelope(
+        kind: String,
+        type: String,
+        componentId: String = this.componentId,
+        payload: String? = null,
+        id: String? = null,
+    ): String {
+        val payloadField = payload?.let { ""","payload":$it""" } ?: ""
+        val idField = id?.let { ""","id":"$it"""" } ?: ""
+        return """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId","type":"$type"$payloadField$idField}
+            """.trimIndent()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewNavigationPolicyTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewNavigationPolicyTest.kt
@@ -1,0 +1,70 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+// Robolectric is required because the navigation-policy helper parses origins via android.net.Uri.
+@RunWith(RobolectricTestRunner::class)
+class WebViewNavigationPolicyTest {
+
+    @Test
+    fun `allows same-origin main-frame navigation on a different path`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://assets.example.com/promo/step-two.html",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `blocks cross-origin main-frame navigation even over https`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://evil.example.org/phish.html",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `blocks non-https navigation in any frame`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "http://assets.example.com/promo/index.html",
+                isMainFrame = false,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "custom://assets.example.com/",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `allows cross-origin https sub-frame loads`() {
+        // Sub-frame isolation is expected from the server-provided CSP, not this navigation policy.
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://other.example.com/frame.html",
+                isMainFrame = false,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `blocks unparseable main-frame navigation targets`() {
+        assertThat(
+            shouldBlockWebViewNavigation(url = null, isMainFrame = true, expectedOrigin = "https://a.example"),
+        ).isTrue()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
@@ -1,0 +1,66 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WebViewUrlResolverTest {
+
+    @Test
+    fun `resolves static https url unchanged`() {
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isEqualTo("https://paywalls.revenuecat.com/index.html")
+    }
+
+    @Test
+    fun `resolves static https url with characters accepted by WebView`() {
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/index.html?filters=a|b")
+
+        assertThat(result).isEqualTo("https://paywalls.revenuecat.com/index.html?filters=a|b")
+    }
+
+    @Test
+    fun `returns null for url containing template placeholders`() {
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/{{ custom.animal }}.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for malformed url`() {
+        val result = WebViewUrlResolver.resolve("not a url")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for malformed https url`() {
+        val result = WebViewUrlResolver.resolve("https:///missing-host")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for non https url`() {
+        val result = WebViewUrlResolver.resolve("http://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for file url`() {
+        val result = WebViewUrlResolver.resolve("file:///android_asset/index.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for custom scheme url`() {
+        val result = WebViewUrlResolver.resolve("myapp://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isNull()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -49,6 +49,7 @@ import com.revenuecat.purchases.ui.revenuecatui.OfferingSelection
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
 import com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogicParams
 import com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic
 import com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogicWithCallback
@@ -659,6 +660,44 @@ class PaywallViewModelTest {
         coVerify(exactly = 1) { purchases.awaitOfferings() }
         model.updateOptions(options2)
         coVerify(exactly = 1) { purchases.awaitOfferings() }
+    }
+
+    @Test
+    fun `updateOptions refreshes the web view message handler in place without rebuilding`(): Unit = runBlocking {
+        val offering = Offering(
+            identifier = "offering-id",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
+            paywallComponents = Offering.PaywallComponents(UiConfig(), emptyPaywallComponentsData),
+        )
+        val handlerA = PaywallWebViewMessageHandler { _, _ -> }
+        val handlerB = PaywallWebViewMessageHandler { _, _ -> }
+        fun optionsWith(handler: PaywallWebViewMessageHandler) =
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offering)
+                .setWebViewMessageHandler(handler)
+                .build()
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            optionsWith(handlerA),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+        )
+        val state = model.state.value as PaywallState.Loaded.Components
+        assertThat(state.webViewMessageHandler).isSameAs(handlerA)
+
+        // Same paywall, only the handler differs (handler is excluded from hashCode).
+        model.updateOptions(optionsWith(handlerB))
+
+        // No rebuild: the loaded state instance is preserved (same selections/scroll), and it now
+        // carries the new handler so web_view components see the latest one.
+        assertThat(model.state.value).isSameAs(state)
+        assertThat(state.webViewMessageHandler).isSameAs(handlerB)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -45,6 +45,7 @@ import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
 import com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic
 import com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogicParams
 import com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult
@@ -639,6 +640,38 @@ class PaywallViewModelWorkflowTest {
         assertThat(
             (step2State!!.mergedCustomVariables["highlight_color"] as? CustomVariableValue.String)?.value,
         ).isEqualTo("gold")
+    }
+
+    @Test
+    fun `pre-warmed workflow steps carry the web view message handler and follow updateOptions swaps`() {
+        val handlerA = PaywallWebViewMessageHandler { _, _ -> }
+        val handlerB = PaywallWebViewMessageHandler { _, _ -> }
+        fun optionsWith(handler: PaywallWebViewMessageHandler) =
+            PaywallOptions.Builder(dismissRequest = {})
+                .setWebViewMessageHandler(handler)
+                .build()
+        val vm = PaywallViewModelImpl(
+            resourceProvider = MockResourceProvider(),
+            purchases = purchases,
+            options = optionsWith(handlerA),
+            colorScheme = TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            backgroundDispatcher = testDispatcher,
+        )
+
+        vm.startWorkflowPresentationFromResult(fetchResult, testOfferings, null, uiConfig)
+        // Let the background pre-warm finish so step-2 is cached without navigating to it.
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // The pre-warmed (not navigated-to) step carries the handler from options.
+        assertThat(vm.workflowState.value?.stepStates?.get("step-2")?.webViewMessageHandler)
+            .isSameAs(handlerA)
+
+        // Swapping the handler refreshes already-cached pre-warmed steps in place.
+        vm.updateOptions(optionsWith(handlerB))
+        assertThat(vm.workflowState.value?.stepStates?.get("step-2")?.webViewMessageHandler)
+            .isSameAs(handlerB)
     }
 
     // endregion


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates the Paywalls V2 `web_view` feature into a single PR. This supersedes the stacked draft PRs [#3650](https://github.com/RevenueCat/purchases-android/pull/3650)–[#3729](https://github.com/RevenueCat/purchases-android/pull/3729).
For https://linear.app/revenuecat/issue/PWENG-98
A `web_view` component embeds hosted web content inside a paywall:

1. **Schema** (`:purchases`) — `WebViewComponent` with URL, optional `id` / `protocol_version`, and size (no native fallback stack)
2. **Compose rendering** — `WebViewComponentView` with fit placeholders, HTTPS-only URL resolution; terminal load/renderer failures render nothing
3. **Envelope / value types** — message kinds (`connect` / `init` / `reject` / `message` / `request` / `response` / `error`), flat `payload` for `rc:variables`, non-finite numbers → JSON null
4. **JavaScript bridge** — handshake at hard-coded host protocol version `1`, origin validation, resize / variables messaging
5. **Paywall wiring** — `PaywallOptions.setWebViewMessageHandler` and `PaywallDialogOptions.setWebViewMessageHandler`

### No native fallback (by design)

`web_view` does **not** support a native `fallback` stack. Older/dashboard payloads that still include `fallback` are ignored at decode time (`ignoreUnknownKeys`). On terminal failure the WebView is destroyed and nothing is rendered — apps must use an SDK that supports `web_view`.

### Lifecycle & security hardening (follow-up on this PR)

| Fix | Behavior |
|---|---|
| **Document handshake reset** | `onMainFrameNavigationStarted` (from `onPageStarted`) closes the channel, clears fit/resize thresholds, resets Compose dimensions, and drops outbound work queued for prior document generations so same-origin navigation / reload can `connect` again |
| **Immutable WebView identity** | Compose `key(WebViewIdentity(url, componentId, widthFit, heightFit))` recreates WebView + bridge when those fields change; locale / message handler still update in place; bridge holders are identity-scoped so old `onRelease` cannot release a replacement bridge |
| **Renderer termination** | `onRenderProcessGone` returns `true`, marks an idempotent terminal failure, destroys the dead WebView, and renders nothing |
| **Inbound origin validation** | Migrated JS→native to `WebViewCompat.addWebMessageListener`; frames are gated on listener `sourceOrigin` + `isMainFrame` (not top-level URL alone). Missing `WEB_MESSAGE_LISTENER` takes the same terminal failure path |

Client-side CSP injection remains deliberately absent; HTTPS-only + same-origin main-frame navigation stay.

### Cross-platform contract decisions (aligned with iOS)

| Decision | Value |
|---|---|
| Host protocol version | Hard-coded `1` (schema `protocol_version` is decoded but not used for handshake) |
| `rc:variables` payload | Flat map (not nested under a `variables` key) |
| Frame size / depth | 64 KiB cap + pre-parse JSON depth scan (max depth 16 / frame 17) |
| Resize | Clamp to 10,000 CSS px; apply threshold 1 px |
| Fit placeholders | 100h / 300w until content reports size |
| Navigation | HTTPS-only (any frame); same-origin main-frame only; case-insensitive host compare |
| Native fallback stack | None — force SDK update rather than degrade to a native stack |

### Client-side CSP deliberately dropped

**Reviewers should not look for client-side Content-Security-Policy injection.** The CSP is served by the backend with the web content (same model as iOS).

### Supersedes

| PR | Branch |
|----|--------|
| [#3650](https://github.com/RevenueCat/purchases-android/pull/3650) | schema |
| [#3651](https://github.com/RevenueCat/purchases-android/pull/3651) | rendering |
| [#3652](https://github.com/RevenueCat/purchases-android/pull/3652) | client CSP ← excluded |
| [#3662](https://github.com/RevenueCat/purchases-android/pull/3662) | value types |
| [#3654](https://github.com/RevenueCat/purchases-android/pull/3654) | message model |
| [#3663](https://github.com/RevenueCat/purchases-android/pull/3663) | variables provider |
| [#3655](https://github.com/RevenueCat/purchases-android/pull/3655) | JS bridge |
| [#3653](https://github.com/RevenueCat/purchases-android/pull/3653) | messaging wiring |
| [#3729](https://github.com/RevenueCat/purchases-android/pull/3729) | hardening + contract alignment |

### Line-count note

This PR exceeds Danger's 300-production-line limit by design (`skip-pr-lines-changed-check`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b7a3e33-91c7-4e22-9872-c2a2473ba396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b7a3e33-91c7-4e22-9872-c2a2473ba396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

