### PR TITLE
chore(ci): api-check: show diff when api-check fails, only check api files

### DIFF
--- a/scripts/api-check.sh
+++ b/scripts/api-check.sh
@@ -2,11 +2,18 @@
 
 exit_code=0
 
+# Metalava signature files; only these should gate the check so unrelated
+# tracked-file churn (e.g. mise.lock) doesn't fail it.
+api_paths=(':(glob)**/api.txt' ':(glob)**/api-*.txt')
+
 # Run the api-dump.sh script to generate the API dump
 ./scripts/api-dump.sh || exit_code=$?
-# Check if there are any dirty changes in git
-if ! git diff --quiet; then
-  echo "API dump has changes, run the scripts/api-dump.sh script to generate the API dump, review and commit them."
+# Check if there are any dirty changes in the API signature files
+if ! git diff --quiet -- "${api_paths[@]}"; then
+  echo "Diff:"
+  git --no-pager diff -- "${api_paths[@]}"
+  echo
+  echo "API dump has changes, run the scripts/api-dump.sh script to generate the API dump, review and commit them." >&2
   exit_code=1
 fi
 


### PR DESCRIPTION
When the `metalava` check fails we have no info in the log as to _why_, so debugging it is a bit of a pain.

This PR:
- scopes the check to the metalava signature files (`*/api.txt`, `*/api-*.txt`), so unrelated tracked-file churn (e.g. a `mise.lock` rewrite) no longer fails it
- prints that `git diff` to stdout on failure so the changes show up directly in the log; the guidance message goes to stderr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the CI api-check shell script; no runtime or security-sensitive code paths.
> 
> **Overview**
> **CI `api-check` now only fails on Metalava signature drift**, not on any dirty tracked file (e.g. `mise.lock` rewrites). The post-dump `git diff` is limited to `**/api.txt` and `**/api-*.txt` via pathspec globs.
> 
> **On failure, the log shows what changed:** the script prints a labeled `git diff` of those files to stdout and sends the “run api-dump” guidance to stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 261d99785ea1f7ff9a298c22045a3e718a81fffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->