### PR TITLE
feat(remote-config): force app_start on the first config request

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -1173,7 +1173,7 @@ internal class Backend(
         val path = endpoint.getPath()
         // Include the app user in the key: the path carries the domain but not the app_user_id (sent in the
         // request body), so concurrent calls for different users must not be deduped onto a single shared request.
-        val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path, appUserID, fetchContext.wireName), appInBackground)
+        val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path, appUserID), appInBackground)
 
         val baseURL = appConfig.baseURL
         // The manifest is an opaque token replayed verbatim; omitted on the first run when there is none.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -104,10 +104,10 @@ internal class RemoteConfigManager(
     @Volatile
     private var lastRefreshAttemptAt: Date? = null
 
-    // Forces the first committed request of the session to report AppStart, regardless of the caller's context, so
-    // the backend always sees app_start on a fresh app open. Guarded by [cacheLock]; set once when that request
-    // is committed.
-    private var hasCommittedInitialRequest = false
+    // Forces requests to report AppStart until the first one succeeds, regardless of the caller's context, so the
+    // backend always sees app_start on a fresh app open. Guarded by [cacheLock]; set when a request succeeds, so a
+    // failed attempt keeps forcing AppStart until a later attempt delivers it.
+    private var hasSucceededInitialRequest = false
 
     // The app user a cold on-demand read should sync for, rebound by clearCache() under [cacheLock] atomically
     // with the epoch bump, so it can never lag the identity change the way [appUserIDProvider] (backed by the
@@ -196,7 +196,7 @@ internal class RemoteConfigManager(
                     isRefreshing.set(true)
                     requestEpoch = epoch.get()
                     requestAppUserID = currentAppUserID ?: appUserID
-                    requestFetchContext = resolveCommittedFetchContext(fetchContext)
+                    requestFetchContext = fetchContextForRequest(fetchContext)
                     refreshCompletion = CompletableDeferred()
                     true
                 }
@@ -237,11 +237,19 @@ internal class RemoteConfigManager(
         return lastAttempt == null || Duration.between(lastAttempt, now) >= REFRESH_ATTEMPT_COOLDOWN
     }
 
-    // Overrides the first committed request's context to AppStart. Must be called within [cacheLock].
-    private fun resolveCommittedFetchContext(requested: RemoteConfigFetchContext): RemoteConfigFetchContext {
-        if (hasCommittedInitialRequest) return requested
-        hasCommittedInitialRequest = true
-        return RemoteConfigFetchContext.AppStart
+    // Overrides a request's context to AppStart until the first request succeeds. Must be called within [cacheLock].
+    private fun fetchContextForRequest(requested: RemoteConfigFetchContext): RemoteConfigFetchContext {
+        return if (hasSucceededInitialRequest) requested else RemoteConfigFetchContext.AppStart
+    }
+
+    // Records that a request succeeded so later requests stop being forced to AppStart. Drops stale successes whose
+    // epoch changed meanwhile (an identity change already reset the guard via [clearCache]).
+    private fun markInitialRequestSucceeded(requestEpoch: Int) {
+        synchronized(cacheLock) {
+            if (epoch.get() == requestEpoch) {
+                hasSucceededInitialRequest = true
+            }
+        }
     }
 
     /**
@@ -259,6 +267,7 @@ internal class RemoteConfigManager(
             // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
             return
         }
+        markInitialRequestSucceeded(requestEpoch)
         if (container == null) {
             handleNotModified(requestEpoch)
             return

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -104,10 +104,11 @@ internal class RemoteConfigManager(
     @Volatile
     private var lastRefreshAttemptAt: Date? = null
 
-    // Forces requests to report AppStart until the first one succeeds, regardless of the caller's context, so the
-    // backend always sees app_start on a fresh app open. Guarded by [cacheLock]; set when a request succeeds, so a
-    // failed attempt keeps forcing AppStart until a later attempt delivers it.
-    private var hasSucceededInitialRequest = false
+    // Forces requests to report AppStart until the session's first config is committed, regardless of the caller's
+    // context, so the backend always sees app_start on a fresh app open. Guarded by [cacheLock]; set only once config
+    // is durably committed (persisted from a 200 or the fallback) or confirmed current (204), so a failed request or
+    // an undecodable/unpersistable 200 keeps forcing AppStart until a later attempt actually commits config.
+    private var hasCommittedInitialConfig = false
 
     // The app user a cold on-demand read should sync for, rebound by clearCache() under [cacheLock] atomically
     // with the epoch bump, so it can never lag the identity change the way [appUserIDProvider] (backed by the
@@ -237,19 +238,10 @@ internal class RemoteConfigManager(
         return lastAttempt == null || Duration.between(lastAttempt, now) >= REFRESH_ATTEMPT_COOLDOWN
     }
 
-    // Overrides a request's context to AppStart until the first request succeeds. Must be called within [cacheLock].
+    // Overrides a request's context to AppStart until the session's first config is committed. Must be called within
+    // [cacheLock].
     private fun fetchContextForRequest(requested: RemoteConfigFetchContext): RemoteConfigFetchContext {
-        return if (hasSucceededInitialRequest) requested else RemoteConfigFetchContext.AppStart
-    }
-
-    // Records that a request succeeded so later requests stop being forced to AppStart. Drops stale successes whose
-    // epoch changed meanwhile (an identity change already reset the guard via [clearCache]).
-    private fun markInitialRequestSucceeded(requestEpoch: Int) {
-        synchronized(cacheLock) {
-            if (epoch.get() == requestEpoch) {
-                hasSucceededInitialRequest = true
-            }
-        }
+        return if (hasCommittedInitialConfig) requested else RemoteConfigFetchContext.AppStart
     }
 
     /**
@@ -267,7 +259,6 @@ internal class RemoteConfigManager(
             // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
             return
         }
-        markInitialRequestSucceeded(requestEpoch)
         if (container == null) {
             handleNotModified(requestEpoch)
             return
@@ -360,6 +351,7 @@ internal class RemoteConfigManager(
         synchronized(cacheLock) {
             if (epoch.get() == requestEpoch) {
                 lastRefreshedAt = dateProvider.now
+                hasCommittedInitialConfig = true
                 isRefreshing.set(false)
                 completeRefresh()
             }
@@ -786,6 +778,7 @@ internal class RemoteConfigManager(
 
         if (persisted) {
             lastRefreshedAt = dateProvider.now
+            hasCommittedInitialConfig = true
             debugLog {
                 "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +
                     "${blobRefsToKeep.size} blobs wanted)."

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -104,6 +104,11 @@ internal class RemoteConfigManager(
     @Volatile
     private var lastRefreshAttemptAt: Date? = null
 
+    // Forces the first committed request of the session to report AppStart, regardless of the caller's context, so
+    // the backend always sees app_start on a fresh app open. Guarded by [cacheLock]; set once when that request
+    // is committed.
+    private var hasCommittedInitialRequest = false
+
     // The app user a cold on-demand read should sync for, rebound by clearCache() under [cacheLock] atomically
     // with the epoch bump, so it can never lag the identity change the way [appUserIDProvider] (backed by the
     // device cache) can. Null until the first identity change; awaitConfigForRead() falls back to the provider
@@ -162,6 +167,7 @@ internal class RemoteConfigManager(
         }
         var requestEpoch = 0
         var requestAppUserID = appUserID
+        var requestFetchContext = fetchContext
         // Acquire the in-flight guard and capture the epoch together under the lock that also guards
         // clearCache()'s epoch bump + guard release. Otherwise an identity change could slip its bump
         // between getAndSet(true) and epoch.get(), stranding this request with a stale epoch: its
@@ -190,6 +196,7 @@ internal class RemoteConfigManager(
                     isRefreshing.set(true)
                     requestEpoch = epoch.get()
                     requestAppUserID = currentAppUserID ?: appUserID
+                    requestFetchContext = resolveCommittedFetchContext(fetchContext)
                     refreshCompletion = CompletableDeferred()
                     true
                 }
@@ -205,7 +212,7 @@ internal class RemoteConfigManager(
         backend.getRemoteConfig(
             appInBackground = appInBackground,
             appUserID = requestAppUserID,
-            fetchContext = fetchContext,
+            fetchContext = requestFetchContext,
             domain = domain,
             // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
             manifest = persisted?.manifest,
@@ -228,6 +235,13 @@ internal class RemoteConfigManager(
     private fun isRefreshAttemptCooldownElapsed(now: Date): Boolean {
         val lastAttempt = lastRefreshAttemptAt
         return lastAttempt == null || Duration.between(lastAttempt, now) >= REFRESH_ATTEMPT_COOLDOWN
+    }
+
+    // Overrides the first committed request's context to AppStart. Must be called within [cacheLock].
+    private fun resolveCommittedFetchContext(requested: RemoteConfigFetchContext): RemoteConfigFetchContext {
+        if (hasCommittedInitialRequest) return requested
+        hasCommittedInitialRequest = true
+        return RemoteConfigFetchContext.AppStart
     }
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -447,7 +447,7 @@ class BackendGetRemoteConfigTest {
     }
 
     @Test
-    fun `getRemoteConfig does not dedup concurrent calls for different fetch contexts`() {
+    fun `getRemoteConfig dedups concurrent calls with different fetch contexts`() {
         mockHttpResult(payload = HTTPResult.Payload.RCFormat(buildContainer()), delayMs = 200)
         val lock = CountDownLatch(2)
         asyncBackend.getRemoteConfig(
@@ -472,7 +472,8 @@ class BackendGetRemoteConfigTest {
         )
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
         assertThat(lock.count).isEqualTo(0)
-        verify(exactly = 2) {
+        // The fetch context is not part of the dedup key, so concurrent calls share a single request.
+        verify(exactly = 1) {
             httpClient.performRequest(
                 mockBaseURL,
                 Endpoint.GetRemoteConfig(testDomain),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -130,6 +130,56 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `the first request is forced to the app_start fetch context regardless of the requested context`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
+    }
+
+    @Test
+    fun `the first stale request is forced to the app_start fetch context regardless of the requested context`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfigIfStale(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.Foreground,
+        )
+
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
+    }
+
+    @Test
+    fun `only the first request is forced to the app_start fetch context`() {
+        every { diskCache.read() } returns null
+
+        // First committed request is forced to AppStart, even though IdentityChange was requested.
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+
+        // The next committed request reports its own context.
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.IdentityChange)
+    }
+
+    @Test
     fun `refreshRemoteConfigIfStale refreshes on the first call in a process`() {
         every { diskCache.read() } returns null
 
@@ -1180,12 +1230,20 @@ class RemoteConfigManagerTest {
         every { diskCache.write(any()) } answers { state = firstArg(); true }
         val manager = readManager(appUserIDProvider = { TEST_APP_USER_ID })
 
+        // The first committed request is forced to AppStart, so prime it before asserting the on-demand read's Read.
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
+        )
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+
         // Nothing is in flight and nothing is cached: the read triggers its own sync and waits for it.
         var result: ConfigTopic? = null
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             result = manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
         // The on-demand sync is issued as foreground for the current user with a read fetch context.
         assertThat(capturedAppUserID).isEqualTo(TEST_APP_USER_ID)
         assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.Read)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -217,6 +217,95 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `forcing stops once a 200 config is persisted`() {
+        every { diskCache.read() } returns null
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.sources:etag",
+              "active_topics": [],
+              "topics": {}
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
+        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.IdentityChange)
+    }
+
+    @Test
+    fun `a 200 that fails to parse keeps forcing app_start`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
+        // A 200 whose body fails to parse commits nothing, so the initial config is still not committed.
+        onSuccess.invoke(containerWithConfig("{ not valid json"), VerificationResult.VERIFIED)
+
+        // The next request must still be forced to AppStart, since no config landed yet.
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
+    }
+
+    @Test
+    fun `forcing stops once the fallback commits its config`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
+
+        // The main request fails on a cold cache, routing to the fallback, which commits its config.
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        onFallbackSuccess.invoke(
+            remoteConfiguration(
+                """
+                {
+                  "domain": "app",
+                  "manifest": "v1.fallback.sources:etag",
+                  "active_topics": [],
+                  "topics": {}
+                }
+                """.trimIndent(),
+            ),
+            VerificationResult.VERIFIED,
+        )
+
+        // The fallback commit counts as the initial config, so later requests report their own context.
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.IdentityChange)
+    }
+
+    @Test
     fun `refreshRemoteConfigIfStale refreshes on the first call in a process`() {
         every { diskCache.read() } returns null
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -180,6 +180,43 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `requests keep being forced to app_start until one succeeds`() {
+        every { diskCache.read() } returns null
+
+        // A failed first request must not consume the forced AppStart, so the next attempt is forced too.
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        onFallbackError.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
+
+        // Once a request succeeds, the forcing stops and later requests report their own context.
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.IdentityChange,
+        )
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.IdentityChange)
+    }
+
+    @Test
     fun `refreshRemoteConfigIfStale refreshes on the first call in a process`() {
         every { diskCache.read() } returns null
 

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/request_001.json
@@ -22,7 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigFallbackUser",
-    "fetch_context": "read",
+    "fetch_context": "app_start",
     "prefetched_blobs": []
   }
 }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/request_001.json
@@ -22,7 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
-    "fetch_context": "read",
+    "fetch_context": "app_start",
     "prefetched_blobs": []
   }
 }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/request_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/request_001.json
@@ -22,7 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
-    "fetch_context": "read",
+    "fetch_context": "app_start",
     "prefetched_blobs": []
   }
 }


### PR DESCRIPTION
### Motivation
On a fresh app open the backend should bypass its 30-min config cache. If another trigger (e.g. a `Read` from `getOfferings`) wins the race to send the first `/v1/config` request, the backend would only see that context and could serve stale config. Follow-up to the `fetch_context` work (#3768), per the team decision.

### Description
- `RemoteConfigManager` overrides the first committed request of the session to `AppStart`, regardless of the caller's context; subsequent requests report their real context.
- Removed `fetch_context` from the request dedup cache key, so concurrent requests differing only by context now coalesce.
- Added unit tests for the forced first request and that only the first one is overridden.

### Checklist
- [x] Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which `fetch_context` the backend receives on cold start and how concurrent config requests coalesce, which can affect server-side cache bypass and telemetry; behavior is well covered by new unit tests.
> 
> **Overview**
> Ensures the backend sees **`app_start`** on a fresh app open even when another trigger (e.g. a **`Read`** from offerings) wins the race to call `/v1/config`.
> 
> **`RemoteConfigManager`** tracks **`hasCommittedInitialConfig`** and, under **`cacheLock`**, overrides the outgoing **`fetch_context`** to **`AppStart`** until config is actually committed—a successful persist (200 or fallback), or a **204** that confirms the cache is current. Failed requests, unparseable 200s, or failed persists keep forcing **`AppStart`** on later attempts; after commit, callers’ real contexts are sent again.
> 
> **`Backend.getRemoteConfig`** drops **`fetch_context`** from the in-flight dedup key (still keyed by path + **`app_user_id`** + background flag), so concurrent config calls that differ only by context share one HTTP request. Tests and integration golden files were updated for **`app_start`** on cold first requests and for dedup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2869d89cd212a745bb576ee54331f2e65beeded7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->