### PR TITLE
feat(remote-config): add internal usesRemoteConfigAPISources dangerous setting

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
@@ -24,6 +24,13 @@ public class DangerousSettings internal constructor(
     internal val applyObfuscatedAccountIdToSubscriptionChanges: Boolean = false,
 
     /**
+     * Whether main-API requests resolve their base host from the remote-config API sources
+     * instead of the static [AppConfig] base URL. Disabled by default; enabled in tests while
+     * remote-config-driven host resolution is being validated.
+     */
+    internal val usesRemoteConfigAPISources: Boolean = false,
+
+    /**
      * Enables RevenueCat Workflows (multipage paywalls). Internal RevenueCat use only.
      */
     @InternalRevenueCatAPI
@@ -35,6 +42,7 @@ public class DangerousSettings internal constructor(
         customEntitlementComputation = false,
         uiPreviewMode = false,
         applyObfuscatedAccountIdToSubscriptionChanges = false,
+        usesRemoteConfigAPISources = false,
         useWorkflows = false,
     )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/DangerousSettingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/DangerousSettingsTest.kt
@@ -31,6 +31,18 @@ class DangerousSettingsTest {
         assertThat(dangerousSettings.uiPreviewMode).isFalse
     }
 
+    @Test
+    fun `default usesRemoteConfigAPISources is false`() {
+        val dangerousSettings = DangerousSettings()
+        assertThat(dangerousSettings.usesRemoteConfigAPISources).isFalse
+    }
+
+    @Test
+    fun `usesRemoteConfigAPISources can be enabled`() {
+        val dangerousSettings = DangerousSettings(usesRemoteConfigAPISources = true)
+        assertThat(dangerousSettings.usesRemoteConfigAPISources).isTrue
+    }
+
     @OptIn(InternalRevenueCatAPI::class)
     @Test
     fun `forPreviewMode sets uiPreviewMode to true and autoSyncPurchases to false`() {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -508,6 +508,7 @@ class AppConfigTest {
                 "customEntitlementComputation=false, " +
                 "uiPreviewMode=false, " +
                 "applyObfuscatedAccountIdToSubscriptionChanges=false, " +
+                "usesRemoteConfigAPISources=false, " +
                 "useWorkflows=false), " +
                 "languageTag='', " +
                 "versionName='', " +


### PR DESCRIPTION
### Checklist
- [x] Unit tests

### Motivation
Groundwork for #3715. We want to start merging the API-sources host-resolution work without enabling it in production until it's more thoroughly tested.

### Description
- Adds a disabled-by-default internal `usesRemoteConfigAPISources` dangerous setting. #3715 will gate main-API host resolution behind it, so it can merge as a no-op while tests enable it on CI.

iOS counterpart: RevenueCat/purchases-ios#7236

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an internal default-false setting with no production code paths reading it yet; behavior stays unchanged until a later PR.
> 
> **Overview**
> Adds an **internal**, **off-by-default** `usesRemoteConfigAPISources` flag on `DangerousSettings` so a follow-up can switch main-API base host resolution from static `AppConfig` to remote-config API sources without turning that on in production yet.
> 
> The public `DangerousSettings(autoSyncPurchases)` constructor wires the flag to `false`. Unit tests cover the default and enabling it; `AppConfigTest`’s `toString` expectation is updated for the new field. **No SDK behavior changes in this PR**—only the configuration hook and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c709a57bc580565866e0b1ccb7206205ed1b9aab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->