### PR TITLE
refactor(remote-config): RCContainer improvements

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -614,13 +614,13 @@ internal class HTTPClient(
 
     /**
      * Verifies an RC Container Format response. The backend signs the leading config element's (element 0)
-     * **uncompressed** bytes — the config part / `main_body` — so we [decode][RCElement.decodedBytes] the
-     * element first and verify the signature over those bytes. Per-element compression is transparent to the
-     * signature (as it is to the element checksum), so a codec change never invalidates a signed config.
-     * The per-element container checksums are untrusted lookup hints, not a trust anchor: inline blob elements
-     * are not signed and are instead authenticated transitively by hashing against the `blob_ref` in the signed
-     * config. This endpoint is not ETag-cached and sends no post params, but the signature does cover the request
-     * [nonce].
+     * **uncompressed** bytes — the config part / `main_body` — so we verify the signature over
+     * [RCContainer.config], which is the element already decoded by the container. Per-element compression is
+     * transparent to the signature (as it is to the element checksum), so a codec change never invalidates a
+     * signed config. The per-element container checksums are untrusted lookup hints, not a trust anchor: inline
+     * blob elements are not signed and are instead authenticated transitively by hashing against the `blob_ref`
+     * in the signed config. This endpoint is not ETag-cached and sends no post params, but the signature does
+     * cover the request [nonce].
      */
     private fun verifyRCFormatResponse(
         urlPath: String,
@@ -629,7 +629,7 @@ internal class HTTPClient(
         nonce: String?,
     ): VerificationResult {
         val bodyBytes = try {
-            RCContainer.parse(payloadBytes).config.decodedBytes()
+            RCContainer.parse(payloadBytes).config
         } catch (e: RCContainerFormatException) {
             errorLog(e) { NetworkStrings.VERIFICATION_ERROR.format(urlPath) }
             return VerificationResult.FAILED

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCContainer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCContainer.kt
@@ -13,33 +13,38 @@ import java.nio.ByteOrder
  * Element:          checksum byte[24]  | element_size u32 | reserved u32 | element[element_size] | pad→8
  * ```
  * Elements repeat until the backing buffer is exhausted (the format stores no count). Element 0 is
- * always the [config]; the remaining elements are content-addressed by checksum.
+ * always the config; the remaining elements are content-addressed by checksum.
  *
  * The low byte of each element's `reserved` u32 is its content-encoding codec ([RCContentEncoding]):
  * `element_size` is then the **on-wire (compressed)** length, while the checksum covers the
  * **uncompressed** bytes. Header `flags` are parsed and ignored (forward-compatible).
  *
- * [config] and each [RCElement] expose read-only views that share the backing buffer, so parsing
- * copies no field bytes. The content-addressed [elements] map is built lazily: only its base64 keys
- * allocate, and only on first access. Element bodies are always zero-copy views.
+ * This class turns that raw form into usable content. [config] (always needed) is decoded and verified up
+ * front during [parse]. The content blobs — often large and mostly unwanted on a given sync — stay compressed
+ * in [contentElements]; a consumer iterates those and decodes (via [RCElement.decode], which verifies) only
+ * the ones it wants, one at a time, so the whole payload is never held uncompressed at once. Parsing of the
+ * content blobs stays zero-copy: [contentElements] are views over the backing buffer.
  */
 internal class RCContainer private constructor(
     /** Format version from the header (always [SUPPORTED_VERSION] for a successful parse). */
     val version: Int,
     /** Reserved header flags (compression/encryption/etc.); currently unused. */
     val flags: Int,
-    /** Element 0: the config. [RCElement.data] is a read-only, zero-copy view over the config bytes. */
-    val config: RCElement,
-    /** Elements 1..n in order. The zero-copy iteration path; no checksum keys are materialized. */
+    /**
+     * The decoded, verified config JSON bytes (element 0). The backend may GZIP the config once it crosses a
+     * size threshold; [parse] decodes it transparently, so callers get the uncompressed content regardless of
+     * the on-wire codec. Its bytes are hashed against the config element's checksum during [parse] (a mismatch,
+     * unsupported codec, or corrupt stream fails the parse); authentication remains the response signature over
+     * these bytes (in `HTTPClient`), with the checksum only guarding against accidental corruption.
+     */
+    val config: ByteArray,
+    /**
+     * Elements 1..n in wire order — the raw, on-wire, zero-copy content blobs. Decode the ones you want via
+     * [RCElement.decode] (which verifies) one at a time; decoding them all at once would hold the whole
+     * uncompressed payload in memory, and inline blobs can be large.
+     */
     val contentElements: List<RCElement>,
 ) {
-    /**
-     * The non-config elements addressed by their URL-safe base64 checksum (matching the backend's
-     * ref encoding in the config JSON / URLs). Built lazily from [contentElements]; identical
-     * payloads collapse to one entry (last wins). Element bodies remain the same zero-copy views as
-     * in [contentElements].
-     */
-    val elements: Map<String, RCElement> by lazy { contentElements.associateBy { it.checksumBase64() } }
 
     companion object {
         private const val MAGIC_R = 'R'.code.toByte()
@@ -65,9 +70,10 @@ internal class RCContainer private constructor(
         /**
          * Parses [buffer] from its current position. The buffer is consumed up to the end of the
          * last element. A defensive read-only duplicate is taken so the caller's position/limit
-         * are not modified.
+         * are not modified. The config element (element 0) is decoded and verified here, into [config].
          *
-         * @throws RCContainerFormatException if the bytes are not a valid RC Container Format v1 payload.
+         * @throws RCContainerFormatException if the bytes are not a valid RC Container Format v1 payload, or
+         *   if the config element cannot be decoded/verified.
          */
         fun parse(buffer: ByteBuffer): RCContainer {
             // slice() (not duplicate()) so the working buffer's position 0 coincides with the
@@ -88,7 +94,7 @@ internal class RCContainer private constructor(
                     "Truncated element header: need $ELEMENT_HEADER_SIZE bytes, " +
                         "got ${source.remaining()}."
                 }
-                val checksum = source.sliceBytes(CHECKSUM_SIZE.toLong(), "checksum")
+                val checksum = ByteArray(CHECKSUM_SIZE).also { source.get(it) }
                 val size = source.readUnsignedInt()
                 val reserved = source.readUnsignedInt()
                 // The codec id lives in the low byte of the reserved u32; upper bytes stay reserved.
@@ -102,7 +108,7 @@ internal class RCContainer private constructor(
                 }
                 val data = source.sliceBytes(size, "element")
                 source.alignTo(ALIGNMENT)
-                parsed.add(RCElement(checksum = checksum, data = data, reserved = reserved, codec = codec))
+                parsed.add(RCElement(checksum = checksum, data = data, codec = codec))
             }
 
             if (parsed.isEmpty()) {
@@ -112,8 +118,9 @@ internal class RCContainer private constructor(
             return RCContainer(
                 version = version,
                 flags = flags,
-                config = parsed.first(),
-                // element 0 is the config; content elements are 1..n
+                // element 0 is the config (decoded and verified up front, since it is always needed);
+                // content elements are 1..n and stay compressed until consumed.
+                config = parsed.first().decode(),
                 contentElements = parsed.drop(1),
             )
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCContentEncoding.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCContentEncoding.kt
@@ -30,15 +30,14 @@ internal enum class RCContentEncoding(val id: Int) {
         fun fromId(id: Int): RCContentEncoding? = values().firstOrNull { it.id == id }
 
         /**
-         * Returns the uncompressed bytes of [source] for the given [codecId].
-         *
-         * [NONE] returns [source] unchanged (zero-copy). [GZIP] inflates into a fresh read-only buffer. Any
-         * other codec (including the known-but-unsupported [BROTLI]/[ZSTD]) or a corrupt gzip stream throws
+         * The uncompressed bytes of [source] for the given [codecId], as a fresh [ByteArray] detached from
+         * [source]'s backing buffer. [NONE] copies the bytes out; [GZIP] inflates into a new array. Any other
+         * codec (including the known-but-unsupported [BROTLI]/[ZSTD]) or a corrupt gzip stream throws
          * [RCContainerFormatException]; callers treat that as a verification/decode failure.
          */
-        fun decode(source: ByteBuffer, codecId: Int): ByteBuffer = when (fromId(codecId)) {
-            NONE -> source
-            GZIP -> ByteBuffer.wrap(gunzip(source)).asReadOnlyBuffer()
+        fun decode(source: ByteBuffer, codecId: Int): ByteArray = when (fromId(codecId)) {
+            NONE -> source.toByteArray()
+            GZIP -> gunzip(source)
             BROTLI, ZSTD, null ->
                 throw RCContainerFormatException("Unsupported content encoding id $codecId.")
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCElement.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCElement.kt
@@ -7,89 +7,48 @@ import java.security.MessageDigest
 /**
  * A single element within an [RCContainer].
  *
- * Both [checksum] and [data] are zero-copy, read-only views over the container's backing buffer:
- * no element bytes are copied or hashed during parsing. [data] holds the **on-wire** bytes, which
- * may be compressed per [codec]; [decode] yields the uncompressed content. The [checksum] always
- * covers the uncompressed bytes, so callers that need integrity verification opt in via
- * [isChecksumValid] (which decodes first).
+ * [data] is a zero-copy, read-only view over the container's backing buffer — the potentially large payload
+ * is never copied during parsing. It holds the **on-wire** bytes, which may be compressed per [codec]; [decode]
+ * yields the uncompressed content as a fresh [ByteArray] (detached from the backing buffer), hashing it against
+ * [checksum] before returning. Decoding is therefore inseparable from verification: there is no way to obtain
+ * decoded bytes that don't match the element's content address. [checksum] is the small (24-byte) content
+ * address, copied out during parsing since it is always needed (as a ref and for verification).
  */
 internal class RCElement(
-    /** The stored SHA-256 of the **uncompressed** content truncated to 192 bits, as a 24-byte read-only view. */
-    val checksum: ByteBuffer,
+    /** The stored SHA-256 of the **uncompressed** content, truncated to 192 bits (24 bytes). */
+    val checksum: ByteArray,
     /** A read-only, zero-copy view over this element's on-wire (possibly compressed) bytes. */
     val data: ByteBuffer,
-    /** The element header's reserved u32 (its low byte is the [codec]; upper bytes reserved). */
-    val reserved: Long = 0,
     /** The content-encoding codec id (see [RCContentEncoding]); 0 ([RCContentEncoding.NONE]) when uncompressed. */
     val codec: Int = RCContentEncoding.NONE.id,
 ) {
     /**
-     * The uncompressed element content. [RCContentEncoding.NONE] returns the zero-copy [data] view; a
-     * compressed codec inflates into a fresh buffer. Throws [RCContainerFormatException] for an
-     * unsupported codec or a corrupt compressed stream.
+     * The uncompressed, integrity-verified content as a fresh [ByteArray] detached from the backing buffer:
+     * decodes per [codec], then hashes the result against [checksum] before returning it, so decoded bytes
+     * always match the element's content address (and holding them doesn't pin the request buffer alive).
+     * Throws [RCContainerFormatException] for an unsupported codec, a corrupt stream, or a checksum mismatch.
      */
-    fun decode(): ByteBuffer = RCContentEncoding.decode(data, codec)
+    fun decode(): ByteArray {
+        val decoded = RCContentEncoding.decode(data, codec)
+        if (!matchesChecksum(decoded)) {
+            throw RCContainerFormatException("RC element checksum verification failed.")
+        }
+        return decoded
+    }
 
-    /**
-     * Decodes the element and checks its SHA-256 (truncated to the stored [checksum]'s length) against
-     * [checksum]. The backend stores `sha256(uncompressed)` truncated to its leftmost [checksum] bytes
-     * (192 bits). An unsupported codec or corrupt stream makes [decode] throw, which is treated as a
-     * failed verification (returns `false`).
-     */
-    @Suppress("SwallowedException") // An undecodable element simply fails verification.
-    fun isChecksumValid(): Boolean = try {
-        matchesChecksum(decode())
-    } catch (e: RCContainerFormatException) {
-        false
+    /** The verification step baked into [decode]: does [content] hash to the stored (truncated) [checksum]? */
+    private fun matchesChecksum(content: ByteArray): Boolean {
+        val computed = MessageDigest.getInstance(SHA_256_ALGORITHM).digest(content)
+        // [checksum] is the SHA-256 truncated to 192 bits, so compare against that many leading digest bytes.
+        return computed.copyOf(checksum.size).contentEquals(checksum)
     }
 
     /**
-     * Compares [content]'s SHA-256 (truncated to the stored [checksum]'s length) against [checksum].
-     * Lets callers that already decoded the bytes verify them without inflating twice. Neither
-     * [content] nor [checksum] is consumed (both are read via duplicates).
+     * The [checksum] as a URL-safe, unpadded base64 string, matching the backend's ref encoding in the config
+     * JSON / URLs (24 bytes -> 32 chars).
      */
-    fun matchesChecksum(content: ByteBuffer): Boolean {
-        val digest = MessageDigest.getInstance(SHA_256_ALGORITHM)
-        // rewind so we hash the full content even if a caller has already read from the shared view.
-        digest.update(content.duplicate().apply { rewind() })
-        val computed = digest.digest()
-
-        val expected = checksum.duplicate().apply { rewind() }
-        val length = expected.remaining()
-        return (0 until length).all { computed[it] == expected.get() }
-    }
-
-    /**
-     * The stored [checksum] as a URL-safe, unpadded base64 string, matching the backend's ref
-     * encoding in the config JSON / URLs (24 bytes -> 32 chars).
-     */
-    fun checksumBase64(): String {
-        val view = checksum.duplicate().apply { rewind() }
-        val bytes = ByteArray(view.remaining())
-        view.get(bytes)
-        return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
-    }
-
-    /** A copy of this element's [data] bytes (the payload exactly as received). */
-    fun dataBytes(): ByteArray {
-        val view = data.duplicate().apply { rewind() }
-        val bytes = ByteArray(view.remaining())
-        view.get(bytes)
-        return bytes
-    }
-
-    /**
-     * A copy of this element's decoded (uncompressed) bytes. Mirrors [dataBytes] but runs the payload
-     * through [decode] first, so callers that need the logical content (checksum/signature/JSON) get the
-     * same bytes regardless of the on-wire [codec]. Throws [RCContainerFormatException] for an unsupported
-     * codec or a corrupt compressed stream.
-     */
-    fun decodedBytes(): ByteArray {
-        val view = decode().duplicate().apply { rewind() }
-        val bytes = ByteArray(view.remaining())
-        view.get(bytes)
-        return bytes
-    }
+    fun checksumBase64(): String =
+        Base64.encodeToString(checksum, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
 
     private companion object {
         private const val SHA_256_ALGORITHM = "SHA-256"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcher.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.io.IOException
 import java.net.HttpURLConnection
-import java.nio.ByteBuffer
 import java.util.PriorityQueue
 
 /** The placeholder a blob source URL template carries; substituted with the blob ref before download. */
@@ -240,7 +239,7 @@ internal class RemoteConfigBlobFetcher(
         }
         // A failed disk write isn't a source problem, so don't condemn the source: report the blob as unavailable
         // (yields false, stops) and let a later sync/on-demand read re-fetch it.
-        return if (blobStore.write(ref, ByteBuffer.wrap(bytes))) {
+        return if (blobStore.write(ref, bytes)) {
             verboseLog { "Downloaded and stored remote config blob '$ref' (${bytes.size} bytes) from $url." }
             DownloadOutcome.SUCCESS
         } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStore.kt
@@ -5,7 +5,6 @@ import androidx.core.util.AtomicFile
 import com.revenuecat.purchases.common.errorLog
 import java.io.File
 import java.io.IOException
-import java.nio.ByteBuffer
 
 /**
  * A content-addressed, on-disk cache for remote-config blobs. Each blob is stored as one file under
@@ -56,21 +55,18 @@ internal class RemoteConfigBlobStore(
      * partial. An interrupted write leaves only the `.new` orphan, whose name is not a valid ref — it is
      * invisible to the index scan and pruned by [retainOnly].
      */
-    fun write(ref: String, data: ByteBuffer): Boolean {
+    fun write(ref: String, data: ByteArray): Boolean {
         val target = blobFile(ref)
         if (target == null) {
             errorLog { "Refusing to write remote config blob with malformed ref '$ref'." }
             return false
         }
         return try {
-            val view = data.duplicate()
-            val bytes = ByteArray(view.remaining())
-            view.get(bytes)
             // startWrite creates the blobs directory when missing.
             val atomicFile = AtomicFile(target)
             val out = atomicFile.startWrite()
             try {
-                out.write(bytes)
+                out.write(data)
                 atomicFile.finishWrite(out)
             } catch (e: IOException) {
                 atomicFile.failWrite(out)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -283,7 +283,7 @@ internal class RemoteConfigManager(
         }
         scope.launch {
             try {
-                val response = RemoteConfiguration.parse(container.config.decode())
+                val response = RemoteConfiguration.parse(container.config)
                 synchronized(cacheLock) {
                     if (epoch.get() != requestEpoch) return@launch
                     persist(previous = persisted, response = response, container = container)
@@ -859,24 +859,21 @@ internal class RemoteConfigManager(
 
     /** Caches inlined content elements the config still wants, whose bytes match their content-address ref. */
     private fun extractInlineBlobs(container: RCContainer, refsToKeep: Set<String>) {
-        container.elements.forEach { (ref, element) ->
-            if (ref !in refsToKeep) return@forEach
-            // Decode once (the on-wire bytes may be compressed), then verify and store the uncompressed
-            // bytes: the blob store is content-addressed by the hash of the uncompressed payload.
+        // Decide by ref before decoding so a blob we don't need (not referenced, or already cached) is never
+        // decompressed, and decode one at a time so the whole uncompressed payload is never held at once —
+        // inline blobs can be large.
+        container.contentElements.forEach { element ->
+            val ref = element.checksumBase64()
+            if (ref !in refsToKeep || blobStore.contains(ref)) return@forEach
             val decoded = try {
                 element.decode()
             } catch (e: RCContainerFormatException) {
-                errorLog(e) { "Skipping remote config blob '$ref': could not decode element." }
+                errorLog(e) { "Skipping remote config blob '$ref': could not decode or verify its content." }
                 return@forEach
             }
-            if (element.matchesChecksum(decoded)) {
-                val size = decoded.remaining()
-                // write() logs its own error on failure; only report success when it actually stored the blob.
-                if (blobStore.write(ref, decoded)) {
-                    verboseLog { "Stored inlined remote config blob '$ref' ($size bytes)." }
-                }
-            } else {
-                errorLog { "Skipping remote config blob '$ref': checksum verification failed." }
+            // write() logs its own error on failure; only report success when it actually stored the blob.
+            if (blobStore.write(ref, decoded)) {
+                verboseLog { "Stored inlined remote config blob '$ref' (${decoded.size} bytes)." }
             }
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -48,9 +48,8 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         assertThat(error).isNull()
         assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
         val rcContainer = requireNotNull(container) { "Expected a 200 container, got 204 (no content)." }
-        assertThat(rcContainer.config.isChecksumValid()).isTrue()
 
-        val config = RemoteConfiguration.parse(rcContainer.config.decode())
+        val config = RemoteConfiguration.parse(rcContainer.config)
         assertThat(config.domain).isEqualTo("app")
         assertThat(config.manifest).isNotEmpty()
         assertThat(config.activeTopics).contains("sources", "ui_config", "workflows")
@@ -85,24 +84,20 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
         val rcContainer = requireNotNull(container) { "Expected a 200 container, got 204 (no content)." }
 
-        val config = RemoteConfiguration.parse(rcContainer.config.decode())
+        val config = RemoteConfiguration.parse(rcContainer.config)
 
-        // Pick a workflows item whose blob was inlined in the container, so we can decode it directly.
+        // The refs of workflows items whose bodies the container may have inlined.
         val workflows = requireNotNull(config.topics["workflows"]) { "Expected a workflows topic." }
-        val ref = requireNotNull(
-            workflows.values.mapNotNull { it.blobRef }.firstOrNull { it in rcContainer.elements },
-        ) { "Expected a workflows item with an inlined blob_ref." }
-        val element = rcContainer.elements.getValue(ref)
+        val wantedRefs = workflows.values.mapNotNull { it.blobRef }.toSet()
 
-        // isChecksumValid() decodes (uncompresses) the element and checks the SHA-256 of the
-        // uncompressed bytes against the advertised ref, so a true result proves the uncompression
-        // produced exactly the content the backend addressed.
-        assertThat(element.isChecksumValid()).isTrue()
+        // Find an inlined workflows item and capture its decoded bytes. decode() uncompresses and checks the
+        // SHA-256 against the advertised ref, so the bytes are exactly the content the backend addressed there.
+        val element = requireNotNull(rcContainer.contentElements.firstOrNull { it.checksumBase64() in wantedRefs }) {
+            "Expected a workflows item with an inlined blob_ref."
+        }
 
         // The decoded bytes are real, structured content (a non-empty JSON object), not garbage.
-        val decodedView = element.decode().duplicate().apply { rewind() }
-        val decodedBytes = ByteArray(decodedView.remaining()).also { decodedView.get(it) }
-        val json = JsonProvider.defaultJson.parseToJsonElement(decodedBytes.decodeToString())
+        val json = JsonProvider.defaultJson.parseToJsonElement(element.decode().decodeToString())
         assertThat(json.jsonObject).isNotEmpty()
     }
 
@@ -179,7 +174,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         assertThat(firstError).isNull()
         assertThat(firstVerification).isEqualTo(VerificationResult.VERIFIED)
         val rcContainer = requireNotNull(firstContainer) { "Expected a 200 container on the first run." }
-        val manifest = RemoteConfiguration.parse(rcContainer.config.decode()).manifest
+        val manifest = RemoteConfiguration.parse(rcContainer.config).manifest
 
         // Replaying that manifest with nothing changed server-side -> 204 (success, but no container to parse).
         // A non-`app_start` context is required: the backend always fully resolves an `app_start` request, so it
@@ -213,7 +208,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         val (firstError, firstContainer, _) = fetchRemoteConfig(manifest = null)
         assertThat(firstError).isNull()
         val rcContainer = requireNotNull(firstContainer) { "Expected a 200 container on the first run." }
-        val manifest = RemoteConfiguration.parse(rcContainer.config.decode()).manifest
+        val manifest = RemoteConfiguration.parse(rcContainer.config).manifest
 
         // The 204 carries no body, but its signature covers the request context. Under enforcement a verification
         // failure would surface as an error, so a null error with a VERIFIED result confirms the 204 was verified.

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -445,11 +445,11 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
     }
 
     @Test
-    fun `performRequest verifies the config part bytes regardless of the element checksum`() {
+    fun `performRequest fails RC Format verification when the config element checksum does not match`() {
         val endpoint = Endpoint.GetRemoteConfig("app")
         val configBytes = "{\"config\":true}".toByteArray()
-        // The element checksum is an untrusted lookup hint: a mismatch must not affect verification, which is
-        // anchored on the signature over the config part bytes.
+        // The config element's checksum guards against accidental corruption and is verified when the
+        // container decodes element 0 during parse; a mismatch fails the parse before signing.
         val container = buildContainer(configBytes, configChecksum = ByteArray(24) { 0x7F })
 
         mockSigningResult(VerificationResult.VERIFIED)
@@ -465,18 +465,8 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         server.takeRequest()
 
-        assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
-        verify(exactly = 1) {
-            mockSigningManager.verifyResponse(
-                urlPath = endpoint.getPath(),
-                "test-signature",
-                "test-nonce",
-                match<ByteArray> { it.contentEquals(configBytes) },
-                "1234567890",
-                "test-etag",
-                postFieldsToSignHeader = null
-            )
-        }
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.FAILED)
+        assertSigningNotPerformed()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -111,8 +111,7 @@ class BackendGetRemoteConfigTest {
 
         val parsed = container ?: fail("Expected container to be non-null").let { return }
         assertThat(parsed.version).isEqualTo(1)
-        assertThat(parsed.config.data.let { buf -> ByteArray(buf.remaining()).also { buf.duplicate().get(it) } })
-            .isEqualTo(config)
+        assertThat(parsed.config).isEqualTo(config)
         assertThat(parsed.contentElements).hasSize(1)
         assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/RCContainerBackwardsCompatTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/RCContainerBackwardsCompatTest.kt
@@ -29,10 +29,8 @@ class RCContainerBackwardsCompatTest {
 
         assertThat(container.version).isEqualTo(1)
         assertThat(container.flags).isEqualTo(0)
-        assertThat(container.config.data.readBytes()).isEqualTo(RCContainerTestData.CONFIG_JSON)
-        assertThat(container.config.isChecksumValid()).isTrue()
+        assertThat(container.config).isEqualTo(RCContainerTestData.CONFIG_JSON)
         assertThat(container.contentElements).isEmpty()
-        assertThat(container.elements).isEmpty()
     }
 
     @Test
@@ -40,11 +38,11 @@ class RCContainerBackwardsCompatTest {
         val container = parseFixture("v1_single_element.bin")
         val blob = RCContainerTestData.WORKFLOW_BLOB
 
-        assertThat(container.config.data.readBytes()).isEqualTo(RCContainerTestData.CONFIG_JSON)
+        assertThat(container.config).isEqualTo(RCContainerTestData.CONFIG_JSON)
         assertThat(container.contentElements).hasSize(1)
         assertThat(container.contentElements[0].data.readBytes()).isEqualTo(blob)
-        assertThat(container.contentElements[0].isChecksumValid()).isTrue()
-        assertThat(container.elements[RCContainerTestData.refOf(blob)]!!.data.readBytes()).isEqualTo(blob)
+        assertThat(container.contentElements[0].checksumBase64()).isEqualTo(RCContainerTestData.refOf(blob))
+        assertThat(container.contentElements[0].decode()).isEqualTo(blob)
     }
 
     @Test
@@ -57,11 +55,11 @@ class RCContainerBackwardsCompatTest {
             RCContainerTestData.LARGE_BLOB,
         )
 
-        assertThat(container.config.data.readBytes()).isEqualTo(RCContainerTestData.CONFIG_JSON)
+        assertThat(container.config).isEqualTo(RCContainerTestData.CONFIG_JSON)
         assertThat(container.contentElements).hasSize(expected.size)
         expected.forEachIndexed { index, blob ->
-            assertThat(container.contentElements[index].data.readBytes()).isEqualTo(blob)
-            assertThat(container.contentElements[index].isChecksumValid()).isTrue()
+            // decode() verifies as it decompresses, so this also checks each element against its checksum.
+            assertThat(container.contentElements[index].decode()).isEqualTo(blob)
         }
         // The 300-byte element proves little-endian size decoding survives round-trips.
         assertThat(container.contentElements[3].data.remaining()).isEqualTo(300)
@@ -72,7 +70,7 @@ class RCContainerBackwardsCompatTest {
         val container = parseFixture("v1_empty_config.bin")
         val blob = RCContainerTestData.WORKFLOW_BLOB
 
-        assertThat(container.config.data.remaining()).isEqualTo(0)
+        assertThat(container.config).isEmpty()
         assertThat(container.contentElements).hasSize(1)
         assertThat(container.contentElements[0].data.readBytes()).isEqualTo(blob)
     }
@@ -82,7 +80,7 @@ class RCContainerBackwardsCompatTest {
         val container = parseFixture("v1_flags_set.bin")
 
         assertThat(container.flags).isEqualTo(0x07)
-        assertThat(container.config.data.readBytes()).isEqualTo(RCContainerTestData.CONFIG_JSON)
+        assertThat(container.config).isEqualTo(RCContainerTestData.CONFIG_JSON)
     }
 
     @Test
@@ -90,24 +88,23 @@ class RCContainerBackwardsCompatTest {
         val container = parseFixture("v1_gzip_element.bin")
         val blob = RCContainerTestData.WORKFLOW_BLOB
 
-        assertThat(container.config.data.readBytes()).isEqualTo(RCContainerTestData.CONFIG_JSON)
+        assertThat(container.config).isEqualTo(RCContainerTestData.CONFIG_JSON)
         assertThat(container.contentElements).hasSize(1)
         val element = container.contentElements[0]
         assertThat(element.codec).isEqualTo(RCContentEncoding.GZIP.id)
-        // The on-wire body is compressed, but decode() recovers the original and the checksum verifies.
+        // The on-wire body is compressed, but decode() recovers the original and verifies it as it does.
         assertThat(element.data.readBytes()).isNotEqualTo(blob)
-        assertThat(element.decode().readBytes()).isEqualTo(blob)
-        assertThat(element.isChecksumValid()).isTrue()
-        assertThat(container.elements[RCContainerTestData.refOf(blob)]!!.decode().readBytes()).isEqualTo(blob)
+        assertThat(element.decode()).isEqualTo(blob)
+        assertThat(element.checksumBase64()).isEqualTo(RCContainerTestData.refOf(blob))
     }
 
     @Test
-    fun `duplicate-elements fixture collapses in the content-addressed map`() {
+    fun `duplicate-elements fixture keeps both copies under the same ref`() {
         val container = parseFixture("v1_duplicate_elements.bin")
 
-        // Both copies remain in the ordered list, but content-addressing collapses them in the map.
+        // Both copies remain in the ordered list, addressed by the same content ref.
         assertThat(container.contentElements).hasSize(2)
-        assertThat(container.elements).hasSize(1)
+        assertThat(container.contentElements.map { it.checksumBase64() }.distinct()).hasSize(1)
     }
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/RCContainerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/RCContainerTest.kt
@@ -27,10 +27,8 @@ class RCContainerTest {
 
         assertThat(container.version).isEqualTo(1)
         assertThat(container.flags).isEqualTo(0x07)
-        assertThat(container.config.data.readBytes()).isEqualTo(config)
-        assertThat(container.config.isChecksumValid()).isTrue()
+        assertThat(container.config).isEqualTo(config)
         assertThat(container.contentElements).isEmpty()
-        assertThat(container.elements).isEmpty()
     }
 
     @Test
@@ -91,7 +89,8 @@ class RCContainerTest {
 
         assertThat(container.contentElements).hasSize(1)
         assertThat(container.contentElements[0].data.readBytes()).isEqualTo(element)
-        assertThat(container.elements[refOf(element)]!!.data.readBytes()).isEqualTo(element)
+        // The element is content-addressed by the hash of its (uncompressed) bytes.
+        assertThat(container.contentElements[0].checksumBase64()).isEqualTo(refOf(element))
     }
 
     @Test
@@ -109,7 +108,7 @@ class RCContainerTest {
         assertThat(container.contentElements).hasSize(elements.size)
         elements.forEachIndexed { index, expected ->
             assertThat(container.contentElements[index].data.readBytes()).isEqualTo(expected)
-            assertThat(container.elements[refOf(expected)]!!.data.readBytes()).isEqualTo(expected)
+            assertThat(container.contentElements[index].checksumBase64()).isEqualTo(refOf(expected))
         }
     }
 
@@ -123,20 +122,20 @@ class RCContainerTest {
         val ref = refOf(element)
         assertThat(ref).hasSize(32)
         assertThat(ref).doesNotContain("=")
-        assertThat(container.elements).containsKey(ref)
-        assertThat(container.elements[ref]!!.data.readBytes()).isEqualTo(element)
+        assertThat(container.contentElements.single().checksumBase64()).isEqualTo(ref)
     }
 
     @Test
-    fun `identical content elements collapse to one map entry`() {
+    fun `identical content elements are parsed as separate elements sharing a ref`() {
         val element = "duplicate".toByteArray()
         val bytes = buildContainer(elements = listOf(element, element.copyOf()))
 
         val container = RCContainer.parse(bytes)
 
-        // Both are present in the ordered list, but content-addressing collapses them in the map.
+        // Both copies are present in the ordered list, addressed by the same content ref.
         assertThat(container.contentElements).hasSize(2)
-        assertThat(container.elements).hasSize(1)
+        assertThat(container.contentElements.map { it.checksumBase64() })
+            .containsExactly(refOf(element), refOf(element))
     }
 
     @Test
@@ -147,7 +146,7 @@ class RCContainerTest {
 
         val container = RCContainer.parse(bytes)
 
-        assertThat(container.config.data.readBytes()).isEqualTo("abc".toByteArray())
+        assertThat(container.config).isEqualTo("abc".toByteArray())
         assertThat(container.contentElements[0].data.readBytes()).isEqualTo(element)
     }
 
@@ -158,7 +157,7 @@ class RCContainerTest {
 
         val container = RCContainer.parse(bytes)
 
-        assertThat(container.config.data.remaining()).isEqualTo(0)
+        assertThat(container.config).isEmpty()
         assertThat(container.contentElements[0].data.readBytes()).isEqualTo(element)
     }
 
@@ -176,30 +175,6 @@ class RCContainerTest {
     }
 
     @Test
-    fun `isChecksumValid returns true for a correct checksum`() {
-        val element = "verify-me".toByteArray()
-        val bytes = buildContainer(elements = listOf(element))
-
-        val container = RCContainer.parse(bytes)
-
-        assertThat(container.contentElements[0].isChecksumValid()).isTrue()
-    }
-
-    @Test
-    fun `isChecksumValid returns false for a corrupted element`() {
-        val element = "verify-me".toByteArray()
-        // Store a checksum that does not match the element bytes.
-        val bytes = buildContainer(
-            elements = listOf(element),
-            checksumOverride = { _, _ -> ByteArray(24) { 0 } },
-        )
-
-        val container = RCContainer.parse(bytes)
-
-        assertThat(container.contentElements[0].isChecksumValid()).isFalse()
-    }
-
-    @Test
     fun `gzip element decodes to its uncompressed bytes and verifies`() {
         val element = "compress-me-".repeat(20).toByteArray()
         val bytes = buildContainer(
@@ -214,27 +189,61 @@ class RCContainerTest {
         // The on-wire bytes are compressed (and smaller than the original)...
         assertThat(parsed.data.readBytes()).isNotEqualTo(element)
         assertThat(parsed.data.remaining()).isLessThan(element.size)
-        // ...but decode() yields the original and the checksum verifies against the uncompressed bytes.
-        assertThat(parsed.decode().readBytes()).isEqualTo(element)
-        assertThat(parsed.isChecksumValid()).isTrue()
+        // ...but decode() yields the original (verifying against the uncompressed bytes as it does).
+        assertThat(parsed.decode()).isEqualTo(element)
         // The content address is the hash of the uncompressed bytes, unchanged by compression.
-        assertThat(container.elements).containsKey(refOf(element))
+        assertThat(parsed.checksumBase64()).isEqualTo(refOf(element))
     }
 
     @Test
-    fun `gzip config element decodes for parsing`() {
+    fun `gzip config element is decoded during parsing`() {
         val config = "{\"hello\":\"world\"}".toByteArray()
+        // The config is gzipped on the wire; parse must decode it into container.config.
         val bytes = buildContainer(config = config, codecForIndex = { RCContentEncoding.GZIP.id })
 
         val container = RCContainer.parse(bytes)
 
-        assertThat(container.config.codec).isEqualTo(RCContentEncoding.GZIP.id)
-        assertThat(container.config.decode().readBytes()).isEqualTo(config)
-        assertThat(container.config.isChecksumValid()).isTrue()
+        assertThat(container.config).isEqualTo(config)
     }
 
     @Test
-    fun `unsupported codec makes decode throw and checksum invalid`() {
+    fun `parse throws when the config element checksum does not match its bytes`() {
+        // Store a checksum for the config (element 0) that does not match its bytes.
+        val bytes = buildContainer(
+            config = "{\"hello\":\"world\"}".toByteArray(),
+            checksumOverride = { _, _ -> ByteArray(24) { 0 } },
+        )
+
+        assertThatThrownBy { RCContainer.parse(bytes) }.isInstanceOf(RCContainerFormatException::class.java)
+    }
+
+    @Test
+    fun `contentElements decode to their uncompressed bytes and re-iterate`() {
+        val blobs = listOf("a".toByteArray(), "bb".toByteArray(), "ccc".repeat(30).toByteArray())
+        val container = RCContainer.parse(buildContainer(elements = blobs))
+
+        assertThat(container.contentElements.map { it.decode() }).containsExactlyElementsOf(blobs)
+        // Iterating doesn't consume: the elements are still there for another pass.
+        assertThat(container.contentElements.map { it.decode() }).containsExactlyElementsOf(blobs)
+    }
+
+    @Test
+    fun `decode throws when the element checksum does not match its bytes`() {
+        val blob = "verify-me".toByteArray()
+        // Store a checksum that does not match the (content) element bytes.
+        val bytes = buildContainer(
+            elements = listOf(blob),
+            checksumOverride = { index, element -> if (index == 1) ByteArray(24) { 0 } else RCContainerTestData.sha256(element) },
+        )
+
+        val parsed = RCContainer.parse(bytes).contentElements.single()
+
+        // The bytes decompress, but they do not hash to the (tampered) checksum, so decode() rejects them.
+        assertThatThrownBy { parsed.decode() }.isInstanceOf(RCContainerFormatException::class.java)
+    }
+
+    @Test
+    fun `unsupported codec makes decode throw`() {
         listOf(RCContentEncoding.BROTLI.id, RCContentEncoding.ZSTD.id, 9).forEach { codecId ->
             val element = "payload".toByteArray()
             val bytes = buildContainer(
@@ -246,12 +255,11 @@ class RCContainerTest {
 
             assertThat(parsed.codec).isEqualTo(codecId)
             assertThatThrownBy { parsed.decode() }.isInstanceOf(RCContainerFormatException::class.java)
-            assertThat(parsed.isChecksumValid()).isFalse()
         }
     }
 
     @Test
-    fun `corrupt gzip body fails verification without throwing`() {
+    fun `corrupt gzip body makes decode throw`() {
         val element = "compress-me-".repeat(20).toByteArray()
         val bytes = buildContainer(
             elements = listOf(element),
@@ -264,23 +272,23 @@ class RCContainerTest {
 
         val parsed = RCContainer.parse(bytes).contentElements[0]
 
-        assertThat(parsed.isChecksumValid()).isFalse()
+        assertThatThrownBy { parsed.decode() }.isInstanceOf(RCContainerFormatException::class.java)
     }
 
     @Test
-    fun `config data is a zero-copy view over the source buffer`() {
-        val config = "ABCD".toByteArray()
-        // Element 0 (config) body begins at offset 8 (header) + 32 (checksum + size + reserved) = 40.
-        val bytes = buildContainer(config = config)
-        val configOffset = 8 + 24 + 4 + 4
+    fun `content element data is a zero-copy view over the source buffer`() {
+        val element = "ABCD".toByteArray()
+        // Empty config: header(8) + config elem header(32) + config body(0) + content elem header(32) = 72.
+        val bytes = buildContainer(config = ByteArray(0), elements = listOf(element))
+        val elementOffset = 8 + 32 + 32
 
         val container = RCContainer.parse(bytes)
-        val data = container.config.data
+        val data = container.contentElements[0].data
 
         assertThat(data.get(0)).isEqualTo('A'.code.toByte())
 
         // Mutating the backing array is reflected in the view: no copy was made during parse.
-        bytes[configOffset] = 'Z'.code.toByte()
+        bytes[elementOffset] = 'Z'.code.toByte()
         assertThat(data.get(0)).isEqualTo('Z'.code.toByte())
     }
 
@@ -305,7 +313,7 @@ class RCContainerTest {
 
         val parsed = RCContainer.parse(buffer)
 
-        assertThat(parsed.config.data.readBytes()).isEqualTo("cfg".toByteArray())
+        assertThat(parsed.config).isEqualTo("cfg".toByteArray())
         assertThat(parsed.contentElements[0].data.readBytes()).isEqualTo("e".toByteArray())
         // The overload must not consume the caller's position.
         assertThat(buffer.position()).isEqualTo(prefix.size)
@@ -322,7 +330,7 @@ class RCContainerTest {
 
         val parsed = RCContainer.parse(buffer)
 
-        assertThat(parsed.config.data.readBytes()).isEqualTo("abc".toByteArray())
+        assertThat(parsed.config).isEqualTo("abc".toByteArray())
         assertThat(parsed.contentElements[0].data.readBytes()).isEqualTo("element".toByteArray())
         assertThat(buffer.position()).isEqualTo(prefix.size)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobFetcherTest.kt
@@ -33,7 +33,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.ByteArrayInputStream
-import java.nio.ByteBuffer
 import java.security.MessageDigest
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
@@ -88,9 +87,9 @@ class RemoteConfigBlobFetcherTest {
 
         // The placeholder is substituted with the ref before the request is made.
         verify { urlConnectionFactory.createConnection(urlFor(ref), any()) }
-        val written = slot<ByteBuffer>()
+        val written = slot<ByteArray>()
         verify { blobStore.write(ref, capture(written)) }
-        assertThat(written.captured.toBytes()).isEqualTo(bytes)
+        assertThat(written.captured).isEqualTo(bytes)
     }
 
     @Test
@@ -450,11 +449,6 @@ class RemoteConfigBlobFetcherTest {
     private fun refOf(bytes: ByteArray): String {
         val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
         return Base64.encodeToString(digest.copyOf(REF_HASH_BYTES), Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
-    }
-
-    private fun ByteBuffer.toBytes(): ByteArray {
-        val view = duplicate().apply { rewind() }
-        return ByteArray(view.remaining()).also { view.get(it) }
     }
 
     private class FakeTopicStore(private val sources: ConfigTopic?) : RemoteConfigTopicStore {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigBlobStoreTest.kt
@@ -11,7 +11,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.File
-import java.nio.ByteBuffer
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -49,35 +48,26 @@ class RemoteConfigBlobStoreTest {
     fun `write then read round-trips the blob bytes`() {
         val bytes = byteArrayOf(1, 2, 3, 4, 5)
 
-        blobStore.write(refA, ByteBuffer.wrap(bytes))
+        blobStore.write(refA, bytes)
 
         assertThat(blobStore.read(refA)).isEqualTo(bytes)
     }
 
     @Test
     fun `write returns true when the blob is persisted`() {
-        assertThat(blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1, 2, 3)))).isTrue
+        assertThat(blobStore.write(refA, byteArrayOf(1, 2, 3))).isTrue
     }
 
     @Test
     fun `write returns false for a malformed ref`() {
-        assertThat(blobStore.write("../escape", ByteBuffer.wrap(byteArrayOf(6, 6, 6)))).isFalse
-    }
-
-    @Test
-    fun `write does not consume the caller's buffer`() {
-        val buffer = ByteBuffer.wrap(byteArrayOf(9, 8, 7))
-
-        blobStore.write(refA, buffer)
-
-        assertThat(buffer.position()).isEqualTo(0)
+        assertThat(blobStore.write("../escape", byteArrayOf(6, 6, 6))).isFalse
     }
 
     @Test
     fun `contains reflects whether a blob has been written`() {
         assertThat(blobStore.contains(refA)).isFalse
 
-        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
+        blobStore.write(refA, byteArrayOf(1))
 
         assertThat(blobStore.contains(refA)).isTrue
     }
@@ -89,7 +79,7 @@ class RemoteConfigBlobStoreTest {
 
     @Test
     fun `contains and cachedRefs load blobs already on disk from a previous instance`() {
-        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
+        blobStore.write(refA, byteArrayOf(1))
 
         // A fresh instance over the same directory must discover the existing blob via its one-time disk scan.
         val reopened = RemoteConfigBlobStore(applicationContext)
@@ -100,8 +90,8 @@ class RemoteConfigBlobStoreTest {
 
     @Test
     fun `cachedRefs reflects the written blobs`() {
-        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
-        blobStore.write(refB, ByteBuffer.wrap(byteArrayOf(2)))
+        blobStore.write(refA, byteArrayOf(1))
+        blobStore.write(refB, byteArrayOf(2))
 
         assertThat(blobStore.cachedRefs()).containsExactlyInAnyOrder(refA, refB)
     }
@@ -113,8 +103,8 @@ class RemoteConfigBlobStoreTest {
 
     @Test
     fun `retainOnly deletes unreferenced blobs and keeps referenced ones`() {
-        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
-        blobStore.write(refB, ByteBuffer.wrap(byteArrayOf(2)))
+        blobStore.write(refA, byteArrayOf(1))
+        blobStore.write(refB, byteArrayOf(2))
 
         blobStore.retainOnly(setOf(refA))
 
@@ -124,7 +114,7 @@ class RemoteConfigBlobStoreTest {
 
     @Test
     fun `retainOnly prunes orphan side files and invalid-named files the index never tracks`() {
-        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
+        blobStore.write(refA, byteArrayOf(1))
         // Simulate the AtomicFile side file left by a write interrupted mid-flight, plus a stray
         // invalid-named file.
         val blobsDir = File(File(testFolder, "RevenueCat"), "blobs")
@@ -154,13 +144,13 @@ class RemoteConfigBlobStoreTest {
         assertThat(reopened.cachedRefs()).isEmpty()
 
         // A retry completes normally, replacing the leftover side file.
-        assertThat(blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(3, 4)))).isTrue
+        assertThat(blobStore.write(refA, byteArrayOf(3, 4))).isTrue
         assertThat(blobStore.read(refA)).isEqualTo(byteArrayOf(3, 4))
     }
 
     @Test
     fun `read self-heals the index when the underlying file is gone`() {
-        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
+        blobStore.write(refA, byteArrayOf(1))
         assertThat(blobStore.contains(refA)).isTrue
 
         // The file disappears from under us (e.g. external removal); the index still claims it.
@@ -173,7 +163,7 @@ class RemoteConfigBlobStoreTest {
 
     @Test
     fun `retainOnly with an empty set clears the cache`() {
-        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
+        blobStore.write(refA, byteArrayOf(1))
 
         blobStore.retainOnly(emptySet())
 
@@ -182,8 +172,8 @@ class RemoteConfigBlobStoreTest {
 
     @Test
     fun `clear deletes every cached blob`() {
-        blobStore.write(refA, ByteBuffer.wrap(byteArrayOf(1)))
-        blobStore.write(refB, ByteBuffer.wrap(byteArrayOf(2)))
+        blobStore.write(refA, byteArrayOf(1))
+        blobStore.write(refB, byteArrayOf(2))
 
         blobStore.clear()
 
@@ -203,7 +193,7 @@ class RemoteConfigBlobStoreTest {
     fun `a malformed ref is rejected and cannot escape the blobs directory`() {
         val malformed = "../escape"
 
-        blobStore.write(malformed, ByteBuffer.wrap(byteArrayOf(6, 6, 6)))
+        blobStore.write(malformed, byteArrayOf(6, 6, 6))
 
         assertThat(blobStore.contains(malformed)).isFalse
         assertThat(blobStore.read(malformed)).isNull()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -38,7 +38,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.nio.ByteBuffer
 import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -520,15 +519,16 @@ class RemoteConfigManagerTest {
               "topics": { "sources": { "default": { "blob_ref": "$REF_VALID" } } }
             }
         """.trimIndent()
-        val validData = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
+        val validData = byteArrayOf(1, 2, 3)
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(
             containerWithConfig(
                 response,
-                elements = mapOf(
-                    REF_VALID to inlineElement(validData, checksumValid = true),
-                    REF_TAMPERED to inlineElement(ByteBuffer.wrap(byteArrayOf(9)), checksumValid = false),
+                blobs = listOf(
+                    inlineElement(REF_VALID, validData),
+                    // A tampered blob fails verification: its decode() throws, so it is skipped.
+                    inlineElement(REF_TAMPERED, decoded = null),
                 ),
             ),
             VerificationResult.VERIFIED,
@@ -550,16 +550,16 @@ class RemoteConfigManagerTest {
               "topics": { "sources": { "default": { "blob_ref": "$REF_VALID" } } }
             }
         """.trimIndent()
-        val wantedData = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
+        val wantedData = byteArrayOf(1, 2, 3)
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(
             containerWithConfig(
                 response,
-                elements = mapOf(
-                    REF_VALID to inlineElement(wantedData, checksumValid = true),
-                    // Valid bytes, but not in prefetch_blobs nor referenced by any active topic.
-                    REF_UNWANTED to inlineElement(ByteBuffer.wrap(byteArrayOf(7)), checksumValid = true),
+                blobs = listOf(
+                    inlineElement(REF_VALID, wantedData),
+                    // Valid bytes, but not in prefetch_blobs nor referenced by any active topic (never decoded).
+                    inlineElement(REF_UNWANTED, byteArrayOf(7)),
                 ),
             ),
             VerificationResult.VERIFIED,
@@ -587,7 +587,7 @@ class RemoteConfigManagerTest {
         onSuccess.invoke(
             containerWithConfig(
                 response,
-                elements = mapOf(REF_VALID to inlineElement(ByteBuffer.wrap(byteArrayOf(1, 2, 3)), checksumValid = true)),
+                blobs = listOf(inlineElement(REF_VALID, byteArrayOf(1, 2, 3))),
             ),
             VerificationResult.VERIFIED,
         )
@@ -2317,12 +2317,18 @@ class RemoteConfigManagerTest {
         topics = topics,
     )
 
-    private fun inlineElement(data: ByteBuffer, checksumValid: Boolean): RCElement {
+    /**
+     * A fake inline blob element for a container mock: [ref] is what the manager reads to decide whether it
+     * wants the blob; [decoded] is the bytes decode() yields, or null to model a bad blob whose decode() throws.
+     */
+    private fun inlineElement(ref: String, decoded: ByteArray?): RCElement {
         val element = mockk<RCElement>()
-        every { element.data } returns data
-        // The manager decodes (codec-aware) then verifies the decoded bytes against the checksum.
-        every { element.decode() } returns data
-        every { element.matchesChecksum(any()) } returns checksumValid
+        every { element.checksumBase64() } returns ref
+        if (decoded == null) {
+            every { element.decode() } throws RCContainerFormatException("checksum verification failed")
+        } else {
+            every { element.decode() } returns decoded
+        }
         return element
     }
 
@@ -2330,21 +2336,16 @@ class RemoteConfigManagerTest {
     private fun remoteConfiguration(json: String): RemoteConfiguration =
         RemoteConfiguration.parse(json.toByteArray())
 
-    private fun containerWithConfig(json: String, elements: Map<String, RCElement> = emptyMap()): RCContainer {
-        val element = mockk<RCElement>()
-        every { element.decode() } returns ByteBuffer.wrap(json.toByteArray())
+    private fun containerWithConfig(json: String, blobs: List<RCElement> = emptyList()): RCContainer {
         val container = mockk<RCContainer>()
-        every { container.config } returns element
-        every { container.elements } returns elements
+        every { container.config } returns json.toByteArray()
+        every { container.contentElements } returns blobs
         return container
     }
 
     private fun containerWithUndecodableConfig(): RCContainer {
-        val element = mockk<RCElement>()
-        every { element.decode() } throws RCContainerFormatException("Unsupported content encoding id 2.")
         val container = mockk<RCContainer>()
-        every { container.config } returns element
-        every { container.elements } returns emptyMap()
+        every { container.config } throws RCContainerFormatException("Unsupported content encoding id 2.")
         return container
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -39,7 +39,6 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.ByteArrayInputStream
 import java.net.HttpURLConnection
-import java.nio.ByteBuffer
 import java.security.MessageDigest
 
 /**
@@ -384,18 +383,15 @@ class WorkflowsConfigIntegrationTest {
     )
 
     private fun containerWith(configJson: String, vararg blobs: Pair<String, String>): RCContainer {
-        val configElement = mockk<RCElement>()
-        every { configElement.decode() } returns ByteBuffer.wrap(configJson.toByteArray())
-        val elements = blobs.associate { (ref, json) ->
+        val blobElements = blobs.map { (ref, json) ->
             val element = mockk<RCElement>()
-            val bytes = ByteBuffer.wrap(json.toByteArray())
-            every { element.decode() } returns bytes
-            every { element.matchesChecksum(any()) } returns true
-            ref to element
+            every { element.checksumBase64() } returns ref
+            every { element.decode() } returns json.toByteArray()
+            element
         }
         val container = mockk<RCContainer>()
-        every { container.config } returns configElement
-        every { container.elements } returns elements
+        every { container.config } returns configJson.toByteArray()
+        every { container.contentElements } returns blobElements
         return container
     }
 


### PR DESCRIPTION
### Motivation

- Move checksum check to `decode()`, no alternative ways of getting the content, guarantees checksums are done.
- The config is converted to bytes right away, as it is always needed and non-optional. The config validation can also fail for trusted entitlement signatures, so if the hash doesn't match it should also behave in a similar way.
- When decoding elements, we allocate byte array, copying from the buffer if we must (when data is not compressed) to simplify usages that currently need to duplicate and handle this themselves.
- The design ensures all elements are only decoded once: "consumed": config is decoded right away, and getting blobs removes them from RCContainer, no double decoding by mistake.
- RCElement leaks a bit into the blob processing, we want to check if references are in cache before attempting to decode.

The `reserved` field is removed from `RCElement` since it was stored but never read by any caller. We can re-add it later if needed, no point in having it in code when unused.

Tests are updated throughout: mocks no longer stub `decode()` returning a `ByteBuffer` or `matchesChecksum`, and the `elements` map is no longer asserted. A new test covers the case where a content element's checksum doesn't match (parse succeeds, but `decode()` throws), and the config-checksum-mismatch case now asserts that `parse` itself throws.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote-config container parsing, response signature inputs, and inline blob extraction—security-adjacent paths—but behavior is covered by updated unit and integration tests; config checksum mismatches now fail earlier than before.
> 
> **Overview**
> Refactors how **RC Container Format v1** is consumed so integrity checks are harder to skip and large payloads stay compressed until needed.
> 
> **`RCContainer` / `RCElement`:** Element 0 is **decoded and checksum-verified during `parse`**, exposed as `config: ByteArray` (not an `RCElement`). Content blobs stay as zero-copy `contentElements`; the lazy **`elements` checksum map is removed**—callers use `checksumBase64()` on each element. **`RCElement.decode()`** now always returns a detached **`ByteArray`** and **throws on checksum mismatch** (replacing separate `isChecksumValid` / `matchesChecksum` / `decodedBytes` paths). **`RCContentEncoding.decode`** always materializes bytes; unused **`reserved`** on `RCElement` is dropped.
> 
> **Call sites:** `HTTPClient` signs/verifies over `RCContainer.parse(...).config` and **fails RC-format verification when config parse fails** (including bad config checksum). **`RemoteConfigManager`** parses config directly, extracts inline blobs by iterating `contentElements` (ref filter + skip if already cached) before decode. **`RemoteConfigBlobStore` / `RemoteConfigBlobFetcher`** take **`ByteArray`** instead of `ByteBuffer`.
> 
> Tests and integration fixtures are updated for the new API and stricter config checksum behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fefdce31a9a66678830840c86d0a0bd89a65827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->