### PR TITLE
feat(paywalls): Support Custom components

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
@@ -59,24 +59,29 @@ internal class PaywallComponentSerializer : KSerializer<PaywallComponent> {
             "tabs" -> jsonDecoder.json.decodeFromJsonElement<TabsComponent>(json)
             "video" -> jsonDecoder.json.decodeFromJsonElement<VideoComponent>(json)
             "countdown" -> jsonDecoder.json.decodeFromJsonElement<CountdownComponent>(json)
-            "web_view" -> {
-                // protocol_version is required; gate on the raw value BEFORE decoding so an absent,
-                // malformed, or unsupported (forward-incompatible) version falls back like an
-                // unrecognized component instead of failing to decode. The backend also guarantees
-                // protocol_version == 1 at publish time; this is client-side defense in depth.
-                val declaredVersion = (json["protocol_version"] as? JsonPrimitive)?.intOrNull
-                if (declaredVersion == WebViewComponent.SUPPORTED_PROTOCOL_VERSION) {
-                    jsonDecoder.json.decodeFromJsonElement<WebViewComponent>(json)
-                } else {
-                    decodeFallback(
-                        jsonDecoder,
-                        json,
-                        "No fallback provided for web_view with unsupported protocol_version: $declaredVersion",
-                    )
-                }
-            }
+            "web_view" -> decodeWebViewOrFallback(jsonDecoder, json)
             "fallback_header" -> FallbackHeaderComponent
             else -> decodeFallback(jsonDecoder, json, "No fallback provided for unknown type: $type")
+        }
+    }
+
+    // Gate on the raw protocol_version BEFORE decoding so an absent, malformed, or unsupported
+    // (forward-incompatible) version falls back like an unrecognized component instead of failing to
+    // decode the whole paywall. The backend also guarantees protocol_version == 1 at publish time; this
+    // is client-side defense in depth.
+    private fun decodeWebViewOrFallback(
+        jsonDecoder: JsonDecoder,
+        json: JsonObject,
+    ): PaywallComponent {
+        val declaredVersion = (json["protocol_version"] as? JsonPrimitive)?.intOrNull
+        return if (declaredVersion == WebViewComponent.SUPPORTED_PROTOCOL_VERSION) {
+            jsonDecoder.json.decodeFromJsonElement<WebViewComponent>(json)
+        } else {
+            decodeFallback(
+                jsonDecoder,
+                json,
+                "No fallback provided for web_view with unsupported protocol_version: $declaredVersion",
+            )
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -61,16 +60,12 @@ internal class PaywallComponentSerializer : KSerializer<PaywallComponent> {
             "video" -> jsonDecoder.json.decodeFromJsonElement<VideoComponent>(json)
             "countdown" -> jsonDecoder.json.decodeFromJsonElement<CountdownComponent>(json)
             "web_view" -> {
-                // Gate on the raw protocol_version BEFORE decoding, so an unsupported (and possibly
-                // forward-incompatible) version falls back like an unrecognized component instead of
-                // failing to decode against today's schema. The backend also rejects
-                // protocol_version != 1 at publish time; this is client-side defense in depth.
-                val versionElement = json["protocol_version"]
-                val declaredVersion = (versionElement as? JsonPrimitive)?.intOrNull
-                val versionSupported = versionElement == null ||
-                    versionElement is JsonNull ||
-                    declaredVersion == WebViewComponent.SUPPORTED_PROTOCOL_VERSION
-                if (versionSupported) {
+                // protocol_version is required; gate on the raw value BEFORE decoding so an absent,
+                // malformed, or unsupported (forward-incompatible) version falls back like an
+                // unrecognized component instead of failing to decode. The backend also guarantees
+                // protocol_version == 1 at publish time; this is client-side defense in depth.
+                val declaredVersion = (json["protocol_version"] as? JsonPrimitive)?.intOrNull
+                if (declaredVersion == WebViewComponent.SUPPORTED_PROTOCOL_VERSION) {
                     jsonDecoder.json.decodeFromJsonElement<WebViewComponent>(json)
                 } else {
                     decodeFallback(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
@@ -10,8 +10,11 @@ import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -57,12 +60,38 @@ internal class PaywallComponentSerializer : KSerializer<PaywallComponent> {
             "tabs" -> jsonDecoder.json.decodeFromJsonElement<TabsComponent>(json)
             "video" -> jsonDecoder.json.decodeFromJsonElement<VideoComponent>(json)
             "countdown" -> jsonDecoder.json.decodeFromJsonElement<CountdownComponent>(json)
-            "web_view" -> jsonDecoder.json.decodeFromJsonElement<WebViewComponent>(json)
+            "web_view" -> {
+                // Gate on the raw protocol_version BEFORE decoding, so an unsupported (and possibly
+                // forward-incompatible) version falls back like an unrecognized component instead of
+                // failing to decode against today's schema. The backend also rejects
+                // protocol_version != 1 at publish time; this is client-side defense in depth.
+                val versionElement = json["protocol_version"]
+                val declaredVersion = (versionElement as? JsonPrimitive)?.intOrNull
+                val versionSupported = versionElement == null ||
+                    versionElement is JsonNull ||
+                    declaredVersion == WebViewComponent.SUPPORTED_PROTOCOL_VERSION
+                if (versionSupported) {
+                    jsonDecoder.json.decodeFromJsonElement<WebViewComponent>(json)
+                } else {
+                    decodeFallback(
+                        jsonDecoder,
+                        json,
+                        "No fallback provided for web_view with unsupported protocol_version: $declaredVersion",
+                    )
+                }
+            }
             "fallback_header" -> FallbackHeaderComponent
-            else -> json["fallback"]
-                ?.let { it as? JsonObject }
-                ?.let { jsonDecoder.json.decodeFromJsonElement<PaywallComponent>(it) }
-                ?: throw SerializationException("No fallback provided for unknown type: $type")
+            else -> decodeFallback(jsonDecoder, json, "No fallback provided for unknown type: $type")
         }
     }
+
+    private fun decodeFallback(
+        jsonDecoder: JsonDecoder,
+        json: JsonObject,
+        missingFallbackMessage: String,
+    ): PaywallComponent =
+        json["fallback"]
+            ?.let { it as? JsonObject }
+            ?.let { jsonDecoder.json.decodeFromJsonElement<PaywallComponent>(it) }
+            ?: throw SerializationException(missingFallbackMessage)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
@@ -57,6 +57,7 @@ internal class PaywallComponentSerializer : KSerializer<PaywallComponent> {
             "tabs" -> jsonDecoder.json.decodeFromJsonElement<TabsComponent>(json)
             "video" -> jsonDecoder.json.decodeFromJsonElement<VideoComponent>(json)
             "countdown" -> jsonDecoder.json.decodeFromJsonElement<CountdownComponent>(json)
+            "web_view" -> jsonDecoder.json.decodeFromJsonElement<WebViewComponent>(json)
             "fallback_header" -> FallbackHeaderComponent
             else -> json["fallback"]
                 ?.let { it as? JsonObject }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
@@ -65,15 +65,17 @@ internal class PaywallComponentSerializer : KSerializer<PaywallComponent> {
         }
     }
 
-    // Gate on the raw protocol_version BEFORE decoding so an absent, malformed, or unsupported
-    // (forward-incompatible) version falls back like an unrecognized component instead of failing to
-    // decode the whole paywall. The backend also guarantees protocol_version == 1 at publish time; this
-    // is client-side defense in depth.
+    // Gate on the raw protocol_version before decoding, so an unsupported (forward-incompatible) version falls
+    // back without this SDK understanding that protocol's other fields. A missing or malformed version is a bad
+    // response rather than a newer protocol, so it fails the decode like an invalid v1 body would.
     private fun decodeWebViewOrFallback(
         jsonDecoder: JsonDecoder,
         json: JsonObject,
     ): PaywallComponent {
-        val declaredVersion = (json["protocol_version"] as? JsonPrimitive)?.intOrNull
+        val rawVersion = json["protocol_version"]
+        // intOrNull parses digits regardless of quoting, so exclude string primitives first.
+        val declaredVersion = (rawVersion as? JsonPrimitive)?.takeUnless { it.isString }?.intOrNull
+            ?: throw SerializationException("web_view protocol_version is missing or malformed: $rawVersion")
         return if (declaredVersion == WebViewComponent.SUPPORTED_PROTOCOL_VERSION) {
             jsonDecoder.json.decodeFromJsonElement<WebViewComponent>(json)
         } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -34,4 +34,16 @@ public class WebViewComponent(
     public val protocolVersion: Int,
     @get:JvmSynthetic
     public val size: Size,
-) : PaywallComponent
+) : PaywallComponent {
+
+    public companion object {
+        /**
+         * The host<->component bridge protocol version this SDK implements. A config declaring any
+         * other version is treated as an unrecognized component (rendered via its `fallback`). This is
+         * the single source of truth: `WebViewEnvelope.DEFAULT_PROTOCOL_VERSION` in `:ui:revenuecatui`
+         * derives from it, so the schema gate and the runtime handshake can never disagree.
+         */
+        @InternalRevenueCatAPI
+        public const val SUPPORTED_PROTOCOL_VERSION: Int = 1
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.paywalls.components
 
 import androidx.compose.runtime.Immutable
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.SerialName
@@ -34,6 +35,8 @@ public class WebViewComponent(
     public val protocolVersion: Int,
     @get:JvmSynthetic
     public val size: Size,
+    @get:JvmSynthetic
+    public val overrides: List<ComponentOverride<PartialWebViewComponent>> = emptyList(),
 ) : PaywallComponent {
 
     public companion object {
@@ -47,3 +50,17 @@ public class WebViewComponent(
         public const val SUPPORTED_PROTOCOL_VERSION: Int = 1
     }
 }
+
+/**
+ * The subset of [WebViewComponent] properties that can be adjusted by a rule-based
+ * [ComponentOverride]. Only [visible] is overridable; `url` and `size` always come from the base
+ * component.
+ */
+@InternalRevenueCatAPI
+@Poko
+@Serializable
+@Immutable
+public class PartialWebViewComponent(
+    @get:JvmSynthetic
+    public val visible: Boolean? = true,
+) : PartialComponent

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -4,7 +4,9 @@ import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.utils.filter
+import kotlinx.serialization.SerializationException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -64,6 +66,71 @@ class WebViewComponentTests {
             WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
             actual,
         )
+    }
+
+    @Test
+    fun `unsupported protocol_version renders the fallback component`() {
+        // A version this SDK cannot service is treated like an unrecognized component: the author's
+        // fallback is rendered instead of the web view.
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "protocol_version": 2,
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "fallback": {
+                "type": "stack",
+                "name": "web_view_fallback",
+                "components": []
+              }
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
+
+        assertThat(actual).isInstanceOf(StackComponent::class.java)
+        // Prove it is the author's fallback that came back, not some other stack.
+        assertThat((actual as StackComponent).name).isEqualTo("web_view_fallback")
+    }
+
+    @Test
+    fun `unsupported protocol_version renders the fallback even when the body is not valid v1 schema`() {
+        // Forward-compat: a future protocol version may ship an incompatible body (here, no `url`,
+        // which v1 requires). The version gate must route to the fallback BEFORE attempting to decode
+        // the body as today's WebViewComponent, so this must not throw.
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "protocol_version": 2,
+              "entrypoint": "https://paywalls.revenuecat.com/v2-bundle/index.html",
+              "fallback": {
+                "type": "stack",
+                "name": "web_view_fallback",
+                "components": []
+              }
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
+
+        assertThat(actual).isInstanceOf(StackComponent::class.java)
+        assertThat((actual as StackComponent).name).isEqualTo("web_view_fallback")
+    }
+
+    @Test
+    fun `unsupported protocol_version without a fallback throws`() {
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "protocol_version": 2,
+              "url": "https://paywalls.revenuecat.com/index.html"
+            }
+            """
+
+        assertThatThrownBy { JsonTools.json.decodeFromString<PaywallComponent>(json) }
+            .isInstanceOf(SerializationException::class.java)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -13,6 +13,8 @@ import kotlin.test.assertEquals
 
 class WebViewComponentTests {
 
+    private val fillFitSize = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit())
+
     @Language("json")
     private val fullJson = """
         {
@@ -41,18 +43,21 @@ class WebViewComponentTests {
         assertThat(webView.visible).isTrue()
         assertThat(webView.protocolVersion).isEqualTo(1)
         assertThat(webView.url).isEqualTo("https://assets.pawwalls.com/web_bundles/123/index.html")
-        assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()))
+        assertThat(webView.size).isEqualTo(fillFitSize)
     }
 
     @Test
     fun `ignores schema fallback field`() {
-        // web_view intentionally has no native fallback stack; older/dashboard payloads that
-        // still include `fallback` must decode without error (unknown keys are ignored).
+        // web_view intentionally has no native fallback stack; a supported-version payload that
+        // still includes `fallback` must decode as the web view (unknown keys are ignored).
         @Language("json")
         val json = """
             {
               "type": "web_view",
+              "id": "promo_web_view",
+              "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
               "fallback": {
                 "type": "stack",
                 "components": []
@@ -63,7 +68,12 @@ class WebViewComponentTests {
         val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
 
         assertEquals(
-            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            WebViewComponent(
+                url = "https://paywalls.revenuecat.com/index.html",
+                id = "promo_web_view",
+                protocolVersion = 1,
+                size = fillFitSize,
+            ),
             actual,
         )
     }
@@ -125,12 +135,37 @@ class WebViewComponentTests {
             {
               "type": "web_view",
               "protocol_version": 2,
+              "id": "promo_web_view",
               "url": "https://paywalls.revenuecat.com/index.html"
             }
             """
 
         assertThatThrownBy { JsonTools.json.decodeFromString<PaywallComponent>(json) }
             .isInstanceOf(SerializationException::class.java)
+    }
+
+    @Test
+    fun `missing protocol_version renders the fallback component`() {
+        // protocol_version is required; an absent version is treated like an unsupported one and
+        // routes to the author's fallback rather than decoding as a web view.
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "id": "promo_web_view",
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "fallback": {
+                "type": "stack",
+                "name": "web_view_fallback",
+                "components": []
+              }
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
+
+        assertThat(actual).isInstanceOf(StackComponent::class.java)
+        assertThat((actual as StackComponent).name).isEqualTo("web_view_fallback")
     }
 
     @Test
@@ -141,7 +176,10 @@ class WebViewComponentTests {
         val json = """
             {
               "type": "web_view",
+              "id": "promo_web_view",
+              "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
               "capabilities": {
                 "network_access": { "allowed_domains": ["api.segment.io"] },
                 "camera": true,
@@ -156,7 +194,12 @@ class WebViewComponentTests {
         val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
 
         assertEquals(
-            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            WebViewComponent(
+                url = "https://paywalls.revenuecat.com/index.html",
+                id = "promo_web_view",
+                protocolVersion = 1,
+                size = fillFitSize,
+            ),
             actual,
         )
     }
@@ -167,8 +210,10 @@ class WebViewComponentTests {
         val templateJson = """
             {
               "type": "web_view",
+              "id": "promo_web_view",
               "protocol_version": 1,
-              "url": "https://paywalls.revenuecat.com/{{ custom.animal }}.html"
+              "url": "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
             }
             """
 
@@ -177,39 +222,53 @@ class WebViewComponentTests {
         assertEquals(
             WebViewComponent(
                 url = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
+                id = "promo_web_view",
                 protocolVersion = 1,
+                size = fillFitSize,
             ),
             actual,
         )
     }
 
     @Test
-    fun `deserializes minimal shape with defaults for missing optional fields`() {
-        // Older/partial configs may omit protocol_version and size. These should still
-        // decode without crashing, using defaults.
+    fun `decodes with defaults for missing name and visible`() {
+        // Only name and visible are optional; id, url, protocol_version, and size are required.
         @Language("json")
-        val minimalJson = """
+        val json = """
             {
               "type": "web_view",
-              "url": "https://paywalls.revenuecat.com/index.html"
+              "id": "promo_web_view",
+              "protocol_version": 1,
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
             }
             """
 
-        val actual = JsonTools.json.decodeFromString<PaywallComponent>(minimalJson)
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
 
         assertEquals(
-            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            WebViewComponent(
+                url = "https://paywalls.revenuecat.com/index.html",
+                id = "promo_web_view",
+                protocolVersion = 1,
+                size = fillFitSize,
+            ),
             actual,
         )
         val webView = actual as WebViewComponent
-        assertThat(webView.protocolVersion).isNull()
-        assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()))
+        assertThat(webView.name).isNull()
+        assertThat(webView.visible).isNull()
     }
 
     @Test
     fun `filter treats web_view as a leaf component`() {
         // web_view has no child components, so filtering a tree should return only the component itself.
-        val webView = WebViewComponent(url = "https://paywalls.revenuecat.com/index.html")
+        val webView = WebViewComponent(
+            url = "https://paywalls.revenuecat.com/index.html",
+            id = "promo_web_view",
+            protocolVersion = 1,
+            size = fillFitSize,
+        )
 
         val matches = webView.filter { it is WebViewComponent }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -5,18 +5,11 @@ import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.utils.filter
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import kotlin.test.assertEquals
 
-/**
- * Decodes [WebViewComponent] directly (not via [PaywallComponent]) because the polymorphic
- * `"web_view" ->` serializer registration lands in A8. A8 restores polymorphic decode tests.
- */
 class WebViewComponentTests {
-
-    private val fillFitSize = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit())
 
     @Language("json")
     private val fullJson = """
@@ -36,14 +29,17 @@ class WebViewComponentTests {
 
     @Test
     fun `deserializes full Khepri schema`() {
-        val webView = JsonTools.json.decodeFromString<WebViewComponent>(fullJson)
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(fullJson)
+
+        assertThat(actual).isInstanceOf(WebViewComponent::class.java)
+        val webView = actual as WebViewComponent
 
         assertThat(webView.id).isEqualTo("promo_web_view")
         assertThat(webView.name).isEqualTo("Promo web component")
         assertThat(webView.visible).isTrue()
         assertThat(webView.protocolVersion).isEqualTo(1)
         assertThat(webView.url).isEqualTo("https://assets.pawwalls.com/web_bundles/123/index.html")
-        assertThat(webView.size).isEqualTo(fillFitSize)
+        assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()))
     }
 
     @Test
@@ -54,10 +50,7 @@ class WebViewComponentTests {
         val json = """
             {
               "type": "web_view",
-              "id": "promo_web_view",
-              "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html",
-              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
               "fallback": {
                 "type": "stack",
                 "components": []
@@ -65,15 +58,10 @@ class WebViewComponentTests {
             }
             """
 
-        val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
 
         assertEquals(
-            WebViewComponent(
-                url = "https://paywalls.revenuecat.com/index.html",
-                id = "promo_web_view",
-                protocolVersion = 1,
-                size = fillFitSize,
-            ),
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
             actual,
         )
     }
@@ -86,10 +74,7 @@ class WebViewComponentTests {
         val json = """
             {
               "type": "web_view",
-              "id": "promo_web_view",
-              "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html",
-              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
               "capabilities": {
                 "network_access": { "allowed_domains": ["api.segment.io"] },
                 "camera": true,
@@ -101,15 +86,10 @@ class WebViewComponentTests {
             }
             """
 
-        val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
 
         assertEquals(
-            WebViewComponent(
-                url = "https://paywalls.revenuecat.com/index.html",
-                id = "promo_web_view",
-                protocolVersion = 1,
-                size = fillFitSize,
-            ),
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
             actual,
         )
     }
@@ -120,109 +100,49 @@ class WebViewComponentTests {
         val templateJson = """
             {
               "type": "web_view",
-              "id": "promo_web_view",
               "protocol_version": 1,
-              "url": "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
-              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
+              "url": "https://paywalls.revenuecat.com/{{ custom.animal }}.html"
             }
             """
 
-        val actual = JsonTools.json.decodeFromString<WebViewComponent>(templateJson)
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(templateJson)
 
         assertEquals(
             WebViewComponent(
                 url = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
-                id = "promo_web_view",
                 protocolVersion = 1,
-                size = fillFitSize,
             ),
             actual,
         )
     }
 
     @Test
-    fun `decodes with defaults for missing name and visible`() {
-        // Only name and visible are optional; id, url, protocol_version, and size are required.
+    fun `deserializes minimal shape with defaults for missing optional fields`() {
+        // Older/partial configs may omit protocol_version and size. These should still
+        // decode without crashing, using defaults.
         @Language("json")
-        val json = """
+        val minimalJson = """
             {
               "type": "web_view",
-              "id": "promo_web_view",
-              "protocol_version": 1,
-              "url": "https://paywalls.revenuecat.com/index.html",
-              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
-            }
-            """
-
-        val actual = JsonTools.json.decodeFromString<WebViewComponent>(json)
-
-        assertEquals(
-            WebViewComponent(
-                url = "https://paywalls.revenuecat.com/index.html",
-                id = "promo_web_view",
-                protocolVersion = 1,
-                size = fillFitSize,
-            ),
-            actual,
-        )
-        assertThat(actual.name).isNull()
-        assertThat(actual.visible).isNull()
-    }
-
-    @Test
-    fun `fails to decode when required id is missing`() {
-        @Language("json")
-        val json = """
-            {
-              "type": "web_view",
-              "protocol_version": 1,
-              "url": "https://paywalls.revenuecat.com/index.html",
-              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
-            }
-            """
-
-        assertThatThrownBy { JsonTools.json.decodeFromString<WebViewComponent>(json) }
-    }
-
-    @Test
-    fun `fails to decode when required protocol_version is missing`() {
-        @Language("json")
-        val json = """
-            {
-              "type": "web_view",
-              "id": "promo_web_view",
-              "url": "https://paywalls.revenuecat.com/index.html",
-              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
-            }
-            """
-
-        assertThatThrownBy { JsonTools.json.decodeFromString<WebViewComponent>(json) }
-    }
-
-    @Test
-    fun `fails to decode when required size is missing`() {
-        @Language("json")
-        val json = """
-            {
-              "type": "web_view",
-              "id": "promo_web_view",
-              "protocol_version": 1,
               "url": "https://paywalls.revenuecat.com/index.html"
             }
             """
 
-        assertThatThrownBy { JsonTools.json.decodeFromString<WebViewComponent>(json) }
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(minimalJson)
+
+        assertEquals(
+            WebViewComponent(url = "https://paywalls.revenuecat.com/index.html"),
+            actual,
+        )
+        val webView = actual as WebViewComponent
+        assertThat(webView.protocolVersion).isNull()
+        assertThat(webView.size).isEqualTo(Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()))
     }
 
     @Test
     fun `filter treats web_view as a leaf component`() {
         // web_view has no child components, so filtering a tree should return only the component itself.
-        val webView = WebViewComponent(
-            url = "https://paywalls.revenuecat.com/index.html",
-            id = "promo_web_view",
-            protocolVersion = 1,
-            size = fillFitSize,
-        )
+        val webView = WebViewComponent(url = "https://paywalls.revenuecat.com/index.html")
 
         val matches = webView.filter { it is WebViewComponent }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -145,14 +145,29 @@ class WebViewComponentTests {
     }
 
     @Test
-    fun `missing protocol_version renders the fallback component`() {
-        // protocol_version is required; an absent version is treated like an unsupported one and
-        // routes to the author's fallback rather than decoding as a web view.
-        @Language("json")
+    fun `missing protocol_version throws even with a fallback`() {
+        assertMalformedVersionThrows(protocolVersionField = "")
+    }
+
+    @Test
+    fun `quoted protocol_version throws instead of being coerced`() {
+        // intOrNull parses digits regardless of quoting, so a quoted "1" must not slip past the gate.
+        assertMalformedVersionThrows(""""protocol_version": "1",""")
+    }
+
+    @Test
+    fun `non-numeric protocol_version throws even with a fallback`() {
+        assertMalformedVersionThrows(""""protocol_version": true,""")
+    }
+
+    // A malformed version is a bad response rather than a newer protocol, so it fails the whole decode
+    // (default paywall) instead of rendering the author's fallback.
+    private fun assertMalformedVersionThrows(protocolVersionField: String) {
         val json = """
             {
               "type": "web_view",
               "id": "promo_web_view",
+              $protocolVersionField
               "url": "https://paywalls.revenuecat.com/index.html",
               "fallback": {
                 "type": "stack",
@@ -162,10 +177,23 @@ class WebViewComponentTests {
             }
             """
 
-        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
+        assertThatThrownBy { JsonTools.json.decodeFromString<PaywallComponent>(json) }
+            .isInstanceOf(SerializationException::class.java)
+    }
 
-        assertThat(actual).isInstanceOf(StackComponent::class.java)
-        assertThat((actual as StackComponent).name).isEqualTo("web_view_fallback")
+    @Test
+    fun `supported protocol_version with another required field missing still throws`() {
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "protocol_version": 1,
+              "url": "https://paywalls.revenuecat.com/index.html"
+            }
+            """
+
+        assertThatThrownBy { JsonTools.json.decodeFromString<PaywallComponent>(json) }
+            .isInstanceOf(SerializationException::class.java)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.paywalls.components
 
 import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.utils.filter
@@ -301,5 +302,51 @@ class WebViewComponentTests {
         val matches = webView.filter { it is WebViewComponent }
 
         assertThat(matches).containsExactly(webView)
+    }
+
+    @Test
+    fun `decodes with no overrides by default`() {
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(fullJson) as WebViewComponent
+
+        assertThat(actual.overrides).isEmpty()
+    }
+
+    @Test
+    fun `decodes a rule-based visibility override, matching the dashboard-published shape`() {
+        // Regression test: a dashboard rule that shows/hides a web_view previously failed SDK
+        // decoding entirely with `extra_forbidden` on `...web_view.overrides` (PWENG-152).
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "id": "promo_web_view",
+              "protocol_version": 1,
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
+              "overrides": [
+                {
+                  "conditions": [{ "type": "selected" }],
+                  "properties": { "visible": false }
+                },
+                {
+                  "conditions": [{ "type": "expanded" }],
+                  "properties": { "visible": true }
+                }
+              ]
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json) as WebViewComponent
+
+        assertThat(actual.overrides).containsExactly(
+            ComponentOverride(
+                conditions = listOf(ComponentOverride.Condition.Selected),
+                properties = PartialWebViewComponent(visible = false),
+            ),
+            ComponentOverride(
+                conditions = listOf(ComponentOverride.Condition.Expanded),
+                properties = PartialWebViewComponent(visible = true),
+            ),
+        )
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedWebViewPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedWebViewPartial.kt
@@ -1,0 +1,19 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import com.revenuecat.purchases.paywalls.components.PartialWebViewComponent
+import dev.drewhamilton.poko.Poko
+
+@Poko
+internal class PresentedWebViewPartial(
+    @get:JvmSynthetic val partial: PartialWebViewComponent,
+) : PresentedPartial<PresentedWebViewPartial> {
+    override fun combine(with: PresentedWebViewPartial?): PresentedWebViewPartial {
+        val otherPartial = with?.partial
+
+        return PresentedWebViewPartial(
+            partial = PartialWebViewComponent(
+                visible = otherPartial?.visible ?: partial.visible,
+            ),
+        )
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -96,6 +96,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ImageComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
@@ -980,6 +981,7 @@ private val ComponentStyle.shouldIgnoreTopWindowInsets: Boolean
     get() = when (this) {
         is ImageComponentStyle -> ignoreTopWindowInsets
         is VideoComponentStyle -> ignoreTopWindowInsets
+        is WebViewComponentStyle -> ignoreTopWindowInsets
         else -> false
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -590,7 +590,6 @@ internal class StyleFactory(
                 visible = component.visible ?: DEFAULT_VISIBILITY,
                 size = component.size,
                 componentId = component.id,
-                protocolVersion = component.protocolVersion,
             ),
         )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -574,13 +574,25 @@ internal class StyleFactory(
             is TabsComponent -> createTabsComponentStyle(component)
             is VideoComponent -> createVideoComponentStyle(component)
             is FallbackHeaderComponent -> Result.Success(null)
-            // Stub until Part 8 wires createWebViewComponentStyle; null style is filtered like FallbackHeader.
-            is WebViewComponent -> Result.Success(null)
+            is WebViewComponent -> createWebViewComponentStyle(component)
             is CountdownComponent -> createCountdownComponentStyle(
                 component,
             )
         }
     }
+
+    private fun StyleFactoryScope.createWebViewComponentStyle(
+        component: WebViewComponent,
+    ): Result<WebViewComponentStyle, NonEmptyList<PaywallValidationError>> =
+        Result.Success(
+            WebViewComponentStyle(
+                url = component.url,
+                visible = component.visible ?: DEFAULT_VISIBILITY,
+                size = component.size,
+                componentId = component.id,
+                protocolVersion = component.protocolVersion,
+            ),
+        )
 
     private fun StyleFactoryScope.createCountdownComponentStyle(
         component: CountdownComponent,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -48,6 +48,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.PresentedTabsPartial
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedTimelineItemPartial
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedTimelinePartial
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedVideoPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedWebViewPartial
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.LocalizationDictionary
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.imageForAllLocales
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.stringForAllLocales
@@ -576,15 +577,23 @@ internal class StyleFactory(
     private fun StyleFactoryScope.createWebViewComponentStyle(
         component: WebViewComponent,
     ): Result<WebViewComponentStyle, NonEmptyList<PaywallValidationError>> =
-        Result.Success(
-            WebViewComponentStyle(
-                url = component.url,
-                visible = component.visible ?: DEFAULT_VISIBILITY,
-                size = component.size,
-                componentId = component.id,
-                ignoreTopWindowInsets = ignoreTopWindowInsets,
-            ),
-        )
+        component.overrides
+            .toPresentedOverrides(stripRules) { partial -> Result.Success(PresentedWebViewPartial(partial)) }
+            .mapError { nonEmptyListOf(it) }
+            .map { presentedOverrides ->
+                WebViewComponentStyle(
+                    url = component.url,
+                    visible = component.visible ?: DEFAULT_VISIBILITY,
+                    size = component.size,
+                    componentId = component.id,
+                    overrides = presentedOverrides,
+                    rcPackage = rcPackage,
+                    resolvedOffer = resolvedOffer,
+                    tabIndex = tabControlIndex,
+                    offerEligibility = offerEligibility,
+                    ignoreTopWindowInsets = ignoreTopWindowInsets,
+                )
+            }
 
     private fun StyleFactoryScope.createCountdownComponentStyle(
         component: CountdownComponent,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -188,7 +188,8 @@ internal class StyleFactory(
             var topWindowInsetsApplied = false
 
             /**
-             * Whether the first visual component in the tree is a full-width image or video (a "hero image").
+             * Whether the first visual component in the tree is a full-width image, video or web_view (a
+             * "hero image").
              * This is tracked separately from [topWindowInsetsApplied] because a hero image can appear
              * outside a ZLayer (e.g. directly in a Vertical stack), in which case it doesn't affect
              * top window insets application but still needs to be detected for header padding logic.
@@ -201,9 +202,9 @@ internal class StyleFactory(
             private var stillLookingForHeaderMedia = true
 
             /**
-             * This will be called for every component in the tree, and will determine whether we have a header image
-             * or video that needs special top-window-insets treatment. A header image is found if the first
-             * non-container component is an image component with a Fill width and a ZLayer parent stack.
+             * This will be called for every component in the tree, and will determine whether we have header media
+             * that needs special top-window-insets treatment. Header media is found if the first non-container
+             * component is an image, video or web_view component with a Fill width and a ZLayer parent stack.
              */
             fun handleHeaderMediaViewWindowInsets(component: PaywallComponent) {
                 when (component) {
@@ -222,18 +223,14 @@ internal class StyleFactory(
                         }
                     }
 
-                    is ImageComponent -> {
+                    is ImageComponent,
+                    is VideoComponent,
+                    is WebViewComponent,
+                    -> {
                         if (stillLookingForHeaderMedia) {
-                            ignoreTopWindowInsets = component.isHeaderImage
-                            heroImageDetected = component.isHeaderImage
-                        }
-                        stillLookingForHeaderMedia = false
-                    }
-
-                    is VideoComponent -> {
-                        if (stillLookingForHeaderMedia) {
-                            ignoreTopWindowInsets = component.isHeaderVideo
-                            heroImageDetected = component.isHeaderVideo
+                            val isHero = component.isHeaderMedia
+                            ignoreTopWindowInsets = isHero
+                            heroImageDetected = isHero
                         }
                         stillLookingForHeaderMedia = false
                     }
@@ -244,25 +241,20 @@ internal class StyleFactory(
             }
 
             private val PaywallComponent.isHeaderMedia: Boolean
-                get() = isHeaderImage || isHeaderVideo
+                get() = when (this) {
+                    is ImageComponent -> size.width.isFill
+                    is VideoComponent -> size.width.isFill
+                    is WebViewComponent -> size.width.isFill
+                    else -> false
+                }
 
-            private val PaywallComponent.isHeaderImage: Boolean
-                get() = this is ImageComponent &&
-                    when (size.width) {
-                        is SizeConstraint.Fill -> true
-                        is SizeConstraint.Fit,
-                        is SizeConstraint.Fixed,
-                        -> false
-                    }
-
-            private val PaywallComponent.isHeaderVideo: Boolean
-                get() = this is VideoComponent &&
-                    when (size.width) {
-                        is SizeConstraint.Fill -> true
-                        is SizeConstraint.Fit,
-                        is SizeConstraint.Fixed,
-                        -> false
-                    }
+            private val SizeConstraint.isFill: Boolean
+                get() = when (this) {
+                    is SizeConstraint.Fill -> true
+                    is SizeConstraint.Fit,
+                    is SizeConstraint.Fixed,
+                    -> false
+                }
         }
 
         val windowInsetsState = WindowInsetsState()
@@ -590,6 +582,7 @@ internal class StyleFactory(
                 visible = component.visible ?: DEFAULT_VISIBILITY,
                 size = component.size,
                 componentId = component.id,
+                ignoreTopWindowInsets = ignoreTopWindowInsets,
             ),
         )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -12,4 +12,5 @@ internal data class WebViewComponentStyle(
     override val size: Size,
     /** Schema `web_view.id`, sent to the content during the handshake. A blank id renders nothing. */
     val componentId: String,
+    val ignoreTopWindowInsets: Boolean = false,
 ) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -3,7 +3,13 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.style
 
 import androidx.compose.runtime.Immutable
+import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverride
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedWebViewPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageContext
+import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
+import com.revenuecat.purchases.ui.revenuecatui.helpers.ResolvedOffer
 
 @Immutable
 internal data class WebViewComponentStyle(
@@ -12,5 +18,32 @@ internal data class WebViewComponentStyle(
     override val size: Size,
     /** Schema `web_view.id`, sent to the content during the handshake. A blank id renders nothing. */
     val componentId: String,
+    val overrides: List<PresentedOverride<PresentedWebViewPartial>>,
+    /**
+     * If this is non-null and equal to the currently selected package, the `selected` [overrides] will be used if
+     * available.
+     */
+    @get:JvmSynthetic
+    override val rcPackage: Package?,
+    /**
+     * The resolved offer for this package, containing the subscription option and promo offer status.
+     * Used to determine offer eligibility and pricing phase information.
+     */
+    @get:JvmSynthetic
+    override val resolvedOffer: ResolvedOffer? = null,
+    /**
+     * If this is non-null and equal to the currently selected tab index, the `selected` [overrides] will be used if
+     * available. This should only be set for web views inside tab control elements. Not for all web views within a
+     * tab.
+     */
+    @get:JvmSynthetic
+    override val tabIndex: Int?,
+    /**
+     * The pre-computed offer eligibility for this component's package context.
+     * Used for applying conditional overrides based on intro/promo offer status.
+     * Null if this component is not in a package scope.
+     */
+    @get:JvmSynthetic
+    override val offerEligibility: OfferEligibility? = null,
     val ignoreTopWindowInsets: Boolean = false,
-) : ComponentStyle
+) : ComponentStyle, PackageContext

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentState.kt
@@ -1,0 +1,114 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.window.core.layout.WindowWidthSizeClass
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
+import com.revenuecat.purchases.ui.revenuecatui.components.ConditionContext
+import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
+import com.revenuecat.purchases.ui.revenuecatui.components.buildPresentedPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDelegate
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallStateStore
+
+@Stable
+@JvmSynthetic
+@Composable
+internal fun rememberUpdatedWebViewComponentState(
+    style: WebViewComponentStyle,
+    paywallState: PaywallState.Loaded.Components,
+): WebViewComponentState = rememberUpdatedWebViewComponentState(
+    style = style,
+    selectedPackageInfoProvider = { paywallState.selectedPackageInfo },
+    selectedTabIndexProvider = { paywallState.selectedTabIndex },
+    selectedOfferEligibilityProvider = { paywallState.selectedOfferEligibility },
+    customVariablesProvider = { paywallState.mergedCustomVariables },
+    stateStoreProvider = { paywallState.stateStore },
+)
+
+@Suppress("LongParameterList")
+@Stable
+@JvmSynthetic
+@Composable
+private fun rememberUpdatedWebViewComponentState(
+    style: WebViewComponentStyle,
+    selectedPackageInfoProvider: () -> PaywallState.Loaded.Components.SelectedPackageInfo?,
+    selectedTabIndexProvider: () -> Int,
+    selectedOfferEligibilityProvider: () -> OfferEligibility,
+    customVariablesProvider: () -> Map<String, CustomVariableValue>,
+    stateStoreProvider: () -> PaywallStateStore,
+): WebViewComponentState {
+    val windowSize = currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass
+
+    return remember(style) {
+        WebViewComponentState(
+            initialWindowSize = windowSize,
+            style = style,
+            selectedPackageInfoProvider = selectedPackageInfoProvider,
+            selectedTabIndexProvider = selectedTabIndexProvider,
+            selectedOfferEligibilityProvider = selectedOfferEligibilityProvider,
+            customVariablesProvider = customVariablesProvider,
+            stateStoreProvider = stateStoreProvider,
+        )
+    }.apply {
+        update(windowSize = windowSize)
+    }
+}
+
+@Suppress("LongParameterList")
+@Stable
+internal class WebViewComponentState(
+    initialWindowSize: WindowWidthSizeClass,
+    private val style: WebViewComponentStyle,
+    private val selectedPackageInfoProvider: () -> PaywallState.Loaded.Components.SelectedPackageInfo?,
+    private val selectedTabIndexProvider: () -> Int,
+    private val selectedOfferEligibilityProvider: () -> OfferEligibility,
+    private val customVariablesProvider: () -> Map<String, CustomVariableValue> = { emptyMap() },
+    private val stateStoreProvider: () -> PaywallStateStore = { PaywallStateStore(emptyMap()) },
+) {
+    private var windowSize by mutableStateOf(initialWindowSize)
+
+    private val packageAwareDelegate = PackageAwareDelegate(
+        style = style,
+        selectedPackageInfoProvider = selectedPackageInfoProvider,
+        selectedTabIndexProvider = selectedTabIndexProvider,
+        selectedOfferEligibilityProvider = selectedOfferEligibilityProvider,
+    )
+
+    private val presentedPartial by derivedStateOf {
+        val windowCondition = ScreenCondition.from(windowSize)
+        val componentState =
+            if (packageAwareDelegate.isSelected) ComponentViewState.SELECTED else ComponentViewState.DEFAULT
+
+        style.overrides.buildPresentedPartial(
+            windowCondition,
+            packageAwareDelegate.offerEligibility,
+            componentState,
+            conditionContext = ConditionContext(
+                selectedPackageId = selectedPackageInfoProvider()?.rcPackage?.identifier,
+                customVariables = customVariablesProvider(),
+                stateReader = stateStoreProvider()::currentValueOrDefault,
+            ),
+        )
+    }
+
+    // url/componentId/size always come from the base component; only visible is overridable.
+    @get:JvmSynthetic
+    val visible by derivedStateOf { presentedPartial?.partial?.visible ?: style.visible }
+
+    @JvmSynthetic
+    fun update(windowSize: WindowWidthSizeClass? = null) {
+        if (windowSize != null) this.windowSize = windowSize
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -42,14 +42,14 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 @JvmSynthetic
 @Composable
-// `state` is unused in v1 but kept for the uniform ComponentView signature (variables land later).
-@Suppress("LongMethod", "ReturnCount", "UnusedParameter")
+@Suppress("LongMethod", "ReturnCount")
 internal fun WebViewComponentView(
     style: WebViewComponentStyle,
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
 ) {
-    if (!style.visible) return
+    val webViewState = rememberUpdatedWebViewComponentState(style, state)
+    if (!webViewState.visible) return
 
     val resolvedUrl = remember(style.url) {
         WebViewUrlResolver.resolve(style.url)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -1,7 +1,10 @@
 @file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -63,7 +66,10 @@ internal data class WebViewEnvelope(
         const val CHANNEL: String = "rc-web-components"
         const val NATIVE_OBJECT_NAME: String = "rcWebComponents"
         const val RECEIVE_FUNCTION: String = "__rcWebComponentsReceive"
-        const val DEFAULT_PROTOCOL_VERSION: Int = 1
+
+        // Single source of truth lives in the schema module so the decode-time gate and this runtime
+        // handshake version can never disagree.
+        const val DEFAULT_PROTOCOL_VERSION: Int = WebViewComponent.SUPPORTED_PROTOCOL_VERSION
 
         private val json = Json {
             ignoreUnknownKeys = true

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -524,7 +524,7 @@ internal fun PaywallComponent.containsUnsupportedCondition(): Boolean = when (th
     is TabControlToggleComponent -> false
     is TabControlComponent -> false
     is FallbackHeaderComponent -> false
-    is WebViewComponent -> false
+    is WebViewComponent -> overrides.hasUnsupportedCondition()
 }
 
 @JvmSynthetic

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallComponentDataValidationTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallComponentDataValidationTests.kt
@@ -18,6 +18,7 @@ import com.revenuecat.purchases.paywalls.components.PartialTextComponent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import kotlinx.serialization.SerializationException
@@ -947,6 +948,59 @@ class PaywallComponentDataValidationTests {
                                         height = 100u,
                                     ),
                                 )
+                            ),
+                            TestData.Components.monthlyPackageComponent,
+                        )
+                    ),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    header = HeaderComponent(stack = StackComponent(components = emptyList())),
+                ),
+            ),
+            componentsLocalizations = mapOf(
+                defaultLocale to mapOf(LocalizationKey("key1") to LocalizationData.Text("value1")),
+            ),
+            defaultLocaleIdentifier = defaultLocale,
+        )
+        val offering = Offering(
+            identifier = "identifier",
+            serverDescription = "serverDescription",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly),
+            paywallComponents = Offering.PaywallComponents(UiConfig(), data),
+        )
+
+        // Act
+        val validated = offering.validatedPaywall(TestData.Constants.currentColorScheme, MockResourceProvider())
+
+        // Assert
+        assertTrue(validated is PaywallValidationResult.Components)
+        assertNull(validated.errors)
+        val result = validated as PaywallValidationResult.Components
+        assertTrue(result.mainStackHasHeroImage)
+        assertNotNull(result.header)
+    }
+
+    @Test
+    fun `Should set mainStackHasHeroImage when header and full-width web_view coexist`() {
+        // Arrange - web_view directly in the root Vertical stack, not wrapped in a ZLayer
+        val defaultLocale = LocaleId("en_US")
+        val data = PaywallComponentsData(
+            id = "paywall_id",
+            templateName = "template",
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(
+                        dimension = Dimension.Vertical(HorizontalAlignment.CENTER, START),
+                        components = listOf(
+                            WebViewComponent(
+                                url = "https://bundle-hash.components.revenuecat-static.com/index.html",
+                                id = "hero_web_view",
+                                protocolVersion = 1,
+                                size = Size(
+                                    width = SizeConstraint.Fill,
+                                    height = SizeConstraint.Fit(default = 400u),
+                                ),
                             ),
                             TestData.Components.monthlyPackageComponent,
                         )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -138,23 +138,6 @@ class StyleFactoryTests {
         assertThat(style.visible).isFalse()
         assertThat(style.size).isEqualTo(size)
         assertThat(style.componentId).isEqualTo("promo_web_view")
-        assertThat(style.protocolVersion).isEqualTo(1)
-    }
-
-    @Test
-    fun `Should pass protocolVersion through to the WebViewComponentStyle`() {
-        val component = WebViewComponent(
-            url = "https://paywalls.revenuecat.com/index.html",
-            id = "promo_web_view",
-            protocolVersion = 1,
-            size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()),
-        )
-
-        val result = styleFactory.create(component)
-
-        assertThat(result).isInstanceOf(Result.Success::class.java)
-        val style = (result as Result.Success).value.componentStyle as WebViewComponentStyle
-        assertThat(style.protocolVersion).isEqualTo(1)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -125,6 +125,7 @@ class StyleFactoryTests {
         val component = WebViewComponent(
             url = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
             id = "promo_web_view",
+            protocolVersion = 1,
             visible = false,
             size = size,
         )
@@ -137,14 +138,16 @@ class StyleFactoryTests {
         assertThat(style.visible).isFalse()
         assertThat(style.size).isEqualTo(size)
         assertThat(style.componentId).isEqualTo("promo_web_view")
-        assertThat(style.protocolVersion).isNull()
+        assertThat(style.protocolVersion).isEqualTo(1)
     }
 
     @Test
     fun `Should pass protocolVersion through to the WebViewComponentStyle`() {
         val component = WebViewComponent(
             url = "https://paywalls.revenuecat.com/index.html",
+            id = "promo_web_view",
             protocolVersion = 1,
+            size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()),
         )
 
         val result = styleFactory.create(component)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -120,30 +120,38 @@ class StyleFactoryTests {
     }
 
     @Test
-    fun `Should return null style for WebViewComponent until style factory is wired`() {
-        // Stub arm mirrors FallbackHeaderComponent: createInternal returns Result.Success(null),
-        // so a web_view nested in a stack is filtered out. Real WebViewComponentStyle lands later.
-        val stackComponent = StackComponent(
-            components = listOf(
-                WebViewComponent(
-                    url = "https://paywalls.revenuecat.com/index.html",
-                    id = "promo_web_view",
-                    protocolVersion = 1,
-                    size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()),
-                ),
-                TextComponent(
-                    text = LOCALIZATION_KEY_TEXT_1,
-                    color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
-                ),
-            ),
+    fun `Should create a WebViewComponentStyle for a WebViewComponent`() {
+        val size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit())
+        val component = WebViewComponent(
+            url = "https://paywalls.revenuecat.com/{{ custom.animal }}.html",
+            id = "promo_web_view",
+            visible = false,
+            size = size,
         )
 
-        val result = styleFactory.create(stackComponent)
+        val result = styleFactory.create(component)
 
         assertThat(result).isInstanceOf(Result.Success::class.java)
-        val style = (result as Result.Success).value.componentStyle as StackComponentStyle
-        assertThat(style.children).hasSize(1)
-        assertThat(style.children[0]).isInstanceOf(TextComponentStyle::class.java)
+        val style = (result as Result.Success).value.componentStyle as WebViewComponentStyle
+        assertThat(style.url).isEqualTo("https://paywalls.revenuecat.com/{{ custom.animal }}.html")
+        assertThat(style.visible).isFalse()
+        assertThat(style.size).isEqualTo(size)
+        assertThat(style.componentId).isEqualTo("promo_web_view")
+        assertThat(style.protocolVersion).isNull()
+    }
+
+    @Test
+    fun `Should pass protocolVersion through to the WebViewComponentStyle`() {
+        val component = WebViewComponent(
+            url = "https://paywalls.revenuecat.com/index.html",
+            protocolVersion = 1,
+        )
+
+        val result = styleFactory.create(component)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as WebViewComponentStyle
+        assertThat(style.protocolVersion).isEqualTo(1)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.paywalls.components.PackageComponent
 import com.revenuecat.purchases.paywalls.components.PartialImageComponent
 import com.revenuecat.purchases.paywalls.components.PartialPackageComponent
 import com.revenuecat.purchases.paywalls.components.PartialTextComponent
+import com.revenuecat.purchases.paywalls.components.PartialWebViewComponent
 import com.revenuecat.purchases.paywalls.components.PurchaseButtonComponent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.TabControlButtonComponent
@@ -138,6 +139,33 @@ class StyleFactoryTests {
         assertThat(style.visible).isFalse()
         assertThat(style.size).isEqualTo(size)
         assertThat(style.componentId).isEqualTo("promo_web_view")
+        assertThat(style.overrides).isEmpty()
+    }
+
+    @Test
+    fun `WebViewComponentStyle overrides are populated from component overrides`() {
+        // Arrange
+        val webViewComponent = WebViewComponent(
+            url = "https://paywalls.revenuecat.com/index.html",
+            id = "promo_web_view",
+            protocolVersion = 1,
+            size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()),
+            overrides = listOf(
+                ComponentOverride(
+                    conditions = listOf(ComponentOverride.Condition.Selected),
+                    properties = PartialWebViewComponent(visible = false),
+                ),
+            ),
+        )
+
+        // Act
+        val result = styleFactory.create(webViewComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as WebViewComponentStyle
+        assertThat(style.overrides).hasSize(1)
+        assertThat(style.overrides[0].properties.partial.visible).isFalse()
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -1348,6 +1348,169 @@ class StyleFactoryTests {
         assertThat(secondImage.ignoreTopWindowInsets).isFalse()
     }
 
+    private fun heroWebViewComponent(width: SizeConstraint = SizeConstraint.Fill) = WebViewComponent(
+        url = "https://bundle-hash.components.revenuecat-static.com/index.html",
+        id = "hero_web_view",
+        protocolVersion = 1,
+        size = Size(width = width, height = SizeConstraint.Fit(default = 400u)),
+    )
+
+    private fun textComponent() = TextComponent(
+        text = LOCALIZATION_KEY_TEXT_1,
+        color = ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb())),
+    )
+
+    @Test
+    fun `Should ignore top window insets for the first full-width web_view in the first z-stack`() {
+        // Arrange
+        val stackComponent = StackComponent(
+            components = listOf(
+                StackComponent(
+                    components = listOf(heroWebViewComponent()),
+                    dimension = Dimension.ZLayer(
+                        alignment = TwoDimensionalAlignment.TOP,
+                    )
+                ),
+                textComponent(),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isTrue()
+        val style = styleResult.componentStyle as StackComponentStyle
+        // The root stack should not apply top window insets (the ZLayer child handles it).
+        assertThat(style.applyTopWindowInsets).isFalse()
+        val firstZStack = style.children[0] as StackComponentStyle
+        assertThat(firstZStack.applyTopWindowInsets).isTrue()
+        val webView = firstZStack.children[0] as WebViewComponentStyle
+        assertThat(webView.ignoreTopWindowInsets).isTrue()
+    }
+
+    @Test
+    fun `Should not ignore top window insets for the first web_view in the first z-stack if it is not full-width`() {
+        // Arrange
+        val stackComponent = StackComponent(
+            components = listOf(
+                StackComponent(
+                    components = listOf(heroWebViewComponent(width = SizeConstraint.Fixed(200u))),
+                    dimension = Dimension.ZLayer(
+                        alignment = TwoDimensionalAlignment.TOP,
+                    )
+                ),
+                textComponent(),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isFalse()
+        val style = styleResult.componentStyle as StackComponentStyle
+        assertThat(style.applyTopWindowInsets).isTrue()
+        val firstZStack = style.children[0] as StackComponentStyle
+        assertThat(firstZStack.applyTopWindowInsets).isFalse()
+        val webView = firstZStack.children[0] as WebViewComponentStyle
+        assertThat(webView.ignoreTopWindowInsets).isFalse()
+    }
+
+    @Test
+    fun `Should ignore top window insets for the first full-width web_view in the root`() {
+        // Arrange
+        val stackComponent = StackComponent(
+            components = listOf(
+                heroWebViewComponent(),
+                textComponent(),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isTrue()
+        val style = styleResult.componentStyle as StackComponentStyle
+        assertThat(style.applyTopWindowInsets).isTrue()
+        val webView = style.children[0] as WebViewComponentStyle
+        assertThat(webView.ignoreTopWindowInsets).isTrue()
+    }
+
+    @Test
+    fun `Should not ignore top window insets for a web_view that is not the first component`() {
+        // Arrange
+        val stackComponent = StackComponent(
+            components = listOf(
+                textComponent(),
+                heroWebViewComponent(),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isFalse()
+        val style = styleResult.componentStyle as StackComponentStyle
+        assertThat(style.applyTopWindowInsets).isTrue()
+        val webView = style.children[1] as WebViewComponentStyle
+        assertThat(webView.ignoreTopWindowInsets).isFalse()
+    }
+
+    @Test
+    fun `Should ignore top window insets for a full-width web_view preceded by a FallbackHeaderComponent`() {
+        // Arrange
+        // FallbackHeaderComponent is injected as the first element of the body stack by the dashboard.
+        // It should not prematurely stop hero detection.
+        val stackComponent = StackComponent(
+            components = listOf(
+                FallbackHeaderComponent,
+                heroWebViewComponent(),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isTrue()
+        val style = styleResult.componentStyle as StackComponentStyle
+        val webView = style.children[0] as WebViewComponentStyle
+        assertThat(webView.ignoreTopWindowInsets).isTrue()
+    }
+
     @Test
     fun `PackageComponentStyle visible defaults to true when component visible is null`() {
         // Arrange

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentStateTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentStateTest.kt
@@ -1,0 +1,101 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.window.core.layout.WindowWidthSizeClass
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.paywalls.components.PartialWebViewComponent
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverride
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedWebViewPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallStateStore
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Only `visible` is overridable on web_view (url/size always come from the base style); these tests
+ * exercise the wiring from [WebViewComponentStyle.overrides] through [WebViewComponentState.visible].
+ */
+@RunWith(AndroidJUnit4::class)
+class WebViewComponentStateTest {
+
+    private val size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit())
+
+    private fun styleWithOverrides(
+        visible: Boolean,
+        overrides: List<PresentedOverride<PresentedWebViewPartial>>,
+        rcPackage: Package? = null,
+    ) = WebViewComponentStyle(
+        url = "https://paywalls.revenuecat.com/index.html",
+        visible = visible,
+        size = size,
+        componentId = "promo_web_view",
+        overrides = overrides,
+        rcPackage = rcPackage,
+        tabIndex = null,
+    )
+
+    private fun state(
+        style: WebViewComponentStyle,
+        windowSize: WindowWidthSizeClass = WindowWidthSizeClass.COMPACT,
+        selectedPackageInfo: PaywallState.Loaded.Components.SelectedPackageInfo? = null,
+    ) = WebViewComponentState(
+        initialWindowSize = windowSize,
+        style = style,
+        selectedPackageInfoProvider = { selectedPackageInfo },
+        selectedTabIndexProvider = { 0 },
+        selectedOfferEligibilityProvider = { OfferEligibility.Ineligible },
+        customVariablesProvider = { emptyMap() },
+        stateStoreProvider = { PaywallStateStore(emptyMap()) },
+    )
+
+    @Test
+    fun `falls back to the base component's visible when no override applies`() {
+        val style = styleWithOverrides(visible = true, overrides = emptyList())
+
+        assertThat(state(style).visible).isTrue()
+        assertThat(state(styleWithOverrides(visible = false, overrides = emptyList())).visible).isFalse()
+    }
+
+    @Test
+    fun `hides a base-visible web_view under a matching expanded override`() {
+        val overrides = listOf(
+            PresentedOverride(
+                conditions = listOf(ComponentOverride.Condition.Expanded),
+                properties = PresentedWebViewPartial(PartialWebViewComponent(visible = false)),
+            ),
+        )
+        val style = styleWithOverrides(visible = true, overrides = overrides)
+
+        assertThat(state(style, windowSize = WindowWidthSizeClass.COMPACT).visible).isTrue()
+        assertThat(state(style, windowSize = WindowWidthSizeClass.EXPANDED).visible).isFalse()
+    }
+
+    @Test
+    fun `shows a base-hidden web_view under a matching selected override`() {
+        val rcPackage = TestData.Packages.monthly
+        val overrides = listOf(
+            PresentedOverride(
+                conditions = listOf(ComponentOverride.Condition.Selected),
+                properties = PresentedWebViewPartial(PartialWebViewComponent(visible = true)),
+            ),
+        )
+        val style = styleWithOverrides(visible = false, overrides = overrides, rcPackage = rcPackage)
+        val selectedPackageInfo = PaywallState.Loaded.Components.SelectedPackageInfo(
+            rcPackage = rcPackage,
+            uniqueId = rcPackage.identifier,
+            offerEligibility = OfferEligibility.Ineligible,
+        )
+
+        // Not selected: keeps the base (hidden) value.
+        assertThat(state(style, selectedPackageInfo = null).visible).isFalse()
+        // Selected: the override applies.
+        assertThat(state(style, selectedPackageInfo = selectedPackageInfo).visible).isTrue()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOfferingToStateTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOfferingToStateTest.kt
@@ -1,0 +1,48 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * End-to-end activation check: a components config with `web_view` validates and lands as
+ * [WebViewComponentStyle] in the paywall state (serializer + StyleFactory wiring).
+ */
+@RunWith(AndroidJUnit4::class)
+class WebViewOfferingToStateTest {
+
+    @Test
+    fun `components config with web_view produces WebViewComponentStyle in paywall state`() {
+        val webViewUrl = "https://paywalls.revenuecat.com/index.html"
+        val webViewId = "promo_web_view"
+        val size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit())
+
+        val state = FakePaywallState(
+            components = listOf(
+                WebViewComponent(
+                    url = webViewUrl,
+                    id = webViewId,
+                    protocolVersion = 1,
+                    size = size,
+                ),
+            ),
+            packages = listOf(TestData.Packages.monthly),
+        )
+
+        val rootStack = state.stack as StackComponentStyle
+        val webViewStyle = rootStack.children.filterIsInstance<WebViewComponentStyle>().single()
+        assertThat(webViewStyle.url).isEqualTo(webViewUrl)
+        assertThat(webViewStyle.componentId).isEqualTo(webViewId)
+        assertThat(webViewStyle.protocolVersion).isEqualTo(1)
+        assertThat(webViewStyle.size).isEqualTo(size)
+        assertThat(webViewStyle.visible).isTrue()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOfferingToStateTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewOfferingToStateTest.kt
@@ -41,7 +41,6 @@ class WebViewOfferingToStateTest {
         val webViewStyle = rootStack.children.filterIsInstance<WebViewComponentStyle>().single()
         assertThat(webViewStyle.url).isEqualTo(webViewUrl)
         assertThat(webViewStyle.componentId).isEqualTo(webViewId)
-        assertThat(webViewStyle.protocolVersion).isEqualTo(1)
         assertThat(webViewStyle.size).isEqualTo(size)
         assertThat(webViewStyle.visible).isTrue()
     }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation
Final part of the `web_view` series (splitting #3757). This is the activation PR: the only change that alters runtime behavior, so reverting it alone turns the `web_view` feature off. All downstack parts (schema, transport envelope, navigation policy, JS bridge, Compose view, kotlinx transport refactor, WebView profile isolation) are merged; this now sits standalone on `main`.

### Description
- Register `"web_view"` in the `PaywallComponent` deserializer
- Replace the StyleFactory stub (`Result.Success(null)`) with `createWebViewComponentStyle`
- Add `WebViewComponent.SUPPORTED_PROTOCOL_VERSION` as the single source of truth for the supported version; the runtime handshake in `:ui:revenuecatui` derives from it, so the decode-time gate and the handshake cannot disagree
- Absent, malformed, or unsupported `protocol_version` renders the component `fallback` (same path as an unknown component), gated on the raw value before decode for forward compatibility
- Tests: `WebViewComponentTests` decode and version-gate cases, `StyleFactoryTests`, and e2e `WebViewOfferingToStateTest` (a config with `web_view` produces a `WebViewComponentStyle` in the paywall state)

### Submodule
No `web_view` preview fixtures on the resources submodule; pointer left untouched.

Verified locally: `WebViewComponentTests`, `StyleFactoryTests`, `webview.*` (incl. e2e), `detektAll`.

**Labels:** `pr:feat`, `pr:RevenueCatUI`, `feat:Paywalls_V2`

### After merge
Close #3757 as superseded (do not merge it).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall config decoding and runtime rendering for a new component type, including forward-compat fallback vs hard-fail on bad `protocol_version`; mistakes could break paywall load or show wrong fallback content, but behavior is heavily tested and gated on protocol version before body decode.
> 
> **Overview**
> **Turns on Paywalls V2 `web_view` end-to-end** by wiring polymorphic decode, style creation, and the existing Compose web view instead of the StyleFactory stub that dropped the component.
> 
> The `PaywallComponent` serializer now handles `"web_view"` with a **pre-decode `protocol_version` gate**: supported v1 decodes to `WebViewComponent`; unsupported versions use the author’s `fallback` (even when the body isn’t valid v1); missing or malformed versions fail the decode. `WebViewComponent.SUPPORTED_PROTOCOL_VERSION` is the single source of truth, and `WebViewEnvelope.DEFAULT_PROTOCOL_VERSION` derives from it.
> 
> **Schema/UI parity with other components:** `overrides` and `PartialWebViewComponent` (visibility only), `PresentedWebViewPartial`, full `WebViewComponentStyle` with package/tab context, and `WebViewComponentState` so rule-based visibility works in `WebViewComponentView`. Full-width `web_view` is treated like image/video for hero/header top inset behavior.
> 
> Tests cover decode/version gating, overrides (PWENG-152), StyleFactory hero cases, and e2e offering-to-state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e75c0fe8f619cd903452eea41b24a7502ad7818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->