### PR TITLE
fix: store ETag cache payloads in files instead of SharedPreferences

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -24,7 +24,8 @@ internal data class ETagData(
 /**
  * Everything the ETag cache persists about a response except its payload, stored as a small flat JSON
  * under [ETagManager.metadataKey]; the payload lives in an [ETagPayloadStore] file. The versioned key
- * keeps downgrades safe: older SDKs only read the bare URL key and simply refetch.
+ * keeps downgrades safe: older SDKs only read the bare URL key and simply refetch, and anything they
+ * wrote there is swept at the next upgraded launch ([ETagManager.removeLegacyEntries]).
  *
  * `origin` is intentionally not persisted: stored results always read back as [HTTPResult.Origin.CACHE].
  */
@@ -124,7 +125,9 @@ internal data class ETagCacheMetadata(
 @Suppress("TooManyFunctions")
 internal class ETagManager(
     context: Context,
-    private val prefs: Lazy<SharedPreferences> = lazy { initializeSharedPreferences(context) },
+    private val prefs: Lazy<SharedPreferences> = lazy {
+        initializeSharedPreferences(context).also(::removeLegacyEntries)
+    },
     private val dateProvider: DateProvider = DefaultDateProvider(),
     private val payloadStore: ETagPayloadStore = ETagPayloadStore(context),
 ) {
@@ -247,7 +250,6 @@ internal class ETagManager(
         return prefs.value.getString(metadataKey(urlString), null)?.let { ETagCacheMetadata.deserialize(it) }
     }
 
-
     private fun shouldStoreBackendResult(resultFromBackend: HTTPResult): Boolean {
         val responseCode = resultFromBackend.responseCode
         return responseCode != RCHTTPStatusCodes.NOT_MODIFIED &&
@@ -271,6 +273,22 @@ internal class ETagManager(
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal fun metadataKey(urlString: String): String = METADATA_KEY_PREFIX + urlString
+
+        /**
+         * Removes entries from older SDK formats (bare URL keys), which are dropped rather than
+         * migrated: their values would otherwise stay parsed in the prefs in-memory map for the
+         * process lifetime. Runs on the already-loaded key set and never parses a value; the edit
+         * only happens when something is stale.
+         */
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal fun removeLegacyEntries(prefs: SharedPreferences) {
+            val legacyKeys = prefs.all.keys.filterNot { it.startsWith(METADATA_KEY_PREFIX) }
+            if (legacyKeys.isNotEmpty()) {
+                val editor = prefs.edit()
+                legacyKeys.forEach(editor::remove)
+                editor.apply()
+            }
+        }
 
         fun initializeSharedPreferences(context: Context): SharedPreferences =
             context.getSharedPreferences(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -22,9 +22,10 @@ internal data class ETagData(
 
 /**
  * Everything the ETag cache persists about a response except its payload. Stored as a small flat JSON
- * under the URL key, while the payload is stored verbatim under a separate key ([ETagManager.payloadKey])
- * so caching a large response never re-encodes a string we already hold in memory
- * (https://github.com/RevenueCat/purchases-android/issues/3628).
+ * under the URL key, while the payload is stored verbatim in a file ([ETagPayloadStore]) so caching a
+ * large response never re-encodes a string we already hold in memory
+ * (https://github.com/RevenueCat/purchases-android/issues/3628) nor retains it in the SharedPreferences
+ * in-memory map for the process lifetime.
  *
  * `origin` is intentionally not persisted: stored results always read back as [HTTPResult.Origin.CACHE].
  *
@@ -126,6 +127,7 @@ internal class ETagManager(
     context: Context,
     private val prefs: Lazy<SharedPreferences> = lazy { initializeSharedPreferences(context) },
     private val dateProvider: DateProvider = DefaultDateProvider(),
+    private val payloadStore: ETagPayloadStore = ETagPayloadStore(context),
 ) {
 
     internal fun getETagHeaders(
@@ -193,14 +195,32 @@ internal class ETagManager(
         val serialized = prefs.value.getString(urlString, null) ?: return null
         val metadata = ETagCacheMetadata.deserialize(serialized)
         if (metadata != null) {
-            // Read without the monitor: a concurrent storeResult() landing between the two getString calls can
-            // pair the old metadata with the new payload for this one read. The window is nanoseconds, requires
+            // Read without the monitor: a concurrent storeResult() landing between the metadata read and the
+            // payload read can pair the old metadata with the new payload for this one read. It requires
             // concurrent same-URL traffic, and the worst case is one response served with the previous entry's
             // metadata fields — accepted to keep reads lock-free.
-            val payload = prefs.value.getString(payloadKey(urlString), null) ?: return null
+            val payload = readPayload(urlString) ?: return null
             return metadata.toHTTPResult(payload)
         }
         return null
+    }
+
+    private fun readPayload(urlString: String): String? {
+        return payloadStore.read(urlString) ?: migratePrefsPayload(urlString)
+    }
+
+    /**
+     * An earlier release stored the payload under a second SharedPreferences key instead of a file.
+     * Move such payloads to the file store on first read; the prefs key is only removed once the file
+     * write is durable, so a failed write retries on the next read.
+     */
+    @Synchronized
+    private fun migratePrefsPayload(urlString: String): String? {
+        val prefsPayload = prefs.value.getString(payloadKey(urlString), null) ?: return null
+        if (payloadStore.write(urlString, prefsPayload)) {
+            prefs.value.edit().remove(payloadKey(urlString)).apply()
+        }
+        return prefsPayload
     }
 
     internal fun storeBackendResultIfNoError(
@@ -215,7 +235,10 @@ internal class ETagManager(
 
     @Synchronized
     internal fun clearCaches() {
+        // Prefs (metadata) first: a crash in between leaves orphan payload files, which are harmless and
+        // overwritten later, rather than metadata pointing at purged payloads.
         prefs.value.edit().clear().apply()
+        payloadStore.clear()
     }
 
     @Synchronized
@@ -225,19 +248,23 @@ internal class ETagManager(
         eTag: String,
     ) {
         val metadata = ETagCacheMetadata.fromResult(result, ETagData(eTag, dateProvider.now))
-        prefs.value.edit()
-            .putString(urlString, metadata.serialize())
-            // The payload is stored verbatim under its own key: embedding it inside the metadata JSON
-            // would re-escape a multi-MB string we already hold, which OOMed on large /offerings
-            // responses (https://github.com/RevenueCat/purchases-android/issues/3628).
-            .putString(payloadKey(urlString), result.payloadText)
-            .apply()
+        // Payload file first, and metadata only once that write is durable: metadata present must imply
+        // the payload was written. The payload lives in a file rather than in the prefs JSON because
+        // re-escaping a multi-MB string OOMed on large /offerings responses
+        // (https://github.com/RevenueCat/purchases-android/issues/3628), and SharedPreferences would keep
+        // it parsed in the app heap for the process lifetime.
+        if (payloadStore.write(urlString, result.payloadText)) {
+            prefs.value.edit()
+                .putString(urlString, metadata.serialize())
+                .apply()
+        }
     }
 
     private fun getStoredMetadata(urlString: String): ETagCacheMetadata? {
         val serialized = prefs.value.getString(urlString, null) ?: return null
         return ETagCacheMetadata.deserialize(serialized)
     }
+
 
     private fun shouldStoreBackendResult(resultFromBackend: HTTPResult): Boolean {
         val responseCode = resultFromBackend.responseCode
@@ -256,8 +283,10 @@ internal class ETagManager(
     }
 
     companion object {
-        // Cache keys are endpoint URLs from URL(baseURL, path).toString(), which never carry a '#'
-        // fragment, so this suffix cannot collide with another URL's entry.
+        // Where an earlier release kept the payload in SharedPreferences. Only read (and removed) by
+        // [migratePrefsPayload]; new payloads go to [ETagPayloadStore]. Cache keys are endpoint URLs
+        // from URL(baseURL, path).toString(), which never carry a '#' fragment, so this suffix cannot
+        // collide with another URL's entry.
         private const val PAYLOAD_KEY_SUFFIX = "#rc_payload"
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.strings.NetworkStrings
+import com.revenuecat.purchases.utils.optNullableLong
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Date
@@ -43,6 +44,12 @@ internal data class ETagCacheMetadata(
     val verificationResult: VerificationResult,
     val isLoadShedderResponse: Boolean,
     val isFallbackURL: Boolean,
+    /**
+     * Expected byte size of the stored payload file, used to detect files truncated by a power loss
+     * (payload writes are not fsynced). `null` skips the check (entries whose payload was migrated
+     * rather than freshly stored).
+     */
+    val payloadSizeBytes: Long? = null,
 ) {
     fun serialize(): String {
         return JSONObject().apply {
@@ -53,6 +60,7 @@ internal data class ETagCacheMetadata(
             put(SERIALIZATION_NAME_VERIFICATION_RESULT, verificationResult.name)
             put(SERIALIZATION_NAME_IS_LOAD_SHEDDER_RESPONSE, isLoadShedderResponse)
             put(SERIALIZATION_NAME_IS_FALLBACK_URL, isFallbackURL)
+            payloadSizeBytes?.let { put(SERIALIZATION_NAME_PAYLOAD_SIZE_BYTES, it) }
         }.toString()
     }
 
@@ -76,6 +84,7 @@ internal data class ETagCacheMetadata(
         private const val SERIALIZATION_NAME_VERIFICATION_RESULT = "verificationResult"
         private const val SERIALIZATION_NAME_IS_LOAD_SHEDDER_RESPONSE = "isLoadShedderResponse"
         private const val SERIALIZATION_NAME_IS_FALLBACK_URL = "isFallbackURL"
+        private const val SERIALIZATION_NAME_PAYLOAD_SIZE_BYTES = "payloadSizeBytes"
 
         fun fromResult(result: HTTPResult, eTagData: ETagData): ETagCacheMetadata {
             return ETagCacheMetadata(
@@ -111,6 +120,7 @@ internal data class ETagCacheMetadata(
                     verificationResult = verificationResult,
                     isLoadShedderResponse = jsonObject.optBoolean(SERIALIZATION_NAME_IS_LOAD_SHEDDER_RESPONSE, false),
                     isFallbackURL = jsonObject.optBoolean(SERIALIZATION_NAME_IS_FALLBACK_URL, false),
+                    payloadSizeBytes = jsonObject.optNullableLong(SERIALIZATION_NAME_PAYLOAD_SIZE_BYTES),
                 )
             } catch (e: JSONException) {
                 null
@@ -196,28 +206,39 @@ internal class ETagManager(
         val metadata = ETagCacheMetadata.deserialize(serialized)
         if (metadata != null) {
             // Read without the monitor: a concurrent storeResult() landing between the metadata read and the
-            // payload read can pair the old metadata with the new payload for this one read. It requires
-            // concurrent same-URL traffic, and the worst case is one response served with the previous entry's
-            // metadata fields — accepted to keep reads lock-free.
-            val payload = readPayload(urlString) ?: return null
+            // payload read makes the size check fail, so the worst case is one spurious cache miss (and its
+            // refresh retry) under concurrent same-URL traffic; accepted to keep reads lock-free. (Reads
+            // only take the monitor while an entry still needs migrating to the file store.)
+            val payload = readPayload(urlString, metadata) ?: return null
             return metadata.toHTTPResult(payload)
         }
         return null
     }
 
-    private fun readPayload(urlString: String): String? {
-        return payloadStore.read(urlString) ?: migratePrefsPayload(urlString)
+    /**
+     * The size check matters because a truncated payload would not read as a miss on its own: it fails
+     * to parse only downstream, where [HTTPResult.body] swallows the JSONException, and the server keeps
+     * answering 304 for its eTag, so the entry would error indefinitely instead of healing as a miss here.
+     */
+    private fun readPayload(urlString: String, metadata: ETagCacheMetadata): String? {
+        return payloadStore.read(urlString, metadata.payloadSizeBytes)
+            ?: migratePrefsPayload(urlString, metadata.payloadSizeBytes)
     }
 
     /**
-     * An earlier release stored the payload under a second SharedPreferences key instead of a file.
-     * Move such payloads to the file store on first read; the prefs key is only removed once the file
-     * write is durable, so a failed write retries on the next read.
+     * A release that included the split-prefs cache format but not this file store (if one ships between
+     * the two) stored the payload under a second SharedPreferences key. Move such payloads to the file
+     * store on first read; the prefs key is only removed once the file write succeeds, so a failed
+     * write retries on the next read.
      */
     @Synchronized
-    private fun migratePrefsPayload(urlString: String): String? {
-        val prefsPayload = prefs.value.getString(payloadKey(urlString), null) ?: return null
-        if (payloadStore.write(urlString, prefsPayload)) {
+    private fun migratePrefsPayload(urlString: String, expectedSizeBytes: Long?): String? {
+        // No prefs payload: re-check the file under the monitor, since a concurrent store or migration
+        // may have created it after the caller's lock-free read missed. The size check still applies:
+        // without it, a truncated file rejected by the caller would be served through this fallback.
+        val prefsPayload = prefs.value.getString(payloadKey(urlString), null)
+            ?: return payloadStore.read(urlString, expectedSizeBytes)
+        if (payloadStore.write(urlString, prefsPayload) != null) {
             prefs.value.edit().remove(payloadKey(urlString)).apply()
         }
         return prefsPayload
@@ -235,9 +256,10 @@ internal class ETagManager(
 
     @Synchronized
     internal fun clearCaches() {
-        // Prefs (metadata) first: a crash in between leaves orphan payload files, which are harmless and
-        // overwritten later, rather than metadata pointing at purged payloads.
-        prefs.value.edit().clear().apply()
+        // Prefs (metadata) first, and synchronously (commit, not apply): a crash in between then leaves
+        // orphan payload files, which are harmless and overwritten later, rather than metadata pointing
+        // at purged payloads.
+        prefs.value.edit().clear().commit()
         payloadStore.clear()
     }
 
@@ -247,17 +269,26 @@ internal class ETagManager(
         result: HTTPResult,
         eTag: String,
     ) {
-        val metadata = ETagCacheMetadata.fromResult(result, ETagData(eTag, dateProvider.now))
-        // Payload file first, and metadata only once that write is durable: metadata present must imply
-        // the payload was written. The payload lives in a file rather than in the prefs JSON because
-        // re-escaping a multi-MB string OOMed on large /offerings responses
-        // (https://github.com/RevenueCat/purchases-android/issues/3628), and SharedPreferences would keep
-        // it parsed in the app heap for the process lifetime.
-        if (payloadStore.write(urlString, result.payloadText)) {
-            prefs.value.edit()
-                .putString(urlString, metadata.serialize())
-                .apply()
-        }
+        persistEntry(
+            urlString,
+            ETagCacheMetadata.fromResult(result, ETagData(eTag, dateProvider.now)),
+            result.payloadText,
+        )
+    }
+
+    /**
+     * Persists a split-format entry: payload file first, and metadata only once that write succeeded, so
+     * metadata present always implies its payload was written. The metadata records the payload's byte
+     * size, which reads verify to catch files truncated by a power loss. The same edit drops any payload
+     * stored under the legacy prefs key, so a stale copy can neither linger in the prefs in-memory map nor
+     * be resurrected by [migratePrefsPayload] after the payload file is purged.
+     */
+    private fun persistEntry(urlString: String, metadata: ETagCacheMetadata, payload: String) {
+        val payloadSizeBytes = payloadStore.write(urlString, payload) ?: return
+        prefs.value.edit()
+            .putString(urlString, metadata.copy(payloadSizeBytes = payloadSizeBytes).serialize())
+            .remove(payloadKey(urlString))
+            .apply()
     }
 
     private fun getStoredMetadata(urlString: String): ETagCacheMetadata? {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -23,13 +23,10 @@ internal data class ETagData(
 
 /**
  * Everything the ETag cache persists about a response except its payload, stored as a small flat JSON
- * under the URL key; the payload lives in an [ETagPayloadStore] file.
+ * under [ETagManager.metadataKey]; the payload lives in an [ETagPayloadStore] file. The versioned key
+ * keeps downgrades safe: older SDKs only read the bare URL key and simply refetch.
  *
  * `origin` is intentionally not persisted: stored results always read back as [HTTPResult.Origin.CACHE].
- *
- * Downgrade note: older SDKs cannot parse this format and fail these entries as request errors (not
- * crashes) without self-healing until the cache is cleared, since the failure happens before any
- * response could overwrite the entry. Accepted tradeoff for keeping the URL as the metadata key.
  */
 @OptIn(InternalRevenueCatAPI::class)
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -194,17 +191,14 @@ internal class ETagManager(
 
     @Suppress("ReturnCount")
     internal fun getStoredResult(urlString: String): HTTPResult? {
-        val serialized = prefs.value.getString(urlString, null) ?: return null
-        val metadata = ETagCacheMetadata.deserialize(serialized)
-        if (metadata != null) {
-            // Lock-free read: a store racing between the metadata and payload reads fails the size check,
-            // costing one spurious miss plus its refresh retry. The size check itself is what turns a
-            // truncated file into a miss here: downstream, HTTPResult.body swallows the parse failure and
-            // the server keeps answering 304 for its eTag, so a bad entry would never heal.
-            val payload = payloadStore.read(urlString, metadata.payloadSizeBytes) ?: return null
-            return metadata.toHTTPResult(payload)
-        }
-        return null
+        val serialized = prefs.value.getString(metadataKey(urlString), null) ?: return null
+        val metadata = ETagCacheMetadata.deserialize(serialized) ?: return null
+        // Lock-free read: a store racing between the metadata and payload reads fails the size check,
+        // costing one spurious miss plus its refresh retry. The size check itself is what turns a
+        // truncated file into a miss here: downstream, HTTPResult.body swallows the parse failure and
+        // the server keeps answering 304 for its eTag, so a bad entry would never heal.
+        val payload = payloadStore.read(urlString, metadata.payloadSizeBytes) ?: return null
+        return metadata.toHTTPResult(payload)
     }
 
     internal fun storeBackendResultIfNoError(
@@ -245,13 +239,12 @@ internal class ETagManager(
     private fun persistEntry(urlString: String, metadata: ETagCacheMetadata, payload: String) {
         val payloadSizeBytes = payloadStore.write(urlString, payload) ?: return
         prefs.value.edit()
-            .putString(urlString, metadata.copy(payloadSizeBytes = payloadSizeBytes).serialize())
+            .putString(metadataKey(urlString), metadata.copy(payloadSizeBytes = payloadSizeBytes).serialize())
             .apply()
     }
 
     private fun getStoredMetadata(urlString: String): ETagCacheMetadata? {
-        val serialized = prefs.value.getString(urlString, null) ?: return null
-        return ETagCacheMetadata.deserialize(serialized)
+        return prefs.value.getString(metadataKey(urlString), null)?.let { ETagCacheMetadata.deserialize(it) }
     }
 
 
@@ -272,6 +265,13 @@ internal class ETagManager(
     }
 
     companion object {
+        // Downgrade safety: older SDKs look up the bare URL key, so versioned entries are inert to
+        // them and they simply refetch. URLs are always absolute, so no URL starts with "v2:".
+        private const val METADATA_KEY_PREFIX = "v2:"
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal fun metadataKey(urlString: String): String = METADATA_KEY_PREFIX + urlString
+
         fun initializeSharedPreferences(context: Context): SharedPreferences =
             context.getSharedPreferences(
                 "${context.packageName}_preferences_etags",

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -219,9 +219,9 @@ internal class ETagManager(
 
     @Synchronized
     internal fun clearCaches() {
-        // Metadata first, synchronously: a crash in between leaves harmless orphan payload files rather
-        // than metadata pointing at purged payloads.
-        prefs.value.edit().clear().commit()
+        // Metadata first: its in-memory clear is immediate, so readers miss before ever touching files.
+        // A crash before the async disk flush leaves metadata without payloads, a self-healing miss.
+        prefs.value.edit().clear().apply()
         payloadStore.clear()
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.common.networking
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.DateProvider
@@ -284,9 +285,7 @@ internal class ETagManager(
         internal fun removeLegacyEntries(prefs: SharedPreferences) {
             val legacyKeys = prefs.all.keys.filterNot { it.startsWith(METADATA_KEY_PREFIX) }
             if (legacyKeys.isNotEmpty()) {
-                val editor = prefs.edit()
-                legacyKeys.forEach(editor::remove)
-                editor.apply()
+                prefs.edit { legacyKeys.forEach(::remove) }
             }
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -22,18 +22,14 @@ internal data class ETagData(
 )
 
 /**
- * Everything the ETag cache persists about a response except its payload. Stored as a small flat JSON
- * under the URL key, while the payload is stored verbatim in a file ([ETagPayloadStore]) so caching a
- * large response never re-encodes a string we already hold in memory
- * (https://github.com/RevenueCat/purchases-android/issues/3628) nor retains it in the SharedPreferences
- * in-memory map for the process lifetime.
+ * Everything the ETag cache persists about a response except its payload, stored as a small flat JSON
+ * under the URL key; the payload lives in an [ETagPayloadStore] file.
  *
  * `origin` is intentionally not persisted: stored results always read back as [HTTPResult.Origin.CACHE].
  *
- * Downgrade note: older SDK versions cannot parse this format — after a downgrade, reads of split
- * entries fail (as request errors, not crashes) and do not self-heal until the cache is cleared
- * (e.g. identity change) since the failure happens before any response could overwrite the entry.
- * Accepted tradeoff for keeping the URL as the metadata key; see PR #3774.
+ * Downgrade note: older SDKs cannot parse this format and fail these entries as request errors (not
+ * crashes) without self-healing until the cache is cleared, since the failure happens before any
+ * response could overwrite the entry. Accepted tradeoff for keeping the URL as the metadata key.
  */
 @OptIn(InternalRevenueCatAPI::class)
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -44,10 +40,7 @@ internal data class ETagCacheMetadata(
     val verificationResult: VerificationResult,
     val isLoadShedderResponse: Boolean,
     val isFallbackURL: Boolean,
-    /**
-     * Expected byte size of the stored payload file, used to detect files truncated by a power loss
-     * (payload writes are not fsynced). `null` (absent from the serialized entry) skips the check.
-     */
+    /** Verified on read to detect truncated payload files; `null` skips the check. */
     val payloadSizeBytes: Long? = null,
 ) {
     fun serialize(): String {
@@ -204,14 +197,10 @@ internal class ETagManager(
         val serialized = prefs.value.getString(urlString, null) ?: return null
         val metadata = ETagCacheMetadata.deserialize(serialized)
         if (metadata != null) {
-            // Read without the monitor: a concurrent storeResult() landing between the metadata read and the
-            // payload read makes the size check fail, so the worst case is one spurious cache miss (and its
-            // refresh retry) under concurrent same-URL traffic; accepted to keep reads lock-free. (Reads
-            // only take the monitor while an entry still needs migrating to the file store.)
-            // The size check matters because a truncated payload would not read as a miss on its own: it
-            // fails to parse only downstream, where HTTPResult.body swallows the JSONException, and the
-            // server keeps answering 304 for its eTag, so the entry would error indefinitely instead of
-            // healing as a miss here.
+            // Lock-free read: a store racing between the metadata and payload reads fails the size check,
+            // costing one spurious miss plus its refresh retry. The size check itself is what turns a
+            // truncated file into a miss here: downstream, HTTPResult.body swallows the parse failure and
+            // the server keeps answering 304 for its eTag, so a bad entry would never heal.
             val payload = payloadStore.read(urlString, metadata.payloadSizeBytes) ?: return null
             return metadata.toHTTPResult(payload)
         }
@@ -230,9 +219,8 @@ internal class ETagManager(
 
     @Synchronized
     internal fun clearCaches() {
-        // Prefs (metadata) first, and synchronously (commit, not apply): a crash in between then leaves
-        // orphan payload files, which are harmless and overwritten later, rather than metadata pointing
-        // at purged payloads.
+        // Metadata first, synchronously: a crash in between leaves harmless orphan payload files rather
+        // than metadata pointing at purged payloads.
         prefs.value.edit().clear().commit()
         payloadStore.clear()
     }
@@ -251,9 +239,8 @@ internal class ETagManager(
     }
 
     /**
-     * Persists a split-format entry: payload file first, and metadata only once that write succeeded, so
-     * metadata present always implies its payload was written. The metadata records the payload's byte
-     * size, which reads verify to catch files truncated by a power loss.
+     * Payload file first, metadata only once that write succeeded: metadata present always implies its
+     * payload was written.
      */
     private fun persistEntry(urlString: String, metadata: ETagCacheMetadata, payload: String) {
         val payloadSizeBytes = payloadStore.write(urlString, payload) ?: return

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -46,8 +46,7 @@ internal data class ETagCacheMetadata(
     val isFallbackURL: Boolean,
     /**
      * Expected byte size of the stored payload file, used to detect files truncated by a power loss
-     * (payload writes are not fsynced). `null` skips the check (entries whose payload was migrated
-     * rather than freshly stored).
+     * (payload writes are not fsynced). `null` (absent from the serialized entry) skips the check.
      */
     val payloadSizeBytes: Long? = null,
 ) {
@@ -209,39 +208,14 @@ internal class ETagManager(
             // payload read makes the size check fail, so the worst case is one spurious cache miss (and its
             // refresh retry) under concurrent same-URL traffic; accepted to keep reads lock-free. (Reads
             // only take the monitor while an entry still needs migrating to the file store.)
-            val payload = readPayload(urlString, metadata) ?: return null
+            // The size check matters because a truncated payload would not read as a miss on its own: it
+            // fails to parse only downstream, where HTTPResult.body swallows the JSONException, and the
+            // server keeps answering 304 for its eTag, so the entry would error indefinitely instead of
+            // healing as a miss here.
+            val payload = payloadStore.read(urlString, metadata.payloadSizeBytes) ?: return null
             return metadata.toHTTPResult(payload)
         }
         return null
-    }
-
-    /**
-     * The size check matters because a truncated payload would not read as a miss on its own: it fails
-     * to parse only downstream, where [HTTPResult.body] swallows the JSONException, and the server keeps
-     * answering 304 for its eTag, so the entry would error indefinitely instead of healing as a miss here.
-     */
-    private fun readPayload(urlString: String, metadata: ETagCacheMetadata): String? {
-        return payloadStore.read(urlString, metadata.payloadSizeBytes)
-            ?: migratePrefsPayload(urlString, metadata.payloadSizeBytes)
-    }
-
-    /**
-     * A release that included the split-prefs cache format but not this file store (if one ships between
-     * the two) stored the payload under a second SharedPreferences key. Move such payloads to the file
-     * store on first read; the prefs key is only removed once the file write succeeds, so a failed
-     * write retries on the next read.
-     */
-    @Synchronized
-    private fun migratePrefsPayload(urlString: String, expectedSizeBytes: Long?): String? {
-        // No prefs payload: re-check the file under the monitor, since a concurrent store or migration
-        // may have created it after the caller's lock-free read missed. The size check still applies:
-        // without it, a truncated file rejected by the caller would be served through this fallback.
-        val prefsPayload = prefs.value.getString(payloadKey(urlString), null)
-            ?: return payloadStore.read(urlString, expectedSizeBytes)
-        if (payloadStore.write(urlString, prefsPayload) != null) {
-            prefs.value.edit().remove(payloadKey(urlString)).apply()
-        }
-        return prefsPayload
     }
 
     internal fun storeBackendResultIfNoError(
@@ -279,15 +253,12 @@ internal class ETagManager(
     /**
      * Persists a split-format entry: payload file first, and metadata only once that write succeeded, so
      * metadata present always implies its payload was written. The metadata records the payload's byte
-     * size, which reads verify to catch files truncated by a power loss. The same edit drops any payload
-     * stored under the legacy prefs key, so a stale copy can neither linger in the prefs in-memory map nor
-     * be resurrected by [migratePrefsPayload] after the payload file is purged.
+     * size, which reads verify to catch files truncated by a power loss.
      */
     private fun persistEntry(urlString: String, metadata: ETagCacheMetadata, payload: String) {
         val payloadSizeBytes = payloadStore.write(urlString, payload) ?: return
         prefs.value.edit()
             .putString(urlString, metadata.copy(payloadSizeBytes = payloadSizeBytes).serialize())
-            .remove(payloadKey(urlString))
             .apply()
     }
 
@@ -314,15 +285,6 @@ internal class ETagManager(
     }
 
     companion object {
-        // Where an earlier release kept the payload in SharedPreferences. Only read (and removed) by
-        // [migratePrefsPayload]; new payloads go to [ETagPayloadStore]. Cache keys are endpoint URLs
-        // from URL(baseURL, path).toString(), which never carry a '#' fragment, so this suffix cannot
-        // collide with another URL's entry.
-        private const val PAYLOAD_KEY_SUFFIX = "#rc_payload"
-
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-        internal fun payloadKey(urlString: String): String = "$urlString$PAYLOAD_KEY_SUFFIX"
-
         fun initializeSharedPreferences(context: Context): SharedPreferences =
             context.getSharedPreferences(
                 "${context.packageName}_preferences_etags",

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.models.Checksum
+import java.io.DataInputStream
 import java.io.File
+import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
@@ -62,20 +64,27 @@ internal class ETagPayloadStore(
      * Returns the payload, or `null` for a miss: no file, undecodable bytes, or a size mismatch
      * against [expectedSizeBytes] (the size [write] returned; `null` skips the check).
      */
-    @Suppress("SwallowedException")
+    @Suppress("SwallowedException", "ReturnCount")
     fun read(urlString: String, expectedSizeBytes: Long? = null): String? {
-        val file = fileFor(urlString)
         return try {
-            if (expectedSizeBytes != null && file.length() != expectedSizeBytes) {
-                return null
+            FileInputStream(fileFor(urlString)).use { input ->
+                // The open descriptor pins one file identity, so a concurrent rename cannot swap the
+                // payload between the size check and the read.
+                val sizeBytes = input.channel.size()
+                val size = sizeBytes.toInt()
+                if ((expectedSizeBytes != null && sizeBytes != expectedSizeBytes) || size.toLong() != sizeBytes) {
+                    return null
+                }
+                val bytes = ByteArray(size)
+                DataInputStream(input).readFully(bytes)
+                // Strict decoding (unlike String(bytes), which silently substitutes U+FFFD) so a corrupt
+                // file reads back as a cache miss instead of serving garbage as a valid cached response.
+                Charsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes))
+                    .toString()
             }
-            // Strict decoding (unlike String(bytes), which silently substitutes U+FFFD) so a corrupt file
-            // reads back as a cache miss instead of serving garbage as a valid cached response.
-            Charsets.UTF_8.newDecoder()
-                .onMalformedInput(CodingErrorAction.REPORT)
-                .onUnmappableCharacter(CodingErrorAction.REPORT)
-                .decode(ByteBuffer.wrap(file.readBytes()))
-                .toString()
         } catch (e: FileNotFoundException) {
             // No payload for this URL: a plain cache miss, not an error.
             null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
@@ -11,6 +11,7 @@ import java.io.IOException
 import java.io.OutputStream
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
+import java.nio.charset.CoderResult
 import java.nio.charset.CodingErrorAction
 
 /**
@@ -100,34 +101,57 @@ internal class ETagPayloadStore(
     }
 
     /**
-     * UTF-8 encodes [payload] into [out] through a fixed-size buffer. A plain `Writer.write(String)`
+     * UTF-8 encodes [payload] into [out] through fixed-size buffers. A plain `Writer.write(String)`
      * copies the whole string into a fresh `char[]` first, a payload-sized allocation, the exact cost
-     * this store exists to avoid; `CharBuffer.wrap` reads the string in place. Encoding is strict
-     * (REPORT, matching [read]'s decoder): a payload the encoder cannot represent fails the write and
-     * stays uncached, rather than being silently altered.
+     * this store exists to avoid. The string is copied through a fixed `char[]` chunk instead of
+     * `CharBuffer.wrap(payload)`: a wrapped string is not array-backed, which forces the encoder off its
+     * fast array loop into per-char access. Encoding is strict (REPORT, matching [read]'s decoder): a
+     * payload the encoder cannot represent fails the write and stays uncached, rather than being
+     * silently altered.
      */
     private fun encodeTo(out: OutputStream, payload: String) {
         val encoder = Charsets.UTF_8.newEncoder()
             .onMalformedInput(CodingErrorAction.REPORT)
             .onUnmappableCharacter(CodingErrorAction.REPORT)
-        val charBuffer = CharBuffer.wrap(payload)
+        val chunk = CharArray(CHUNK_CHARS)
+        val charBuffer = CharBuffer.wrap(chunk)
+        // Sized so a full chunk always encodes in one pass (UTF-8 is at most 3 bytes per UTF-16 char).
         val byteBuffer = ByteBuffer.allocate(WRITE_BUFFER_BYTES)
-        var encoded = false
+        var payloadPosition = 0
+        // Chars the encoder left unconsumed at a chunk edge (a high surrogate whose pair is in the next
+        // chunk); carried to the front of the next chunk so pairs are never encoded split.
+        var carriedChars = 0
+        do {
+            val charsToCopy = minOf(chunk.size - carriedChars, payload.length - payloadPosition)
+            payload.toCharArray(chunk, carriedChars, payloadPosition, payloadPosition + charsToCopy)
+            payloadPosition += charsToCopy
+            val isLastChunk = payloadPosition == payload.length
+            charBuffer.position(0)
+            charBuffer.limit(carriedChars + charsToCopy)
+            drainInto(out, byteBuffer) { encoder.encode(charBuffer, byteBuffer, isLastChunk) }
+            carriedChars = charBuffer.remaining()
+            if (carriedChars > 0) {
+                System.arraycopy(chunk, charBuffer.position(), chunk, 0, carriedChars)
+            }
+        } while (payloadPosition < payload.length)
+        drainInto(out, byteBuffer) { encoder.flush(byteBuffer) }
+    }
+
+    /** Runs [step] until it reports underflow, writing whatever it put in [byteBuffer] after each round. */
+    private inline fun drainInto(out: OutputStream, byteBuffer: ByteBuffer, step: () -> CoderResult) {
         while (true) {
-            val result = if (!encoded) encoder.encode(charBuffer, byteBuffer, true) else encoder.flush(byteBuffer)
+            val result = step()
             if (result.isError) result.throwException()
             out.write(byteBuffer.array(), 0, byteBuffer.position())
             byteBuffer.clear()
-            if (result.isUnderflow) {
-                if (encoded) break
-                encoded = true
-            }
+            if (result.isUnderflow) return
         }
     }
 
     private companion object {
         const val DIRECTORY_NAME = "rc_etag_payloads"
         const val TEMP_SUFFIX = ".tmp"
-        const val WRITE_BUFFER_BYTES = 64 * 1024
+        const val CHUNK_CHARS = 64 * 1024
+        const val WRITE_BUFFER_BYTES = 256 * 1024
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
@@ -15,27 +15,17 @@ import java.nio.charset.CoderResult
 import java.nio.charset.CodingErrorAction
 
 /**
- * Stores ETag cache payloads as one file per URL under a cache directory, so caching a multi-MB response
- * costs neither JSON re-encoding nor permanent heap retention (SharedPreferences keeps its whole file parsed
- * in memory for the process lifetime; see https://github.com/RevenueCat/purchases-android/issues/3628).
+ * Stores ETag cache payloads as one file per URL, so multi-MB payloads are neither re-encoded nor
+ * retained in the SharedPreferences heap map (https://github.com/RevenueCat/purchases-android/issues/3628).
  *
- * Writes encode straight from the payload string into a fixed-size buffer, so storing never allocates
- * payload-sized memory. Each write goes to a temporary file that is atomically renamed over the final one,
- * so readers only ever see complete payloads: a read concurrent with a write serves the previous complete
- * payload. (androidx AtomicFile is deliberately not used: its openRead mutates the filesystem, deleting a
- * concurrent writer's in-flight file, and its finishWrite reports rename failures only to logcat.)
+ * Writes stream through fixed-size buffers into a temp file committed by atomic rename (androidx
+ * AtomicFile is unsafe here: its openRead deletes a concurrent writer's in-flight file and its
+ * finishWrite hides rename failures). Writes are not fsynced; callers verify the size [write] returns
+ * on [read] instead, turning files truncated by power loss into misses. A stale same-length file is
+ * accepted: it serves the previous complete payload.
  *
- * Writes are deliberately not fsynced, keeping disk latency off the request path. A power loss shortly
- * after a write can therefore leave a truncated file behind; callers guard against that by recording the
- * size [write] returns and passing it back to [read], which verifies it against the file. (The other
- * power-loss residue, a stale same-length file behind fresher metadata, is accepted: it is the complete
- * previous payload and simply serves as a stale response until the content next changes.)
- *
- * Reads return the payload string, or `null` for a missing/truncated/unreadable file, which callers treat
- * as a cache miss ([ETagManager]'s existing self-heal contract). Living under [Context.getCacheDir] means
- * the system may purge files under storage pressure; that also reads back as a miss.
- *
- * No eviction beyond per-URL overwrite and [clear]: parity with the SharedPreferences store it replaces.
+ * `null` reads are cache misses that self-heal via [ETagManager]'s refresh retry; the OS may purge
+ * [Context.getCacheDir]. No eviction beyond overwrite and [clear], at parity with the prefs store.
  */
 @OptIn(InternalRevenueCatAPI::class)
 internal class ETagPayloadStore(
@@ -53,9 +43,8 @@ internal class ETagPayloadStore(
             return null
         }
         val file = fileFor(urlString)
-        // One temp file per target, overwritten by the next write and removed by the rename on success,
-        // so a crash mid-write leaves at most one orphan that self-cleans. Writes for the same URL never
-        // run concurrently ([ETagManager] serializes them), and readers never open temp files.
+        // Never opened by readers; a crash mid-write leaves one orphan that the next write overwrites.
+        // Same-URL writes are serialized by [ETagManager].
         val tempFile = File(directory, file.name + TEMP_SUFFIX)
         return try {
             FileOutputStream(tempFile).use { out -> encodeTo(out, payload) }
@@ -67,15 +56,14 @@ internal class ETagPayloadStore(
     }
 
     /**
-     * Returns the payload for [urlString], or `null` for a miss: no file, a size mismatch against
-     * [expectedSizeBytes] (pass the size [write] returned; `null` skips the check), or undecodable bytes.
+     * Returns the payload, or `null` for a miss: no file, undecodable bytes, or a size mismatch
+     * against [expectedSizeBytes] (the size [write] returned; `null` skips the check).
      */
     @Suppress("SwallowedException")
     fun read(urlString: String, expectedSizeBytes: Long? = null): String? {
         val file = fileFor(urlString)
         return try {
             if (expectedSizeBytes != null && file.length() != expectedSizeBytes) {
-                // Truncated by a power loss (writes are not fsynced) or otherwise tampered with.
                 return null
             }
             // Strict decoding (unlike String(bytes), which silently substitutes U+FFFD) so a corrupt file
@@ -101,13 +89,9 @@ internal class ETagPayloadStore(
     }
 
     /**
-     * UTF-8 encodes [payload] into [out] through fixed-size buffers. A plain `Writer.write(String)`
-     * copies the whole string into a fresh `char[]` first, a payload-sized allocation, the exact cost
-     * this store exists to avoid. The string is copied through a fixed `char[]` chunk instead of
-     * `CharBuffer.wrap(payload)`: a wrapped string is not array-backed, which forces the encoder off its
-     * fast array loop into per-char access. Encoding is strict (REPORT, matching [read]'s decoder): a
-     * payload the encoder cannot represent fails the write and stays uncached, rather than being
-     * silently altered.
+     * Streams [payload] to [out] via a `char[]` chunk: `CharBuffer.wrap(payload)` has no backing array,
+     * which forces the encoder off its fast path and measured a >60x slower store on ART. REPORT so an
+     * unencodable payload fails the write instead of being silently altered.
      */
     private fun encodeTo(out: OutputStream, payload: String) {
         val encoder = Charsets.UTF_8.newEncoder()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
@@ -1,0 +1,109 @@
+package com.revenuecat.purchases.common.networking
+
+import android.content.Context
+import androidx.core.util.AtomicFile
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.models.toHexString
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.io.OutputStream
+import java.nio.ByteBuffer
+import java.nio.CharBuffer
+import java.nio.charset.CodingErrorAction
+import java.security.MessageDigest
+
+/**
+ * Stores ETag cache payloads as one file per URL under a cache directory, so caching a multi-MB response
+ * costs neither JSON re-encoding nor permanent heap retention (SharedPreferences keeps its whole file parsed
+ * in memory for the process lifetime; see https://github.com/RevenueCat/purchases-android/issues/3628).
+ *
+ * Writes are atomic and crash-safe via [AtomicFile] and encode straight from the payload string into a
+ * fixed-size buffer, so storing never allocates payload-sized memory. Reads return the payload string, or
+ * `null` for a missing/unreadable file, which callers treat as a cache miss ([ETagManager]'s existing
+ * self-heal contract). Living under [Context.getCacheDir] means the system may purge files under storage
+ * pressure; that also reads back as a miss.
+ *
+ * No eviction beyond per-URL overwrite and [clear] — parity with the SharedPreferences store it replaces.
+ */
+internal class ETagPayloadStore(
+    private val directory: File,
+) {
+    constructor(context: Context) : this(File(context.cacheDir, DIRECTORY_NAME))
+
+    /** Returns `true` once the payload is durably on disk; callers must not persist metadata otherwise. */
+    @Suppress("ReturnCount")
+    fun write(urlString: String, payload: String): Boolean {
+        if (!directory.exists() && !directory.mkdirs()) {
+            errorLog { "Failed to create ETag payload directory: $directory" }
+            return false
+        }
+        val atomicFile = AtomicFile(fileFor(urlString))
+        return try {
+            val out = atomicFile.startWrite()
+            try {
+                encodeTo(out, payload)
+                atomicFile.finishWrite(out)
+            } catch (e: IOException) {
+                atomicFile.failWrite(out)
+                throw e
+            }
+            true
+        } catch (e: IOException) {
+            errorLog(e) { "Failed to persist ETag payload to disk." }
+            false
+        }
+    }
+
+    @Suppress("SwallowedException")
+    fun read(urlString: String): String? {
+        val atomicFile = AtomicFile(fileFor(urlString))
+        return try {
+            String(atomicFile.readFully(), Charsets.UTF_8)
+        } catch (e: FileNotFoundException) {
+            // No payload for this URL — a plain cache miss, not an error.
+            null
+        } catch (e: IOException) {
+            errorLog(e) { "Failed to read ETag payload from disk." }
+            null
+        }
+    }
+
+    fun clear() {
+        directory.deleteRecursively()
+    }
+
+    private fun fileFor(urlString: String): File {
+        val hash = MessageDigest.getInstance("SHA-256").digest(urlString.toByteArray()).toHexString()
+        return File(directory, hash)
+    }
+
+    /**
+     * UTF-8 encodes [payload] into [out] through a fixed-size buffer. A plain `Writer.write(String)` copies
+     * the whole string into a fresh `char[]` first — a payload-sized allocation, the exact cost this store
+     * exists to avoid — while `CharBuffer.wrap` reads the string in place.
+     */
+    private fun encodeTo(out: OutputStream, payload: String) {
+        val encoder = Charsets.UTF_8.newEncoder()
+            .onMalformedInput(CodingErrorAction.REPLACE)
+            .onUnmappableCharacter(CodingErrorAction.REPLACE)
+        val charBuffer = CharBuffer.wrap(payload)
+        val byteBuffer = ByteBuffer.allocate(WRITE_BUFFER_BYTES)
+        var encoded = false
+        while (true) {
+            val result = if (!encoded) encoder.encode(charBuffer, byteBuffer, true) else encoder.flush(byteBuffer)
+            if (result.isError) result.throwException()
+            out.write(byteBuffer.array(), 0, byteBuffer.position())
+            byteBuffer.clear()
+            if (result.isUnderflow) {
+                if (encoded) break
+                encoded = true
+            }
+        }
+    }
+
+    private companion object {
+        const val DIRECTORY_NAME = "rc_etag_payloads"
+        const val WRITE_BUFFER_BYTES = 64 * 1024
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
@@ -38,9 +38,12 @@ internal class ETagPayloadStore(
      * callers must not persist metadata for a failed write.
      */
     fun write(urlString: String, payload: String): Long? {
-        if (!directory.exists() && !directory.mkdirs()) {
-            errorLog { "Failed to create ETag payload directory: $directory" }
-            return null
+        if (!directory.exists()) {
+            deleteTrash()
+            if (!directory.mkdirs()) {
+                errorLog { "Failed to create ETag payload directory: $directory" }
+                return null
+            }
         }
         val file = fileFor(urlString)
         // Never opened by readers; a crash mid-write leaves one orphan that the next write overwrites.
@@ -81,7 +84,19 @@ internal class ETagPayloadStore(
     }
 
     fun clear() {
-        directory.deleteRecursively()
+        // Renaming is a constant-time metadata op, safe on the main thread (configure, logIn/logOut);
+        // the trashed directory is deleted by the next write, which runs on a background thread.
+        if (!directory.exists()) return
+        val trash = File(directory.parentFile, directory.name + TRASH_SUFFIX + System.nanoTime())
+        if (!directory.renameTo(trash)) {
+            directory.deleteRecursively()
+        }
+    }
+
+    private fun deleteTrash() {
+        directory.parentFile
+            ?.listFiles { file -> file.name.startsWith(directory.name + TRASH_SUFFIX) }
+            ?.forEach { it.deleteRecursively() }
     }
 
     private fun fileFor(urlString: String): File {
@@ -135,6 +150,7 @@ internal class ETagPayloadStore(
     private companion object {
         const val DIRECTORY_NAME = "rc_etag_payloads"
         const val TEMP_SUFFIX = ".tmp"
+        const val TRASH_SUFFIX = ".trash"
         const val CHUNK_CHARS = 64 * 1024
         const val WRITE_BUFFER_BYTES = 256 * 1024
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
@@ -1,67 +1,89 @@
 package com.revenuecat.purchases.common.networking
 
 import android.content.Context
-import androidx.core.util.AtomicFile
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.errorLog
-import com.revenuecat.purchases.models.toHexString
+import com.revenuecat.purchases.models.Checksum
 import java.io.File
 import java.io.FileNotFoundException
+import java.io.FileOutputStream
 import java.io.IOException
 import java.io.OutputStream
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
 import java.nio.charset.CodingErrorAction
-import java.security.MessageDigest
 
 /**
  * Stores ETag cache payloads as one file per URL under a cache directory, so caching a multi-MB response
  * costs neither JSON re-encoding nor permanent heap retention (SharedPreferences keeps its whole file parsed
  * in memory for the process lifetime; see https://github.com/RevenueCat/purchases-android/issues/3628).
  *
- * Writes are atomic and crash-safe via [AtomicFile] and encode straight from the payload string into a
- * fixed-size buffer, so storing never allocates payload-sized memory. Reads return the payload string, or
- * `null` for a missing/unreadable file, which callers treat as a cache miss ([ETagManager]'s existing
- * self-heal contract). Living under [Context.getCacheDir] means the system may purge files under storage
- * pressure; that also reads back as a miss.
+ * Writes encode straight from the payload string into a fixed-size buffer, so storing never allocates
+ * payload-sized memory. Each write goes to a temporary file that is atomically renamed over the final one,
+ * so readers only ever see complete payloads: a read concurrent with a write serves the previous complete
+ * payload. (androidx AtomicFile is deliberately not used: its openRead mutates the filesystem, deleting a
+ * concurrent writer's in-flight file, and its finishWrite reports rename failures only to logcat.)
  *
- * No eviction beyond per-URL overwrite and [clear] — parity with the SharedPreferences store it replaces.
+ * Writes are deliberately not fsynced, keeping disk latency off the request path. A power loss shortly
+ * after a write can therefore leave a truncated file behind; callers guard against that by recording the
+ * size [write] returns and passing it back to [read], which verifies it against the file. (The other
+ * power-loss residue, a stale same-length file behind fresher metadata, is accepted: it is the complete
+ * previous payload and simply serves as a stale response until the content next changes.)
+ *
+ * Reads return the payload string, or `null` for a missing/truncated/unreadable file, which callers treat
+ * as a cache miss ([ETagManager]'s existing self-heal contract). Living under [Context.getCacheDir] means
+ * the system may purge files under storage pressure; that also reads back as a miss.
+ *
+ * No eviction beyond per-URL overwrite and [clear]: parity with the SharedPreferences store it replaces.
  */
+@OptIn(InternalRevenueCatAPI::class)
 internal class ETagPayloadStore(
     private val directory: File,
 ) {
     constructor(context: Context) : this(File(context.cacheDir, DIRECTORY_NAME))
 
-    /** Returns `true` once the payload is durably on disk; callers must not persist metadata otherwise. */
-    @Suppress("ReturnCount")
-    fun write(urlString: String, payload: String): Boolean {
+    /**
+     * Returns the payload's size in bytes once the file is in place, or `null` when the write failed;
+     * callers must not persist metadata for a failed write.
+     */
+    fun write(urlString: String, payload: String): Long? {
         if (!directory.exists() && !directory.mkdirs()) {
             errorLog { "Failed to create ETag payload directory: $directory" }
-            return false
+            return null
         }
-        val atomicFile = AtomicFile(fileFor(urlString))
+        val file = fileFor(urlString)
+        // One temp file per target, overwritten by the next write and removed by the rename on success,
+        // so a crash mid-write leaves at most one orphan that self-cleans. Writes for the same URL never
+        // run concurrently ([ETagManager] serializes them), and readers never open temp files.
+        val tempFile = File(directory, file.name + TEMP_SUFFIX)
         return try {
-            val out = atomicFile.startWrite()
-            try {
-                encodeTo(out, payload)
-                atomicFile.finishWrite(out)
-            } catch (e: IOException) {
-                atomicFile.failWrite(out)
-                throw e
-            }
-            true
+            FileOutputStream(tempFile).use { out -> encodeTo(out, payload) }
+            if (tempFile.renameTo(file)) file.length() else null
         } catch (e: IOException) {
             errorLog(e) { "Failed to persist ETag payload to disk." }
-            false
+            null
         }
     }
 
+    /**
+     * Returns the payload for [urlString], or `null` for a miss: no file, a size mismatch against
+     * [expectedSizeBytes] (pass the size [write] returned; `null` skips the check), or undecodable bytes.
+     */
     @Suppress("SwallowedException")
-    fun read(urlString: String): String? {
-        val atomicFile = AtomicFile(fileFor(urlString))
+    fun read(urlString: String, expectedSizeBytes: Long? = null): String? {
+        val file = fileFor(urlString)
         return try {
-            String(atomicFile.readFully(), Charsets.UTF_8)
+            if (expectedSizeBytes != null && file.length() != expectedSizeBytes) {
+                // Truncated by a power loss (writes are not fsynced) or otherwise tampered with.
+                return null
+            }
+            // Strict decoding (unlike String(bytes), which silently substitutes U+FFFD) so a corrupt file
+            // reads back as a cache miss instead of serving garbage as a valid cached response.
+            Charsets.UTF_8.newDecoder()
+                .decode(ByteBuffer.wrap(file.readBytes()))
+                .toString()
         } catch (e: FileNotFoundException) {
-            // No payload for this URL — a plain cache miss, not an error.
+            // No payload for this URL: a plain cache miss, not an error.
             null
         } catch (e: IOException) {
             errorLog(e) { "Failed to read ETag payload from disk." }
@@ -74,19 +96,20 @@ internal class ETagPayloadStore(
     }
 
     private fun fileFor(urlString: String): File {
-        val hash = MessageDigest.getInstance("SHA-256").digest(urlString.toByteArray()).toHexString()
-        return File(directory, hash)
+        return File(directory, Checksum.generate(urlString.toByteArray(), Checksum.Algorithm.SHA256).value)
     }
 
     /**
-     * UTF-8 encodes [payload] into [out] through a fixed-size buffer. A plain `Writer.write(String)` copies
-     * the whole string into a fresh `char[]` first — a payload-sized allocation, the exact cost this store
-     * exists to avoid — while `CharBuffer.wrap` reads the string in place.
+     * UTF-8 encodes [payload] into [out] through a fixed-size buffer. A plain `Writer.write(String)`
+     * copies the whole string into a fresh `char[]` first, a payload-sized allocation, the exact cost
+     * this store exists to avoid; `CharBuffer.wrap` reads the string in place. Encoding is strict
+     * (REPORT, matching [read]'s decoder): a payload the encoder cannot represent fails the write and
+     * stays uncached, rather than being silently altered.
      */
     private fun encodeTo(out: OutputStream, payload: String) {
         val encoder = Charsets.UTF_8.newEncoder()
-            .onMalformedInput(CodingErrorAction.REPLACE)
-            .onUnmappableCharacter(CodingErrorAction.REPLACE)
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
         val charBuffer = CharBuffer.wrap(payload)
         val byteBuffer = ByteBuffer.allocate(WRITE_BUFFER_BYTES)
         var encoded = false
@@ -104,6 +127,7 @@ internal class ETagPayloadStore(
 
     private companion object {
         const val DIRECTORY_NAME = "rc_etag_payloads"
+        const val TEMP_SUFFIX = ".tmp"
         const val WRITE_BUFFER_BYTES = 64 * 1024
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
@@ -31,7 +31,7 @@ import java.nio.charset.CodingErrorAction
 internal class ETagPayloadStore(
     private val directory: File,
 ) {
-    constructor(context: Context) : this(File(context.cacheDir, DIRECTORY_NAME))
+    constructor(context: Context) : this(File(File(context.cacheDir, VENDOR_DIRECTORY), DIRECTORY_NAME))
 
     /**
      * Returns the payload's size in bytes once the file is in place, or `null` when the write failed;
@@ -150,7 +150,8 @@ internal class ETagPayloadStore(
     }
 
     private companion object {
-        const val DIRECTORY_NAME = "rc_etag_payloads"
+        const val VENDOR_DIRECTORY = "RevenueCat"
+        const val DIRECTORY_NAME = "etag_payloads"
         const val TEMP_SUFFIX = ".tmp"
         const val TRASH_SUFFIX = ".trash"
         const val CHUNK_CHARS = 64 * 1024

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
@@ -72,6 +72,8 @@ internal class ETagPayloadStore(
             // Strict decoding (unlike String(bytes), which silently substitutes U+FFFD) so a corrupt file
             // reads back as a cache miss instead of serving garbage as a valid cached response.
             Charsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
                 .decode(ByteBuffer.wrap(file.readBytes()))
                 .toString()
         } catch (e: FileNotFoundException) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JSONObjectExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JSONObjectExtensions.kt
@@ -16,6 +16,9 @@ internal fun JSONObject.optNullableString(name: String): String? = takeIf { this
 
 internal fun JSONObject.optNullableInt(name: String): Int? = takeIf { this.has(name) }?.getNullableInt(name)
 
+internal fun JSONObject.optNullableLong(name: String): Long? =
+    takeIf { this.has(name) && !this.isNull(name) }?.getLong(name)
+
 internal fun <T> JSONObject.toMap(deep: Boolean = false): Map<String, T> {
     return this.keys().asSequence().map { jsonKey ->
         if (deep) {

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -116,6 +116,7 @@ internal abstract class BaseBackendIntegrationTest {
         diagnosticsDispatcher = Dispatcher(Executors.newSingleThreadScheduledExecutor(), runningIntegrationTests = true)
         sharedPreferencesEditor = mockk<SharedPreferences.Editor>().apply {
             every { putString(any(), any()) } returns this
+            every { remove(any()) } returns this
             every { apply() } just Runs
         }
         sharedPreferences = mockk<SharedPreferences>().apply {

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.common.networking.ETagPayloadStore
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import io.mockk.Runs
@@ -26,6 +27,7 @@ import org.junit.Assume
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 import org.junit.rules.TestName
 import org.junit.runner.RunWith
 import java.io.File
@@ -60,6 +62,9 @@ internal abstract class BaseBackendIntegrationTest {
 
     @get:Rule
     val testName = TestName()
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
 
     lateinit var appConfig: AppConfig
     lateinit var dispatcher: Dispatcher
@@ -117,7 +122,11 @@ internal abstract class BaseBackendIntegrationTest {
             every { getString(any(), any()) } answers { secondArg() as String? }
             every { edit() } returns sharedPreferencesEditor
         }
-        eTagManager = ETagManager(mockk(), lazy { sharedPreferences })
+        eTagManager = ETagManager(
+            mockk(),
+            lazy { sharedPreferences },
+            payloadStore = ETagPayloadStore(temporaryFolder.newFolder()),
+        )
         signingManager = spyk(SigningManager(signatureVerificationMode, appConfig, apiKey()))
         deviceCache = DeviceCache(sharedPreferences, apiKey())
         httpClient = HTTPClient(

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/FallbackURLBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/FallbackURLBackendIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.backend_integration_tests
 
 import com.revenuecat.purchases.ForceServerErrorStrategy
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.HTTPResponseOriginalSource
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
@@ -42,7 +43,7 @@ internal class FallbackURLBackendIntegrationTest: BaseBackendIntegrationTest() {
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
             sharedPreferencesEditor.putString(
-                "https://api-production.8-lives-cat.io/v1/product_entitlement_mapping",
+                ETagManager.metadataKey("https://api-production.8-lives-cat.io/v1/product_entitlement_mapping"),
                 any(),
             )
         }
@@ -95,7 +96,7 @@ internal class FallbackURLBackendIntegrationTest: BaseBackendIntegrationTest() {
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
             sharedPreferencesEditor.putString(
-                "https://api-production.8-lives-cat.io/v1/offerings",
+                ETagManager.metadataKey("https://api-production.8-lives-cat.io/v1/offerings"),
                 any(),
             )
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderUSEast1BackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderUSEast1BackendIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.backend_integration_tests
 
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.HTTPResponseOriginalSource
+import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
@@ -145,7 +146,7 @@ internal open class LoadShedderUSEast1BackendIntegrationTest: BaseBackendIntegra
         val urlString = URL(appConfig.baseURL, Endpoint.GetOfferings("test-user-id").getPath()).toString()
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
-            sharedPreferencesEditor.putString(urlString, any())
+            sharedPreferencesEditor.putString(ETagManager.metadataKey(urlString), any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
         assertSigningNotPerformed()

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.common.events.BackendEvent
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.EventsRequest
 import com.revenuecat.purchases.common.events.toBackendEvent
+import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
@@ -56,7 +57,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         val urlString = URL(appConfig.baseURL, Endpoint.GetProductEntitlementMapping.getPath()).toString()
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
-            sharedPreferencesEditor.putString(urlString, any())
+            sharedPreferencesEditor.putString(ETagManager.metadataKey(urlString), any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
         assertSigningNotPerformed()
@@ -107,7 +108,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         val urlString = URL(appConfig.baseURL, Endpoint.GetOfferings("test-user-id").getPath()).toString()
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
-            sharedPreferencesEditor.putString(urlString, any())
+            sharedPreferencesEditor.putString(ETagManager.metadataKey(urlString), any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
         assertSigningNotPerformed()
@@ -153,7 +154,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         val urlString = URL(appConfig.baseURL, Endpoint.LogIn.getPath()).toString()
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
-            sharedPreferencesEditor.putString(urlString, any())
+            sharedPreferencesEditor.putString(ETagManager.metadataKey(urlString), any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
         assertSigningNotPerformed()
@@ -181,7 +182,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         val urlString = URL(appConfig.baseURL, Endpoint.LogIn.getPath()).toString()
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
-            sharedPreferencesEditor.putString(urlString, any())
+            sharedPreferencesEditor.putString(ETagManager.metadataKey(urlString), any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
         assertSigningPerformed()
@@ -224,7 +225,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         val urlString = URL(AppConfig.paywallEventsURL, Endpoint.PostEvents.getPath()).toString()
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
-            sharedPreferencesEditor.putString(urlString, any())
+            sharedPreferencesEditor.putString(ETagManager.metadataKey(urlString), any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
         assertSigningNotPerformed()
@@ -272,7 +273,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         val urlString = URL(AppConfig.adEventsURL, Endpoint.PostEvents.getPath()).toString()
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
-            sharedPreferencesEditor.putString(urlString, any())
+            sharedPreferencesEditor.putString(ETagManager.metadataKey(urlString), any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
         assertSigningNotPerformed()

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.revenuecat.purchases.ForceServerErrorStrategy
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.remoteconfig.DefaultRemoteConfigSourceProvider
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobFetcher
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
@@ -60,7 +61,7 @@ internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegr
             // The fallback endpoint is a plain-JSON GET, so its response is ETag-cached under the fallback URL,
             // confirming the exact host + path we hit.
             sharedPreferencesEditor.putString(
-                "https://api-production.8-lives-cat.io/v1/config/app",
+                ETagManager.metadataKey("https://api-production.8-lives-cat.io/v1/config/app"),
                 any(),
             )
         }
@@ -108,7 +109,7 @@ internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegr
         // one write to the fallback URL key proves the ETag round-trip happened (a plain re-fetch would store twice).
         verify(exactly = 1) {
             sharedPreferencesEditor.putString(
-                "https://api-production.8-lives-cat.io/v1/config/app",
+                ETagManager.metadataKey("https://api-production.8-lives-cat.io/v1/config/app"),
                 any(),
             )
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerMemoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerMemoryTest.kt
@@ -112,11 +112,9 @@ class ETagManagerMemoryTest {
     }
 
     /**
-     * Exercises every code path the measured blocks hit — the three [ETagManager] operations plus AssertJ
-     * and `org.json`'s parsing constructor — once, against a separate URL in a separate prefs file, before
-     * any measurement. The first-ever use of those libraries in the process pays a multi-MB
-     * classloading/static-init allocation cost that would otherwise be misattributed to whichever measured
-     * operation runs first, drowning out the KB-scale steady-state costs the regression gate is about.
+     * Exercises every measured code path once (the three [ETagManager] operations, AssertJ, org.json)
+     * against a separate prefs file and URL, so first-use classloading/static-init allocations
+     * (multi-MB) are not misattributed to whichever measured operation runs first.
      */
     private fun warmUpMeasuredCodePaths() {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -167,11 +165,7 @@ class ETagManagerMemoryTest {
         return getThreadAllocatedBytes(threadId) - before
     }
 
-    // Reflection is used here (instead of importing java.lang.management.ManagementFactory /
-    // com.sun.management.ThreadMXBean directly) because this module compiles Kotlin with jvmTarget 1.8 on a
-    // newer JDK, which makes Kotlin restrict the compile-time JDK API surface to java.base only, hiding the
-    // java.management/jdk.management modules these classes live in. The classes themselves are present at
-    // runtime, so reflection resolves them without needing a build-wide compiler flag change.
+    // Reflection because jvmTarget 1.8 hides java.management at compile time; see the class KDoc.
     private fun getThreadAllocatedBytes(threadId: Long): Long {
         val threadMXBean = managementFactoryGetThreadMXBean.invoke(null)
         return getThreadAllocatedBytesMethod.invoke(threadMXBean, threadId) as Long

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerMemoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerMemoryTest.kt
@@ -95,12 +95,15 @@ class ETagManagerMemoryTest {
         assertThat(cacheHit!!.payloadText).isEqualTo(payload)
         assertThat(cacheHit!!.origin).isEqualTo(HTTPResult.Origin.CACHE)
 
-        // Regression gate for #3628: none of the cache hot paths may allocate anywhere near payload size.
-        // The legacy combined format allocated tens of MB per operation on this 5MB payload.
+        // Regression gates for #3628. Store and header reads must not allocate anywhere near payload size
+        // (the legacy combined format allocated tens of MB per operation on this 5MB payload; the store's
+        // encoder writes through a fixed buffer). The 304 read rebuilds the payload string from its file, so
+        // its cost is payload-proportional by design — the deliberate tradeoff for not retaining the payload
+        // in the SharedPreferences in-memory map for the process lifetime — but bounded to a small multiple.
         val maxAllowedBytes = 1024L * 1024L
         assertThat(storeBytes).isLessThan(maxAllowedBytes)
         assertThat(headerBytes).isLessThan(maxAllowedBytes)
-        assertThat(notModifiedBytes).isLessThan(maxAllowedBytes)
+        assertThat(notModifiedBytes).isLessThan(3L * payload.length * Char.SIZE_BYTES)
 
         println("ETagManager memory profile (payload ${payload.length} chars, ~${payload.length / (1024 * 1024)}MB)")
         println("  storeBackendResultIfNoError: ${storeBytes / 1024} KB allocated")
@@ -157,6 +160,9 @@ class ETagManagerMemoryTest {
     private fun measureAllocatedBytes(block: () -> Unit): Long {
         val threadId = Thread.currentThread().id
         val before = getThreadAllocatedBytes(threadId)
+        // -1 means allocation tracking is disabled/unsupported on this JVM, which would make every gate
+        // pass vacuously (0 bytes measured). Fail loudly instead.
+        check(before >= 0) { "ThreadMXBean allocation tracking is unavailable; the memory gates cannot run." }
         block()
         return getThreadAllocatedBytes(threadId) - before
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerMemoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerMemoryTest.kt
@@ -98,8 +98,8 @@ class ETagManagerMemoryTest {
         // Regression gates for #3628. Store and header reads must not allocate anywhere near payload size
         // (the legacy combined format allocated tens of MB per operation on this 5MB payload; the store's
         // encoder writes through a fixed buffer). The 304 read rebuilds the payload string from its file, so
-        // its cost is payload-proportional by design — the deliberate tradeoff for not retaining the payload
-        // in the SharedPreferences in-memory map for the process lifetime — but bounded to a small multiple.
+        // its cost is payload-proportional by design (the deliberate tradeoff for not retaining the payload
+        // in the SharedPreferences in-memory map for the process lifetime) but bounded to a small multiple.
         val maxAllowedBytes = 1024L * 1024L
         assertThat(storeBytes).isLessThan(maxAllowedBytes)
         assertThat(headerBytes).isLessThan(maxAllowedBytes)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerMemoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerMemoryTest.kt
@@ -103,6 +103,9 @@ class ETagManagerMemoryTest {
         val maxAllowedBytes = 1024L * 1024L
         assertThat(storeBytes).isLessThan(maxAllowedBytes)
         assertThat(headerBytes).isLessThan(maxAllowedBytes)
+        // Deterministic (exact allocation counting, no timing): file byte[] (~1x payload.length for
+        // ASCII) + decoder char[] (2x) + String copy (up to 2x) = ~5x length, ~3.9x measured; 6x allows
+        // for JDKs without compact strings.
         assertThat(notModifiedBytes).isLessThan(3L * payload.length * Char.SIZE_BYTES)
 
         println("ETagManager memory profile (payload ${payload.length} chars, ~${payload.length / (1024 * 1024)}MB)")

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -753,6 +753,24 @@ class ETagManagerTest {
     }
 
     @Test
+    fun `a corrupt versioned entry reads as a miss for cached results`() {
+        val urlString = "http://localhost:100/v1/subscribers/appUserID"
+        every { mockedPrefs.getString(ETagManager.metadataKey(urlString), null) } returns "not json"
+
+        assertThat(underTest.getStoredResult(urlString)).isNull()
+    }
+
+    @Test
+    fun `metadata is not stored when the payload write fails`() {
+        val urlString = "http://localhost:100/v1/subscribers/appUserID"
+        every { payloadStore.write(urlString, any()) } returns null
+
+        underTest.storeBackendResultIfNoError(urlString, HTTPResult.createResult(), eTagInResponse = "etag")
+
+        assertThat(putStringKeys).isEmpty()
+    }
+
+    @Test
     fun `ETagCacheMetadata toHTTPResult rebuilds the result with CACHE origin`() {
         val metadata = ETagCacheMetadata.fromResult(
             HTTPResult.createResult(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -348,7 +348,7 @@ class ETagManagerTest {
         // Byte-for-byte what we received: never escaped, and never written into the prefs JSON.
         // (ETagManagerMemoryTest gates the allocation cost of this path.)
         assertThat(payloadStore.read(urlString)).isEqualTo(payload)
-        assertThat(putStringKeys).containsExactly(urlString)
+        assertThat(putStringKeys).containsExactly(ETagManager.metadataKey(urlString))
     }
 
     @Test
@@ -719,7 +719,7 @@ class ETagManagerTest {
             ETagData("etag", testDate),
         )
         val corrupted = metadata.serialize().replace("NOT_REQUESTED", "SOMETHING_UNKNOWN")
-        every { mockedPrefs.getString(urlString, null) } returns corrupted
+        every { mockedPrefs.getString(ETagManager.metadataKey(urlString), null) } returns corrupted
 
         val eTagHeaders = underTest.getETagHeaders(urlString, verificationRequested = false)
 
@@ -734,7 +734,7 @@ class ETagManagerTest {
             HTTPResult.createResult(payload = payload, origin = HTTPResult.Origin.CACHE),
             ETagData("etag", testDate),
         ).copy(payloadSizeBytes = payload.length + 100L)
-        every { mockedPrefs.getString(urlString, null) } returns metadata.serialize()
+        every { mockedPrefs.getString(ETagManager.metadataKey(urlString), null) } returns metadata.serialize()
         payloadStore.write(urlString, payload)
 
         assertThat(underTest.getStoredResult(urlString)).isNull()
@@ -747,7 +747,7 @@ class ETagManagerTest {
             HTTPResult.createResult(origin = HTTPResult.Origin.CACHE),
             ETagData("etag", testDate),
         )
-        every { mockedPrefs.getString(urlString, null) } returns metadata.serialize()
+        every { mockedPrefs.getString(ETagManager.metadataKey(urlString), null) } returns metadata.serialize()
 
         assertThat(underTest.getStoredResult(urlString)).isNull()
     }
@@ -810,7 +810,7 @@ class ETagManagerTest {
             ETagCacheMetadata.fromResult(httpResult, ETagData(expectedETag, expectedLastRefreshTime))
         }
         every {
-            mockedPrefs.getString(urlString, null)
+            mockedPrefs.getString(ETagManager.metadataKey(urlString), null)
         } returns metadata?.serialize()
         if (metadata != null) {
             payloadStore.write(urlString, httpResult.payloadText)
@@ -826,7 +826,7 @@ class ETagManagerTest {
     ) {
         val storedByKey = putStringKeys.zip(putStringValues).toMap()
 
-        val metadata = ETagCacheMetadata.deserialize(storedByKey.getValue(urlString))
+        val metadata = ETagCacheMetadata.deserialize(storedByKey.getValue(ETagManager.metadataKey(urlString)))
         assertThat(metadata).isNotNull
         assertThat(metadata!!.eTagData.eTag).isEqualTo(eTagInResponse)
         assertThat(metadata.eTagData.lastRefreshTime?.time).isEqualTo(lastRefreshTime?.time)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -708,16 +708,6 @@ class ETagManagerTest {
     }
 
     @Test
-    fun `an unparseable cache entry is treated as a miss`() {
-        val urlString = "http://localhost:100/v1/subscribers/appUserID"
-        every { mockedPrefs.getString(urlString, null) } returns "not json"
-
-        val eTagHeaders = underTest.getETagHeaders(urlString, verificationRequested = false)
-
-        assertThat(eTagHeaders[HTTPRequest.ETAG_HEADER_NAME]).isEmpty()
-    }
-
-    @Test
     fun `a v2 entry with an unknown verification result reads as a miss`() {
         val urlString = "http://localhost:100/v1/subscribers/appUserID"
         val metadata = ETagCacheMetadata.fromResult(
@@ -873,7 +863,7 @@ class ETagManagerTest {
         urlString: String,
         expectedLastRefreshTime: Date? = Date(),
         httpResult: HTTPResult = HTTPResult.createResult(origin = HTTPResult.Origin.CACHE)
-    ): ETagCacheMetadata? {
+    ) {
         val metadata = expectedETag?.let {
             ETagCacheMetadata.fromResult(httpResult, ETagData(expectedETag, expectedLastRefreshTime))
         }
@@ -883,7 +873,6 @@ class ETagManagerTest {
         if (metadata != null) {
             payloadStore.write(urlString, httpResult.payloadText)
         }
-        return metadata
     }
 
     private fun assertStoredResponse(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -11,6 +11,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -31,7 +32,7 @@ class ETagManagerTest {
             get() = testDate
     }
     private val mockedPrefs = mockk<SharedPreferences>()
-    private val payloadStore: ETagPayloadStore by lazy { ETagPayloadStore(temporaryFolder.newFolder()) }
+    private val payloadStore: ETagPayloadStore by lazy { spyk(ETagPayloadStore(temporaryFolder.newFolder())) }
     private val underTest: ETagManager by lazy {
         ETagManager(mockk(), lazy { mockedPrefs }, testDateProvider, payloadStore)
     }
@@ -60,6 +61,9 @@ class ETagManagerTest {
         every {
             mockEditor.apply()
         } just Runs
+        every {
+            mockEditor.commit()
+        } returns true
         every {
             mockEditor.clear()
         } returns mockEditor
@@ -207,14 +211,14 @@ class ETagManagerTest {
     // endregion ETag headers usage verification tests
 
     @Test
-    fun `getETagHeaders does not need the cached payload`() {
+    fun `getETagHeaders does not read the cached payload`() {
         val urlString = "http://localhost:100/v1/subscribers/appUserID"
         mockCachedHTTPResult(expectedETag = "etag", urlString = urlString)
-        payloadStore.clear()
 
         val eTagHeaders = underTest.getETagHeaders(urlString, verificationRequested = false)
 
         assertThat(eTagHeaders[HTTPRequest.ETAG_HEADER_NAME]).isEqualTo("etag")
+        verify(exactly = 0) { payloadStore.read(any()) }
     }
 
     @Test
@@ -349,6 +353,18 @@ class ETagManagerTest {
         // (ETagManagerMemoryTest gates the allocation cost of this path.)
         assertThat(payloadStore.read(urlString)).isEqualTo(payload)
         assertThat(putStringKeys).containsExactly(urlString)
+    }
+
+    @Test
+    fun `storeBackendResultIfNoError drops a stale prefs payload left by an earlier release`() {
+        val urlString = "http://localhost:100/v1/subscribers/appUserID"
+        val result = HTTPResult.createResult(payload = "{\"fresh\":true}")
+
+        underTest.storeBackendResultIfNoError(urlString, result, eTagInResponse = "etag")
+
+        // Without this, the stale prefs payload would stay parsed in the prefs in-memory map and could be
+        // resurrected by the prefs-payload migration if the payload file is later purged.
+        assertThat(removedKeys).containsExactly(ETagManager.payloadKey(urlString))
     }
 
     @Test
@@ -663,6 +679,7 @@ class ETagManagerTest {
             verificationResult = VERIFIED,
             isLoadShedderResponse = true,
             isFallbackURL = true,
+            payloadSizeBytes = 12345L,
         )
 
         val deserialized = ETagCacheMetadata.deserialize(metadata.serialize())
@@ -723,6 +740,20 @@ class ETagManagerTest {
         val eTagHeaders = underTest.getETagHeaders(urlString, verificationRequested = false)
 
         assertThat(eTagHeaders[HTTPRequest.ETAG_HEADER_NAME]).isEmpty()
+    }
+
+    @Test
+    fun `a payload file whose size does not match the metadata is treated as a miss`() {
+        val urlString = "http://localhost:100/v1/subscribers/appUserID"
+        val payload = "{\"key\":\"value\"}"
+        val metadata = ETagCacheMetadata.fromResult(
+            HTTPResult.createResult(payload = payload, origin = HTTPResult.Origin.CACHE),
+            ETagData("etag", testDate),
+        ).copy(payloadSizeBytes = payload.length + 100L)
+        every { mockedPrefs.getString(urlString, null) } returns metadata.serialize()
+        payloadStore.write(urlString, payload)
+
+        assertThat(underTest.getStoredResult(urlString)).isNull()
     }
 
     @Test
@@ -835,6 +866,7 @@ class ETagManagerTest {
         assertThat(metadata!!.eTagData.eTag).isEqualTo(eTagInResponse)
         assertThat(metadata.eTagData.lastRefreshTime?.time).isEqualTo(lastRefreshTime?.time)
         assertThat(metadata.responseCode).isEqualTo(RCHTTPStatusCodes.SUCCESS)
+        assertThat(metadata.payloadSizeBytes).isEqualTo(responsePayload.toByteArray().size.toLong())
 
         assertThat(payloadStore.read(urlString)).isEqualTo(responsePayload)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -1,6 +1,8 @@
 package com.revenuecat.purchases.common.networking
 
+import android.content.Context
 import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.VerificationResult.*
@@ -772,6 +774,22 @@ class ETagManagerTest {
         underTest.storeBackendResultIfNoError(urlString, HTTPResult.createResult(), eTagInResponse = "etag")
 
         assertThat(putStringKeys).isEmpty()
+    }
+
+    @Test
+    fun `legacy entries are swept when the default prefs initialize`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val urlString = "http://localhost:100/v1/subscribers/appUserID"
+        val realPrefs = ETagManager.initializeSharedPreferences(context)
+        realPrefs.edit()
+            .putString(urlString, "legacy blob")
+            .putString(ETagManager.metadataKey(urlString), "{}")
+            .commit()
+
+        ETagManager(context).getETagHeaders(urlString, verificationRequested = false)
+
+        assertThat(realPrefs.contains(urlString)).isFalse
+        assertThat(realPrefs.contains(ETagManager.metadataKey(urlString))).isTrue
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -14,7 +14,9 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.Date
@@ -29,10 +31,17 @@ class ETagManagerTest {
             get() = testDate
     }
     private val mockedPrefs = mockk<SharedPreferences>()
-    private val underTest = ETagManager(mockk(), lazy { mockedPrefs }, testDateProvider)
+    private val payloadStore: ETagPayloadStore by lazy { ETagPayloadStore(temporaryFolder.newFolder()) }
+    private val underTest: ETagManager by lazy {
+        ETagManager(mockk(), lazy { mockedPrefs }, testDateProvider, payloadStore)
+    }
     private val putStringKeys = mutableListOf<String>()
     private val putStringValues = mutableListOf<String>()
+    private val removedKeys = mutableListOf<String>()
     private val mockEditor = mockk<SharedPreferences.Editor>()
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
 
     @Before
     fun setup() {
@@ -40,7 +49,13 @@ class ETagManagerTest {
             mockedPrefs.edit()
         } returns mockEditor
         every {
+            mockedPrefs.getString(any(), null)
+        } returns null
+        every {
             mockEditor.putString(capture(putStringKeys), capture(putStringValues))
+        } returns mockEditor
+        every {
+            mockEditor.remove(capture(removedKeys))
         } returns mockEditor
         every {
             mockEditor.apply()
@@ -192,13 +207,14 @@ class ETagManagerTest {
     // endregion ETag headers usage verification tests
 
     @Test
-    fun `getETagHeaders does not read the cached payload`() {
+    fun `getETagHeaders does not need the cached payload`() {
         val urlString = "http://localhost:100/v1/subscribers/appUserID"
         mockCachedHTTPResult(expectedETag = "etag", urlString = urlString)
+        payloadStore.clear()
 
-        underTest.getETagHeaders(urlString, verificationRequested = false)
+        val eTagHeaders = underTest.getETagHeaders(urlString, verificationRequested = false)
 
-        verify(exactly = 0) { mockedPrefs.getString(ETagManager.payloadKey(urlString), null) }
+        assertThat(eTagHeaders[HTTPRequest.ETAG_HEADER_NAME]).isEqualTo("etag")
     }
 
     @Test
@@ -310,7 +326,7 @@ class ETagManagerTest {
     }
 
     @Test
-    fun `storeBackendResultIfNoError stores metadata and payload under separate keys`() {
+    fun `storeBackendResultIfNoError stores metadata in prefs and the payload in the payload store`() {
         val urlString = "http://localhost:100/v1/subscribers/appUserID"
         val payload = "{\"key\":\"value\"}"
         val result = HTTPResult.createResult(payload = payload)
@@ -321,7 +337,7 @@ class ETagManagerTest {
     }
 
     @Test
-    fun `storeBackendResultIfNoError stores the payload string verbatim without re-encoding`() {
+    fun `storeBackendResultIfNoError stores the payload without JSON re-encoding`() {
         val urlString = "http://localhost:100/v1/subscribers/appUserID"
         // Quote-dense payload: the legacy combined format would escape every quote twice.
         val payload = "{\"offerings\":[{\"id\":\"premium\",\"desc\":\"a \\\"quoted\\\" name\"}]}"
@@ -329,9 +345,10 @@ class ETagManagerTest {
 
         underTest.storeBackendResultIfNoError(urlString, result, eTagInResponse = "etag")
 
-        val storedByKey = putStringKeys.zip(putStringValues).toMap()
-        // Reference equality: the exact string instance we already held is stored — zero copies, zero escaping.
-        assertThat(storedByKey.getValue(ETagManager.payloadKey(urlString))).isSameAs(result.payloadText)
+        // Byte-for-byte what we received: never escaped, and never written into the prefs JSON.
+        // (ETagManagerMemoryTest gates the allocation cost of this path.)
+        assertThat(payloadStore.read(urlString)).isEqualTo(payload)
+        assertThat(putStringKeys).containsExactly(urlString)
     }
 
     @Test
@@ -345,9 +362,12 @@ class ETagManagerTest {
     }
 
     @Test
-    fun `Clearing caches removes all shared preferences`() {
+    fun `Clearing caches removes all shared preferences and stored payloads`() {
+        payloadStore.write("http://localhost:100/v1/subscribers/appUserID", "payload")
+
         underTest.clearCaches()
 
+        assertThat(payloadStore.read("http://localhost:100/v1/subscribers/appUserID")).isNull()
         verify {
             mockEditor.clear()
         }
@@ -719,6 +739,24 @@ class ETagManagerTest {
     }
 
     @Test
+    fun `a payload stored in prefs by an earlier release is served and moved to the payload store`() {
+        val urlString = "http://localhost:100/v1/subscribers/appUserID"
+        val payload = "{\"fromPrefs\":true}"
+        val metadata = ETagCacheMetadata.fromResult(
+            HTTPResult.createResult(payload = payload, origin = HTTPResult.Origin.CACHE),
+            ETagData("etag", testDate),
+        )
+        every { mockedPrefs.getString(urlString, null) } returns metadata.serialize()
+        every { mockedPrefs.getString(ETagManager.payloadKey(urlString), null) } returns payload
+
+        val storedResult = underTest.getStoredResult(urlString)
+
+        assertThat(storedResult?.payloadText).isEqualTo(payload)
+        assertThat(payloadStore.read(urlString)).isEqualTo(payload)
+        assertThat(removedKeys).containsExactly(ETagManager.payloadKey(urlString))
+    }
+
+    @Test
     fun `ETagCacheMetadata toHTTPResult rebuilds the result with CACHE origin`() {
         val metadata = ETagCacheMetadata.fromResult(
             HTTPResult.createResult(
@@ -778,9 +816,9 @@ class ETagManagerTest {
         every {
             mockedPrefs.getString(urlString, null)
         } returns metadata?.serialize()
-        every {
-            mockedPrefs.getString(ETagManager.payloadKey(urlString), null)
-        } returns metadata?.let { httpResult.payloadText }
+        if (metadata != null) {
+            payloadStore.write(urlString, httpResult.payloadText)
+        }
         return metadata
     }
 
@@ -798,6 +836,6 @@ class ETagManagerTest {
         assertThat(metadata.eTagData.lastRefreshTime?.time).isEqualTo(lastRefreshTime?.time)
         assertThat(metadata.responseCode).isEqualTo(RCHTTPStatusCodes.SUCCESS)
 
-        assertThat(storedByKey.getValue(ETagManager.payloadKey(urlString))).isEqualTo(responsePayload)
+        assertThat(payloadStore.read(urlString)).isEqualTo(responsePayload)
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -38,7 +38,6 @@ class ETagManagerTest {
     }
     private val putStringKeys = mutableListOf<String>()
     private val putStringValues = mutableListOf<String>()
-    private val removedKeys = mutableListOf<String>()
     private val mockEditor = mockk<SharedPreferences.Editor>()
 
     @get:Rule
@@ -54,9 +53,6 @@ class ETagManagerTest {
         } returns null
         every {
             mockEditor.putString(capture(putStringKeys), capture(putStringValues))
-        } returns mockEditor
-        every {
-            mockEditor.remove(capture(removedKeys))
         } returns mockEditor
         every {
             mockEditor.apply()
@@ -353,18 +349,6 @@ class ETagManagerTest {
         // (ETagManagerMemoryTest gates the allocation cost of this path.)
         assertThat(payloadStore.read(urlString)).isEqualTo(payload)
         assertThat(putStringKeys).containsExactly(urlString)
-    }
-
-    @Test
-    fun `storeBackendResultIfNoError drops a stale prefs payload left by an earlier release`() {
-        val urlString = "http://localhost:100/v1/subscribers/appUserID"
-        val result = HTTPResult.createResult(payload = "{\"fresh\":true}")
-
-        underTest.storeBackendResultIfNoError(urlString, result, eTagInResponse = "etag")
-
-        // Without this, the stale prefs payload would stay parsed in the prefs in-memory map and could be
-        // resurrected by the prefs-payload migration if the payload file is later purged.
-        assertThat(removedKeys).containsExactly(ETagManager.payloadKey(urlString))
     }
 
     @Test
@@ -764,27 +748,8 @@ class ETagManagerTest {
             ETagData("etag", testDate),
         )
         every { mockedPrefs.getString(urlString, null) } returns metadata.serialize()
-        every { mockedPrefs.getString(ETagManager.payloadKey(urlString), null) } returns null
 
         assertThat(underTest.getStoredResult(urlString)).isNull()
-    }
-
-    @Test
-    fun `a payload stored in prefs by an earlier release is served and moved to the payload store`() {
-        val urlString = "http://localhost:100/v1/subscribers/appUserID"
-        val payload = "{\"fromPrefs\":true}"
-        val metadata = ETagCacheMetadata.fromResult(
-            HTTPResult.createResult(payload = payload, origin = HTTPResult.Origin.CACHE),
-            ETagData("etag", testDate),
-        )
-        every { mockedPrefs.getString(urlString, null) } returns metadata.serialize()
-        every { mockedPrefs.getString(ETagManager.payloadKey(urlString), null) } returns payload
-
-        val storedResult = underTest.getStoredResult(urlString)
-
-        assertThat(storedResult?.payloadText).isEqualTo(payload)
-        assertThat(payloadStore.read(urlString)).isEqualTo(payload)
-        assertThat(removedKeys).containsExactly(ETagManager.payloadKey(urlString))
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -38,6 +38,7 @@ class ETagManagerTest {
     }
     private val putStringKeys = mutableListOf<String>()
     private val putStringValues = mutableListOf<String>()
+    private val removedKeys = mutableListOf<String>()
     private val mockEditor = mockk<SharedPreferences.Editor>()
 
     @get:Rule
@@ -53,6 +54,9 @@ class ETagManagerTest {
         } returns null
         every {
             mockEditor.putString(capture(putStringKeys), capture(putStringValues))
+        } returns mockEditor
+        every {
+            mockEditor.remove(capture(removedKeys))
         } returns mockEditor
         every {
             mockEditor.apply()
@@ -768,6 +772,34 @@ class ETagManagerTest {
         underTest.storeBackendResultIfNoError(urlString, HTTPResult.createResult(), eTagInResponse = "etag")
 
         assertThat(putStringKeys).isEmpty()
+    }
+
+    @Test
+    fun `legacy entries are swept without parsing their values`() {
+        val v2Key = ETagManager.metadataKey("http://localhost:100/v1/subscribers/appUserID")
+        every { mockedPrefs.all } returns mapOf(
+            v2Key to "{}",
+            "http://localhost:100/v1/subscribers/appUserID" to "huge legacy blob",
+            "http://localhost:100/v1/offerings#rc_payload" to "stale dev payload",
+        )
+
+        ETagManager.removeLegacyEntries(mockedPrefs)
+
+        assertThat(removedKeys).containsExactlyInAnyOrder(
+            "http://localhost:100/v1/subscribers/appUserID",
+            "http://localhost:100/v1/offerings#rc_payload",
+        )
+    }
+
+    @Test
+    fun `the sweep does not edit prefs when nothing is stale`() {
+        every { mockedPrefs.all } returns mapOf(
+            ETagManager.metadataKey("http://localhost:100/v1/subscribers/appUserID") to "{}",
+        )
+
+        ETagManager.removeLegacyEntries(mockedPrefs)
+
+        verify(exactly = 0) { mockedPrefs.edit() }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagPayloadStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagPayloadStoreTest.kt
@@ -119,6 +119,19 @@ class ETagPayloadStoreTest {
     }
 
     @Test
+    fun `cleared payloads are trashed and deleted by the next write`() {
+        underTest.write(url, "payload")
+
+        underTest.clear()
+        val afterClear = temporaryFolder.root.list()!!
+        assertThat(afterClear).hasSize(1)
+        assertThat(afterClear.single()).contains(".trash")
+
+        underTest.write(url, "again")
+        assertThat(temporaryFolder.root.list()!!).containsExactly("payloads")
+    }
+
+    @Test
     fun `write returns null when the directory cannot be used`() {
         val blockedByFile = ETagPayloadStore(temporaryFolder.newFile())
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagPayloadStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagPayloadStoreTest.kt
@@ -30,8 +30,28 @@ class ETagPayloadStoreTest {
     fun `write and read round-trip a payload`() {
         val payload = "{\"offerings\":[{\"id\":\"premium\",\"desc\":\"a \\\"quoted\\\" name\"}]}\nwith\nnewlines"
 
-        assertThat(underTest.write(url, payload)).isTrue
+        assertThat(underTest.write(url, payload)).isNotNull
         assertThat(underTest.read(url)).isEqualTo(payload)
+    }
+
+    @Test
+    fun `write returns the encoded size which read verifies`() {
+        val payload = "ascii payload"
+
+        val sizeBytes = underTest.write(url, payload)
+
+        assertThat(sizeBytes).isEqualTo(payload.length.toLong())
+        assertThat(underTest.read(url, expectedSizeBytes = sizeBytes)).isEqualTo(payload)
+    }
+
+    @Test
+    fun `a payload file with an unexpected size reads back as a miss`() {
+        val sizeBytes = underTest.write(url, "the full payload")!!
+        val payloadFile = File(directory, directory.list()!!.single())
+        payloadFile.writeText("the full pay")
+
+        assertThat(underTest.read(url, expectedSizeBytes = sizeBytes)).isNull()
+        assertThat(underTest.read(url)).isEqualTo("the full pay")
     }
 
     @Test
@@ -47,7 +67,7 @@ class ETagPayloadStoreTest {
             append("\"}")
         }
 
-        assertThat(underTest.write(url, payload)).isTrue
+        assertThat(underTest.write(url, payload)).isNotNull
         assertThat(underTest.read(url)).isEqualTo(payload)
     }
 
@@ -79,11 +99,59 @@ class ETagPayloadStoreTest {
     }
 
     @Test
+    fun `a leftover temp file from a crashed write does not affect reads or later writes`() {
+        underTest.write(url, "good")
+        val payloadFileName = directory.list()!!.single()
+        File(directory, "$payloadFileName.tmp").writeText("partial write from a crashed process")
+
+        assertThat(underTest.read(url)).isEqualTo("good")
+        assertThat(underTest.write(url, "newer")).isNotNull
+        assertThat(underTest.read(url)).isEqualTo("newer")
+    }
+
+    @Test
     fun `write works again after clear`() {
         underTest.write(url, "payload")
         underTest.clear()
 
-        assertThat(underTest.write(url, "again")).isTrue
+        assertThat(underTest.write(url, "again")).isNotNull
         assertThat(underTest.read(url)).isEqualTo("again")
+    }
+
+    @Test
+    fun `write returns null when the directory cannot be used`() {
+        val blockedByFile = ETagPayloadStore(temporaryFolder.newFile())
+
+        assertThat(blockedByFile.write(url, "payload")).isNull()
+        assertThat(blockedByFile.read(url)).isNull()
+    }
+
+    @Test
+    fun `an empty payload round-trips with a zero size`() {
+        val sizeBytes = underTest.write(url, "")
+
+        assertThat(sizeBytes).isEqualTo(0L)
+        assertThat(underTest.read(url, expectedSizeBytes = 0L)).isEqualTo("")
+
+        underTest.clear()
+        // A missing file also has length 0: the size check alone must not turn it into a hit.
+        assertThat(underTest.read(url, expectedSizeBytes = 0L)).isNull()
+    }
+
+    @Test
+    fun `a payload the encoder cannot represent fails the write instead of being altered`() {
+        val payloadWithUnpairedSurrogate = "{\"key\":\"\uD83C\"}"
+
+        assertThat(underTest.write(url, payloadWithUnpairedSurrogate)).isNull()
+        assertThat(underTest.read(url)).isNull()
+    }
+
+    @Test
+    fun `a corrupt payload file reads back as a miss instead of garbage`() {
+        underTest.write(url, "valid")
+        val payloadFile = File(directory, directory.list()!!.single())
+        payloadFile.writeBytes(byteArrayOf(0x7B, -1, -2, 0x22))
+
+        assertThat(underTest.read(url)).isNull()
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagPayloadStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagPayloadStoreTest.kt
@@ -1,0 +1,89 @@
+package com.revenuecat.purchases.common.networking
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class ETagPayloadStoreTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val url = "https://api.revenuecat.com/v1/subscribers/appUserID/offerings"
+
+    private val directory: File by lazy { File(temporaryFolder.root, "payloads") }
+    private val underTest: ETagPayloadStore by lazy { ETagPayloadStore(directory) }
+
+    @Test
+    fun `read returns null when nothing was written`() {
+        assertThat(underTest.read(url)).isNull()
+    }
+
+    @Test
+    fun `write and read round-trip a payload`() {
+        val payload = "{\"offerings\":[{\"id\":\"premium\",\"desc\":\"a \\\"quoted\\\" name\"}]}\nwith\nnewlines"
+
+        assertThat(underTest.write(url, payload)).isTrue
+        assertThat(underTest.read(url)).isEqualTo(payload)
+    }
+
+    @Test
+    fun `round-trips multi-byte content larger than the encode buffer`() {
+        // Surrogate pairs (4-byte UTF-8) sized well past the 64KB encode buffer, so pairs end up split
+        // across buffer boundaries at many different offsets.
+        val payload = buildString {
+            append("{\"emoji\":\"")
+            repeat(60_000) { index ->
+                append("🎉")
+                append('a' + (index % 3))
+            }
+            append("\"}")
+        }
+
+        assertThat(underTest.write(url, payload)).isTrue
+        assertThat(underTest.read(url)).isEqualTo(payload)
+    }
+
+    @Test
+    fun `write overwrites the previous payload for the same url`() {
+        underTest.write(url, "first")
+        underTest.write(url, "second")
+
+        assertThat(underTest.read(url)).isEqualTo("second")
+    }
+
+    @Test
+    fun `payloads for different urls do not collide`() {
+        val otherUrl = "$url#rc_payload"
+        underTest.write(url, "one")
+        underTest.write(otherUrl, "two")
+
+        assertThat(underTest.read(url)).isEqualTo("one")
+        assertThat(underTest.read(otherUrl)).isEqualTo("two")
+    }
+
+    @Test
+    fun `clear removes all payloads`() {
+        underTest.write(url, "payload")
+        underTest.clear()
+
+        assertThat(underTest.read(url)).isNull()
+        assertThat(directory.exists()).isFalse
+    }
+
+    @Test
+    fun `write works again after clear`() {
+        underTest.write(url, "payload")
+        underTest.clear()
+
+        assertThat(underTest.write(url, "again")).isTrue
+        assertThat(underTest.read(url)).isEqualTo("again")
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagPayloadStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagPayloadStoreTest.kt
@@ -132,6 +132,31 @@ class ETagPayloadStoreTest {
     }
 
     @Test
+    fun `write returns null when the directory cannot be created`() {
+        val fileAsParent = temporaryFolder.newFile()
+        val blocked = ETagPayloadStore(File(fileAsParent, "payloads"))
+
+        assertThat(blocked.write(url, "payload")).isNull()
+    }
+
+    @Test
+    fun `write returns null when the payload file cannot be replaced`() {
+        val payloadFileName = underTest.write(url, "original").let { directory.list()!!.single() }
+        val blockingDirectory = File(directory, payloadFileName)
+        blockingDirectory.deleteRecursively()
+        File(blockingDirectory, "child").apply { parentFile!!.mkdirs(); writeText("blocks the rename") }
+
+        assertThat(underTest.write(url, "new payload")).isNull()
+    }
+
+    @Test
+    fun `clear on a store that never wrote is a no-op`() {
+        underTest.clear()
+
+        assertThat(underTest.read(url)).isNull()
+    }
+
+    @Test
     fun `write returns null when the directory cannot be used`() {
         val blockedByFile = ETagPayloadStore(temporaryFolder.newFile())
 


### PR DESCRIPTION
Stacked on #3774. **Must ship in the same release**: the intermediate payload format from that PR never ships, so devices migrate legacy entries directly to the file store.

#3774 stopped the ETag cache from re-encoding payloads, but they still lived in SharedPreferences, which keeps its whole file parsed in the app heap for the process lifetime.

This moves the payload to one file per URL under `cacheDir` (sha256-named), keeping the small metadata JSON in prefs:

- Writes stream through fixed-size buffers (no payload-sized allocations) to a temp file committed by an atomic checked rename.
- Writes are not fsynced, keeping disk latency off the request path. Instead, metadata records the payload byte size and reads verify it, so a file truncated by power loss reads as a miss and heals through the existing refresh retry. 
- The payload is read from disk only on 304 hits, decoded strictly so corrupt bytes read as a miss. Metadata reads (every request) stay in SharedPreferences.

## Measurements

5MB offerings-like payload. Allocations from `ETagManagerMemoryTest`; latency from an instrumented release build on a Xiaomi Mi 9T Pro (Snapdragon 855), medians of 10.

Memory, allocated per operation:

<details>
<summary> Click to expand </summary>

| Operation | main | #3774 | this PR |
|---|---|---|---|
| Store response | 49.3 MB | 151 KB | 190 KB |
| `getETagHeaders` (every request) | 46.8 MB | 2 KB | 3 KB |
| 304 cache hit | 46.8 MB | 3 KB | ~20 MB transient |
| **Retained in heap, process lifetime** | **~2x payload** | **~1x payload** | **~200 bytes** |

</details>

Latency, on device:

<details>

Measured on a release build, Xiaomi Mi 9T Pro, 5MB payload, median [min–p90] of 100 iterations:

| Operation | main | #3774 | this PR |
|---|---|---|---|
| Store | 735 ms [670–786] | 151 µs [142–196] | 16.6 ms [15.5–18.5] |
| Headers (every request) | 565 ms [550–631] | 130 µs [126–145] | 53 µs [42–142] |
| 304 hit | 564 ms [551–598] | 151 µs [139–514] | 29.5 ms [28.6–30.1] |
| Miss | 5 / 12 µs | 5 / 12 µs | 5 / 12 µs |

</details>

The 304 read rebuilding the payload from disk is the deliberate trade for zero permanent
retention. 

## Known limitation: SDK downgrade

Same as #3774: older SDKs cannot read the new format; entries fail as
request errors until the cache is cleared. Additionally, orphaned
payload files linger in `cacheDir` after a downgrade until the OS
purges them.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core HTTP caching for all SDK network responses; mistakes could cause cache misses, stale data, or failed stores, but failures degrade to refetch rather than serving corrupt JSON.
> 
> **Overview**
> Moves **ETag response bodies** out of SharedPreferences into **per-URL files** under `cacheDir` (`ETagPayloadStore`), while **small metadata JSON** (eTag, status, verification, etc.) stays in prefs under **`v2:`-prefixed keys**. This targets [#3628](https://github.com/RevenueCat/purchases-android/issues/3628): large offerings payloads no longer sit in the prefs in-memory map for the process lifetime.
> 
> **`ETagManager`** writes the payload file first (streaming UTF-8 with fixed buffers, temp file + rename), records **`payloadSizeBytes`** in metadata, and only then persists metadata. **304 / cache hits** load the body from disk with a size check and strict decoding so truncated or corrupt files become cache misses that can heal via the existing refresh path. **`clearCaches`** clears prefs and payload files. On upgrade, **`removeLegacyEntries`** drops bare-URL and old `#rc_payload` prefs keys without parsing values.
> 
> New **`ETagPayloadStore`** tests and expanded **`ETagManager`** / memory regression tests cover the split store, legacy sweep, and allocation bounds (304 reads are allowed to allocate proportionally to payload size).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82768df2d1291f869bef9501160a4c4a785976d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->