### PR TITLE
feat(paywalls): web_view JavaScript bridge (6/8)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ testLibraries = "1.6.1"
 tink = "1.8.0"
 viewmodelCompose = "2.4.0"
 window = "1.1.0"
+webkit = "1.12.1"
 junit = "1.2.1"
 uiautomator = "2.3.0"
 benchmarkMacroJunit4 = "1.3.4"
@@ -85,6 +86,7 @@ androidx-browser = { module = "androidx.browser:browser", version.ref = "browser
 androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidxCardView" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidxConstraintLayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
+androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "webkit" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreference" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
 androidx-legacy-core-ui = { module = "androidx.legacy:legacy-support-core-ui", version.ref = "legacyCoreUi" }

--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -150,6 +150,67 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public abstract void performRestoreWithCompletion(com.revenuecat.purchases.CustomerInfo customerInfo, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult,kotlin.Unit> completion);
   }
 
+  public interface PaywallWebViewController {
+    method public void postMessage(String componentId, String type, java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> variables);
+    method public void postVariables(String componentId, java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> variables);
+  }
+
+  @dev.drewhamilton.poko.Poko public final class PaywallWebViewMessage {
+    ctor public PaywallWebViewMessage(String componentId, String type, optional java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? responses, optional String? error);
+    method public String getComponentId();
+    method public String? getError();
+    method public java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? getResponses();
+    method public String getType();
+    property public final String componentId;
+    property public final String? error;
+    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue>? responses;
+    property public final String type;
+  }
+
+  public fun interface PaywallWebViewMessageHandler {
+    method public void onMessage(com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessage message, com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController controller);
+  }
+
+  public abstract class PaywallWebViewValue {
+  }
+
+  public static final class PaywallWebViewValue.Array extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Array(java.util.List<? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value);
+    method public java.util.List<com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> getValue();
+    property public final java.util.List<com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value;
+  }
+
+  public static final class PaywallWebViewValue.Boolean extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Boolean(boolean value);
+    method public boolean getValue();
+    property public final boolean value;
+  }
+
+  public static final class PaywallWebViewValue.Null extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue.Null INSTANCE;
+  }
+
+  public static final class PaywallWebViewValue.Number extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Number(double value);
+    ctor public PaywallWebViewValue.Number(float value);
+    ctor public PaywallWebViewValue.Number(int value);
+    ctor public PaywallWebViewValue.Number(long value);
+    method public double getValue();
+    property public final double value;
+  }
+
+  public static final class PaywallWebViewValue.Object extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.Object(java.util.Map<java.lang.String,? extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value);
+    method public java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> getValue();
+    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue> value;
+  }
+
+  public static final class PaywallWebViewValue.String extends com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue {
+    ctor public PaywallWebViewValue.String(String value);
+    method public String getValue();
+    property public final String value;
+  }
+
   @Deprecated public interface PurchaseLogic extends com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic {
     method @Deprecated public suspend Object? performPurchase(android.app.Activity activity, com.revenuecat.purchases.Package rcPackage, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult>);
     method @Deprecated public default suspend Object? performPurchase(android.app.Activity activity, com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogicParams params, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult>);

--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -99,6 +99,7 @@ dependencies {
     implementation(libs.compose.ui.google.fonts)
 
     implementation(libs.androidx.core)
+    implementation(libs.androidx.webkit)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewMessage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewMessage.kt
@@ -1,0 +1,93 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import dev.drewhamilton.poko.Poko
+
+/**
+ * A validated message received from a Paywalls V2 `web_view` component.
+ *
+ * Messages follow the RevenueCat web view postMessage envelope. Known [type]s include:
+ * - `rc:step-loaded`
+ * - `rc:step-complete` (carries [responses])
+ * - `rc:request-variables`
+ * - `rc:error` (carries [error])
+ *
+ * @property componentId The canonical component id (the `web_view.id` from the paywall schema). This
+ * matches the id API consumers see in the paywall configuration.
+ * @property type The message type, e.g. `rc:step-complete`.
+ * @property responses The structured responses for a `rc:step-complete` message, if any.
+ * @property error The error description for a `rc:error` message, if any.
+ */
+@Poko
+public class PaywallWebViewMessage(
+    public val componentId: String,
+    public val type: String,
+    public val responses: Map<String, PaywallWebViewValue>? = null,
+    public val error: String? = null,
+)
+
+/**
+ * Lets app code send messages back into a Paywalls V2 `web_view` component, for example in response to
+ * a `rc:request-variables` message.
+ *
+ * Outgoing messages preserve the RevenueCat web view postMessage envelope and are validated before
+ * being delivered to the web view.
+ */
+public interface PaywallWebViewController {
+
+    /**
+     * Sends a `rc:variables` message into the web view targeting [componentId]. The SDK already replies
+     * with SDK-managed variables (such as `locale`); use this to provide additional values. The flat
+     * [variables] map is sent as the transport envelope's `payload` field (not nested under a
+     * `variables` key). Reserved SDK-managed top-level keys cannot be overwritten; provide
+     * app-specific values under `custom`.
+     */
+    public fun postVariables(
+        componentId: String,
+        variables: Map<String, PaywallWebViewValue>,
+    )
+
+    /**
+     * Sends a message of the given [type] into the web view targeting [componentId]. The flat
+     * [variables] map is sent as the transport envelope's `payload` field (not nested under a
+     * `variables` key). Use [postVariables] for the common `rc:variables` case.
+     */
+    public fun postMessage(
+        componentId: String,
+        type: String,
+        variables: Map<String, PaywallWebViewValue>,
+    )
+}
+
+/**
+ * Receives validated messages from Paywalls V2 `web_view` components.
+ *
+ * Set this on [PaywallOptions.Builder.setWebViewMessageHandler]. The handler is always invoked on the
+ * main thread. The app decides what to do with each message: the SDK does not automatically dismiss the
+ * paywall or trigger a purchase in response to `rc:step-complete`.
+ *
+ * ### Usage
+ * ```kotlin
+ * PaywallOptions.Builder { /* dismiss */ }
+ *     .setWebViewMessageHandler { message, controller ->
+ *         when (message.type) {
+ *             "rc:request-variables" -> controller.postVariables(
+ *                 componentId = message.componentId,
+ *                 variables = mapOf(
+ *                     "custom" to PaywallWebViewValue.Object(
+ *                         mapOf("app_segment" to PaywallWebViewValue.String("high_intent")),
+ *                     ),
+ *                 ),
+ *             )
+ *             "rc:step-complete" -> { /* read message.responses, navigate, log analytics, etc. */ }
+ *             "rc:error" -> { /* log message.error */ }
+ *         }
+ *     }
+ *     .build()
+ * ```
+ */
+public fun interface PaywallWebViewMessageHandler {
+    public fun onMessage(
+        message: PaywallWebViewMessage,
+        controller: PaywallWebViewController,
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValue.kt
@@ -1,0 +1,144 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A JSON-compatible value used in messages exchanged with a Paywalls V2 `web_view` component.
+ *
+ * Only JSON-like values are supported: [String], [Number], [Boolean], [Object], [Array] and [Null].
+ * Functions, binary blobs, dates, and platform-specific objects are intentionally not representable.
+ *
+ * @see PaywallWebViewMessage
+ * @see PaywallWebViewController
+ */
+// Modeled as an abstract class with a closed set of subtypes (mirroring [CustomVariableValue]) rather
+// than a sealed class, to stay binary-compatible as public API.
+public abstract class PaywallWebViewValue internal constructor() {
+
+    /**
+     * A string value.
+     */
+    public class String(public val value: kotlin.String) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is String && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.String(value=$value)"
+    }
+
+    /**
+     * A numeric value (integer or decimal). Stored as a [Double].
+     *
+     * Non-finite values (`NaN`, infinities) cannot be represented in JSON and serialize as JSON
+     * `null` when sent into the web view. Equality follows [Double.equals] semantics (consistent
+     * with [hashCode]): `NaN` equals `NaN`, and `-0.0` does not equal `0.0`.
+     */
+    public class Number(public val value: kotlin.Double) : PaywallWebViewValue() {
+        public constructor(value: kotlin.Int) : this(value.toDouble())
+        public constructor(value: kotlin.Long) : this(value.toDouble())
+        public constructor(value: kotlin.Float) : this(value.toDouble())
+
+        override fun equals(other: Any?): kotlin.Boolean = other is Number && value.equals(other.value)
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Number(value=$value)"
+    }
+
+    /**
+     * A boolean value.
+     */
+    public class Boolean(public val value: kotlin.Boolean) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Boolean && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Boolean(value=$value)"
+    }
+
+    /**
+     * A JSON object: a map of string keys to [PaywallWebViewValue]s.
+     */
+    public class Object(public val value: Map<kotlin.String, PaywallWebViewValue>) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Object && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Object(value=$value)"
+    }
+
+    /**
+     * A JSON array: an ordered list of [PaywallWebViewValue]s.
+     */
+    public class Array(public val value: List<PaywallWebViewValue>) : PaywallWebViewValue() {
+        override fun equals(other: Any?): kotlin.Boolean = other is Array && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Array(value=$value)"
+    }
+
+    /**
+     * A JSON `null` value.
+     */
+    public object Null : PaywallWebViewValue() {
+        override fun toString(): kotlin.String = "PaywallWebViewValue.Null"
+    }
+
+    internal companion object {
+        /**
+         * Converts an `org.json` value (or Kotlin primitive) into a [PaywallWebViewValue], rejecting
+         * anything that is not JSON-compatible or that exceeds [remainingDepth] levels of nesting.
+         *
+         * @return the converted value, or `null` if the value is not JSON-compatible or too deeply nested.
+         */
+        @Suppress("ReturnCount", "CyclomaticComplexMethod")
+        fun fromJson(value: Any?, remainingDepth: Int): PaywallWebViewValue? {
+            return when (value) {
+                null, JSONObject.NULL -> Null
+                is kotlin.String -> String(value)
+                is kotlin.Boolean -> Boolean(value)
+                is Int -> Number(value)
+                is Long -> Number(value)
+                is Double -> Number(value)
+                is Float -> Number(value)
+                is JSONObject -> {
+                    if (remainingDepth <= 0) return null
+                    val map = LinkedHashMap<kotlin.String, PaywallWebViewValue>(value.length())
+                    for (key in value.keys()) {
+                        map[key] = fromJson(value.get(key), remainingDepth - 1) ?: return null
+                    }
+                    Object(map)
+                }
+                is JSONArray -> {
+                    if (remainingDepth <= 0) return null
+                    val list = ArrayList<PaywallWebViewValue>(value.length())
+                    for (index in 0 until value.length()) {
+                        list.add(fromJson(value.get(index), remainingDepth - 1) ?: return null)
+                    }
+                    Array(list)
+                }
+                // Numbers stored by org.json as BigDecimal/BigInteger, or any other type, are not supported.
+                else -> (value as? kotlin.Number)?.let { Number(it.toDouble()) }
+            }
+        }
+    }
+}
+
+/**
+ * Converts this value into a representation accepted by [JSONObject]/[JSONArray] when serializing a
+ * message to send into the web view. Whole numbers are emitted as integers (e.g. `100`, not `100.0`).
+ * Non-finite numbers serialize as JSON `null`: JSON cannot represent them, `org.json`'s `put` throws
+ * for them, and one bad number must never destroy an otherwise-valid outbound message.
+ */
+internal fun PaywallWebViewValue.toJsonRepresentation(): Any = when (this) {
+    is PaywallWebViewValue.String -> value
+    is PaywallWebViewValue.Boolean -> value
+    is PaywallWebViewValue.Number -> when {
+        !value.isFinite() -> JSONObject.NULL
+        value % 1.0 == 0.0 -> value.toLong()
+        else -> value
+    }
+    is PaywallWebViewValue.Object -> JSONObject().apply {
+        value.forEach { (key, child) -> put(key, child.toJsonRepresentation()) }
+    }
+    is PaywallWebViewValue.Array -> JSONArray().apply {
+        value.forEach { child -> put(child.toJsonRepresentation()) }
+    }
+    else -> JSONObject.NULL
+}
+
+internal fun Map<String, PaywallWebViewValue>.toJsonObject(): JSONObject = JSONObject().apply {
+    forEach { (key, value) -> put(key, value.toJsonRepresentation()) }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -1,0 +1,87 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.graphics.Bitmap
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+
+/**
+ * [WebViewClient] for Paywalls V2 `web_view` components. Owns navigation policy, main-frame document
+ * lifecycle notifications, and a single terminal failure path shared by URL errors, HTTP errors, and
+ * renderer termination.
+ */
+internal class PaywallWebViewClient(
+    private val expectedOrigin: String?,
+    private val onMainFrameNavigationStarted: (url: String?) -> Unit,
+    private val onMainFrameLoadFailed: () -> Unit,
+) : WebViewClient() {
+
+    @Volatile
+    private var failed: Boolean = false
+
+    private fun markFailed() {
+        if (failed) return
+        failed = true
+        onMainFrameLoadFailed()
+    }
+
+    override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+        super.onPageStarted(view, url, favicon)
+        // onPageStarted is main-frame only and marks a new JavaScript document.
+        onMainFrameNavigationStarted(url)
+        // shouldOverrideUrlLoading is not called for POST navigations, so re-check the policy
+        // here and kill any main-frame load that slipped through (cross-origin / non-HTTPS).
+        if (shouldBlockWebViewNavigation(
+                url = url,
+                isMainFrame = true,
+                expectedOrigin = expectedOrigin,
+            )
+        ) {
+            view.stopLoading()
+        }
+    }
+
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        return shouldBlockWebViewNavigation(
+            url = request.url?.toString(),
+            isMainFrame = request.isForMainFrame,
+            expectedOrigin = expectedOrigin,
+        )
+    }
+
+    override fun onReceivedError(
+        view: WebView,
+        request: WebResourceRequest,
+        error: WebResourceError,
+    ) {
+        if (request.isForMainFrame) {
+            markFailed()
+        }
+    }
+
+    override fun onReceivedHttpError(
+        view: WebView,
+        request: WebResourceRequest,
+        errorResponse: WebResourceResponse,
+    ) {
+        if (request.isForMainFrame && errorResponse.statusCode >= HTTP_ERROR_STATUS_MIN) {
+            markFailed()
+        }
+    }
+
+    override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
+        markFailed()
+        // Returning true tells the platform we handled the dead renderer; the dead WebView must not
+        // be reused. Composition removes it via the failure path + AndroidView.onRelease.
+        return true
+    }
+
+    private companion object {
+        private const val HTTP_ERROR_STATUS_MIN = 400
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProvider.kt
@@ -1,0 +1,58 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+
+/**
+ * Builds the `variables` payload sent to a `web_view` component in response to `rc:request-variables`.
+ *
+ * Produces a flat map shaped like:
+ * ```json
+ * { "locale": "en-US" }
+ * ```
+ *
+ * Only safe, already-available system context is exposed: the paywall locale. The paywall's
+ * dashboard-defined custom variables are intentionally NOT passed across the bridge in v1. API keys,
+ * email addresses, the Purchases SDK instance, and storage are never included.
+ *
+ * [KEY_LOCALE] is a reserved SDK-managed top-level key: app-provided variables may not overwrite it.
+ */
+internal object PaywallWebViewVariablesProvider {
+
+    const val KEY_LOCALE: String = "locale"
+
+    val reservedKeys: Set<String> = setOf(KEY_LOCALE)
+
+    /**
+     * The SDK-managed system variables exposed to the web view.
+     *
+     * @param locale a BCP-47-ish locale string, e.g. `en-US`.
+     */
+    fun sdkManagedVariables(
+        locale: String,
+    ): Map<String, PaywallWebViewValue> = linkedMapOf(
+        KEY_LOCALE to PaywallWebViewValue.String(locale),
+    )
+
+    /**
+     * Removes reserved SDK-managed top-level keys from app-provided variables so they cannot overwrite
+     * SDK values, logging a warning for any that were dropped.
+     */
+    fun sanitizeAppProvidedVariables(
+        variables: Map<String, PaywallWebViewValue>,
+    ): Map<String, PaywallWebViewValue> {
+        val sanitized = variables.filterKeys { key ->
+            val reserved = key in reservedKeys
+            if (reserved) {
+                Logger.w(
+                    "Ignoring reserved web view variable key '$key'. Reserved SDK-managed keys cannot be " +
+                        "overwritten.",
+                )
+            }
+            !reserved
+        }
+        return sanitized
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -1,0 +1,174 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.json.JSONObject
+
+/**
+ * Wire-format envelopes for the `workflow-web-components-sdk` transport layer.
+ *
+ * Matches [RevenueCat/workflow-web-components-sdk](https://github.com/RevenueCat/workflow-web-components-sdk):
+ * channel `rc-web-components`, handshake kinds `connect` / `init` / `reject`, and app frames
+ * `message` / `request` / `response` / `error`.
+ *
+ * On Android the host installs `rcWebComponents` via `WebViewCompat.addWebMessageListener` so inbound
+ * frames carry a platform `sourceOrigin` / `isMainFrame`. The content still calls
+ * `rcWebComponents.postMessage(jsonString)`.
+ */
+internal object WebViewEnvelope {
+
+    const val CHANNEL: String = "rc-web-components"
+    const val NATIVE_OBJECT_NAME: String = "rcWebComponents"
+    const val RECEIVE_FUNCTION: String = "__rcWebComponentsReceive"
+    const val DEFAULT_PROTOCOL_VERSION: Int = 1
+
+    /** Maximum UTF-8 byte length accepted for a single inbound frame. */
+    const val MAX_PAYLOAD_BYTES: Int = 65_536
+
+    /**
+     * Maximum nesting depth for a payload tree. The whole-frame pre-parse scan allows one extra
+     * level for the envelope object itself ([MAX_FRAME_DEPTH]).
+     */
+    const val MAX_NESTING_DEPTH: Int = 16
+
+    const val KIND_CONNECT: String = "connect"
+    const val KIND_INIT: String = "init"
+    const val KIND_REJECT: String = "reject"
+    const val KIND_MESSAGE: String = "message"
+    const val KIND_REQUEST: String = "request"
+    const val KIND_RESPONSE: String = "response"
+    const val KIND_ERROR: String = "error"
+
+    private val ENVELOPE_KINDS: Set<String> = setOf(
+        KIND_CONNECT,
+        KIND_INIT,
+        KIND_REJECT,
+        KIND_MESSAGE,
+        KIND_REQUEST,
+        KIND_RESPONSE,
+        KIND_ERROR,
+    )
+
+    internal data class Parsed(
+        val kind: String,
+        val protocolVersion: Int,
+        val componentId: String,
+        val type: String?,
+        val id: String?,
+        val payload: JSONObject?,
+        val error: String?,
+    )
+
+    /**
+     * Coarse structural depth budget for a whole inbound frame: the envelope object itself plus a
+     * payload tree of at most [MAX_NESTING_DEPTH] levels. The precise per-tree limit is still
+     * enforced during app-message conversion; this scan exists only to stop hostile input before
+     * recursion happens.
+     */
+    private const val MAX_FRAME_DEPTH: Int = MAX_NESTING_DEPTH + 1
+
+    @Suppress("ReturnCount", "CyclomaticComplexMethod")
+    fun parse(rawJson: String): Parsed? {
+        if (rawJson.toByteArray(Charsets.UTF_8).size > MAX_PAYLOAD_BYTES) return null
+
+        // Enforce the nesting budget BEFORE org.json parses: JSONTokener recurses per nesting
+        // level, and tens of thousands of levels fit inside the 64 KiB frame limit, so a hostile
+        // deeply-nested frame could otherwise overflow the stack before any post-parse check runs.
+        if (exceedsMaxDepth(rawJson)) return null
+
+        val json = try {
+            JSONObject(rawJson)
+        } catch (@Suppress("SwallowedException") _: org.json.JSONException) {
+            return null
+        }
+
+        if (json.opt(WebViewMessageField.CHANNEL) != CHANNEL) return null
+
+        val protocolVersion = json.opt(WebViewMessageField.PROTOCOL_VERSION)
+        if (protocolVersion !is Number || !protocolVersion.toDouble().isFinite()) return null
+
+        val kind = json.opt(WebViewMessageField.KIND) as? String
+        if (kind == null || kind !in ENVELOPE_KINDS) return null
+
+        val componentId = json.opt(WebViewMessageField.COMPONENT_ID) as? String ?: return null
+
+        val type = json.opt(WebViewMessageField.TYPE) as? String
+        if (json.has(WebViewMessageField.TYPE) && type == null) return null
+
+        val id = json.opt(WebViewMessageField.ID) as? String
+        if (json.has(WebViewMessageField.ID) && id == null) return null
+
+        val error = json.opt(WebViewMessageField.ERROR) as? String
+        if (json.has(WebViewMessageField.ERROR) && error == null) return null
+
+        val payload = when (val payloadValue = json.opt(WebViewMessageField.PAYLOAD)) {
+            null, JSONObject.NULL -> null
+            is JSONObject -> payloadValue
+            else -> return null
+        }
+
+        return Parsed(
+            kind = kind,
+            protocolVersion = protocolVersion.toInt(),
+            componentId = componentId,
+            type = type,
+            id = id,
+            payload = payload,
+            error = error,
+        )
+    }
+
+    /**
+     * Non-recursive scan of the raw JSON characters, tracking `{`/`[` nesting outside string
+     * literals (honoring `\` escapes). Returns `true` when the depth exceeds [MAX_FRAME_DEPTH].
+     */
+    @Suppress("LoopWithTooManyJumpStatements")
+    fun exceedsMaxDepth(rawJson: String): Boolean {
+        var depth = 0
+        var inString = false
+        var escaped = false
+
+        for (char in rawJson) {
+            if (inString) {
+                when {
+                    escaped -> escaped = false
+                    char == '\\' -> escaped = true
+                    char == '"' -> inString = false
+                }
+                continue
+            }
+
+            when (char) {
+                '"' -> inString = true
+                '{', '[' -> {
+                    depth += 1
+                    if (depth > MAX_FRAME_DEPTH) return true
+                }
+                '}', ']' -> depth -= 1
+                else -> Unit
+            }
+        }
+
+        return false
+    }
+
+    @Suppress("LongParameterList")
+    fun build(
+        kind: String,
+        protocolVersion: Int,
+        componentId: String,
+        type: String? = null,
+        id: String? = null,
+        payload: JSONObject? = null,
+        error: String? = null,
+    ): JSONObject = JSONObject().apply {
+        put(WebViewMessageField.CHANNEL, CHANNEL)
+        put(WebViewMessageField.PROTOCOL_VERSION, protocolVersion)
+        put(WebViewMessageField.KIND, kind)
+        put(WebViewMessageField.COMPONENT_ID, componentId)
+        type?.let { put(WebViewMessageField.TYPE, it) }
+        id?.let { put(WebViewMessageField.ID, it) }
+        payload?.let { put(WebViewMessageField.PAYLOAD, it) }
+        error?.let { put(WebViewMessageField.ERROR, it) }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -3,8 +3,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.net.Uri
-import android.os.Handler
-import android.os.Looper
 import android.webkit.WebView
 import androidx.annotation.MainThread
 import androidx.webkit.WebViewCompat
@@ -14,6 +12,11 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
 import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.toJsonObject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 
@@ -33,12 +36,15 @@ import java.lang.ref.WeakReference
  * ## Document lifecycle
  * Each main-frame navigation creates a new JavaScript document that must re-handshake. Call
  * [onMainFrameNavigationStarted] from `WebViewClient.onPageStarted` so a fresh `connect` is accepted
- * and outbound work queued for a previous document generation is dropped.
+ * and work queued for the previous document's [documentScope] is cancelled.
  *
  * ## Lifecycle & threading
  * The bridge holds only a [WeakReference] to the [WebView] (no Activity/Context), and stops delivering
- * messages once [release] is called. Inbound callbacks are hopped onto the main thread; app callbacks
- * and all WebView interactions happen on the main thread.
+ * messages once [release] is called. All main-thread work for the current JavaScript document runs on
+ * a per-document [CoroutineScope] (`Dispatchers.Main.immediate`); that scope is cancelled and replaced
+ * on every main-frame navigation and cancelled permanently on [release], so work queued for a dead
+ * document or a released bridge never runs. App callbacks and all WebView interactions happen on the
+ * main thread.
  */
 @Suppress("LongParameterList", "TooManyFunctions")
 internal class WebViewJavaScriptBridge(
@@ -52,7 +58,6 @@ internal class WebViewJavaScriptBridge(
     private val onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
     private val onDocumentReset: () -> Unit = {},
     private val onSecureMessagingUnsupported: () -> Unit = {},
-    private val mainHandler: Handler = Handler(Looper.getMainLooper()),
     private val isWebMessageListenerSupported: () -> Boolean = {
         WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
     },
@@ -79,21 +84,29 @@ internal class WebViewJavaScriptBridge(
     private val protocolVersion: Int = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION
 
     // Refreshed from the latest paywall state on every recomposition via update().
-    @Volatile private var locale: String = locale
+    private var locale: String = locale
 
-    @Volatile private var messageHandler: PaywallWebViewMessageHandler? = messageHandler
+    private var messageHandler: PaywallWebViewMessageHandler? = messageHandler
 
-    @Volatile private var released: Boolean = false
+    private var released: Boolean = false
 
-    @Volatile private var channelOpen: Boolean = false
+    private var channelOpen: Boolean = false
 
-    @Volatile private var messageListenerInstalled: Boolean = false
+    private var messageListenerInstalled: Boolean = false
+
+    // Deliberately no CoroutineExceptionHandler: uncaught exceptions should crash like the old
+    // Handler.post path — do not swallow bugs in a security-sensitive path.
+    private fun newDocumentScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     /**
-     * Incremented on every main-frame document start. Outbound [WebView.evaluateJavascript] work
-     * captures the generation at enqueue time and is dropped if a newer document has started.
+     * Scope for all main-thread work belonging to the CURRENT JavaScript document.
+     * Cancelled and replaced on every main-frame navigation (see
+     * [onMainFrameNavigationStarted]) and cancelled permanently on [release] —
+     * cancellation is what guarantees that work queued for a dead document or a
+     * released bridge never runs.
      */
-    @Volatile private var documentGeneration: Int = 0
+    private var documentScope: CoroutineScope = newDocumentScope()
 
     // Last content sizes applied per fit axis (main thread only), for the resize apply-threshold.
     private var lastAppliedWidthCssPx: Int? = null
@@ -101,8 +114,7 @@ internal class WebViewJavaScriptBridge(
 
     private val webMessageListener = WebViewCompat.WebMessageListener { _, message, sourceOrigin, isMainFrame, _ ->
         val data = message.data ?: return@WebMessageListener
-        mainHandler.post {
-            if (released) return@post
+        documentScope.launch {
             handleInboundMessage(
                 json = data,
                 sourceOrigin = sourceOrigin,
@@ -154,7 +166,8 @@ internal class WebViewJavaScriptBridge(
     @Suppress("UnusedParameter")
     fun onMainFrameNavigationStarted(url: String?) {
         if (released) return
-        documentGeneration += 1
+        documentScope.cancel()
+        documentScope = newDocumentScope()
         channelOpen = false
         lastAppliedWidthCssPx = null
         lastAppliedHeightCssPx = null
@@ -169,6 +182,7 @@ internal class WebViewJavaScriptBridge(
     fun release() {
         released = true
         channelOpen = false
+        documentScope.cancel()
         val webView = webViewRef.get()
         if (messageListenerInstalled && webView != null) {
             uninstallWebMessageListener(webView, WebViewEnvelope.NATIVE_OBJECT_NAME)
@@ -225,8 +239,7 @@ internal class WebViewJavaScriptBridge(
      */
     internal fun postMessage(json: String) {
         val originUri = expectedOrigin?.let { Uri.parse(it) }
-        mainHandler.post {
-            if (released) return@post
+        documentScope.launch {
             handleInboundMessage(json = json, sourceOrigin = originUri, isMainFrame = true)
         }
     }
@@ -239,8 +252,7 @@ internal class WebViewJavaScriptBridge(
         sourceOrigin: Uri?,
         isMainFrame: Boolean,
     ) {
-        mainHandler.post {
-            if (released) return@post
+        documentScope.launch {
             handleInboundMessage(json = json, sourceOrigin = sourceOrigin, isMainFrame = isMainFrame)
         }
     }
@@ -408,11 +420,8 @@ internal class WebViewJavaScriptBridge(
     }
 
     private fun deliverEnvelope(envelope: JSONObject) {
-        val generationAtEnqueue = documentGeneration
-        runOnMainThread {
-            if (released) return@runOnMainThread
-            if (generationAtEnqueue != documentGeneration) return@runOnMainThread
-            val webView = webViewRef.get() ?: return@runOnMainThread
+        documentScope.launch {
+            val webView = webViewRef.get() ?: return@launch
             val kind = envelope.optString(WebViewMessageField.KIND)
             val allowBeforeNavigation = kind in HANDSHAKE_OUTBOUND_KINDS
             // Defense in depth: drop outbound work if the top-level URL left the expected origin
@@ -422,7 +431,7 @@ internal class WebViewJavaScriptBridge(
                     "Dropping outbound web view message: current origin does not match the " +
                         "resolved component origin.",
                 )
-                return@runOnMainThread
+                return@launch
             }
             val payload = envelope.toString().escapeForJavaScript()
             webView.evaluateJavascript(
@@ -458,18 +467,6 @@ internal class WebViewJavaScriptBridge(
         return when {
             currentOrigin == null -> allowBeforeNavigation
             else -> currentOrigin == expectedOrigin
-        }
-    }
-
-    private fun runOnMainThread(block: () -> Unit) {
-        if (Looper.myLooper() == Looper.getMainLooper()) {
-            if (released) return
-            block()
-        } else {
-            mainHandler.post {
-                if (released) return@post
-                block()
-            }
         }
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -1,0 +1,504 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.webkit.WebView
+import androidx.annotation.MainThread
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import com.revenuecat.purchases.ui.revenuecatui.toJsonObject
+import org.json.JSONObject
+import java.lang.ref.WeakReference
+
+/**
+ * Installs and drives the bidirectional bridge between a Paywalls V2 `web_view` component and native
+ * code. One bridge is created per rendered `web_view`.
+ *
+ * ## Transport
+ * Implements the native Android host contract from `workflow-web-components-sdk`:
+ * - JS → native: `rcWebComponents.postMessage(jsonString)` via [WebViewCompat.addWebMessageListener]
+ * - native → JS: `window.__rcWebComponentsReceive(data)` via [WebView.evaluateJavascript]
+ * - Wire format: `{ channel: "rc-web-components", kind, protocol_version, component_id, … }`
+ *
+ * Inbound frames are validated against the message listener's `sourceOrigin` and `isMainFrame` —
+ * the WebView's top-level URL alone is not sufficient (same-origin subframes and navigation races).
+ *
+ * ## Document lifecycle
+ * Each main-frame navigation creates a new JavaScript document that must re-handshake. Call
+ * [onMainFrameNavigationStarted] from `WebViewClient.onPageStarted` so a fresh `connect` is accepted
+ * and outbound work queued for a previous document generation is dropped.
+ *
+ * ## Lifecycle & threading
+ * The bridge holds only a [WeakReference] to the [WebView] (no Activity/Context), and stops delivering
+ * messages once [release] is called. Inbound callbacks are hopped onto the main thread; app callbacks
+ * and all WebView interactions happen on the main thread.
+ */
+@Suppress("LongParameterList", "TooManyFunctions")
+internal class WebViewJavaScriptBridge(
+    webView: WebView,
+    private val componentId: String,
+    expectedUrl: String,
+    locale: String,
+    messageHandler: PaywallWebViewMessageHandler?,
+    private val sizeToContentWidth: Boolean = false,
+    private val sizeToContentHeight: Boolean = false,
+    private val onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
+    private val onDocumentReset: () -> Unit = {},
+    private val onSecureMessagingUnsupported: () -> Unit = {},
+    private val mainHandler: Handler = Handler(Looper.getMainLooper()),
+    private val isWebMessageListenerSupported: () -> Boolean = {
+        WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+    },
+    private val installWebMessageListener: (
+        WebView,
+        String,
+        Set<String>,
+        WebViewCompat.WebMessageListener,
+    ) -> Unit = { view, jsObjectName, allowedOrigins, listener ->
+        WebViewCompat.addWebMessageListener(view, jsObjectName, allowedOrigins, listener)
+    },
+    private val uninstallWebMessageListener: (WebView, String) -> Unit = { view, jsObjectName ->
+        WebViewCompat.removeWebMessageListener(view, jsObjectName)
+    },
+) : PaywallWebViewController {
+
+    private val webViewRef = WeakReference(webView)
+    private val expectedOrigin: String? = expectedUrl.toOriginOrNull()
+
+    // The single protocol version this SDK build implements. Deliberately NOT the schema's
+    // `protocol_version`: the envelope version is the wire+SDK major the CONTENT speaks, and the
+    // host must never accept a handshake for a version it cannot service, even if a future schema
+    // declares one.
+    private val protocolVersion: Int = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION
+
+    // Refreshed from the latest paywall state on every recomposition via update().
+    @Volatile private var locale: String = locale
+
+    @Volatile private var messageHandler: PaywallWebViewMessageHandler? = messageHandler
+
+    @Volatile private var released: Boolean = false
+
+    @Volatile private var channelOpen: Boolean = false
+
+    @Volatile private var messageListenerInstalled: Boolean = false
+
+    /**
+     * Incremented on every main-frame document start. Outbound [WebView.evaluateJavascript] work
+     * captures the generation at enqueue time and is dropped if a newer document has started.
+     */
+    @Volatile private var documentGeneration: Int = 0
+
+    // Last content sizes applied per fit axis (main thread only), for the resize apply-threshold.
+    private var lastAppliedWidthCssPx: Int? = null
+    private var lastAppliedHeightCssPx: Int? = null
+
+    private val webMessageListener = WebViewCompat.WebMessageListener { _, message, sourceOrigin, isMainFrame, _ ->
+        val data = message.data ?: return@WebMessageListener
+        mainHandler.post {
+            if (released) return@post
+            handleInboundMessage(
+                json = data,
+                sourceOrigin = sourceOrigin,
+                isMainFrame = isMainFrame,
+            )
+        }
+    }
+
+    /**
+     * Registers the secure message listener on the WebView. Call once, when the WebView is created.
+     * If [WebViewFeature.WEB_MESSAGE_LISTENER] is unavailable, invokes [onSecureMessagingUnsupported]
+     * so the host can take the terminal failure path.
+     */
+    @MainThread
+    fun attach() {
+        val webView = webViewRef.get() ?: return
+        val origin = expectedOrigin
+        if (origin == null || !isWebMessageListenerSupported()) {
+            onSecureMessagingUnsupported()
+            return
+        }
+        installWebMessageListener(
+            webView,
+            WebViewEnvelope.NATIVE_OBJECT_NAME,
+            setOf(origin),
+            webMessageListener,
+        )
+        messageListenerInstalled = true
+    }
+
+    /**
+     * Refreshes the locale and the app message handler from the latest paywall state. Call from
+     * `AndroidView`'s update block.
+     */
+    fun update(
+        locale: String,
+        messageHandler: PaywallWebViewMessageHandler?,
+    ) {
+        this.locale = locale
+        this.messageHandler = messageHandler
+    }
+
+    /**
+     * Marks the start of a new main-frame JavaScript document (initial load, same-origin
+     * navigation, or reload). Resets the handshake and fit/resize threshold state so the new
+     * document can `connect` again.
+     */
+    @MainThread
+    @Suppress("UnusedParameter")
+    fun onMainFrameNavigationStarted(url: String?) {
+        if (released) return
+        documentGeneration += 1
+        channelOpen = false
+        lastAppliedWidthCssPx = null
+        lastAppliedHeightCssPx = null
+        onDocumentReset()
+    }
+
+    /**
+     * Stops the bridge. After this call no further inbound messages are delivered and no outbound
+     * messages are sent. Call from `AndroidView`'s onRelease block.
+     */
+    @MainThread
+    fun release() {
+        released = true
+        channelOpen = false
+        val webView = webViewRef.get()
+        if (messageListenerInstalled && webView != null) {
+            uninstallWebMessageListener(webView, WebViewEnvelope.NATIVE_OBJECT_NAME)
+            messageListenerInstalled = false
+        }
+    }
+
+    /**
+     * Processes an inbound transport frame. Production traffic arrives via [webMessageListener];
+     * tests call this directly with an explicit [sourceOrigin] and [isMainFrame].
+     */
+    @MainThread
+    @Suppress("ReturnCount")
+    internal fun handleInboundMessage(
+        json: String,
+        sourceOrigin: Uri?,
+        isMainFrame: Boolean,
+    ) {
+        if (released) return
+
+        if (!isSourceTrusted(sourceOrigin = sourceOrigin, isMainFrame = isMainFrame)) {
+            Logger.w(
+                "Dropping inbound web view message: source origin is not the resolved component " +
+                    "origin or the frame is not the main frame.",
+            )
+            return
+        }
+
+        if (json.toByteArray(Charsets.UTF_8).size > WebViewEnvelope.MAX_PAYLOAD_BYTES) {
+            Logger.w(
+                "Dropping inbound web view message: payload exceeds " +
+                    "${WebViewEnvelope.MAX_PAYLOAD_BYTES} bytes.",
+            )
+            return
+        }
+
+        val envelope = WebViewEnvelope.parse(json) ?: run {
+            Logger.w("Dropping inbound web view message: not a valid transport envelope.")
+            return
+        }
+
+        when (envelope.kind) {
+            WebViewEnvelope.KIND_CONNECT -> handleConnect(envelope)
+            WebViewEnvelope.KIND_MESSAGE,
+            WebViewEnvelope.KIND_REQUEST,
+            -> handleAppFrame(envelope)
+            else -> Unit
+        }
+    }
+
+    /**
+     * Test helper: posts [json] onto the main thread as a trusted main-frame message from
+     * [expectedOrigin], mirroring the WebMessageListener hop.
+     */
+    internal fun postMessage(json: String) {
+        val originUri = expectedOrigin?.let { Uri.parse(it) }
+        mainHandler.post {
+            if (released) return@post
+            handleInboundMessage(json = json, sourceOrigin = originUri, isMainFrame = true)
+        }
+    }
+
+    /**
+     * Test helper for explicit origin / main-frame combinations.
+     */
+    internal fun postMessage(
+        json: String,
+        sourceOrigin: Uri?,
+        isMainFrame: Boolean,
+    ) {
+        mainHandler.post {
+            if (released) return@post
+            handleInboundMessage(json = json, sourceOrigin = sourceOrigin, isMainFrame = isMainFrame)
+        }
+    }
+
+    @MainThread
+    private fun handleConnect(envelope: WebViewEnvelope.Parsed) {
+        if (channelOpen || released) return
+
+        if (envelope.protocolVersion != protocolVersion) {
+            deliverEnvelope(
+                WebViewEnvelope.build(
+                    kind = WebViewEnvelope.KIND_REJECT,
+                    protocolVersion = protocolVersion,
+                    componentId = "",
+                    error = "Unsupported protocol_version ${envelope.protocolVersion}; " +
+                        "native host supports $protocolVersion",
+                ),
+            )
+            return
+        }
+
+        channelOpen = true
+        deliverEnvelope(
+            WebViewEnvelope.build(
+                kind = WebViewEnvelope.KIND_INIT,
+                protocolVersion = protocolVersion,
+                componentId = componentId,
+            ),
+        )
+        sendFitIfNeeded()
+    }
+
+    private fun sendFitIfNeeded() {
+        if (!sizeToContentWidth && !sizeToContentHeight) return
+        val payload = JSONObject().apply {
+            if (sizeToContentWidth) put("width", true)
+            if (sizeToContentHeight) put("height", true)
+        }
+        deliverEnvelope(
+            WebViewEnvelope.build(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                protocolVersion = protocolVersion,
+                componentId = componentId,
+                type = WebViewMessageType.FIT,
+                payload = payload,
+            ),
+        )
+    }
+
+    @MainThread
+    @Suppress("ReturnCount")
+    private fun handleAppFrame(envelope: WebViewEnvelope.Parsed) {
+        if (!channelOpen) return
+
+        // Any transport `request` without a correlation `id` is undeliverable — drop it before
+        // any handling, matching iOS and the web host.
+        if (envelope.kind == WebViewEnvelope.KIND_REQUEST && envelope.id == null) {
+            Logger.w("Dropping inbound web view message: transport request is missing 'id'.")
+            return
+        }
+
+        // `resize` is SDK-internal regardless of kind; it never reaches the app handler.
+        if (envelope.type == WebViewMessageType.RESIZE) {
+            handleResize(envelope)
+            return
+        }
+
+        val parsed = WebViewMessageParser.parse(
+            envelope = envelope,
+            expectedComponentId = componentId,
+        ) ?: return
+
+        val message = parsed.message
+
+        if (message.type == WebViewMessageType.REQUEST_VARIABLES) {
+            val variables = PaywallWebViewVariablesProvider.sdkManagedVariables(locale = locale)
+            val requestId = parsed.requestId
+            if (requestId != null) {
+                deliverEnvelope(
+                    WebViewEnvelope.build(
+                        kind = WebViewEnvelope.KIND_RESPONSE,
+                        protocolVersion = protocolVersion,
+                        componentId = componentId,
+                        type = parsed.requestType,
+                        id = requestId,
+                        payload = variables.toJsonObject(),
+                    ),
+                )
+            } else {
+                postVariablesMessage(componentId = componentId, variables = variables)
+            }
+        }
+
+        messageHandler?.onMessage(message, this)
+    }
+
+    @MainThread
+    private fun handleResize(envelope: WebViewEnvelope.Parsed) {
+        if (envelope.componentId != componentId) return
+        val payload = envelope.payload ?: return
+
+        val width = applyResize(
+            reported = payload.resizeDimension("width").takeIf { sizeToContentWidth },
+            lastApplied = lastAppliedWidthCssPx,
+        )?.also { lastAppliedWidthCssPx = it }
+        val height = applyResize(
+            reported = payload.resizeDimension("height").takeIf { sizeToContentHeight },
+            lastApplied = lastAppliedHeightCssPx,
+        )?.also { lastAppliedHeightCssPx = it }
+
+        if (width != null || height != null) {
+            onContentResize(width, height)
+        }
+    }
+
+    /**
+     * Returns the value to apply for one axis, or `null` when there is nothing new to apply:
+     * missing/invalid report, non-fit axis, or a change smaller than [RESIZE_APPLY_THRESHOLD_CSS_PX]
+     * against the last applied value (guards report/apply feedback loops — HTML content's reported
+     * width often just echoes the imposed viewport width).
+     */
+    @Suppress("ReturnCount")
+    private fun applyResize(reported: Int?, lastApplied: Int?): Int? {
+        if (reported == null) return null
+        if (lastApplied != null && kotlin.math.abs(reported - lastApplied) < RESIZE_APPLY_THRESHOLD_CSS_PX) {
+            return null
+        }
+        return reported
+    }
+
+    override fun postVariables(componentId: String, variables: Map<String, PaywallWebViewValue>) {
+        postVariablesMessage(
+            componentId = componentId,
+            variables = PaywallWebViewVariablesProvider.sanitizeAppProvidedVariables(variables),
+        )
+    }
+
+    override fun postMessage(componentId: String, type: String, variables: Map<String, PaywallWebViewValue>) {
+        postAppMessage(
+            componentId = componentId,
+            type = type,
+            payload = variables.toJsonObject(),
+        )
+    }
+
+    private fun postVariablesMessage(componentId: String, variables: Map<String, PaywallWebViewValue>) {
+        postAppMessage(
+            componentId = componentId,
+            type = WebViewMessageType.VARIABLES,
+            payload = variables.toJsonObject(),
+        )
+    }
+
+    private fun postAppMessage(componentId: String, type: String, payload: JSONObject) {
+        if (!channelOpen) return
+        deliverEnvelope(
+            WebViewEnvelope.build(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                protocolVersion = protocolVersion,
+                componentId = componentId,
+                type = type,
+                payload = payload,
+            ),
+        )
+    }
+
+    private fun deliverEnvelope(envelope: JSONObject) {
+        val generationAtEnqueue = documentGeneration
+        runOnMainThread {
+            if (released) return@runOnMainThread
+            if (generationAtEnqueue != documentGeneration) return@runOnMainThread
+            val webView = webViewRef.get() ?: return@runOnMainThread
+            val kind = envelope.optString(WebViewMessageField.KIND)
+            val allowBeforeNavigation = kind in HANDSHAKE_OUTBOUND_KINDS
+            // Defense in depth: drop outbound work if the top-level URL left the expected origin
+            // (e.g. after a policy hole). Inbound validation uses sourceOrigin separately.
+            if (!isCurrentUrlTrusted(webView, allowBeforeNavigation = allowBeforeNavigation)) {
+                Logger.w(
+                    "Dropping outbound web view message: current origin does not match the " +
+                        "resolved component origin.",
+                )
+                return@runOnMainThread
+            }
+            val payload = envelope.toString().escapeForJavaScript()
+            webView.evaluateJavascript(
+                "if (window.${WebViewEnvelope.RECEIVE_FUNCTION}) { " +
+                    "window.${WebViewEnvelope.RECEIVE_FUNCTION}($payload); " +
+                    "}",
+                null,
+            )
+        }
+    }
+
+    /**
+     * Whether [sourceOrigin] matches the resolved component origin and the frame is the main frame.
+     * Subframe messages are always rejected — isolation for those is expected from the server CSP.
+     */
+    @MainThread
+    @Suppress("ReturnCount")
+    private fun isSourceTrusted(sourceOrigin: Uri?, isMainFrame: Boolean): Boolean {
+        if (!isMainFrame) return false
+        if (expectedOrigin == null) return false
+        val origin = sourceOrigin?.toOriginOrNull() ?: return false
+        return origin == expectedOrigin
+    }
+
+    /**
+     * Whether the WebView's current top-level URL still has the expected origin. Used only as an
+     * outbound defense-in-depth check; inbound traffic is gated by [isSourceTrusted].
+     */
+    @MainThread
+    private fun isCurrentUrlTrusted(webView: WebView, allowBeforeNavigation: Boolean): Boolean {
+        if (expectedOrigin == null) return false
+        val currentOrigin = webView.url?.toOriginOrNull()
+        return when {
+            currentOrigin == null -> allowBeforeNavigation
+            else -> currentOrigin == expectedOrigin
+        }
+    }
+
+    private fun runOnMainThread(block: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            if (released) return
+            block()
+        } else {
+            mainHandler.post {
+                if (released) return@post
+                block()
+            }
+        }
+    }
+
+    private companion object {
+        private val HANDSHAKE_OUTBOUND_KINDS: Set<String> = setOf(
+            WebViewEnvelope.KIND_INIT,
+            WebViewEnvelope.KIND_REJECT,
+        )
+
+        /** Cap a content-reported dimension so a buggy/hostile bundle can't blow up layout. */
+        private const val MAX_RESIZE_CSS_PX = 10_000.0
+
+        /** Minimum per-axis change (CSS px) before a new report is applied. */
+        private const val RESIZE_APPLY_THRESHOLD_CSS_PX = 1
+
+        /** A validated, clamped resize dimension, or `null` when absent, non-finite, or not positive. */
+        @Suppress("ReturnCount")
+        fun JSONObject.resizeDimension(key: String): Int? {
+            if (!has(key)) return null
+            val value = optDouble(key)
+            if (!value.isFinite() || value <= 0) return null
+            return value.coerceAtMost(MAX_RESIZE_CSS_PX).toInt()
+        }
+
+        /**
+         * JSON is a subset of JS object-literal syntax, but the U+2028/U+2029 separators are valid in
+         * JSON strings yet terminate JS statements. Escape them so the payload is safe to embed.
+         */
+        fun String.escapeForJavaScript(): String =
+            replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParser.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParser.kt
@@ -1,0 +1,154 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessage
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import org.json.JSONObject
+
+/**
+ * Parses and validates raw JSON strings received from a `web_view` component into typed
+ * [PaywallWebViewMessage]s before they reach app code.
+ *
+ * Payloads use the `workflow-web-components-sdk` transport envelope (`channel`,
+ * `protocol_version`, `kind`, `component_id`, …). App-level messages arrive as `kind`
+ * `message` or `request` with a `type` such as `rc:step-loaded`.
+ *
+ * Returns `null` for handshake frames, transport errors, malformed payloads, wrong
+ * `component_id`, or unknown app message types.
+ */
+internal object WebViewMessageParser {
+
+    internal data class ParsedAppMessage(
+        val message: PaywallWebViewMessage,
+        /** Set when the inbound frame is a transport `request` that expects a `response`. */
+        val requestId: String? = null,
+        val requestType: String? = null,
+    )
+
+    /**
+     * Parses an already-validated transport envelope (size/structure checks done by the caller)
+     * into a typed app message. Avoids re-parsing the raw JSON a second time.
+     */
+    fun parse(envelope: WebViewEnvelope.Parsed, expectedComponentId: String): ParsedAppMessage? {
+        return when (envelope.kind) {
+            WebViewEnvelope.KIND_MESSAGE,
+            WebViewEnvelope.KIND_REQUEST,
+            -> parseAppMessage(envelope, expectedComponentId)
+
+            else -> null
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun parseAppMessage(
+        envelope: WebViewEnvelope.Parsed,
+        expectedComponentId: String,
+    ): ParsedAppMessage? {
+        if (envelope.componentId != expectedComponentId) {
+            Logger.w("Dropping web view message: 'component_id' does not match the rendered web_view.")
+            return null
+        }
+
+        val type = envelope.type?.takeIf { it.isNotEmpty() }
+        if (type == null) {
+            Logger.w("Dropping web view message: missing or non-string 'type'.")
+            return null
+        }
+
+        val message = when (type) {
+            WebViewMessageType.STEP_LOADED,
+            WebViewMessageType.REQUEST_VARIABLES,
+            -> PaywallWebViewMessage(componentId = envelope.componentId, type = type)
+
+            WebViewMessageType.STEP_COMPLETE -> {
+                val responses = parseResponses(envelope.payload) ?: return null
+                PaywallWebViewMessage(
+                    componentId = envelope.componentId,
+                    type = type,
+                    responses = responses.value,
+                )
+            }
+
+            WebViewMessageType.ERROR -> {
+                val error = parseError(envelope) ?: return null
+                PaywallWebViewMessage(componentId = envelope.componentId, type = type, error = error)
+            }
+
+            else -> {
+                Logger.d("Dropping web view message: unknown type '$type'.")
+                return null
+            }
+        }
+
+        val requestId = if (envelope.kind == WebViewEnvelope.KIND_REQUEST) envelope.id else null
+
+        return ParsedAppMessage(
+            message = message,
+            requestId = requestId,
+            requestType = type,
+        )
+    }
+
+    private fun parseError(envelope: WebViewEnvelope.Parsed): String? {
+        val payloadError = envelope.payload?.opt(WebViewMessageField.ERROR) as? String
+        val error = payloadError ?: envelope.error
+        if (error == null) {
+            Logger.w("Dropping web view message: 'rc:error' requires a string 'error'.")
+            return null
+        }
+        return error
+    }
+
+    /**
+     * Parses the `responses` object for a `rc:step-complete` message. The responses may live under
+     * `payload.responses` or directly in `payload` when the content sends only response fields.
+     */
+    private class ParsedResponses(val value: Map<String, PaywallWebViewValue>)
+
+    @Suppress("ReturnCount")
+    private fun parseResponses(payload: JSONObject?): ParsedResponses? {
+        if (payload == null || payload.length() == 0) {
+            return ParsedResponses(emptyMap())
+        }
+
+        val responsesJson = when {
+            payload.has(WebViewMessageField.RESPONSES) && !payload.isNull(WebViewMessageField.RESPONSES) ->
+                payload.opt(WebViewMessageField.RESPONSES) as? JSONObject
+
+            payload.keys().asSequence().any { it in STEP_COMPLETE_RESERVED_PAYLOAD_KEYS } -> {
+                Logger.w(
+                    "Dropping web view message: 'rc:step-complete' payload contains transport fields " +
+                        "without a 'responses' object.",
+                )
+                return null
+            }
+
+            else -> payload
+        }
+
+        if (responsesJson == null) {
+            Logger.w("Dropping web view message: 'responses' must be a JSON object.")
+            return null
+        }
+
+        val converted = PaywallWebViewValue.fromJson(responsesJson, WebViewEnvelope.MAX_NESTING_DEPTH)
+        if (converted !is PaywallWebViewValue.Object) {
+            Logger.w("Dropping web view message: 'responses' contains non-JSON values or is too deeply nested.")
+            return null
+        }
+        return ParsedResponses(converted.value)
+    }
+
+    private val STEP_COMPLETE_RESERVED_PAYLOAD_KEYS: Set<String> = setOf(
+        WebViewMessageField.CHANNEL,
+        WebViewMessageField.PROTOCOL_VERSION,
+        WebViewMessageField.KIND,
+        WebViewMessageField.TYPE,
+        WebViewMessageField.COMPONENT_ID,
+        WebViewMessageField.ID,
+        WebViewMessageField.ERROR,
+        WebViewMessageField.VARIABLES,
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
@@ -1,0 +1,39 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+/**
+ * Message type identifiers for the RevenueCat `web_view` postMessage protocol (`protocol_version: 1`).
+ * These mirror the shapes used by the web implementation and must not diverge.
+ */
+internal object WebViewMessageType {
+    const val STEP_LOADED = "rc:step-loaded"
+    const val STEP_COMPLETE = "rc:step-complete"
+    const val REQUEST_VARIABLES = "rc:request-variables"
+    const val ERROR = "rc:error"
+    const val VARIABLES = "rc:variables"
+
+    /** Host → content: which axes the native host sizes to the content (`fit`). */
+    const val FIT = "fit"
+
+    /** Content → host: reported content box size in CSS pixels. */
+    const val RESIZE = "resize"
+}
+
+/**
+ * Field names used in the flat message envelope. The envelope is intentionally flat: message-specific
+ * fields such as [RESPONSES], [ERROR] and [VARIABLES] live at the top level rather than under a
+ * generic `payload` key.
+ */
+internal object WebViewMessageField {
+    const val CHANNEL = "channel"
+    const val PROTOCOL_VERSION = "protocol_version"
+    const val KIND = "kind"
+    const val TYPE = "type"
+    const val COMPONENT_ID = "component_id"
+    const val ID = "id"
+    const val PAYLOAD = "payload"
+    const val RESPONSES = "responses"
+    const val ERROR = "error"
+    const val VARIABLES = "variables"
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOrigins.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOrigins.kt
@@ -1,0 +1,61 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.net.Uri
+import java.util.Locale
+
+/**
+ * The origin of this URL as `scheme://host[:port]`, or `null` if it lacks a host. Host comparison is
+ * case-insensitive. Default ports (443 for https, 80 for http) are omitted.
+ *
+ * Accepts both full URLs and bare origins (as provided by [WebViewCompat.WebMessageListener]).
+ */
+@Suppress("ReturnCount", "MagicNumber")
+internal fun String.toOriginOrNull(): String? {
+    val uri = Uri.parse(this)
+    return uri.toOriginOrNull()
+}
+
+/**
+ * The origin of this [Uri] as `scheme://host[:port]`, or `null` if it lacks a host.
+ */
+@Suppress("ReturnCount", "MagicNumber")
+internal fun Uri.toOriginOrNull(): String? {
+    val scheme = scheme?.lowercase(Locale.US) ?: return null
+    val host = host?.takeIf { it.isNotBlank() }?.lowercase(Locale.US) ?: return null
+    val effectivePort = when {
+        port != -1 -> port
+        scheme == "https" -> 443
+        scheme == "http" -> 80
+        else -> -1
+    }
+    val portSuffix = when {
+        effectivePort == -1 -> ""
+        scheme == "https" && effectivePort == 443 -> ""
+        scheme == "http" && effectivePort == 80 -> ""
+        else -> ":$effectivePort"
+    }
+    return "$scheme://$host$portSuffix"
+}
+
+/**
+ * Navigation policy for `web_view` content, applied from `shouldOverrideUrlLoading`:
+ *
+ * - Any non-HTTPS navigation is blocked (any frame).
+ * - Main-frame navigation is additionally restricted to the resolved component URL's origin
+ *   (same-origin different-path navigation stays allowed). This makes cross-origin message races
+ *   structurally impossible; the bridge's per-message origin check remains as defense in depth.
+ * - Cross-origin sub-frame loads are not blocked here; isolation for those is expected from the
+ *   server-provided Content-Security-Policy served with the web content.
+ */
+@Suppress("ReturnCount")
+internal fun shouldBlockWebViewNavigation(
+    url: String?,
+    isMainFrame: Boolean,
+    expectedOrigin: String?,
+): Boolean {
+    val origin = url?.toOriginOrNull() ?: return true
+    if (!origin.startsWith("https://")) return true
+    return isMainFrame && origin != expectedOrigin
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolver.kt
@@ -1,0 +1,19 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.net.Uri
+
+internal object WebViewUrlResolver {
+
+    fun resolve(url: String): String? {
+        if (url.contains("{{")) return null
+
+        val uri = Uri.parse(url)
+        return url.takeIf {
+            uri.scheme == HTTPS_SCHEME && !uri.host.isNullOrBlank()
+        }
+    }
+
+    private const val HTTPS_SCHEME = "https"
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValueTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWebViewValueTest.kt
@@ -1,0 +1,113 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+
+internal class PaywallWebViewValueTest {
+
+    @Test
+    fun `fromJson converts primitives`() {
+        assertThat(PaywallWebViewValue.fromJson("hello", 8)).isEqualTo(PaywallWebViewValue.String("hello"))
+        assertThat(PaywallWebViewValue.fromJson(true, 8)).isEqualTo(PaywallWebViewValue.Boolean(true))
+        assertThat(PaywallWebViewValue.fromJson(42, 8)).isEqualTo(PaywallWebViewValue.Number(42))
+        assertThat(PaywallWebViewValue.fromJson(3.5, 8)).isEqualTo(PaywallWebViewValue.Number(3.5))
+        assertThat(PaywallWebViewValue.fromJson(null, 8)).isEqualTo(PaywallWebViewValue.Null)
+        assertThat(PaywallWebViewValue.fromJson(JSONObject.NULL, 8)).isEqualTo(PaywallWebViewValue.Null)
+    }
+
+    @Test
+    fun `fromJson converts nested objects and arrays`() {
+        val json = JSONObject("""{"a":1,"b":["x",false],"c":{"d":null}}""")
+
+        val value = PaywallWebViewValue.fromJson(json, 8)
+
+        assertThat(value).isInstanceOf(PaywallWebViewValue.Object::class.java)
+        val obj = (value as PaywallWebViewValue.Object).value
+        assertThat(obj["a"]).isEqualTo(PaywallWebViewValue.Number(1))
+        assertThat(obj["b"]).isEqualTo(
+            PaywallWebViewValue.Array(listOf(PaywallWebViewValue.String("x"), PaywallWebViewValue.Boolean(false))),
+        )
+        assertThat(obj["c"]).isEqualTo(
+            PaywallWebViewValue.Object(mapOf("d" to PaywallWebViewValue.Null)),
+        )
+    }
+
+    @Test
+    fun `fromJson returns null when too deeply nested`() {
+        val json = JSONObject("""{"a":{"b":{"c":1}}}""")
+
+        // Allow only 2 levels: top object (1) -> a (2) -> b would exceed.
+        assertThat(PaywallWebViewValue.fromJson(json, 2)).isNull()
+    }
+
+    @Test
+    fun `toJsonRepresentation emits whole numbers as integers`() {
+        assertThat(PaywallWebViewValue.Number(100.0).toJsonRepresentation()).isEqualTo(100L)
+        assertThat(PaywallWebViewValue.Number(99.99).toJsonRepresentation()).isEqualTo(99.99)
+    }
+
+    @Test
+    fun `toJsonRepresentation serializes non-finite numbers as JSON null`() {
+        // JSON cannot represent NaN/infinity and org.json's put() throws for them; one bad number
+        // must never destroy an otherwise-valid outbound message.
+        assertThat(PaywallWebViewValue.Number(Double.POSITIVE_INFINITY).toJsonRepresentation())
+            .isEqualTo(JSONObject.NULL)
+        assertThat(PaywallWebViewValue.Number(Double.NEGATIVE_INFINITY).toJsonRepresentation())
+            .isEqualTo(JSONObject.NULL)
+        assertThat(PaywallWebViewValue.Number(Double.NaN).toJsonRepresentation())
+            .isEqualTo(JSONObject.NULL)
+    }
+
+    @Test
+    fun `a map containing non-finite numbers serializes without throwing`() {
+        val json = mapOf(
+            "bad" to PaywallWebViewValue.Number(Double.NaN),
+            "good" to PaywallWebViewValue.String("kept"),
+        ).toJsonObject()
+
+        assertThat(json.isNull("bad")).isTrue()
+        assertThat(json.getString("good")).isEqualTo("kept")
+    }
+
+    @Test
+    fun `number equality and hashCode are mutually consistent for edge values`() {
+        // Double.equals semantics: NaN equals NaN; -0.0 does not equal 0.0. Both agree with hashCode.
+        val nan1 = PaywallWebViewValue.Number(Double.NaN)
+        val nan2 = PaywallWebViewValue.Number(Double.NaN)
+        assertThat(nan1).isEqualTo(nan2)
+        assertThat(nan1.hashCode()).isEqualTo(nan2.hashCode())
+
+        val negativeZero = PaywallWebViewValue.Number(-0.0)
+        val positiveZero = PaywallWebViewValue.Number(0.0)
+        assertThat(negativeZero).isNotEqualTo(positiveZero)
+        assertThat(negativeZero.hashCode()).isNotEqualTo(positiveZero.hashCode())
+    }
+
+    @Test
+    fun `toJsonObject round-trips a map`() {
+        val map = mapOf(
+            "locale" to PaywallWebViewValue.String("en-US"),
+            "custom" to PaywallWebViewValue.Object(
+                mapOf(
+                    "plan" to PaywallWebViewValue.String("annual"),
+                    "count" to PaywallWebViewValue.Number(3),
+                    "flag" to PaywallWebViewValue.Boolean(true),
+                    "list" to PaywallWebViewValue.Array(listOf(PaywallWebViewValue.Number(1))),
+                    "nothing" to PaywallWebViewValue.Null,
+                ),
+            ),
+        )
+
+        val json = map.toJsonObject()
+
+        assertThat(json.getString("locale")).isEqualTo("en-US")
+        val custom = json.getJSONObject("custom")
+        assertThat(custom.getString("plan")).isEqualTo("annual")
+        assertThat(custom.getInt("count")).isEqualTo(3)
+        assertThat(custom.getBoolean("flag")).isTrue()
+        assertThat(custom.get("list")).isInstanceOf(JSONArray::class.java)
+        assertThat(custom.isNull("nothing")).isTrue()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
@@ -1,0 +1,109 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.content.Context
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class PaywallWebViewClientTest {
+
+    private lateinit var webView: TrackingWebView
+    private val expectedOrigin = "https://assets.example.com"
+    private val navigations = mutableListOf<String?>()
+    private var failureCount = 0
+
+    private lateinit var client: PaywallWebViewClient
+
+    private class TrackingWebView(context: Context) : WebView(context) {
+        var stopLoadingCount: Int = 0
+            private set
+
+        override fun stopLoading() {
+            stopLoadingCount += 1
+            super.stopLoading()
+        }
+    }
+
+    @Before
+    fun setUp() {
+        webView = TrackingWebView(ApplicationProvider.getApplicationContext())
+        navigations.clear()
+        failureCount = 0
+        client = PaywallWebViewClient(
+            expectedOrigin = expectedOrigin,
+            onMainFrameNavigationStarted = { navigations.add(it) },
+            onMainFrameLoadFailed = { failureCount += 1 },
+        )
+    }
+
+    @Test
+    fun `onPageStarted notifies main-frame document start`() {
+        client.onPageStarted(webView, "https://assets.example.com/promo/index.html", null)
+
+        assertThat(navigations).containsExactly("https://assets.example.com/promo/index.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `onPageStarted does not stop same-origin https loads`() {
+        client.onPageStarted(webView, "https://assets.example.com/promo/step-two.html", null)
+
+        assertThat(navigations).containsExactly("https://assets.example.com/promo/step-two.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `onPageStarted stops blocked cross-origin loads that bypass shouldOverrideUrlLoading`() {
+        // POST navigations skip shouldOverrideUrlLoading; onPageStarted is the backstop.
+        client.onPageStarted(webView, "https://evil.example.org/phish.html", null)
+
+        assertThat(navigations).containsExactly("https://evil.example.org/phish.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `onPageStarted stops blocked non-https loads`() {
+        client.onPageStarted(webView, "http://assets.example.com/promo/insecure.html", null)
+
+        assertThat(navigations).containsExactly("http://assets.example.com/promo/insecure.html")
+        assertThat(webView.stopLoadingCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `onRenderProcessGone returns true and activates failure once`() {
+        val detail = mockk<RenderProcessGoneDetail>(relaxed = true)
+
+        val first = client.onRenderProcessGone(webView, detail)
+        val second = client.onRenderProcessGone(webView, detail)
+
+        assertThat(first).isTrue()
+        assertThat(second).isTrue()
+        assertThat(failureCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `main-frame URL and HTTP errors share the terminal failure path`() {
+        val request = mockk<WebResourceRequest>()
+        every { request.isForMainFrame } returns true
+        val error = mockk<WebResourceError>(relaxed = true)
+        val response = mockk<WebResourceResponse>()
+        every { response.statusCode } returns 500
+
+        client.onReceivedError(webView, request, error)
+        client.onReceivedHttpError(webView, request, response)
+        client.onRenderProcessGone(webView, mockk(relaxed = true))
+
+        assertThat(failureCount).isEqualTo(1)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProviderTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewVariablesProviderTest.kt
@@ -1,0 +1,34 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class PaywallWebViewVariablesProviderTest {
+
+    @Test
+    fun `sdkManagedVariables exposes only the locale system variable`() {
+        val variables = PaywallWebViewVariablesProvider.sdkManagedVariables(locale = "en-US")
+
+        // Only the locale system variable is exposed; nothing else is passed across the bridge in v1.
+        assertThat(variables).hasSize(1)
+        assertThat(variables[PaywallWebViewVariablesProvider.KEY_LOCALE])
+            .isEqualTo(PaywallWebViewValue.String("en-US"))
+    }
+
+    @Test
+    fun `sanitizeAppProvidedVariables drops reserved keys`() {
+        val sanitized = PaywallWebViewVariablesProvider.sanitizeAppProvidedVariables(
+            mapOf(
+                "locale" to PaywallWebViewValue.String("zz-ZZ"),
+                "app_segment" to PaywallWebViewValue.String("high_intent"),
+            ),
+        )
+
+        assertThat(sanitized).doesNotContainKey("locale")
+        assertThat(sanitized).containsKey("app_segment")
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelopeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelopeTest.kt
@@ -1,0 +1,295 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class WebViewEnvelopeTest {
+
+    private val componentId = "promo_web_view"
+
+    @Test
+    fun `parses a valid message envelope`() {
+        val parsed = WebViewEnvelope.parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_LOADED,
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.kind).isEqualTo(WebViewEnvelope.KIND_MESSAGE)
+        assertThat(parsed.protocolVersion).isEqualTo(1)
+        assertThat(parsed.componentId).isEqualTo(componentId)
+        assertThat(parsed.type).isEqualTo(WebViewMessageType.STEP_LOADED)
+        assertThat(parsed.id).isNull()
+        assertThat(parsed.payload).isNull()
+        assertThat(parsed.error).isNull()
+    }
+
+    @Test
+    fun `parses optional envelope fields`() {
+        val parsed = WebViewEnvelope.parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_REQUEST,
+                type = WebViewMessageType.REQUEST_VARIABLES,
+                id = "req-1",
+                payload = """{"responses":{"selected_plan":"annual"}}""",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.id).isEqualTo("req-1")
+        assertThat(parsed.payload).isNotNull
+        assertThat(parsed.payload!!.getJSONObject("responses").getString("selected_plan"))
+            .isEqualTo("annual")
+    }
+
+    @Test
+    fun `parses handshake connect frames`() {
+        val parsed = WebViewEnvelope.parse(
+            """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"connect","component_id":""}
+            """.trimIndent(),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.kind).isEqualTo(WebViewEnvelope.KIND_CONNECT)
+        assertThat(parsed.componentId).isEmpty()
+    }
+
+    @Test
+    fun `rejects wrong channel`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"other","protocol_version":1,"kind":"message","component_id":"promo_web_view","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects missing protocol_version`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","kind":"message","component_id":"promo_web_view","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects non-finite protocol_version`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":NaN,"kind":"message","component_id":"promo_web_view","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message without component_id`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"message","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with non-string type`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"message","component_id":"promo_web_view","type":123}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with non-string id`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"request","component_id":"promo_web_view","type":"rc:request-variables","id":1}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with non-string error`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"error","component_id":"promo_web_view","error":false}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with non-object payload`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"message","component_id":"promo_web_view","type":"rc:step-complete","payload":"nope"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects unknown kind outside whitelist`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"ping","component_id":"promo_web_view"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `accepts every whitelisted kind`() {
+        val kinds = listOf(
+            WebViewEnvelope.KIND_CONNECT,
+            WebViewEnvelope.KIND_INIT,
+            WebViewEnvelope.KIND_REJECT,
+            WebViewEnvelope.KIND_MESSAGE,
+            WebViewEnvelope.KIND_REQUEST,
+            WebViewEnvelope.KIND_RESPONSE,
+            WebViewEnvelope.KIND_ERROR,
+        )
+
+        kinds.forEach { kind ->
+            val parsed = WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId"}
+                """.trimIndent(),
+            )
+            assertThat(parsed).describedAs("kind=$kind").isNotNull
+            assertThat(parsed!!.kind).isEqualTo(kind)
+        }
+    }
+
+    @Test
+    fun `rejects malformed json`() {
+        assertThat(WebViewEnvelope.parse("""not json""")).isNull()
+    }
+
+    @Test
+    fun `rejects non-object json`() {
+        assertThat(WebViewEnvelope.parse("""["a","b"]""")).isNull()
+    }
+
+    @Test
+    fun `rejects oversized payload`() {
+        val hugeValue = "x".repeat(WebViewEnvelope.MAX_PAYLOAD_BYTES + 1)
+        val raw = envelope(
+            kind = WebViewEnvelope.KIND_MESSAGE,
+            type = WebViewMessageType.ERROR,
+            payload = """{"error":"$hugeValue"}""",
+        )
+        assertThat(raw.toByteArray(Charsets.UTF_8).size).isGreaterThan(WebViewEnvelope.MAX_PAYLOAD_BYTES)
+        assertThat(WebViewEnvelope.parse(raw)).isNull()
+    }
+
+    @Test
+    fun `accepts frame depth at MAX_NESTING_DEPTH plus one before recursive parsing`() {
+        // Envelope object (+1) plus a payload tree of MAX_NESTING_DEPTH → MAX_FRAME_DEPTH.
+        val depth = WebViewEnvelope.MAX_NESTING_DEPTH + 1
+
+        assertThat(WebViewEnvelope.exceedsMaxDepth(nestedArray(depth))).isFalse()
+    }
+
+    @Test
+    fun `rejects frame depth beyond MAX_NESTING_DEPTH plus one before recursive parsing`() {
+        val depth = WebViewEnvelope.MAX_NESTING_DEPTH + 2
+
+        assertThat(WebViewEnvelope.exceedsMaxDepth(nestedArray(depth))).isTrue()
+    }
+
+    @Test
+    fun `rejects a hostile deeply nested frame before recursive parsing`() {
+        // ~30k nesting levels fit inside the 64 KiB frame limit; the pre-parse structural scan
+        // must reject this before org.json's recursive tokenizer ever runs (stack-overflow guard).
+        val depth = 30_000
+        val nested = "[".repeat(depth) + "]".repeat(depth)
+
+        val parsed = WebViewEnvelope.parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"deep":$nested}}""",
+            ),
+        )
+
+        assertThat(parsed).isNull()
+    }
+
+    @Test
+    fun `build emits required and optional fields`() {
+        val payload = JSONObject("""{"responses":{"ok":true}}""")
+        val json = WebViewEnvelope.build(
+            kind = WebViewEnvelope.KIND_RESPONSE,
+            protocolVersion = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
+            componentId = componentId,
+            type = WebViewMessageType.VARIABLES,
+            id = "req-1",
+            payload = payload,
+            error = "boom",
+        )
+
+        assertThat(json.getString(WebViewMessageField.CHANNEL)).isEqualTo(WebViewEnvelope.CHANNEL)
+        assertThat(json.getInt(WebViewMessageField.PROTOCOL_VERSION))
+            .isEqualTo(WebViewEnvelope.DEFAULT_PROTOCOL_VERSION)
+        assertThat(json.getString(WebViewMessageField.KIND)).isEqualTo(WebViewEnvelope.KIND_RESPONSE)
+        assertThat(json.getString(WebViewMessageField.COMPONENT_ID)).isEqualTo(componentId)
+        assertThat(json.getString(WebViewMessageField.TYPE)).isEqualTo(WebViewMessageType.VARIABLES)
+        assertThat(json.getString(WebViewMessageField.ID)).isEqualTo("req-1")
+        assertThat(json.getJSONObject(WebViewMessageField.PAYLOAD).toString())
+            .isEqualTo(payload.toString())
+        assertThat(json.getString(WebViewMessageField.ERROR)).isEqualTo("boom")
+    }
+
+    @Test
+    fun `build omits null optional fields`() {
+        val json = WebViewEnvelope.build(
+            kind = WebViewEnvelope.KIND_INIT,
+            protocolVersion = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
+            componentId = componentId,
+        )
+
+        assertThat(json.has(WebViewMessageField.TYPE)).isFalse()
+        assertThat(json.has(WebViewMessageField.ID)).isFalse()
+        assertThat(json.has(WebViewMessageField.PAYLOAD)).isFalse()
+        assertThat(json.has(WebViewMessageField.ERROR)).isFalse()
+    }
+
+    private fun nestedArray(depth: Int): String = "[".repeat(depth) + "0" + "]".repeat(depth)
+
+    private fun envelope(
+        kind: String,
+        type: String,
+        componentId: String = this.componentId,
+        payload: String? = null,
+        id: String? = null,
+    ): String {
+        val payloadField = payload?.let { ""","payload":$it""" } ?: ""
+        val idField = id?.let { ""","id":"$it"""" } ?: ""
+        return """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId","type":"$type"$payloadField$idField}
+            """.trimIndent()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -1,0 +1,831 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.os.Looper
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewController
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessage
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowWebView
+
+@RunWith(RobolectricTestRunner::class)
+internal class WebViewJavaScriptBridgeTest {
+
+    private val componentId = "promo_web_view"
+    private val expectedUrl = "https://assets.example.com/promo/index.html"
+
+    private lateinit var webView: WebView
+    private lateinit var shadowWebView: ShadowWebView
+    private val received = mutableListOf<PaywallWebViewMessage>()
+    private val installedListeners = mutableListOf<Boolean>()
+
+    @Before
+    fun setUp() {
+        webView = WebView(ApplicationProvider.getApplicationContext())
+        shadowWebView = shadowOf(webView)
+        received.clear()
+        installedListeners.clear()
+    }
+
+    private fun bridge(
+        handler: PaywallWebViewMessageHandler? = PaywallWebViewMessageHandler { message, _ -> received.add(message) },
+        locale: String = "en-US",
+        navigateTo: String? = expectedUrl,
+        sizeToContentWidth: Boolean = false,
+        sizeToContentHeight: Boolean = false,
+        onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
+        onDocumentReset: () -> Unit = {},
+        onSecureMessagingUnsupported: () -> Unit = {},
+        webMessageListenerSupported: Boolean = true,
+        trackInstallState: Boolean = false,
+    ): WebViewJavaScriptBridge {
+        val bridge = WebViewJavaScriptBridge(
+            webView = webView,
+            componentId = componentId,
+            expectedUrl = expectedUrl,
+            locale = locale,
+            messageHandler = handler,
+            sizeToContentWidth = sizeToContentWidth,
+            sizeToContentHeight = sizeToContentHeight,
+            onContentResize = onContentResize,
+            onDocumentReset = onDocumentReset,
+            onSecureMessagingUnsupported = onSecureMessagingUnsupported,
+            isWebMessageListenerSupported = { webMessageListenerSupported },
+            installWebMessageListener = { _, _, _, _ ->
+                if (trackInstallState) installedListeners.add(true)
+            },
+            uninstallWebMessageListener = { _, _ ->
+                if (trackInstallState) installedListeners.add(false)
+            },
+        )
+        bridge.attach()
+        navigateTo?.let { webView.loadUrl(it) }
+        return bridge
+    }
+
+    private fun idleMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun connect(bridge: WebViewJavaScriptBridge) {
+        bridge.postMessage(
+            """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"connect","component_id":""}
+            """.trimIndent(),
+        )
+        idleMainLooper()
+    }
+
+    private fun appMessage(
+        type: String,
+        payload: String? = null,
+        kind: String = WebViewEnvelope.KIND_MESSAGE,
+        id: String? = null,
+    ): String {
+        val payloadField = payload?.let { ""","payload":$it""" } ?: ""
+        val idField = id?.let { ""","id":"$it"""" } ?: ""
+        return """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId","type":"$type"$payloadField$idField}
+            """.trimIndent()
+    }
+
+    @Test
+    fun `completes connect handshake with init`() {
+        val bridge = bridge()
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("window.__rcWebComponentsReceive(")
+        assertThat(script).contains("\"kind\":\"init\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+    }
+
+    @Test
+    fun `completes connect handshake before the web view URL is available`() {
+        val bridge = bridge(navigateTo = null)
+        assertThat(webView.url).isNull()
+
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"kind\":\"init\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+    }
+
+    @Test
+    fun `rejects unsupported protocol version`() {
+        val bridge = bridge()
+        bridge.postMessage(
+            """
+            {"channel":"rc-web-components","protocol_version":2,"kind":"connect","component_id":""}
+            """.trimIndent(),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"kind\":\"reject\"")
+        assertThat(script).contains("Unsupported protocol_version 2")
+    }
+
+    @Test
+    fun `delivers valid message after handshake`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+        assertThat(received.single().componentId).isEqualTo("promo_web_view")
+        assertThat(received.single().type).isEqualTo("rc:step-loaded")
+    }
+
+    @Test
+    fun `ignores app messages before handshake`() {
+        bridge().postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `rejects messages for a different component id`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.STEP_LOADED,
+            ).replace(componentId, "other_web_view"),
+        )
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `request-variables auto-sends rc variables with locale only`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
+        idleMainLooper()
+
+        assertThat(received.single().type).isEqualTo("rc:request-variables")
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("window.__rcWebComponentsReceive(")
+        assertThat(script).contains("\"kind\":\"message\"")
+        assertThat(script).contains("\"rc:variables\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+        assertThat(script).contains("\"locale\":\"en-US\"")
+        assertThat(script).doesNotContain("\"custom\"")
+    }
+
+    @Test
+    fun `request-variables transport request also sends response`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.REQUEST_VARIABLES,
+                kind = WebViewEnvelope.KIND_REQUEST,
+                id = "req-1",
+            ),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"kind\":\"response\"")
+        assertThat(script).contains("\"id\":\"req-1\"")
+        assertThat(script).contains("\"locale\":\"en-US\"")
+        assertThat(script).doesNotContain("\"rc:variables\"")
+    }
+
+    @Test
+    fun `app can reply with extra variables through the controller`() {
+        val handler = PaywallWebViewMessageHandler { message, controller ->
+            received.add(message)
+            if (message.type == WebViewMessageType.REQUEST_VARIABLES) {
+                controller.postVariables(
+                    componentId = message.componentId,
+                    variables = mapOf(
+                        "custom" to PaywallWebViewValue.Object(
+                            mapOf("app_segment" to PaywallWebViewValue.String("high_intent")),
+                        ),
+                    ),
+                )
+            }
+        }
+        val bridge = bridge(handler = handler)
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"rc:variables\"")
+        assertThat(script).contains("\"app_segment\":\"high_intent\"")
+    }
+
+    @Test
+    fun `controller postVariables drops reserved keys`() {
+        val controllerHolder = arrayOfNulls<PaywallWebViewController>(1)
+        val handler = PaywallWebViewMessageHandler { _, controller -> controllerHolder[0] = controller }
+        val bridge = bridge(handler = handler)
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        controllerHolder[0]!!.postVariables(
+            componentId = componentId,
+            variables = mapOf(
+                "locale" to PaywallWebViewValue.String("zz-ZZ"),
+                "custom" to PaywallWebViewValue.Object(mapOf("k" to PaywallWebViewValue.String("v"))),
+            ),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).doesNotContain("zz-ZZ")
+        assertThat(script).contains("\"k\":\"v\"")
+    }
+
+    @Test
+    fun `does not deliver messages after release`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.release()
+
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `does not execute queued outbound evaluateJavascript after release`() {
+        val bridge = bridge()
+        connect(bridge)
+        val background = Thread {
+            bridge.postMessage(
+                componentId = componentId,
+                type = "rc:queued",
+                variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+            )
+        }
+        background.start()
+        background.join()
+        bridge.release()
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).doesNotContain("rc:queued")
+    }
+
+    @Test
+    fun `re-validates source origin at main-thread delivery`() {
+        val bridge = bridge()
+        connect(bridge)
+        val background = Thread {
+            bridge.postMessage(
+                json = appMessage(WebViewMessageType.STEP_LOADED),
+                sourceOrigin = android.net.Uri.parse("https://evil.example.org"),
+                isMainFrame = true,
+            )
+        }
+        background.start()
+        background.join()
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `treats host comparison as case insensitive`() {
+        val bridge = bridge(navigateTo = "https://Assets.Example.COM/promo/index.html")
+        connect(bridge)
+        bridge.postMessage(
+            json = appMessage(WebViewMessageType.STEP_LOADED),
+            sourceOrigin = android.net.Uri.parse("https://Assets.Example.COM"),
+            isMainFrame = true,
+        )
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+    }
+
+    @Test
+    fun `rejects messages from an unexpected source origin`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            json = appMessage(WebViewMessageType.STEP_LOADED),
+            sourceOrigin = android.net.Uri.parse("https://evil.example.org"),
+            isMainFrame = true,
+        )
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `rejects messages that are not from the main frame`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            json = appMessage(WebViewMessageType.STEP_LOADED),
+            sourceOrigin = android.net.Uri.parse("https://assets.example.com"),
+            isMainFrame = false,
+        )
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `allows messages from the same origin on a different path`() {
+        val bridge = bridge(navigateTo = "https://assets.example.com/promo/step-two.html")
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+    }
+
+    @Test
+    fun `does not deliver outbound messages after navigation to an unexpected origin`() {
+        val bridge = bridge(navigateTo = "https://evil.example.org/phish.html")
+        connect(bridge)
+        bridge.postMessage(
+            componentId = componentId,
+            type = "rc:custom",
+            variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+        )
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).isNull()
+    }
+
+    @Test
+    fun `treats the default https port as the same origin`() {
+        val bridge = bridge(navigateTo = "https://assets.example.com:443/promo/index.html")
+        connect(bridge)
+        bridge.postMessage(
+            componentId = componentId,
+            type = "rc:custom",
+            variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+        )
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"type\":\"rc:custom\"")
+    }
+
+    @Test
+    fun `delivers rc step-complete responses to the handler without sending an outbound message`() {
+        val bridge = bridge()
+        connect(bridge)
+        val scriptAfterConnect = shadowWebView.lastEvaluatedJavascript
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"selected_plan":"annual","accepted_terms":true}}""",
+            ),
+        )
+        idleMainLooper()
+
+        val message = received.single()
+        assertThat(message.type).isEqualTo("rc:step-complete")
+        assertThat(message.responses?.get("selected_plan")).isEqualTo(PaywallWebViewValue.String("annual"))
+        assertThat(message.responses?.get("accepted_terms")).isEqualTo(PaywallWebViewValue.Boolean(true))
+        assertThat(shadowWebView.lastEvaluatedJavascript).isEqualTo(scriptAfterConnect)
+    }
+
+    @Test
+    fun `delivers rc error to the handler`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.ERROR,
+                payload = """{"error":"Something went wrong"}""",
+            ),
+        )
+        idleMainLooper()
+
+        val message = received.single()
+        assertThat(message.type).isEqualTo("rc:error")
+        assertThat(message.error).isEqualTo("Something went wrong")
+    }
+
+    @Test
+    fun `does not deliver malformed messages to the handler`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage("""not even json""")
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `auto-sends rc variables even when no handler is set`() {
+        val bridge = bridge(handler = null)
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"rc:variables\"")
+        assertThat(script).contains("\"locale\":\"en-US\"")
+    }
+
+    @Test
+    fun `update refreshes the variables sent on a subsequent request`() {
+        val bridge = bridge(locale = "en-US")
+        connect(bridge)
+        bridge.update(
+            locale = "fr-FR",
+            messageHandler = null,
+        )
+
+        bridge.postMessage(appMessage(WebViewMessageType.REQUEST_VARIABLES))
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"locale\":\"fr-FR\"")
+        assertThat(script).doesNotContain("en-US")
+    }
+
+    @Test
+    fun `generic postMessage sends transport envelope with payload`() {
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postMessage(
+            componentId = componentId,
+            type = "rc:custom",
+            variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("window.__rcWebComponentsReceive(")
+        assertThat(script).contains("\"kind\":\"message\"")
+        assertThat(script).contains("\"type\":\"rc:custom\"")
+        assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+        assertThat(script).contains("\"payload\":{\"foo\":\"bar\"}")
+    }
+
+    @Test
+    fun `escapes line and paragraph separators in outbound payloads`() {
+        val raw = "a\u2028b\u2029c"
+        val bridge = bridge()
+        connect(bridge)
+        bridge.postVariables(
+            componentId = componentId,
+            variables = mapOf(
+                "custom" to PaywallWebViewValue.Object(mapOf("note" to PaywallWebViewValue.String(raw))),
+            ),
+        )
+        idleMainLooper()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).doesNotContain("\u2028")
+        assertThat(script).doesNotContain("\u2029")
+        assertThat(script).contains("\\u2028")
+        assertThat(script).contains("\\u2029")
+    }
+
+    @Test
+    fun `attach installs the web message listener when supported`() {
+        bridge(trackInstallState = true)
+
+        assertThat(installedListeners).containsExactly(true)
+    }
+
+    @Test
+    fun `attach reports unsupported secure messaging when the feature is missing`() {
+        var unsupported = false
+        bridge(
+            webMessageListenerSupported = false,
+            onSecureMessagingUnsupported = { unsupported = true },
+            trackInstallState = true,
+        )
+
+        assertThat(unsupported).isTrue()
+        assertThat(installedListeners).isEmpty()
+    }
+
+    @Test
+    fun `release removes the web message listener`() {
+        val bridge = bridge(trackInstallState = true)
+        assertThat(installedListeners).containsExactly(true)
+
+        bridge.release()
+
+        assertThat(installedListeners).containsExactly(true, false)
+    }
+
+    @Test
+    fun `sends fit message after init when height is fit`() {
+        val bridge = bridge(sizeToContentHeight = true)
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"type\":\"fit\"")
+        assertThat(script).contains("\"height\":true")
+        assertThat(script).doesNotContain("\"width\":true")
+    }
+
+    @Test
+    fun `reports content resize from inbound resize message`() {
+        var reportedWidth: Int? = null
+        var reportedHeight: Int? = null
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = true,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx ->
+                reportedWidth = widthCssPx
+                reportedHeight = heightCssPx
+            },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.RESIZE,
+                payload = """{"width":320,"height":480}""",
+            ),
+        )
+        idleMainLooper()
+
+        assertThat(reportedWidth).isEqualTo(320)
+        assertThat(reportedHeight).isEqualTo(480)
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `resize ignores non-fit axes`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = false,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":400,"height":500}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(null to 500)
+    }
+
+    @Test
+    fun `resize clamps oversized values and drops invalid values per axis`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = true,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        connect(bridge)
+        // Invalid width (negative) with a valid, oversized height: height still applies, clamped.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":-1,"height":99999}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(null to 10_000)
+    }
+
+    @Test
+    fun `resize applies a per-axis change threshold`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentWidth = true,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":200,"height":300}"""),
+        )
+        // Same values re-reported: below the 1px threshold on both axes, no callback at all.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":200,"height":300}"""),
+        )
+        // One axis changes: only that axis is delivered.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"width":200,"height":301}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(200 to 300, null to 301)
+    }
+
+    @Test
+    fun `handles resize sent as a transport request without forwarding to the app handler`() {
+        var reportedHeight: Int? = null
+        val bridge = bridge(
+            sizeToContentHeight = true,
+            onContentResize = { _, heightCssPx -> reportedHeight = heightCssPx },
+        )
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(
+                type = WebViewMessageType.RESIZE,
+                payload = """{"height":250}""",
+                kind = WebViewEnvelope.KIND_REQUEST,
+                id = "resize-1",
+            ),
+        )
+        idleMainLooper()
+
+        assertThat(reportedHeight).isEqualTo(250)
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `drops any transport request without an id`() {
+        val bridge = bridge()
+        connect(bridge)
+
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.STEP_LOADED, kind = WebViewEnvelope.KIND_REQUEST),
+        )
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.REQUEST_VARIABLES, kind = WebViewEnvelope.KIND_REQUEST),
+        )
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+        // No auto-reply was sent for the id-less variables request.
+        assertThat(shadowWebView.lastEvaluatedJavascript).doesNotContain("rc:variables")
+    }
+
+    @Test
+    fun `rejects hostile deeply nested frames without crashing`() {
+        val bridge = bridge()
+        connect(bridge)
+
+        val depth = 30_000
+        val nested = "[".repeat(depth) + "]".repeat(depth)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.STEP_COMPLETE, payload = """{"responses":{"deep":$nested}}"""),
+        )
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `initial document connect produces one init`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+    }
+
+    @Test
+    fun `duplicate connect in the same document is ignored`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        val afterFirst = shadowWebView.lastEvaluatedJavascript
+        connect(bridge)
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).isEqualTo(afterFirst)
+    }
+
+    @Test
+    fun `after navigation starts app frames are rejected until reconnect`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `new document connect produces a second init`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+        webView.loadUrl("https://assets.example.com/promo/step-two.html")
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+        assertThat(received).isEmpty()
+
+        connect(bridge)
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+        assertThat(received).hasSize(1)
+    }
+
+    @Test
+    fun `rc fit is resent after reconnect when height is fit`() {
+        val bridge = bridge(sizeToContentHeight = true)
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"type\":\"fit\"")
+
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+        webView.loadUrl("https://assets.example.com/promo/step-two.html")
+        connect(bridge)
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"type\":\"fit\"")
+        assertThat(script).contains("\"height\":true")
+    }
+
+    @Test
+    fun `resize threshold state is reset between documents`() {
+        val resizes = mutableListOf<Pair<Int?, Int?>>()
+        val bridge = bridge(
+            handler = null,
+            sizeToContentHeight = true,
+            onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
+        )
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"height":300}"""),
+        )
+        idleMainLooper()
+        assertThat(resizes).containsExactly(null to 300)
+
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+        webView.loadUrl("https://assets.example.com/promo/step-two.html")
+        connect(bridge)
+        // Same height as before the document reset — must apply again because threshold state cleared.
+        bridge.postMessage(
+            appMessage(type = WebViewMessageType.RESIZE, payload = """{"height":300}"""),
+        )
+        idleMainLooper()
+
+        assertThat(resizes).containsExactly(null to 300, null to 300)
+    }
+
+    @Test
+    fun `document reset clears compose content dimensions`() {
+        var resets = 0
+        val bridge = bridge(onDocumentReset = { resets += 1 })
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/reload.html")
+
+        assertThat(resets).isEqualTo(2)
+    }
+
+    @Test
+    fun `queued outbound message from the old document is not delivered after navigation`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        val background = Thread {
+            bridge.postMessage(
+                componentId = componentId,
+                type = "rc:queued",
+                variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
+            )
+        }
+        background.start()
+        background.join()
+        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+        idleMainLooper()
+
+        assertThat(shadowWebView.lastEvaluatedJavascript).doesNotContain("rc:queued")
+    }
+
+    @Test
+    fun `reload follows the same reconnect behavior`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted(expectedUrl)
+        connect(bridge)
+        bridge.onMainFrameNavigationStarted(expectedUrl) // reload
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+        assertThat(received).isEmpty()
+
+        connect(bridge)
+        bridge.postMessage(appMessage(WebViewMessageType.STEP_LOADED))
+        idleMainLooper()
+
+        assertThat(received).hasSize(1)
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -792,23 +792,42 @@ internal class WebViewJavaScriptBridgeTest {
     }
 
     @Test
-    fun `queued outbound message from the old document is not delivered after navigation`() {
+    fun `inbound message queued before document reset is dropped`() {
+        val bridge = bridge()
+        val background = Thread {
+            bridge.postMessage(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"connect","component_id":""}
+                """.trimIndent(),
+            )
+        }
+        background.start()
+        background.join()
+        bridge.onMainFrameNavigationStarted(null)
+        idleMainLooper()
+
+        // Stale connect was cancelled with the old document scope — channel stays closed.
+        assertThat(shadowWebView.lastEvaluatedJavascript).isNull()
+    }
+
+    @Test
+    fun `outbound message queued before document reset is dropped`() {
         val bridge = bridge()
         bridge.onMainFrameNavigationStarted(expectedUrl)
         connect(bridge)
         val background = Thread {
             bridge.postMessage(
                 componentId = componentId,
-                type = "rc:queued",
+                type = "rc:x",
                 variables = mapOf("foo" to PaywallWebViewValue.String("bar")),
             )
         }
         background.start()
         background.join()
-        bridge.onMainFrameNavigationStarted("https://assets.example.com/promo/step-two.html")
+        bridge.onMainFrameNavigationStarted(null)
         idleMainLooper()
 
-        assertThat(shadowWebView.lastEvaluatedJavascript).doesNotContain("rc:queued")
+        assertThat(shadowWebView.lastEvaluatedJavascript).doesNotContain("rc:x")
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParserTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageParserTest.kt
@@ -1,0 +1,235 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class WebViewMessageParserTest {
+
+    private val componentId = "promo_web_view"
+
+    @Test
+    fun `parses rc step-loaded`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_LOADED,
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        val message = parsed!!.message
+        assertThat(message.type).isEqualTo("rc:step-loaded")
+        assertThat(message.componentId).isEqualTo("promo_web_view")
+        assertThat(message.responses).isNull()
+        assertThat(message.error).isNull()
+    }
+
+    @Test
+    fun `parses rc step-complete with responses in payload`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"selected_plan":"annual","accepted_terms":true,"count":3}}""",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        val responses = parsed!!.message.responses
+        assertThat(responses).isNotNull
+        assertThat(responses!!["selected_plan"]).isEqualTo(PaywallWebViewValue.String("annual"))
+        assertThat(responses["accepted_terms"]).isEqualTo(PaywallWebViewValue.Boolean(true))
+        assertThat(responses["count"]).isEqualTo(PaywallWebViewValue.Number(3))
+    }
+
+    @Test
+    fun `parses rc step-complete without responses as empty map`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.responses).isEmpty()
+    }
+
+    @Test
+    fun `parses rc request-variables as message`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.REQUEST_VARIABLES,
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.type).isEqualTo("rc:request-variables")
+        assertThat(parsed.requestId).isNull()
+    }
+
+    @Test
+    fun `parses rc request-variables as transport request`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_REQUEST,
+                type = WebViewMessageType.REQUEST_VARIABLES,
+                id = "req-1",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.type).isEqualTo("rc:request-variables")
+        assertThat(parsed.requestId).isEqualTo("req-1")
+    }
+
+    @Test
+    fun `parses rc error from payload`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.ERROR,
+                payload = """{"error":"Boom"}""",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.message.error).isEqualTo("Boom")
+    }
+
+    @Test
+    fun `rejects message without type`() {
+        assertThat(
+            parse(
+                """{"channel":"rc-web-components","protocol_version":1,"kind":"message","component_id":"promo_web_view"}""",
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects message with wrong component_id`() {
+        assertThat(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_LOADED,
+                componentId = "other_web_view",
+            ).let(::parse),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects rc step-complete with non-object responses`() {
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = WebViewMessageType.STEP_COMPLETE,
+                    payload = """{"responses":"nope"}""",
+                ),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects rc step-complete payload with transport fields and no responses object`() {
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = WebViewMessageType.STEP_COMPLETE,
+                    payload = """{"type":"rc:step-complete","selected_plan":"annual"}""",
+                ),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects rc error without error string`() {
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = WebViewMessageType.ERROR,
+                ),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `drops unknown message types`() {
+        assertThat(
+            parse(
+                envelope(
+                    kind = WebViewEnvelope.KIND_MESSAGE,
+                    type = "rc:something-new",
+                ),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects excessively nested responses`() {
+        val depth = WebViewEnvelope.MAX_NESTING_DEPTH + 2
+        val opening = "{\"a\":".repeat(depth)
+        val closing = "}".repeat(depth)
+        val nested = opening + "1" + closing
+        val raw = envelope(
+            kind = WebViewEnvelope.KIND_MESSAGE,
+            type = WebViewMessageType.STEP_COMPLETE,
+            payload = """{"responses":$nested}""",
+        )
+        assertThat(parse(raw)).isNull()
+    }
+
+    @Test
+    fun `accepts null and nested json-compatible values in responses`() {
+        val parsed = parse(
+            envelope(
+                kind = WebViewEnvelope.KIND_MESSAGE,
+                type = WebViewMessageType.STEP_COMPLETE,
+                payload = """{"responses":{"maybe":null,"list":[1,"two",false],"obj":{"k":"v"}}}""",
+            ),
+        )
+
+        assertThat(parsed).isNotNull
+        val responses = parsed!!.message.responses!!
+        assertThat(responses["maybe"]).isEqualTo(PaywallWebViewValue.Null)
+        assertThat(responses["list"]).isInstanceOf(PaywallWebViewValue.Array::class.java)
+        assertThat(responses["obj"]).isInstanceOf(PaywallWebViewValue.Object::class.java)
+    }
+
+    @Test
+    fun `ignores handshake frames`() {
+        assertThat(
+            parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1,"kind":"connect","component_id":""}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    private fun parse(raw: String): WebViewMessageParser.ParsedAppMessage? {
+        val envelope = WebViewEnvelope.parse(raw) ?: return null
+        return WebViewMessageParser.parse(envelope, expectedComponentId = componentId)
+    }
+
+    private fun envelope(
+        kind: String,
+        type: String,
+        componentId: String = this.componentId,
+        payload: String? = null,
+        id: String? = null,
+    ): String {
+        val payloadField = payload?.let { ""","payload":$it""" } ?: ""
+        val idField = id?.let { ""","id":"$it"""" } ?: ""
+        return """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId","type":"$type"$payloadField$idField}
+            """.trimIndent()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewNavigationPolicyTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewNavigationPolicyTest.kt
@@ -1,0 +1,70 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+// Robolectric is required because the navigation-policy helper parses origins via android.net.Uri.
+@RunWith(RobolectricTestRunner::class)
+class WebViewNavigationPolicyTest {
+
+    @Test
+    fun `allows same-origin main-frame navigation on a different path`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://assets.example.com/promo/step-two.html",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `blocks cross-origin main-frame navigation even over https`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://evil.example.org/phish.html",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `blocks non-https navigation in any frame`() {
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "http://assets.example.com/promo/index.html",
+                isMainFrame = false,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "custom://assets.example.com/",
+                isMainFrame = true,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `allows cross-origin https sub-frame loads`() {
+        // Sub-frame isolation is expected from the server-provided CSP, not this navigation policy.
+        assertThat(
+            shouldBlockWebViewNavigation(
+                url = "https://other.example.com/frame.html",
+                isMainFrame = false,
+                expectedOrigin = "https://assets.example.com",
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `blocks unparseable main-frame navigation targets`() {
+        assertThat(
+            shouldBlockWebViewNavigation(url = null, isMainFrame = true, expectedOrigin = "https://a.example"),
+        ).isTrue()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewUrlResolverTest.kt
@@ -1,0 +1,66 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WebViewUrlResolverTest {
+
+    @Test
+    fun `resolves static https url unchanged`() {
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isEqualTo("https://paywalls.revenuecat.com/index.html")
+    }
+
+    @Test
+    fun `resolves static https url with characters accepted by WebView`() {
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/index.html?filters=a|b")
+
+        assertThat(result).isEqualTo("https://paywalls.revenuecat.com/index.html?filters=a|b")
+    }
+
+    @Test
+    fun `returns null for url containing template placeholders`() {
+        val result = WebViewUrlResolver.resolve("https://paywalls.revenuecat.com/{{ custom.animal }}.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for malformed url`() {
+        val result = WebViewUrlResolver.resolve("not a url")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for malformed https url`() {
+        val result = WebViewUrlResolver.resolve("https:///missing-host")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for non https url`() {
+        val result = WebViewUrlResolver.resolve("http://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for file url`() {
+        val result = WebViewUrlResolver.resolve("file:///android_asset/index.html")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null for custom scheme url`() {
+        val result = WebViewUrlResolver.resolve("myapp://paywalls.revenuecat.com/index.html")
+
+        assertThat(result).isNull()
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Part **6 of 8** splitting #3757; **inert until Part 8**.

**Depends on Parts 1, 4, and 5** (#3780, #3782, #3783). This branch currently merges those heads so it compiles standalone; **rebase onto `main` after those three merge** (drop the merge commits). Do not merge this PR until its dependencies land.

### Description
JavaScript bridge for the `rc-web-components` channel between hosted web content and native:

- `WebViewJavaScriptBridge` (origin helpers live in Part 5’s `WebViewOrigins.kt`)
- `WebViewMessageParser` (app-message layer)
- `PaywallWebViewVariablesProvider`
- androidx.webkit dependency (`webkit = 1.12.1`)

**Cleanups vs consolidated #3757:**
1. Removed unused raw-string `parse(rawJson, …)` overload
2. Removed duplicate request-without-`id` check from the parser (kept in the bridge)
3. Parser depth/size constants reference `WebViewEnvelope`
4. Replaced hand-rolled `Handler` / `@Volatile` / `documentGeneration` threading with a per-document main-confined `CoroutineScope` (see Threading model)

**Danger:** exceeds the 300-production-line limit. This is one cohesive security-sensitive bridge + its tests; please apply `skip-pr-lines-changed-check` with that justification.

Verified: webview package unit tests (incl. two new queued-work-dropped tests), full `:ui:revenuecatui:testDefaultsDebugUnitTest`, `detektAll`, `api-check` (no-op).

**Labels:** `pr:feat`, `pr:RevenueCatUI`, `feat:Paywalls_V2`, `skip-pr-lines-changed-check`

### Threading model

Follow-up commit on this PR migrates `WebViewJavaScriptBridge` off `Handler`/`@Volatile`/`documentGeneration` onto a single main-confined, per-document `CoroutineScope` (`Dispatchers.Main.immediate`). Protocol logic is unchanged. Net line reduction on the bridge file; zero public API / Gradle / wire-protocol changes.

Behavior deltas vs the Handler implementation:

1. Inbound frames queued before a main-frame navigation are now DROPPED with the old document's scope instead of being processed after the reset. This closes an edge where a stale document's `connect` could re-open the channel post-reset. Strictly safer; covered by a new test.
2. Stale outbound work is now dropped via scope cancellation instead of the `documentGeneration` counter — same guarantee, structural mechanism.
3. Exception routing keeps crash parity (no CoroutineExceptionHandler).

### Series (splitting #3757)

PWENG-98

| Part | PR | Notes |
|------|-----|--------|
| 1/8 | #3780 | main |
| 2/8 | #3784 | base PR 1; retarget after merge |
| 3/8 | #3781 | independent |
| 4/8 | #3782 | independent |
| 5/8 | #3783 | independent |
| 6/8 | #3785 | after PRs 1+4+5 |
| 7/8 | #3786 | after PRs 2+3+6 |
| 8/8 | #3787 | activation |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

