### PR TITLE
fix(paywalls): apply top window insets to the hero ZLayer, not the first nested stack

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -160,15 +160,18 @@ internal class StyleFactory(
 
         private class WindowInsetsState {
             /**
-             * Whether the current component should apply the top window insets. This field is reset when it is read,
-             * as it should only be set on a single component.
+             * The stack that should apply the top window insets, if any. Tracked by reference (rather than a
+             * flag consumed by the next stack style built) because children styles are built before their
+             * parent's: a flag intended for a hero ZLayer would otherwise be consumed by the first stack
+             * nested inside one of its overlay children (e.g. a close button's stack).
              */
-            var applyTopWindowInsets = false
-                get() {
-                    val value = field
-                    field = false
-                    return value
-                }
+            private var stackAwaitingTopWindowInsets: StackComponent? = null
+
+            /**
+             * Whether [component] should apply the top window insets.
+             */
+            fun shouldApplyTopWindowInsets(component: StackComponent): Boolean =
+                stackAwaitingTopWindowInsets === component
 
             /**
              * Whether the current component should ignore the top window insets. This field is reset when it is read,
@@ -207,17 +210,12 @@ internal class StyleFactory(
             fun handleHeaderMediaViewWindowInsets(component: PaywallComponent) {
                 when (component) {
                     is StackComponent -> if (stillLookingForHeaderMedia) {
-                        applyTopWindowInsets = when (component.dimension) {
-                            is Dimension.ZLayer -> {
-                                val hasHero = component.components.firstOrNull()?.isHeaderMedia == true
-                                topWindowInsetsApplied = hasHero
-                                heroImageDetected = hasHero
-                                hasHero
-                            }
+                        when (component.dimension) {
+                            is Dimension.ZLayer -> handleZLayerHeaderStack(component)
 
                             is Dimension.Horizontal,
                             is Dimension.Vertical,
-                            -> false
+                            -> Unit
                         }
                     }
 
@@ -240,6 +238,13 @@ internal class StyleFactory(
                     is FallbackHeaderComponent -> { /* Skip: does not affect hero image detection. */ }
                     else -> stillLookingForHeaderMedia = false
                 }
+            }
+
+            private fun handleZLayerHeaderStack(component: StackComponent) {
+                val hasHero = component.components.firstOrNull()?.isHeaderMedia == true
+                topWindowInsetsApplied = hasHero
+                heroImageDetected = hasHero
+                if (hasHero) stackAwaitingTopWindowInsets = component
             }
 
             private val PaywallComponent.isHeaderMedia: Boolean
@@ -267,9 +272,10 @@ internal class StyleFactory(
         val windowInsetsState = WindowInsetsState()
 
         /**
-         * Whether the current component should apply the top window insets.
+         * Whether [component] should apply the top window insets.
          */
-        val applyTopWindowInsets by windowInsetsState::applyTopWindowInsets
+        fun shouldApplyTopWindowInsets(component: StackComponent): Boolean =
+            windowInsetsState.shouldApplyTopWindowInsets(component)
 
         /**
          * Whether the current component should ignore the top window insets.
@@ -926,7 +932,7 @@ internal class StyleFactory(
             countdownDate = countdownDate,
             countFrom = countFrom,
             overrides = presentedOverrides,
-            applyTopWindowInsets = applyTopWindowInsets,
+            applyTopWindowInsets = shouldApplyTopWindowInsets(component),
         )
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -1185,6 +1185,72 @@ class StyleFactoryTests {
     }
 
     @Test
+    fun `Should apply top window insets to the hero z-stack even when an overlay child contains a stack`() {
+        // Arrange
+        val imageUrls = ThemeImageUrls(
+            light = ImageUrls(
+                original = URL("https://assets.pawwalls.com/1151049_1732039548.png"),
+                webp = URL("https://assets.pawwalls.com/1151049_1732039548.webp"),
+                webpLowRes = URL("https://assets.pawwalls.com/1151049_low_res_1732039548.webp"),
+                width = 547.toUInt(),
+                height = 257.toUInt(),
+            ),
+        )
+        // Mirrors a hero header: a z-stack with a full-width image and a close button overlay. The
+        // button wraps its own stack, which is built before the z-stack's style is.
+        val closeButton = ButtonComponent(
+            action = ButtonComponent.Action.NavigateBack,
+            stack = StackComponent(
+                components = listOf(
+                    ImageComponent(
+                        source = imageUrls,
+                        size = Size(width = SizeConstraint.Fixed(32u), height = SizeConstraint.Fixed(32u)),
+                    ),
+                ),
+                dimension = Dimension.Vertical(
+                    alignment = HorizontalAlignment.TRAILING,
+                    distribution = FlexDistribution.SPACE_BETWEEN,
+                ),
+            ),
+        )
+        val stackComponent = StackComponent(
+            components = listOf(
+                StackComponent(
+                    components = listOf(
+                        ImageComponent(
+                            source = imageUrls,
+                            size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fixed(150u)),
+                        ),
+                        closeButton,
+                    ),
+                    dimension = Dimension.ZLayer(
+                        alignment = TwoDimensionalAlignment.TOP_TRAILING,
+                    )
+                ),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.START,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as StackComponentStyle
+        assertThat(style.applyTopWindowInsets).isFalse()
+        val zStack = style.children[0] as StackComponentStyle
+        assertThat(zStack.applyTopWindowInsets).isTrue()
+        val heroImage = zStack.children[0] as ImageComponentStyle
+        assertThat(heroImage.ignoreTopWindowInsets).isTrue()
+        // The button's inner stack must not consume the insets meant for the z-stack.
+        val buttonStyle = zStack.children[1] as ButtonComponentStyle
+        assertThat(buttonStyle.stackComponentStyle.applyTopWindowInsets).isFalse()
+    }
+
+    @Test
     fun `Should not ignore top window insets for the first image in the first z-stack if it is not full-width`() {
         // Arrange
         val imageUrls = ThemeImageUrls(


### PR DESCRIPTION
Fixes a paywall with a hero image + close button overlay rendering the close button roughly a status-bar height lower on Android than on iOS.

**Root cause:** the "apply top window insets" mark for a hero ZLayer was a self-resetting flag consumed by the *next stack style constructed*. Children are built before their parent, so a close button's inner stack consumed it instead of the ZLayer. Now the target stack is tracked by reference.

<details>
<summary>Details: mechanism, testing, and known gaps</summary>

### Mechanism

When the first visual component of a paywall is a full-width image inside a ZLayer (the "hero" case), `StyleFactory` marks that ZLayer to receive the top window insets, so its overlay children get pushed below the status bar while the hero image extends behind it.

That mark was a self-resetting boolean read by the next `StackComponentStyle` constructor. Since children styles are built before their parent's style, an overlay child containing a stack of its own — like a close button, whose content is a stack — consumed the flag first:

- the close button's inner stack applied the status-bar inset to its content, pushing the icon down, and
- the ZLayer itself ended up with `applyTopWindowInsets = false`, losing its hero inset handling entirely.

The fix tracks the stack that should apply the top insets by reference (`stackAwaitingTopWindowInsets`), so only the intended ZLayer picks it up regardless of construction order.

### Testing

- New `StyleFactoryTests` case mirroring the affected layout (hero ZLayer with a close-button overlay). It fails on `main` (`zStack.applyTopWindowInsets` is `false`, the button's inner stack got `true`) and passes with this change.
- Existing window-insets tests in `StyleFactoryTests` pass unchanged.
- `detektAll` passes. The two failing tests in the full `:ui:revenuecatui` suite (`TextComponentViewVariablesTests` timezone-dependent date, `PaywallComponentsTemplatePreviewRecorder` missing local preview-resources checkout) also fail on unmodified `main`.

### Known gaps

- Paparazzi snapshots render with zero window insets, so this fix produces no snapshot diff and cannot be screenshot-tested with the current harness.
- On-device before/after verification with the affected paywall layout is still pending.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
