### PR TITLE
Run Maestro workflow tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1080,6 +1080,8 @@ workflows:
           requires:
             - prepare-tests
       - run-maestro-workflow-tests:
+          context:
+            - maestro
           requires:
             - prepare-tests
       - run-integration-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -860,6 +860,39 @@ jobs:
       - store_test_results:
           path: maestro/report.xml
 
+  run-maestro-workflow-tests:
+    description: "Run Maestro workflow (multipage paywall) tests for E2E Tester app"
+    <<: *android-machine-emulator
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - install-mise-tools
+      - android/create_avd:
+          avd_name: test-e2e-workflow-tester
+          system_image: system-images;android-32;google_apis;x86_64
+          install: true
+      - android/start_emulator:
+          avd_name: test-e2e-workflow-tester
+          # The workflow project key is baked in at build time (BuildConfig.WORKFLOWS_API_KEY),
+          # which makes E2ETestsApplication configure against the workflow project with
+          # DangerousSettings.forWorkflows(). This is a separate build from the annual flow.
+          post_emulator_launch_assemble_command: ./gradlew test-apps:e2etests:assembleDebug -PE2E_WORKFLOWS_API_KEY=$WORKFLOWS_TEST_STORE_API_KEY
+      - android/restore_gradle_cache
+      - run:
+          name: Install E2E Tester on emulator
+          command: |
+            adb install test-apps/e2etests/build/outputs/apk/debug/e2etests-debug.apk
+      - revenuecat/install-maestro
+      - run:
+          name: Run Maestro workflow tests
+          command: |
+            maestro test --format junit --output maestro/workflow-report.xml maestro/workflows/
+      - store_artifacts:
+          path: ~/.maestro/tests/
+      - store_test_results:
+          path: maestro/workflow-report.xml
+
   generate-baseline-profiles:
     description: "Generate baseline profiles using Gradle Managed Devices and open a PR"
     <<: *android-machine-emulator
@@ -1046,6 +1079,9 @@ workflows:
       - run-maestro-e2e-tests:
           requires:
             - prepare-tests
+      - run-maestro-workflow-tests:
+          requires:
+            - prepare-tests
       - run-integration-tests:
           requires:
             - prepare-tests
@@ -1070,6 +1106,7 @@ workflows:
             - assemble-paywall-tester-release
             - run-backend-integration-tests
             - run-maestro-e2e-tests
+            - run-maestro-workflow-tests
             - run-revenuecatui-ui-tests
             - run-integration-tests
             - run-purchases-integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -876,7 +876,8 @@ jobs:
           avd_name: test-e2e-workflow-tester
           # The workflow project key is baked in at build time (BuildConfig.WORKFLOWS_API_KEY),
           # which makes E2ETestsApplication configure against the workflow project with
-          # DangerousSettings.forWorkflows(). This is a separate build from the annual flow.
+          # DangerousSettings.forWorkflows(). A single APK can only target one project, so this
+          # is built and run separately from run-maestro-e2e-tests.
           post_emulator_launch_assemble_command: ./gradlew test-apps:e2etests:assembleDebug -PE2E_WORKFLOWS_API_KEY=$WORKFLOWS_TEST_STORE_API_KEY
       - android/restore_gradle_cache
       - run:


### PR DESCRIPTION
## What changed

Adds a dedicated `run-maestro-workflow-tests` CircleCI job that runs the workflow (multipage paywall) Maestro flows in `maestro/workflows/`, which until now ran only locally.

The workflow flows can't share the existing `run-maestro-e2e-tests` build. `E2ETestsApplication` selects the backend project and enables `DangerousSettings.forWorkflows()` at build time based on `BuildConfig.WORKFLOWS_API_KEY`, so a single APK can only serve one project. The new job therefore runs on its own emulator and builds with `-PE2E_WORKFLOWS_API_KEY=$WORKFLOWS_TEST_STORE_API_KEY`, which points the app at the workflow project. No `sed` on `Constants.kt` is needed because the app ignores `Constants.API_KEY` when the workflow key is present.

The key is read from the `maestro` CircleCI context, attached to the job in the workflow graph.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes that add a parallel emulator job and consume a context secret; no production app or SDK runtime behavior changes in this diff.
> 
> **Overview**
> **Adds CI coverage for multipage paywall Maestro flows** in `maestro/workflows/`, which previously ran only locally.
> 
> A new **`run-maestro-workflow-tests`** job mirrors the existing E2E Maestro setup (emulator, E2E tester APK, Maestro JUnit output) but builds with **`-PE2E_WORKFLOWS_API_KEY=$WORKFLOWS_TEST_STORE_API_KEY`** so the app targets the workflow project at compile time—no `Constants.kt` `sed` step. It uses a separate AVD (`test-e2e-workflow-tester`) because one APK cannot serve both the standard E2E and workflow projects.
> 
> The **`build-test-deploy`** workflow wires the job after `prepare-tests`, attaches the **`maestro`** context for the API key, and includes it in the **release `hold`** approval gate alongside `run-maestro-e2e-tests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6bb6403770f363bd69c0cb3dae280b774ff0af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->