### PR TITLE
fix(remote-config): verify remote config signature over the decoded config element

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -614,7 +614,9 @@ internal class HTTPClient(
 
     /**
      * Verifies an RC Container Format response. The backend signs the leading config element's (element 0)
-     * bytes exactly as received — the config part / `main_body` — so we verify the signature over those bytes.
+     * **uncompressed** bytes — the config part / `main_body` — so we [decode][RCElement.decodedBytes] the
+     * element first and verify the signature over those bytes. Per-element compression is transparent to the
+     * signature (as it is to the element checksum), so a codec change never invalidates a signed config.
      * The per-element container checksums are untrusted lookup hints, not a trust anchor: inline blob elements
      * are not signed and are instead authenticated transitively by hashing against the `blob_ref` in the signed
      * config. This endpoint is not ETag-cached and sends no post params, but the signature does cover the request
@@ -626,8 +628,8 @@ internal class HTTPClient(
         payloadBytes: ByteArray,
         nonce: String?,
     ): VerificationResult {
-        val config = try {
-            RCContainer.parse(payloadBytes).config
+        val bodyBytes = try {
+            RCContainer.parse(payloadBytes).config.decodedBytes()
         } catch (e: RCContainerFormatException) {
             errorLog(e) { NetworkStrings.VERIFICATION_ERROR.format(urlPath) }
             return VerificationResult.FAILED
@@ -636,7 +638,7 @@ internal class HTTPClient(
             urlPath = urlPath,
             signatureString = connection.getHeaderField(HTTPResult.SIGNATURE_HEADER_NAME),
             nonce = nonce,
-            bodyBytes = config.dataBytes(),
+            bodyBytes = bodyBytes,
             requestTime = getRequestTimeHeader(connection),
             eTag = getETagHeader(connection),
             postFieldsToSignHeader = null,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCElement.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCElement.kt
@@ -78,6 +78,19 @@ internal class RCElement(
         return bytes
     }
 
+    /**
+     * A copy of this element's decoded (uncompressed) bytes. Mirrors [dataBytes] but runs the payload
+     * through [decode] first, so callers that need the logical content (checksum/signature/JSON) get the
+     * same bytes regardless of the on-wire [codec]. Throws [RCContainerFormatException] for an unsupported
+     * codec or a corrupt compressed stream.
+     */
+    fun decodedBytes(): ByteArray {
+        val view = decode().duplicate().apply { rewind() }
+        val bytes = ByteArray(view.remaining())
+        view.get(bytes)
+        return bytes
+    }
+
     private companion object {
         private const val SHA_256_ALGORITHM = "SHA-256"
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -50,7 +50,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         val rcContainer = requireNotNull(container) { "Expected a 200 container, got 204 (no content)." }
         assertThat(rcContainer.config.isChecksumValid()).isTrue()
 
-        val config = RemoteConfiguration.parse(rcContainer.config.data)
+        val config = RemoteConfiguration.parse(rcContainer.config.decode())
         assertThat(config.domain).isEqualTo("app")
         assertThat(config.manifest).isNotEmpty()
         assertThat(config.activeTopics).contains("sources", "ui_config", "workflows")
@@ -85,7 +85,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
         val rcContainer = requireNotNull(container) { "Expected a 200 container, got 204 (no content)." }
 
-        val config = RemoteConfiguration.parse(rcContainer.config.data)
+        val config = RemoteConfiguration.parse(rcContainer.config.decode())
 
         // Pick a workflows item whose blob was inlined in the container, so we can decode it directly.
         val workflows = requireNotNull(config.topics["workflows"]) { "Expected a workflows topic." }
@@ -179,10 +179,13 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         assertThat(firstError).isNull()
         assertThat(firstVerification).isEqualTo(VerificationResult.VERIFIED)
         val rcContainer = requireNotNull(firstContainer) { "Expected a 200 container on the first run." }
-        val manifest = RemoteConfiguration.parse(rcContainer.config.data).manifest
+        val manifest = RemoteConfiguration.parse(rcContainer.config.decode()).manifest
 
         // Replaying that manifest with nothing changed server-side -> 204 (success, but no container to parse).
-        val (secondError, secondContainer, secondVerification) = fetchRemoteConfig(manifest = manifest)
+        // A non-`app_start` context is required: the backend always fully resolves an `app_start` request, so it
+        // never returns 204 for one.
+        val (secondError, secondContainer, secondVerification) =
+            fetchRemoteConfig(manifest = manifest, fetchContext = RemoteConfigFetchContext.Foreground)
         assertThat(secondError).isNull()
         assertThat(secondContainer).isNull()
         assertThat(secondVerification).isEqualTo(VerificationResult.VERIFIED)
@@ -210,11 +213,13 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         val (firstError, firstContainer, _) = fetchRemoteConfig(manifest = null)
         assertThat(firstError).isNull()
         val rcContainer = requireNotNull(firstContainer) { "Expected a 200 container on the first run." }
-        val manifest = RemoteConfiguration.parse(rcContainer.config.data).manifest
+        val manifest = RemoteConfiguration.parse(rcContainer.config.decode()).manifest
 
         // The 204 carries no body, but its signature covers the request context. Under enforcement a verification
         // failure would surface as an error, so a null error with a VERIFIED result confirms the 204 was verified.
-        val (secondError, secondContainer, secondVerification) = fetchRemoteConfig(manifest = manifest)
+        // A non-`app_start` context is required: an `app_start` request is always fully resolved (never 204).
+        val (secondError, secondContainer, secondVerification) =
+            fetchRemoteConfig(manifest = manifest, fetchContext = RemoteConfigFetchContext.Foreground)
         assertThat(secondError).isNull()
         assertThat(secondContainer).isNull()
         assertThat(secondVerification).isEqualTo(VerificationResult.VERIFIED)
@@ -227,6 +232,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
     private fun fetchRemoteConfig(
         manifest: String?,
         prefetchedBlobs: List<String> = emptyList(),
+        fetchContext: RemoteConfigFetchContext = RemoteConfigFetchContext.AppStart,
     ): Triple<PurchasesError?, RCContainer?, VerificationResult?> {
         every { appConfig.isDebugBuild } returns false
 
@@ -237,7 +243,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
             backend.getRemoteConfig(
                 appInBackground = false,
                 appUserID = "integrationTestRemoteConfigUser",
-                fetchContext = RemoteConfigFetchContext.AppStart,
+                fetchContext = fetchContext,
                 domain = "app",
                 manifest = manifest,
                 prefetchedBlobs = prefetchedBlobs,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPRequest
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCContentEncoding
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.common.verification.SignatureVerificationException
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
@@ -22,6 +23,7 @@ import org.robolectric.annotation.Config
 import java.io.ByteArrayOutputStream
 import java.security.MessageDigest
 import java.util.Date
+import java.util.zip.GZIPOutputStream
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -478,6 +480,41 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
     }
 
     @Test
+    fun `performRequest verifies a GZIP-compressed config element over its decoded bytes`() {
+        val endpoint = Endpoint.GetRemoteConfig("app")
+        val configBytes = "{\"config\":true}".toByteArray()
+        // Once the config element crosses the backend's size threshold it is served GZIP-compressed (codec 1).
+        // The signature covers the uncompressed config bytes, so verification must decode before signing.
+        val container = buildContainer(configBytes, codec = RCContentEncoding.GZIP.id)
+
+        mockSigningResult(VerificationResult.VERIFIED)
+        enqueueRCFormat(container)
+
+        val result = client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            postFieldsToSign = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
+        verify(exactly = 1) {
+            mockSigningManager.verifyResponse(
+                urlPath = endpoint.getPath(),
+                "test-signature",
+                "test-nonce",
+                match<ByteArray> { it.contentEquals(configBytes) },
+                "1234567890",
+                "test-etag",
+                postFieldsToSignHeader = null
+            )
+        }
+    }
+
+    @Test
     fun `performRequest fails RC Format verification when the response is not a valid RC Container`() {
         val endpoint = Endpoint.GetRemoteConfig("app")
 
@@ -599,7 +636,10 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
     private fun buildContainer(
         config: ByteArray,
         configChecksum: ByteArray = sha256Truncated(config),
+        codec: Int = RCContentEncoding.NONE.id,
     ): ByteArray {
+        // The checksum always covers the uncompressed config; only the on-wire body is (optionally) compressed.
+        val body = if (codec == RCContentEncoding.GZIP.id) gzip(config) else config
         val out = ByteArrayOutputStream()
         out.write('R'.code)
         out.write('C'.code)
@@ -607,12 +647,18 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
         out.write(0) // flags
         repeat(4) { out.write(0) } // header reserved
         out.write(configChecksum)
-        out.writeUInt32LE(config.size)
-        out.writeUInt32LE(0) // element reserved
-        out.write(config)
+        out.writeUInt32LE(body.size)
+        out.writeUInt32LE(codec) // element reserved; low byte is the content-encoding codec id
+        out.write(body)
         while (out.size() % 8 != 0) {
             out.write(0)
         }
+        return out.toByteArray()
+    }
+
+    private fun gzip(data: ByteArray): ByteArray {
+        val out = ByteArrayOutputStream()
+        GZIPOutputStream(out).use { it.write(data) }
         return out.toByteArray()
     }
 

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/can fetch remote config/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/can fetch remote config/response_001.json
@@ -2,7 +2,7 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3704",
+    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/decodes an inline workflows content blob/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/decodes an inline workflows content blob/response_001.json
@@ -2,7 +2,7 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3704",
+    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/response_001.json
@@ -2,7 +2,7 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3704",
+    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/response_001.json
@@ -2,7 +2,7 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3704",
+    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/replaying the manifest returns no content/request_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/replaying the manifest returns no content/request_002.json
@@ -22,7 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
-    "fetch_context": "app_start",
+    "fetch_context": "foreground",
     "manifest": "TEST_STATIC_VALUE",
     "prefetched_blobs": []
   }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/replaying the manifest returns no content/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/replaying the manifest returns no content/response_001.json
@@ -2,7 +2,7 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3704",
+    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the no content response when verification is enforced/request_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the no content response when verification is enforced/request_002.json
@@ -22,7 +22,7 @@
   },
   "body": {
     "app_user_id": "integrationTestRemoteConfigUser",
-    "fetch_context": "app_start",
+    "fetch_context": "foreground",
     "manifest": "TEST_STATIC_VALUE",
     "prefetched_blobs": []
   }

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the no content response when verification is enforced/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the no content response when verification is enforced/response_001.json
@@ -2,7 +2,7 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3704",
+    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the signed response when verification is enforced/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the signed response when verification is enforced/response_001.json
@@ -2,7 +2,7 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3704",
+    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },


### PR DESCRIPTION
## Problem

The `/v1/config` backend GZIP-compresses the config element (element 0) once the response crosses a size threshold. Per-element compression is transparent to the element checksum and the response signature (both cover the uncompressed bytes), but signature verification was hashing the on-wire (compressed) bytes via `config.dataBytes()`, so verification started failing (`VerificationResult.FAILED`, and a thrown `SignatureVerificationException` under enforcement).

This also includes changes to make test pass a non `fetch_context: app_start` for tests that require a 204 temporarily while we work on a backend fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive response signature verification for remote config; behavior change is narrow and covered by new GZIP and integration tests.
> 
> **Overview**
> Fixes **remote config signature verification** when the backend serves the config element **GZIP-compressed**: verification now hashes **`decodedBytes()`** (uncompressed logical content) instead of on-wire **`dataBytes()`**, matching how the server signs the config and keeping verification valid when compression is enabled.
> 
> Adds **`RCElement.decodedBytes()`** as the shared helper for callers that need uncompressed bytes (signature, JSON parse, checksum semantics).
> 
> **Tests:** unit coverage for GZIP RC containers in `HTTPClientVerificationTest`; integration tests parse config via **`decode()`**; manifest-replay / 204 scenarios use **`fetch_context: foreground`** because **`app_start` always fully resolves** and never returns 204. Golden fixtures updated for larger compressed responses and the foreground replay requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb0d74048cf9ce2cdb03e07902b30d366dbd79b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->