### PR TITLE
feat(paywalls): web_view schema component, not yet registered (3)

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -3,8 +3,6 @@ package com.revenuecat.purchases.paywalls.components
 import androidx.compose.runtime.Immutable
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.properties.Size
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -35,5 +33,5 @@ public class WebViewComponent(
     @get:JvmSynthetic
     public val protocolVersion: Int,
     @get:JvmSynthetic
-    public val size: Size = Size(width = Fill, height = SizeConstraint.Fit()),
+    public val size: Size,
 ) : PaywallComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -26,14 +26,14 @@ public class WebViewComponent(
     @get:JvmSynthetic
     public val url: String,
     @get:JvmSynthetic
-    public val id: String? = null,
+    public val id: String,
     @get:JvmSynthetic
     public val name: String? = null,
     @get:JvmSynthetic
     public val visible: Boolean? = null,
     @SerialName("protocol_version")
     @get:JvmSynthetic
-    public val protocolVersion: Int? = null,
+    public val protocolVersion: Int,
     @get:JvmSynthetic
     public val size: Size = Size(width = Fill, height = SizeConstraint.Fit()),
 ) : PaywallComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -1,0 +1,39 @@
+package com.revenuecat.purchases.paywalls.components
+
+import androidx.compose.runtime.Immutable
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A Paywalls V2 component that renders generic hosted web content (a web bundle entrypoint) inside a
+ * web view.
+ *
+ * Only [protocolVersion] `1` is currently supported. Isolation from external sources is expected from
+ * the Content-Security-Policy served by the backend with the web content; the bundle must be fully
+ * self-contained.
+ */
+@InternalRevenueCatAPI
+@Poko
+@Serializable
+@SerialName("web_view")
+@Immutable
+public class WebViewComponent(
+    @get:JvmSynthetic
+    public val url: String,
+    @get:JvmSynthetic
+    public val id: String? = null,
+    @get:JvmSynthetic
+    public val name: String? = null,
+    @get:JvmSynthetic
+    public val visible: Boolean? = null,
+    @SerialName("protocol_version")
+    @get:JvmSynthetic
+    public val protocolVersion: Int? = null,
+    @get:JvmSynthetic
+    public val size: Size = Size(width = Fill, height = SizeConstraint.Fit),
+) : PaywallComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -35,5 +35,5 @@ public class WebViewComponent(
     @get:JvmSynthetic
     public val protocolVersion: Int? = null,
     @get:JvmSynthetic
-    public val size: Size = Size(width = Fill, height = SizeConstraint.Fit),
+    public val size: Size = Size(width = Fill, height = SizeConstraint.Fit()),
 ) : PaywallComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentFilterExtension.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentFilterExtension.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 
 /**
  * Returns all PaywallComponent that satisfy the predicate.
@@ -74,6 +75,7 @@ internal fun PaywallComponent.filter(predicate: (PaywallComponent) -> Boolean): 
             is ImageComponent,
             is IconComponent,
             is TextComponent,
+            is WebViewComponent,
             -> {
                 // These don't have child components.
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
@@ -115,6 +116,7 @@ internal class PaywallComponentsImagePreDownloader(
                     is TabControlToggleComponent,
                     is TextComponent,
                     is TimelineComponent,
+                    is WebViewComponent,
                     -> emptySet()
                 }
             }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.utils.filter
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -51,6 +52,8 @@ class WebViewComponentTests {
         val json = """
             {
               "type": "web_view",
+              "id": "promo_web_view",
+              "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html",
               "fallback": {
                 "type": "stack",
@@ -62,7 +65,7 @@ class WebViewComponentTests {
         val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
 
         assertEquals(
-            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html", id = "promo_web_view", protocolVersion = 1),
             actual,
         )
     }
@@ -75,6 +78,8 @@ class WebViewComponentTests {
         val json = """
             {
               "type": "web_view",
+              "id": "promo_web_view",
+              "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html",
               "capabilities": {
                 "network_access": { "allowed_domains": ["api.segment.io"] },
@@ -90,7 +95,7 @@ class WebViewComponentTests {
         val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
 
         assertEquals(
-            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html", id = "promo_web_view", protocolVersion = 1),
             actual,
         )
     }
@@ -101,6 +106,7 @@ class WebViewComponentTests {
         val templateJson = """
             {
               "type": "web_view",
+              "id": "promo_web_view",
               "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/{{ custom.animal }}.html"
             }
@@ -111,6 +117,7 @@ class WebViewComponentTests {
         assertEquals(
             WebViewComponent(
                 url = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
+                id = "promo_web_view",
                 protocolVersion = 1,
             ),
             actual,
@@ -118,31 +125,65 @@ class WebViewComponentTests {
     }
 
     @Test
-    fun `deserializes minimal shape with defaults for missing optional fields`() {
-        // Older/partial configs may omit protocol_version and size. These should still
-        // decode without crashing, using defaults.
+    fun `deserializes required shape with defaults for missing optional fields`() {
+        // Only name, visible, and size are optional; id, url, and protocol_version are required.
         @Language("json")
-        val minimalJson = """
+        val json = """
             {
               "type": "web_view",
+              "id": "promo_web_view",
+              "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html"
             }
             """
 
-        val actual = JsonTools.json.decodeFromString<WebViewComponent>(minimalJson)
+        val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
 
         assertEquals(
-            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html", id = "promo_web_view", protocolVersion = 1),
             actual,
         )
-        assertThat(actual.protocolVersion).isNull()
+        assertThat(actual.name).isNull()
+        assertThat(actual.visible).isNull()
         assertThat(actual.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()))
+    }
+
+    @Test
+    fun `fails to decode when required id is missing`() {
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "protocol_version": 1,
+              "url": "https://paywalls.revenuecat.com/index.html"
+            }
+            """
+
+        assertThatThrownBy { JsonTools.json.decodeFromString<WebViewComponent>(json) }
+    }
+
+    @Test
+    fun `fails to decode when required protocol_version is missing`() {
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "id": "promo_web_view",
+              "url": "https://paywalls.revenuecat.com/index.html"
+            }
+            """
+
+        assertThatThrownBy { JsonTools.json.decodeFromString<WebViewComponent>(json) }
     }
 
     @Test
     fun `filter treats web_view as a leaf component`() {
         // web_view has no child components, so filtering a tree should return only the component itself.
-        val webView = WebViewComponent(url = "https://paywalls.revenuecat.com/index.html")
+        val webView = WebViewComponent(
+            url = "https://paywalls.revenuecat.com/index.html",
+            id = "promo_web_view",
+            protocolVersion = 1,
+        )
 
         val matches = webView.filter { it is WebViewComponent }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -40,7 +40,7 @@ class WebViewComponentTests {
         assertThat(webView.visible).isTrue()
         assertThat(webView.protocolVersion).isEqualTo(1)
         assertThat(webView.url).isEqualTo("https://assets.pawwalls.com/web_bundles/123/index.html")
-        assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit))
+        assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()))
     }
 
     @Test
@@ -136,7 +136,7 @@ class WebViewComponentTests {
             actual,
         )
         assertThat(actual.protocolVersion).isNull()
-        assertThat(actual.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit))
+        assertThat(actual.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()))
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -16,6 +16,8 @@ import kotlin.test.assertEquals
  */
 class WebViewComponentTests {
 
+    private val fillFitSize = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit())
+
     @Language("json")
     private val fullJson = """
         {
@@ -41,7 +43,7 @@ class WebViewComponentTests {
         assertThat(webView.visible).isTrue()
         assertThat(webView.protocolVersion).isEqualTo(1)
         assertThat(webView.url).isEqualTo("https://assets.pawwalls.com/web_bundles/123/index.html")
-        assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()))
+        assertThat(webView.size).isEqualTo(fillFitSize)
     }
 
     @Test
@@ -55,6 +57,7 @@ class WebViewComponentTests {
               "id": "promo_web_view",
               "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
               "fallback": {
                 "type": "stack",
                 "components": []
@@ -65,7 +68,12 @@ class WebViewComponentTests {
         val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
 
         assertEquals(
-            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html", id = "promo_web_view", protocolVersion = 1),
+            WebViewComponent(
+                url = "https://paywalls.revenuecat.com/index.html",
+                id = "promo_web_view",
+                protocolVersion = 1,
+                size = fillFitSize,
+            ),
             actual,
         )
     }
@@ -81,6 +89,7 @@ class WebViewComponentTests {
               "id": "promo_web_view",
               "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
               "capabilities": {
                 "network_access": { "allowed_domains": ["api.segment.io"] },
                 "camera": true,
@@ -95,7 +104,12 @@ class WebViewComponentTests {
         val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
 
         assertEquals(
-            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html", id = "promo_web_view", protocolVersion = 1),
+            WebViewComponent(
+                url = "https://paywalls.revenuecat.com/index.html",
+                id = "promo_web_view",
+                protocolVersion = 1,
+                size = fillFitSize,
+            ),
             actual,
         )
     }
@@ -108,7 +122,8 @@ class WebViewComponentTests {
               "type": "web_view",
               "id": "promo_web_view",
               "protocol_version": 1,
-              "url": "https://paywalls.revenuecat.com/{{ custom.animal }}.html"
+              "url": "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
             }
             """
 
@@ -119,33 +134,39 @@ class WebViewComponentTests {
                 url = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
                 id = "promo_web_view",
                 protocolVersion = 1,
+                size = fillFitSize,
             ),
             actual,
         )
     }
 
     @Test
-    fun `deserializes required shape with defaults for missing optional fields`() {
-        // Only name, visible, and size are optional; id, url, and protocol_version are required.
+    fun `decodes with defaults for missing name and visible`() {
+        // Only name and visible are optional; id, url, protocol_version, and size are required.
         @Language("json")
         val json = """
             {
               "type": "web_view",
               "id": "promo_web_view",
               "protocol_version": 1,
-              "url": "https://paywalls.revenuecat.com/index.html"
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
             }
             """
 
         val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
 
         assertEquals(
-            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html", id = "promo_web_view", protocolVersion = 1),
+            WebViewComponent(
+                url = "https://paywalls.revenuecat.com/index.html",
+                id = "promo_web_view",
+                protocolVersion = 1,
+                size = fillFitSize,
+            ),
             actual,
         )
         assertThat(actual.name).isNull()
         assertThat(actual.visible).isNull()
-        assertThat(actual.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()))
     }
 
     @Test
@@ -155,7 +176,8 @@ class WebViewComponentTests {
             {
               "type": "web_view",
               "protocol_version": 1,
-              "url": "https://paywalls.revenuecat.com/index.html"
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
             }
             """
 
@@ -169,6 +191,22 @@ class WebViewComponentTests {
             {
               "type": "web_view",
               "id": "promo_web_view",
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
+            }
+            """
+
+        assertThatThrownBy { JsonTools.json.decodeFromString<WebViewComponent>(json) }
+    }
+
+    @Test
+    fun `fails to decode when required size is missing`() {
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "id": "promo_web_view",
+              "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html"
             }
             """
@@ -183,6 +221,7 @@ class WebViewComponentTests {
             url = "https://paywalls.revenuecat.com/index.html",
             id = "promo_web_view",
             protocolVersion = 1,
+            size = fillFitSize,
         )
 
         val matches = webView.filter { it is WebViewComponent }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -1,0 +1,151 @@
+package com.revenuecat.purchases.paywalls.components
+
+import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.utils.filter
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Decodes [WebViewComponent] directly (not via [PaywallComponent]) because the polymorphic
+ * `"web_view" ->` serializer registration lands in A8. A8 restores polymorphic decode tests.
+ */
+class WebViewComponentTests {
+
+    @Language("json")
+    private val fullJson = """
+        {
+          "id": "promo_web_view",
+          "type": "web_view",
+          "protocol_version": 1,
+          "url": "https://assets.pawwalls.com/web_bundles/123/index.html",
+          "size": {
+            "width": { "type": "fill" },
+            "height": { "type": "fit" }
+          },
+          "visible": true,
+          "name": "Promo web component"
+        }
+        """
+
+    @Test
+    fun `deserializes full Khepri schema`() {
+        val webView = JsonTools.json.decodeFromString<WebViewComponent>(fullJson)
+
+        assertThat(webView.id).isEqualTo("promo_web_view")
+        assertThat(webView.name).isEqualTo("Promo web component")
+        assertThat(webView.visible).isTrue()
+        assertThat(webView.protocolVersion).isEqualTo(1)
+        assertThat(webView.url).isEqualTo("https://assets.pawwalls.com/web_bundles/123/index.html")
+        assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit))
+    }
+
+    @Test
+    fun `ignores schema fallback field`() {
+        // web_view intentionally has no native fallback stack; older/dashboard payloads that
+        // still include `fallback` must decode without error (unknown keys are ignored).
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "fallback": {
+                "type": "stack",
+                "components": []
+              }
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
+
+        assertEquals(
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            actual,
+        )
+    }
+
+    @Test
+    fun `ignores capabilities declared by the schema`() {
+        // Isolation from external sources is expected from the server-provided CSP, so any
+        // schema-declared capabilities are decoded-and-ignored rather than failing to parse.
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "capabilities": {
+                "network_access": { "allowed_domains": ["api.segment.io"] },
+                "camera": true,
+                "microphone": true,
+                "clipboard_write": true,
+                "clipboard_read": true,
+                "geolocation": true
+              }
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
+
+        assertEquals(
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            actual,
+        )
+    }
+
+    @Test
+    fun `deserializes template url correctly`() {
+        @Language("json")
+        val templateJson = """
+            {
+              "type": "web_view",
+              "protocol_version": 1,
+              "url": "https://paywalls.revenuecat.com/{{ custom.animal }}.html"
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<WebViewComponent>(templateJson)
+
+        assertEquals(
+            WebViewComponent(
+                url = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
+                protocolVersion = 1,
+            ),
+            actual,
+        )
+    }
+
+    @Test
+    fun `deserializes minimal shape with defaults for missing optional fields`() {
+        // Older/partial configs may omit protocol_version and size. These should still
+        // decode without crashing, using defaults.
+        @Language("json")
+        val minimalJson = """
+            {
+              "type": "web_view",
+              "url": "https://paywalls.revenuecat.com/index.html"
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<WebViewComponent>(minimalJson)
+
+        assertEquals(
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            actual,
+        )
+        assertThat(actual.protocolVersion).isNull()
+        assertThat(actual.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit))
+    }
+
+    @Test
+    fun `filter treats web_view as a leaf component`() {
+        // web_view has no child components, so filtering a tree should return only the component itself.
+        val webView = WebViewComponent(url = "https://paywalls.revenuecat.com/index.html")
+
+        val matches = webView.filter { it is WebViewComponent }
+
+        assertThat(matches).containsExactly(webView)
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -27,6 +27,7 @@ import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
@@ -573,6 +574,8 @@ internal class StyleFactory(
             is TabsComponent -> createTabsComponentStyle(component)
             is VideoComponent -> createVideoComponentStyle(component)
             is FallbackHeaderComponent -> Result.Success(null)
+            // Stub until A6 wires createWebViewComponentStyle; null style is filtered like FallbackHeader.
+            is WebViewComponent -> Result.Success(null)
             is CountdownComponent -> createCountdownComponentStyle(
                 component,
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -574,7 +574,7 @@ internal class StyleFactory(
             is TabsComponent -> createTabsComponentStyle(component)
             is VideoComponent -> createVideoComponentStyle(component)
             is FallbackHeaderComponent -> Result.Success(null)
-            // Stub until A6 wires createWebViewComponentStyle; null style is filtered like FallbackHeader.
+            // Stub until Part 8 wires createWebViewComponentStyle; null style is filtered like FallbackHeader.
             is WebViewComponent -> Result.Success(null)
             is CountdownComponent -> createCountdownComponentStyle(
                 component,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -25,6 +25,7 @@ import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.common.LocalizationData
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
@@ -516,6 +517,7 @@ internal fun PaywallComponent.containsUnsupportedCondition(): Boolean = when (th
     is TabControlToggleComponent -> false
     is TabControlComponent -> false
     is FallbackHeaderComponent -> false
+    is WebViewComponent -> false
 }
 
 @JvmSynthetic

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -129,6 +129,7 @@ class StyleFactoryTests {
                     url = "https://paywalls.revenuecat.com/index.html",
                     id = "promo_web_view",
                     protocolVersion = 1,
+                    size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()),
                 ),
                 TextComponent(
                     text = LOCALIZATION_KEY_TEXT_1,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -125,7 +125,11 @@ class StyleFactoryTests {
         // so a web_view nested in a stack is filtered out. Real WebViewComponentStyle lands later.
         val stackComponent = StackComponent(
             components = listOf(
-                WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+                WebViewComponent(
+                    url = "https://paywalls.revenuecat.com/index.html",
+                    id = "promo_web_view",
+                    protocolVersion = 1,
+                ),
                 TextComponent(
                     text = LOCALIZATION_KEY_TEXT_1,
                     color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.paywalls.components.TabControlComponent
 import com.revenuecat.purchases.paywalls.components.TabControlToggleComponent
 import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
@@ -116,6 +117,28 @@ class StyleFactoryTests {
             .isEqualTo(localizations.getValue(localeId)[LOCALIZATION_KEY_TEXT_1]!!.value)
         val colorStyle = style.color.light as ColorStyle.Solid
         assertThat(colorStyle.color).isEqualTo(expectedColor)
+    }
+
+    @Test
+    fun `Should return null style for WebViewComponent until style factory is wired`() {
+        // Stub arm mirrors FallbackHeaderComponent: createInternal returns Result.Success(null),
+        // so a web_view nested in a stack is filtered out. Real WebViewComponentStyle lands later.
+        val stackComponent = StackComponent(
+            components = listOf(
+                WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+                TextComponent(
+                    text = LOCALIZATION_KEY_TEXT_1,
+                    color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                ),
+            ),
+        )
+
+        val result = styleFactory.create(stackComponent)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as StackComponentStyle
+        assertThat(style.children).hasSize(1)
+        assertThat(style.children[0]).isInstanceOf(TextComponentStyle::class.java)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentViewTests.kt
@@ -39,6 +39,7 @@ import com.revenuecat.purchases.paywalls.components.TabsComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
@@ -1298,7 +1299,8 @@ class TabsComponentViewTests {
                 is IconComponent,
                 is TextComponent,
                 is VideoComponent,
-                    -> {
+                is WebViewComponent,
+                -> {
                     // These don't have child components.
                 }
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

> [!NOTE]
> This has some spots that are essentially no ops for now. In the final PR in this chain they get their actual logic

### Motivation
Part **3** splitting #3757; **inert until Part 8** (#3787).

Adds the `WebViewComponent` schema type to the sealed `PaywallComponent` hierarchy, with compiler-forced `when` arms, but does **not** register `"web_view"` in `PaywallComponentSerializer`. Until Part 8, paywall JSON with `web_view` still hits the existing unknown-type fallback.

### Description
- New `WebViewComponent` (`@InternalRevenueCatAPI`)
- Sealed-when stubs: filter leaf, image pre-downloader `emptySet()`, `containsUnsupportedCondition -> false`, StyleFactory `Result.Success(null)` (mirrors `FallbackHeaderComponent`)
- TabsComponentViewTests when-arm
- Decode tests use direct `WebViewComponent` serializer (polymorphic route restored in Part 8)
- StyleFactory stub test asserting null style

**Not in this PR:** serializer registration (part 8), `createWebViewComponentStyle` (part 8). The app-facing `webViewMessageHandler` was dropped from v1 entirely.

Verified: purchases + UI unit tests for touched suites, `detektAll`, `api-check.sh`.

**Labels:** `pr:feat` (purchases-module schema; UI stubs accompany sealed hierarchy)


### Series (splitting #3757)

PWENG-98

Parts 1 and 2 were dropped. Not a linear stack: parts 3, 4, 5 are independent
(each off `main`); `webview/deps-1-5` merges all three; the tail stacks linearly on
that merge (6a -> 6b -> 7 -> 8).

| Part | PR | Base | Notes |
|------|-----|------|-------|
| 1 | ~~#3780~~ | - | dropped; value types collapsed to `Map<String, String>` |
| 2 | ~~#3784~~ | - | dropped; app-facing message handler cut from v1 |
| 3 | #3781 | `main` | schema component, not yet registered |
| 4 | #3782 | `main` | transport envelope + JSON hardening |
| 5 | #3783 | `main` | navigation policy + origin helpers |
| 6a | #3796 | `webview/deps-1-5` | SDK variables provider |
| 6b | #3798 | #3796 | JavaScript bridge |
| 7 | #3786 | #3798 | Compose view + style |
| 8 | #3787 | #3786 | activation + unsupported protocol_version fallback |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


