### PR TITLE
Small optimization to keep a single copy of the json response string in memory

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPResult.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPResult.kt
@@ -71,7 +71,8 @@ public data class HTTPResult(
             }
     }
 
-    val payloadText: String = payload.text
+    val payloadText: String
+        get() { return payload.text }
 
     internal companion object {
         internal const val ETAG_HEADER_NAME = "X-RevenueCat-ETag"


### PR DESCRIPTION
### Description
We basically had the whole response as a string twice in memory. This removes one so we just delegate to the other use

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny implementation change on a networking DTO with no API or logic changes; low blast radius.
> 
> **Overview**
> **`HTTPResult.payloadText`** is no longer initialized as a separate stored property at instance creation. It now uses a **custom getter** that returns **`payload.text`**, so the JSON body string is not held twice on each result (once inside **`Payload.Text`** and again on **`HTTPResult`**).
> 
> Call sites still use **`result.payloadText`** the same way; behavior is unchanged—only when the value is resolved and how much is retained on the object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1dbcb39981fbed4b40407caeb89e56cd65dffff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->