### PR TITLE
Trust user CAs in debug builds of paywalls tester for proxying

### DIFF
--- a/examples/paywall-tester/src/main/AndroidManifest.xml
+++ b/examples/paywall-tester/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
             android:label="@string/app_name"
             android:roundIcon="@mipmap/icon_round"
             android:backupAgent="com.revenuecat.purchases.backup.RevenueCatBackupAgent"
+            android:networkSecurityConfig="@xml/network_security_config"
             android:supportsRtl="true"
             android:theme="@style/Theme.Purchasesandroid">
         <activity

--- a/examples/paywall-tester/src/main/res/xml/network_security_config.xml
+++ b/examples/paywall-tester/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!--
+        Trust user-installed CA certificates in debuggable builds only, so HTTP debugging
+        proxies such as Proxyman or Charles can decrypt the app's HTTPS traffic.
+        Release builds are unaffected: they keep the default of trusting only system CAs.
+    -->
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>


### PR DESCRIPTION
Adds a `network_security_config.xml` to the paywall-tester app and references it from the manifest via `android:networkSecurityConfig`. In debuggable builds only, the app now trusts user-installed CA certificates in addition to system ones, so HTTP debugging proxies such as Proxyman or Charles can decrypt the app's HTTPS traffic while developing against paywalls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app-only change scoped to debuggable builds; release TLS trust is unchanged.
> 
> **Overview**
> The **paywall-tester** example app can now use HTTPS debugging proxies (Proxyman, Charles, etc.) during development.
> 
> A new `network_security_config.xml` uses Android’s **`debug-overrides`** so **debuggable builds** trust **user-installed** CAs in addition to system CAs. The manifest wires this in via `android:networkSecurityConfig`. **Release builds** keep the default behavior (system CAs only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e873cb5c3307b4d03e2bf6c60bd0e559e39d5d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->