### PR TITLE
fix(remote-config): skip decoding paywall components under workflows to save memory

### DIFF
--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -221,10 +221,11 @@ package com.revenuecat.purchases {
 
   @dev.drewhamilton.poko.Poko public final class Offering {
     ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages);
-    ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.paywalls.PaywallData? paywall, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.Offering.PaywallComponents? paywallComponents, optional java.net.URL? webCheckoutURL);
+    ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.paywalls.PaywallData? paywall, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.Offering.PaywallComponents? paywallComponents, optional java.net.URL? webCheckoutURL, optional @com.revenuecat.purchases.InternalRevenueCatAPI boolean hasPaywallComponents);
     method public operator com.revenuecat.purchases.Package get(String s);
     method public com.revenuecat.purchases.Package? getAnnual();
     method public java.util.List<com.revenuecat.purchases.Package> getAvailablePackages();
+    method public boolean getHasPaywallComponents();
     method public String getIdentifier();
     method public com.revenuecat.purchases.Package? getLifetime();
     method public java.util.Map<java.lang.String,java.lang.Object> getMetadata();
@@ -244,6 +245,7 @@ package com.revenuecat.purchases {
     property public final com.revenuecat.purchases.Package? annual;
     property public final java.util.List<com.revenuecat.purchases.Package> availablePackages;
     property public final boolean hasPaywall;
+    property public final boolean hasPaywallComponents;
     property public final String identifier;
     property public final com.revenuecat.purchases.Package? lifetime;
     property public final java.util.Map<java.lang.String,java.lang.Object> metadata;

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -221,11 +221,10 @@ package com.revenuecat.purchases {
 
   @dev.drewhamilton.poko.Poko public final class Offering {
     ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages);
-    ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.paywalls.PaywallData? paywall, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.Offering.PaywallComponents? paywallComponents, optional java.net.URL? webCheckoutURL, optional @com.revenuecat.purchases.InternalRevenueCatAPI boolean hasPaywallComponents);
+    ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.paywalls.PaywallData? paywall, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.Offering.PaywallComponents? paywallComponents, optional java.net.URL? webCheckoutURL);
     method public operator com.revenuecat.purchases.Package get(String s);
     method public com.revenuecat.purchases.Package? getAnnual();
     method public java.util.List<com.revenuecat.purchases.Package> getAvailablePackages();
-    method public boolean getHasPaywallComponents();
     method public String getIdentifier();
     method public com.revenuecat.purchases.Package? getLifetime();
     method public java.util.Map<java.lang.String,java.lang.Object> getMetadata();
@@ -245,7 +244,6 @@ package com.revenuecat.purchases {
     property public final com.revenuecat.purchases.Package? annual;
     property public final java.util.List<com.revenuecat.purchases.Package> availablePackages;
     property public final boolean hasPaywall;
-    property public final boolean hasPaywallComponents;
     property public final String identifier;
     property public final com.revenuecat.purchases.Package? lifetime;
     property public final java.util.Map<java.lang.String,java.lang.Object> metadata;

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -188,10 +188,11 @@ package com.revenuecat.purchases {
 
   @dev.drewhamilton.poko.Poko public final class Offering {
     ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages);
-    ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.paywalls.PaywallData? paywall, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.Offering.PaywallComponents? paywallComponents, optional java.net.URL? webCheckoutURL);
+    ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.paywalls.PaywallData? paywall, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.Offering.PaywallComponents? paywallComponents, optional java.net.URL? webCheckoutURL, optional @com.revenuecat.purchases.InternalRevenueCatAPI boolean hasPaywallComponents);
     method public operator com.revenuecat.purchases.Package get(String s);
     method public com.revenuecat.purchases.Package? getAnnual();
     method public java.util.List<com.revenuecat.purchases.Package> getAvailablePackages();
+    method public boolean getHasPaywallComponents();
     method public String getIdentifier();
     method public com.revenuecat.purchases.Package? getLifetime();
     method public java.util.Map<java.lang.String,java.lang.Object> getMetadata();
@@ -211,6 +212,7 @@ package com.revenuecat.purchases {
     property public final com.revenuecat.purchases.Package? annual;
     property public final java.util.List<com.revenuecat.purchases.Package> availablePackages;
     property public final boolean hasPaywall;
+    property public final boolean hasPaywallComponents;
     property public final String identifier;
     property public final com.revenuecat.purchases.Package? lifetime;
     property public final java.util.Map<java.lang.String,java.lang.Object> metadata;

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -188,11 +188,10 @@ package com.revenuecat.purchases {
 
   @dev.drewhamilton.poko.Poko public final class Offering {
     ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages);
-    ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.paywalls.PaywallData? paywall, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.Offering.PaywallComponents? paywallComponents, optional java.net.URL? webCheckoutURL, optional @com.revenuecat.purchases.InternalRevenueCatAPI boolean hasPaywallComponents);
+    ctor public Offering(String identifier, String serverDescription, java.util.Map<java.lang.String,?> metadata, java.util.List<com.revenuecat.purchases.Package> availablePackages, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.paywalls.PaywallData? paywall, optional @com.revenuecat.purchases.InternalRevenueCatAPI com.revenuecat.purchases.Offering.PaywallComponents? paywallComponents, optional java.net.URL? webCheckoutURL);
     method public operator com.revenuecat.purchases.Package get(String s);
     method public com.revenuecat.purchases.Package? getAnnual();
     method public java.util.List<com.revenuecat.purchases.Package> getAvailablePackages();
-    method public boolean getHasPaywallComponents();
     method public String getIdentifier();
     method public com.revenuecat.purchases.Package? getLifetime();
     method public java.util.Map<java.lang.String,java.lang.Object> getMetadata();
@@ -212,7 +211,6 @@ package com.revenuecat.purchases {
     property public final com.revenuecat.purchases.Package? annual;
     property public final java.util.List<com.revenuecat.purchases.Package> availablePackages;
     property public final boolean hasPaywall;
-    property public final boolean hasPaywallComponents;
     property public final String identifier;
     property public final com.revenuecat.purchases.Package? lifetime;
     property public final java.util.Map<java.lang.String,java.lang.Object> metadata;

--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -45,6 +45,10 @@ abstract class BasePurchasesIntegrationTest {
     protected open val initialActivePurchasesToUse: Map<String, StoreTransaction> = emptyMap()
     protected open val initialForceSigningErrors: Boolean = false
 
+    // Optional dangerous settings applied at configure time (e.g. to enable workflows). Null keeps the default.
+    @OptIn(InternalRevenueCatAPI::class)
+    internal open val dangerousSettings: DangerousSettings? = null
+
     protected val testTimeout = 10.seconds
     protected val currentTimestamp = Date().time
     protected val testUserId = "android-integration-test-$currentTimestamp"
@@ -153,6 +157,7 @@ abstract class BasePurchasesIntegrationTest {
                 entitlementVerificationMode,
                 forceServerErrorStrategyDelegate,
                 forceSigningErrors,
+                dangerousSettings,
             )
 
             postSetupTestCallback(it)

--- a/purchases/src/androidTestCustomEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesTestConfigurationExtensions.kt
+++ b/purchases/src/androidTestCustomEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesTestConfigurationExtensions.kt
@@ -11,11 +11,12 @@ internal fun Purchases.Companion.configureSdk(
     entitlementVerificationMode: EntitlementVerificationMode? = null,
     forceServerErrorStrategy: ForceServerErrorStrategy? = null,
     forceSigningErrors: Boolean = false,
+    dangerousSettings: DangerousSettings? = null,
 ) {
     Purchases.configure(
         PurchasesConfiguration.Builder(context, Constants.apiKey)
             .appUserID(appUserID)
-            .dangerousSettings(DangerousSettings(customEntitlementComputation = true))
+            .dangerousSettings(dangerousSettings ?: DangerousSettings(customEntitlementComputation = true))
             .apply {
                 if (entitlementVerificationMode != null) {
                     entitlementVerificationMode(entitlementVerificationMode)

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/PurchasesTestConfigurationExtensions.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/PurchasesTestConfigurationExtensions.kt
@@ -11,6 +11,7 @@ internal fun Purchases.Companion.configureSdk(
     entitlementVerificationMode: EntitlementVerificationMode? = null,
     forceServerErrorStrategy: ForceServerErrorStrategy? = null,
     forceSigningErrors: Boolean = false,
+    dangerousSettings: DangerousSettings? = null,
 ) {
     Purchases.configure(
         PurchasesConfiguration.Builder(context, Constants.apiKey)
@@ -18,6 +19,9 @@ internal fun Purchases.Companion.configureSdk(
             .apply {
                 if (entitlementVerificationMode != null) {
                     entitlementVerificationMode(entitlementVerificationMode)
+                }
+                if (dangerousSettings != null) {
+                    dangerousSettings(dangerousSettings)
                 }
             }
             .build(),

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/workflows/ProductionWorkflowsPaywallComponentsIntegrationTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/workflows/ProductionWorkflowsPaywallComponentsIntegrationTest.kt
@@ -1,0 +1,162 @@
+package com.revenuecat.purchases.integration.workflows
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.BasePurchasesIntegrationTest
+import com.revenuecat.purchases.Constants
+import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.ForceServerErrorStrategy
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.getOfferingsWith
+import com.revenuecat.purchases.helpers.mockQueryProductDetails
+import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URL
+
+/**
+ * End-to-end check of the workflows paywall-components memory optimization + kill-switch fallback:
+ * - With workflows on and `/v1/config` healthy, `getOfferings` returns an offering whose `paywallComponents`
+ *   were NOT captured (memory saved), yet `hasPaywall` is still true (cheap presence flag).
+ * - After a `/v1/config` 4xx trips the session kill switch, the offerings cache is invalidated and a refetch
+ *   re-parses with remote config disabled, so `paywallComponents` are captured and decodable again for the
+ *   fallback render path.
+ *
+ * Drives the real backend (the production test project's current offering ships `paywall_components` + `ui_config`)
+ * with mocked billing; only `/v1/config` is faked, via [ForceServerErrorStrategy.fakeResponseWithoutPerformingRequest].
+ */
+@RunWith(AndroidJUnit4::class)
+@OptIn(InternalRevenueCatAPI::class)
+class ProductionWorkflowsPaywallComponentsIntegrationTest : BasePurchasesIntegrationTest() {
+
+    override val environmentConfig get() = Constants.production
+
+    override val dangerousSettings: DangerousSettings get() = DangerousSettings.forWorkflows()
+
+    override var forceServerErrorsStrategy: ForceServerErrorStrategy? = RemoteConfigKillSwitchFake()
+
+    private val remoteConfigFake get() = forceServerErrorsStrategy as RemoteConfigKillSwitchFake
+
+    @Before
+    fun setup() {
+        ensureBlockFinishes { latch ->
+            setUpTest {
+                latch.countDown()
+            }
+        }
+    }
+
+    @Test
+    fun offeringsSkipPaywallComponentsUntilRemoteConfigKillSwitch() {
+        confirmProductionBackendEnvironment()
+        mockBillingAbstract.mockQueryProductDetails()
+
+        // Phase 1: remote config healthy (faked 204) + workflows on => components are NOT captured, but the
+        // offering still reports a paywall via the cheap presence flag.
+        val phase1Current = fetchCurrentOffering()
+        assertThat(phase1Current.hasPaywall).isTrue()
+        assertThat(phase1Current.paywallComponents).isNull()
+
+        // Phase 2: make /v1/config return a 4xx and force a refresh => the session kill switch trips, the
+        // orchestrator invalidates the in-memory offerings cache and refetches.
+        remoteConfigFake.disableRemoteConfig = true
+        triggerRemoteConfigRefresh()
+
+        // Phase 3: after the kill switch, a fetch re-parses with remote config disabled, so paywall components are
+        // captured and available for the fallback render path.
+        val phase3Current = awaitCurrentOfferingWithComponents()
+        assertThat(phase3Current.hasPaywall).isTrue()
+        assertThat(phase3Current.paywallComponents).isNotNull
+        // Force the lazy decode to prove the captured component tree is valid.
+        assertThat(phase3Current.paywallComponents!!.data).isNotNull
+    }
+
+    private fun fetchCurrentOffering(): Offering {
+        var offerings: Offerings? = null
+        ensureBlockFinishes { latch ->
+            onActivityReady {
+                Purchases.sharedInstance.getOfferingsWith(
+                    onError = { error -> fail("Expected to fetch offerings but got error: ${error.message}") },
+                    onSuccess = {
+                        offerings = it
+                        latch.countDown()
+                    },
+                )
+            }
+        }
+        return offerings?.current ?: fail("Expected a current offering")
+    }
+
+    private fun triggerRemoteConfigRefresh() {
+        // syncAttributesAndOfferingsIfNeeded runs an unconditional remote-config refresh, which now hits the faked
+        // 4xx and disables the endpoint for the session.
+        ensureBlockFinishes { latch ->
+            onActivityReady {
+                Purchases.sharedInstance.syncAttributesAndOfferingsIfNeeded(
+                    object : SyncAttributesAndOfferingsCallback {
+                        override fun onSuccess(offerings: Offerings) = latch.countDown()
+                        override fun onError(error: PurchasesError) = latch.countDown()
+                    },
+                )
+            }
+        }
+    }
+
+    private fun awaitCurrentOfferingWithComponents(): Offering {
+        // The disable + cache invalidation + refetch happen asynchronously, so poll until the refetched offering
+        // carries the decoded components (bounded, so a regression fails instead of hanging).
+        var current: Offering? = null
+        repeat(MAX_POLL_ATTEMPTS) {
+            current = fetchCurrentOffering()
+            if (current?.paywallComponents != null) return current!!
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        return current ?: fail("Expected a current offering with paywall components after the kill switch")
+    }
+
+    private inner class RemoteConfigKillSwitchFake : ForceServerErrorStrategy {
+        @Volatile
+        var disableRemoteConfig = false
+
+        override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean = false
+
+        override fun fakeResponseWithoutPerformingRequest(baseURL: URL, endpoint: Endpoint): HTTPResult? {
+            if (endpoint !is Endpoint.GetRemoteConfig) return null
+            return if (disableRemoteConfig) {
+                // A 4xx client error => SHOULD_DISABLE => session kill switch.
+                fakeResult(
+                    RCHTTPStatusCodes.BAD_REQUEST,
+                    """{"code":7000,"message":"remote config disabled for test"}""",
+                )
+            } else {
+                // 204 => success no-op: keeps remote config enabled without fabricating a real RC container.
+                fakeResult(RCHTTPStatusCodes.NO_CONTENT, "")
+            }
+        }
+
+        private fun fakeResult(responseCode: Int, payload: String) = HTTPResult(
+            responseCode = responseCode,
+            payload = payload,
+            origin = HTTPResult.Origin.BACKEND,
+            requestDate = null,
+            verificationResult = VerificationResult.NOT_REQUESTED,
+            isLoadShedderResponse = false,
+            isFallbackURL = false,
+        )
+    }
+
+    private companion object {
+        const val MAX_POLL_ATTEMPTS = 20
+        const val POLL_INTERVAL_MS = 500L
+    }
+}

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/workflows/ProductionWorkflowsPaywallComponentsIntegrationTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/workflows/ProductionWorkflowsPaywallComponentsIntegrationTest.kt
@@ -7,22 +7,24 @@ import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.ForceServerErrorStrategy
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
-import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.awaitOfferings
+import com.revenuecat.purchases.awaitSyncAttributesAndOfferingsIfNeeded
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
-import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.helpers.mockQueryProductDetails
-import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.net.URL
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * End-to-end check of the workflows paywall-components memory optimization + kill-switch fallback:
@@ -57,20 +59,21 @@ class ProductionWorkflowsPaywallComponentsIntegrationTest : BasePurchasesIntegra
     }
 
     @Test
-    fun offeringsSkipPaywallComponentsUntilRemoteConfigKillSwitch() {
+    fun offeringsSkipPaywallComponentsUntilRemoteConfigKillSwitch() = runBlocking<Unit> {
         confirmProductionBackendEnvironment()
         mockBillingAbstract.mockQueryProductDetails()
 
         // Phase 1: remote config healthy (faked 204) + workflows on => components are NOT captured, but the
         // offering still reports a paywall via the cheap presence flag.
-        val phase1Current = fetchCurrentOffering()
+        val phase1Current = currentOffering()
         assertThat(phase1Current.hasPaywall).isTrue()
         assertThat(phase1Current.paywallComponents).isNull()
 
         // Phase 2: make /v1/config return a 4xx and force a refresh => the session kill switch trips, the
-        // orchestrator invalidates the in-memory offerings cache and refetches.
+        // orchestrator invalidates the in-memory offerings cache and refetches. syncAttributesAndOfferingsIfNeeded
+        // runs an unconditional remote-config refresh, which now hits the faked 4xx.
         remoteConfigFake.disableRemoteConfig = true
-        triggerRemoteConfigRefresh()
+        runCatching { Purchases.sharedInstance.awaitSyncAttributesAndOfferingsIfNeeded() }
 
         // Phase 3: after the kill switch, a fetch re-parses with remote config disabled, so paywall components are
         // captured and available for the fallback render path.
@@ -81,50 +84,21 @@ class ProductionWorkflowsPaywallComponentsIntegrationTest : BasePurchasesIntegra
         assertThat(phase3Current.paywallComponents!!.data).isNotNull
     }
 
-    private fun fetchCurrentOffering(): Offering {
-        var offerings: Offerings? = null
-        ensureBlockFinishes { latch ->
-            onActivityReady {
-                Purchases.sharedInstance.getOfferingsWith(
-                    onError = { error -> fail("Expected to fetch offerings but got error: ${error.message}") },
-                    onSuccess = {
-                        offerings = it
-                        latch.countDown()
-                    },
-                )
-            }
-        }
-        return offerings?.current ?: fail("Expected a current offering")
-    }
+    private suspend fun currentOffering(): Offering =
+        Purchases.sharedInstance.awaitOfferings().current ?: fail("Expected a current offering")
 
-    private fun triggerRemoteConfigRefresh() {
-        // syncAttributesAndOfferingsIfNeeded runs an unconditional remote-config refresh, which now hits the faked
-        // 4xx and disables the endpoint for the session.
-        ensureBlockFinishes { latch ->
-            onActivityReady {
-                Purchases.sharedInstance.syncAttributesAndOfferingsIfNeeded(
-                    object : SyncAttributesAndOfferingsCallback {
-                        override fun onSuccess(offerings: Offerings) = latch.countDown()
-                        override fun onError(error: PurchasesError) = latch.countDown()
-                    },
-                )
-            }
-        }
-    }
-
-    private fun awaitCurrentOfferingWithComponents(): Offering {
-        // The disable + cache invalidation + refetch happen asynchronously, so poll until the refetched offering
-        // carries the decoded components (bounded, so a regression fails instead of hanging).
-        var current: Offering? = null
+    private suspend fun awaitCurrentOfferingWithComponents(): Offering {
+        // The disable + cache invalidation + refetch happen asynchronously, so retry until the refetched offering
+        // carries the captured components (bounded, so a regression fails instead of hanging).
         repeat(MAX_POLL_ATTEMPTS) {
-            current = fetchCurrentOffering()
-            if (current?.paywallComponents != null) return current!!
-            Thread.sleep(POLL_INTERVAL_MS)
+            val current = currentOffering()
+            if (current.paywallComponents != null) return current
+            delay(POLL_INTERVAL)
         }
-        return current ?: fail("Expected a current offering with paywall components after the kill switch")
+        return fail("Expected a current offering with paywall components after the kill switch")
     }
 
-    private inner class RemoteConfigKillSwitchFake : ForceServerErrorStrategy {
+    private class RemoteConfigKillSwitchFake : ForceServerErrorStrategy {
         @Volatile
         var disableRemoteConfig = false
 
@@ -157,6 +131,6 @@ class ProductionWorkflowsPaywallComponentsIntegrationTest : BasePurchasesIntegra
 
     private companion object {
         const val MAX_POLL_ATTEMPTS = 20
-        const val POLL_INTERVAL_MS = 500L
+        val POLL_INTERVAL: Duration = 500.milliseconds
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -33,11 +33,6 @@ constructor(
     @InternalRevenueCatAPI
     public val paywallComponents: PaywallComponents? = null,
     public val webCheckoutURL: URL? = null,
-    // Whether the backend served a components paywall for this offering, tracked independently of whether
-    // [paywallComponents] was actually decoded. Under workflows the components are served from `/v1/config` and
-    // not captured here to save memory, but [hasPaywall] must still report the offering as paywall-capable.
-    @InternalRevenueCatAPI
-    public val hasPaywallComponents: Boolean = false,
 ) {
     @OptIn(InternalRevenueCatAPI::class)
     public constructor(
@@ -54,6 +49,13 @@ constructor(
         paywallComponents = null,
         webCheckoutURL = null,
     )
+
+    // Whether the backend served a components paywall for this offering, tracked independently of whether
+    // [paywallComponents] was actually decoded. Under workflows the components are served from `/v1/config` and are
+    // not captured here to save memory, but [hasPaywall] must still report the offering as paywall-capable. Kept
+    // internal (module-only, not in the primary constructor) so it stays out of the public API and out of the
+    // @Poko-generated equals/hashCode/toString; the parser sets it right after construction.
+    internal var hasPaywallComponents: Boolean = false
 
     @InternalRevenueCatAPI
     public class PaywallComponents private constructor(
@@ -186,7 +188,6 @@ constructor(
             paywall = this.paywall,
             paywallComponents = this.paywallComponents,
             webCheckoutURL = this.webCheckoutURL,
-            hasPaywallComponents = this.hasPaywallComponents,
-        )
+        ).also { it.hasPaywallComponents = this.hasPaywallComponents }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -33,6 +33,11 @@ constructor(
     @InternalRevenueCatAPI
     public val paywallComponents: PaywallComponents? = null,
     public val webCheckoutURL: URL? = null,
+    // Whether the backend served a components paywall for this offering, tracked independently of whether
+    // [paywallComponents] was actually decoded. Under workflows the components are served from `/v1/config` and
+    // not captured here to save memory, but [hasPaywall] must still report the offering as paywall-capable.
+    @InternalRevenueCatAPI
+    public val hasPaywallComponents: Boolean = false,
 ) {
     @OptIn(InternalRevenueCatAPI::class)
     public constructor(
@@ -99,7 +104,7 @@ constructor(
     @OptIn(InternalRevenueCatAPI::class)
     @get:JvmName("hasPaywall")
     public val hasPaywall: Boolean
-        get() = paywall != null || paywallComponents != null
+        get() = paywall != null || paywallComponents != null || hasPaywallComponents
 
     /**
      * Lifetime package type configured in the RevenueCat dashboard, if available.
@@ -181,6 +186,7 @@ constructor(
             paywall = this.paywall,
             paywallComponents = this.paywallComponents,
             webCheckoutURL = this.webCheckoutURL,
+            hasPaywallComponents = this.hasPaywallComponents,
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/OfferingParserFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/OfferingParserFactory.kt
@@ -11,12 +11,13 @@ internal object OfferingParserFactory {
 
     fun createOfferingParser(
         store: Store,
+        shouldParsePaywallComponents: () -> Boolean = { true },
     ): OfferingParser {
         return when (store) {
-            Store.TEST_STORE -> SimulatedStoreOfferingParser()
-            Store.PLAY_STORE -> GoogleOfferingParser()
-            Store.AMAZON -> AmazonOfferingParser()
-            Store.GALAXY -> GalaxyOfferingParser()
+            Store.TEST_STORE -> SimulatedStoreOfferingParser(shouldParsePaywallComponents)
+            Store.PLAY_STORE -> GoogleOfferingParser(shouldParsePaywallComponents)
+            Store.AMAZON -> AmazonOfferingParser(shouldParsePaywallComponents)
+            Store.GALAXY -> GalaxyOfferingParser(shouldParsePaywallComponents)
             else -> {
                 errorLog { "Incompatible store ($store) used" }
                 throw IllegalArgumentException("Couldn't configure SDK. Incompatible store ($store) used")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -159,6 +159,5 @@ internal fun Offering.withPresentedContext(placementId: String?, targeting: Offe
         paywall = this.paywall,
         paywallComponents = this.paywallComponents,
         webCheckoutURL = this.webCheckoutURL,
-        hasPaywallComponents = this.hasPaywallComponents,
-    )
+    ).also { it.hasPaywallComponents = this.hasPaywallComponents }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -159,5 +159,6 @@ internal fun Offering.withPresentedContext(placementId: String?, targeting: Offe
         paywall = this.paywall,
         paywallComponents = this.paywallComponents,
         webCheckoutURL = this.webCheckoutURL,
+        hasPaywallComponents = this.hasPaywallComponents,
     )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -369,7 +369,13 @@ internal class PurchasesFactory(
                 diagnosticsTracker,
                 uiPreviewMode = appConfig.uiPreviewMode,
             )
-            val offeringParser = OfferingParserFactory.createOfferingParser(finalStore)
+            // Under workflows, paywall components are served from `/v1/config`, so skip capturing the raw
+            // component JSON at parse time (memory). Reverts to decoding once the 4xx kill switch disables remote
+            // config (or when workflows are off / customEntitlementComputation), so the fallback render path has
+            // the components after a refetch. Evaluated per parse against the volatile `isDisabled`.
+            val offeringParser = OfferingParserFactory.createOfferingParser(finalStore) {
+                remoteConfigManager?.isDisabled ?: true
+            }
 
             var diagnosticsSynchronizer: DiagnosticsSynchronizer? = null
             @Suppress("ComplexCondition")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -294,13 +294,17 @@ internal class PurchasesOrchestrator(
             log(LogIntent.WARNING) { ConfigureStrings.AUTO_SYNC_PURCHASES_DISABLED }
         }
 
-        // When the `/v1/config` 4xx kill-switch trips, workflow-served paywalls are no longer available, so
-        // refetch offerings from the network: the parser skips capturing paywall components while the endpoint
-        // is live, and this refetch (with the endpoint now disabled) decodes them for the fallback render path.
+        // When the `/v1/config` 4xx kill-switch trips, workflow-served paywalls are no longer available, so the
+        // cached offerings (parsed while the endpoint was live, with paywall components skipped) can no longer
+        // serve the fallback render path. Invalidate the in-memory cache first so any getOfferings caller in the
+        // window before the refetch lands takes the cache-miss -> network path and gets freshly decoded
+        // components, instead of being served the stale null-component objects. The refetch (with the endpoint
+        // now disabled) then repopulates the cache proactively.
         remoteConfigManager?.registerListener(object : RemoteConfigCommitListener {
             // Only the disable transition matters here; commits/invalidations are handled by the config providers.
             override fun onConfigCommitted(generation: Int) = Unit
             override fun onRemoteConfigDisabled(generation: Int) {
+                offeringsManager.clearInMemoryOfferingsCache()
                 offeringsManager.fetchAndCacheOfferings(appUserID, state.appInBackground)
             }
         })

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -304,7 +304,7 @@ internal class PurchasesOrchestrator(
             // Only the disable transition matters here; commits/invalidations are handled by the config providers.
             override fun onConfigCommitted(generation: Int) = Unit
             override fun onRemoteConfigDisabled(generation: Int) {
-                offeringsManager.clearInMemoryOfferingsCache()
+                offeringsManager.clearInMemoryOfferingsCache(invalidateInFlightFetches = true)
                 offeringsManager.fetchAndCacheOfferings(appUserID, state.appInBackground)
             }
         })

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -47,6 +47,7 @@ import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigCommitListener
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.sha1
@@ -292,6 +293,17 @@ internal class PurchasesOrchestrator(
         if (!appConfig.dangerousSettings.autoSyncPurchases) {
             log(LogIntent.WARNING) { ConfigureStrings.AUTO_SYNC_PURCHASES_DISABLED }
         }
+
+        // When the `/v1/config` 4xx kill-switch trips, workflow-served paywalls are no longer available, so
+        // refetch offerings from the network: the parser skips capturing paywall components while the endpoint
+        // is live, and this refetch (with the endpoint now disabled) decodes them for the fallback render path.
+        remoteConfigManager?.registerListener(object : RemoteConfigCommitListener {
+            // Only the disable transition matters here; commits/invalidations are handled by the config providers.
+            override fun onConfigCommitted(generation: Int) = Unit
+            override fun onRemoteConfigDisabled(generation: Int) {
+                offeringsManager.fetchAndCacheOfferings(appUserID, state.appInBackground)
+            }
+        })
     }
 
     /** @suppress */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonOfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonOfferingParser.kt
@@ -4,7 +4,9 @@ import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.models.StoreProduct
 import org.json.JSONObject
 
-internal class AmazonOfferingParser : OfferingParser() {
+internal class AmazonOfferingParser(
+    shouldParsePaywallComponents: () -> Boolean = { true },
+) : OfferingParser(shouldParsePaywallComponents) {
     override fun findMatchingProduct(
         productsById: Map<String, List<StoreProduct>>,
         packageJson: JSONObject,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/GoogleOfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/GoogleOfferingParser.kt
@@ -4,7 +4,9 @@ import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.models.StoreProduct
 import org.json.JSONObject
 
-internal class GoogleOfferingParser : OfferingParser() {
+internal class GoogleOfferingParser(
+    shouldParsePaywallComponents: () -> Boolean = { true },
+) : OfferingParser(shouldParsePaywallComponents) {
     override fun findMatchingProduct(
         productsById: Map<String, List<StoreProduct>>,
         packageJson: JSONObject,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -172,8 +172,7 @@ internal abstract class OfferingParser(
                 paywallData,
                 paywallComponents,
                 webCheckoutURL,
-                hasPaywallComponents = hasPaywallComponents,
-            )
+            ).also { it.hasPaywallComponents = hasPaywallComponents }
         } else {
             null
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -24,7 +24,13 @@ import org.json.JSONObject
 import java.net.MalformedURLException
 import java.net.URL
 
-internal abstract class OfferingParser {
+internal abstract class OfferingParser(
+    // Whether to actually build [Offering.PaywallComponents] (capturing the raw component JSON) when an offering
+    // carries `paywall_components`. Evaluated per parse: under workflows with remote config still enabled the
+    // components are served from `/v1/config`, so capturing them here is dead memory. Reverts to `true` once the
+    // 4xx kill switch disables remote config, so a subsequent refetch decodes them for the fallback render path.
+    private val shouldParsePaywallComponents: () -> Boolean = { true },
+) {
 
     protected abstract fun findMatchingProduct(
         productsById: Map<String, List<StoreProduct>>,
@@ -149,26 +155,11 @@ internal abstract class OfferingParser {
         }
 
         val paywallComponentsJson = offeringJson.optJSONObject("paywall_components")
-        val paywallComponents = if (
-            paywallComponentsJson != null &&
-            uiConfig != null &&
-            paywallComponentsJson.hasPaywallComponentsShape()
-        ) {
-            // Defer the (potentially expensive) component-tree deserialization until the paywall is actually
-            // accessed/displayed. Capturing the raw JSON string here is cheap; without this we would eagerly
-            // deserialize every cached offering's component tree at load, even those that are never shown.
-            val rawPaywallComponents = paywallComponentsJson.toString()
-            // A content hash of the raw JSON serves as the equality key, so comparing offerings (e.g. cached vs
-            // network) never forces the lazy decode.
-            Offering.PaywallComponents(uiConfig, componentsHash = rawPaywallComponents.sha256()) {
-                json.decodeFromString<PaywallComponentsData>(rawPaywallComponents)
-            }
-        } else {
-            if (paywallComponentsJson != null && uiConfig != null) {
-                warnLog { "Skipping paywall components data with unexpected shape for offering" }
-            }
-            null
-        }
+        // Presence is tracked independently of whether we decode: [Offering.hasPaywall] must keep reporting a
+        // components paywall even when we skip capturing it (workflows serve it), so external integrators still
+        // see the offering as paywall-capable.
+        val hasPaywallComponents = hasWellShapedPaywallComponents(paywallComponentsJson, uiConfig)
+        val paywallComponents = createPaywallComponents(paywallComponentsJson, uiConfig, hasPaywallComponents)
 
         val webCheckoutURL = offeringJson.getWebCheckoutURL()
 
@@ -181,9 +172,44 @@ internal abstract class OfferingParser {
                 paywallData,
                 paywallComponents,
                 webCheckoutURL,
+                hasPaywallComponents = hasPaywallComponents,
             )
         } else {
             null
+        }
+    }
+
+    /** Whether the backend sent a `paywall_components` object with the required shape for the given [uiConfig]. */
+    @OptIn(InternalRevenueCatAPI::class)
+    private fun hasWellShapedPaywallComponents(paywallComponentsJson: JSONObject?, uiConfig: UiConfig?): Boolean =
+        paywallComponentsJson != null && uiConfig != null && paywallComponentsJson.hasPaywallComponentsShape()
+
+    /**
+     * Builds the (lazily-decoded) [Offering.PaywallComponents] from the raw JSON, or `null` when there is nothing
+     * to build ([hasWellShaped] is false) or when [shouldParsePaywallComponents] says to skip capturing it.
+     */
+    @OptIn(InternalRevenueCatAPI::class)
+    @Suppress("ReturnCount")
+    private fun createPaywallComponents(
+        paywallComponentsJson: JSONObject?,
+        uiConfig: UiConfig?,
+        hasWellShaped: Boolean,
+    ): Offering.PaywallComponents? {
+        if (paywallComponentsJson == null || uiConfig == null) return null
+        if (!hasWellShaped) {
+            warnLog { "Skipping paywall components data with unexpected shape for offering" }
+            return null
+        }
+        if (!shouldParsePaywallComponents()) return null
+
+        // Defer the (potentially expensive) component-tree deserialization until the paywall is actually
+        // accessed/displayed. Capturing the raw JSON string here is cheap; without this we would eagerly
+        // deserialize every cached offering's component tree at load, even those that are never shown.
+        val rawPaywallComponents = paywallComponentsJson.toString()
+        // A content hash of the raw JSON serves as the equality key, so comparing offerings (e.g. cached vs
+        // network) never forces the lazy decode.
+        return Offering.PaywallComponents(uiConfig, componentsHash = rawPaywallComponents.sha256()) {
+            json.decodeFromString<PaywallComponentsData>(rawPaywallComponents)
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -281,20 +281,33 @@ internal class OfferingsManager(
                 handleErrorFetchingOfferings(error, onError)
             },
             onSuccess = { offeringsResultData ->
-                offeringsResultData.offerings.current?.let {
-                    offeringImagePreDownloader.preDownloadOfferingImages(it)
-                }
-                offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
-                // Only write if no invalidation happened since this fetch started; otherwise this result is stale
-                // (a newer refetch owns the cache now) and writing it would clobber the fresher offerings. The
-                // parsed result is still delivered to the caller below so an in-flight request never hangs.
+                // Only handle this result if no invalidation happened since this fetch started. If the generation
+                // moved, this parse is stale: it ran while remote config was still enabled, so paywall components
+                // were skipped (hasPaywall == true but paywallComponents == null). Re-parse the same response JSON
+                // instead of delivering it. Remote config is guaranteed disabled by the time the guard fires
+                // (RemoteConfigManager flips isDisabled before bumping the generation that triggers the invalidating
+                // clear), so createOfferings now decodes the components. On the re-entry the generation matches, so
+                // the decoded result is cached and delivered to the original caller. This re-runs the store-product
+                // query; it is bounded to once per session because the kill-switch disable is one-shot.
                 if (cacheGeneration.get() == fetchGeneration) {
+                    offeringsResultData.offerings.current?.let {
+                        offeringImagePreDownloader.preDownloadOfferingImages(it)
+                    }
+                    offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                     offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
+                    val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
+                    workflowManager?.onPaywallConfigReady(onComplete = dispatchSuccess) ?: dispatchSuccess()
                 } else {
                     log(LogIntent.DEBUG) { OfferingStrings.OFFERINGS_CACHE_INVALIDATED_SKIPPING_STALE_WRITE }
+                    createAndCacheOfferings(
+                        offeringsJSON = offeringsJSON,
+                        originalDataSource = originalDataSource,
+                        loadedFromDiskCache = loadedFromDiskCache,
+                        fetchGeneration = cacheGeneration.get(),
+                        onError = onError,
+                        onSuccess = onSuccess,
+                    )
                 }
-                val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
-                workflowManager?.onPaywallConfigReady(onComplete = dispatchSuccess) ?: dispatchSuccess()
             },
         )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -24,6 +24,7 @@ import com.revenuecat.purchases.utils.OfferingImagePreDownloader
 import com.revenuecat.purchases.utils.optNullableString
 import org.json.JSONObject
 import java.util.Date
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
 
 @OptIn(InternalRevenueCatAPI::class)
@@ -43,6 +44,12 @@ internal class OfferingsManager(
 ) {
 
     private val emptyOfferings: Offerings = Offerings(current = null, all = emptyMap())
+
+    // Bumped by an invalidating clearInMemoryOfferingsCache (the `/v1/config` kill-switch flow only). A fetch
+    // captures it when it starts and re-checks it right before writing to the cache: a fetch that began before such
+    // an invalidation (e.g. one parsed while remote config was still enabled, with paywall components skipped) must
+    // not clobber the cache the invalidation's own refetch is repopulating. See PurchasesOrchestrator.
+    private val cacheGeneration = AtomicInteger(0)
 
     val cachedCurrentOfferingIdentifier: String?
         get() = offeringsCache.cachedOfferings?.current?.identifier
@@ -171,7 +178,19 @@ internal class OfferingsManager(
         }
     }
 
-    fun clearInMemoryOfferingsCache() {
+    /**
+     * Clears the in-memory offerings cache.
+     *
+     * [invalidateInFlightFetches] is only set by the `/v1/config` kill-switch flow: it bumps the cache generation
+     * so any fetch already in flight (parsed with the now-stale, pre-disable config, with paywall components
+     * skipped) drops its cache write instead of clobbering the offerings the kill-switch refetch is repopulating.
+     * All other callers leave it false to preserve previous behavior (a late in-flight write still lands) when
+     * remote config is disabled or workflows are off.
+     */
+    fun clearInMemoryOfferingsCache(invalidateInFlightFetches: Boolean = false) {
+        if (invalidateInFlightFetches) {
+            cacheGeneration.incrementAndGet()
+        }
         offeringsCache.clearInMemoryOfferingsCache()
     }
 
@@ -194,6 +213,9 @@ internal class OfferingsManager(
             return
         }
         log(LogIntent.RC_SUCCESS) { OfferingStrings.OFFERINGS_START_UPDATE_FROM_NETWORK }
+        // Snapshot the cache generation at fetch start so a cache invalidation that races this fetch can drop its
+        // (now stale) write instead of clobbering the fresher offerings the invalidation's refetch is producing.
+        val fetchGeneration = cacheGeneration.get()
         backend.getOfferings(
             appUserID,
             appInBackground,
@@ -202,6 +224,7 @@ internal class OfferingsManager(
                     offeringsJSON = body,
                     originalDataSource = originalDataSource,
                     loadedFromDiskCache = false,
+                    fetchGeneration = fetchGeneration,
                     onError,
                     onSuccess,
                 )
@@ -228,6 +251,7 @@ internal class OfferingsManager(
                                 offeringsJSON = cachedOfferingsResponse,
                                 originalDataSource = originalDataSource,
                                 loadedFromDiskCache = true,
+                                fetchGeneration = fetchGeneration,
                                 onError,
                                 onSuccess,
                             )
@@ -245,6 +269,7 @@ internal class OfferingsManager(
         offeringsJSON: JSONObject,
         originalDataSource: HTTPResponseOriginalSource,
         loadedFromDiskCache: Boolean,
+        fetchGeneration: Int,
         onError: ((PurchasesError) -> Unit)? = null,
         onSuccess: ((OfferingsResultData) -> Unit)? = null,
     ) {
@@ -260,7 +285,14 @@ internal class OfferingsManager(
                     offeringImagePreDownloader.preDownloadOfferingImages(it)
                 }
                 offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
-                offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
+                // Only write if no invalidation happened since this fetch started; otherwise this result is stale
+                // (a newer refetch owns the cache now) and writing it would clobber the fresher offerings. The
+                // parsed result is still delivered to the caller below so an in-flight request never hangs.
+                if (cacheGeneration.get() == fetchGeneration) {
+                    offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
+                } else {
+                    log(LogIntent.DEBUG) { OfferingStrings.OFFERINGS_CACHE_INVALIDATED_SKIPPING_STALE_WRITE }
+                }
                 val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
                 workflowManager?.onPaywallConfigReady(onComplete = dispatchSuccess) ?: dispatchSuccess()
             },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigCommitListener.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigCommitListener.kt
@@ -18,4 +18,9 @@ internal fun interface RemoteConfigCommitListener {
 
     // Default no-op so a listener that only reacts to commits (re-warm) needn't handle invalidation explicitly.
     fun onConfigInvalidated(generation: Int) {}
+
+    // Fired exactly once, the first time the `/v1/config` 4xx session kill-switch trips (never on an
+    // identity-change wipe, unlike [onConfigInvalidated]). Lets a listener react specifically to the endpoint
+    // becoming unavailable for the session — e.g. refetch offerings so the paywall-components fallback is decoded.
+    fun onRemoteConfigDisabled(generation: Int) {}
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -380,6 +380,10 @@ internal class RemoteConfigManager(
             disabled = true
             val invalidatedGeneration = generation.incrementAndGet()
             listeners.forEach { it.onConfigInvalidated(invalidatedGeneration) }
+            // Distinct one-shot signal (this branch runs once, guarded by !disabled): lets consumers refetch
+            // offerings so paywall components — skipped while the endpoint was live — get decoded for the
+            // fallback render path.
+            listeners.forEach { it.onRemoteConfigDisabled(invalidatedGeneration) }
         }
         if (releaseGuardIfOwned(requestEpoch)) {
             errorLog(error)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyOfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyOfferingParser.kt
@@ -4,7 +4,9 @@ import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.models.StoreProduct
 import org.json.JSONObject
 
-internal class GalaxyOfferingParser : OfferingParser() {
+internal class GalaxyOfferingParser(
+    shouldParsePaywallComponents: () -> Boolean = { true },
+) : OfferingParser(shouldParsePaywallComponents) {
     override fun findMatchingProduct(
         productsById: Map<String, List<StoreProduct>>,
         packageJson: JSONObject,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/simulatedstore/SimulatedStoreOfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/simulatedstore/SimulatedStoreOfferingParser.kt
@@ -4,7 +4,9 @@ import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.models.StoreProduct
 import org.json.JSONObject
 
-internal class SimulatedStoreOfferingParser : OfferingParser() {
+internal class SimulatedStoreOfferingParser(
+    shouldParsePaywallComponents: () -> Boolean = { true },
+) : OfferingParser(shouldParsePaywallComponents) {
     override fun findMatchingProduct(
         productsById: Map<String, List<StoreProduct>>,
         packageJson: JSONObject,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -68,6 +68,8 @@ internal object OfferingStrings {
         "https://rev.cat/how-to-configure-offerings.\nMore information: https://rev.cat/why-are-offerings-empty"
     const val ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE = "Error fetching offerings. Using disk cache."
     const val TARGETING_ERROR = "Error while parsing targeting - skipping"
+    const val OFFERINGS_CACHE_INVALIDATED_SKIPPING_STALE_WRITE =
+        "Offerings cache was invalidated during fetch; skipping stale cache write."
 }
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
@@ -47,6 +47,23 @@ internal class OfferingPaywallComponentsLazyTest {
     }
 
     @Test
+    fun `hasPaywall is true when hasPaywallComponents flag is set even though paywallComponents is skipped`() {
+        // Simulates the workflows path: components are not captured (null) but presence is flagged.
+        val offering = Offering(
+            identifier = "offering",
+            serverDescription = "desc",
+            metadata = emptyMap(),
+            availablePackages = emptyList(),
+            paywall = null,
+            paywallComponents = null,
+            webCheckoutURL = null,
+            hasPaywallComponents = true,
+        )
+
+        assertThat(offering.hasPaywall).isTrue()
+    }
+
+    @Test
     fun `equals is true for same uiConfig and componentsHash, without forcing the decode`() {
         val uiConfig = mockk<UiConfig>()
         var decodeCount = 0

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
@@ -57,8 +57,7 @@ internal class OfferingPaywallComponentsLazyTest {
             paywall = null,
             paywallComponents = null,
             webCheckoutURL = null,
-            hasPaywallComponents = true,
-        )
+        ).also { it.hasPaywallComponents = true }
 
         assertThat(offering.hasPaywall).isTrue()
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
@@ -46,6 +46,11 @@ class OfferingsTest {
         Store.PLAY_STORE,
     )
 
+    // Parser that skips capturing paywall_components (as under workflows with remote config still enabled).
+    private val skippingPaywallComponentsParser = OfferingParserFactory.createOfferingParser(
+        Store.PLAY_STORE,
+    ) { false }
+
     @Test
     fun `createPackage returns null if packageJson planIdentifier doesnt match any sub StoreProduct base plan ids`() {
         val storeProductAnnual = getStoreProduct(productIdentifier, annualPeriod, annualBasePlanId)
@@ -707,6 +712,34 @@ class OfferingsTest {
         val paywallComponents = offerings.all.values.first().paywallComponents ?: fail("paywallComponents is null")
         // Accessing `data` forces the deferred decode of the raw JSON captured at parse time.
         assertThat(paywallComponents.data.defaultLocaleIdentifier).isEqualTo(LocaleId("en_US"))
+    }
+
+    @Test
+    fun `createOfferings skips paywallComponents when shouldParsePaywallComponents is false but keeps hasPaywall`() {
+        // Arrange
+        val storeProductMonthly = getStoreProduct(productIdentifier, monthlyPeriod, monthlyBasePlanId)
+        val storeProductAnnual = getStoreProduct(productIdentifier, annualPeriod, annualBasePlanId)
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly, storeProductAnnual))
+        val uiConfigJson = getUiConfigJson(
+            colors = mapOf("primary" to "#ff00ff"),
+            fonts = mapOf("primary" to FontInfo.Name("Roboto")),
+            localizations = mapOf("en_US" to mapOf(VariableLocalizationKey.MONTHLY to "monthly")),
+            variableCompatibilityMap = mapOf("new var" to "guaranteed var"),
+            functionCompatibilityMap = mapOf("new fun" to "guaranteed fun")
+        )
+        val offeringJson = getOfferingJSON(paywallComponents = getPaywallComponentsDataJson())
+        val offeringsJson = getOfferingsJSON(offerings = JSONArray(listOf(offeringJson)), uiConfig = uiConfigJson)
+
+        // Act
+        val offerings = skippingPaywallComponentsParser.createOfferings(offeringsJson, products)
+
+        // Assert
+        assertThat(offerings.all.size).isEqualTo(1)
+        val offering = offerings.all.values.first()
+        // The raw component JSON is not captured (memory saved)...
+        assertThat(offering.paywallComponents).isNull()
+        // ...but the offering is still reported as paywall-capable so integrators see it.
+        assertThat(offering.hasPaywall).isTrue()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -2993,7 +2993,8 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
-    fun `remote config disable triggers an offerings network refetch`() {
+    fun `remote config disable invalidates the offerings cache then refetches from network`() {
+        every { mockOfferingsManager.clearInMemoryOfferingsCache() } just Runs
         every { mockOfferingsManager.fetchAndCacheOfferings(appUserId, false, any(), any()) } just Runs
 
         // Capture the disable listener the orchestrator registered on construction.
@@ -3002,9 +3003,10 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
 
         listenerSlot.captured.onRemoteConfigDisabled(generation = 1)
 
-        // The refetch re-parses offerings with remote config now disabled, decoding paywall components for the
-        // fallback render path.
-        verify(exactly = 1) {
+        // The in-memory cache must be dropped BEFORE the refetch, so getOfferings callers in the window take the
+        // cache-miss -> network path (freshly decoded components) instead of the stale null-component offerings.
+        verifyOrder {
+            mockOfferingsManager.clearInMemoryOfferingsCache()
             mockOfferingsManager.fetchAndCacheOfferings(appUserId, false, any(), any())
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -2994,7 +2994,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
 
     @Test
     fun `remote config disable invalidates the offerings cache then refetches from network`() {
-        every { mockOfferingsManager.clearInMemoryOfferingsCache() } just Runs
+        every { mockOfferingsManager.clearInMemoryOfferingsCache(true) } just Runs
         every { mockOfferingsManager.fetchAndCacheOfferings(appUserId, false, any(), any()) } just Runs
 
         // Capture the disable listener the orchestrator registered on construction.
@@ -3006,7 +3006,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         // The in-memory cache must be dropped BEFORE the refetch, so getOfferings callers in the window take the
         // cache-miss -> network path (freshly decoded components) instead of the stale null-component offerings.
         verifyOrder {
-            mockOfferingsManager.clearInMemoryOfferingsCache()
+            mockOfferingsManager.clearInMemoryOfferingsCache(true)
             mockOfferingsManager.fetchAndCacheOfferings(appUserId, false, any(), any())
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -11,6 +11,7 @@ import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.ReplaceProductInfo
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigCommitListener
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
@@ -47,6 +48,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import io.mockk.verifyAll
@@ -2987,6 +2989,23 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
 
         verify(exactly = 5) {
             mockRemoteConfigManager.refreshRemoteConfig(false, appUserId, RemoteConfigFetchContext.Read)
+        }
+    }
+
+    @Test
+    fun `remote config disable triggers an offerings network refetch`() {
+        every { mockOfferingsManager.fetchAndCacheOfferings(appUserId, false, any(), any()) } just Runs
+
+        // Capture the disable listener the orchestrator registered on construction.
+        val listenerSlot = slot<RemoteConfigCommitListener>()
+        verify { mockRemoteConfigManager.registerListener(capture(listenerSlot)) }
+
+        listenerSlot.captured.onRemoteConfigDisabled(generation = 1)
+
+        // The refetch re-parses offerings with remote config now disabled, decoding paywall components for the
+        // fallback render path.
+        verify(exactly = 1) {
+            mockOfferingsManager.fetchAndCacheOfferings(appUserId, false, any(), any())
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.utils.OfferingImagePreDownloader
 import com.revenuecat.purchases.utils.STUB_OFFERING_IDENTIFIER
 import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
 import com.revenuecat.purchases.utils.stubOfferings
+import io.mockk.CapturingSlot
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -92,6 +93,51 @@ class OfferingsManagerTest {
     }
 
     // endregion clearInMemoryOfferingsCache
+
+    // region cache write invalidation guard
+
+    @Test
+    fun `in-flight fetch write is dropped after an invalidating clear (kill-switch)`() {
+        every { cache.clearInMemoryOfferingsCache() } just Runs
+        mockDeviceCache()
+        val onSuccessSlot = captureFactoryOnSuccess()
+
+        // The fetch reaches the factory but its parsed result is not delivered yet (still in flight).
+        offeringsManager.fetchAndCacheOfferings(appUserId, appInBackground = false)
+
+        // Kill switch trips: invalidate in-flight fetches, then the in-flight parse finally completes.
+        offeringsManager.clearInMemoryOfferingsCache(invalidateInFlightFetches = true)
+        onSuccessSlot.captured.invoke(OfferingsResultData(testOfferings, setOf(productId), emptySet()))
+
+        verify(exactly = 0) { cache.cacheOfferings(any(), any()) }
+    }
+
+    @Test
+    fun `in-flight fetch write lands when no clear happens`() {
+        mockDeviceCache()
+        val onSuccessSlot = captureFactoryOnSuccess()
+
+        offeringsManager.fetchAndCacheOfferings(appUserId, appInBackground = false)
+        onSuccessSlot.captured.invoke(OfferingsResultData(testOfferings, setOf(productId), emptySet()))
+
+        verify(exactly = 1) { cache.cacheOfferings(any(), any()) }
+    }
+
+    @Test
+    fun `in-flight fetch write lands after a non-invalidating clear (previous behavior preserved)`() {
+        every { cache.clearInMemoryOfferingsCache() } just Runs
+        mockDeviceCache()
+        val onSuccessSlot = captureFactoryOnSuccess()
+
+        offeringsManager.fetchAndCacheOfferings(appUserId, appInBackground = false)
+        // A plain clear (locale override / remote config disabled path) must not drop the late write.
+        offeringsManager.clearInMemoryOfferingsCache()
+        onSuccessSlot.captured.invoke(OfferingsResultData(testOfferings, setOf(productId), emptySet()))
+
+        verify(exactly = 1) { cache.cacheOfferings(any(), any()) }
+    }
+
+    // endregion cache write invalidation guard
 
     // region onAppForeground
 
@@ -903,6 +949,24 @@ class OfferingsManagerTest {
                 lambda<(PurchasesError) -> Unit>().captured.invoke(error)
             }
         }
+    }
+
+    /**
+     * Captures the offerings factory `onSuccess` lambda without invoking it, so a test can drive the parse
+     * completion manually (simulating a fetch still in flight while the cache is cleared).
+     */
+    private fun captureFactoryOnSuccess(): CapturingSlot<(OfferingsResultData) -> Unit> {
+        val onSuccessSlot = slot<(OfferingsResultData) -> Unit>()
+        every {
+            offeringsFactory.createOfferings(
+                offeringsJSON = any(),
+                originalDataSource = any(),
+                loadedFromDiskCache = any(),
+                onError = any(),
+                onSuccess = capture(onSuccessSlot),
+            )
+        } just Runs
+        return onSuccessSlot
     }
 
     private fun mockBackendResponseSuccess(response: String = ONE_OFFERINGS_RESPONSE) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -109,7 +109,43 @@ class OfferingsManagerTest {
         offeringsManager.clearInMemoryOfferingsCache(invalidateInFlightFetches = true)
         onSuccessSlot.captured.invoke(OfferingsResultData(testOfferings, setOf(productId), emptySet()))
 
+        // The stale parse is dropped (a re-parse is issued instead, but its onSuccess is never fired here).
         verify(exactly = 0) { cache.cacheOfferings(any(), any()) }
+    }
+
+    @Test
+    fun `stale in-flight parse is re-parsed and only the decoded result is delivered and cached`() {
+        every { cache.clearInMemoryOfferingsCache() } just Runs
+        mockDeviceCache()
+        val onSuccessSlot = captureFactoryOnSuccess()
+
+        // Two distinguishable results: the in-flight parse (pre-disable, paywall components skipped) and the
+        // re-parse (post-disable, components decoded). Distinct instances so we can assert which one is used.
+        val staleOfferings = testOfferings.copy(current = null)
+        val decodedOfferings = testOfferings
+
+        var delivered: OfferingsResultData? = null
+        offeringsManager.fetchAndCacheOfferings(
+            appUserId,
+            appInBackground = false,
+            onSuccess = { delivered = it },
+        )
+
+        // Kill switch trips: invalidate in-flight fetches.
+        offeringsManager.clearInMemoryOfferingsCache(invalidateInFlightFetches = true)
+
+        // The in-flight (pre-disable) parse completes -> guard is stale -> a re-parse is issued.
+        onSuccessSlot.captured.invoke(OfferingsResultData(staleOfferings, setOf(productId), emptySet()))
+        // The re-parse completes -> generation now matches -> cached and delivered.
+        onSuccessSlot.captured.invoke(OfferingsResultData(decodedOfferings, setOf(productId), emptySet()))
+
+        assertThat(delivered).isNotNull
+        assertThat(delivered!!.offerings).isEqualTo(decodedOfferings)
+        verify(exactly = 2) {
+            offeringsFactory.createOfferings(any(), any(), any(), onError = any(), onSuccess = any())
+        }
+        verify(exactly = 1) { cache.cacheOfferings(decodedOfferings, any()) }
+        verify(exactly = 0) { cache.cacheOfferings(staleOfferings, any()) }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -689,14 +689,14 @@ class RemoteConfigManagerTest {
         val recorder = RecordingCommitListener()
         manager.registerListener(recorder)
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onError.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
         )
 
         // Further refreshes are no-ops (already disabled), so the disable signal must not fire again.
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         assertThat(recorder.disabled).containsExactly(1)
     }
@@ -725,7 +725,7 @@ class RemoteConfigManagerTest {
             }
         """.trimIndent()
 
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
 
         assertThat(recorder.disabled).isEmpty()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -684,6 +684,54 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `a 4xx disable signals onRemoteConfigDisabled exactly once`() {
+        every { diskCache.read() } returns null
+        val recorder = RecordingCommitListener()
+        manager.registerListener(recorder)
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
+
+        // Further refreshes are no-ops (already disabled), so the disable signal must not fire again.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+
+        assertThat(recorder.disabled).containsExactly(1)
+    }
+
+    @Test
+    fun `clearCache does not signal onRemoteConfigDisabled`() {
+        val recorder = RecordingCommitListener()
+        manager.registerListener(recorder)
+
+        manager.clearCache(TEST_APP_USER_ID)
+
+        assertThat(recorder.disabled).isEmpty()
+    }
+
+    @Test
+    fun `a normal commit does not signal onRemoteConfigDisabled`() {
+        every { diskCache.read() } returns null
+        val recorder = RecordingCommitListener()
+        manager.registerListener(recorder)
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1",
+              "active_topics": ["sources"],
+              "topics": { "sources": { "default": { "blob_ref": "b" } } }
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID)
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        assertThat(recorder.disabled).isEmpty()
+    }
+
+    @Test
     fun `committedTopicOrNull returns committed data without triggering a sync`() = runTest {
         every { diskCache.read() } returns persisted(
             manifest = "m",
@@ -2119,6 +2167,7 @@ class RemoteConfigManagerTest {
     private class RecordingCommitListener : RemoteConfigCommitListener {
         val committed = mutableListOf<Int>()
         val invalidated = mutableListOf<Int>()
+        val disabled = mutableListOf<Int>()
 
         override fun onConfigCommitted(generation: Int) {
             committed += generation
@@ -2126,6 +2175,10 @@ class RemoteConfigManagerTest {
 
         override fun onConfigInvalidated(generation: Int) {
             invalidated += generation
+        }
+
+        override fun onRemoteConfigDisabled(generation: Int) {
+            disabled += generation
         }
     }
 


### PR DESCRIPTION
## Description

Stacked on top of #3759.

With this PR, we won't keep the `Offering.paywallComponents` in memory if remote config is enabled. In case we get a killswitch from the config endpoint, we would refetch offerings but then keep it in memory on that attempt

We also add an instrumentation test to confirm the kill switch behaves as expected.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offerings parsing, caching, and paywall fallback when remote config is disabled—important for paywall display but scoped to workflows and covered by new unit/integration tests.
> 
> **Overview**
> When **workflows** are on and `/v1/config` is still enabled, offerings parsing **no longer retains** `paywallComponents` JSON in memory (components come from remote config instead). **`hasPaywall`** still reflects a components paywall via a new internal **`hasPaywallComponents`** presence flag.
> 
> If remote config hits a **session 4xx kill switch**, the SDK fires **`onRemoteConfigDisabled`**, **clears** the in-memory offerings cache (with a generation guard so stale in-flight parses cannot overwrite the cache), **refetches** offerings, and **captures** paywall components again for the fallback render path.
> 
> Integration tests can pass **`DangerousSettings`** (e.g. workflows) through **`configureSdk`**. A new **production integration test** fakes `/v1/config` to assert the skip-then-fallback behavior end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c7516ec2c69cafbe2f56ef9d8ea080510312745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->