### PR TITLE
feat(paywalls): internal types for web_view messaging (1/9)

### DIFF
--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -150,67 +150,6 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public abstract void performRestoreWithCompletion(com.revenuecat.purchases.CustomerInfo customerInfo, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult,kotlin.Unit> completion);
   }
 
-  public interface PaywallWebViewController {
-    method public void postMessage(String componentId, String type, java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> variables);
-    method public void postVariables(String componentId, java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> variables);
-  }
-
-  @dev.drewhamilton.poko.Poko public final class PaywallWebViewMessage {
-    ctor public PaywallWebViewMessage(String componentId, String type, optional java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? responses, optional String? error);
-    method public String getComponentId();
-    method public String? getError();
-    method public java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? getResponses();
-    method public String getType();
-    property public final String componentId;
-    property public final String? error;
-    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? responses;
-    property public final String type;
-  }
-
-  public fun interface PaywallWebViewMessageHandler {
-    method public void onMessage(com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessage message, com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController controller);
-  }
-
-  public abstract class PaywallWebViewValue {
-  }
-
-  public static final class PaywallWebViewValue.Array extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
-    ctor public PaywallWebViewValue.Array(java.util.List<? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value);
-    method public java.util.List<com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> getValue();
-    property public final java.util.List<com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value;
-  }
-
-  public static final class PaywallWebViewValue.Boolean extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
-    ctor public PaywallWebViewValue.Boolean(boolean value);
-    method public boolean getValue();
-    property public final boolean value;
-  }
-
-  public static final class PaywallWebViewValue.Null extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
-    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue.Null INSTANCE;
-  }
-
-  public static final class PaywallWebViewValue.Number extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
-    ctor public PaywallWebViewValue.Number(double value);
-    ctor public PaywallWebViewValue.Number(float value);
-    ctor public PaywallWebViewValue.Number(int value);
-    ctor public PaywallWebViewValue.Number(long value);
-    method public double getValue();
-    property public final double value;
-  }
-
-  public static final class PaywallWebViewValue.Object extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
-    ctor public PaywallWebViewValue.Object(java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value);
-    method public java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> getValue();
-    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value;
-  }
-
-  public static final class PaywallWebViewValue.String extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
-    ctor public PaywallWebViewValue.String(String value);
-    method public String getValue();
-    property public final String value;
-  }
-
   @Deprecated public interface PurchaseLogic extends com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic {
     method @Deprecated public suspend Object? performPurchase(android.app.Activity activity, com.revenuecat.purchases.Package rcPackage, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult>);
     method @Deprecated public default suspend Object? performPurchase(android.app.Activity activity, com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogicParams params, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult>);

--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -150,6 +150,67 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public abstract void performRestoreWithCompletion(com.revenuecat.purchases.CustomerInfo customerInfo, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult,kotlin.Unit> completion);
   }
 
+  public interface PaywallWebViewController {
+    method public void postMessage(String componentId, String type, java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> variables);
+    method public void postVariables(String componentId, java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> variables);
+  }
+
+  @dev.drewhamilton.poko.Poko public final class PaywallWebViewMessage {
+    ctor public PaywallWebViewMessage(String componentId, String type, optional java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? responses, optional String? error);
+    method public String getComponentId();
+    method public String? getError();
+    method public java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? getResponses();
+    method public String getType();
+    property public final String componentId;
+    property public final String? error;
+    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? responses;
+    property public final String type;
+  }
+
+  public fun interface PaywallWebViewMessageHandler {
+    method public void onMessage(com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessage message, com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController controller);
+  }
+
+  public abstract class PaywallWebViewValue {
+  }
+
+  public static final class PaywallWebViewValue.Array extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Array(java.util.List<? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value);
+    method public java.util.List<com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> getValue();
+    property public final java.util.List<com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value;
+  }
+
+  public static final class PaywallWebViewValue.Boolean extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Boolean(boolean value);
+    method public boolean getValue();
+    property public final boolean value;
+  }
+
+  public static final class PaywallWebViewValue.Null extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue.Null INSTANCE;
+  }
+
+  public static final class PaywallWebViewValue.Number extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Number(double value);
+    ctor public PaywallWebViewValue.Number(float value);
+    ctor public PaywallWebViewValue.Number(int value);
+    ctor public PaywallWebViewValue.Number(long value);
+    method public double getValue();
+    property public final double value;
+  }
+
+  public static final class PaywallWebViewValue.Object extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Object(java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value);
+    method public java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> getValue();
+    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value;
+  }
+
+  public static final class PaywallWebViewValue.String extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.String(String value);
+    method public String getValue();
+    property public final String value;
+  }
+
   @Deprecated public interface PurchaseLogic extends com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic {
     method @Deprecated public suspend Object? performPurchase(android.app.Activity activity, com.revenuecat.purchases.Package rcPackage, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult>);
     method @Deprecated public default suspend Object? performPurchase(android.app.Activity activity, com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogicParams params, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult>);

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewMessage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewMessage.kt
@@ -18,11 +18,11 @@ import dev.drewhamilton.poko.Poko
  * @property error The error description for a `rc:error` message, if any.
  */
 @Poko
-public class PaywallWebViewMessage(
-    public val componentId: String,
-    public val type: String,
-    public val responses: Map<String, PaywallWebViewValue>? = null,
-    public val error: String? = null,
+internal class PaywallWebViewMessage(
+    val componentId: String,
+    val type: String,
+    val responses: Map<String, PaywallWebViewValue>? = null,
+    val error: String? = null,
 )
 
 /**
@@ -32,7 +32,7 @@ public class PaywallWebViewMessage(
  * Outgoing messages preserve the RevenueCat web view postMessage envelope and are validated before
  * being delivered to the web view.
  */
-public interface PaywallWebViewController {
+internal interface PaywallWebViewController {
 
     /**
      * Sends a `rc:variables` message into the web view targeting [componentId]. The SDK already replies
@@ -41,7 +41,7 @@ public interface PaywallWebViewController {
      * `variables` key). Reserved SDK-managed top-level keys cannot be overwritten; provide
      * app-specific values under `custom`.
      */
-    public fun postVariables(
+    fun postVariables(
         componentId: String,
         variables: Map<String, PaywallWebViewValue>,
     )
@@ -51,7 +51,7 @@ public interface PaywallWebViewController {
      * [variables] map is sent as the transport envelope's `payload` field (not nested under a
      * `variables` key). Use [postVariables] for the common `rc:variables` case.
      */
-    public fun postMessage(
+    fun postMessage(
         componentId: String,
         type: String,
         variables: Map<String, PaywallWebViewValue>,
@@ -85,8 +85,8 @@ public interface PaywallWebViewController {
  *     .build()
  * ```
  */
-public fun interface PaywallWebViewMessageHandler {
-    public fun onMessage(
+internal fun interface PaywallWebViewMessageHandler {
+    fun onMessage(
         message: PaywallWebViewMessage,
         controller: PaywallWebViewController,
     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewMessage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewMessage.kt
@@ -1,0 +1,93 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import dev.drewhamilton.poko.Poko
+
+/**
+ * A validated message received from a Paywalls V2 `web_view` component.
+ *
+ * Messages follow the RevenueCat web view postMessage envelope. Known [type]s include:
+ * - `rc:step-loaded`
+ * - `rc:step-complete` (carries [responses])
+ * - `rc:request-variables`
+ * - `rc:error` (carries [error])
+ *
+ * @property componentId The canonical component id (the `web_view.id` from the paywall schema). This
+ * matches the id API consumers see in the paywall configuration.
+ * @property type The message type, e.g. `rc:step-complete`.
+ * @property responses The structured responses for a `rc:step-complete` message, if any.
+ * @property error The error description for a `rc:error` message, if any.
+ */
+@Poko
+public class PaywallWebViewMessage(
+    public val componentId: String,
+    public val type: String,
+    public val responses: Map<String, PaywallWebViewValue>? = null,
+    public val error: String? = null,
+)
+
+/**
+ * Lets app code send messages back into a Paywalls V2 `web_view` component, for example in response to
+ * a `rc:request-variables` message.
+ *
+ * Outgoing messages preserve the RevenueCat web view postMessage envelope and are validated before
+ * being delivered to the web view.
+ */
+public interface PaywallWebViewController {
+
+    /**
+     * Sends a `rc:variables` message into the web view targeting [componentId]. The SDK already replies
+     * with SDK-managed variables (such as `locale`); use this to provide additional values. The flat
+     * [variables] map is sent as the transport envelope's `payload` field (not nested under a
+     * `variables` key). Reserved SDK-managed top-level keys cannot be overwritten; provide
+     * app-specific values under `custom`.
+     */
+    public fun postVariables(
+        componentId: String,
+        variables: Map<String, PaywallWebViewValue>,
+    )
+
+    /**
+     * Sends a message of the given [type] into the web view targeting [componentId]. The flat
+     * [variables] map is sent as the transport envelope's `payload` field (not nested under a
+     * `variables` key). Use [postVariables] for the common `rc:variables` case.
+     */
+    public fun postMessage(
+        componentId: String,
+        type: String,
+        variables: Map<String, PaywallWebViewValue>,
+    )
+}
+
+/**
+ * Receives validated messages from Paywalls V2 `web_view` components.
+ *
+ * Set this on [PaywallOptions.Builder.setWebViewMessageHandler]. The handler is always invoked on the
+ * main thread. The app decides what to do with each message: the SDK does not automatically dismiss the
+ * paywall or trigger a purchase in response to `rc:step-complete`.
+ *
+ * ### Usage
+ * ```kotlin
+ * PaywallOptions.Builder { /* dismiss */ }
+ *     .setWebViewMessageHandler { message, controller ->
+ *         when (message.type) {
+ *             "rc:request-variables" -> controller.postVariables(
+ *                 componentId = message.componentId,
+ *                 variables = mapOf(
+ *                     "custom" to PaywallWebViewValue.Object(
+ *                         mapOf("app_segment" to PaywallWebViewValue.String("high_intent")),
+ *                     ),
+ *                 ),
+ *             )
+ *             "rc:step-complete" -> { /* read message.responses, navigate, log analytics, etc. */ }
+ *             "rc:error" -> { /* log message.error */ }
+ *         }
+ *     }
+ *     .build()
+ * ```
+ */
+public fun interface PaywallWebViewMessageHandler {
+    public fun onMessage(
+        message: PaywallWebViewMessage,
+        controller: PaywallWebViewController,
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
@@ -12,14 +12,13 @@ import org.json.JSONObject
  * @see PaywallWebViewMessage
  * @see PaywallWebViewController
  */
-// Modeled as an abstract class with a closed set of subtypes (mirroring [CustomVariableValue]) rather
-// than a sealed class, to stay binary-compatible as public API.
-public abstract class PaywallWebViewValue internal constructor() {
+// Modeled as an abstract class with a closed set of subtypes (mirroring [CustomVariableValue]).
+internal abstract class PaywallWebViewValue {
 
     /**
      * A string value.
      */
-    public class String(public val value: kotlin.String) : PaywallWebViewValue() {
+    class String(val value: kotlin.String) : PaywallWebViewValue() {
         override fun equals(other: Any?): kotlin.Boolean = other is String && value == other.value
         override fun hashCode(): Int = value.hashCode()
         override fun toString(): kotlin.String = "PaywallWebViewValue.String(value=$value)"
@@ -32,10 +31,10 @@ public abstract class PaywallWebViewValue internal constructor() {
      * `null` when sent into the web view. Equality follows [Double.equals] semantics (consistent
      * with [hashCode]): `NaN` equals `NaN`, and `-0.0` does not equal `0.0`.
      */
-    public class Number(public val value: kotlin.Double) : PaywallWebViewValue() {
-        public constructor(value: kotlin.Int) : this(value.toDouble())
-        public constructor(value: kotlin.Long) : this(value.toDouble())
-        public constructor(value: kotlin.Float) : this(value.toDouble())
+    class Number(val value: kotlin.Double) : PaywallWebViewValue() {
+        constructor(value: kotlin.Int) : this(value.toDouble())
+        constructor(value: kotlin.Long) : this(value.toDouble())
+        constructor(value: kotlin.Float) : this(value.toDouble())
 
         override fun equals(other: Any?): kotlin.Boolean = other is Number && value.equals(other.value)
         override fun hashCode(): Int = value.hashCode()
@@ -45,7 +44,7 @@ public abstract class PaywallWebViewValue internal constructor() {
     /**
      * A boolean value.
      */
-    public class Boolean(public val value: kotlin.Boolean) : PaywallWebViewValue() {
+    class Boolean(val value: kotlin.Boolean) : PaywallWebViewValue() {
         override fun equals(other: Any?): kotlin.Boolean = other is Boolean && value == other.value
         override fun hashCode(): Int = value.hashCode()
         override fun toString(): kotlin.String = "PaywallWebViewValue.Boolean(value=$value)"
@@ -54,7 +53,7 @@ public abstract class PaywallWebViewValue internal constructor() {
     /**
      * A JSON object: a map of string keys to [PaywallWebViewValue]s.
      */
-    public class Object(public val value: Map<kotlin.String, PaywallWebViewValue>) : PaywallWebViewValue() {
+    class Object(val value: Map<kotlin.String, PaywallWebViewValue>) : PaywallWebViewValue() {
         override fun equals(other: Any?): kotlin.Boolean = other is Object && value == other.value
         override fun hashCode(): Int = value.hashCode()
         override fun toString(): kotlin.String = "PaywallWebViewValue.Object(value=$value)"
@@ -63,7 +62,7 @@ public abstract class PaywallWebViewValue internal constructor() {
     /**
      * A JSON array: an ordered list of [PaywallWebViewValue]s.
      */
-    public class Array(public val value: List<PaywallWebViewValue>) : PaywallWebViewValue() {
+    class Array(val value: List<PaywallWebViewValue>) : PaywallWebViewValue() {
         override fun equals(other: Any?): kotlin.Boolean = other is Array && value == other.value
         override fun hashCode(): Int = value.hashCode()
         override fun toString(): kotlin.String = "PaywallWebViewValue.Array(value=$value)"
@@ -72,7 +71,7 @@ public abstract class PaywallWebViewValue internal constructor() {
     /**
      * A JSON `null` value.
      */
-    public object Null : PaywallWebViewValue() {
+    object Null : PaywallWebViewValue() {
         override fun toString(): kotlin.String = "PaywallWebViewValue.Null"
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
@@ -1,0 +1,144 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A JSON-compatible value used in messages exchanged with a Paywalls V2 `web_view` component.
+ *
+ * Only JSON-like values are supported: [String], [Number], [Boolean], [Object], [Array] and [Null].
+ * Functions, binary blobs, dates, and platform-specific objects are intentionally not representable.
+ *
+ * @see PaywallWebViewMessage
+ * @see PaywallWebViewController
+ */
+// Modeled as an abstract class with a closed set of subtypes (mirroring [CustomVariableValue]) rather
+// than a sealed class, to stay binary-compatible as public API.
+public abstract class PaywallWebViewValue internal constructor() {
+
+    /**
+     * A string value.
+     */
+    public class String(public val value: kotlin.String) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is String && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.String(value=$value)"
+    }
+
+    /**
+     * A numeric value (integer or decimal). Stored as a [Double].
+     *
+     * Non-finite values (`NaN`, infinities) cannot be represented in JSON and serialize as JSON
+     * `null` when sent into the web view. Equality follows [Double.equals] semantics (consistent
+     * with [hashCode]): `NaN` equals `NaN`, and `-0.0` does not equal `0.0`.
+     */
+    public class Number(public val value: kotlin.Double) : PaywallWebViewValue() {
+        public constructor(value: kotlin.Int) : this(value.toDouble())
+        public constructor(value: kotlin.Long) : this(value.toDouble())
+        public constructor(value: kotlin.Float) : this(value.toDouble())
+
+        override fun equals(other: Any?): kotlin.Boolean = other is Number && value.equals(other.value)
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Number(value=$value)"
+    }
+
+    /**
+     * A boolean value.
+     */
+    public class Boolean(public val value: kotlin.Boolean) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Boolean && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Boolean(value=$value)"
+    }
+
+    /**
+     * A JSON object: a map of string keys to [PaywallWebViewValue]s.
+     */
+    public class Object(public val value: Map<kotlin.String, PaywallWebViewValue>) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Object && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Object(value=$value)"
+    }
+
+    /**
+     * A JSON array: an ordered list of [PaywallWebViewValue]s.
+     */
+    public class Array(public val value: List<PaywallWebViewValue>) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Array && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Array(value=$value)"
+    }
+
+    /**
+     * A JSON `null` value.
+     */
+    public object Null : PaywallWebViewValue() {
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Null"
+    }
+
+    internal companion object {
+        /**
+         * Converts an `org.json` value (or Kotlin primitive) into a [PaywallWebViewValue], rejecting
+         * anything that is not JSON-compatible or that exceeds [remainingDepth] levels of nesting.
+         *
+         * @return the converted value, or `null` if the value is not JSON-compatible or too deeply nested.
+         */
+        @Suppress("ReturnCount", "CyclomaticComplexMethod")
+        fun fromJson(value: Any?, remainingDepth: Int): PaywallWebViewValue? {
+            return when (value) {
+                null, JSONObject.NULL -> Null
+                is kotlin.String -> String(value)
+                is kotlin.Boolean -> Boolean(value)
+                is Int -> Number(value)
+                is Long -> Number(value)
+                is Double -> Number(value)
+                is Float -> Number(value)
+                is JSONObject -> {
+                    if (remainingDepth <= 0) return null
+                    val map = LinkedHashMap<kotlin.String, PaywallWebViewValue>(value.length())
+                    for (key in value.keys()) {
+                        map[key] = fromJson(value.get(key), remainingDepth - 1) ?: return null
+                    }
+                    Object(map)
+                }
+                is JSONArray -> {
+                    if (remainingDepth <= 0) return null
+                    val list = ArrayList<PaywallWebViewValue>(value.length())
+                    for (index in 0 until value.length()) {
+                        list.add(fromJson(value.get(index), remainingDepth - 1) ?: return null)
+                    }
+                    Array(list)
+                }
+                // Numbers stored by org.json as BigDecimal/BigInteger, or any other type, are not supported.
+                else -> (value as? kotlin.Number)?.let { Number(it.toDouble()) }
+            }
+        }
+    }
+}
+
+/**
+ * Converts this value into a representation accepted by [JSONObject]/[JSONArray] when serializing a
+ * message to send into the web view. Whole numbers are emitted as integers (e.g. `100`, not `100.0`).
+ * Non-finite numbers serialize as JSON `null`: JSON cannot represent them, `org.json`'s `put` throws
+ * for them, and one bad number must never destroy an otherwise-valid outbound message.
+ */
+internal fun PaywallWebViewValue.toJsonRepresentation(): Any = when (this) {
+    is PaywallWebViewValue.String -> value
+    is PaywallWebViewValue.Boolean -> value
+    is PaywallWebViewValue.Number -> when {
+        !value.isFinite() -> JSONObject.NULL
+        value % 1.0 == 0.0 -> value.toLong()
+        else -> value
+    }
+    is PaywallWebViewValue.Object -> JSONObject().apply {
+        value.forEach { (key, child) -> put(key, child.toJsonRepresentation()) }
+    }
+    is PaywallWebViewValue.Array -> JSONArray().apply {
+        value.forEach { child -> put(child.toJsonRepresentation()) }
+    }
+    else -> JSONObject.NULL
+}
+
+internal fun Map<String, PaywallWebViewValue>.toJsonObject(): JSONObject = JSONObject().apply {
+    forEach { (key, value) -> put(key, value.toJsonRepresentation()) }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValueTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValueTest.kt
@@ -1,0 +1,113 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+
+internal class PaywallWebViewValueTest {
+
+    @Test
+    fun `fromJson converts primitives`() {
+        assertThat(PaywallWebViewValue.fromJson("hello", 8)).isEqualTo(PaywallWebViewValue.String("hello"))
+        assertThat(PaywallWebViewValue.fromJson(true, 8)).isEqualTo(PaywallWebViewValue.Boolean(true))
+        assertThat(PaywallWebViewValue.fromJson(42, 8)).isEqualTo(PaywallWebViewValue.Number(42))
+        assertThat(PaywallWebViewValue.fromJson(3.5, 8)).isEqualTo(PaywallWebViewValue.Number(3.5))
+        assertThat(PaywallWebViewValue.fromJson(null, 8)).isEqualTo(PaywallWebViewValue.Null)
+        assertThat(PaywallWebViewValue.fromJson(JSONObject.NULL, 8)).isEqualTo(PaywallWebViewValue.Null)
+    }
+
+    @Test
+    fun `fromJson converts nested objects and arrays`() {
+        val json = JSONObject("""{"a":1,"b":["x",false],"c":{"d":null}}""")
+
+        val value = PaywallWebViewValue.fromJson(json, 8)
+
+        assertThat(value).isInstanceOf(PaywallWebViewValue.Object::class.java)
+        val obj = (value as PaywallWebViewValue.Object).value
+        assertThat(obj["a"]).isEqualTo(PaywallWebViewValue.Number(1))
+        assertThat(obj["b"]).isEqualTo(
+            PaywallWebViewValue.Array(listOf(PaywallWebViewValue.String("x"), PaywallWebViewValue.Boolean(false))),
+        )
+        assertThat(obj["c"]).isEqualTo(
+            PaywallWebViewValue.Object(mapOf("d" to PaywallWebViewValue.Null)),
+        )
+    }
+
+    @Test
+    fun `fromJson returns null when too deeply nested`() {
+        val json = JSONObject("""{"a":{"b":{"c":1}}}""")
+
+        // Allow only 2 levels: top object (1) -> a (2) -> b would exceed.
+        assertThat(PaywallWebViewValue.fromJson(json, 2)).isNull()
+    }
+
+    @Test
+    fun `toJsonRepresentation emits whole numbers as integers`() {
+        assertThat(PaywallWebViewValue.Number(100.0).toJsonRepresentation()).isEqualTo(100L)
+        assertThat(PaywallWebViewValue.Number(99.99).toJsonRepresentation()).isEqualTo(99.99)
+    }
+
+    @Test
+    fun `toJsonRepresentation serializes non-finite numbers as JSON null`() {
+        // JSON cannot represent NaN/infinity and org.json's put() throws for them; one bad number
+        // must never destroy an otherwise-valid outbound message.
+        assertThat(PaywallWebViewValue.Number(Double.POSITIVE_INFINITY).toJsonRepresentation())
+            .isEqualTo(JSONObject.NULL)
+        assertThat(PaywallWebViewValue.Number(Double.NEGATIVE_INFINITY).toJsonRepresentation())
+            .isEqualTo(JSONObject.NULL)
+        assertThat(PaywallWebViewValue.Number(Double.NaN).toJsonRepresentation())
+            .isEqualTo(JSONObject.NULL)
+    }
+
+    @Test
+    fun `a map containing non-finite numbers serializes without throwing`() {
+        val json = mapOf(
+            "bad" to PaywallWebViewValue.Number(Double.NaN),
+            "good" to PaywallWebViewValue.String("kept"),
+        ).toJsonObject()
+
+        assertThat(json.isNull("bad")).isTrue()
+        assertThat(json.getString("good")).isEqualTo("kept")
+    }
+
+    @Test
+    fun `number equality and hashCode are mutually consistent for edge values`() {
+        // Double.equals semantics: NaN equals NaN; -0.0 does not equal 0.0. Both agree with hashCode.
+        val nan1 = PaywallWebViewValue.Number(Double.NaN)
+        val nan2 = PaywallWebViewValue.Number(Double.NaN)
+        assertThat(nan1).isEqualTo(nan2)
+        assertThat(nan1.hashCode()).isEqualTo(nan2.hashCode())
+
+        val negativeZero = PaywallWebViewValue.Number(-0.0)
+        val positiveZero = PaywallWebViewValue.Number(0.0)
+        assertThat(negativeZero).isNotEqualTo(positiveZero)
+        assertThat(negativeZero.hashCode()).isNotEqualTo(positiveZero.hashCode())
+    }
+
+    @Test
+    fun `toJsonObject round-trips a map`() {
+        val map = mapOf(
+            "locale" to PaywallWebViewValue.String("en-US"),
+            "custom" to PaywallWebViewValue.Object(
+                mapOf(
+                    "plan" to PaywallWebViewValue.String("annual"),
+                    "count" to PaywallWebViewValue.Number(3),
+                    "flag" to PaywallWebViewValue.Boolean(true),
+                    "list" to PaywallWebViewValue.Array(listOf(PaywallWebViewValue.Number(1))),
+                    "nothing" to PaywallWebViewValue.Null,
+                ),
+            ),
+        )
+
+        val json = map.toJsonObject()
+
+        assertThat(json.getString("locale")).isEqualTo("en-US")
+        val custom = json.getJSONObject("custom")
+        assertThat(custom.getString("plan")).isEqualTo("annual")
+        assertThat(custom.getInt("count")).isEqualTo(3)
+        assertThat(custom.getBoolean("flag")).isTrue()
+        assertThat(custom.get("list")).isInstanceOf(JSONArray::class.java)
+        assertThat(custom.isNull("nothing")).isTrue()
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Part **1 of 8** splitting #3757 (`cursor/paywalls-web-view-consolidated-a396`) into smaller landable PRs. Lands the internal messaging types for Paywalls V2 `web_view` as **inert** code — nothing registers or activates the component until Part 8.

### Description
Adds SDK-internal models used to exchange messages with hosted web content inside a paywall:

- `PaywallWebViewValue` — typed JSON-compatible values
- `PaywallWebViewMessage` / `PaywallWebViewController` / `PaywallWebViewMessageHandler`
- Unit tests for `PaywallWebViewValue`
- Keeps `ui/revenuecatui/api.txt` unchanged; these types are not public API

**Inert until Part 8.** Until activation, a paywall JSON containing `web_view` continues to hit the existing unknown-type fallback on `main`.

Verified: `:ui:revenuecatui:testDefaultsDebugUnitTest` (PaywallWebViewValueTest), `detektAll`, `./scripts/api-check.sh`.

**Labels:** `pr:feat`, `pr:RevenueCatUI`, `feat:Paywalls_V2`

### Series (splitting #3757)

PWENG-98

| Part | PR | Notes |
|------|-----|--------|
| 1/9 | #3780 | main |
| 2/9 | #3784 | ~~dropped~~ — app-facing message handler removed from scope |
| 3/9 | #3781 | independent |
| 4/9 | #3782 | independent |
| 5/9 | #3783 | independent |
| 6/9 | #3796 | after PRs 1+4; replaces half of #3785 |
| 7/9 | #3798 | bridge; stacks on 6 |
| 8/9 | #3786 | after PRs 3+7 |
| 9/9 | #3787 | activation |

> Series is being converted to a linear Graphite stack: main → 1 → 3 → 4 → 5 → 6 → 7 → 8 → 9 (part 2 dropped).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

