### PR TITLE
test(remote-config): don't send app_start in no-content config tests

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -182,7 +182,12 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         val manifest = RemoteConfiguration.parse(rcContainer.config.data).manifest
 
         // Replaying that manifest with nothing changed server-side -> 204 (success, but no container to parse).
-        val (secondError, secondContainer, secondVerification) = fetchRemoteConfig(manifest = manifest)
+        // A non-app_start context is required: app_start forces a full resolve on the backend, bypassing the
+        // refresh-interval fast path that produces the 204 right after a successful sync.
+        val (secondError, secondContainer, secondVerification) = fetchRemoteConfig(
+            manifest = manifest,
+            fetchContext = RemoteConfigFetchContext.Read,
+        )
         assertThat(secondError).isNull()
         assertThat(secondContainer).isNull()
         assertThat(secondVerification).isEqualTo(VerificationResult.VERIFIED)
@@ -214,7 +219,12 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
 
         // The 204 carries no body, but its signature covers the request context. Under enforcement a verification
         // failure would surface as an error, so a null error with a VERIFIED result confirms the 204 was verified.
-        val (secondError, secondContainer, secondVerification) = fetchRemoteConfig(manifest = manifest)
+        // A non-app_start context is required: app_start forces a full resolve on the backend, bypassing the
+        // refresh-interval fast path that produces the 204 right after a successful sync.
+        val (secondError, secondContainer, secondVerification) = fetchRemoteConfig(
+            manifest = manifest,
+            fetchContext = RemoteConfigFetchContext.Read,
+        )
         assertThat(secondError).isNull()
         assertThat(secondContainer).isNull()
         assertThat(secondVerification).isEqualTo(VerificationResult.VERIFIED)
@@ -226,6 +236,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
      */
     private fun fetchRemoteConfig(
         manifest: String?,
+        fetchContext: RemoteConfigFetchContext = RemoteConfigFetchContext.AppStart,
         prefetchedBlobs: List<String> = emptyList(),
     ): Triple<PurchasesError?, RCContainer?, VerificationResult?> {
         every { appConfig.isDebugBuild } returns false
@@ -237,7 +248,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
             backend.getRemoteConfig(
                 appInBackground = false,
                 appUserID = "integrationTestRemoteConfigUser",
-                fetchContext = RemoteConfigFetchContext.AppStart,
+                fetchContext = fetchContext,
                 domain = "app",
                 manifest = manifest,
                 prefetchedBlobs = prefetchedBlobs,


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation

`ProductionRemoteConfigIntegrationTest` manifest-replay assertions fail on CI because they send `.appStart`, which the backend ([khepri#22748](https://github.com/RevenueCat/khepri/pull/22748)) deliberately uses to bypass the refresh-interval fast path — so the server does a full resolve and returns config instead of the expected `204`.

### Description

The two no-content tests now replay the manifest with a `.read` context, which the backend treats as a normal periodic sync and answers with no content. The initial-fetch tests keep `.appStart`. `fetchContext` is now an explicit parameter on the test helper.

iOS equivalent: RevenueCat/purchases-ios#7222

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to integration test fetch context; no production SDK behavior modified.
> 
> **Overview**
> Fixes flaky **production remote config integration tests** that assert a **204 no-content** response when replaying an unchanged manifest.
> 
> Those replay steps now call `fetchRemoteConfig` with **`RemoteConfigFetchContext.Read`** instead of the default **`AppStart`**. Backend behavior treats `app_start` as a full resolve (bypassing the refresh-interval fast path), so CI was getting **200** instead of **204**. Initial full-fetch tests still use **`AppStart`**.
> 
> The private helper **`fetchRemoteConfig`** gains an explicit **`fetchContext`** parameter (default unchanged) and forwards it to **`backend.getRemoteConfig`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d816b8d2939e5ea5daa4ef777e3c306528ae92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->