### PR TITLE
ci: pin automatic-bump job to Ruby 3.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1182,7 +1182,8 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "release-train", << pipeline.schedule.name >> ]
     jobs:
-      - revenuecat/automatic-bump
+      - revenuecat/automatic-bump:
+          ruby_version: "3.2.0"
 
   biweekly-baseline-profiles:
     when:
@@ -1198,7 +1199,8 @@ workflows:
     when:
       equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
-      - revenuecat/automatic-bump
+      - revenuecat/automatic-bump:
+          ruby_version: "3.2.0"
 
   manual-paywall-tester-release:
     when:


### PR DESCRIPTION
### Motivation
Yesterday's [automatic version bump failed](https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/24694/workflows/0dac9b3b-62a0-4f00-a45a-4fe9658a7015/jobs/281030): the `revenuecat/automatic-bump` orb job defaults to `cimg/ruby:3.1.2`, on which the locked gems requiring Ruby >= 3.2 can't install. Bundler then backtracks to `fastlane 0.0.1` / `nokogiri 1.6.6.4` and fails to build the native extension.

### Description
- Pin both `automatic-bump` workflow usages to Ruby `3.2.0`, matching the same fix applied to the `danger` job in #3744.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CircleCI workflow-only change; no application or release logic is modified.
> 
> **Overview**
> Pins **`ruby_version: "3.2.0"`** on both **`revenuecat/automatic-bump`** invocations—the scheduled **release-train** workflow and the **manual `bump`** pipeline—so the orb no longer uses its default Ruby 3.1.2 image.
> 
> This aligns automatic version bumps with the repo’s locked gems (Ruby ≥ 3.2) and the same pin already used for **`revenuecat/danger`**, avoiding Bundler resolution failures during bump runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10387f383bd459887b05d8593d6e7c1a18c01aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->