### PR TITLE
Open the default paywall for offerings without a workflow

### DIFF
--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -427,11 +427,6 @@ public class Purchases internal constructor(
     public suspend fun resolveWorkflow(offeringId: String): WorkflowResolution =
         purchasesOrchestrator.resolveWorkflow(offeringId)
 
-    @InternalRevenueCatAPI
-    @get:JvmSynthetic
-    public val isRemoteConfigDisabled: Boolean
-        get() = purchasesOrchestrator.isRemoteConfigDisabled
-
     /**
      * Gets the StoreProduct(s) for the given list of product ids for all product types.
      * @param [productIds] List of productIds

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -23,6 +23,7 @@ import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.deeplinks.DeepLinkParser
 import com.revenuecat.purchases.interfaces.Callback
@@ -423,8 +424,13 @@ public class Purchases internal constructor(
 
     @InternalRevenueCatAPI
     @JvmSynthetic
-    public suspend fun workflowIdForOfferingId(offeringId: String): String? =
-        purchasesOrchestrator.workflowIdForOfferingId(offeringId)
+    public suspend fun resolveWorkflow(offeringId: String): WorkflowResolution =
+        purchasesOrchestrator.resolveWorkflow(offeringId)
+
+    @InternalRevenueCatAPI
+    @get:JvmSynthetic
+    public val isRemoteConfigDisabled: Boolean
+        get() = purchasesOrchestrator.isRemoteConfigDisabled
 
     /**
      * Gets the StoreProduct(s) for the given list of product ids for all product types.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -57,6 +57,7 @@ import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowManager
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.common.workflows.WorkflowsConfigProvider
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.deeplinks.WebPurchaseRedemptionHelper
@@ -624,8 +625,12 @@ internal class PurchasesOrchestrator(
         return manager.getWorkflow(workflowId)
     }
 
-    suspend fun workflowIdForOfferingId(offeringId: String): String? =
-        workflowManager?.workflowIdForOfferingId(offeringId)
+    suspend fun resolveWorkflow(offeringId: String): WorkflowResolution =
+        workflowManager?.resolveWorkflow(offeringId) ?: WorkflowResolution.NoWorkflow
+
+    /** Whether the `/v1/config` endpoint has been disabled for this session by a 4xx client error. */
+    val isRemoteConfigDisabled: Boolean
+        get() = remoteConfigManager?.isDisabled == true
 
     suspend fun getUiConfig(): UiConfig {
         val provider = uiConfigProvider

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -628,10 +628,6 @@ internal class PurchasesOrchestrator(
     suspend fun resolveWorkflow(offeringId: String): WorkflowResolution =
         workflowManager?.resolveWorkflow(offeringId) ?: WorkflowResolution.NoWorkflow
 
-    /** Whether the `/v1/config` endpoint has been disabled for this session by a 4xx client error. */
-    val isRemoteConfigDisabled: Boolean
-        get() = remoteConfigManager?.isDisabled == true
-
     suspend fun getUiConfig(): UiConfig {
         val provider = uiConfigProvider
         if (appConfig.uiPreviewMode || provider == null) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -101,8 +101,8 @@ internal class WorkflowManager(
             null
         }
 
-    suspend fun workflowIdForOfferingId(offeringId: String): String? =
-        workflowsConfigProvider.workflowIdForOfferingId(offeringId)
+    suspend fun resolveWorkflow(offeringId: String): WorkflowResolution =
+        workflowsConfigProvider.resolveWorkflow(offeringId)
 
     /**
      * Invokes [onComplete] once the config-endpoint paywall data `getOfferings` depends on is ready — the

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
@@ -1,5 +1,3 @@
-@file:OptIn(InternalRevenueCatAPI::class)
-
 package com.revenuecat.purchases.common.workflows
 
 import com.revenuecat.purchases.InternalRevenueCatAPI

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
@@ -1,0 +1,28 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.workflows
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+
+/**
+ * Outcome of resolving an offering to its workflow through the `/v1/config` workflows topic. It lets the paywall
+ * render path tell apart three situations that a bare `workflowId?` conflates:
+ *
+ * - [Found]: the offering maps to a workflow id, which should be served through the workflows path.
+ * - [NoWorkflow]: the workflows topic was readable and the offering genuinely has no workflow. This is a
+ *   workflowless offering that should render its regular or default paywall.
+ * - [Unresolved]: the workflows topic could not be read at all — the `/v1/config` endpoint is disabled by a 4xx
+ *   kill switch, or a sync failed transiently — so whether the offering has a workflow is unknown. The caller
+ *   decides how to recover based on whether remote config is disabled.
+ */
+@InternalRevenueCatAPI
+public sealed class WorkflowResolution {
+    @InternalRevenueCatAPI
+    public data class Found(val workflowId: String) : WorkflowResolution()
+
+    @InternalRevenueCatAPI
+    public object NoWorkflow : WorkflowResolution()
+
+    @InternalRevenueCatAPI
+    public object Unresolved : WorkflowResolution()
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
@@ -18,15 +18,11 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
  */
 @InternalRevenueCatAPI
 public sealed class WorkflowResolution {
-    @InternalRevenueCatAPI
     public data class Found(val workflowId: String) : WorkflowResolution()
 
-    @InternalRevenueCatAPI
     public object NoWorkflow : WorkflowResolution()
 
-    @InternalRevenueCatAPI
     public object Disabled : WorkflowResolution()
 
-    @InternalRevenueCatAPI
     public object Unavailable : WorkflowResolution()
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
@@ -6,14 +6,17 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 
 /**
  * Outcome of resolving an offering to its workflow through the `/v1/config` workflows topic. It lets the paywall
- * render path tell apart three situations that a bare `workflowId?` conflates:
+ * render path tell apart four situations that a bare `workflowId?` conflates, so each can recover differently
+ * without the caller needing to inspect remote-config state directly:
  *
  * - [Found]: the offering maps to a workflow id, which should be served through the workflows path.
  * - [NoWorkflow]: the workflows topic was readable and the offering genuinely has no workflow. This is a
  *   workflowless offering that should render its regular or default paywall.
- * - [Unresolved]: the workflows topic could not be read at all — the `/v1/config` endpoint is disabled by a 4xx
- *   kill switch, or a sync failed transiently — so whether the offering has a workflow is unknown. The caller
- *   decides how to recover based on whether remote config is disabled.
+ * - [Disabled]: the topic could not be read because the `/v1/config` endpoint is disabled for the session by a
+ *   4xx kill switch. The offering was parsed with its paywall components skipped while workflows were enabled,
+ *   so the caller should reload offerings — which now re-parse with those components — to recover its paywall.
+ * - [Unavailable]: the topic could not be read for some other (transient) reason, so whether the offering has a
+ *   workflow is unknown and reloading would not recover anything. The caller should surface an error.
  */
 @InternalRevenueCatAPI
 public sealed class WorkflowResolution {
@@ -24,5 +27,8 @@ public sealed class WorkflowResolution {
     public object NoWorkflow : WorkflowResolution()
 
     @InternalRevenueCatAPI
-    public object Unresolved : WorkflowResolution()
+    public object Disabled : WorkflowResolution()
+
+    @InternalRevenueCatAPI
+    public object Unavailable : WorkflowResolution()
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -72,9 +72,10 @@ internal class WorkflowsConfigProvider(
 
     /**
      * Resolves an offering to its workflow through the `/v1/config` workflows topic, distinguishing a genuinely
-     * workflowless offering ([WorkflowResolution.NoWorkflow]) from a topic that could not be read at all
-     * ([WorkflowResolution.Unresolved], i.e. the endpoint is disabled or a sync failed transiently). Memory-first:
-     * a warm cache resolves synchronously; only a miss reads the topic (which may trigger a sync).
+     * workflowless offering ([WorkflowResolution.NoWorkflow]) from a topic that could not be read because the
+     * endpoint is disabled ([WorkflowResolution.Disabled]) or a sync failed transiently
+     * ([WorkflowResolution.Unavailable]). Memory-first: a warm cache resolves synchronously; only a miss reads the
+     * topic (which may trigger a sync).
      */
     suspend fun resolveWorkflow(offeringId: String): WorkflowResolution {
         cache.cached?.let { cached ->
@@ -84,12 +85,18 @@ internal class WorkflowsConfigProvider(
         val generation = manager.configGeneration
         val topic = manager.topic(RemoteConfigTopic.Workflows)
         verboseLog { "workflows topic ${if (topic == null) "is absent" else "has ${topic.size} item(s)"}" }
-        // A null topic means it could not be read: the /v1/config endpoint is disabled (4xx kill switch) or a
-        // sync failed transiently. Whether this offering has a workflow is unknown, so leave the recovery
-        // decision to the caller instead of pretending it is workflowless.
+        // A null topic means it could not be read. If the /v1/config endpoint is disabled (4xx kill switch) the
+        // offering was parsed with its components skipped, so the caller can reload offerings to recover them;
+        // any other (transient) failure is unrecoverable and should surface an error. Either way this is not the
+        // same as a genuinely workflowless offering.
         return if (topic == null) {
-            verboseLog { "Workflows topic unavailable while resolving offering '$offeringId'" }
-            WorkflowResolution.Unresolved
+            if (manager.isDisabled) {
+                verboseLog { "Workflows topic unavailable (remote config disabled) resolving offering '$offeringId'" }
+                WorkflowResolution.Disabled
+            } else {
+                verboseLog { "Workflows topic unavailable resolving offering '$offeringId'" }
+                WorkflowResolution.Unavailable
+            }
         } else {
             val matches = topic.entries
                 .filter { (_, item) -> item.metadata.stringOrNull(KEY_OFFERING_IDENTIFIER) == offeringId }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -77,7 +77,13 @@ internal class WorkflowsConfigProvider(
      * ([WorkflowResolution.Unavailable]). Memory-first: a warm cache resolves synchronously; only a miss reads the
      * topic (which may trigger a sync).
      */
+    @Suppress("ReturnCount")
     suspend fun resolveWorkflow(offeringId: String): WorkflowResolution {
+        // Once the endpoint is disabled (4xx kill switch) the offering was parsed with its components skipped, so
+        // resolution must always yield Disabled (→ offerings reload) — even off a warm cache. Check the flag
+        // before the fast path: disabling sets isDisabled and invalidates this cache non-atomically, so a warm
+        // cache can briefly coexist with isDisabled, and a stale Found/NoWorkflow here would skip the reload.
+        if (manager.isDisabled) return WorkflowResolution.Disabled
         cache.cached?.let { cached ->
             return cached.offeringToWorkflowId[offeringId]?.let { WorkflowResolution.Found(it) }
                 ?: WorkflowResolution.NoWorkflow

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -70,31 +70,55 @@ internal class WorkflowsConfigProvider(
         return workflowId == null || cached.workflows.containsKey(workflowId)
     }
 
-    suspend fun workflowIdForOfferingId(offeringId: String): String? {
-        cache.cached?.let { return it.offeringToWorkflowId[offeringId] }
+    /**
+     * Resolves an offering to its workflow through the `/v1/config` workflows topic, distinguishing a genuinely
+     * workflowless offering ([WorkflowResolution.NoWorkflow]) from a topic that could not be read at all
+     * ([WorkflowResolution.Unresolved], i.e. the endpoint is disabled or a sync failed transiently). Memory-first:
+     * a warm cache resolves synchronously; only a miss reads the topic (which may trigger a sync).
+     */
+    suspend fun resolveWorkflow(offeringId: String): WorkflowResolution {
+        cache.cached?.let { cached ->
+            return cached.offeringToWorkflowId[offeringId]?.let { WorkflowResolution.Found(it) }
+                ?: WorkflowResolution.NoWorkflow
+        }
         val generation = manager.configGeneration
         val topic = manager.topic(RemoteConfigTopic.Workflows)
         verboseLog { "workflows topic ${if (topic == null) "is absent" else "has ${topic.size} item(s)"}" }
-        val matches = topic
-            ?.entries
-            ?.filter { (_, item) -> item.metadata.stringOrNull(KEY_OFFERING_IDENTIFIER) == offeringId }
-            .orEmpty()
-        if (matches.size > 1) {
-            warnLog { "Duplicate offering_identifier '$offeringId' in workflows topic: ${matches.map { it.key }}" }
-        }
-        // Last entry wins on duplicates.
-        val workflowId = matches.lastOrNull()?.key
-        verboseLog {
-            if (workflowId != null) {
-                "Resolved offering '$offeringId' to workflow '$workflowId'"
-            } else {
-                "No workflow found for offering '$offeringId'"
+        // A null topic means it could not be read: the /v1/config endpoint is disabled (4xx kill switch) or a
+        // sync failed transiently. Whether this offering has a workflow is unknown, so leave the recovery
+        // decision to the caller instead of pretending it is workflowless.
+        return if (topic == null) {
+            verboseLog { "Workflows topic unavailable while resolving offering '$offeringId'" }
+            WorkflowResolution.Unresolved
+        } else {
+            val matches = topic.entries
+                .filter { (_, item) -> item.metadata.stringOrNull(KEY_OFFERING_IDENTIFIER) == offeringId }
+            if (matches.size > 1) {
+                warnLog { "Duplicate offering_identifier '$offeringId' in workflows topic: ${matches.map { it.key }}" }
             }
+            // Last entry wins on duplicates.
+            val workflowId = matches.lastOrNull()?.key
+            verboseLog {
+                if (workflowId != null) {
+                    "Resolved offering '$offeringId' to workflow '$workflowId'"
+                } else {
+                    "No workflow found for offering '$offeringId'"
+                }
+            }
+            // If an identity-change invalidation advanced the generation while the topic was read, the resolved
+            // id may belong to the previous user; prefer whatever the (now newer) cache holds instead.
+            val resolvedId = if (cache.isCurrent(generation)) {
+                workflowId
+            } else {
+                cache.cached?.offeringToWorkflowId?.get(offeringId)
+            }
+            resolvedId?.let { WorkflowResolution.Found(it) } ?: WorkflowResolution.NoWorkflow
         }
-        // If an identity-change invalidation advanced the generation while the topic was read, the resolved id
-        // may belong to the previous user; prefer whatever the (now newer) cache holds instead.
-        return if (cache.isCurrent(generation)) workflowId else cache.cached?.offeringToWorkflowId?.get(offeringId)
     }
+
+    /** The resolved workflow id for [offeringId], or `null` when none is mapped or the topic is unavailable. */
+    suspend fun workflowIdForOfferingId(offeringId: String): String? =
+        (resolveWorkflow(offeringId) as? WorkflowResolution.Found)?.workflowId
 
     /**
      * Resolves [workflowId] into a [PublishedWorkflow], or `null` when the item is unknown, its body can be
@@ -105,7 +129,7 @@ internal class WorkflowsConfigProvider(
     suspend fun getWorkflow(workflowId: String): PublishedWorkflow? {
         cache.cached?.workflows?.get(workflowId)?.let { return it.value }
         val generation = manager.configGeneration
-        val workflow = resolveWorkflow(workflowId)
+        val workflow = resolveWorkflowBody(workflowId)
         // If an identity-change invalidation advanced the generation while the body was resolved, it may belong
         // to the previous user; prefer whatever the (now newer) cache holds instead of serving it.
         return when {
@@ -116,7 +140,7 @@ internal class WorkflowsConfigProvider(
     }
 
     /** Reads + parses a workflow body straight from the config layer, bypassing the in-memory cache. */
-    private suspend fun resolveWorkflow(workflowId: String): PublishedWorkflow? {
+    private suspend fun resolveWorkflowBody(workflowId: String): PublishedWorkflow? {
         val body = resolveWorkflowBytes(workflowId) ?: return null
         return decodeWorkflow(workflowId, body)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -190,12 +190,12 @@ class WorkflowManagerTest {
     }
 
     @Test
-    fun `workflowIdForOfferingId delegates to the provider`() = runTest {
-        coEvery { mockProvider.workflowIdForOfferingId("off_1") } returns "wf_1"
+    fun `resolveWorkflow delegates to the provider`() = runTest {
+        coEvery { mockProvider.resolveWorkflow("off_1") } returns WorkflowResolution.Found("wf_1")
 
-        val result = workflowManager.workflowIdForOfferingId("off_1")
+        val result = workflowManager.resolveWorkflow("off_1")
 
-        assertThat(result).isEqualTo("wf_1")
+        assertThat(result).isEqualTo(WorkflowResolution.Found("wf_1"))
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
@@ -288,6 +288,38 @@ internal class WorkflowsConfigProviderTest {
         assertThat(provider.workflowIdForOfferingId(CURRENT_OFFERING)).isNull()
     }
 
+    @Test
+    fun `resolveWorkflow returns Found when the topic maps the offering to a workflow`() = runTest {
+        every { manager.configGeneration } returns 0
+        coEvery { manager.topic(RemoteConfigTopic.Workflows) } returns topicWith(
+            WF_CURRENT to configItem(prefetch = false, offeringId = CURRENT_OFFERING),
+        )
+
+        assertThat(provider.resolveWorkflow(CURRENT_OFFERING))
+            .isEqualTo(WorkflowResolution.Found(WF_CURRENT))
+    }
+
+    @Test
+    fun `resolveWorkflow returns NoWorkflow when the topic is readable but has no mapping`() = runTest {
+        every { manager.configGeneration } returns 0
+        coEvery { manager.topic(RemoteConfigTopic.Workflows) } returns topicWith(
+            WF_CURRENT to configItem(prefetch = false, offeringId = CURRENT_OFFERING),
+        )
+
+        // The topic committed fine; this offering simply has no workflow, so it is workflowless (not unknown).
+        assertThat(provider.resolveWorkflow(OTHER_OFFERING)).isEqualTo(WorkflowResolution.NoWorkflow)
+    }
+
+    @Test
+    fun `resolveWorkflow returns Unresolved when the topic cannot be read`() = runTest {
+        every { manager.configGeneration } returns 0
+        // A disabled endpoint (4xx) or a transient sync failure surfaces as a null topic; whether the offering
+        // has a workflow is unknown, so the caller — not the provider — decides how to recover.
+        coEvery { manager.topic(RemoteConfigTopic.Workflows) } returns null
+
+        assertThat(provider.resolveWorkflow(CURRENT_OFFERING)).isEqualTo(WorkflowResolution.Unresolved)
+    }
+
     private fun stubTopic() {
         coEvery { manager.committedTopicOrNull(RemoteConfigTopic.Workflows) } returns topicWith(
             WF_PREFETCH to configItem(prefetch = true, offeringId = null),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
@@ -311,14 +311,25 @@ internal class WorkflowsConfigProviderTest {
     }
 
     @Test
-    fun `resolveWorkflow returns Unresolved when the topic cannot be read`() = runTest {
+    fun `resolveWorkflow returns Disabled when the topic cannot be read and remote config is disabled`() = runTest {
         every { manager.configGeneration } returns 0
-        // A disabled endpoint (4xx) or a transient sync failure surfaces as a null topic; whether the offering
-        // has a workflow is unknown, so the caller — not the provider — decides how to recover.
         coEvery { manager.topic(RemoteConfigTopic.Workflows) } returns null
+        // A 4xx kill switch: the offering's components were skipped, so the caller can reload to recover them.
+        every { manager.isDisabled } returns true
 
-        assertThat(provider.resolveWorkflow(CURRENT_OFFERING)).isEqualTo(WorkflowResolution.Unresolved)
+        assertThat(provider.resolveWorkflow(CURRENT_OFFERING)).isEqualTo(WorkflowResolution.Disabled)
     }
+
+    @Test
+    fun `resolveWorkflow returns Unavailable when the topic cannot be read and remote config is not disabled`() =
+        runTest {
+            every { manager.configGeneration } returns 0
+            coEvery { manager.topic(RemoteConfigTopic.Workflows) } returns null
+            // A transient failure: reloading would recover nothing, so the caller surfaces an error.
+            every { manager.isDisabled } returns false
+
+            assertThat(provider.resolveWorkflow(CURRENT_OFFERING)).isEqualTo(WorkflowResolution.Unavailable)
+        }
 
     private fun stubTopic() {
         coEvery { manager.committedTopicOrNull(RemoteConfigTopic.Workflows) } returns topicWith(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
@@ -33,6 +33,8 @@ internal class WorkflowsConfigProviderTest {
 
     @Before
     fun setUp() {
+        // Default: endpoint live. Tests exercising the 4xx kill switch override this to true.
+        every { manager.isDisabled } returns false
         currentLogHandler = object : LogHandler {
             override fun v(tag: String, msg: String) {}
             override fun d(tag: String, msg: String) {}
@@ -318,6 +320,26 @@ internal class WorkflowsConfigProviderTest {
         every { manager.isDisabled } returns true
 
         assertThat(provider.resolveWorkflow(CURRENT_OFFERING)).isEqualTo(WorkflowResolution.Disabled)
+    }
+
+    @Test
+    fun `resolveWorkflow returns Disabled from a warm cache when remote config is disabled`() = runTest {
+        // Race: on a 4xx kill switch the disabled flag is set before the workflow cache is invalidated, so a
+        // concurrent resolution can still see a warm cache. The warm-cache fast path must honor isDisabled and
+        // yield Disabled (→ offerings reload) instead of the stale Found/NoWorkflow, or the components skipped
+        // while workflows were enabled are never recovered.
+        stubTopic()
+        stubWorkflowBody(WF_PREFETCH)
+        stubWorkflowBody(WF_CURRENT)
+        provider.warm(generation = 0)
+        assertThat(provider.isWarmForCurrentOffering()).isTrue
+
+        every { manager.isDisabled } returns true
+
+        // CURRENT_OFFERING maps to WF_CURRENT in the warm cache, so the fast path would return Found without the
+        // isDisabled guard; OTHER_OFFERING is unmapped and would return NoWorkflow. Both must yield Disabled.
+        assertThat(provider.resolveWorkflow(CURRENT_OFFERING)).isEqualTo(WorkflowResolution.Disabled)
+        assertThat(provider.resolveWorkflow("unmapped_off")).isEqualTo(WorkflowResolution.Disabled)
     }
 
     @Test

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
@@ -70,5 +71,7 @@ internal class MockPurchasesType(
         throw NotImplementedError("Mock implementation for previews only")
     }
 
-    override suspend fun workflowIdForOfferingId(offeringId: String): String? = null
+    override suspend fun resolveWorkflow(offeringId: String): WorkflowResolution = WorkflowResolution.NoWorkflow
+
+    override val isRemoteConfigDisabled: Boolean = false
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -72,6 +72,4 @@ internal class MockPurchasesType(
     }
 
     override suspend fun resolveWorkflow(offeringId: String): WorkflowResolution = WorkflowResolution.NoWorkflow
-
-    override val isRemoteConfigDisabled: Boolean = false
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -24,6 +24,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.common.workflows.WorkflowScreenType
 import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
@@ -809,31 +810,12 @@ internal class PaywallViewModelImpl(
         // deliberately do NOT gate on `paywallComponents`, which is going away.
         val workflowOffering = selectedOffering
         if (useWorkflowsEndpoint && workflowOffering != null && workflowOffering.paywall == null) {
-            try {
-                if (presentWorkflow(workflowOffering, offeringsForExitOfferLookup)) return
-
-                // A missing offering-to-workflow mapping is expected for workflowless offerings. There is no
-                // workflow endpoint failure to recover from, so render the offering's regular or default paywall.
-                clearWorkflowState()
-            } catch (e: PurchasesException) {
-                // A workflow endpoint failure, including the 4xx kill switch, means the offering object was
-                // likely parsed while components were skipped. Re-fetch it after the kill switch so its
-                // offerings-provided paywall components can be rendered.
-                val reloadedOfferings = purchases.awaitOfferings()
-                val reloadedOffering = reloadedOfferings[workflowOffering.identifier]
-                selectedOffering = reloadedOffering?.let { offering ->
-                    workflowOffering.presentedOfferingContext?.let(offering::copy) ?: offering
+            when (val outcome = presentWorkflowOrResolveFallback(workflowOffering, offeringsForExitOfferLookup)) {
+                WorkflowOutcome.Presented -> return
+                is WorkflowOutcome.Fallback -> {
+                    selectedOffering = outcome.offering
+                    offeringsForExitOfferLookup = outcome.offerings
                 }
-                offeringsForExitOfferLookup = reloadedOfferings
-                // A prior render on this ViewModel may have been a successful workflow, leaving
-                // _workflowState non-null. InternalPaywall renders the workflow UI whenever workflowState
-                // is non-null, so without clearing it the stale workflow would mask the offerings fallback
-                // we're about to set via updatePaywallState.
-                clearWorkflowState()
-                Logger.w(
-                    "Paywalls: Failed to fetch workflow for offering '${workflowOffering.identifier}' " +
-                        "(${e.message}). Falling back to the offerings-provided paywall.",
-                )
             }
         }
 
@@ -875,13 +857,77 @@ internal class PaywallViewModelImpl(
         return true
     }
 
-    private suspend fun presentWorkflow(offering: Offering, preloadedOfferings: Offerings?): Boolean {
-        // Resolve the offering to its configured workflow id, which aligns with the prefetch cache key. The
-        // config path has no backend lazy offering→workflow conversion, so a missing mapping falls through to
-        // the offering's regular or default paywall instead of attempting a guaranteed-miss blob read.
-        val workflowIdentifier = purchases.workflowIdForOfferingId(offering.identifier) ?: return false
+    private sealed interface WorkflowOutcome {
+        /** The workflow was presented; the caller should stop and not render an offerings paywall. */
+        object Presented : WorkflowOutcome
+
+        /** Render the offering's own paywall using [offering] and [offerings] instead of a workflow. */
+        data class Fallback(val offering: Offering, val offerings: Offerings?) : WorkflowOutcome
+    }
+
+    /**
+     * Resolves [workflowOffering] to its workflow and either presents it or decides how to fall back: a
+     * workflowless offering renders its own paywall, a 4xx kill switch reloads offerings to recover the
+     * components skipped during the workflows-enabled parse, and a transient failure throws (→ error state).
+     */
+    @Suppress("ReturnCount")
+    private suspend fun presentWorkflowOrResolveFallback(
+        workflowOffering: Offering,
+        preloadedOfferings: Offerings?,
+    ): WorkflowOutcome {
+        when (val resolution = purchases.resolveWorkflow(workflowOffering.identifier)) {
+            is WorkflowResolution.Found -> {
+                try {
+                    presentWorkflow(resolution.workflowId, workflowOffering, preloadedOfferings)
+                    return WorkflowOutcome.Presented
+                } catch (e: PurchasesException) {
+                    // The workflow id resolved but its body or ui config could not be served. A 4xx kill switch
+                    // means the offering was parsed with its components skipped, so reload it from /offerings to
+                    // recover them; any other (transient) failure surfaces as an error rather than silently
+                    // degrading to a different paywall.
+                    if (!purchases.isRemoteConfigDisabled) throw e
+                    Logger.w(
+                        "Paywalls: Failed to fetch workflow for offering '${workflowOffering.identifier}' " +
+                            "(${e.message}). Falling back to the offerings-provided paywall.",
+                    )
+                    val reloaded = reloadOfferingAfterConfigDisabled(workflowOffering)
+                    return WorkflowOutcome.Fallback(reloaded.offering, reloaded.offerings)
+                }
+            }
+            WorkflowResolution.NoWorkflow -> {
+                // The workflows topic was readable and this offering genuinely has no workflow, so render its
+                // regular or default paywall. A prior render on this ViewModel may have been a successful
+                // workflow, leaving _workflowState non-null; InternalPaywall renders the workflow UI whenever
+                // workflowState is non-null, so clear it or the stale workflow would mask the offerings fallback.
+                clearWorkflowState()
+                return WorkflowOutcome.Fallback(workflowOffering, preloadedOfferings)
+            }
+            WorkflowResolution.Unresolved -> {
+                // The workflows topic could not be read at all, so whether this offering has a workflow is
+                // unknown. A 4xx kill switch means the offering was parsed with its components skipped, so reload
+                // it from /offerings to recover them. A transient failure instead surfaces as an error rather
+                // than silently degrading to the default paywall.
+                if (!purchases.isRemoteConfigDisabled) {
+                    throw PurchasesException(
+                        PurchasesError(
+                            PurchasesErrorCode.UnknownError,
+                            "Could not resolve the workflow for offering '${workflowOffering.identifier}'.",
+                        ),
+                    )
+                }
+                Logger.w(
+                    "Paywalls: Workflows unavailable for offering '${workflowOffering.identifier}' after a " +
+                        "remote config disable. Falling back to the offerings-provided paywall.",
+                )
+                val reloaded = reloadOfferingAfterConfigDisabled(workflowOffering)
+                return WorkflowOutcome.Fallback(reloaded.offering, reloaded.offerings)
+            }
+        }
+    }
+
+    private suspend fun presentWorkflow(workflowId: String, offering: Offering, preloadedOfferings: Offerings?) {
         coroutineScope {
-            val workflowDeferred = async { purchases.awaitGetWorkflow(workflowIdentifier) }
+            val workflowDeferred = async { purchases.awaitGetWorkflow(workflowId) }
             val uiConfigDeferred = async { purchases.awaitGetUiConfig() }
             val offeringsDeferred = async { preloadedOfferings ?: purchases.awaitOfferings() }
             startWorkflowPresentation(
@@ -891,8 +937,25 @@ internal class PaywallViewModelImpl(
                 offering.presentedOfferingContext,
             )
         }
-        return true
     }
+
+    /**
+     * Reloads offerings after the `/v1/config` endpoint was disabled by a 4xx kill switch. The disable makes
+     * `/offerings` re-parse with the paywall components that were skipped while workflows were enabled, so the
+     * offering's own paywall can be recovered. Falls back to [originalOffering] when it is no longer present in
+     * the reloaded offerings (rather than leaving no offering to render), and clears any stale workflow state so
+     * the fallback isn't masked by a prior successful workflow render.
+     */
+    private suspend fun reloadOfferingAfterConfigDisabled(originalOffering: Offering): ReloadedOffering {
+        val reloadedOfferings = purchases.awaitOfferings()
+        val reloadedOffering = reloadedOfferings[originalOffering.identifier]?.let { offering ->
+            originalOffering.presentedOfferingContext?.let(offering::copy) ?: offering
+        } ?: originalOffering
+        clearWorkflowState()
+        return ReloadedOffering(reloadedOffering, reloadedOfferings)
+    }
+
+    private data class ReloadedOffering(val offering: Offering, val offerings: Offerings)
 
     private suspend fun resolveOfferingSelection(offeringSelection: OfferingSelection): ResolvedOfferingSelection =
         when (offeringSelection) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -812,10 +812,9 @@ internal class PaywallViewModelImpl(
                 return
             } catch (e: PurchasesException) {
                 // The workflow could not be served — the config endpoint is disabled for the session
-                // (4xx kill switch), unreachable, or the offering has no workflow yet. Degrade to the
-                // paywall /offerings already delivered so the app still shows something; rethrow
-                // (→ PaywallState.Error) only when there is nothing to fall back to.
-                if (selectedOffering.paywallComponents == null) throw e
+                // (4xx kill switch), unreachable, or the offering has no workflow yet. Degrade to the normal
+                // paywall path so the app still shows something. If no paywall data was delivered either,
+                // updatePaywallState will generate the default paywall for the offering.
                 // A prior render on this ViewModel may have been a successful workflow, leaving
                 // _workflowState non-null. InternalPaywall renders the workflow UI whenever workflowState
                 // is non-null, so without clearing it the stale workflow would mask the offerings fallback
@@ -823,7 +822,7 @@ internal class PaywallViewModelImpl(
                 clearWorkflowState()
                 Logger.w(
                     "Paywalls: Failed to fetch workflow for offering '${selectedOffering.identifier}' " +
-                        "(${e.message}). Falling back to the offerings-provided paywall.",
+                        "(${e.message}). Falling back to the offerings-provided or default paywall.",
                 )
             }
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -868,7 +868,7 @@ internal class PaywallViewModelImpl(
     /**
      * Resolves [workflowOffering] to its workflow and either presents it or decides how to fall back: a
      * workflowless offering renders its own paywall, a 4xx kill switch reloads offerings to recover the
-     * components skipped during the workflows-enabled parse, and a transient failure throws (→ error state).
+     * components skipped during the workflows-enabled parse, and any other failure throws (→ error state).
      */
     @Suppress("ReturnCount")
     private suspend fun presentWorkflowOrResolveFallback(
@@ -881,17 +881,12 @@ internal class PaywallViewModelImpl(
                     presentWorkflow(resolution.workflowId, workflowOffering, preloadedOfferings)
                     return WorkflowOutcome.Presented
                 } catch (e: PurchasesException) {
-                    // The workflow id resolved but its body or ui config could not be served. A 4xx kill switch
-                    // means the offering was parsed with its components skipped, so reload it from /offerings to
-                    // recover them; any other (transient) failure surfaces as an error rather than silently
-                    // degrading to a different paywall.
-                    if (!purchases.isRemoteConfigDisabled) throw e
-                    Logger.w(
-                        "Paywalls: Failed to fetch workflow for offering '${workflowOffering.identifier}' " +
-                            "(${e.message}). Falling back to the offerings-provided paywall.",
-                    )
-                    val reloaded = reloadOfferingAfterConfigDisabled(workflowOffering)
-                    return WorkflowOutcome.Fallback(reloaded.offering, reloaded.offerings)
+                    // The workflow id resolved but its body or ui config could not be served. Reloading offerings
+                    // would only yield the offering's skipped-away components, so surface the error instead of
+                    // silently degrading to a different paywall. Clear any stale workflow UI first so the error
+                    // isn't masked by a prior successful workflow render.
+                    clearWorkflowState()
+                    throw e
                 }
             }
             WorkflowResolution.NoWorkflow -> {
@@ -902,25 +897,26 @@ internal class PaywallViewModelImpl(
                 clearWorkflowState()
                 return WorkflowOutcome.Fallback(workflowOffering, preloadedOfferings)
             }
-            WorkflowResolution.Unresolved -> {
-                // The workflows topic could not be read at all, so whether this offering has a workflow is
-                // unknown. A 4xx kill switch means the offering was parsed with its components skipped, so reload
-                // it from /offerings to recover them. A transient failure instead surfaces as an error rather
-                // than silently degrading to the default paywall.
-                if (!purchases.isRemoteConfigDisabled) {
-                    throw PurchasesException(
-                        PurchasesError(
-                            PurchasesErrorCode.UnknownError,
-                            "Could not resolve the workflow for offering '${workflowOffering.identifier}'.",
-                        ),
-                    )
-                }
+            WorkflowResolution.Disabled -> {
+                // A 4xx kill switch disabled remote config. The offering was parsed with its components skipped,
+                // so reload it from /offerings — which now re-parse with those components — to recover its paywall.
                 Logger.w(
                     "Paywalls: Workflows unavailable for offering '${workflowOffering.identifier}' after a " +
                         "remote config disable. Falling back to the offerings-provided paywall.",
                 )
                 val reloaded = reloadOfferingAfterConfigDisabled(workflowOffering)
                 return WorkflowOutcome.Fallback(reloaded.offering, reloaded.offerings)
+            }
+            WorkflowResolution.Unavailable -> {
+                // The workflows topic could not be read and remote config is not disabled (a transient failure),
+                // so whether this offering has a workflow is unknown and reloading would recover nothing. Surface
+                // an error rather than silently degrading to the default paywall.
+                throw PurchasesException(
+                    PurchasesError(
+                        PurchasesErrorCode.UnknownError,
+                        "Could not resolve the workflow for offering '${workflowOffering.identifier}'.",
+                    ),
+                )
             }
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -799,37 +799,47 @@ internal class PaywallViewModelImpl(
         }
 
         val resolvedOfferingSelection = resolveOfferingSelection(offeringSelection)
-        val selectedOffering = resolvedOfferingSelection.selectedOffering
+        var selectedOffering = resolvedOfferingSelection.selectedOffering
+        var offeringsForExitOfferLookup = resolvedOfferingSelection.offeringsForExitOfferLookup
 
         // When workflows are enabled, every non-legacy paywall is served through the workflows
         // path. `offering.paywall == null` is the durable marker of a non-legacy (workflow)
         // paywall: a legacy v1 paywall always carries `offering.paywall`, and that field stays
         // even after `paywallComponents` is removed and all V2 paywalls move to workflows. We
         // deliberately do NOT gate on `paywallComponents`, which is going away.
-        if (useWorkflowsEndpoint && selectedOffering != null && selectedOffering.paywall == null) {
+        val workflowOffering = selectedOffering
+        if (useWorkflowsEndpoint && workflowOffering != null && workflowOffering.paywall == null) {
             try {
-                presentWorkflow(selectedOffering, resolvedOfferingSelection.offeringsForExitOfferLookup)
-                return
+                if (presentWorkflow(workflowOffering, offeringsForExitOfferLookup)) return
+
+                // A missing offering-to-workflow mapping is expected for workflowless offerings. There is no
+                // workflow endpoint failure to recover from, so render the offering's regular or default paywall.
+                clearWorkflowState()
             } catch (e: PurchasesException) {
-                // The workflow could not be served — the config endpoint is disabled for the session
-                // (4xx kill switch), unreachable, or the offering has no workflow yet. Degrade to the normal
-                // paywall path so the app still shows something. If no paywall data was delivered either,
-                // updatePaywallState will generate the default paywall for the offering.
+                // A workflow endpoint failure, including the 4xx kill switch, means the offering object was
+                // likely parsed while components were skipped. Re-fetch it after the kill switch so its
+                // offerings-provided paywall components can be rendered.
+                val reloadedOfferings = purchases.awaitOfferings()
+                val reloadedOffering = reloadedOfferings[workflowOffering.identifier] ?: reloadedOfferings.current
+                selectedOffering = reloadedOffering?.let { offering ->
+                    workflowOffering.presentedOfferingContext?.let(offering::copy) ?: offering
+                }
+                offeringsForExitOfferLookup = reloadedOfferings
                 // A prior render on this ViewModel may have been a successful workflow, leaving
                 // _workflowState non-null. InternalPaywall renders the workflow UI whenever workflowState
                 // is non-null, so without clearing it the stale workflow would mask the offerings fallback
                 // we're about to set via updatePaywallState.
                 clearWorkflowState()
                 Logger.w(
-                    "Paywalls: Failed to fetch workflow for offering '${selectedOffering.identifier}' " +
-                        "(${e.message}). Falling back to the offerings-provided or default paywall.",
+                    "Paywalls: Failed to fetch workflow for offering '${workflowOffering.identifier}' " +
+                        "(${e.message}). Falling back to the offerings-provided paywall.",
                 )
             }
         }
 
         val exitOfferingId = selectedOffering?.paywallComponents?.data?.exitOffers?.dismiss?.offeringId
 
-        val offerings = resolvedOfferingSelection.offeringsForExitOfferLookup
+        val offerings = offeringsForExitOfferLookup
         updateExitOfferData(
             if (exitOfferingId != null && offerings != null) {
                 ExitOfferData.Configured(
@@ -865,18 +875,11 @@ internal class PaywallViewModelImpl(
         return true
     }
 
-    private suspend fun presentWorkflow(offering: Offering, preloadedOfferings: Offerings?) {
+    private suspend fun presentWorkflow(offering: Offering, preloadedOfferings: Offerings?): Boolean {
         // Resolve the offering to its configured workflow id, which aligns with the prefetch cache key. The
-        // config path has no backend lazy offering→workflow conversion, so a missing mapping should fail
-        // immediately instead of attempting a guaranteed-miss blob read (and potentially an on-demand sync).
-        val workflowIdentifier = purchases.workflowIdForOfferingId(offering.identifier) ?: run {
-            throw PurchasesException(
-                PurchasesError(
-                    PurchasesErrorCode.UnknownError,
-                    "No workflow is configured for offering '${offering.identifier}'.",
-                ),
-            )
-        }
+        // config path has no backend lazy offering→workflow conversion, so a missing mapping falls through to
+        // the offering's regular or default paywall instead of attempting a guaranteed-miss blob read.
+        val workflowIdentifier = purchases.workflowIdForOfferingId(offering.identifier) ?: return false
         coroutineScope {
             val workflowDeferred = async { purchases.awaitGetWorkflow(workflowIdentifier) }
             val uiConfigDeferred = async { purchases.awaitGetUiConfig() }
@@ -888,6 +891,7 @@ internal class PaywallViewModelImpl(
                 offering.presentedOfferingContext,
             )
         }
+        return true
     }
 
     private suspend fun resolveOfferingSelection(offeringSelection: OfferingSelection): ResolvedOfferingSelection =

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -820,7 +820,7 @@ internal class PaywallViewModelImpl(
                 // likely parsed while components were skipped. Re-fetch it after the kill switch so its
                 // offerings-provided paywall components can be rendered.
                 val reloadedOfferings = purchases.awaitOfferings()
-                val reloadedOffering = reloadedOfferings[workflowOffering.identifier] ?: reloadedOfferings.current
+                val reloadedOffering = reloadedOfferings[workflowOffering.identifier]
                 selectedOffering = reloadedOffering?.let { offering ->
                     workflowOffering.presentedOfferingContext?.let(offering::copy) ?: offering
                 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -76,8 +76,6 @@ internal interface PurchasesType {
 
     suspend fun resolveWorkflow(offeringId: String): WorkflowResolution
 
-    val isRemoteConfigDisabled: Boolean
-
     val useWorkflows: Boolean
 }
 
@@ -159,10 +157,6 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
     @OptIn(InternalRevenueCatAPI::class)
     override suspend fun resolveWorkflow(offeringId: String): WorkflowResolution =
         purchases.resolveWorkflow(offeringId)
-
-    @OptIn(InternalRevenueCatAPI::class)
-    override val isRemoteConfigDisabled: Boolean
-        get() = purchases.isRemoteConfigDisabled
 
     @OptIn(InternalRevenueCatAPI::class)
     override val useWorkflows: Boolean

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.awaitRestore
 import com.revenuecat.purchases.awaitSyncPurchases
 import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
@@ -73,7 +74,9 @@ internal interface PurchasesType {
     @Throws(PurchasesException::class)
     suspend fun awaitGetUiConfig(): UiConfig
 
-    suspend fun workflowIdForOfferingId(offeringId: String): String?
+    suspend fun resolveWorkflow(offeringId: String): WorkflowResolution
+
+    val isRemoteConfigDisabled: Boolean
 
     val useWorkflows: Boolean
 }
@@ -154,8 +157,12 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
     override suspend fun awaitGetUiConfig(): UiConfig = purchases.awaitGetUiConfig()
 
     @OptIn(InternalRevenueCatAPI::class)
-    override suspend fun workflowIdForOfferingId(offeringId: String): String? =
-        purchases.workflowIdForOfferingId(offeringId)
+    override suspend fun resolveWorkflow(offeringId: String): WorkflowResolution =
+        purchases.resolveWorkflow(offeringId)
+
+    @OptIn(InternalRevenueCatAPI::class)
+    override val isRemoteConfigDisabled: Boolean
+        get() = purchases.isRemoteConfigDisabled
 
     @OptIn(InternalRevenueCatAPI::class)
     override val useWorkflows: Boolean

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
@@ -67,5 +68,7 @@ internal class MockPurchasesType(
         throw NotImplementedError("Mock implementation")
     }
 
-    override suspend fun workflowIdForOfferingId(offeringId: String): String? = null
+    override suspend fun resolveWorkflow(offeringId: String): WorkflowResolution = WorkflowResolution.NoWorkflow
+
+    override val isRemoteConfigDisabled: Boolean = false
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -69,6 +69,4 @@ internal class MockPurchasesType(
     }
 
     override suspend fun resolveWorkflow(offeringId: String): WorkflowResolution = WorkflowResolution.NoWorkflow
-
-    override val isRemoteConfigDisabled: Boolean = false
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -3198,22 +3198,27 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and the workflow fetch fails, falls back to the offerings-provided paywall`() {
-        // The config endpoint may be disabled for the session (4xx kill switch) or unreachable, or the
-        // offering may have no workflow yet. The offering still carries the paywall /offerings delivered,
-        // so the paywall renders through the regular components path instead of erroring.
+    fun `when useWorkflows is true and the workflow fetch fails, reloads its paywall from offerings`() {
+        // A 4xx disables the config endpoint for the session. The initial offering was parsed while workflows
+        // were enabled, so it has no components. Reload it from /offerings after the disable to get its paywall.
         val workflowId = "wfl-unavailable"
+        val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
+        val reloadedOfferings = Offerings(
+            current = offeringWithWPL,
+            all = mapOf(offeringWithWPL.identifier to offeringWithWPL),
+        )
         coEvery { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns workflowId
         coEvery { purchases.awaitGetWorkflow(workflowId) } throws PurchasesException(
             PurchasesError(PurchasesErrorCode.UnknownError, "Workflow is unavailable from remote config."),
         )
+        coEvery { purchases.awaitOfferings() } returns reloadedOfferings
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
             purchases,
             PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
                 .setListener(listener)
-                .setOffering(offeringWithWPL)
+                .setOffering(offeringWithoutComponents)
                 .build(),
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
@@ -3222,11 +3227,14 @@ class PaywallViewModelTest {
         )
 
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+        val reloadedOffering = (model.state.value as PaywallState.Loaded.Components).offering
+        assertThat(reloadedOffering.identifier).isEqualTo(offeringWithWPL.identifier)
+        assertThat(reloadedOffering.paywallComponents).isNotNull()
         coVerify(exactly = 1) { purchases.awaitGetWorkflow(workflowId) }
     }
 
     @Test
-    fun `when useWorkflows is true and the workflow fetch fails with no fallback paywall, renders the default paywall`() {
+    fun `when useWorkflows is true and no workflow is mapped with no paywall data, renders the default paywall`() {
         val offeringWithoutPaywallData = Offering(
             identifier = "offering-no-paywall-data",
             serverDescription = "description",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -3226,7 +3226,7 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and the workflow fetch fails with no fallback paywall, surfaces the error`() {
+    fun `when useWorkflows is true and the workflow fetch fails with no fallback paywall, renders the default paywall`() {
         val offeringWithoutPaywallData = Offering(
             identifier = "offering-no-paywall-data",
             serverDescription = "description",
@@ -3250,7 +3250,7 @@ class PaywallViewModelTest {
             useWorkflowsEndpoint = true,
         )
 
-        assertThat(model.state.value).isInstanceOf(PaywallState.Error::class.java)
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Legacy::class.java)
         coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -37,6 +37,7 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.common.workflows.WorkflowScreen
 import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.common.workflows.WorkflowTrigger
@@ -232,7 +233,8 @@ class PaywallViewModelTest {
         coEvery { purchases.awaitSyncPurchases() } returns customerInfo
         every { purchases.preferredUILocaleOverride } returns null
         every { purchases.useWorkflows } returns false
-        coEvery { purchases.workflowIdForOfferingId(any()) } returns null
+        coEvery { purchases.resolveWorkflow(any()) } returns WorkflowResolution.NoWorkflow
+        every { purchases.isRemoteConfigDisabled } returns false
         coEvery { purchases.awaitGetUiConfig() } returns UiConfig()
 
         every { listener.onPurchaseStarted(any()) } just runs
@@ -1425,7 +1427,7 @@ class PaywallViewModelTest {
             steps = mapOf("step-1" to stepOne, "step-2" to stepTwo),
             screens = mapOf("screen-1" to workflowScreen),
         )
-        coEvery { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns "wfl-test"
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Found("wfl-test")
         coEvery { purchases.awaitGetWorkflow("wfl-test") } returns workflow
 
         val model = PaywallViewModelImpl(
@@ -1483,7 +1485,7 @@ class PaywallViewModelTest {
             steps = mapOf("step-1" to stepOne),
             screens = mapOf("screen-1" to workflowScreen),
         )
-        coEvery { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns "wfl-test"
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Found("wfl-test")
         coEvery { purchases.awaitGetWorkflow("wfl-test") } returns workflow
 
         val model = PaywallViewModelImpl(
@@ -3130,7 +3132,7 @@ class PaywallViewModelTest {
         // offeringWithWPL has no legacy paywall (offering.paywall == null), so it is served through
         // the workflows endpoint. With a mapped workflow id, that id (not the offering id) is used.
         val workflowId = "wfl-real-id"
-        coEvery { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns workflowId
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Found(workflowId)
         val workflowScreen = WorkflowScreen(
             templateName = "template",
             revision = 0,
@@ -3176,9 +3178,9 @@ class PaywallViewModelTest {
 
     @Test
     fun `when useWorkflows is true and offering has no mapped workflow, skips fetch and falls back`() {
-        // The config endpoint cannot lazily convert an offering id into a workflow. A missing mapping should
-        // therefore fall back immediately to the components paywall already delivered by offerings.
-        coEvery { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns null
+        // The config endpoint cannot lazily convert an offering id into a workflow. A workflowless offering
+        // should therefore fall back immediately to the components paywall already delivered by offerings.
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.NoWorkflow
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
@@ -3207,10 +3209,11 @@ class PaywallViewModelTest {
             current = offeringWithWPL,
             all = mapOf(offeringWithWPL.identifier to offeringWithWPL),
         )
-        coEvery { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns workflowId
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Found(workflowId)
         coEvery { purchases.awaitGetWorkflow(workflowId) } throws PurchasesException(
             PurchasesError(PurchasesErrorCode.UnknownError, "Workflow is unavailable from remote config."),
         )
+        every { purchases.isRemoteConfigDisabled } returns true
         coEvery { purchases.awaitOfferings() } returns reloadedOfferings
 
         val model = PaywallViewModelImpl(
@@ -3234,6 +3237,94 @@ class PaywallViewModelTest {
     }
 
     @Test
+    fun `when useWorkflows is true and the workflow fetch fails transiently, surfaces the error`() {
+        // The workflow id resolved but its body could not be fetched, and remote config is NOT disabled (a
+        // transient failure). Reloading offerings would re-parse with components still skipped, so there is
+        // nothing to recover — the paywall surfaces the error instead of silently degrading.
+        val workflowId = "wfl-unavailable"
+        val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Found(workflowId)
+        coEvery { purchases.awaitGetWorkflow(workflowId) } throws PurchasesException(
+            PurchasesError(PurchasesErrorCode.UnknownError, "Workflow is unavailable from remote config."),
+        )
+        every { purchases.isRemoteConfigDisabled } returns false
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offeringWithoutComponents)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.state.value).isInstanceOf(PaywallState.Error::class.java)
+        coVerify(exactly = 0) { purchases.awaitOfferings() }
+    }
+
+    @Test
+    fun `when useWorkflows is true and the workflows topic is unresolved after a disable, reloads from offerings`() {
+        // A 4xx disabled the config endpoint before the workflow id could be resolved. The offering was parsed
+        // with its components skipped, so reload it from /offerings after the disable to recover its paywall.
+        val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
+        val reloadedOfferings = Offerings(
+            current = offeringWithWPL,
+            all = mapOf(offeringWithWPL.identifier to offeringWithWPL),
+        )
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Unresolved
+        every { purchases.isRemoteConfigDisabled } returns true
+        coEvery { purchases.awaitOfferings() } returns reloadedOfferings
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offeringWithoutComponents)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+        val reloadedOffering = (model.state.value as PaywallState.Loaded.Components).offering
+        assertThat(reloadedOffering.paywallComponents).isNotNull()
+        coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
+    }
+
+    @Test
+    fun `when useWorkflows is true and the workflows topic is unresolved transiently, surfaces the error`() {
+        // The workflows topic could not be read but remote config is NOT disabled (a transient sync failure).
+        // Reloading offerings would not recover components, so surface the error instead of degrading to default.
+        val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Unresolved
+        every { purchases.isRemoteConfigDisabled } returns false
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offeringWithoutComponents)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.state.value).isInstanceOf(PaywallState.Error::class.java)
+        coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
+        coVerify(exactly = 0) { purchases.awaitOfferings() }
+    }
+
+    @Test
     fun `when useWorkflows is true and no workflow is mapped with no paywall data, renders the default paywall`() {
         val offeringWithoutPaywallData = Offering(
             identifier = "offering-no-paywall-data",
@@ -3243,7 +3334,7 @@ class PaywallViewModelTest {
             paywallComponents = null,
             webCheckoutURL = null,
         )
-        coEvery { purchases.workflowIdForOfferingId(offeringWithoutPaywallData.identifier) } returns null
+        coEvery { purchases.resolveWorkflow(offeringWithoutPaywallData.identifier) } returns WorkflowResolution.NoWorkflow
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
@@ -3290,7 +3381,7 @@ class PaywallViewModelTest {
             steps = mapOf("step-1" to WorkflowStep(id = "step-1", type = "screen", screenId = "screen-1")),
             screens = mapOf("screen-1" to workflowScreen),
         )
-        coEvery { purchases.workflowIdForOfferingId(offeringWithWPL.identifier) } returns "wfl-test"
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Found("wfl-test")
         coEvery { purchases.awaitGetWorkflow("wfl-test") } returns workflow
 
         val model = PaywallViewModelImpl(
@@ -3318,7 +3409,7 @@ class PaywallViewModelTest {
             paywallComponents = Offering.PaywallComponents(UiConfig(), emptyPaywallComponentsData),
             webCheckoutURL = null,
         )
-        coEvery { purchases.workflowIdForOfferingId(fallbackOffering.identifier) } returns null
+        coEvery { purchases.resolveWorkflow(fallbackOffering.identifier) } returns WorkflowResolution.NoWorkflow
 
         model.updateOptions(
             PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -234,7 +234,6 @@ class PaywallViewModelTest {
         every { purchases.preferredUILocaleOverride } returns null
         every { purchases.useWorkflows } returns false
         coEvery { purchases.resolveWorkflow(any()) } returns WorkflowResolution.NoWorkflow
-        every { purchases.isRemoteConfigDisabled } returns false
         coEvery { purchases.awaitGetUiConfig() } returns UiConfig()
 
         every { listener.onPurchaseStarted(any()) } just runs
@@ -3200,54 +3199,16 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and the workflow fetch fails, reloads its paywall from offerings`() {
-        // A 4xx disables the config endpoint for the session. The initial offering was parsed while workflows
-        // were enabled, so it has no components. Reload it from /offerings after the disable to get its paywall.
-        val workflowId = "wfl-unavailable"
-        val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
-        val reloadedOfferings = Offerings(
-            current = offeringWithWPL,
-            all = mapOf(offeringWithWPL.identifier to offeringWithWPL),
-        )
-        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Found(workflowId)
-        coEvery { purchases.awaitGetWorkflow(workflowId) } throws PurchasesException(
-            PurchasesError(PurchasesErrorCode.UnknownError, "Workflow is unavailable from remote config."),
-        )
-        every { purchases.isRemoteConfigDisabled } returns true
-        coEvery { purchases.awaitOfferings() } returns reloadedOfferings
-
-        val model = PaywallViewModelImpl(
-            MockResourceProvider(),
-            purchases,
-            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
-                .setListener(listener)
-                .setOffering(offeringWithoutComponents)
-                .build(),
-            TestData.Constants.currentColorScheme,
-            isDarkMode = false,
-            shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
-        )
-
-        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
-        val reloadedOffering = (model.state.value as PaywallState.Loaded.Components).offering
-        assertThat(reloadedOffering.identifier).isEqualTo(offeringWithWPL.identifier)
-        assertThat(reloadedOffering.paywallComponents).isNotNull()
-        coVerify(exactly = 1) { purchases.awaitGetWorkflow(workflowId) }
-    }
-
-    @Test
-    fun `when useWorkflows is true and the workflow fetch fails transiently, surfaces the error`() {
-        // The workflow id resolved but its body could not be fetched, and remote config is NOT disabled (a
-        // transient failure). Reloading offerings would re-parse with components still skipped, so there is
-        // nothing to recover — the paywall surfaces the error instead of silently degrading.
+    fun `when useWorkflows is true and the workflow fetch fails, surfaces the error`() {
+        // The workflow id resolved but its body or ui config could not be served. Reloading offerings would only
+        // yield the offering's skipped-away components, so the paywall surfaces the error instead of silently
+        // degrading to a different paywall.
         val workflowId = "wfl-unavailable"
         val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
         coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Found(workflowId)
         coEvery { purchases.awaitGetWorkflow(workflowId) } throws PurchasesException(
             PurchasesError(PurchasesErrorCode.UnknownError, "Workflow is unavailable from remote config."),
         )
-        every { purchases.isRemoteConfigDisabled } returns false
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
@@ -3267,16 +3228,15 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and the workflows topic is unresolved after a disable, reloads from offerings`() {
-        // A 4xx disabled the config endpoint before the workflow id could be resolved. The offering was parsed
-        // with its components skipped, so reload it from /offerings after the disable to recover its paywall.
+    fun `when useWorkflows is true and the workflows topic is disabled by a 4xx, reloads its paywall from offerings`() {
+        // A 4xx disabled the config endpoint for the session. The initial offering was parsed while workflows
+        // were enabled, so it has no components. Reload it from /offerings after the disable to get its paywall.
         val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
         val reloadedOfferings = Offerings(
             current = offeringWithWPL,
             all = mapOf(offeringWithWPL.identifier to offeringWithWPL),
         )
-        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Unresolved
-        every { purchases.isRemoteConfigDisabled } returns true
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Disabled
         coEvery { purchases.awaitOfferings() } returns reloadedOfferings
 
         val model = PaywallViewModelImpl(
@@ -3294,17 +3254,17 @@ class PaywallViewModelTest {
 
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
         val reloadedOffering = (model.state.value as PaywallState.Loaded.Components).offering
+        assertThat(reloadedOffering.identifier).isEqualTo(offeringWithWPL.identifier)
         assertThat(reloadedOffering.paywallComponents).isNotNull()
         coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
     }
 
     @Test
-    fun `when useWorkflows is true and the workflows topic is unresolved transiently, surfaces the error`() {
-        // The workflows topic could not be read but remote config is NOT disabled (a transient sync failure).
-        // Reloading offerings would not recover components, so surface the error instead of degrading to default.
+    fun `when useWorkflows is true and the workflows topic is unavailable, surfaces the error`() {
+        // The workflows topic could not be read and remote config is not disabled (a transient failure), so
+        // reloading offerings would recover nothing — surface the error instead of degrading to the default.
         val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
-        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Unresolved
-        every { purchases.isRemoteConfigDisabled } returns false
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Unavailable
 
         val model = PaywallViewModelImpl(
             MockResourceProvider(),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -21,6 +21,7 @@ import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.paywalls.components.PackageComponent
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.common.workflows.WorkflowScreen
 import com.revenuecat.purchases.common.workflows.WorkflowScreenType
 import com.revenuecat.purchases.common.workflows.WorkflowStep
@@ -920,7 +921,7 @@ class PaywallViewModelWorkflowTest {
         val immediateMain = UnconfinedTestDispatcher()
         Dispatchers.setMain(immediateMain)
         try {
-            coEvery { purchases.workflowIdForOfferingId(offeringId) } returns workflow.id
+            coEvery { purchases.resolveWorkflow(offeringId) } returns WorkflowResolution.Found(workflow.id)
             coEvery { purchases.awaitGetWorkflow(workflow.id) } returns fetchResult
             coEvery { purchases.awaitGetUiConfig() } returns uiConfig
             coEvery { purchases.awaitOfferings() } returns testOfferings
@@ -940,7 +941,7 @@ class PaywallViewModelWorkflowTest {
     fun `a cold cache shows Loading then the loaded workflow after the async read`() = runTest {
         // A cold read really suspends; the same single path shows Loading until it resolves.
         val gate = CompletableDeferred<Unit>()
-        coEvery { purchases.workflowIdForOfferingId(any()) } returns workflow.id
+        coEvery { purchases.resolveWorkflow(any()) } returns WorkflowResolution.Found(workflow.id)
         coEvery { purchases.awaitGetWorkflow(any()) } coAnswers { gate.await(); fetchResult }
         coEvery { purchases.awaitGetUiConfig() } returns uiConfig
         coEvery { purchases.awaitOfferings() } returns testOfferings


### PR DESCRIPTION
With workflows enabled, offerings are parsed without their paywall components, and every non-legacy paywall is served through the workflows path. An offering with no workflow, or one that can't be served, would fall through and fail rendering.

Resolving an offering to its workflow now distinguishes four outcomes, each recovering differently:

- has a workflow → serve it
- has no workflow → render its regular (via offering) or default paywall
- config endpoint disabled by a 4xx → reload `/offerings` (which re-parse with the previously skipped components) and render that
- topic transiently unavailable → surface an error rather than silently degrading


https://github.com/user-attachments/assets/dba14d61-6e27-4f17-9d9f-b107b66a003e



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core paywall render and fallback behavior when workflows and remote config are enabled, including offerings reload on config disable; scope is focused and covered by new unit tests.
> 
> **Overview**
> With workflows enabled, offerings without a mapped workflow or with broken config could fail to render instead of showing a regular or default paywall. **Offering→workflow resolution now returns a `WorkflowResolution` sealed type** (`Found`, `NoWorkflow`, `Disabled`, `Unavailable`) instead of a nullable workflow id, so callers can tell workflowless offerings apart from config kill-switch and transient failures.
> 
> **`WorkflowsConfigProvider.resolveWorkflow`** checks `isDisabled` before the warm-cache fast path (so stale cache cannot skip an offerings reload after a 4xx disable) and maps a missing workflows topic to `Disabled` vs `Unavailable`.
> 
> **`PaywallViewModel`** branches on each outcome: present the workflow on `Found`; fall back to embedded/default paywall on `NoWorkflow`; reload `/offerings` on `Disabled` to recover skipped paywall components; show error on `Unavailable` or when a resolved workflow body fails to load (no silent degrade). Public/internal API surface switches from `workflowIdForOfferingId` to `resolveWorkflow` through `Purchases` and `PurchasesType`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit befb92fcefc713809b3a93bbec97a9349b58edb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->