### PR TITLE
Reset bottom sheet content identity when switching sheets

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -355,6 +355,7 @@ internal fun SimpleSheetState.show(
                     .conditional(sheet.size == null) { fillMaxWidth() },
             )
         },
+        contentKey = sheet.id,
         onDismiss = {
             val sheetSelected = state.selectedPackageInfo
             val resulting = state.peekSelectedPackageInfoAfterSheetDismiss()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/SimpleBottomSheetScaffold.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/SimpleBottomSheetScaffold.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -61,7 +62,12 @@ internal fun SimpleBottomSheetScaffold(
         ) {
             BackHandler { sheetState.hide() }
 
-            sheetState.content()
+            // Key the content by the sheet's identity so switching to a different sheet gives it a
+            // fresh composition instead of reusing the previous sheet's views (e.g. a playing video)
+            // when the switch happens before the exit animation completes.
+            key(sheetState.contentKey) {
+                sheetState.content()
+            }
         }
     }
 }
@@ -76,6 +82,15 @@ internal class SimpleSheetState {
     var content: @Composable () -> Unit by mutableStateOf({})
         private set
 
+    /**
+     * A stable identity for the current [content]. Used to key the content in the scaffold so that
+     * switching to a different sheet resets the content's composition identity, instead of reusing
+     * the previous sheet's views (e.g. a playing video) via positional identity.
+     */
+    @get:JvmSynthetic
+    var contentKey: Any? by mutableStateOf(null)
+        private set
+
     @get:JvmSynthetic
     var visible by mutableStateOf(false)
         private set
@@ -85,10 +100,12 @@ internal class SimpleSheetState {
     fun show(
         backgroundBlur: Boolean,
         content: @Composable () -> Unit,
+        contentKey: Any? = null,
         onDismiss: (() -> Unit)? = null,
     ) {
         this.backgroundBlur = backgroundBlur
         this.content = content
+        this.contentKey = contentKey
         this.onDismiss = onDismiss
         visible = true
     }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/SimpleBottomSheetScaffoldTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/SimpleBottomSheetScaffoldTests.kt
@@ -1,0 +1,61 @@
+package com.revenuecat.purchases.ui.revenuecatui.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SimpleBottomSheetScaffoldTests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /**
+     * Regression test for a bug where opening a different sheet before the previous one finished its
+     * exit animation reused the previous sheet's content (identity was positional), so e.g. a video
+     * from the first sheet kept playing in the second. Keying the sheet content by its identity makes
+     * switching sheets dispose the previous content and compose the new one from scratch.
+     */
+    @Test
+    fun `showing a different sheet disposes the previous sheet content`(): Unit = with(composeTestRule) {
+        val sheetState = SimpleSheetState()
+        val events = mutableListOf<String>()
+
+        // A single content call site whose subtree is tracked by id. Both sheets funnel through the
+        // same call site (as they do in production), so only content keying can reset their identity.
+        fun trackingContent(id: String): @Composable () -> Unit = {
+            DisposableEffect(Unit) {
+                events += "compose:$id"
+                onDispose { events += "dispose:$id" }
+            }
+        }
+
+        setContent {
+            SimpleBottomSheetScaffold(
+                sheetState = sheetState,
+                modifier = Modifier.fillMaxSize(),
+                content = { Box(Modifier.fillMaxSize()) },
+            )
+        }
+
+        runOnUiThread {
+            sheetState.show(backgroundBlur = false, content = trackingContent("A"), contentKey = "A")
+        }
+        waitForIdle()
+
+        runOnUiThread {
+            sheetState.show(backgroundBlur = false, content = trackingContent("B"), contentKey = "B")
+        }
+        waitForIdle()
+
+        assertThat(events).containsExactlyInAnyOrder("compose:A", "dispose:A", "compose:B")
+    }
+}


### PR DESCRIPTION
On paywalls with Sheet components, closing one sheet and quickly opening a different one caused the video from the previously-open sheet to keep playing in the newly-opened sheet. Text and titles updated correctly, only videos were affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Compose lifecycle fix for bottom sheets with an optional API default; low risk to purchase or auth flows.
> 
> **Overview**
> Fixes paywall sheet switches where **video from the previous sheet kept playing** if a new sheet opened before the exit animation finished. Compose was reusing the same slot at the sheet content call site, so media players were not torn down.
> 
> `SimpleSheetState.show` now accepts an optional **`contentKey`**, and `SimpleBottomSheetScaffold` wraps sheet content in **`key(contentKey)`** so a different sheet gets a fresh composition. Paywall navigation passes **`sheet.id`** as that key.
> 
> Adds a Compose UI regression test that asserts the first sheet’s content is **disposed** when a second sheet is shown with a different key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1651baa8b49e174ecb545df5ab447398bf7e1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->