### PR TITLE
fix(remote-config): lazy-decode workflows cache to reduce memory

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -29,15 +29,18 @@ import kotlinx.serialization.json.JsonPrimitive
  * sync, resolving inline vs `blob_ref`, downloading and reading the body — it delegates to [RemoteConfigManager]
  * through `topic()` / `blobData()`. It never sees the blob store, the fetcher, or the disk cache.
  *
- * On top of the on-demand suspend reads it keeps a small in-memory cache of **parsed** workflows so a paywall
- * render can read one without a disk + JSON hop: [getWorkflow] and [workflowIdForOfferingId] are **memory-first**
- * — a cache hit returns synchronously (the suspend fn never actually suspends, so it resumes on the caller's
- * thread with no dispatch), and only a miss touches [RemoteConfigManager]. Only workflows worth holding are
- * cached: an item flagged `prefetch`, or the one associated with the current offering (its `offering_identifier`
- * equals [currentOfferingIdProvider]'s value). The full `offering_identifier -> workflowId` map (metadata only)
- * is cached for every offering. Both are re-warmed on every config commit and dropped on identity change /
- * disable, guarded by [RemoteConfigManager.configGeneration] (store-if-newer) so a slower disk warm never
- * clobbers a fresher network commit.
+ * On top of the on-demand suspend reads it keeps a small in-memory cache so a paywall render can read a workflow
+ * without a disk + JSON hop: [getWorkflow] and [workflowIdForOfferingId] are **memory-first** — a cache hit
+ * returns synchronously (the suspend fn never actually suspends, so it resumes on the caller's thread with no
+ * dispatch), and only a miss touches [RemoteConfigManager]. To keep memory low the cache holds the **raw workflow
+ * body bytes**, not the decoded [PublishedWorkflow] graph (which retains an entire paywall component tree +
+ * localizations per screen); the decode is deferred behind a [Lazy] and runs on first [getWorkflow] access, on
+ * the caller's (main) thread, and is retained thereafter — mirroring `Offering.PaywallComponents`. Only workflows
+ * worth holding are cached: an item flagged `prefetch`, or the one associated with the current offering (its
+ * `offering_identifier` equals [currentOfferingIdProvider]'s value). The full `offering_identifier -> workflowId`
+ * map (metadata only) is cached for every offering. Both are re-warmed on every config commit and dropped on
+ * identity change / disable, guarded by [RemoteConfigManager.configGeneration] (store-if-newer) so a slower disk
+ * warm never clobbers a fresher network commit.
  */
 @Suppress("TooManyFunctions")
 internal class WorkflowsConfigProvider(
@@ -47,7 +50,8 @@ internal class WorkflowsConfigProvider(
 ) : RemoteConfigCommitListener {
 
     private class Cached(
-        val workflows: Map<String, PublishedWorkflow>,
+        // Raw body bytes per workflow, decoded lazily (on first access, on the caller's thread) and retained.
+        val workflows: Map<String, Lazy<PublishedWorkflow?>>,
         val offeringToWorkflowId: Map<String, String>,
     )
 
@@ -56,11 +60,13 @@ internal class WorkflowsConfigProvider(
     /**
      * Whether the in-memory cache already holds what the current offering's paywall needs, so the offerings
      * readiness gate can deliver synchronously. True when the cache is populated and either there is no current
-     * offering, the current offering has no workflow mapping (legacy/embedded paywall), or its workflow is parsed.
+     * offering, the current offering has no workflow mapping (legacy/embedded paywall), or its body is in memory
+     * (ready to decode synchronously on read).
      */
     fun isWarmForCurrentOffering(): Boolean {
         val cached = cache.cached ?: return false
         val workflowId = currentOfferingIdProvider()?.let { cached.offeringToWorkflowId[it] }
+        // "Has the body in memory" — the decode is deferred, so this never forces a parse.
         return workflowId == null || cached.workflows.containsKey(workflowId)
     }
 
@@ -92,11 +98,12 @@ internal class WorkflowsConfigProvider(
 
     /**
      * Resolves [workflowId] into a [PublishedWorkflow], or `null` when the item is unknown, its body can be
-     * neither read nor downloaded, or the body fails to parse. Memory-first: a cached (parsed) workflow returns
-     * synchronously; only a miss reads through [RemoteConfigManager] (disk/network + JSON parse).
+     * neither read nor downloaded, or the body fails to parse. Memory-first: a cached workflow returns
+     * synchronously — the body bytes are already in memory, so the [Lazy] decode runs on this (caller) thread
+     * without suspending. Only a miss reads through [RemoteConfigManager] (disk/network + JSON parse).
      */
     suspend fun getWorkflow(workflowId: String): PublishedWorkflow? {
-        cache.cached?.workflows?.get(workflowId)?.let { return it }
+        cache.cached?.workflows?.get(workflowId)?.let { return it.value }
         val generation = manager.configGeneration
         val workflow = resolveWorkflow(workflowId)
         // If an identity-change invalidation advanced the generation while the body was resolved, it may belong
@@ -104,17 +111,27 @@ internal class WorkflowsConfigProvider(
         return when {
             workflow == null -> null
             cache.isCurrent(generation) -> workflow
-            else -> cache.cached?.workflows?.get(workflowId)
+            else -> cache.cached?.workflows?.get(workflowId)?.value
         }
     }
 
     /** Reads + parses a workflow body straight from the config layer, bypassing the in-memory cache. */
     private suspend fun resolveWorkflow(workflowId: String): PublishedWorkflow? {
-        val body = manager.blobData(RemoteConfigTopic.Workflows, workflowId) { it } ?: run {
-            errorLog { "Workflow '$workflowId' is unavailable from remote config." }
-            return null
-        }
-        return try {
+        val body = resolveWorkflowBytes(workflowId) ?: return null
+        return decodeWorkflow(workflowId, body)
+    }
+
+    /** Reads a workflow body's raw bytes from the config layer (disk/network); no decode. */
+    private suspend fun resolveWorkflowBytes(workflowId: String): ByteArray? =
+        manager.blobData(RemoteConfigTopic.Workflows, workflowId) { it }
+            ?: run {
+                errorLog { "Workflow '$workflowId' is unavailable from remote config." }
+                null
+            }
+
+    /** Parses raw workflow body bytes into a [PublishedWorkflow], or `null` on a parse failure. */
+    private fun decodeWorkflow(workflowId: String, body: ByteArray): PublishedWorkflow? =
+        try {
             val workflow = WorkflowJsonParser.parsePublishedWorkflow(body.decodeToString())
             debugLog { "Parsed workflow '$workflowId' (${workflow.steps.size} step(s))" }
             workflow
@@ -122,7 +139,6 @@ internal class WorkflowsConfigProvider(
             errorLog(e) { "Failed to parse workflow '$workflowId' body." }
             null
         }
-    }
 
     /**
      * Forces the `workflows` topic to be synced (or confirms it already is) **and** waits for its
@@ -142,6 +158,12 @@ internal class WorkflowsConfigProvider(
      * (no `/v1/config` sync) when the `workflows` topic isn't committed yet, so a cold-disk init warm never
      * triggers a network config fetch. Caches only eligible workflows (prefetch or current offering); the
      * offering->workflowId map covers every offering.
+     *
+     * Only the **raw body bytes** are pre-loaded here (the expensive IO/network hop, on this warm's dispatcher);
+     * the [PublishedWorkflow] decode is deferred behind a [Lazy] and runs on first [getWorkflow] access, so
+     * warming never retains a decoded workflow graph. An eligible workflow is cached iff its bytes resolve;
+     * whether those bytes later parse is decided lazily on read (a bad body reads back as `null`, not a warm-time
+     * exclusion).
      */
     suspend fun warm(generation: Int) {
         // Already warm for this (or a newer) generation and the current offering — nothing to do.
@@ -160,12 +182,14 @@ internal class WorkflowsConfigProvider(
                 eligibleIds += workflowId
             }
         }
-        // Resolve from committed config (not the cache we're rebuilding).
+        // Pre-load bytes from committed config (not the cache we're rebuilding); defer the decode.
         val workflows = coroutineScope {
             eligibleIds.distinct()
-                .map { id -> async { id to resolveWorkflow(id) } }
+                .map { id -> async { id to resolveWorkflowBytes(id) } }
                 .awaitAll()
-        }.mapNotNull { (id, workflow) -> workflow?.let { id to it } }.toMap()
+        }.mapNotNull { (id, bytes) ->
+            bytes?.let { id to lazy(LazyThreadSafetyMode.SYNCHRONIZED) { decodeWorkflow(id, it) } }
+        }.toMap()
         verboseLog {
             "Warmed workflows cache: ${workflows.size} eligible workflow(s), " +
                 "${offeringToWorkflowId.size} offering mapping(s)."

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/GoldenFileRecorder.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/GoldenFileRecorder.kt
@@ -125,6 +125,7 @@ class GoldenFileRecorder(
             "Alt-Svc",
             "X-Revenuecat-App-Id",
             "x-revenuecat-app-id",
+            "Content-Length",
         )
 
         /**

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
@@ -11,6 +11,8 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -72,6 +74,44 @@ internal class WorkflowsConfigProviderTest {
         assertThat(workflow).isNotNull
         // Only the one read during warm; the memory-first getWorkflow did not touch the config layer again.
         coVerify(exactly = 1) { manager.blobData(RemoteConfigTopic.Workflows, WF_CURRENT, any<(ByteArray) -> ByteArray?>()) }
+    }
+
+    @Test
+    fun `warm pre-loads bytes but defers the decode until the first getWorkflow, then retains it`() = runTest {
+        mockkObject(WorkflowJsonParser) {
+            stubTopic()
+            stubWorkflowBody(WF_PREFETCH)
+            stubWorkflowBody(WF_CURRENT)
+
+            provider.warm(generation = 0)
+            // Bytes are in memory (the offering is warm), but nothing has been decoded yet.
+            assertThat(provider.isWarmForCurrentOffering()).isTrue
+            verify(exactly = 0) { WorkflowJsonParser.parsePublishedWorkflow(any()) }
+
+            assertThat(provider.getWorkflow(WF_CURRENT)).isNotNull
+            verify(exactly = 1) { WorkflowJsonParser.parsePublishedWorkflow(any()) }
+
+            // A second read is served from the retained decode, not re-parsed.
+            assertThat(provider.getWorkflow(WF_CURRENT)).isNotNull
+            verify(exactly = 1) { WorkflowJsonParser.parsePublishedWorkflow(any()) }
+        }
+    }
+
+    @Test
+    fun `a malformed workflow body warms as bytes but reads back null`() = runTest {
+        stubTopic()
+        stubWorkflowBody(WF_PREFETCH)
+        // WF_CURRENT's body resolves but is not valid PublishedWorkflow JSON.
+        coEvery {
+            manager.blobData(RemoteConfigTopic.Workflows, WF_CURRENT, any<(ByteArray) -> ByteArray?>())
+        } answers { thirdArg<(ByteArray) -> ByteArray?>().invoke("not a workflow".toByteArray()) }
+
+        provider.warm(generation = 0)
+
+        // The body was cached (bytes resolved), so the gate treats the current offering as warm...
+        assertThat(provider.isWarmForCurrentOffering()).isTrue
+        // ...but the deferred decode fails synchronously on read, surfacing as null (no warm-time exclusion).
+        assertThat(provider.getWorkflow(WF_CURRENT)).isNull()
     }
 
     @Test
@@ -170,7 +210,7 @@ internal class WorkflowsConfigProviderTest {
         provider.warm(generation = 0)
         assertThat(provider.isWarmForCurrentOffering()).isTrue
 
-        // The current offering switches to one whose workflow was not eligible (so not parsed).
+        // The current offering switches to one whose workflow was not eligible (so its body was not cached).
         currentOfferingId = OTHER_OFFERING
 
         assertThat(provider.isWarmForCurrentOffering()).isFalse

--- a/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform offerings backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform offerings backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 502,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "960",
     "Content-Type": "text\/html",
     "Server": "CloudFront"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform offerings backend request/response_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform offerings backend request/response_002.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "94043",
     "Server": "cloudflare"
   },
   "body": {

--- a/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform product entitlement mapping backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform product entitlement mapping backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 502,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "960",
     "Content-Type": "text\/html",
     "Server": "CloudFront"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform product entitlement mapping backend request/response_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform product entitlement mapping backend request/response_002.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "266",
     "Server": "cloudflare"
   },
   "body": {

--- a/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform verified offerings backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform verified offerings backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 502,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "960",
     "Content-Type": "text\/html",
     "Server": "CloudFront"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform verified offerings backend request/response_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform verified offerings backend request/response_002.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "94043",
     "Server": "cloudflare"
   },
   "body": {

--- a/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform verified product entitlement mapping backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform verified product entitlement mapping backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 502,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "960",
     "Content-Type": "text\/html",
     "Server": "CloudFront"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform verified product entitlement mapping backend request/response_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/FallbackURLBackendIntegrationTest/can perform verified product entitlement mapping backend request/response_002.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "266",
     "Server": "cloudflare"
   },
   "body": {

--- a/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast1BackendIntegrationTest/can perform offerings backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast1BackendIntegrationTest/can perform offerings backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "91379",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "server": "envoy",

--- a/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast1BackendIntegrationTest/can perform product entitlement mapping backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast1BackendIntegrationTest/can perform product entitlement mapping backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "515",
     "Content-Type": "application\/json",
     "server": "envoy",
     "strict-transport-security": "max-age= 63072000; includeSubdomains; preload",

--- a/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast1BackendIntegrationTest/can perform verified offerings backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast1BackendIntegrationTest/can perform verified offerings backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "91379",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "server": "envoy",

--- a/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast1BackendIntegrationTest/can perform verified product entitlement mapping backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast1BackendIntegrationTest/can perform verified product entitlement mapping backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "515",
     "Content-Type": "application\/json",
     "server": "envoy",
     "strict-transport-security": "max-age= 63072000; includeSubdomains; preload",

--- a/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast2BackendIntegrationTest/can perform offerings backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast2BackendIntegrationTest/can perform offerings backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "91379",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "server": "envoy",

--- a/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast2BackendIntegrationTest/can perform product entitlement mapping backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast2BackendIntegrationTest/can perform product entitlement mapping backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "515",
     "Content-Type": "application\/json",
     "server": "envoy",
     "strict-transport-security": "max-age= 63072000; includeSubdomains; preload",

--- a/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast2BackendIntegrationTest/can perform verified offerings backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast2BackendIntegrationTest/can perform verified offerings backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "91379",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "server": "envoy",

--- a/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast2BackendIntegrationTest/can perform verified product entitlement mapping backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/LoadShedderUSEast2BackendIntegrationTest/can perform verified product entitlement mapping backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "515",
     "Content-Type": "application\/json",
     "server": "envoy",
     "strict-transport-security": "max-age= 63072000; includeSubdomains; preload",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendEventsTest/can post events without errors/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendEventsTest/can post events without errors/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can get customer center config data/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can get customer center config data/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "9421",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform login backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform login backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "369",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform offerings backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform offerings backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "23453",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform product entitlement mapping backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform product entitlement mapping backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "253",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform verified login backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform verified login backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "369",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform verified offerings backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform verified offerings backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "23453",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform verified product entitlement mapping backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can perform verified product entitlement mapping backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "253",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can post ad events backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can post ad events backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can postPaywallEvents backend request/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionBackendIntegrationTest/can postPaywallEvents backend request/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "3",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/a second fallback request is served from the ETag cache/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "1206",
     "Server": "cloudflare"
   },
   "body": {

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/can fetch remote config from the fallback endpoint/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/can fetch remote config from the fallback endpoint/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "1206",
     "Server": "cloudflare"
   },
   "body": {

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 502,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "960",
     "Content-Type": "text\/html",
     "Server": "CloudFront"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/response_002.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/domain layer falls back to the fallback endpoint when the main request fails with no cached config/response_002.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "1206",
     "Server": "cloudflare"
   },
   "body": {

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/verifies the fallback response without a nonce when verification is enforced/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigFallbackIntegrationTest/verifies the fallback response without a nonce when verification is enforced/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "1206",
     "Server": "cloudflare"
   },
   "body": {

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/can fetch remote config/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/can fetch remote config/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/decodes an inline workflows content blob/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/decodes an inline workflows content blob/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/fetches, persists and reads an inlined workflows blob back through the manager facade/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/reads and deserializes a workflows blob into a typed value through the facade/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/replaying the manifest returns no content/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/replaying the manifest returns no content/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the no content response when verification is enforced/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the no content response when verification is enforced/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the signed response when verification is enforced/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionRemoteConfigIntegrationTest/verifies the signed response when verification is enforced/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "11024",
     "Content-Type": "application\/x-rc-format",
     "server": "envoy"
   },

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionVirtualCurrenciesIntegrationTest/can fetch virtual currencies with a balance of 0/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionVirtualCurrenciesIntegrationTest/can fetch virtual currencies with a balance of 0/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "306",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",

--- a/purchases/src/test/resources/backend_integration_tests_golden/ProductionVirtualCurrenciesIntegrationTest/can fetch virtual currencies with a balance of greater than 0/response_001.json
+++ b/purchases/src/test/resources/backend_integration_tests_golden/ProductionVirtualCurrenciesIntegrationTest/can fetch virtual currencies with a balance of greater than 0/response_001.json
@@ -2,7 +2,6 @@
   "statusCode": 200,
   "headers": {
     "Connection": "keep-alive",
-    "Content-Length": "310",
     "Content-Type": "application\/json",
     "access-control-allow-origin": "*",
     "access-control-expose-headers": "X-Request-Id",


### PR DESCRIPTION
## Description

`WorkflowsConfigProvider` cached fully-decoded `PublishedWorkflow` graphs (each holding a `ComponentsConfig` tree + localizations per screen), and `warm()` decoded every eligible workflow eagerly.

Now, we will cache the raw body bytes but not decode it until it's requested (when presenting a workflow), effectively saving some good memory.  Some initial numbers:
```
  ┌─────────────────────────────────┬──────────┬──────────┬─────────────┐                                                                                                                                        
  │         Metric (median)         │  RC ON   │  RC OFF  │  ON−OFF Δ   │                                                                                                                                        
  ├─────────────────────────────────┼──────────┼──────────┼─────────────┤                                                                                                                                        
  │ Heap retained (HeapSizeLast)    │ 62.5 MB  │ 55.8 MB  │ +6.7 MB     │                                                                                                                                        
  ├─────────────────────────────────┼──────────┼──────────┼─────────────┤                                                                                                                                        
  │ Heap peak (HeapSizeMax)         │ 146.5 MB │ 171.7 MB │ −25.1 MB    │                                                                                                                                        
  ├─────────────────────────────────┼──────────┼──────────┼─────────────┤                                                                                                                                        
  │ Anon RSS retained (RssAnonLast) │ 91.9 MB  │ 99.5 MB  │ −7.6 MB     │                                                                                                                                        
  ├─────────────────────────────────┼──────────┼──────────┼─────────────┤                                                                                                                                        
  │ Anon RSS peak (RssAnonMax)      │ 167.1 MB │ 185.4 MB │ −18.3 MB    │                                                                                                                                                                                                                                                                     
  └─────────────────────────────────┴──────────┴──────────┴─────────────┘
```
Before this change, the memory usage when workflows/config endpoint was enabled increased much more substantially

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall workflow cache timing (decode on first access, often main thread) on the offerings readiness path, though behavior is covered by new unit tests.
> 
> **Overview**
> **`WorkflowsConfigProvider`** no longer stores fully parsed **`PublishedWorkflow`** graphs in the in-memory warm cache. **`warm()`** now pre-loads only **raw workflow body bytes** (same eligibility: prefetch + current offering); JSON parsing is deferred behind **`Lazy`** and runs on the **first `getWorkflow`** on the caller’s thread, then stays cached. Readiness (**`isWarmForCurrentOffering`**) is based on having bytes in memory, not a completed decode—invalid JSON can still count as warm but **`getWorkflow`** returns **`null`** on read.
> 
> Tests cover deferred parsing, malformed bodies, and golden recording now strips **`Content-Length`** from captured responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a1fc8cf290cf0d4463e2e2c45ce7ff5a1599c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->