### PR TITLE
feat(paywalls): web_view navigation policy and origin helpers (5)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -1,0 +1,87 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.graphics.Bitmap
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+
+/**
+ * [WebViewClient] for Paywalls V2 `web_view` components. Owns navigation policy, main-frame document
+ * lifecycle notifications, and a single terminal failure path shared by URL errors, HTTP errors, and
+ * renderer termination.
+ */
+internal class PaywallWebViewClient(
+    private val expectedOrigin: String?,
+    private val onMainFrameNavigationStarted: (url: String?) -> Unit,
+    private val onMainFrameLoadFailed: () -> Unit,
+) : WebViewClient() {
+
+    @Volatile
+    private var failed: Boolean = false
+
+    private fun markFailed() {
+        if (failed) return
+        failed = true
+        onMainFrameLoadFailed()
+    }
+
+    override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+        super.onPageStarted(view, url, favicon)
+        // onPageStarted is main-frame only and marks a new JavaScript document.
+        onMainFrameNavigationStarted(url)
+        // shouldOverrideUrlLoading is not called for POST navigations, so re-check the policy
+        // here and kill any main-frame load that slipped through (cross-origin / non-HTTPS).
+        if (shouldBlockWebViewNavigation(
+                url = url,
+                isMainFrame = true,
+                expectedOrigin = expectedOrigin,
+            )
+        ) {
+            view.stopLoading()
+        }
+    }
+
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        return shouldBlockWebViewNavigation(
+            url = request.url?.toString(),
+            isMainFrame = request.isForMainFrame,
+            expectedOrigin = expectedOrigin,
+        )
+    }
+
+    override fun onReceivedError(
+        view: WebView,
+        request: WebResourceRequest,
+        error: WebResourceError,
+    ) {
+        if (request.isForMainFrame) {
+            markFailed()
+        }
+    }
+
+    override fun onReceivedHttpError(
+        view: WebView,
+        request: WebResourceRequest,
+        errorResponse: WebResourceResponse,
+    ) {
+        if (request.isForMainFrame && errorResponse.statusCode >= HTTP_ERROR_STATUS_MIN) {
+            markFailed()
+        }
+    }
+
+    override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
+        markFailed()
+        // Returning true tells the platform we handled the dead renderer; the dead WebView must not
+        // be reused. Composition removes it via the failure path + AndroidView.onRelease.
+        return true
+    }
+
+    private companion object {
+        private const val HTTP_ERROR_STATUS_MIN = 400
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -30,8 +30,14 @@ internal class PaywallWebViewClient(
         onMainFrameLoadFailed()
     }
 
+    @Suppress("ReturnCount")
     override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
         super.onPageStarted(view, url, favicon)
+        // Terminal failure is one-shot: once failed, suppress any later document-start signals.
+        if (failed) return
+        // about:blank and other host-less / null documents are not paywall loads; ignore them
+        // instead of treating them as a blocked navigation (which would fire a false failure).
+        if (url?.toOriginOrNull() == null) return
         // shouldOverrideUrlLoading is not called for POST navigations, so re-check the policy
         // here and kill any main-frame load that slipped through (cross-origin / non-HTTPS).
         if (shouldBlockWebViewNavigation(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -33,13 +33,13 @@ internal class PaywallWebViewClient(
     @Suppress("ReturnCount")
     override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
         super.onPageStarted(view, url, favicon)
-        // Terminal failure is one-shot: once failed, suppress any later document-start signals.
+        // Once failed, emit no further document-start signals.
         if (failed) return
-        // about:blank and other host-less / null documents are not paywall loads; ignore them
-        // instead of treating them as a blocked navigation (which would fire a false failure).
+        // about:blank / host-less documents aren't paywall loads; ignore them (shouldBlock would
+        // otherwise treat them as a failure).
         if (url?.toOriginOrNull() == null) return
-        // shouldOverrideUrlLoading is not called for POST navigations, so re-check the policy
-        // here and kill any main-frame load that slipped through (cross-origin / non-HTTPS).
+        // POST navigations skip shouldOverrideUrlLoading; re-check here to kill any main-frame load
+        // that slipped through.
         if (shouldBlockWebViewNavigation(
                 url = url,
                 isMainFrame = true,
@@ -50,7 +50,6 @@ internal class PaywallWebViewClient(
             markFailed()
             return
         }
-        // onPageStarted is main-frame only and marks a new JavaScript document.
         onMainFrameNavigationStarted(url)
     }
 
@@ -84,8 +83,7 @@ internal class PaywallWebViewClient(
 
     override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
         markFailed()
-        // Returning true tells the platform we handled the dead renderer; the dead WebView must not
-        // be reused. Composition removes it via the failure path + AndroidView.onRelease.
+        // true = handled; the dead WebView must not be reused (removed via the failure path).
         return true
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -32,8 +32,6 @@ internal class PaywallWebViewClient(
 
     override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
         super.onPageStarted(view, url, favicon)
-        // onPageStarted is main-frame only and marks a new JavaScript document.
-        onMainFrameNavigationStarted(url)
         // shouldOverrideUrlLoading is not called for POST navigations, so re-check the policy
         // here and kill any main-frame load that slipped through (cross-origin / non-HTTPS).
         if (shouldBlockWebViewNavigation(
@@ -43,7 +41,11 @@ internal class PaywallWebViewClient(
             )
         ) {
             view.stopLoading()
+            markFailed()
+            return
         }
+        // onPageStarted is main-frame only and marks a new JavaScript document.
+        onMainFrameNavigationStarted(url)
     }
 
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
@@ -69,7 +71,7 @@ internal class PaywallWebViewClient(
         request: WebResourceRequest,
         errorResponse: WebResourceResponse,
     ) {
-        if (request.isForMainFrame && errorResponse.statusCode >= HTTP_ERROR_STATUS_MIN) {
+        if (request.isForMainFrame) {
             markFailed()
         }
     }
@@ -79,9 +81,5 @@ internal class PaywallWebViewClient(
         // Returning true tells the platform we handled the dead renderer; the dead WebView must not
         // be reused. Composition removes it via the failure path + AndroidView.onRelease.
         return true
-    }
-
-    private companion object {
-        private const val HTTP_ERROR_STATUS_MIN = 400
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOrigins.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOrigins.kt
@@ -1,0 +1,61 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.net.Uri
+import java.util.Locale
+
+/**
+ * The origin of this URL as `scheme://host[:port]`, or `null` if it lacks a host. Host comparison is
+ * case-insensitive. Default ports (443 for https, 80 for http) are omitted.
+ *
+ * Accepts both full URLs and bare origins (as provided by [WebViewCompat.WebMessageListener]).
+ */
+@Suppress("ReturnCount", "MagicNumber")
+internal fun String.toOriginOrNull(): String? {
+    val uri = Uri.parse(this)
+    return uri.toOriginOrNull()
+}
+
+/**
+ * The origin of this [Uri] as `scheme://host[:port]`, or `null` if it lacks a host.
+ */
+@Suppress("ReturnCount", "MagicNumber")
+internal fun Uri.toOriginOrNull(): String? {
+    val scheme = scheme?.lowercase(Locale.US) ?: return null
+    val host = host?.takeIf { it.isNotBlank() }?.lowercase(Locale.US) ?: return null
+    val effectivePort = when {
+        port != -1 -> port
+        scheme == "https" -> 443
+        scheme == "http" -> 80
+        else -> -1
+    }
+    val portSuffix = when {
+        effectivePort == -1 -> ""
+        scheme == "https" && effectivePort == 443 -> ""
+        scheme == "http" && effectivePort == 80 -> ""
+        else -> ":$effectivePort"
+    }
+    return "$scheme://$host$portSuffix"
+}
+
+/**
+ * Navigation policy for `web_view` content, applied from `shouldOverrideUrlLoading`:
+ *
+ * - Any non-HTTPS navigation is blocked (any frame).
+ * - Main-frame navigation is additionally restricted to the resolved component URL's origin
+ *   (same-origin different-path navigation stays allowed). This makes cross-origin message races
+ *   structurally impossible; the bridge's per-message origin check remains as defense in depth.
+ * - Cross-origin sub-frame loads are not blocked here; isolation for those is expected from the
+ *   server-provided Content-Security-Policy served with the web content.
+ */
+@Suppress("ReturnCount")
+internal fun shouldBlockWebViewNavigation(
+    url: String?,
+    isMainFrame: Boolean,
+    expectedOrigin: String?,
+): Boolean {
+    val origin = url?.toOriginOrNull() ?: return true
+    if (!origin.startsWith("https://")) return true
+    return isMainFrame && origin != expectedOrigin
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOrigins.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOrigins.kt
@@ -24,17 +24,11 @@ internal fun String.toOriginOrNull(): String? {
 internal fun Uri.toOriginOrNull(): String? {
     val scheme = scheme?.lowercase(Locale.US) ?: return null
     val host = host?.takeIf { it.isNotBlank() }?.lowercase(Locale.US) ?: return null
-    val effectivePort = when {
-        port != -1 -> port
-        scheme == "https" -> 443
-        scheme == "http" -> 80
-        else -> -1
-    }
     val portSuffix = when {
-        effectivePort == -1 -> ""
-        scheme == "https" && effectivePort == 443 -> ""
-        scheme == "http" && effectivePort == 80 -> ""
-        else -> ":$effectivePort"
+        port == -1 -> ""
+        scheme == "https" && port == 443 -> ""
+        scheme == "http" && port == 80 -> ""
+        else -> ":$port"
     }
     return "$scheme://$host$portSuffix"
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOrigins.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOrigins.kt
@@ -57,5 +57,6 @@ internal fun shouldBlockWebViewNavigation(
 ): Boolean {
     val origin = url?.toOriginOrNull() ?: return true
     if (!origin.startsWith("https://")) return true
-    return isMainFrame && origin != expectedOrigin
+    val normalizedExpectedOrigin = expectedOrigin?.toOriginOrNull()
+    return isMainFrame && origin != normalizedExpectedOrigin
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
@@ -1,0 +1,19 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.net.Uri
+
+internal object WebViewUrlResolver {
+
+    fun resolve(url: String): String? {
+        if (url.contains("{{")) return null
+
+        val uri = Uri.parse(url)
+        return url.takeIf {
+            uri.scheme == HTTPS_SCHEME && !uri.host.isNullOrBlank()
+        }
+    }
+
+    private const val HTTPS_SCHEME = "https"
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
@@ -11,7 +11,7 @@ internal object WebViewUrlResolver {
 
         val uri = Uri.parse(url)
         return url.takeIf {
-            uri.scheme == HTTPS_SCHEME && !uri.host.isNullOrBlank()
+            uri.scheme.equals(HTTPS_SCHEME, ignoreCase = true) && !uri.host.isNullOrBlank()
         }
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
@@ -56,14 +56,6 @@ internal class PaywallWebViewClientTest {
     }
 
     @Test
-    fun `onPageStarted does not stop same-origin https loads`() {
-        client.onPageStarted(webView, "https://assets.example.com/promo/step-two.html", null)
-
-        assertThat(navigations).containsExactly("https://assets.example.com/promo/step-two.html")
-        assertThat(webView.stopLoadingCount).isEqualTo(0)
-    }
-
-    @Test
     fun `onPageStarted stops blocked cross-origin loads that bypass shouldOverrideUrlLoading`() {
         // POST navigations skip shouldOverrideUrlLoading; onPageStarted is the backstop.
         client.onPageStarted(webView, "https://evil.example.org/phish.html", null)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
@@ -1,0 +1,109 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.content.Context
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class PaywallWebViewClientTest {
+
+    private lateinit var webView: TrackingWebView
+    private val expectedOrigin = "https://assets.example.com"
+    private val navigations = mutableListOf<String?>()
+    private var failureCount = 0
+
+    private lateinit var client: PaywallWebViewClient
+
+    private class TrackingWebView(context: Context) : WebView(context) {
+        var stopLoadingCount: Int = 0
+            private set
+
+        override fun stopLoading() {
+            stopLoadingCount += 1
+            super.stopLoading()
+        }
+    }
+
+    @Before
+    fun setUp() {
+        webView = TrackingWebView(ApplicationProvider.getApplicationContext())
+        navigations.clear()
+        failureCount = 0
+        client = PaywallWebViewClient(
+            expectedOrigin = expectedOrigin,
+            onMainFrameNavigationStarted = { navigations.add(it) },
+            onMainFrameLoadFailed = { failureCount += 1 },
+        )
+    }
+
+    @Test
+    fun `onPageStarted notifies main-frame document start`() {
+        client.onPageStarted(webView, "https://assets.example.com/promo/index.html", null)
+
+        assertThat(navigations).containsExactly("https://assets.example.com/promo/index.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `onPageStarted does not stop same-origin https loads`() {
+        client.onPageStarted(webView, "https://assets.example.com/promo/step-two.html", null)
+
+        assertThat(navigations).containsExactly("https://assets.example.com/promo/step-two.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `onPageStarted stops blocked cross-origin loads that bypass shouldOverrideUrlLoading`() {
+        // POST navigations skip shouldOverrideUrlLoading; onPageStarted is the backstop.
+        client.onPageStarted(webView, "https://evil.example.org/phish.html", null)
+
+        assertThat(navigations).containsExactly("https://evil.example.org/phish.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `onPageStarted stops blocked non-https loads`() {
+        client.onPageStarted(webView, "http://assets.example.com/promo/insecure.html", null)
+
+        assertThat(navigations).containsExactly("http://assets.example.com/promo/insecure.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `onRenderProcessGone returns true and activates failure once`() {
+        val detail = mockk<RenderProcessGoneDetail>(relaxed = true)
+
+        val first = client.onRenderProcessGone(webView, detail)
+        val second = client.onRenderProcessGone(webView, detail)
+
+        assertThat(first).isTrue()
+        assertThat(second).isTrue()
+        assertThat(failureCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `main-frame URL and HTTP errors share the terminal failure path`() {
+        val request = mockk<WebResourceRequest>()
+        every { request.isForMainFrame } returns true
+        val error = mockk<WebResourceError>(relaxed = true)
+        val response = mockk<WebResourceResponse>()
+        every { response.statusCode } returns 500
+
+        client.onReceivedError(webView, request, error)
+        client.onReceivedHttpError(webView, request, response)
+        client.onRenderProcessGone(webView, mockk(relaxed = true))
+
+        assertThat(failureCount).isEqualTo(1)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
@@ -68,16 +68,18 @@ internal class PaywallWebViewClientTest {
         // POST navigations skip shouldOverrideUrlLoading; onPageStarted is the backstop.
         client.onPageStarted(webView, "https://evil.example.org/phish.html", null)
 
-        assertThat(navigations).containsExactly("https://evil.example.org/phish.html")
+        assertThat(navigations).isEmpty()
         assertThat(webView.stopLoadingCount).isEqualTo(1)
+        assertThat(failureCount).isEqualTo(1)
     }
 
     @Test
     fun `onPageStarted stops blocked non-https loads`() {
         client.onPageStarted(webView, "http://assets.example.com/promo/insecure.html", null)
 
-        assertThat(navigations).containsExactly("http://assets.example.com/promo/insecure.html")
+        assertThat(navigations).isEmpty()
         assertThat(webView.stopLoadingCount).isEqualTo(1)
+        assertThat(failureCount).isEqualTo(1)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
@@ -83,6 +83,37 @@ internal class PaywallWebViewClientTest {
     }
 
     @Test
+    fun `onPageStarted ignores about blank without failing`() {
+        client.onPageStarted(webView, "about:blank", null)
+
+        assertThat(navigations).isEmpty()
+        assertThat(webView.stopLoadingCount).isEqualTo(0)
+        assertThat(failureCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `onPageStarted ignores a null url without failing`() {
+        client.onPageStarted(webView, null, null)
+
+        assertThat(navigations).isEmpty()
+        assertThat(webView.stopLoadingCount).isEqualTo(0)
+        assertThat(failureCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `onPageStarted suppresses document start after a terminal failure`() {
+        val request = mockk<WebResourceRequest>()
+        every { request.isForMainFrame } returns true
+        client.onReceivedError(webView, request, mockk(relaxed = true))
+        assertThat(failureCount).isEqualTo(1)
+
+        client.onPageStarted(webView, "https://assets.example.com/promo/index.html", null)
+
+        assertThat(navigations).isEmpty()
+        assertThat(failureCount).isEqualTo(1)
+    }
+
+    @Test
     fun `onRenderProcessGone returns true and activates failure once`() {
         val detail = mockk<RenderProcessGoneDetail>(relaxed = true)
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewNavigationPolicyTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewNavigationPolicyTest.kt
@@ -1,0 +1,70 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+// Robolectric is required because the navigation-policy helper parses origins via android.net.Uri.
+@RunWith(RobolectricTestRunner::class)
+class WebViewNavigationPolicyTest {
+
+    @Test
+    fun `allows same-origin main-frame navigation on a different path`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://assets.example.com/promo/step-two.html",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `blocks cross-origin main-frame navigation even over https`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://evil.example.org/phish.html",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `blocks non-https navigation in any frame`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "http://assets.example.com/promo/index.html",
+                isMainFrame = false,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "custom://assets.example.com/",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `allows cross-origin https sub-frame loads`() {
+        // Sub-frame isolation is expected from the server-provided CSP, not this navigation policy.
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://other.example.com/frame.html",
+                isMainFrame = false,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `blocks unparseable main-frame navigation targets`() {
+        assertThat(
+            shouldBlockWebViewNavigation(url = null, isMainFrame = true, expectedOrigin = "https://a.example"),
+        ).isTrue()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewNavigationPolicyTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewNavigationPolicyTest.kt
@@ -67,4 +67,15 @@ class WebViewNavigationPolicyTest {
             shouldBlockWebViewNavigation(url = null, isMainFrame = true, expectedOrigin = "https://a.example"),
         ).isTrue()
     }
+
+    @Test
+    fun `normalizes expected origin casing and default port`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://assets.example.com/promo/index.html",
+                isMainFrame = true,
+                expectedOrigin = "https://Assets.Example.COM:443",
+            ),
+        ).isFalse()
+    }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
@@ -1,0 +1,66 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WebViewUrlResolverTest {
+
+    @Test
+    fun `resolves static https url unchanged`() {
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isEqualTo("https://paywalls.revenuecat.com/index.html")
+    }
+
+    @Test
+    fun `resolves static https url with characters accepted by WebView`() {
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/index.html?filters=a|b")
+
+        assertThat(result).isEqualTo("https://paywalls.revenuecat.com/index.html?filters=a|b")
+    }
+
+    @Test
+    fun `returns null for url containing template placeholders`() {
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/{{ custom.animal }}.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for malformed url`() {
+        val result = WebViewUrlResolver.resolve("not a url")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for malformed https url`() {
+        val result = WebViewUrlResolver.resolve("https:///missing-host")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for non https url`() {
+        val result = WebViewUrlResolver.resolve("http://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for file url`() {
+        val result = WebViewUrlResolver.resolve("file:///android_asset/index.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for custom scheme url`() {
+        val result = WebViewUrlResolver.resolve("myapp://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isNull()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
@@ -44,6 +44,13 @@ class WebViewUrlResolverTest {
     }
 
     @Test
+    fun `resolves https url with uppercase scheme`() {
+        val result = WebViewUrlResolver.resolve("HTTPS://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isEqualTo("HTTPS://paywalls.revenuecat.com/index.html")
+    }
+
+    @Test
     fun `returns null for non https url`() {
         val result = WebViewUrlResolver.resolve("http://paywalls.revenuecat.com/index.html")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Part **5** splitting #3757; **inert until Part 8** (#3787).

Navigation policy, origin helpers, and URL resolution for the web_view component — no Compose view or bridge yet.

### Description
- New `WebViewOrigins.kt` (`toOriginOrNull`, `shouldBlockWebViewNavigation`) extracted from the consolidated bridge file
- `PaywallWebViewClient`, `WebViewUrlResolver`
- Tests: client, navigation policy, URL resolver

Verified: 19 unit tests, `detektAll`.

**Labels:** `pr:feat`, `pr:RevenueCatUI`, `feat:Paywalls_V2`


### Series (splitting #3757)

PWENG-98

Parts 1 and 2 were dropped. Not a linear stack: parts 3, 4, 5 are independent
(each off `main`); `webview/deps-1-5` merges all three; the tail stacks linearly on
that merge (6a -> 6b -> 7 -> 8).

| Part | PR | Base | Notes |
|------|-----|------|-------|
| 1 | ~~#3780~~ | - | dropped; value types collapsed to `Map<String, String>` |
| 2 | ~~#3784~~ | - | dropped; app-facing message handler cut from v1 |
| 3 | #3781 | `main` | schema component, not yet registered |
| 4 | #3782 | `main` | transport envelope + JSON hardening |
| 5 | #3783 | `main` | navigation policy + origin helpers |
| 6a | #3796 | `webview/deps-1-5` | SDK variables provider |
| 6b | #3798 | #3796 | JavaScript bridge |
| 7 | #3786 | #3798 | Compose view + style |
| 8 | #3787 | #3786 | activation + unsupported protocol_version fallback |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


