### PR TITLE
Improve memory usage on ETags by making `HTTPResult` body lazy

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPResult.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPResult.kt
@@ -124,17 +124,21 @@ public data class HTTPResult(
         BACKEND, CACHE
     }
 
-    val body: JSONObject = payloadText
-        .takeIf { it.isNotBlank() }
-        ?.let {
-            try {
-                JSONObject(it)
-            } catch (e: JSONException) {
-                errorLog(throwable = e) { "Failed to parse payload as JSON: $it" }
-                null
+    val body: JSONObject by lazy { parseBody() }
+
+    private fun parseBody(): JSONObject {
+        return payloadText
+            .takeIf { it.isNotBlank() }
+            ?.let {
+                try {
+                    JSONObject(it)
+                } catch (e: JSONException) {
+                    errorLog(throwable = e) { "Failed to parse payload as JSON: $it" }
+                    null
+                }
             }
-        }
-        ?: JSONObject()
+            ?: JSONObject()
+    }
 
     val backendErrorCode: Int? = if (!isSuccessful()) body.optInt("code").takeIf { it > 0 } else null
     val backendErrorMessage: String? = if (!isSuccessful()) {


### PR DESCRIPTION
We got OOM reports pointing at JSONObject construction while ETagManager returns a cached HTTPResult through copy(). Keeping the JSON body lazy avoids parsing that cached payload until a caller actually reads result.body.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral refactor in networking with equivalent parse semantics on first `body` access; main effect is deferred work on cache hits.
> 
> **Overview**
> **Defers JSON parsing** on `HTTPResult` by making `body` a `lazy` property backed by a new `parseBody()` helper, instead of building a `JSONObject` in the property initializer on every instance.
> 
> That matters for the ETag path where cached responses are wrapped via `copy()`: those objects no longer pay parse cost unless something actually reads `body` (or derived fields like `backendErrorCode` / `backendErrorMessage` on failed responses). Parsing behavior and error logging on invalid JSON are unchanged once `body` is accessed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6d107522937eee04d7f9c96dd7209d3f122e8d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->