### PR TITLE
Make HTTPResult visibility back to internal

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPResult.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPResult.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.common.networking
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.isSuccessful
@@ -16,9 +15,7 @@ private const val SERIALIZATION_NAME_VERIFICATION_RESULT = "verificationResult"
 private const val SERIALIZATION_NAME_IS_LOAD_SHEDDER_RESPONSE = "isLoadShedderResponse"
 private const val SERIALIZATION_NAME_IS_FALLBACK_URL = "isFallbackURL"
 
-@Suppress("ForbiddenPublicDataClass")
-@InternalRevenueCatAPI
-public data class HTTPResult(
+internal data class HTTPResult(
     val responseCode: Int,
     val payload: Payload,
     val origin: Origin,
@@ -31,7 +28,7 @@ public data class HTTPResult(
      * Convenience constructor for textual (JSON) responses, which keeps the common call sites and the
      * ETag cache deserialization ergonomic. Wraps [payload] in [Payload.Text].
      */
-    public constructor(
+    constructor(
         responseCode: Int,
         payload: String,
         origin: Origin,
@@ -53,10 +50,10 @@ public data class HTTPResult(
      * The response body, which is either textual (JSON, the common case) or raw [RCFormat] bytes (e.g.
      * the RC Container Format returned for `Accept: application/x-rc-format` requests).
      */
-    public sealed interface Payload {
-        public data class Text(val value: String) : Payload
+    sealed interface Payload {
+        data class Text(val value: String) : Payload
 
-        public class RCFormat(public val bytes: ByteArray) : Payload {
+        class RCFormat(val bytes: ByteArray) : Payload {
             override fun equals(other: Any?): Boolean =
                 this === other || (other is RCFormat && bytes.contentEquals(other.bytes))
 
@@ -64,7 +61,7 @@ public data class HTTPResult(
         }
 
         /** The textual payload, or an empty string for a [Payload.RCFormat] body. */
-        public val text: String
+        val text: String
             get() = when (this) {
                 is Text -> value
                 is RCFormat -> ""
@@ -120,7 +117,7 @@ public data class HTTPResult(
         }
     }
 
-    public enum class Origin {
+    enum class Origin {
         BACKEND, CACHE
     }
 


### PR DESCRIPTION
### Description
This makes the HTTPResult back to be internal since it's not actually used anymore. Follow-up from #3765 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visibility-only change with no logic edits; may break code outside the module that depended on the temporarily public type.
> 
> **Overview**
> Reverts **`HTTPResult`** from a public, `@InternalRevenueCatAPI` type to an **`internal`** networking model in `HTTPResult.kt`, following up on a prior exposure change (#3765).
> 
> The diff drops the internal-API annotations and **`public`** visibility on the class, its string-payload constructor, nested **`Payload`** / **`Origin`**, and related members. Behavior and serialization are unchanged; the type is no longer part of the SDK’s public surface and stays usable only inside the `purchases` module (e.g. backend calls and androidTest fakes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dcdc0997259f299ac7b8e10ff4512fa561c6b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->