### PR TITLE
feat(paywalls): web_view transport envelope + JSON hardening (4)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -1,0 +1,174 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.json.JSONObject
+
+/**
+ * Wire-format envelopes for the `workflow-web-components-sdk` transport layer.
+ *
+ * Matches [RevenueCat/workflow-web-components-sdk](https://github.com/RevenueCat/workflow-web-components-sdk):
+ * channel `rc-web-components`, handshake kinds `connect` / `init` / `reject`, and app frames
+ * `message` / `request` / `response` / `error`.
+ *
+ * On Android the host installs `rcWebComponents` via `WebViewCompat.addWebMessageListener` so inbound
+ * frames carry a platform `sourceOrigin` / `isMainFrame`. The content still calls
+ * `rcWebComponents.postMessage(jsonString)`.
+ */
+internal object WebViewEnvelope {
+
+    const val CHANNEL: String = "rc-web-components"
+    const val NATIVE_OBJECT_NAME: String = "rcWebComponents"
+    const val RECEIVE_FUNCTION: String = "__rcWebComponentsReceive"
+    const val DEFAULT_PROTOCOL_VERSION: Int = 1
+
+    /** Maximum UTF-8 byte length accepted for a single inbound frame. */
+    const val MAX_PAYLOAD_BYTES: Int = 65_536
+
+    /**
+     * Maximum nesting depth for a payload tree. The whole-frame pre-parse scan allows one extra
+     * level for the envelope object itself ([MAX_FRAME_DEPTH]).
+     */
+    const val MAX_NESTING_DEPTH: Int = 16
+
+    const val KIND_CONNECT: String = "connect"
+    const val KIND_INIT: String = "init"
+    const val KIND_REJECT: String = "reject"
+    const val KIND_MESSAGE: String = "message"
+    const val KIND_REQUEST: String = "request"
+    const val KIND_RESPONSE: String = "response"
+    const val KIND_ERROR: String = "error"
+
+    private val ENVELOPE_KINDS: Set<String> = setOf(
+        KIND_CONNECT,
+        KIND_INIT,
+        KIND_REJECT,
+        KIND_MESSAGE,
+        KIND_REQUEST,
+        KIND_RESPONSE,
+        KIND_ERROR,
+    )
+
+    internal data class Parsed(
+        val kind: String,
+        val protocolVersion: Int,
+        val componentId: String,
+        val type: String?,
+        val id: String?,
+        val payload: JSONObject?,
+        val error: String?,
+    )
+
+    /**
+     * Coarse structural depth budget for a whole inbound frame: the envelope object itself plus a
+     * payload tree of at most [MAX_NESTING_DEPTH] levels. The precise per-tree limit is still
+     * enforced during app-message conversion; this scan exists only to stop hostile input before
+     * recursion happens.
+     */
+    private const val MAX_FRAME_DEPTH: Int = MAX_NESTING_DEPTH + 1
+
+    @Suppress("ReturnCount", "CyclomaticComplexMethod")
+    fun parse(rawJson: String): Parsed? {
+        if (rawJson.toByteArray(Charsets.UTF_8).size > MAX_PAYLOAD_BYTES) return null
+
+        // Enforce the nesting budget BEFORE org.json parses: JSONTokener recurses per nesting
+        // level, and tens of thousands of levels fit inside the 64 KiB frame limit, so a hostile
+        // deeply-nested frame could otherwise overflow the stack before any post-parse check runs.
+        if (exceedsMaxDepth(rawJson)) return null
+
+        val json = try {
+            JSONObject(rawJson)
+        } catch (@Suppress("SwallowedException") _: org.json.JSONException) {
+            return null
+        }
+
+        if (json.opt(WebViewMessageField.CHANNEL) != CHANNEL) return null
+
+        val protocolVersion = json.opt(WebViewMessageField.PROTOCOL_VERSION)
+        if (protocolVersion !is Number || !protocolVersion.toDouble().isFinite()) return null
+
+        val kind = json.opt(WebViewMessageField.KIND) as? String
+        if (kind == null || kind !in ENVELOPE_KINDS) return null
+
+        val componentId = json.opt(WebViewMessageField.COMPONENT_ID) as? String ?: return null
+
+        val type = json.opt(WebViewMessageField.TYPE) as? String
+        if (json.has(WebViewMessageField.TYPE) && type == null) return null
+
+        val id = json.opt(WebViewMessageField.ID) as? String
+        if (json.has(WebViewMessageField.ID) && id == null) return null
+
+        val error = json.opt(WebViewMessageField.ERROR) as? String
+        if (json.has(WebViewMessageField.ERROR) && error == null) return null
+
+        val payload = when (val payloadValue = json.opt(WebViewMessageField.PAYLOAD)) {
+            null, JSONObject.NULL -> null
+            is JSONObject -> payloadValue
+            else -> return null
+        }
+
+        return Parsed(
+            kind = kind,
+            protocolVersion = protocolVersion.toInt(),
+            componentId = componentId,
+            type = type,
+            id = id,
+            payload = payload,
+            error = error,
+        )
+    }
+
+    /**
+     * Non-recursive scan of the raw JSON characters, tracking `{`/`[` nesting outside string
+     * literals (honoring `\` escapes). Returns `true` when the depth exceeds [MAX_FRAME_DEPTH].
+     */
+    @Suppress("LoopWithTooManyJumpStatements")
+    fun exceedsMaxDepth(rawJson: String): Boolean {
+        var depth = 0
+        var inString = false
+        var escaped = false
+
+        for (char in rawJson) {
+            if (inString) {
+                when {
+                    escaped -> escaped = false
+                    char == '\\' -> escaped = true
+                    char == '"' -> inString = false
+                }
+                continue
+            }
+
+            when (char) {
+                '"' -> inString = true
+                '{', '[' -> {
+                    depth += 1
+                    if (depth > MAX_FRAME_DEPTH) return true
+                }
+                '}', ']' -> depth -= 1
+                else -> Unit
+            }
+        }
+
+        return false
+    }
+
+    @Suppress("LongParameterList")
+    fun build(
+        kind: String,
+        protocolVersion: Int,
+        componentId: String,
+        type: String? = null,
+        id: String? = null,
+        payload: JSONObject? = null,
+        error: String? = null,
+    ): JSONObject = JSONObject().apply {
+        put(WebViewMessageField.CHANNEL, CHANNEL)
+        put(WebViewMessageField.PROTOCOL_VERSION, protocolVersion)
+        put(WebViewMessageField.KIND, kind)
+        put(WebViewMessageField.COMPONENT_ID, componentId)
+        type?.let { put(WebViewMessageField.TYPE, it) }
+        id?.let { put(WebViewMessageField.ID, it) }
+        payload?.let { put(WebViewMessageField.PAYLOAD, it) }
+        error?.let { put(WebViewMessageField.ERROR, it) }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -22,15 +22,6 @@ internal object WebViewEnvelope {
     const val RECEIVE_FUNCTION: String = "__rcWebComponentsReceive"
     const val DEFAULT_PROTOCOL_VERSION: Int = 1
 
-    /** Maximum UTF-8 byte length accepted for a single inbound frame. */
-    const val MAX_PAYLOAD_BYTES: Int = 65_536
-
-    /**
-     * Maximum nesting depth for a payload tree. The whole-frame pre-parse scan allows one extra
-     * level for the envelope object itself ([MAX_FRAME_DEPTH]).
-     */
-    const val MAX_NESTING_DEPTH: Int = 16
-
     const val KIND_CONNECT: String = "connect"
     const val KIND_INIT: String = "init"
     const val KIND_REJECT: String = "reject"
@@ -59,23 +50,8 @@ internal object WebViewEnvelope {
         val error: String?,
     )
 
-    /**
-     * Coarse structural depth budget for a whole inbound frame: the envelope object itself plus a
-     * payload tree of at most [MAX_NESTING_DEPTH] levels. The precise per-tree limit is still
-     * enforced during app-message conversion; this scan exists only to stop hostile input before
-     * recursion happens.
-     */
-    private const val MAX_FRAME_DEPTH: Int = MAX_NESTING_DEPTH + 1
-
     @Suppress("ReturnCount", "CyclomaticComplexMethod")
     fun parse(rawJson: String): Parsed? {
-        if (rawJson.toByteArray(Charsets.UTF_8).size > MAX_PAYLOAD_BYTES) return null
-
-        // Enforce the nesting budget BEFORE org.json parses: JSONTokener recurses per nesting
-        // level, and tens of thousands of levels fit inside the 64 KiB frame limit, so a hostile
-        // deeply-nested frame could otherwise overflow the stack before any post-parse check runs.
-        if (exceedsMaxDepth(rawJson)) return null
-
         val json = try {
             JSONObject(rawJson)
         } catch (@Suppress("SwallowedException") _: org.json.JSONException) {
@@ -116,40 +92,6 @@ internal object WebViewEnvelope {
             payload = payload,
             error = error,
         )
-    }
-
-    /**
-     * Non-recursive scan of the raw JSON characters, tracking `{`/`[` nesting outside string
-     * literals (honoring `\` escapes). Returns `true` when the depth exceeds [MAX_FRAME_DEPTH].
-     */
-    @Suppress("LoopWithTooManyJumpStatements")
-    fun exceedsMaxDepth(rawJson: String): Boolean {
-        var depth = 0
-        var inString = false
-        var escaped = false
-
-        for (char in rawJson) {
-            if (inString) {
-                when {
-                    escaped -> escaped = false
-                    char == '\\' -> escaped = true
-                    char == '"' -> inString = false
-                }
-                continue
-            }
-
-            when (char) {
-                '"' -> inString = true
-                '{', '[' -> {
-                    depth += 1
-                    if (depth > MAX_FRAME_DEPTH) return true
-                }
-                '}', ']' -> depth -= 1
-                else -> Unit
-            }
-        }
-
-        return false
     }
 
     @Suppress("LongParameterList")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -2,6 +2,7 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import org.json.JSONException
 import org.json.JSONObject
 
 /**
@@ -54,7 +55,7 @@ internal object WebViewEnvelope {
     fun parse(rawJson: String): Parsed? {
         val json = try {
             JSONObject(rawJson)
-        } catch (@Suppress("SwallowedException") _: org.json.JSONException) {
+        } catch (@Suppress("SwallowedException") _: JSONException) {
             return null
         }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
@@ -1,0 +1,39 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+/**
+ * Message type identifiers for the RevenueCat `web_view` postMessage protocol (`protocol_version: 1`).
+ * These mirror the shapes used by the web implementation and must not diverge.
+ */
+internal object WebViewMessageType {
+    const val STEP_LOADED = "rc:step-loaded"
+    const val STEP_COMPLETE = "rc:step-complete"
+    const val REQUEST_VARIABLES = "rc:request-variables"
+    const val ERROR = "rc:error"
+    const val VARIABLES = "rc:variables"
+
+    /** Host → content: which axes the native host sizes to the content (`fit`). */
+    const val FIT = "fit"
+
+    /** Content → host: reported content box size in CSS pixels. */
+    const val RESIZE = "resize"
+}
+
+/**
+ * Field names used in the flat message envelope. The envelope is intentionally flat: message-specific
+ * fields such as [RESPONSES], [ERROR] and [VARIABLES] live at the top level rather than under a
+ * generic `payload` key.
+ */
+internal object WebViewMessageField {
+    const val CHANNEL = "channel"
+    const val PROTOCOL_VERSION = "protocol_version"
+    const val KIND = "kind"
+    const val TYPE = "type"
+    const val COMPONENT_ID = "component_id"
+    const val ID = "id"
+    const val PAYLOAD = "payload"
+    const val RESPONSES = "responses"
+    const val ERROR = "error"
+    const val VARIABLES = "variables"
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
@@ -7,12 +7,6 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
  * These mirror the shapes used by the web implementation and must not diverge.
  */
 internal object WebViewMessageType {
-    const val STEP_LOADED = "rc:step-loaded"
-    const val STEP_COMPLETE = "rc:step-complete"
-    const val REQUEST_VARIABLES = "rc:request-variables"
-    const val ERROR = "rc:error"
-    const val VARIABLES = "rc:variables"
-
     /** Host → content: which axes the native host sizes to the content (`fit`). */
     const val FIT = "fit"
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
@@ -21,9 +21,8 @@ internal object WebViewMessageType {
 }
 
 /**
- * Field names used in the flat message envelope. The envelope is intentionally flat: message-specific
- * fields such as [RESPONSES], [ERROR] and [VARIABLES] live at the top level rather than under a
- * generic `payload` key.
+ * Field names used in the transport envelope parsed by [WebViewEnvelope]. Application data lives under
+ * [PAYLOAD]; [ERROR] is used on `error` / `reject` frames.
  */
 internal object WebViewMessageField {
     const val CHANNEL = "channel"
@@ -33,7 +32,5 @@ internal object WebViewMessageField {
     const val COMPONENT_ID = "component_id"
     const val ID = "id"
     const val PAYLOAD = "payload"
-    const val RESPONSES = "responses"
     const val ERROR = "error"
-    const val VARIABLES = "variables"
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelopeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelopeTest.kt
@@ -194,51 +194,6 @@ internal class WebViewEnvelopeTest {
     }
 
     @Test
-    fun `rejects oversized payload`() {
-        val hugeValue = "x".repeat(WebViewEnvelope.MAX_PAYLOAD_BYTES + 1)
-        val raw = envelope(
-            kind = WebViewEnvelope.KIND_MESSAGE,
-            type = WebViewMessageType.ERROR,
-            payload = """{"error":"$hugeValue"}""",
-        )
-        assertThat(raw.toByteArray(Charsets.UTF_8).size).isGreaterThan(WebViewEnvelope.MAX_PAYLOAD_BYTES)
-        assertThat(WebViewEnvelope.parse(raw)).isNull()
-    }
-
-    @Test
-    fun `accepts frame depth at MAX_NESTING_DEPTH plus one before recursive parsing`() {
-        // Envelope object (+1) plus a payload tree of MAX_NESTING_DEPTH → MAX_FRAME_DEPTH.
-        val depth = WebViewEnvelope.MAX_NESTING_DEPTH + 1
-
-        assertThat(WebViewEnvelope.exceedsMaxDepth(nestedArray(depth))).isFalse()
-    }
-
-    @Test
-    fun `rejects frame depth beyond MAX_NESTING_DEPTH plus one before recursive parsing`() {
-        val depth = WebViewEnvelope.MAX_NESTING_DEPTH + 2
-
-        assertThat(WebViewEnvelope.exceedsMaxDepth(nestedArray(depth))).isTrue()
-    }
-
-    @Test
-    fun `rejects a hostile deeply nested frame before recursive parsing`() {
-        // ~30k nesting levels fit inside the 64 KiB frame limit; the pre-parse structural scan
-        // must reject this before org.json's recursive tokenizer ever runs (stack-overflow guard).
-        val depth = 30_000
-        val nested = "[".repeat(depth) + "]".repeat(depth)
-
-        val parsed = WebViewEnvelope.parse(
-            envelope(
-                kind = WebViewEnvelope.KIND_MESSAGE,
-                type = WebViewMessageType.STEP_COMPLETE,
-                payload = """{"responses":{"deep":$nested}}""",
-            ),
-        )
-
-        assertThat(parsed).isNull()
-    }
-
-    @Test
     fun `build emits required and optional fields`() {
         val payload = JSONObject("""{"responses":{"ok":true}}""")
         val json = WebViewEnvelope.build(
@@ -276,8 +231,6 @@ internal class WebViewEnvelopeTest {
         assertThat(json.has(WebViewMessageField.PAYLOAD)).isFalse()
         assertThat(json.has(WebViewMessageField.ERROR)).isFalse()
     }
-
-    private fun nestedArray(depth: Int): String = "[".repeat(depth) + "0" + "]".repeat(depth)
 
     private fun envelope(
         kind: String,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelopeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelopeTest.kt
@@ -1,0 +1,295 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class WebViewEnvelopeTest {
+
+    private val componentId = "promo_web_view"
+
+    @Test
+    fun `parses a valid message envelope`() {
+        val parsed = WebViewEnvelope.parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_LOADED,
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.kind).isEqualTo(WebViewEnvelope.KIND_MESSAGE)
+        assertThat(parsed.protocolVersion).isEqualTo(1)
+        assertThat(parsed.componentId).isEqualTo(componentId)
+        assertThat(parsed.type).isEqualTo(WebViewMessageType.STEP_LOADED)
+        assertThat(parsed.id).isNull()
+        assertThat(parsed.payload).isNull()
+        assertThat(parsed.error).isNull()
+    }
+
+    @Test
+    fun `parses optional envelope fields`() {
+        val parsed = WebViewEnvelope.parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_REQUEST,
+                type = WebViewMessageType.REQUEST_VARIABLES,
+                id = "req-1",
+                payload = """{"responses":{"selected_plan":"annual"}}""",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.id).isEqualTo("req-1")
+        assertThat(parsed.payload).isNotNull
+        assertThat(parsed.payload!!.getJSONObject("responses").getString("selected_plan"))
+            .isEqualTo("annual")
+    }
+
+    @Test
+    fun `parses handshake connect frames`() {
+        val parsed = WebViewEnvelope.parse(
+            """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"connect","component_id":""}
+            """.trimIndent(),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.kind).isEqualTo(WebViewEnvelope.KIND_CONNECT)
+        assertThat(parsed.componentId).isEmpty()
+    }
+
+    @Test
+    fun `rejects wrong channel`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"other","protocol_version":1,"kind":"message","component_id":"promo_web_view","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects missing protocol_version`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","kind":"message","component_id":"promo_web_view","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects non-finite protocol_version`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":NaN,"kind":"message","component_id":"promo_web_view","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message without component_id`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"message","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with non-string type`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"message","component_id":"promo_web_view","type":123}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with non-string id`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"request","component_id":"promo_web_view","type":"rc:request-variables","id":1}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with non-string error`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"error","component_id":"promo_web_view","error":false}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with non-object payload`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"message","component_id":"promo_web_view","type":"rc:step-complete","payload":"nope"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects unknown kind outside whitelist`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"ping","component_id":"promo_web_view"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `accepts every whitelisted kind`() {
+        val kinds = listOf(
+            WebViewEnvelope.KIND_CONNECT,
+            WebViewEnvelope.KIND_INIT,
+            WebViewEnvelope.KIND_REJECT,
+            WebViewEnvelope.KIND_MESSAGE,
+            WebViewEnvelope.KIND_REQUEST,
+            WebViewEnvelope.KIND_RESPONSE,
+            WebViewEnvelope.KIND_ERROR,
+        )
+
+        kinds.forEach { kind ->
+            val parsed = WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId"}
+                """.trimIndent(),
+            )
+            assertThat(parsed).describedAs("kind=$kind").isNotNull
+            assertThat(parsed!!.kind).isEqualTo(kind)
+        }
+    }
+
+    @Test
+    fun `rejects malformed json`() {
+        assertThat(WebViewEnvelope.parse("""not json""")).isNull()
+    }
+
+    @Test
+    fun `rejects non-object json`() {
+        assertThat(WebViewEnvelope.parse("""["a","b"]""")).isNull()
+    }
+
+    @Test
+    fun `rejects oversized payload`() {
+        val hugeValue = "x".repeat(WebViewEnvelope.MAX_PAYLOAD_BYTES + 1)
+        val raw = envelope(
+            kind = WebViewEnvelope.KIND_MESSAGE,
+            type = WebViewMessageType.ERROR,
+            payload = """{"error":"$hugeValue"}""",
+        )
+        assertThat(raw.toByteArray(Charsets.UTF_8).size).isGreaterThan(WebViewEnvelope.MAX_PAYLOAD_BYTES)
+        assertThat(WebViewEnvelope.parse(raw)).isNull()
+    }
+
+    @Test
+    fun `accepts frame depth at MAX_NESTING_DEPTH plus one before recursive parsing`() {
+        // Envelope object (+1) plus a payload tree of MAX_NESTING_DEPTH → MAX_FRAME_DEPTH.
+        val depth = WebViewEnvelope.MAX_NESTING_DEPTH + 1
+
+        assertThat(WebViewEnvelope.exceedsMaxDepth(nestedArray(depth))).isFalse()
+    }
+
+    @Test
+    fun `rejects frame depth beyond MAX_NESTING_DEPTH plus one before recursive parsing`() {
+        val depth = WebViewEnvelope.MAX_NESTING_DEPTH + 2
+
+        assertThat(WebViewEnvelope.exceedsMaxDepth(nestedArray(depth))).isTrue()
+    }
+
+    @Test
+    fun `rejects a hostile deeply nested frame before recursive parsing`() {
+        // ~30k nesting levels fit inside the 64 KiB frame limit; the pre-parse structural scan
+        // must reject this before org.json's recursive tokenizer ever runs (stack-overflow guard).
+        val depth = 30_000
+        val nested = "[".repeat(depth) + "]".repeat(depth)
+
+        val parsed = WebViewEnvelope.parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"deep":$nested}}""",
+            ),
+        )
+
+        assertThat(parsed).isNull()
+    }
+
+    @Test
+    fun `build emits required and optional fields`() {
+        val payload = JSONObject("""{"responses":{"ok":true}}""")
+        val json = WebViewEnvelope.build(
+            kind = WebViewEnvelope.KIND_RESPONSE,
+            protocolVersion = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
+            componentId = componentId,
+            type = WebViewMessageType.VARIABLES,
+            id = "req-1",
+            payload = payload,
+            error = "boom",
+        )
+
+        assertThat(json.getString(WebViewMessageField.CHANNEL)).isEqualTo(WebViewEnvelope.CHANNEL)
+        assertThat(json.getInt(WebViewMessageField.PROTOCOL_VERSION))
+            .isEqualTo(WebViewEnvelope.DEFAULT_PROTOCOL_VERSION)
+        assertThat(json.getString(WebViewMessageField.KIND)).isEqualTo(WebViewEnvelope.KIND_RESPONSE)
+        assertThat(json.getString(WebViewMessageField.COMPONENT_ID)).isEqualTo(componentId)
+        assertThat(json.getString(WebViewMessageField.TYPE)).isEqualTo(WebViewMessageType.VARIABLES)
+        assertThat(json.getString(WebViewMessageField.ID)).isEqualTo("req-1")
+        assertThat(json.getJSONObject(WebViewMessageField.PAYLOAD).toString())
+            .isEqualTo(payload.toString())
+        assertThat(json.getString(WebViewMessageField.ERROR)).isEqualTo("boom")
+    }
+
+    @Test
+    fun `build omits null optional fields`() {
+        val json = WebViewEnvelope.build(
+            kind = WebViewEnvelope.KIND_INIT,
+            protocolVersion = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
+            componentId = componentId,
+        )
+
+        assertThat(json.has(WebViewMessageField.TYPE)).isFalse()
+        assertThat(json.has(WebViewMessageField.ID)).isFalse()
+        assertThat(json.has(WebViewMessageField.PAYLOAD)).isFalse()
+        assertThat(json.has(WebViewMessageField.ERROR)).isFalse()
+    }
+
+    private fun nestedArray(depth: Int): String = "[".repeat(depth) + "0" + "]".repeat(depth)
+
+    private fun envelope(
+        kind: String,
+        type: String,
+        componentId: String = this.componentId,
+        payload: String? = null,
+        id: String? = null,
+    ): String {
+        val payloadField = payload?.let { ""","payload":$it""" } ?: ""
+        val idField = id?.let { ""","id":"$it"""" } ?: ""
+        return """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId","type":"$type"$payloadField$idField}
+            """.trimIndent()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelopeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelopeTest.kt
@@ -16,7 +16,7 @@ internal class WebViewEnvelopeTest {
         val parsed = WebViewEnvelope.parse(
             envelope(
                 kind = WebViewEnvelope.KIND_MESSAGE,
-                type = WebViewMessageType.STEP_LOADED,
+                type = WebViewMessageType.RESIZE,
             ),
         )
 
@@ -24,7 +24,7 @@ internal class WebViewEnvelopeTest {
         assertThat(parsed!!.kind).isEqualTo(WebViewEnvelope.KIND_MESSAGE)
         assertThat(parsed.protocolVersion).isEqualTo(1)
         assertThat(parsed.componentId).isEqualTo(componentId)
-        assertThat(parsed.type).isEqualTo(WebViewMessageType.STEP_LOADED)
+        assertThat(parsed.type).isEqualTo(WebViewMessageType.RESIZE)
         assertThat(parsed.id).isNull()
         assertThat(parsed.payload).isNull()
         assertThat(parsed.error).isNull()
@@ -35,7 +35,7 @@ internal class WebViewEnvelopeTest {
         val parsed = WebViewEnvelope.parse(
             envelope(
                 kind = WebViewEnvelope.KIND_REQUEST,
-                type = WebViewMessageType.REQUEST_VARIABLES,
+                type = WebViewMessageType.RESIZE,
                 id = "req-1",
                 payload = """{"responses":{"selected_plan":"annual"}}""",
             ),
@@ -200,7 +200,7 @@ internal class WebViewEnvelopeTest {
             kind = WebViewEnvelope.KIND_RESPONSE,
             protocolVersion = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
             componentId = componentId,
-            type = WebViewMessageType.VARIABLES,
+            type = WebViewMessageType.RESIZE,
             id = "req-1",
             payload = payload,
             error = "boom",
@@ -211,7 +211,7 @@ internal class WebViewEnvelopeTest {
             .isEqualTo(WebViewEnvelope.DEFAULT_PROTOCOL_VERSION)
         assertThat(json.getString(WebViewMessageField.KIND)).isEqualTo(WebViewEnvelope.KIND_RESPONSE)
         assertThat(json.getString(WebViewMessageField.COMPONENT_ID)).isEqualTo(componentId)
-        assertThat(json.getString(WebViewMessageField.TYPE)).isEqualTo(WebViewMessageType.VARIABLES)
+        assertThat(json.getString(WebViewMessageField.TYPE)).isEqualTo(WebViewMessageType.RESIZE)
         assertThat(json.getString(WebViewMessageField.ID)).isEqualTo("req-1")
         assertThat(json.getJSONObject(WebViewMessageField.PAYLOAD).toString())
             .isEqualTo(payload.toString())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Part **4** splitting #3757; **inert until Part 8** (#3787).

Lands the wire envelope + JSON input hardening used by the web_view message bridge. No runtime wiring yet.

### Description
- `WebViewEnvelope` / `WebViewMessageType` / `WebViewMessageField`
- Envelope unit tests: per-field parse/reject, kind whitelist, `build(...)` emission

Verified: `WebViewEnvelopeTest`, `detektAll`.

**Labels:** `pr:feat`, `pr:RevenueCatUI`, `feat:Paywalls_V2`


### Series (splitting #3757)

PWENG-98

Parts 1 and 2 were dropped. Not a linear stack: parts 3, 4, 5 are independent
(each off `main`); `webview/deps-1-5` merges all three; the tail stacks linearly on
that merge (6a -> 6b -> 7 -> 8).

| Part | PR | Base | Notes |
|------|-----|------|-------|
| 1 | ~~#3780~~ | - | dropped; value types collapsed to `Map<String, String>` |
| 2 | ~~#3784~~ | - | dropped; app-facing message handler cut from v1 |
| 3 | #3781 | `main` | schema component, not yet registered |
| 4 | #3782 | `main` | transport envelope + JSON hardening |
| 5 | #3783 | `main` | navigation policy + origin helpers |
| 6a | #3796 | `webview/deps-1-5` | SDK variables provider |
| 6b | #3798 | #3796 | JavaScript bridge |
| 7 | #3786 | #3798 | Compose view + style |
| 8 | #3787 | #3786 | activation + unsupported protocol_version fallback |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


