### PR TITLE
feat(paywalls): web_view Compose component, unreachable until activation (7)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ComponentView.kt
@@ -30,12 +30,14 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.TabsComponentSt
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TimelineComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabControlButtonView
 import com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabControlToggleView
 import com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabsComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.text.TextComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.timeline.TimelineComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.video.VideoComponentView
+import com.revenuecat.purchases.ui.revenuecatui.components.webview.WebViewComponentView
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
 
@@ -73,6 +75,11 @@ internal fun ComponentView(
             modifier = modifier,
         )
     }
+    is WebViewComponentStyle -> WebViewComponentView(
+        style = style,
+        state = state,
+        modifier = modifier,
+    )
     is ButtonComponentStyle -> ButtonComponentView(
         style = style,
         state = state,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -12,14 +12,14 @@ internal data class WebViewComponentStyle(
     override val size: Size,
     /**
      * The canonical component id from the schema (`web_view.id`), assigned to the content during the
-     * bridge handshake. Required to render; configs that omit it render nothing.
+     * bridge handshake. A blank id renders nothing.
      */
-    val componentId: String? = null,
+    val componentId: String,
     /**
      * The schema-declared `protocol_version`, decoded and preserved for future use. NOT the host's
      * capability: the bridge always advertises [WebViewEnvelope.DEFAULT_PROTOCOL_VERSION][
      * com.revenuecat.purchases.ui.revenuecatui.components.webview.WebViewEnvelope.DEFAULT_PROTOCOL_VERSION]
      * (the single version this SDK build implements) during the handshake, regardless of this value.
      */
-    val protocolVersion: Int? = null,
+    val protocolVersion: Int,
 ) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -12,6 +12,4 @@ internal data class WebViewComponentStyle(
     override val size: Size,
     /** Schema `web_view.id`, sent to the content during the handshake. A blank id renders nothing. */
     val componentId: String,
-    /** Schema-declared `protocol_version`, preserved for future use; the bridge advertises its own. */
-    val protocolVersion: Int,
 ) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -1,0 +1,26 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.style
+
+import androidx.compose.runtime.Immutable
+import com.revenuecat.purchases.paywalls.components.properties.Size
+
+@Immutable
+internal data class WebViewComponentStyle(
+    val url: String,
+    override val visible: Boolean,
+    override val size: Size,
+    /**
+     * The canonical component id from the schema (`web_view.id`), used to scope bidirectional
+     * messages. May be null for legacy/partial configs that omit it, in which case the message bridge
+     * is not installed.
+     */
+    val componentId: String? = null,
+    /**
+     * The schema-declared `protocol_version`, decoded and preserved for future use. NOT the host's
+     * capability: the bridge always advertises [WebViewEnvelope.DEFAULT_PROTOCOL_VERSION][
+     * com.revenuecat.purchases.ui.revenuecatui.components.webview.WebViewEnvelope.DEFAULT_PROTOCOL_VERSION]
+     * (the single version this SDK build implements) during the handshake, regardless of this value.
+     */
+    val protocolVersion: Int? = null,
+) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -10,16 +10,8 @@ internal data class WebViewComponentStyle(
     val url: String,
     override val visible: Boolean,
     override val size: Size,
-    /**
-     * The canonical component id from the schema (`web_view.id`), assigned to the content during the
-     * bridge handshake. A blank id renders nothing.
-     */
+    /** Schema `web_view.id`, sent to the content during the handshake. A blank id renders nothing. */
     val componentId: String,
-    /**
-     * The schema-declared `protocol_version`, decoded and preserved for future use. NOT the host's
-     * capability: the bridge always advertises [WebViewEnvelope.DEFAULT_PROTOCOL_VERSION][
-     * com.revenuecat.purchases.ui.revenuecatui.components.webview.WebViewEnvelope.DEFAULT_PROTOCOL_VERSION]
-     * (the single version this SDK build implements) during the handshake, regardless of this value.
-     */
+    /** Schema-declared `protocol_version`, preserved for future use; the bridge advertises its own. */
     val protocolVersion: Int,
 ) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -11,9 +11,8 @@ internal data class WebViewComponentStyle(
     override val visible: Boolean,
     override val size: Size,
     /**
-     * The canonical component id from the schema (`web_view.id`), used to scope bidirectional
-     * messages. May be null for legacy/partial configs that omit it, in which case the message bridge
-     * is not installed.
+     * The canonical component id from the schema (`web_view.id`), assigned to the content during the
+     * bridge handshake. Required to render; configs that omit it render nothing.
      */
     val componentId: String? = null,
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -38,6 +38,8 @@ internal fun WebViewComponentView(
     if (resolvedUrl == null) return
 
     val componentId = style.componentId
+    // workflow-web-components-sdk requires a host-assigned component id for the handshake.
+    if (componentId.isNullOrBlank()) return
     val locale = state.locale.toLanguageTag()
     val sizeToContentWidth = style.size.width is Fit
     val sizeToContentHeight = style.size.height is Fit
@@ -72,29 +74,27 @@ internal fun WebViewComponentView(
             AndroidView(
                 factory = { context ->
                     WebView(context).apply {
-                        val bridge = componentId?.let { id ->
-                            WebViewJavaScriptBridge(
-                                webView = this,
-                                componentId = id,
-                                expectedUrl = resolvedUrl,
-                                locale = locale,
-                                sizeToContentWidth = sizeToContentWidth,
-                                sizeToContentHeight = sizeToContentHeight,
-                                onContentResize = { widthCssPx, heightCssPx ->
-                                    widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
-                                    heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
-                                },
-                                onDocumentReset = {
-                                    contentWidthCssPx = 0
-                                    contentHeightCssPx = 0
-                                },
-                                onSecureMessagingUnsupported = {
-                                    if (failureFlag.markFailed()) {
-                                        loadFailed = true
-                                    }
-                                },
-                            ).also { createdBridge -> createdBridge.attach() }
-                        }
+                        val bridge = WebViewJavaScriptBridge(
+                            webView = this,
+                            componentId = componentId,
+                            expectedUrl = resolvedUrl,
+                            locale = locale,
+                            sizeToContentWidth = sizeToContentWidth,
+                            sizeToContentHeight = sizeToContentHeight,
+                            onContentResize = { widthCssPx, heightCssPx ->
+                                widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
+                                heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
+                            },
+                            onDocumentReset = {
+                                contentWidthCssPx = 0
+                                contentHeightCssPx = 0
+                            },
+                            onSecureMessagingUnsupported = {
+                                if (failureFlag.markFailed()) {
+                                    loadFailed = true
+                                }
+                            },
+                        ).also { createdBridge -> createdBridge.attach() }
                         bridgeHolder.bridge = bridge
                         configure(
                             expectedOrigin = resolvedUrl.toOriginOrNull(),
@@ -134,10 +134,10 @@ internal fun WebViewComponentView(
 }
 
 /**
- * Placeholder sizes for a `fit` axis until the content reports its size over the bridge — a
- * WebView has no meaningful intrinsic size, so `fit` would otherwise collapse. 100 (height)
- * matches the iOS implementation; 300 (width) matches the web implementation's
- * `FIT_FALLBACK_SIZE_PX`.
+ * Default placeholder sizes for a `fit` axis until the content reports its size over the bridge — a
+ * WebView has no meaningful intrinsic size, so `fit` would otherwise collapse. Used when the schema
+ * omits `fit.default`. 100 (height) matches the iOS implementation; 300 (width) matches the web
+ * implementation's `FIT_FALLBACK_SIZE_PX`.
  */
 internal const val FIT_PLACEHOLDER_HEIGHT: UInt = 100u
 internal const val FIT_PLACEHOLDER_WIDTH: UInt = 300u
@@ -147,13 +147,25 @@ internal fun webViewEffectiveSize(
     contentWidthCssPx: Int,
     contentHeightCssPx: Int,
 ): Size {
-    val width = when (declaredSize.width) {
-        is Fit -> Fixed(if (contentWidthCssPx > 0) contentWidthCssPx.toUInt() else FIT_PLACEHOLDER_WIDTH)
-        else -> declaredSize.width
+    val width = when (val widthConstraint = declaredSize.width) {
+        is Fit -> Fixed(
+            if (contentWidthCssPx > 0) {
+                contentWidthCssPx.toUInt()
+            } else {
+                widthConstraint.default ?: FIT_PLACEHOLDER_WIDTH
+            },
+        )
+        else -> widthConstraint
     }
-    val height = when (declaredSize.height) {
-        is Fit -> Fixed(if (contentHeightCssPx > 0) contentHeightCssPx.toUInt() else FIT_PLACEHOLDER_HEIGHT)
-        else -> declaredSize.height
+    val height = when (val heightConstraint = declaredSize.height) {
+        is Fit -> Fixed(
+            if (contentHeightCssPx > 0) {
+                contentHeightCssPx.toUInt()
+            } else {
+                heightConstraint.default ?: FIT_PLACEHOLDER_HEIGHT
+            },
+        )
+        else -> heightConstraint
     }
     return Size(width = width, height = height)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -41,7 +41,7 @@ internal fun WebViewComponentView(
 
     val componentId = style.componentId
     // workflow-web-components-sdk requires a host-assigned component id for the handshake.
-    if (componentId.isNullOrBlank()) return
+    if (componentId.isBlank()) return
     val sizeToContentWidth = style.size.width is Fit
     val sizeToContentHeight = style.size.height is Fit
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -92,14 +92,18 @@ internal fun WebViewComponentView(
                             onSecureMessagingUnsupported = { loadFailed = true },
                         ).also { createdBridge -> createdBridge.attach() }
                         bridgeHolder.bridge = bridge
-                        configure(
-                            expectedOrigin = resolvedUrl.toOriginOrNull(),
-                            onMainFrameNavigationStarted = { url ->
-                                bridgeHolder.bridge?.onMainFrameNavigationStarted(url)
-                            },
-                            onMainFrameLoadFailed = { loadFailed = true },
-                        )
-                        loadUrl(resolvedUrl)
+                        // attach() may synchronously flag terminal failure (secure messaging
+                        // unsupported); don't start a JS-enabled load we're about to tear down.
+                        if (!loadFailed) {
+                            configure(
+                                expectedOrigin = resolvedUrl.toOriginOrNull(),
+                                onMainFrameNavigationStarted = { url ->
+                                    bridgeHolder.bridge?.onMainFrameNavigationStarted(url)
+                                },
+                                onMainFrameLoadFailed = { loadFailed = true },
+                            )
+                            loadUrl(resolvedUrl)
+                        }
                     }
                 },
                 onRelease = { webView ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -24,7 +24,9 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 
 @JvmSynthetic
 @Composable
-@Suppress("LongMethod", "ReturnCount")
+// `state` is unused in v1 (no variables passed into the content) but kept for the uniform
+// ComponentView signature; it carries locale/variables again when that lands.
+@Suppress("LongMethod", "ReturnCount", "UnusedParameter")
 internal fun WebViewComponentView(
     style: WebViewComponentStyle,
     state: PaywallState.Loaded.Components,
@@ -40,7 +42,6 @@ internal fun WebViewComponentView(
     val componentId = style.componentId
     // workflow-web-components-sdk requires a host-assigned component id for the handshake.
     if (componentId.isNullOrBlank()) return
-    val locale = state.locale.toLanguageTag()
     val sizeToContentWidth = style.size.width is Fit
     val sizeToContentHeight = style.size.height is Fit
 
@@ -78,7 +79,6 @@ internal fun WebViewComponentView(
                             webView = this,
                             componentId = componentId,
                             expectedUrl = resolvedUrl,
-                            locale = locale,
                             sizeToContentWidth = sizeToContentWidth,
                             sizeToContentHeight = sizeToContentHeight,
                             onContentResize = { widthCssPx, heightCssPx ->
@@ -109,11 +109,6 @@ internal fun WebViewComponentView(
                         )
                         loadUrl(resolvedUrl)
                     }
-                },
-                update = {
-                    bridgeHolder.bridge?.update(
-                        locale = locale,
-                    )
                 },
                 onRelease = { webView ->
                     // Only release the bridge that this view installed into this holder.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -3,6 +3,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.graphics.Color
+import android.view.View
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -14,6 +15,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.viewinterop.AndroidView
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
@@ -120,7 +122,9 @@ internal fun WebViewComponentView(
                     webView.webViewClient = WebViewClient()
                     webView.destroy()
                 },
-                modifier = modifier.size(effectiveSize),
+                // Content can momentarily overflow the exact frame mid-resize (fit axes animate
+                // through placeholder -> measured); never paint outside the component's box.
+                modifier = modifier.size(effectiveSize).clipToBounds(),
             )
         }
         // Terminal failure: render nothing rather than retain a dead/unusable WebView.
@@ -181,6 +185,10 @@ private fun WebView.configure(
     setBackgroundColor(Color.TRANSPARENT)
     isVerticalScrollBarEnabled = false
     isHorizontalScrollBarEnabled = false
+    // Match iOS's non-scrolling web view: no overscroll glow/bounce. Native panning of overflowing
+    // fixed-size content is not hard-disabled (that would swallow touchmove from interactive content);
+    // fit axes size to content, so the common case never overflows.
+    overScrollMode = View.OVER_SCROLL_NEVER
     settings.allowContentAccess = false
     settings.allowFileAccess = false
     settings.cacheMode = WebSettings.LOAD_DEFAULT
@@ -188,6 +196,11 @@ private fun WebView.configure(
     settings.javaScriptEnabled = true
     settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
     settings.setGeolocationEnabled(false)
+    // Lock zoom (parity with iOS's injected `maximum-scale=1, user-scalable=no`). The device-width
+    // viewport is left to the content bundle's own `<meta viewport>`, which the backend controls.
+    settings.setSupportZoom(false)
+    settings.builtInZoomControls = false
+    settings.displayZoomControls = false
     webViewClient = PaywallWebViewClient(
         expectedOrigin = expectedOrigin,
         onMainFrameNavigationStarted = onMainFrameNavigationStarted,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
@@ -141,29 +142,20 @@ internal fun webViewEffectiveSize(
     declaredSize: Size,
     contentWidthCssPx: Int,
     contentHeightCssPx: Int,
-): Size {
-    val width = when (val widthConstraint = declaredSize.width) {
-        is Fit -> Fixed(
-            if (contentWidthCssPx > 0) {
-                contentWidthCssPx.toUInt()
-            } else {
-                widthConstraint.default ?: FIT_PLACEHOLDER_WIDTH
-            },
-        )
-        else -> widthConstraint
+): Size = Size(
+    width = resolveFitAxis(declaredSize.width, contentWidthCssPx, FIT_PLACEHOLDER_WIDTH),
+    height = resolveFitAxis(declaredSize.height, contentHeightCssPx, FIT_PLACEHOLDER_HEIGHT),
+)
+
+/**
+ * A `fit` axis resolves to the content-reported size once known, else the schema's `fit.default`, else
+ * [placeholder]. Non-fit axes pass through unchanged.
+ */
+private fun resolveFitAxis(constraint: SizeConstraint, contentCssPx: Int, placeholder: UInt): SizeConstraint =
+    when (constraint) {
+        is Fit -> Fixed(if (contentCssPx > 0) contentCssPx.toUInt() else constraint.default ?: placeholder)
+        else -> constraint
     }
-    val height = when (val heightConstraint = declaredSize.height) {
-        is Fit -> Fixed(
-            if (contentHeightCssPx > 0) {
-                contentHeightCssPx.toUInt()
-            } else {
-                heightConstraint.default ?: FIT_PLACEHOLDER_HEIGHT
-            },
-        )
-        else -> heightConstraint
-    }
-    return Size(width = width, height = height)
-}
 
 /** Mutable holder for the per-WebView bridge instance, shared across factory/update/onRelease. */
 internal class WebViewBridgeHolder {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -1,0 +1,200 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.graphics.Color
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+
+@JvmSynthetic
+@Composable
+@Suppress("LongMethod", "ReturnCount")
+internal fun WebViewComponentView(
+    style: WebViewComponentStyle,
+    state: PaywallState.Loaded.Components,
+    modifier: Modifier = Modifier,
+) {
+    if (!style.visible) return
+
+    val resolvedUrl = remember(style.url) {
+        WebViewUrlResolver.resolve(style.url)
+    }
+    if (resolvedUrl == null) return
+
+    val componentId = style.componentId
+    val locale = state.locale.toLanguageTag()
+    val messageHandler = state.webViewMessageHandler
+    val sizeToContentWidth = style.size.width is Fit
+    val sizeToContentHeight = style.size.height is Fit
+
+    val identity = WebViewIdentity(
+        resolvedUrl = resolvedUrl,
+        componentId = componentId,
+        sizeToContentWidth = sizeToContentWidth,
+        sizeToContentHeight = sizeToContentHeight,
+    )
+
+    // Identity-scoped state: when any immutable bridge field changes, Compose disposes the previous
+    // key subtree (WebView + bridge + measured sizes + failure flag) and creates a fresh one.
+    key(identity) {
+        var contentWidthCssPx by remember { mutableIntStateOf(0) }
+        var contentHeightCssPx by remember { mutableIntStateOf(0) }
+        var loadFailed by remember { mutableStateOf(false) }
+        // Holder is remembered inside the identity key so an old AndroidView.onRelease can only
+        // clear/release the bridge that belonged to that specific view instance.
+        val bridgeHolder = remember { WebViewBridgeHolder() }
+        val failureFlag = remember { LoadFailureFlag() }
+
+        val effectiveSize = remember(style.size, contentWidthCssPx, contentHeightCssPx) {
+            webViewEffectiveSize(
+                declaredSize = style.size,
+                contentWidthCssPx = contentWidthCssPx,
+                contentHeightCssPx = contentHeightCssPx,
+            )
+        }
+
+        if (!loadFailed) {
+            AndroidView(
+                factory = { context ->
+                    WebView(context).apply {
+                        val bridge = componentId?.let { id ->
+                            WebViewJavaScriptBridge(
+                                webView = this,
+                                componentId = id,
+                                expectedUrl = resolvedUrl,
+                                locale = locale,
+                                messageHandler = messageHandler,
+                                sizeToContentWidth = sizeToContentWidth,
+                                sizeToContentHeight = sizeToContentHeight,
+                                onContentResize = { widthCssPx, heightCssPx ->
+                                    widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
+                                    heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
+                                },
+                                onDocumentReset = {
+                                    contentWidthCssPx = 0
+                                    contentHeightCssPx = 0
+                                },
+                                onSecureMessagingUnsupported = {
+                                    if (failureFlag.markFailed()) {
+                                        loadFailed = true
+                                    }
+                                },
+                            ).also { createdBridge -> createdBridge.attach() }
+                        }
+                        bridgeHolder.bridge = bridge
+                        configure(
+                            expectedOrigin = resolvedUrl.toOriginOrNull(),
+                            onMainFrameNavigationStarted = { url ->
+                                bridgeHolder.bridge?.onMainFrameNavigationStarted(url)
+                            },
+                            onMainFrameLoadFailed = {
+                                if (failureFlag.markFailed()) {
+                                    loadFailed = true
+                                }
+                            },
+                        )
+                        loadUrl(resolvedUrl)
+                    }
+                },
+                update = {
+                    bridgeHolder.bridge?.update(
+                        locale = locale,
+                        messageHandler = messageHandler,
+                    )
+                },
+                onRelease = { webView ->
+                    // Only release the bridge that this view installed into this holder.
+                    val bridge = bridgeHolder.bridge
+                    bridgeHolder.bridge = null
+                    bridge?.release()
+                    webView.stopLoading()
+                    webView.webViewClient = WebViewClient()
+                    webView.destroy()
+                },
+                modifier = modifier.size(effectiveSize),
+            )
+        }
+        // Terminal failure: render nothing rather than retain a dead/unusable WebView.
+        // There is intentionally no native fallback stack — apps must use an SDK that
+        // supports web_view.
+    }
+}
+
+/**
+ * Placeholder sizes for a `fit` axis until the content reports its size over the bridge — a
+ * WebView has no meaningful intrinsic size, so `fit` would otherwise collapse. 100 (height)
+ * matches the iOS implementation; 300 (width) matches the web implementation's
+ * `FIT_FALLBACK_SIZE_PX`.
+ */
+internal const val FIT_PLACEHOLDER_HEIGHT: UInt = 100u
+internal const val FIT_PLACEHOLDER_WIDTH: UInt = 300u
+
+internal fun webViewEffectiveSize(
+    declaredSize: Size,
+    contentWidthCssPx: Int,
+    contentHeightCssPx: Int,
+): Size {
+    val width = when (declaredSize.width) {
+        is Fit -> Fixed(if (contentWidthCssPx > 0) contentWidthCssPx.toUInt() else FIT_PLACEHOLDER_WIDTH)
+        else -> declaredSize.width
+    }
+    val height = when (declaredSize.height) {
+        is Fit -> Fixed(if (contentHeightCssPx > 0) contentHeightCssPx.toUInt() else FIT_PLACEHOLDER_HEIGHT)
+        else -> declaredSize.height
+    }
+    return Size(width = width, height = height)
+}
+
+/** Mutable holder for the per-WebView bridge instance, shared across factory/update/onRelease. */
+internal class WebViewBridgeHolder {
+    var bridge: WebViewJavaScriptBridge? = null
+}
+
+/** Idempotent failure latch shared by URL/HTTP/renderer/secure-messaging failure paths. */
+internal class LoadFailureFlag {
+    private var failed: Boolean = false
+
+    fun markFailed(): Boolean {
+        if (failed) return false
+        failed = true
+        return true
+    }
+}
+
+private fun WebView.configure(
+    expectedOrigin: String?,
+    onMainFrameNavigationStarted: (url: String?) -> Unit,
+    onMainFrameLoadFailed: () -> Unit,
+) {
+    setBackgroundColor(Color.TRANSPARENT)
+    isVerticalScrollBarEnabled = false
+    isHorizontalScrollBarEnabled = false
+    settings.allowContentAccess = false
+    settings.allowFileAccess = false
+    settings.cacheMode = WebSettings.LOAD_DEFAULT
+    settings.domStorageEnabled = true
+    settings.javaScriptEnabled = true
+    settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+    settings.setGeolocationEnabled(false)
+    webViewClient = PaywallWebViewClient(
+        expectedOrigin = expectedOrigin,
+        onMainFrameNavigationStarted = onMainFrameNavigationStarted,
+        onMainFrameLoadFailed = onMainFrameLoadFailed,
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -97,8 +97,8 @@ internal fun WebViewComponentView(
                         if (!loadFailed) {
                             configure(
                                 expectedOrigin = resolvedUrl.toOriginOrNull(),
-                                onMainFrameNavigationStarted = { url ->
-                                    bridgeHolder.bridge?.onMainFrameNavigationStarted(url)
+                                onMainFrameNavigationStarted = {
+                                    bridgeHolder.bridge?.onMainFrameNavigationStarted()
                                 },
                                 onMainFrameLoadFailed = { loadFailed = true },
                             )
@@ -156,7 +156,7 @@ internal class WebViewBridgeHolder {
 
 private fun WebView.configure(
     expectedOrigin: String?,
-    onMainFrameNavigationStarted: (url: String?) -> Unit,
+    onMainFrameNavigationStarted: () -> Unit,
     onMainFrameLoadFailed: () -> Unit,
 ) {
     setBackgroundColor(Color.TRANSPARENT)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -27,8 +27,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 
 @JvmSynthetic
 @Composable
-// `state` is unused in v1 (no variables passed into the content) but kept for the uniform
-// ComponentView signature; it carries locale/variables again when that lands.
+// `state` is unused in v1 but kept for the uniform ComponentView signature (variables land later).
 @Suppress("LongMethod", "ReturnCount", "UnusedParameter")
 internal fun WebViewComponentView(
     style: WebViewComponentStyle,
@@ -55,14 +54,13 @@ internal fun WebViewComponentView(
         sizeToContentHeight = sizeToContentHeight,
     )
 
-    // Identity-scoped state: when any immutable bridge field changes, Compose disposes the previous
-    // key subtree (WebView + bridge + measured sizes + failure flag) and creates a fresh one.
+    // key(identity): any change to an immutable bridge field disposes this subtree (WebView + bridge
+    // + measured sizes) and builds a fresh one.
     key(identity) {
         var contentWidthCssPx by remember { mutableIntStateOf(0) }
         var contentHeightCssPx by remember { mutableIntStateOf(0) }
         var loadFailed by remember { mutableStateOf(false) }
-        // Holder is remembered inside the identity key so an old AndroidView.onRelease can only
-        // clear/release the bridge that belonged to that specific view instance.
+        // Remembered inside key(identity) so a stale onRelease can only release its own view's bridge.
         val bridgeHolder = remember { WebViewBridgeHolder() }
 
         val effectiveSize = remember(style.size, contentWidthCssPx, contentHeightCssPx) {
@@ -113,22 +111,17 @@ internal fun WebViewComponentView(
                     webView.webViewClient = WebViewClient()
                     webView.destroy()
                 },
-                // Content can momentarily overflow the exact frame mid-resize (fit axes animate
-                // through placeholder -> measured); never paint outside the component's box.
+                // Clip: content can briefly overflow while a fit axis animates placeholder -> measured.
                 modifier = modifier.size(effectiveSize).clipToBounds(),
             )
         }
-        // Terminal failure: render nothing rather than retain a dead/unusable WebView.
-        // There is intentionally no native fallback stack — apps must use an SDK that
-        // supports web_view.
+        // Terminal failure renders nothing; there is intentionally no native fallback.
     }
 }
 
 /**
- * Default placeholder sizes for a `fit` axis until the content reports its size over the bridge — a
- * WebView has no meaningful intrinsic size, so `fit` would otherwise collapse. Used when the schema
- * omits `fit.default`. 100 (height) matches the iOS implementation; 300 (width) matches the web
- * implementation's `FIT_FALLBACK_SIZE_PX`.
+ * Placeholder `fit`-axis sizes used before content reports a size (a WebView has no intrinsic size)
+ * and the schema omits `fit.default`. 100 (height) matches iOS; 300 (width) matches web.
  */
 internal const val FIT_PLACEHOLDER_HEIGHT: UInt = 100u
 internal const val FIT_PLACEHOLDER_WIDTH: UInt = 300u
@@ -152,7 +145,7 @@ private fun resolveFitAxis(constraint: SizeConstraint, contentCssPx: Int, placeh
         else -> constraint
     }
 
-/** Mutable holder for the per-WebView bridge instance, shared across factory/update/onRelease. */
+/** Holds the per-WebView bridge so factory and onRelease share one instance. */
 internal class WebViewBridgeHolder {
     var bridge: WebViewJavaScriptBridge? = null
 }
@@ -165,9 +158,8 @@ private fun WebView.configure(
     setBackgroundColor(Color.TRANSPARENT)
     isVerticalScrollBarEnabled = false
     isHorizontalScrollBarEnabled = false
-    // Match iOS's non-scrolling web view: no overscroll glow/bounce. Native panning of overflowing
-    // fixed-size content is not hard-disabled (that would swallow touchmove from interactive content);
-    // fit axes size to content, so the common case never overflows.
+    // No overscroll glow/bounce (matches iOS). Native scroll isn't hard-disabled — that would eat
+    // touchmove from interactive content; fit axes size to content, so the common case can't overflow.
     overScrollMode = View.OVER_SCROLL_NEVER
     settings.allowContentAccess = false
     settings.allowFileAccess = false
@@ -176,8 +168,7 @@ private fun WebView.configure(
     settings.javaScriptEnabled = true
     settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
     settings.setGeolocationEnabled(false)
-    // Lock zoom (parity with iOS's injected `maximum-scale=1, user-scalable=no`). The device-width
-    // viewport is left to the content bundle's own `<meta viewport>`, which the backend controls.
+    // Lock zoom (parity with iOS `user-scalable=no`); the bundle sets its own viewport.
     settings.setSupportZoom(false)
     settings.builtInZoomControls = false
     settings.displayZoomControls = false

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -39,7 +39,6 @@ internal fun WebViewComponentView(
 
     val componentId = style.componentId
     val locale = state.locale.toLanguageTag()
-    val messageHandler = state.webViewMessageHandler
     val sizeToContentWidth = style.size.width is Fit
     val sizeToContentHeight = style.size.height is Fit
 
@@ -79,7 +78,6 @@ internal fun WebViewComponentView(
                                 componentId = id,
                                 expectedUrl = resolvedUrl,
                                 locale = locale,
-                                messageHandler = messageHandler,
                                 sizeToContentWidth = sizeToContentWidth,
                                 sizeToContentHeight = sizeToContentHeight,
                                 onContentResize = { widthCssPx, heightCssPx ->
@@ -115,7 +113,6 @@ internal fun WebViewComponentView(
                 update = {
                     bridgeHolder.bridge?.update(
                         locale = locale,
-                        messageHandler = messageHandler,
                     )
                 },
                 onRelease = { webView ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -64,7 +64,6 @@ internal fun WebViewComponentView(
         // Holder is remembered inside the identity key so an old AndroidView.onRelease can only
         // clear/release the bridge that belonged to that specific view instance.
         val bridgeHolder = remember { WebViewBridgeHolder() }
-        val failureFlag = remember { LoadFailureFlag() }
 
         val effectiveSize = remember(style.size, contentWidthCssPx, contentHeightCssPx) {
             webViewEffectiveSize(
@@ -92,11 +91,7 @@ internal fun WebViewComponentView(
                                 contentWidthCssPx = 0
                                 contentHeightCssPx = 0
                             },
-                            onSecureMessagingUnsupported = {
-                                if (failureFlag.markFailed()) {
-                                    loadFailed = true
-                                }
-                            },
+                            onSecureMessagingUnsupported = { loadFailed = true },
                         ).also { createdBridge -> createdBridge.attach() }
                         bridgeHolder.bridge = bridge
                         configure(
@@ -104,11 +99,7 @@ internal fun WebViewComponentView(
                             onMainFrameNavigationStarted = { url ->
                                 bridgeHolder.bridge?.onMainFrameNavigationStarted(url)
                             },
-                            onMainFrameLoadFailed = {
-                                if (failureFlag.markFailed()) {
-                                    loadFailed = true
-                                }
-                            },
+                            onMainFrameLoadFailed = { loadFailed = true },
                         )
                         loadUrl(resolvedUrl)
                     }
@@ -164,17 +155,6 @@ private fun resolveFitAxis(constraint: SizeConstraint, contentCssPx: Int, placeh
 /** Mutable holder for the per-WebView bridge instance, shared across factory/update/onRelease. */
 internal class WebViewBridgeHolder {
     var bridge: WebViewJavaScriptBridge? = null
-}
-
-/** Idempotent failure latch shared by URL/HTTP/renderer/secure-messaging failure paths. */
-internal class LoadFailureFlag {
-    private var failed: Boolean = false
-
-    fun markFailed(): Boolean {
-        if (failed) return false
-        failed = true
-        return true
-    }
 }
 
 private fun WebView.configure(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentity.kt
@@ -1,0 +1,15 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+/**
+ * Immutable configuration that identifies a rendered `web_view` instance. When any field changes the
+ * Compose tree must dispose the previous [android.webkit.WebView] / bridge and create a new pair —
+ * locale and message handler are deliberately excluded so they can update in place.
+ */
+internal data class WebViewIdentity(
+    val resolvedUrl: String,
+    val componentId: String?,
+    val sizeToContentWidth: Boolean,
+    val sizeToContentHeight: Boolean,
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentity.kt
@@ -4,12 +4,11 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 /**
  * Immutable configuration that identifies a rendered `web_view` instance. When any field changes the
- * Compose tree must dispose the previous [android.webkit.WebView] / bridge and create a new pair —
- * locale and message handler are deliberately excluded so they can update in place.
+ * Compose tree must dispose the previous [android.webkit.WebView] / bridge and create a new pair.
  */
 internal data class WebViewIdentity(
     val resolvedUrl: String,
-    val componentId: String?,
+    val componentId: String,
     val sizeToContentWidth: Boolean,
     val sizeToContentHeight: Boolean,
 )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
@@ -1,0 +1,47 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class WebViewEffectiveSizeTest {
+
+    @Test
+    fun `fit axes use placeholders until the content reports a size`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fit(), height = Fit()),
+            contentWidthCssPx = 0,
+            contentHeightCssPx = 0,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(FIT_PLACEHOLDER_WIDTH))
+        assertThat(size.height).isEqualTo(Fixed(FIT_PLACEHOLDER_HEIGHT))
+    }
+
+    @Test
+    fun `fit axes use the reported content size once available`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fit(), height = Fit()),
+            contentWidthCssPx = 320,
+            contentHeightCssPx = 480,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(320u))
+        assertThat(size.height).isEqualTo(Fixed(480u))
+    }
+
+    @Test
+    fun `non-fit axes ignore reported content sizes`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fill, height = Fixed(200u)),
+            contentWidthCssPx = 320,
+            contentHeightCssPx = 480,
+        )
+
+        assertThat(size.width).isEqualTo(Fill)
+        assertThat(size.height).isEqualTo(Fixed(200u))
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
@@ -22,6 +22,18 @@ internal class WebViewEffectiveSizeTest {
     }
 
     @Test
+    fun `fit axes use schema default until the content reports a size`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fit(default = 400u), height = Fit(default = 250u)),
+            contentWidthCssPx = 0,
+            contentHeightCssPx = 0,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(400u))
+        assertThat(size.height).isEqualTo(Fixed(250u))
+    }
+
+    @Test
     fun `fit axes use the reported content size once available`() {
         val size = webViewEffectiveSize(
             declaredSize = Size(width = Fit(), height = Fit()),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewFailurePathTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewFailurePathTest.kt
@@ -1,0 +1,109 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebView
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class WebViewFailurePathTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `renderer termination removes the dead web view`() {
+        var destroyed = false
+        var loadFailedObserved = false
+
+        composeTestRule.setContent {
+            var loadFailed by remember { mutableStateOf(false) }
+            loadFailedObserved = loadFailed
+            if (!loadFailed) {
+                val context = LocalContext.current
+                val holder = remember { WebViewBridgeHolder() }
+                AndroidView(
+                    factory = {
+                        WebView(context).apply {
+                            val client = PaywallWebViewClient(
+                                expectedOrigin = "https://assets.example.com",
+                                onMainFrameNavigationStarted = {},
+                                onMainFrameLoadFailed = { loadFailed = true },
+                            )
+                            setWebViewClient(client)
+                            // Simulate renderer death immediately after creation.
+                            client.onRenderProcessGone(this, mockk<RenderProcessGoneDetail>(relaxed = true))
+                        }
+                    },
+                    onRelease = { webView ->
+                        holder.bridge?.release()
+                        holder.bridge = null
+                        webView.destroy()
+                        destroyed = true
+                    },
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertThat(destroyed).isTrue()
+        assertThat(loadFailedObserved).isTrue()
+    }
+
+    @Test
+    fun `identity change after failure can create a replacement web view`() {
+        val creations = mutableListOf<String>()
+        var identity by mutableStateOf("one")
+        var failNext = true
+
+        composeTestRule.setContent {
+            key(identity) {
+                var loadFailed by remember { mutableStateOf(false) }
+                if (loadFailed) {
+                    Text("failed-$identity")
+                } else {
+                    val context = LocalContext.current
+                    AndroidView(
+                        factory = {
+                            creations.add(identity)
+                            WebView(context).apply {
+                                if (failNext) {
+                                    failNext = false
+                                    val client = PaywallWebViewClient(
+                                        expectedOrigin = "https://assets.example.com",
+                                        onMainFrameNavigationStarted = {},
+                                        onMainFrameLoadFailed = { loadFailed = true },
+                                    )
+                                    setWebViewClient(client)
+                                    client.onRenderProcessGone(this, mockk(relaxed = true))
+                                }
+                            }
+                        },
+                        onRelease = { it.destroy() },
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("failed-one").assertIsDisplayed()
+
+        identity = "two"
+        composeTestRule.waitForIdle()
+
+        assertThat(creations).containsExactly("one", "two")
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
@@ -110,7 +110,6 @@ internal class WebViewIdentityTest {
         composeTestRule.setContent {
             TestWebViewSlot(
                 identity = identity,
-                locale = "en-US",
                 onCreated = { creations.add(it) },
                 onReleased = { releases.add(it) },
             )
@@ -140,7 +139,6 @@ internal class WebViewIdentityTest {
         composeTestRule.setContent {
             TestWebViewSlot(
                 identity = identity,
-                locale = "en-US",
                 onCreated = { creations.add(identity) },
                 onReleased = {},
             )
@@ -155,38 +153,6 @@ internal class WebViewIdentityTest {
         assertThat(creations).hasSize(3)
         assertThat(creations[1].sizeToContentWidth).isTrue()
         assertThat(creations[2].sizeToContentHeight).isTrue()
-    }
-
-    @Test
-    fun `locale only updates do not recreate the web view`() {
-        val creations = mutableListOf<Int>()
-        var identity by mutableStateOf(
-            WebViewIdentity(
-                resolvedUrl = "https://assets.example.com/a.html",
-                componentId = "one",
-                sizeToContentWidth = false,
-                sizeToContentHeight = false,
-            ),
-        )
-        var locale by mutableStateOf("en-US")
-        val updates = mutableListOf<String>()
-
-        composeTestRule.setContent {
-            TestWebViewSlot(
-                identity = identity,
-                locale = locale,
-                onCreated = { creations.add(creations.size) },
-                onReleased = {},
-                onUpdated = { loc -> updates.add(loc) },
-            )
-        }
-        composeTestRule.waitForIdle()
-
-        locale = "fr-FR"
-        composeTestRule.waitForIdle()
-
-        assertThat(creations).hasSize(1)
-        assertThat(updates).contains("fr-FR")
     }
 
     @Test
@@ -205,7 +171,6 @@ internal class WebViewIdentityTest {
         composeTestRule.setContent {
             TestWebViewSlot(
                 identity = identity,
-                locale = "en-US",
                 onCreated = {},
                 onReleased = {},
                 onBridgeCreated = { liveBridges.add(it) },
@@ -262,10 +227,8 @@ internal class WebViewIdentityTest {
 @Composable
 private fun TestWebViewSlot(
     identity: WebViewIdentity,
-    locale: String,
     onCreated: (String?) -> Unit,
     onReleased: (String?) -> Unit,
-    onUpdated: (String) -> Unit = { },
     onBridgeCreated: (WebViewJavaScriptBridge) -> Unit = {},
     onBridgeReleased: (WebViewJavaScriptBridge) -> Unit = {},
 ) {
@@ -280,7 +243,6 @@ private fun TestWebViewSlot(
                             webView = this,
                             componentId = id,
                             expectedUrl = identity.resolvedUrl,
-                            locale = locale,
                             sizeToContentWidth = identity.sizeToContentWidth,
                             sizeToContentHeight = identity.sizeToContentHeight,
                         ).also { created ->
@@ -291,10 +253,6 @@ private fun TestWebViewSlot(
                     bridgeHolder.bridge = bridge
                     onCreated(identity.componentId)
                 }
-            },
-            update = {
-                bridgeHolder.bridge?.update(locale = locale)
-                onUpdated(locale)
             },
             onRelease = { webView ->
                 val bridge = bridgeHolder.bridge

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
@@ -1,0 +1,323 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.webkit.WebView
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import org.junit.runner.Description
+
+@RunWith(AndroidJUnit4::class)
+internal class WebViewIdentityTest {
+
+    val composeTestRule = createComposeRule()
+
+    /**
+     * Mocks must outlive [composeTestRule] teardown: AndroidView.onRelease (and thus
+     * [WebViewJavaScriptBridge.release]) runs when the composition is disposed, which is after
+     * `@After` methods.
+     */
+    @get:Rule
+    val rules: TestRule = RuleChain
+        .outerRule(
+            object : TestRule {
+                override fun apply(base: Statement, description: Description): Statement {
+                    return object : Statement() {
+                        override fun evaluate() {
+                            mockkStatic(WebViewFeature::class, WebViewCompat::class)
+                            every {
+                                WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+                            } returns true
+                            every {
+                                WebViewCompat.addWebMessageListener(any(), any(), any(), any())
+                            } just Runs
+                            every {
+                                WebViewCompat.removeWebMessageListener(any(), any())
+                            } just Runs
+                            try {
+                                base.evaluate()
+                            } finally {
+                                unmockkStatic(WebViewFeature::class, WebViewCompat::class)
+                            }
+                        }
+                    }
+                }
+            },
+        )
+        .around(composeTestRule)
+
+    @Test
+    fun `identity differs when component id changes`() {
+        val base = WebViewIdentity(
+            resolvedUrl = "https://assets.example.com/a.html",
+            componentId = "one",
+            sizeToContentWidth = false,
+            sizeToContentHeight = true,
+        )
+        val changed = base.copy(componentId = "two")
+
+        assertThat(base).isNotEqualTo(changed)
+    }
+
+    @Test
+    fun `identity differs when fit width or height changes`() {
+        val base = WebViewIdentity(
+            resolvedUrl = "https://assets.example.com/a.html",
+            componentId = "one",
+            sizeToContentWidth = false,
+            sizeToContentHeight = false,
+        )
+
+        assertThat(base).isNotEqualTo(base.copy(sizeToContentWidth = true))
+        assertThat(base).isNotEqualTo(base.copy(sizeToContentHeight = true))
+    }
+
+    @Test
+    fun `same url with different component id recreates the web view and bridge`() {
+        val creations = mutableListOf<String?>()
+        val releases = mutableListOf<String?>()
+        var identity by mutableStateOf(
+            WebViewIdentity(
+                resolvedUrl = "https://assets.example.com/a.html",
+                componentId = "one",
+                sizeToContentWidth = false,
+                sizeToContentHeight = false,
+            ),
+        )
+
+        composeTestRule.setContent {
+            TestWebViewSlot(
+                identity = identity,
+                locale = "en-US",
+                messageHandler = null,
+                onCreated = { creations.add(it) },
+                onReleased = { releases.add(it) },
+            )
+        }
+        composeTestRule.waitForIdle()
+        assertThat(creations).containsExactly("one")
+
+        identity = identity.copy(componentId = "two")
+        composeTestRule.waitForIdle()
+
+        assertThat(releases).containsExactly("one")
+        assertThat(creations).containsExactly("one", "two")
+    }
+
+    @Test
+    fun `fixed-to-fit width and height changes recreate the web view`() {
+        val creations = mutableListOf<WebViewIdentity>()
+        var identity by mutableStateOf(
+            WebViewIdentity(
+                resolvedUrl = "https://assets.example.com/a.html",
+                componentId = "one",
+                sizeToContentWidth = false,
+                sizeToContentHeight = false,
+            ),
+        )
+
+        composeTestRule.setContent {
+            TestWebViewSlot(
+                identity = identity,
+                locale = "en-US",
+                messageHandler = null,
+                onCreated = { creations.add(identity) },
+                onReleased = {},
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        identity = identity.copy(sizeToContentWidth = true)
+        composeTestRule.waitForIdle()
+        identity = identity.copy(sizeToContentHeight = true)
+        composeTestRule.waitForIdle()
+
+        assertThat(creations).hasSize(3)
+        assertThat(creations[1].sizeToContentWidth).isTrue()
+        assertThat(creations[2].sizeToContentHeight).isTrue()
+    }
+
+    @Test
+    fun `locale and handler only updates do not recreate the web view`() {
+        val creations = mutableListOf<Int>()
+        var identity by mutableStateOf(
+            WebViewIdentity(
+                resolvedUrl = "https://assets.example.com/a.html",
+                componentId = "one",
+                sizeToContentWidth = false,
+                sizeToContentHeight = false,
+            ),
+        )
+        var locale by mutableStateOf("en-US")
+        var handler by mutableStateOf<PaywallWebViewMessageHandler?>(null)
+        val updates = mutableListOf<Pair<String, PaywallWebViewMessageHandler?>>()
+
+        composeTestRule.setContent {
+            TestWebViewSlot(
+                identity = identity,
+                locale = locale,
+                messageHandler = handler,
+                onCreated = { creations.add(creations.size) },
+                onReleased = {},
+                onUpdated = { loc, msg -> updates.add(loc to msg) },
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        locale = "fr-FR"
+        composeTestRule.waitForIdle()
+        val newHandler = PaywallWebViewMessageHandler { _, _ -> }
+        handler = newHandler
+        composeTestRule.waitForIdle()
+
+        assertThat(creations).hasSize(1)
+        assertThat(updates.map { it.first }).contains("fr-FR")
+        assertThat(updates.map { it.second }).contains(newHandler)
+    }
+
+    @Test
+    fun `old onRelease cannot release the replacement bridge`() {
+        val releasedBridges = mutableListOf<WebViewJavaScriptBridge>()
+        var identity by mutableStateOf(
+            WebViewIdentity(
+                resolvedUrl = "https://assets.example.com/a.html",
+                componentId = "one",
+                sizeToContentWidth = false,
+                sizeToContentHeight = false,
+            ),
+        )
+        val liveBridges = mutableListOf<WebViewJavaScriptBridge>()
+
+        composeTestRule.setContent {
+            TestWebViewSlot(
+                identity = identity,
+                locale = "en-US",
+                messageHandler = null,
+                onCreated = {},
+                onReleased = {},
+                onBridgeCreated = { liveBridges.add(it) },
+                onBridgeReleased = { releasedBridges.add(it) },
+            )
+        }
+        composeTestRule.waitForIdle()
+        val first = liveBridges.single()
+
+        identity = identity.copy(componentId = "two")
+        composeTestRule.waitForIdle()
+
+        assertThat(releasedBridges).containsExactly(first)
+        assertThat(liveBridges).hasSize(2)
+        assertThat(releasedBridges).doesNotContain(liveBridges.last())
+    }
+
+    @Test
+    fun `measured dimensions start at zero for a new identity`() {
+        val initialSizes = mutableListOf<Pair<Int, Int>>()
+        var identity by mutableStateOf(
+            WebViewIdentity(
+                resolvedUrl = "https://assets.example.com/a.html",
+                componentId = "one",
+                sizeToContentWidth = true,
+                sizeToContentHeight = true,
+            ),
+        )
+
+        composeTestRule.setContent {
+            key(identity) {
+                var contentWidthCssPx by remember { mutableIntStateOf(0) }
+                var contentHeightCssPx by remember { mutableIntStateOf(0) }
+                DisposableEffect(Unit) {
+                    initialSizes.add(contentWidthCssPx to contentHeightCssPx)
+                    contentWidthCssPx = 100
+                    onDispose { }
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertThat(initialSizes).containsExactly(0 to 0)
+
+        identity = identity.copy(componentId = "two")
+        composeTestRule.waitForIdle()
+        assertThat(initialSizes).containsExactly(0 to 0, 0 to 0)
+    }
+}
+
+/**
+ * Mirrors the identity-scoped AndroidView / bridge-holder pattern used by [WebViewComponentView]
+ * so lifecycle guarantees can be asserted without spinning up a full paywall state tree.
+ */
+@Composable
+private fun TestWebViewSlot(
+    identity: WebViewIdentity,
+    locale: String,
+    messageHandler: PaywallWebViewMessageHandler?,
+    onCreated: (String?) -> Unit,
+    onReleased: (String?) -> Unit,
+    onUpdated: (String, PaywallWebViewMessageHandler?) -> Unit = { _, _ -> },
+    onBridgeCreated: (WebViewJavaScriptBridge) -> Unit = {},
+    onBridgeReleased: (WebViewJavaScriptBridge) -> Unit = {},
+) {
+    key(identity) {
+        val bridgeHolder = remember { WebViewBridgeHolder() }
+        val context = LocalContext.current
+        AndroidView(
+            factory = {
+                WebView(context).apply {
+                    val bridge = identity.componentId?.let { id ->
+                        WebViewJavaScriptBridge(
+                            webView = this,
+                            componentId = id,
+                            expectedUrl = identity.resolvedUrl,
+                            locale = locale,
+                            messageHandler = messageHandler,
+                            sizeToContentWidth = identity.sizeToContentWidth,
+                            sizeToContentHeight = identity.sizeToContentHeight,
+                        ).also { created ->
+                            created.attach()
+                            onBridgeCreated(created)
+                        }
+                    }
+                    bridgeHolder.bridge = bridge
+                    onCreated(identity.componentId)
+                }
+            },
+            update = {
+                bridgeHolder.bridge?.update(locale = locale, messageHandler = messageHandler)
+                onUpdated(locale, messageHandler)
+            },
+            onRelease = { webView ->
+                val bridge = bridgeHolder.bridge
+                bridgeHolder.bridge = null
+                if (bridge != null) {
+                    onBridgeReleased(bridge)
+                    bridge.release()
+                }
+                onReleased(identity.componentId)
+                webView.destroy()
+            },
+        )
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
@@ -238,17 +238,15 @@ private fun TestWebViewSlot(
         AndroidView(
             factory = {
                 WebView(context).apply {
-                    val bridge = identity.componentId?.let { id ->
-                        WebViewJavaScriptBridge(
-                            webView = this,
-                            componentId = id,
-                            expectedUrl = identity.resolvedUrl,
-                            sizeToContentWidth = identity.sizeToContentWidth,
-                            sizeToContentHeight = identity.sizeToContentHeight,
-                        ).also { created ->
-                            created.attach()
-                            onBridgeCreated(created)
-                        }
+                    val bridge = WebViewJavaScriptBridge(
+                        webView = this,
+                        componentId = identity.componentId,
+                        expectedUrl = identity.resolvedUrl,
+                        sizeToContentWidth = identity.sizeToContentWidth,
+                        sizeToContentHeight = identity.sizeToContentHeight,
+                    ).also { created ->
+                        created.attach()
+                        onBridgeCreated(created)
                     }
                     bridgeHolder.bridge = bridge
                     onCreated(identity.componentId)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
-import com.revenuecat.purchases.ui.revenuecatui.PaywallWebViewMessageHandler
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -112,7 +111,6 @@ internal class WebViewIdentityTest {
             TestWebViewSlot(
                 identity = identity,
                 locale = "en-US",
-                messageHandler = null,
                 onCreated = { creations.add(it) },
                 onReleased = { releases.add(it) },
             )
@@ -143,7 +141,6 @@ internal class WebViewIdentityTest {
             TestWebViewSlot(
                 identity = identity,
                 locale = "en-US",
-                messageHandler = null,
                 onCreated = { creations.add(identity) },
                 onReleased = {},
             )
@@ -161,7 +158,7 @@ internal class WebViewIdentityTest {
     }
 
     @Test
-    fun `locale and handler only updates do not recreate the web view`() {
+    fun `locale only updates do not recreate the web view`() {
         val creations = mutableListOf<Int>()
         var identity by mutableStateOf(
             WebViewIdentity(
@@ -172,30 +169,24 @@ internal class WebViewIdentityTest {
             ),
         )
         var locale by mutableStateOf("en-US")
-        var handler by mutableStateOf<PaywallWebViewMessageHandler?>(null)
-        val updates = mutableListOf<Pair<String, PaywallWebViewMessageHandler?>>()
+        val updates = mutableListOf<String>()
 
         composeTestRule.setContent {
             TestWebViewSlot(
                 identity = identity,
                 locale = locale,
-                messageHandler = handler,
                 onCreated = { creations.add(creations.size) },
                 onReleased = {},
-                onUpdated = { loc, msg -> updates.add(loc to msg) },
+                onUpdated = { loc -> updates.add(loc) },
             )
         }
         composeTestRule.waitForIdle()
 
         locale = "fr-FR"
         composeTestRule.waitForIdle()
-        val newHandler = PaywallWebViewMessageHandler { _, _ -> }
-        handler = newHandler
-        composeTestRule.waitForIdle()
 
         assertThat(creations).hasSize(1)
-        assertThat(updates.map { it.first }).contains("fr-FR")
-        assertThat(updates.map { it.second }).contains(newHandler)
+        assertThat(updates).contains("fr-FR")
     }
 
     @Test
@@ -215,7 +206,6 @@ internal class WebViewIdentityTest {
             TestWebViewSlot(
                 identity = identity,
                 locale = "en-US",
-                messageHandler = null,
                 onCreated = {},
                 onReleased = {},
                 onBridgeCreated = { liveBridges.add(it) },
@@ -273,10 +263,9 @@ internal class WebViewIdentityTest {
 private fun TestWebViewSlot(
     identity: WebViewIdentity,
     locale: String,
-    messageHandler: PaywallWebViewMessageHandler?,
     onCreated: (String?) -> Unit,
     onReleased: (String?) -> Unit,
-    onUpdated: (String, PaywallWebViewMessageHandler?) -> Unit = { _, _ -> },
+    onUpdated: (String) -> Unit = { },
     onBridgeCreated: (WebViewJavaScriptBridge) -> Unit = {},
     onBridgeReleased: (WebViewJavaScriptBridge) -> Unit = {},
 ) {
@@ -292,7 +281,6 @@ private fun TestWebViewSlot(
                             componentId = id,
                             expectedUrl = identity.resolvedUrl,
                             locale = locale,
-                            messageHandler = messageHandler,
                             sizeToContentWidth = identity.sizeToContentWidth,
                             sizeToContentHeight = identity.sizeToContentHeight,
                         ).also { created ->
@@ -305,8 +293,8 @@ private fun TestWebViewSlot(
                 }
             },
             update = {
-                bridgeHolder.bridge?.update(locale = locale, messageHandler = messageHandler)
-                onUpdated(locale, messageHandler)
+                bridgeHolder.bridge?.update(locale = locale)
+                onUpdated(locale)
             },
             onRelease = { webView ->
                 val bridge = bridgeHolder.bridge


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Part **7** splitting #3757; **inert until Part 8** (#3787).

**Based on #3798 (6b).** Cleanly rebased; no temporary merge commits.

### Description
Compose view + style for web_view — required for sealed `ComponentStyle` exhaustiveness, but **unreachable at runtime** until Part 8:

- `WebViewComponentStyle`, `WebViewIdentity`, `WebViewComponentView`
- `ComponentView.kt`: `is WebViewComponentStyle -> WebViewComponentView(...)`
- Tests: identity, failure path, effective size

**This `ComponentView` arm is unreachable:** StyleFactory still returns `Result.Success(null)` for `WebViewComponent` (Part 3 stub) until Part 8 replaces it with `createWebViewComponentStyle`.

Verified: webview unit tests, `detektAll`.

**Labels:** `pr:feat`, `pr:RevenueCatUI`, `feat:Paywalls_V2`


### Series (splitting #3757)

PWENG-98

Parts 1 and 2 were dropped. Not a linear stack: parts 3, 4, 5 are independent
(each off `main`); `webview/deps-1-5` merges all three; the tail stacks linearly on
that merge (6b -> 7 -> 8; 6a folded into 6b, empty net diff).

| Part | PR | Base | Notes |
|------|-----|------|-------|
| 1 | ~~#3780~~ | - | dropped; value types collapsed to `Map<String, String>` |
| 2 | ~~#3784~~ | - | dropped; app-facing message handler cut from v1 |
| 3 | #3781 | `main` | schema component, not yet registered |
| 4 | #3782 | `main` | transport envelope + JSON hardening |
| 5 | #3783 | `main` | navigation policy + origin helpers |
| 6a | ~~#3796~~ | - | folded into 6b; empty net diff |
| 6b | #3798 | `main` | JavaScript bridge (includes former 6a) |
| 7 | #3786 | #3798 | Compose view + style |
| 8 | #3787 | #3786 | activation + unsupported protocol_version fallback |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f8d68f5-c4d5-4bd2-93a1-41b9f6e72c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



