### PR TITLE
feat(remote-config): send fetch_context on config endpoint requests

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -47,6 +47,7 @@ import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
@@ -323,6 +324,11 @@ internal class PurchasesOrchestrator(
             remoteConfigManager?.refreshRemoteConfigIfStale(
                 appInBackground = false,
                 appUserID = identityManager.currentAppUserID,
+                fetchContext = if (firstTimeInForeground) {
+                    RemoteConfigFetchContext.AppStart
+                } else {
+                    RemoteConfigFetchContext.Foreground
+                },
             )
 
             if (shouldRefreshCustomerInfo(firstTimeInForeground)) {
@@ -433,7 +439,11 @@ internal class PurchasesOrchestrator(
         }
 
         subscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserID) {
-            remoteConfigManager?.refreshRemoteConfig(state.appInBackground, appUserID)
+            remoteConfigManager?.refreshRemoteConfig(
+                state.appInBackground,
+                appUserID,
+                RemoteConfigFetchContext.Read,
+            )
             getOfferings(receiveOfferingsCallback, fetchCurrent = true)
         }
     }
@@ -824,7 +834,11 @@ internal class PurchasesOrchestrator(
                             callback?.onReceived(customerInfo, created)
                             customerInfoUpdateHandler.notifyListeners(customerInfo)
                         }
-                        remoteConfigManager?.refreshRemoteConfig(state.appInBackground, newAppUserID)
+                        remoteConfigManager?.refreshRemoteConfig(
+                            state.appInBackground,
+                            newAppUserID,
+                            RemoteConfigFetchContext.IdentityChange,
+                        )
                         offeringsManager.fetchAndCacheOfferings(newAppUserID, state.appInBackground)
                         backupManager.dataChanged()
                     },
@@ -858,7 +872,11 @@ internal class PurchasesOrchestrator(
                 synchronized(this@PurchasesOrchestrator) {
                     state = state.copy(purchaseCallbacksByProductId = Collections.emptyMap())
                 }
-                updateAllCaches(identityManager.currentAppUserID, callback)
+                updateAllCaches(
+                    identityManager.currentAppUserID,
+                    RemoteConfigFetchContext.IdentityChange,
+                    callback,
+                )
                 backupManager.dataChanged()
             }
         }
@@ -1333,7 +1351,11 @@ internal class PurchasesOrchestrator(
         identityManager.switchUser(newAppUserID)
 
         offeringsManager.fetchAndCacheOfferings(newAppUserID, state.appInBackground)
-        remoteConfigManager?.refreshRemoteConfig(state.appInBackground, newAppUserID)
+        remoteConfigManager?.refreshRemoteConfig(
+            state.appInBackground,
+            newAppUserID,
+            RemoteConfigFetchContext.IdentityChange,
+        )
     }
     //endregion
 
@@ -1406,10 +1428,11 @@ internal class PurchasesOrchestrator(
 
     private fun updateAllCaches(
         appUserID: String,
+        fetchContext: RemoteConfigFetchContext,
         completion: ReceiveCustomerInfoCallback? = null,
     ) {
         state.appInBackground.let { appInBackground ->
-            remoteConfigManager?.refreshRemoteConfig(appInBackground, appUserID)
+            remoteConfigManager?.refreshRemoteConfig(appInBackground, appUserID, fetchContext)
             customerInfoHelper.retrieveCustomerInfo(
                 appUserID,
                 CacheFetchPolicy.FETCH_CURRENT,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -28,6 +28,7 @@ import com.revenuecat.purchases.common.networking.RewardVerificationResponse
 import com.revenuecat.purchases.common.networking.WebBillingProductsResponse
 import com.revenuecat.purchases.common.networking.buildPostReceiptResponse
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
@@ -1161,6 +1162,7 @@ internal class Backend(
     fun getRemoteConfig(
         appInBackground: Boolean,
         appUserID: String,
+        fetchContext: RemoteConfigFetchContext,
         domain: String,
         manifest: String?,
         prefetchedBlobs: List<String>,
@@ -1171,12 +1173,13 @@ internal class Backend(
         val path = endpoint.getPath()
         // Include the app user in the key: the path carries the domain but not the app_user_id (sent in the
         // request body), so concurrent calls for different users must not be deduped onto a single shared request.
-        val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path, appUserID), appInBackground)
+        val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path, appUserID, fetchContext.wireName), appInBackground)
 
         val baseURL = appConfig.baseURL
         // The manifest is an opaque token replayed verbatim; omitted on the first run when there is none.
         val body = buildMap<String, Any?> {
             put(APP_USER_ID, appUserID)
+            put("fetch_context", fetchContext.wireName)
             manifest?.let { put("manifest", it) }
             put("prefetched_blobs", prefetchedBlobs)
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigFetchContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigFetchContext.kt
@@ -1,0 +1,14 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+/**
+ * Describes why the SDK is requesting remote config.
+ *
+ * Each case maps to the SDK situation that triggered the config fetch. [wireName] is sent in the remote config
+ * request body as the `fetch_context` field.
+ */
+internal enum class RemoteConfigFetchContext(val wireName: String) {
+    AppStart("app_start"),
+    Foreground("foreground"),
+    IdentityChange("identity_change"),
+    Read("read"),
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -132,17 +132,30 @@ internal class RemoteConfigManager(
     val isDisabled: Boolean
         get() = disabled
 
-    fun refreshRemoteConfigIfStale(appInBackground: Boolean, appUserID: String) {
+    fun refreshRemoteConfigIfStale(
+        appInBackground: Boolean,
+        appUserID: String,
+        fetchContext: RemoteConfigFetchContext,
+    ) {
         if (lastRefreshedAt.isCacheStale(appInBackground, dateProvider)) {
-            refreshRemoteConfig(appInBackground, appUserID, staleGated = true)
+            refreshRemoteConfig(appInBackground, appUserID, fetchContext, staleGated = true)
         }
     }
 
-    fun refreshRemoteConfig(appInBackground: Boolean, appUserID: String) {
-        refreshRemoteConfig(appInBackground, appUserID, staleGated = false)
+    fun refreshRemoteConfig(
+        appInBackground: Boolean,
+        appUserID: String,
+        fetchContext: RemoteConfigFetchContext,
+    ) {
+        refreshRemoteConfig(appInBackground, appUserID, fetchContext, staleGated = false)
     }
 
-    private fun refreshRemoteConfig(appInBackground: Boolean, appUserID: String, staleGated: Boolean) {
+    private fun refreshRemoteConfig(
+        appInBackground: Boolean,
+        appUserID: String,
+        fetchContext: RemoteConfigFetchContext,
+        staleGated: Boolean,
+    ) {
         if (disabled) {
             debugLog { "Remote config is disabled for this session (4xx). Skipping refresh." }
             return
@@ -192,6 +205,7 @@ internal class RemoteConfigManager(
         backend.getRemoteConfig(
             appInBackground = appInBackground,
             appUserID = requestAppUserID,
+            fetchContext = fetchContext,
             domain = domain,
             // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
             manifest = persisted?.manifest,
@@ -430,7 +444,12 @@ internal class RemoteConfigManager(
         val appUserID = (currentAppUserID ?: appUserIDProvider())?.takeIf { it.isNotBlank() }
         if (!disabled && appUserID != null) {
             verboseLog { "Cold remote config read triggering an on-demand sync." }
-            refreshRemoteConfig(appInBackground = false, appUserID = appUserID, staleGated = true)
+            refreshRemoteConfig(
+                appInBackground = false,
+                appUserID = appUserID,
+                fetchContext = RemoteConfigFetchContext.Read,
+                staleGated = true,
+            )
             // Join whatever is now in flight — the sync we just triggered, or one a concurrent caller started.
             awaitInFlightRefresh()
         } else {

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -11,6 +11,7 @@ import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.ReplaceProductInfo
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
 import com.revenuecat.purchases.google.toInAppStoreProduct
@@ -2996,7 +2997,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         )
 
         verify(exactly = 1) {
-            mockRemoteConfigManager.refreshRemoteConfig(false, appUserId)
+            mockRemoteConfigManager.refreshRemoteConfig(false, appUserId, RemoteConfigFetchContext.Read)
         }
     }
 
@@ -3018,7 +3019,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         repeat(6) { purchases.purchasesOrchestrator.syncAttributesAndOfferingsIfNeeded(callback) }
 
         verify(exactly = 5) {
-            mockRemoteConfigManager.refreshRemoteConfig(false, appUserId)
+            mockRemoteConfigManager.refreshRemoteConfig(false, appUserId, RemoteConfigFetchContext.Read)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesLifecycleTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesLifecycleTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.PlatformInfo
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.models.InAppMessageType
 import io.mockk.Runs
 import io.mockk.every
@@ -82,6 +83,24 @@ internal class PurchasesLifecycleTest: BasePurchasesTest() {
             mockRemoteConfigManager.refreshRemoteConfigIfStale(
                 appInBackground = false,
                 appUserID = appUserId,
+                fetchContext = RemoteConfigFetchContext.AppStart,
+            )
+        }
+    }
+
+    @Test
+    fun `onAppForegrounded passes foreground fetch context after the first foreground`() {
+        mockOfferingsManagerAppForeground()
+        purchases.purchasesOrchestrator.state = purchases.purchasesOrchestrator.state.copy(
+            appInBackground = false,
+            firstTimeInForeground = false,
+        )
+        Purchases.sharedInstance.purchasesOrchestrator.onAppForegrounded()
+        verify(exactly = 1) {
+            mockRemoteConfigManager.refreshRemoteConfigIfStale(
+                appInBackground = false,
+                appUserID = appUserId,
+                fetchContext = RemoteConfigFetchContext.Foreground,
             )
         }
     }
@@ -143,7 +162,7 @@ internal class PurchasesLifecycleTest: BasePurchasesTest() {
         verify(exactly = 0) {
             mockCustomerInfoHelper.retrieveCustomerInfo(any(), any(), any(), any(), callback = any())
         }
-        verify(exactly = 0) { mockRemoteConfigManager.refreshRemoteConfigIfStale(any(), any()) }
+        verify(exactly = 0) { mockRemoteConfigManager.refreshRemoteConfigIfStale(any(), any(), any()) }
         verify(exactly = 0) { mockOfferingsManager.onAppForeground(any()) }
         verify(exactly = 0) { mockPostPendingTransactionsHelper.syncPendingPurchaseQueue(any()) }
         verify(exactly = 0) { mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any()) }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobFetcher
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
@@ -236,6 +237,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
             backend.getRemoteConfig(
                 appInBackground = false,
                 appUserID = "integrationTestRemoteConfigUser",
+                fetchContext = RemoteConfigFetchContext.AppStart,
                 domain = "app",
                 manifest = manifest,
                 prefetchedBlobs = prefetchedBlobs,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import io.mockk.every
 import io.mockk.mockk
@@ -97,6 +98,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -146,6 +148,7 @@ class BackendGetRemoteConfigTest {
         isolatedBackend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -168,6 +171,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -190,6 +194,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -213,6 +218,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -237,6 +243,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -246,8 +253,9 @@ class BackendGetRemoteConfigTest {
 
         val body = bodySlot.firstOrNull()
         assertThat(body).isNotNull
-        assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "manifest", "prefetched_blobs")
+        assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "manifest", "prefetched_blobs", "fetch_context")
         assertThat(body?.get("app_user_id")).isEqualTo(testAppUserID)
+        assertThat(body?.get("fetch_context")).isEqualTo("app_start")
         // The manifest is replayed verbatim as the opaque string the SDK received.
         assertThat(body?.get("manifest")).isEqualTo(testManifest)
         assertThat(body?.get("prefetched_blobs")).isEqualTo(listOf("blobRefA"))
@@ -278,6 +286,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -297,6 +306,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = null,
             prefetchedBlobs = emptyList(),
@@ -305,7 +315,7 @@ class BackendGetRemoteConfigTest {
         )
 
         val body = bodySlot.firstOrNull()
-        assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "prefetched_blobs")
+        assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "prefetched_blobs", "fetch_context")
         assertThat(body).doesNotContainKey("manifest")
     }
 
@@ -320,6 +330,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -345,6 +356,7 @@ class BackendGetRemoteConfigTest {
         backend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -366,6 +378,7 @@ class BackendGetRemoteConfigTest {
         asyncBackend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -375,6 +388,7 @@ class BackendGetRemoteConfigTest {
         asyncBackend.getRemoteConfig(
             appInBackground = false,
             appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -401,6 +415,7 @@ class BackendGetRemoteConfigTest {
         asyncBackend.getRemoteConfig(
             appInBackground = false,
             appUserID = "user-a",
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -410,6 +425,7 @@ class BackendGetRemoteConfigTest {
         asyncBackend.getRemoteConfig(
             appInBackground = false,
             appUserID = "user-b",
+            fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
             prefetchedBlobs = testPrefetchedBlobs,
@@ -419,6 +435,43 @@ class BackendGetRemoteConfigTest {
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
         assertThat(lock.count).isEqualTo(0)
         // Different users must each get their own request rather than sharing the first caller's response.
+        verify(exactly = 2) {
+            httpClient.performRequest(
+                mockBaseURL,
+                Endpoint.GetRemoteConfig(testDomain),
+                body = any(),
+                postFieldsToSign = null,
+                requestHeaders = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `getRemoteConfig does not dedup concurrent calls for different fetch contexts`() {
+        mockHttpResult(payload = HTTPResult.Payload.RCFormat(buildContainer()), delayMs = 200)
+        val lock = CountDownLatch(2)
+        asyncBackend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> lock.countDown() },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+        asyncBackend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.Read,
+            domain = testDomain,
+            manifest = testManifest,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> lock.countDown() },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+        lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             httpClient.performRequest(
                 mockBaseURL,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
@@ -80,11 +80,11 @@ class RemoteConfigManagerIntegrationTest {
         )
 
         every {
-            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any())
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any())
         } answers {
-            capturedManifest = arg(3)
-            capturedPrefetchedBlobs = arg(4)
-            onSuccess = arg(5)
+            capturedManifest = arg(4)
+            capturedPrefetchedBlobs = arg(5)
+            onSuccess = arg(6)
         }
     }
 
@@ -154,7 +154,7 @@ class RemoteConfigManagerIntegrationTest {
         assertThat(blobStore.contains(refA)).isTrue
 
         // Start the next sync: it should replay the manifest persisted by the first sync.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = RemoteConfigFetchContext.AppStart)
         assertThat(capturedManifest).isEqualTo("v1.1.workflows:etag1")
         settle(container(workflowsConfig(manifest = "v1.2.workflows:etag2", items = mapOf("wf1234" to refB)), blobB))
 
@@ -171,7 +171,7 @@ class RemoteConfigManagerIntegrationTest {
         sync(container(workflowsConfig(prefetchBlobs = listOf(ref), items = mapOf("wf1234" to ref)), blob))
         assertThat(blobStore.contains(ref)).isTrue
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = RemoteConfigFetchContext.AppStart)
 
         // The blob is now cached on disk, so it is reported back so the server stops re-inlining it.
         assertThat(capturedPrefetchedBlobs).containsExactly(ref)
@@ -341,7 +341,7 @@ class RemoteConfigManagerIntegrationTest {
 
     /** Runs a full refresh and settles it with [container] (null = a 204). */
     private fun sync(container: RCContainer?) {
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = RemoteConfigFetchContext.AppStart)
         settle(container)
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -69,6 +69,7 @@ class RemoteConfigManagerTest {
     private var capturedAppUserID: String? = null
     private var capturedDomain: String? = null
     private var capturedManifest: String? = null
+    private var capturedFetchContext: RemoteConfigFetchContext? = null
     private var capturedPrefetchedBlobs: List<String>? = null
     private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
     private lateinit var onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit
@@ -97,14 +98,15 @@ class RemoteConfigManagerTest {
         every { diskCache.write(any()) } returns true
 
         every {
-            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any())
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any())
         } answers {
             capturedAppUserID = arg(1)
-            capturedDomain = arg(2)
-            capturedManifest = arg(3)
-            capturedPrefetchedBlobs = arg(4)
-            onSuccess = arg(5)
-            onError = arg(6)
+            capturedFetchContext = arg(2)
+            capturedDomain = arg(3)
+            capturedManifest = arg(4)
+            capturedPrefetchedBlobs = arg(5)
+            onSuccess = arg(6)
+            onError = arg(7)
         }
 
         every {
@@ -119,7 +121,7 @@ class RemoteConfigManagerTest {
     fun `first run sends the app domain with no manifest`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         assertThat(capturedAppUserID).isEqualTo(TEST_APP_USER_ID)
         assertThat(capturedDomain).isEqualTo("app")
@@ -131,9 +133,9 @@ class RemoteConfigManagerTest {
     fun `refreshRemoteConfigIfStale refreshes on the first call in a process`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -141,57 +143,57 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         // First refresh completes (204), stamping the in-memory last-sync time.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(null, VerificationResult.VERIFIED)
 
         // Same clock: still within the foreground window, so no new request.
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `refreshRemoteConfigIfStale refreshes again once the window elapses`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(null, VerificationResult.VERIFIED)
 
         currentTimeMillis = FIXED_MILLIS + STALE_FOREGROUND_AGE_MILLIS
 
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `clearCache makes refreshRemoteConfigIfStale refresh again within the window`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(null, VerificationResult.VERIFIED)
 
         // Identity change wipes the cache and the in-memory marker, so the next user refreshes immediately.
         manager.clearCache(TEST_APP_USER_ID)
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `clearCache clears the refresh attempt cooldown`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.NetworkError),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
         )
 
         manager.clearCache(TEST_APP_USER_ID)
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -200,7 +202,7 @@ class RemoteConfigManagerTest {
         // exercises the "failure doesn't stamp the time" bookkeeping in isolation.
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.NetworkError),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -208,51 +210,51 @@ class RemoteConfigManagerTest {
 
         // Same clock: the failure left lastRefreshedAt unset, but the recent attempt keeps stale-gated refreshes
         // from retrying on every caller.
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
 
         currentTimeMillis += REFRESH_ATTEMPT_COOLDOWN_MILLIS + 1
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `a skipped stale-gated refresh while already in flight does not start the cooldown`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         onError.invoke(
             PurchasesError(PurchasesErrorCode.NetworkError),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
         )
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `explicit refresh retries immediately after a retryable failure`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.NetworkError),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
         )
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `replays the persisted opaque manifest on subsequent runs`() {
         every { diskCache.read() } returns persisted(manifest = "v1.123.sources:etag1", domain = "app")
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         assertThat(capturedDomain).isEqualTo("app")
         assertThat(capturedManifest).isEqualTo("v1.123.sources:etag1")
@@ -266,7 +268,7 @@ class RemoteConfigManagerTest {
         )
         every { blobStore.cachedRefs() } returns setOf(REF_VALID)
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         assertThat(capturedPrefetchedBlobs).containsExactly(REF_VALID)
     }
@@ -284,7 +286,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         val written = slot<PersistedRemoteConfigurationState>()
@@ -318,7 +320,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         val written = slot<PersistedRemoteConfigurationState>()
@@ -344,7 +346,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
         val validData = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(
             containerWithConfig(
                 response,
@@ -374,7 +376,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
         val wantedData = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(
             containerWithConfig(
                 response,
@@ -405,7 +407,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(
             containerWithConfig(
                 response,
@@ -432,7 +434,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         val retained = slot<Set<String>>()
@@ -457,7 +459,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         val written = slot<PersistedRemoteConfigurationState>()
@@ -486,7 +488,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         // Re-arm the blob sources before fetching, but only if a prior cycle exhausted them.
@@ -516,7 +518,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         val prefetched = slot<List<String>>()
@@ -539,7 +541,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         val prefetched = slot<List<String>>()
@@ -561,7 +563,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         verify(exactly = 0) { sourceProvider.restartIfExhausted(any()) }
@@ -572,7 +574,7 @@ class RemoteConfigManagerTest {
     fun `a 204 response does not re-arm the sources nor prefetch`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(null, VerificationResult.VERIFIED)
 
         verify(exactly = 0) { sourceProvider.restartIfExhausted(any()) }
@@ -583,7 +585,7 @@ class RemoteConfigManagerTest {
     fun `a 204 response leaves the cache untouched and does no blob work`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(null, VerificationResult.VERIFIED)
 
         verify(exactly = 0) { diskCache.write(any()) }
@@ -595,7 +597,7 @@ class RemoteConfigManagerTest {
     fun `an error leaves the cache untouched`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.UnknownError, "boom"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -608,7 +610,7 @@ class RemoteConfigManagerTest {
     fun `a 4xx disables the endpoint for the session and blocks further refreshes and blob work`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
@@ -617,9 +619,9 @@ class RemoteConfigManagerTest {
         assertThat(manager.isDisabled).isTrue()
 
         // No further config request and no blob fetch happen for the rest of the session.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
         verify(exactly = 0) { blobFetcher.prefetch(any()) }
     }
 
@@ -634,7 +636,7 @@ class RemoteConfigManagerTest {
         )
         val manager = readManager()
         // A 4xx disables the endpoint for the session.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
@@ -701,7 +703,7 @@ class RemoteConfigManagerTest {
                 ),
             )
             val manager = readManager()
-            manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+            manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
             onError.invoke(
                 PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
                 GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
@@ -775,7 +777,7 @@ class RemoteConfigManagerTest {
         // Warm cache: a retryable error settles directly (no cold-start fallback), so a subsequent refresh fires.
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -784,8 +786,8 @@ class RemoteConfigManagerTest {
         assertThat(manager.isDisabled).isFalse()
 
         // The endpoint is still usable, so a subsequent refresh fires.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     // region Fallback endpoint
@@ -794,7 +796,7 @@ class RemoteConfigManagerTest {
     fun `a cold-start retryable error fetches from the fallback endpoint and commits its config`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -831,7 +833,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
         every { blobStore.contains(any()) } returns false
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -861,7 +863,7 @@ class RemoteConfigManagerTest {
     fun `the fallback is not attempted when a retryable error occurs with cached data`() {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -876,7 +878,7 @@ class RemoteConfigManagerTest {
     fun `a 4xx does not attempt the fallback`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
@@ -890,7 +892,7 @@ class RemoteConfigManagerTest {
     fun `a failing fallback releases the guard so a later refresh retries`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -901,15 +903,15 @@ class RemoteConfigManagerTest {
         )
 
         // The fallback settled the sync, so a later refresh is allowed to fire again.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `a failing fallback is throttled for stale-gated retries`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -919,19 +921,19 @@ class RemoteConfigManagerTest {
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
         )
 
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
 
         currentTimeMillis += REFRESH_ATTEMPT_COOLDOWN_MILLIS + 1
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `a 4xx from the fallback disables the endpoint`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -950,7 +952,7 @@ class RemoteConfigManagerTest {
     fun `clearCache does not re-enable an endpoint disabled by a 4xx`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
@@ -960,30 +962,30 @@ class RemoteConfigManagerTest {
         manager.clearCache(TEST_APP_USER_ID)
 
         assertThat(manager.isDisabled).isTrue()
-        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `a refresh while one is already in flight is skipped`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         // The first refresh has not settled yet (the stub captures callbacks without invoking them).
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `a new refresh is allowed after a success settles the in-flight one`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(null, VerificationResult.VERIFIED)
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -991,21 +993,21 @@ class RemoteConfigManagerTest {
         // Warm cache: the error settles the in-flight refresh directly (no cold-start fallback continuation).
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.UnknownError, "boom"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
         )
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `a malformed config payload leaves the cache untouched`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig("{ not valid json"), VerificationResult.VERIFIED)
 
         verify(exactly = 0) { diskCache.write(any()) }
@@ -1026,30 +1028,30 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(config), VerificationResult.VERIFIED)
 
         // The parse failure is caught: nothing is persisted and the cache is left intact.
         verify(exactly = 0) { diskCache.write(any()) }
 
         // The guard was released in the finally block, so a subsequent refresh is allowed to start.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `a config element that fails to decode leaves the cache untouched and releases the guard`() {
         every { diskCache.read() } returns null
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithUndecodableConfig(), VerificationResult.VERIFIED)
 
         // The decode failure is caught: nothing is persisted and the cache is left intact.
         verify(exactly = 0) { diskCache.write(any()) }
 
         // The guard was released in the finally block, so a subsequent refresh is allowed to start.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1073,7 +1075,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         // Identity change wipes the cache before the in-flight request settles.
         manager.clearCache(TEST_APP_USER_ID)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
@@ -1105,7 +1107,7 @@ class RemoteConfigManagerTest {
         }
         every { diskCache.clear() } answers { clearEntered.countDown() }
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         // Run the 200 path on its own thread: it enters the lock and parks inside diskCache.write.
         val persistThread = thread { onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED) }
         check(writeEntered.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "persist did not reach diskCache.write" }
@@ -1140,7 +1142,7 @@ class RemoteConfigManagerTest {
 
         manager.clearCache(TEST_APP_USER_ID)
         // A brand-new sync (e.g. for the new user) proceeds normally: the guard was released by clearCache.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         verify(exactly = 1) { diskCache.write(any()) }
@@ -1168,7 +1170,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         assertThat(readManager(appUserIDProvider = { null }).topic(RemoteConfigTopic.Sources)).isNull()
-        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1183,9 +1185,10 @@ class RemoteConfigManagerTest {
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             result = manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
-        // The on-demand sync is issued as foreground for the current user.
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        // The on-demand sync is issued as foreground for the current user with a read fetch context.
         assertThat(capturedAppUserID).isEqualTo(TEST_APP_USER_ID)
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.Read)
         assertThat(read.isActive).isTrue()
 
         val response = """
@@ -1217,7 +1220,7 @@ class RemoteConfigManagerTest {
         val firstRead = launch(UnconfinedTestDispatcher(testScheduler)) {
             firstResult = manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
         onError.invoke(
             PurchasesError(PurchasesErrorCode.NetworkError),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -1226,13 +1229,13 @@ class RemoteConfigManagerTest {
         assertThat(firstResult).isNull()
 
         assertThat(manager.topic(RemoteConfigTopic.Workflows)).isNull()
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
 
         currentTimeMillis += REFRESH_ATTEMPT_COOLDOWN_MILLIS + 1
         val retryRead = launch(UnconfinedTestDispatcher(testScheduler)) {
             manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
         onError.invoke(
             PurchasesError(PurchasesErrorCode.NetworkError),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -1255,7 +1258,7 @@ class RemoteConfigManagerTest {
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
         assertThat(capturedAppUserID).isEqualTo("new-user")
 
         // Settle the triggered sync so the parked read completes cleanly.
@@ -1284,7 +1287,7 @@ class RemoteConfigManagerTest {
             val read = launch(UnconfinedTestDispatcher(testScheduler)) {
                 manager.topic(RemoteConfigTopic.Workflows)
             }
-            verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+            verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
             assertThat(capturedAppUserID).isEqualTo("new-user")
 
             onSuccess.invoke(null, VerificationResult.VERIFIED)
@@ -1301,7 +1304,7 @@ class RemoteConfigManagerTest {
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
         assertThat(capturedAppUserID).isEqualTo("bootstrap-user")
 
         onSuccess.invoke(null, VerificationResult.VERIFIED)
@@ -1316,7 +1319,7 @@ class RemoteConfigManagerTest {
         val manager = readManager()
 
         // A refresh is in flight: the backend stub captures the callbacks without settling them yet.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         // The topic is not committed yet, so the read parks on the in-flight refresh.
         var result: ConfigTopic? = null
@@ -1352,7 +1355,7 @@ class RemoteConfigManagerTest {
         val manager = readManager()
 
         // A refresh is in flight and never settles; a committed read must not block on it (else this hangs).
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         assertThat(manager.topic(RemoteConfigTopic.Workflows)).containsKey("wf1")
     }
@@ -1459,7 +1462,7 @@ class RemoteConfigManagerTest {
         )
         val manager = readManager()
         // A 4xx disables the endpoint for the session.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
@@ -1483,7 +1486,7 @@ class RemoteConfigManagerTest {
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             result = manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
         // The on-demand sync is issued as foreground for the current user.
         assertThat(capturedAppUserID).isEqualTo(TEST_APP_USER_ID)
         assertThat(read.isActive).isTrue()
@@ -1507,7 +1510,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         assertThat(readManager(appUserIDProvider = { null }).blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isNull()
-        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1515,14 +1518,14 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
         val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
         // A 4xx disables the endpoint for the session (this is the only config request that should ever fire).
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
         )
 
         assertThat(manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isNull()
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1535,7 +1538,7 @@ class RemoteConfigManagerTest {
         val manager = readManager()
 
         // A refresh is in flight: the backend stub captures the callbacks without settling them yet.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         // The item is not committed yet, so the read parks on the in-flight refresh.
         var result: ByteArray? = null
@@ -1573,7 +1576,7 @@ class RemoteConfigManagerTest {
         val manager = readManager()
 
         // A refresh is in flight and never settles; a committed read must not block on it (else this hangs).
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         assertThat(manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isEqualTo(byteArrayOf(9))
     }
@@ -1697,7 +1700,7 @@ class RemoteConfigManagerTest {
 
         assertThat(result).isNull()
         coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
-        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1744,7 +1747,7 @@ class RemoteConfigManagerTest {
         )
         val manager = readManager()
         // A 4xx disables the endpoint for the session.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
@@ -1761,7 +1764,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
         val manager = readManager()
         // A 4xx disables the endpoint for the session.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
@@ -1791,7 +1794,7 @@ class RemoteConfigManagerTest {
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             result = manager.mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
         assertThat(read.isActive).isTrue()
 
         val response = """
@@ -1817,7 +1820,7 @@ class RemoteConfigManagerTest {
     fun `clearCache unblocks a body waiting on an in-flight refresh`() = runTest {
         every { diskCache.read() } returns null
         val manager = readManager()
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         var result: ByteArray? = byteArrayOf(1)
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -1836,7 +1839,7 @@ class RemoteConfigManagerTest {
     fun `close unblocks a body waiting on an in-flight refresh`() = runTest {
         every { diskCache.read() } returns null
         val manager = readManager()
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         var result: ByteArray? = byteArrayOf(1)
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -1855,7 +1858,7 @@ class RemoteConfigManagerTest {
     fun `a 204 unblocks a body waiting on an in-flight refresh`() = runTest {
         every { diskCache.read() } returns null
         val manager = readManager()
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         var result: ByteArray? = byteArrayOf(1)
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -1873,7 +1876,7 @@ class RemoteConfigManagerTest {
     fun `an error unblocks a body waiting on an in-flight refresh`() = runTest {
         every { diskCache.read() } returns null
         val manager = readManager()
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         var result: ByteArray? = byteArrayOf(1)
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -1915,9 +1918,9 @@ class RemoteConfigManagerTest {
         every { diskCache.clear() } answers { state.set(null) }
         every { blobStore.cachedRefs() } returns emptySet()
         every {
-            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any())
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any())
         } answers {
-            arg<(RCContainer?, VerificationResult) -> Unit>(5)
+            arg<(RCContainer?, VerificationResult) -> Unit>(6)
                 .invoke(containerWithConfig(stressResponse), VerificationResult.VERIFIED)
         }
         val manager = RemoteConfigManager(
@@ -1935,7 +1938,7 @@ class RemoteConfigManagerTest {
         val clearer = thread { repeat(STRESS_ITERATIONS) { manager.clearCache(TEST_APP_USER_ID) } }
         val refresher = thread {
             repeat(STRESS_ITERATIONS) {
-                manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+                manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
             }
         }
         // Cold readers constantly wait on (or self-trigger) refreshes; the epoch/guard/completion machinery
@@ -2044,6 +2047,7 @@ class RemoteConfigManagerTest {
 
     private companion object {
         private const val TEST_APP_USER_ID = "test-app-user-id"
+        private val DEFAULT_FETCH_CONTEXT = RemoteConfigFetchContext.AppStart
         private const val FIXED_MILLIS = 1_710_000_000_000L
 
         // Older than the 5-minute foreground staleness window (see Date?.isCacheStale).

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSource
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceHandle
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceProvider
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
 import com.revenuecat.purchases.utils.UrlConnection
 import com.revenuecat.purchases.utils.UrlConnectionFactory
@@ -98,9 +99,9 @@ class WorkflowsConfigIntegrationTest {
         provider = WorkflowsConfigProvider(manager)
 
         every {
-            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any())
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any())
         } answers {
-            onSuccess = arg(5)
+            onSuccess = arg(6)
         }
     }
 
@@ -360,7 +361,7 @@ class WorkflowsConfigIntegrationTest {
             assertThat(completed).isTrue()
             // The topic was already committed by the sync() above — onPaywallConfigReady must not trigger
             // another one; this is what keeps OfferingsManager's gate cheap on a warm cache.
-            verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any()) }
+            verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
         }
 
     // Asset prewarming is out of scope here (covered by WorkflowManagerTest), so the manager gets a stubbed
@@ -373,7 +374,7 @@ class WorkflowsConfigIntegrationTest {
     )
 
     private fun sync(configJson: String, vararg blobs: Pair<String, String>) {
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = "user-1")
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = "user-1", fetchContext = RemoteConfigFetchContext.AppStart)
         onSuccess.invoke(containerWith(configJson, *blobs), VerificationResult.VERIFIED)
     }
 

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/request_001.json
@@ -22,6 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigFallbackUser",
+    "fetch_context": "read",
     "prefetched_blobs": []
   }
 }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/can fetch remote config/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/can fetch remote config/request_001.json
@@ -22,6 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
+    "fetch_context": "app_start",
     "prefetched_blobs": []
   }
 }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/decodes an inline workflows content blob/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/decodes an inline workflows content blob/request_001.json
@@ -22,6 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
+    "fetch_context": "app_start",
     "prefetched_blobs": []
   }
 }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/request_001.json
@@ -22,6 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
+    "fetch_context": "read",
     "prefetched_blobs": []
   }
 }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/request_001.json
@@ -22,6 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
+    "fetch_context": "read",
     "prefetched_blobs": []
   }
 }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/replaying the manifest returns no content/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/replaying the manifest returns no content/request_001.json
@@ -22,6 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
+    "fetch_context": "app_start",
     "prefetched_blobs": []
   }
 }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/replaying the manifest returns no content/request_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/replaying the manifest returns no content/request_002.json
@@ -22,6 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
+    "fetch_context": "app_start",
     "manifest": "TEST_STATIC_VALUE",
     "prefetched_blobs": []
   }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the no content response when verification is enforced/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the no content response when verification is enforced/request_001.json
@@ -22,6 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
+    "fetch_context": "app_start",
     "prefetched_blobs": []
   }
 }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the no content response when verification is enforced/request_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the no content response when verification is enforced/request_002.json
@@ -22,6 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
+    "fetch_context": "app_start",
     "manifest": "TEST_STATIC_VALUE",
     "prefetched_blobs": []
   }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the signed response when verification is enforced/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the signed response when verification is enforced/request_001.json
@@ -22,6 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
+    "fetch_context": "app_start",
     "prefetched_blobs": []
   }
 }

--- a/purchases/src/testCustomEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesLoginTests.kt
+++ b/purchases/src/testCustomEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesLoginTests.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -50,7 +51,9 @@ internal class PurchasesLoginTests : BasePurchasesTest() {
 
         purchases.switchUser(newAppUserID)
 
-        verify(exactly = 1) { mockRemoteConfigManager.refreshRemoteConfig(false, newAppUserID) }
+        verify(exactly = 1) {
+            mockRemoteConfigManager.refreshRemoteConfig(false, newAppUserID, RemoteConfigFetchContext.IdentityChange)
+        }
     }
 
     @Test
@@ -65,7 +68,7 @@ internal class PurchasesLoginTests : BasePurchasesTest() {
 
         verify(exactly = 0) { mockIdentityManager.switchUser(newAppUserID) }
         verify(exactly = 0) { mockOfferingsManager.fetchAndCacheOfferings(newAppUserID, false, any(), any()) }
-        verify(exactly = 0) { mockRemoteConfigManager.refreshRemoteConfig(any(), any()) }
+        verify(exactly = 0) { mockRemoteConfigManager.refreshRemoteConfig(any(), any(), any()) }
     }
     // endregion
 }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -14,6 +14,7 @@ import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.ReplaceProductInfo
 import com.revenuecat.purchases.common.SharedConstants
 import com.revenuecat.purchases.common.events.FeatureEvent
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.google.toInAppStoreProduct
@@ -692,7 +693,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         purchases.logIn(newAppUserID, mockCompletion)
 
         verify(exactly = 1) {
-            mockRemoteConfigManager.refreshRemoteConfig(false, newAppUserID)
+            mockRemoteConfigManager.refreshRemoteConfig(false, newAppUserID, RemoteConfigFetchContext.IdentityChange)
         }
     }
 
@@ -737,7 +738,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         purchases.logOut()
 
         verify(exactly = 1) {
-            mockRemoteConfigManager.refreshRemoteConfig(false, appUserID)
+            mockRemoteConfigManager.refreshRemoteConfig(false, appUserID, RemoteConfigFetchContext.IdentityChange)
         }
     }
 


### PR DESCRIPTION
### Checklist
- [x] Unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
The backend caches resolved config for ~30 minutes, so config changes don't reach clients until the cache expires. Telling the backend why the SDK is fetching lets it decide when to force a fresh resolution. iOS equivalent: RevenueCat/purchases-ios#7214.

### Description
Adds a `fetch_context` field to every `POST /v1/config/{domain}` request, backed by a new `RemoteConfigFetchContext` enum (`app_start`, `foreground`, `identity_change`, `read`) threaded through `RemoteConfigManager` and the orchestrator call sites. It's also part of the backend request cache key, so fetches made for different reasons no longer coalesce (a fresh-wanting fetch can't piggyback on an in-flight `read`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all remote config fetch paths and changes request coalescing behavior; mis-assigned contexts could affect backend cache-bypass logic but does not alter auth or purchase flows.
> 
> **Overview**
> Adds **`fetch_context`** to every `POST /v1/config/{domain}` body so the backend knows why the SDK is fetching (e.g. to bypass stale server-side cache). A new internal **`RemoteConfigFetchContext`** enum (`app_start`, `foreground`, `identity_change`, `read`) is threaded through **`RemoteConfigManager`** and **`PurchasesOrchestrator`** call sites: first foreground uses **AppStart**, later foregrounds **Foreground**, login/logout/switch user **IdentityChange**, sync-attributes/offerings and cold topic reads **Read**.
> 
> **`Backend.getRemoteConfig`** now requires `fetchContext`, sends it in the JSON body, and includes **`fetchContext.wireName`** in the in-flight request dedupe key so concurrent fetches for the same user but different reasons do not share one HTTP call.
> 
> Tests and backend integration golden files were updated for the new parameter and body field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96a826779500c7be9e090e577ab8942012bb8160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->