### PR TITLE
fix: avoid HTTPResult copy re-parsing payload in ETag cache

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -93,13 +93,9 @@ internal class ETagManager(
         )
         eTagHeader?.let { eTagInResponse ->
             if (shouldUseCachedVersion(responseCode)) {
-                val storedResult = getStoredResult(urlString)?.let { storedResult ->
-                    storedResult.copy(
-                        // This assumes we won't store verification failures in the cache and we will clear the cache
-                        // when enabling verification.
-                        verificationResult = verificationResult,
-                        requestDate = requestDate ?: storedResult.requestDate,
-                    )
+                val storedResult = getStoredResult(urlString)?.also { storedResult ->
+                    storedResult.requestDate = requestDate ?: storedResult.requestDate
+                    storedResult.verificationResult = verificationResult
                 }
                 return storedResult
                     ?: if (refreshETag) {
@@ -143,10 +139,15 @@ internal class ETagManager(
         result: HTTPResult,
         eTag: String,
     ) {
-        val cacheResult = result.copy(origin = HTTPResult.Origin.CACHE)
-        val eTagData = ETagData(eTag, dateProvider.now)
-        val httpResultWithETag = HTTPResultWithETag(eTagData, cacheResult)
-        prefs.value.edit().putString(urlString, httpResultWithETag.serialize()).apply()
+        val originalOrigin = result.origin
+        result.origin = HTTPResult.Origin.CACHE
+        try {
+            val eTagData = ETagData(eTag, dateProvider.now)
+            val httpResultWithETag = HTTPResultWithETag(eTagData, result)
+            prefs.value.edit().putString(urlString, httpResultWithETag.serialize()).apply()
+        } finally {
+            result.origin = originalOrigin
+        }
     }
 
     private fun getStoredResultSavedInSharedPreferences(urlString: String): HTTPResultWithETag? {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -95,6 +95,8 @@ internal class ETagManager(
             if (shouldUseCachedVersion(responseCode)) {
                 val storedResult = getStoredResult(urlString)?.also { storedResult ->
                     storedResult.requestDate = requestDate ?: storedResult.requestDate
+                    // This assumes we won't store verification failures in the cache and we will clear the cache
+                    // when enabling verification.
                     storedResult.verificationResult = verificationResult
                 }
                 return storedResult

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPResult.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPResult.kt
@@ -21,9 +21,9 @@ private const val SERIALIZATION_NAME_IS_FALLBACK_URL = "isFallbackURL"
 public data class HTTPResult(
     val responseCode: Int,
     val payload: Payload,
-    val origin: Origin,
-    val requestDate: Date?,
-    val verificationResult: VerificationResult,
+    var origin: Origin,
+    var requestDate: Date?,
+    var verificationResult: VerificationResult,
     val isLoadShedderResponse: Boolean,
     val isFallbackURL: Boolean,
 ) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -554,6 +554,39 @@ class ETagManagerTest {
     }
 
     @Test
+    fun `getHTTPResultFromCacheOrBackend on 304 returns cached payload and origin while updating verification and requestDate`() {
+        val cachedPayload = "{\"cached\":true}"
+        val newRequestDate = Date(1234567890)
+        val cachedHttpResult = HTTPResult.createResult(
+            responseCode = RCHTTPStatusCodes.SUCCESS,
+            payload = cachedPayload,
+            origin = HTTPResult.Origin.CACHE,
+            requestDate = Date(1000),
+            verificationResult = NOT_REQUESTED,
+        )
+        val urlString = "http://localhost:100/v1/subscribers/appUserID"
+        mockCachedHTTPResult("etag", urlString, httpResult = cachedHttpResult)
+
+        val result = underTest.getHTTPResultFromCacheOrBackend(
+            responseCode = RCHTTPStatusCodes.NOT_MODIFIED,
+            payload = "",
+            eTagHeader = "etag",
+            urlString = urlString,
+            refreshETag = false,
+            requestDate = newRequestDate,
+            verificationResult = VERIFIED,
+            isLoadShedderResponse = false,
+            isFallbackURL = false,
+        )
+
+        assertThat(result).isNotNull
+        assertThat(result!!.payloadText).isEqualTo(cachedPayload)
+        assertThat(result.origin).isEqualTo(HTTPResult.Origin.CACHE)
+        assertThat(result.verificationResult).isEqualTo(VERIFIED)
+        assertThat(result.requestDate).isEqualTo(newRequestDate)
+    }
+
+    @Test
     fun `verificationResults are expected between cache and backend`() {
         data class TestCase(
             val cachedVerificationResult: VerificationResult,
@@ -636,5 +669,6 @@ class ETagManagerTest {
         assertThat(deserializedResult.eTagData.lastRefreshTime?.time).isEqualTo(lastRefreshTime?.time)
         assertThat(deserializedResult.httpResult.responseCode).isEqualTo(RCHTTPStatusCodes.SUCCESS)
         assertThat(deserializedResult.httpResult.payloadText).isEqualTo(responsePayload)
+        assertThat(deserializedResult.httpResult.origin).isEqualTo(HTTPResult.Origin.CACHE)
     }
 }


### PR DESCRIPTION
## Description

Copying an `HTTPResult` re-invokes its constructor, which re-parses the entire payload into a new `JSONObject`. For very large offerings responses this keeps two copies of the parsed JSON in memory at once and could crash with `OutOfMemoryError` when reusing the ETag-cached version (`ETagManager.getHTTPResultFromCacheOrBackend`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core HTTP/ETag caching and mutates shared `HTTPResult` instances during store/304 paths; behavior should match prior logic but shared references could surprise callers if they reuse the same object.
> 
> **Overview**
> **ETag cache paths no longer call `HTTPResult.copy()`**, which could re-run the string constructor and duplicate parsed JSON in memory (risk of `OutOfMemoryError` on large offerings when serving 304 cached responses).
> 
> On **304 Not Modified**, `ETagManager` now updates `requestDate` and `verificationResult` on the deserialized cached instance and returns it unchanged otherwise (payload and `CACHE` origin). When **persisting** a backend result, it temporarily sets `origin` to `CACHE` on that same object for serialization, then restores it in a `finally` block.
> 
> `HTTPResult` makes **`origin`**, **`requestDate`**, and **`verificationResult`** mutable (`var`) to support in-place updates. Tests cover 304 behavior and assert stored entries serialize with `Origin.CACHE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9677b23ed763faeadea1833394fb533ef184eb25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->