### PR TITLE
fix(remote-config): Avoid redundant offerings reload on disabled paywall re-presentation

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -900,6 +900,12 @@ internal class PaywallViewModelImpl(
             WorkflowResolution.Disabled -> {
                 // A 4xx kill switch disabled remote config. The offering was parsed with its components skipped,
                 // so reload it from /offerings — which now re-parse with those components — to recover its paywall.
+                // When the resolved offering already carries decoded components (the cache was repopulated when the
+                // kill switch first tripped), render it directly instead of reloading offerings on every present.
+                if (workflowOffering.paywallComponents != null) {
+                    clearWorkflowState()
+                    return WorkflowOutcome.Fallback(workflowOffering, preloadedOfferings)
+                }
                 Logger.w(
                     "Paywalls: Workflows unavailable for offering '${workflowOffering.identifier}' after a " +
                         "remote config disable. Falling back to the offerings-provided paywall.",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -3256,6 +3256,72 @@ class PaywallViewModelTest {
         val reloadedOffering = (model.state.value as PaywallState.Loaded.Components).offering
         assertThat(reloadedOffering.identifier).isEqualTo(offeringWithWPL.identifier)
         assertThat(reloadedOffering.paywallComponents).isNotNull()
+        coVerify(exactly = 1) { purchases.awaitOfferings() }
+        coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
+    }
+
+    @Test
+    fun `when disabled by a 4xx and the offering already carries components, renders without reloading offerings`() {
+        // Once the kill switch has repopulated the offerings cache with decoded components, re-presenting the
+        // paywall renders the resolved offering directly instead of reloading offerings on every presentation.
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Disabled
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOffering(offeringWithWPL)
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+        val offering = (model.state.value as PaywallState.Loaded.Components).offering
+        assertThat(offering.identifier).isEqualTo(offeringWithWPL.identifier)
+        assertThat(offering.paywallComponents).isNotNull()
+        coVerify(exactly = 0) { purchases.awaitOfferings() }
+        coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
+    }
+
+    @Test
+    fun `when disabled by a 4xx and presented by offering id, renders without a redundant offerings reload`() {
+        // The launcher path resolves the offering via awaitOfferings() up front, which after the disable already
+        // carries components. The disabled fallback must not reload offerings a second time.
+        val presentedOfferingContext = PresentedOfferingContext(offeringIdentifier = offeringWithWPL.identifier)
+        val offerings = Offerings(
+            current = offeringWithWPL,
+            all = mapOf(offeringWithWPL.identifier to offeringWithWPL),
+        )
+        coEvery { purchases.awaitOfferings() } returns offerings
+        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Disabled
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOfferingIdAndPresentedOfferingContext(
+                    OfferingSelection.IdAndPresentedOfferingContext(
+                        offeringId = offeringWithWPL.identifier,
+                        presentedOfferingContext = presentedOfferingContext,
+                    ),
+                )
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+        val offering = (model.state.value as PaywallState.Loaded.Components).offering
+        assertThat(offering.identifier).isEqualTo(offeringWithWPL.identifier)
+        assertThat(offering.paywallComponents).isNotNull()
+        coVerify(exactly = 1) { purchases.awaitOfferings() }
         coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
     }
 


### PR DESCRIPTION
When the remote config kill switch is on, re-presenting a Paywalls V2 paywall re-ran workflow resolution and reloaded offerings on every presentation, even though the cache already carried decoded components after the initial recovery. That extra reload stretched the loading state into a visible flash.

Now the disabled fallback renders the resolved offering directly when it already has decoded `paywallComponents`, reloading only when they are missing (a stale `setOffering` object parsed before the kill switch tripped).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted paywall loading optimization; stale offerings without components still reload, with no change to purchase or auth flows.
> 
> **Overview**
> When workflows are **disabled by the remote-config kill switch** (`WorkflowResolution.Disabled`), re-presenting a Paywalls V2 offering no longer always calls `reloadOfferingAfterConfigDisabled` / `awaitOfferings()`.
> 
> If the resolved offering already has **`paywallComponents`** (cache repopulated after the first disable), `PaywallViewModel` **clears stale workflow state** and falls back to that offering directly. **Reload still runs** when components are missing (e.g. stale `setOffering` from before the kill switch).
> 
> Tests lock in **zero extra `awaitOfferings`** for `setOffering` with components, and **only one** fetch on the offering-id launcher path when offerings already include components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bdf6ab0c65adc9385470b34febcc5486a6be4e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->