### PR TITLE
refactor(paywalls): use kotlinx.serialization for web_view transport envelope

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelope.kt
@@ -2,11 +2,15 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
-import org.json.JSONException
-import org.json.JSONObject
+import kotlinx.serialization.Required
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 
 /**
- * Wire-format envelopes for the `workflow-web-components-sdk` transport layer.
+ * Wire-format envelope for the `workflow-web-components-sdk` transport layer.
  *
  * Matches [RevenueCat/workflow-web-components-sdk](https://github.com/RevenueCat/workflow-web-components-sdk):
  * channel `rc-web-components`, handshake kinds `connect` / `init` / `reject`, and app frames
@@ -16,102 +20,65 @@ import org.json.JSONObject
  * frames carry a platform `sourceOrigin` / `isMainFrame`. The content still calls
  * `rcWebComponents.postMessage(jsonString)`.
  */
-internal object WebViewEnvelope {
+@Serializable
+internal data class WebViewEnvelope(
+    // @Required: a frame missing `channel` must fail to decode despite the construction-side default.
+    @Required val channel: String = CHANNEL,
+    @SerialName("protocol_version") val protocolVersion: Int,
+    val kind: Kind,
+    @SerialName("component_id") val componentId: String,
+    val type: String? = null,
+    val id: String? = null,
+    val payload: JsonObject? = null,
+    val error: String? = null,
+) {
 
-    const val CHANNEL: String = "rc-web-components"
-    const val NATIVE_OBJECT_NAME: String = "rcWebComponents"
-    const val RECEIVE_FUNCTION: String = "__rcWebComponentsReceive"
-    const val DEFAULT_PROTOCOL_VERSION: Int = 1
+    @Serializable
+    enum class Kind {
+        @SerialName("connect")
+        CONNECT,
 
-    const val KIND_CONNECT: String = "connect"
-    const val KIND_INIT: String = "init"
-    const val KIND_REJECT: String = "reject"
-    const val KIND_MESSAGE: String = "message"
-    const val KIND_REQUEST: String = "request"
-    const val KIND_RESPONSE: String = "response"
-    const val KIND_ERROR: String = "error"
+        @SerialName("init")
+        INIT,
 
-    private val ENVELOPE_KINDS: Set<String> = setOf(
-        KIND_CONNECT,
-        KIND_INIT,
-        KIND_REJECT,
-        KIND_MESSAGE,
-        KIND_REQUEST,
-        KIND_RESPONSE,
-        KIND_ERROR,
-    )
+        @SerialName("reject")
+        REJECT,
 
-    internal data class Parsed(
-        val kind: String,
-        val protocolVersion: Int,
-        val componentId: String,
-        val type: String?,
-        val id: String?,
-        val payload: JSONObject?,
-        val error: String?,
-    )
+        @SerialName("message")
+        MESSAGE,
 
-    @Suppress("ReturnCount", "CyclomaticComplexMethod")
-    fun parse(rawJson: String): Parsed? {
-        val json = try {
-            JSONObject(rawJson)
-        } catch (@Suppress("SwallowedException") _: JSONException) {
-            return null
-        }
+        @SerialName("request")
+        REQUEST,
 
-        if (json.opt(WebViewMessageField.CHANNEL) != CHANNEL) return null
+        @SerialName("response")
+        RESPONSE,
 
-        val protocolVersion = json.opt(WebViewMessageField.PROTOCOL_VERSION)
-        if (protocolVersion !is Number || !protocolVersion.toDouble().isFinite()) return null
-
-        val kind = json.opt(WebViewMessageField.KIND) as? String
-        if (kind == null || kind !in ENVELOPE_KINDS) return null
-
-        val componentId = json.opt(WebViewMessageField.COMPONENT_ID) as? String ?: return null
-
-        val type = json.opt(WebViewMessageField.TYPE) as? String
-        if (json.has(WebViewMessageField.TYPE) && type == null) return null
-
-        val id = json.opt(WebViewMessageField.ID) as? String
-        if (json.has(WebViewMessageField.ID) && id == null) return null
-
-        val error = json.opt(WebViewMessageField.ERROR) as? String
-        if (json.has(WebViewMessageField.ERROR) && error == null) return null
-
-        val payload = when (val payloadValue = json.opt(WebViewMessageField.PAYLOAD)) {
-            null, JSONObject.NULL -> null
-            is JSONObject -> payloadValue
-            else -> return null
-        }
-
-        return Parsed(
-            kind = kind,
-            protocolVersion = protocolVersion.toInt(),
-            componentId = componentId,
-            type = type,
-            id = id,
-            payload = payload,
-            error = error,
-        )
+        @SerialName("error")
+        ERROR,
     }
 
-    @Suppress("LongParameterList")
-    fun build(
-        kind: String,
-        protocolVersion: Int,
-        componentId: String,
-        type: String? = null,
-        id: String? = null,
-        payload: JSONObject? = null,
-        error: String? = null,
-    ): JSONObject = JSONObject().apply {
-        put(WebViewMessageField.CHANNEL, CHANNEL)
-        put(WebViewMessageField.PROTOCOL_VERSION, protocolVersion)
-        put(WebViewMessageField.KIND, kind)
-        put(WebViewMessageField.COMPONENT_ID, componentId)
-        type?.let { put(WebViewMessageField.TYPE, it) }
-        id?.let { put(WebViewMessageField.ID, it) }
-        payload?.let { put(WebViewMessageField.PAYLOAD, it) }
-        error?.let { put(WebViewMessageField.ERROR, it) }
+    fun toJsonString(): String = json.encodeToString(serializer(), this)
+
+    companion object {
+        const val CHANNEL: String = "rc-web-components"
+        const val NATIVE_OBJECT_NAME: String = "rcWebComponents"
+        const val RECEIVE_FUNCTION: String = "__rcWebComponentsReceive"
+        const val DEFAULT_PROTOCOL_VERSION: Int = 1
+
+        private val json = Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+        }
+
+        /**
+         * Parses an inbound frame, or `null` when it is not a valid `rc-web-components` envelope:
+         * malformed JSON, wrong or missing `channel`, unknown `kind`, or any field whose JSON type
+         * does not match the schema.
+         */
+        fun parse(rawJson: String): WebViewEnvelope? = try {
+            json.decodeFromString(serializer(), rawJson).takeIf { it.channel == CHANNEL }
+        } catch (@Suppress("SwallowedException") _: SerializationException) {
+            null
+        }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -14,7 +14,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import org.json.JSONObject
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.put
 import java.lang.ref.WeakReference
 import kotlin.math.abs
 
@@ -164,9 +168,9 @@ internal class WebViewJavaScriptBridge(
         }
 
         when (envelope.kind) {
-            WebViewEnvelope.KIND_CONNECT -> handleConnect(envelope)
-            WebViewEnvelope.KIND_MESSAGE,
-            WebViewEnvelope.KIND_REQUEST,
+            WebViewEnvelope.Kind.CONNECT -> handleConnect(envelope)
+            WebViewEnvelope.Kind.MESSAGE,
+            WebViewEnvelope.Kind.REQUEST,
             -> handleAppFrame(envelope)
             else -> Logger.w(
                 "Dropping inbound web view message: unexpected envelope kind '${envelope.kind}'.",
@@ -176,13 +180,13 @@ internal class WebViewJavaScriptBridge(
 
     @MainThread
     @Suppress("ReturnCount")
-    private fun handleConnect(envelope: WebViewEnvelope.Parsed) {
+    private fun handleConnect(envelope: WebViewEnvelope) {
         if (channelOpen || released) return
 
         if (envelope.protocolVersion != protocolVersion) {
             deliverEnvelopeNow(
-                WebViewEnvelope.build(
-                    kind = WebViewEnvelope.KIND_REJECT,
+                WebViewEnvelope(
+                    kind = WebViewEnvelope.Kind.REJECT,
                     protocolVersion = protocolVersion,
                     componentId = "",
                     error = "Unsupported protocol_version ${envelope.protocolVersion}; " +
@@ -197,8 +201,8 @@ internal class WebViewJavaScriptBridge(
         // post-then-open order): a handshake whose init is dropped by the outbound origin/webView
         // check can then be retried by a later `connect` instead of wedging the bridge half-open.
         val initDelivered = deliverEnvelopeNow(
-            WebViewEnvelope.build(
-                kind = WebViewEnvelope.KIND_INIT,
+            WebViewEnvelope(
+                kind = WebViewEnvelope.Kind.INIT,
                 protocolVersion = protocolVersion,
                 componentId = componentId,
             ),
@@ -212,14 +216,14 @@ internal class WebViewJavaScriptBridge(
 
     private fun sendFitIfNeeded() {
         if (!sizeToContentWidth && !sizeToContentHeight) return
-        val payload = JSONObject().apply {
+        val payload = buildJsonObject {
             if (sizeToContentWidth) put("width", true)
             if (sizeToContentHeight) put("height", true)
         }
         // Handshake frame (sent right after init) → shares init's allow-before-navigation exception.
         deliverEnvelopeNow(
-            WebViewEnvelope.build(
-                kind = WebViewEnvelope.KIND_MESSAGE,
+            WebViewEnvelope(
+                kind = WebViewEnvelope.Kind.MESSAGE,
                 protocolVersion = protocolVersion,
                 componentId = componentId,
                 type = WebViewMessageType.FIT,
@@ -231,14 +235,14 @@ internal class WebViewJavaScriptBridge(
 
     @MainThread
     @Suppress("ReturnCount")
-    private fun handleAppFrame(envelope: WebViewEnvelope.Parsed) {
+    private fun handleAppFrame(envelope: WebViewEnvelope) {
         if (!channelOpen) {
             Logger.w("Dropping inbound web view message: channel is not open.")
             return
         }
 
         // A `request` frame must carry an id for response correlation; drop malformed ones.
-        if (envelope.kind == WebViewEnvelope.KIND_REQUEST && envelope.id == null) {
+        if (envelope.kind == WebViewEnvelope.Kind.REQUEST && envelope.id == null) {
             Logger.w("Dropping inbound web view message: request frame is missing an id.")
             return
         }
@@ -252,7 +256,7 @@ internal class WebViewJavaScriptBridge(
     }
 
     @MainThread
-    private fun handleResize(envelope: WebViewEnvelope.Parsed) {
+    private fun handleResize(envelope: WebViewEnvelope) {
         if (envelope.componentId != componentId) {
             Logger.w("Dropping inbound web view message: resize component id does not match.")
             return
@@ -297,7 +301,7 @@ internal class WebViewJavaScriptBridge(
      */
     @MainThread
     @Suppress("ReturnCount")
-    private fun deliverEnvelopeNow(envelope: JSONObject, allowBeforeNavigation: Boolean): Boolean {
+    private fun deliverEnvelopeNow(envelope: WebViewEnvelope, allowBeforeNavigation: Boolean): Boolean {
         val webView = webViewRef.get() ?: return false
         // Defense in depth: drop outbound work if the top-level URL left the expected origin.
         if (!isCurrentUrlTrusted(webView, allowBeforeNavigation = allowBeforeNavigation)) {
@@ -307,7 +311,7 @@ internal class WebViewJavaScriptBridge(
             )
             return false
         }
-        val payload = envelope.toString().escapeForJavaScript()
+        val payload = envelope.toJsonString().escapeForJavaScript()
         webView.evaluateJavascript(
             "if (typeof window.${WebViewEnvelope.RECEIVE_FUNCTION} === 'function') { " +
                 "window.${WebViewEnvelope.RECEIVE_FUNCTION}($payload); " +
@@ -350,8 +354,10 @@ internal class WebViewJavaScriptBridge(
          * number (a stringified `"300"` or a boolean is rejected, not coerced).
          */
         @Suppress("ReturnCount")
-        fun JSONObject.resizeDimension(key: String): Int? {
-            val value = (opt(key) as? Number)?.toDouble() ?: return null
+        fun JsonObject.resizeDimension(key: String): Int? {
+            val primitive = this[key] as? JsonPrimitive ?: return null
+            if (primitive.isString) return null
+            val value = primitive.doubleOrNull ?: return null
             if (!value.isFinite() || value <= 0) return null
             return value.coerceAtMost(MAX_RESIZE_CSS_PX).toInt()
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
@@ -13,18 +13,3 @@ internal object WebViewMessageType {
     /** Content → host: reported content box size in CSS pixels. */
     const val RESIZE = "resize"
 }
-
-/**
- * Field names used in the transport envelope parsed by [WebViewEnvelope]. Application data lives under
- * [PAYLOAD]; [ERROR] is used on `error` / `reject` frames.
- */
-internal object WebViewMessageField {
-    const val CHANNEL = "channel"
-    const val PROTOCOL_VERSION = "protocol_version"
-    const val KIND = "kind"
-    const val TYPE = "type"
-    const val COMPONENT_ID = "component_id"
-    const val ID = "id"
-    const val PAYLOAD = "payload"
-    const val ERROR = "error"
-}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelopeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEnvelopeTest.kt
@@ -1,12 +1,12 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.assertj.core.api.Assertions.assertThat
-import org.json.JSONObject
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 internal class WebViewEnvelopeTest {
 
     private val componentId = "promo_web_view"
@@ -15,13 +15,13 @@ internal class WebViewEnvelopeTest {
     fun `parses a valid message envelope`() {
         val parsed = WebViewEnvelope.parse(
             envelope(
-                kind = WebViewEnvelope.KIND_MESSAGE,
+                kind = "message",
                 type = WebViewMessageType.RESIZE,
             ),
         )
 
         assertThat(parsed).isNotNull
-        assertThat(parsed!!.kind).isEqualTo(WebViewEnvelope.KIND_MESSAGE)
+        assertThat(parsed!!.kind).isEqualTo(WebViewEnvelope.Kind.MESSAGE)
         assertThat(parsed.protocolVersion).isEqualTo(1)
         assertThat(parsed.componentId).isEqualTo(componentId)
         assertThat(parsed.type).isEqualTo(WebViewMessageType.RESIZE)
@@ -34,7 +34,7 @@ internal class WebViewEnvelopeTest {
     fun `parses optional envelope fields`() {
         val parsed = WebViewEnvelope.parse(
             envelope(
-                kind = WebViewEnvelope.KIND_REQUEST,
+                kind = "request",
                 type = WebViewMessageType.RESIZE,
                 id = "req-1",
                 payload = """{"responses":{"selected_plan":"annual"}}""",
@@ -44,7 +44,7 @@ internal class WebViewEnvelopeTest {
         assertThat(parsed).isNotNull
         assertThat(parsed!!.id).isEqualTo("req-1")
         assertThat(parsed.payload).isNotNull
-        assertThat(parsed.payload!!.getJSONObject("responses").getString("selected_plan"))
+        assertThat(parsed.payload!!.getValue("responses").jsonObject.getValue("selected_plan").jsonPrimitive.content)
             .isEqualTo("annual")
     }
 
@@ -57,8 +57,23 @@ internal class WebViewEnvelopeTest {
         )
 
         assertThat(parsed).isNotNull
-        assertThat(parsed!!.kind).isEqualTo(WebViewEnvelope.KIND_CONNECT)
+        assertThat(parsed!!.kind).isEqualTo(WebViewEnvelope.Kind.CONNECT)
         assertThat(parsed.componentId).isEmpty()
+    }
+
+    @Test
+    fun `parses explicit null optional fields as absent`() {
+        val parsed = WebViewEnvelope.parse(
+            """
+            {"channel":"rc-web-components","protocol_version":1,"kind":"message","component_id":"promo_web_view","type":null,"id":null,"payload":null,"error":null}
+            """.trimIndent(),
+        )
+
+        assertThat(parsed).isNotNull
+        assertThat(parsed!!.type).isNull()
+        assertThat(parsed.id).isNull()
+        assertThat(parsed.payload).isNull()
+        assertThat(parsed.error).isNull()
     }
 
     @Test
@@ -67,6 +82,17 @@ internal class WebViewEnvelopeTest {
             WebViewEnvelope.parse(
                 """
                 {"channel":"other","protocol_version":1,"kind":"message","component_id":"promo_web_view","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects missing channel`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"protocol_version":1,"kind":"message","component_id":"promo_web_view","type":"rc:step-loaded"}
                 """.trimIndent(),
             ),
         ).isNull()
@@ -89,6 +115,17 @@ internal class WebViewEnvelopeTest {
             WebViewEnvelope.parse(
                 """
                 {"channel":"rc-web-components","protocol_version":NaN,"kind":"message","component_id":"promo_web_view","type":"rc:step-loaded"}
+                """.trimIndent(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `rejects non-integer protocol_version`() {
+        assertThat(
+            WebViewEnvelope.parse(
+                """
+                {"channel":"rc-web-components","protocol_version":1.5,"kind":"message","component_id":"promo_web_view","type":"rc:step-loaded"}
                 """.trimIndent(),
             ),
         ).isNull()
@@ -162,24 +199,24 @@ internal class WebViewEnvelopeTest {
 
     @Test
     fun `accepts every whitelisted kind`() {
-        val kinds = listOf(
-            WebViewEnvelope.KIND_CONNECT,
-            WebViewEnvelope.KIND_INIT,
-            WebViewEnvelope.KIND_REJECT,
-            WebViewEnvelope.KIND_MESSAGE,
-            WebViewEnvelope.KIND_REQUEST,
-            WebViewEnvelope.KIND_RESPONSE,
-            WebViewEnvelope.KIND_ERROR,
+        val kinds = mapOf(
+            "connect" to WebViewEnvelope.Kind.CONNECT,
+            "init" to WebViewEnvelope.Kind.INIT,
+            "reject" to WebViewEnvelope.Kind.REJECT,
+            "message" to WebViewEnvelope.Kind.MESSAGE,
+            "request" to WebViewEnvelope.Kind.REQUEST,
+            "response" to WebViewEnvelope.Kind.RESPONSE,
+            "error" to WebViewEnvelope.Kind.ERROR,
         )
 
-        kinds.forEach { kind ->
+        kinds.forEach { (kind, expected) ->
             val parsed = WebViewEnvelope.parse(
                 """
                 {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId"}
                 """.trimIndent(),
             )
             assertThat(parsed).describedAs("kind=$kind").isNotNull
-            assertThat(parsed!!.kind).isEqualTo(kind)
+            assertThat(parsed!!.kind).isEqualTo(expected)
         }
     }
 
@@ -194,43 +231,52 @@ internal class WebViewEnvelopeTest {
     }
 
     @Test
-    fun `build emits required and optional fields`() {
-        val payload = JSONObject("""{"responses":{"ok":true}}""")
-        val json = WebViewEnvelope.build(
-            kind = WebViewEnvelope.KIND_RESPONSE,
+    fun `toJsonString emits required and optional fields`() {
+        val payload = Json.parseToJsonElement("""{"responses":{"ok":true}}""").jsonObject
+        val encoded = WebViewEnvelope(
+            kind = WebViewEnvelope.Kind.RESPONSE,
             protocolVersion = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
             componentId = componentId,
             type = WebViewMessageType.RESIZE,
             id = "req-1",
             payload = payload,
             error = "boom",
-        )
+        ).toJsonString()
 
-        assertThat(json.getString(WebViewMessageField.CHANNEL)).isEqualTo(WebViewEnvelope.CHANNEL)
-        assertThat(json.getInt(WebViewMessageField.PROTOCOL_VERSION))
-            .isEqualTo(WebViewEnvelope.DEFAULT_PROTOCOL_VERSION)
-        assertThat(json.getString(WebViewMessageField.KIND)).isEqualTo(WebViewEnvelope.KIND_RESPONSE)
-        assertThat(json.getString(WebViewMessageField.COMPONENT_ID)).isEqualTo(componentId)
-        assertThat(json.getString(WebViewMessageField.TYPE)).isEqualTo(WebViewMessageType.RESIZE)
-        assertThat(json.getString(WebViewMessageField.ID)).isEqualTo("req-1")
-        assertThat(json.getJSONObject(WebViewMessageField.PAYLOAD).toString())
-            .isEqualTo(payload.toString())
-        assertThat(json.getString(WebViewMessageField.ERROR)).isEqualTo("boom")
+        val roundTripped = WebViewEnvelope.parse(encoded)
+        assertThat(roundTripped).isNotNull
+        assertThat(roundTripped!!.kind).isEqualTo(WebViewEnvelope.Kind.RESPONSE)
+        assertThat(roundTripped.protocolVersion).isEqualTo(WebViewEnvelope.DEFAULT_PROTOCOL_VERSION)
+        assertThat(roundTripped.componentId).isEqualTo(componentId)
+        assertThat(roundTripped.type).isEqualTo(WebViewMessageType.RESIZE)
+        assertThat(roundTripped.id).isEqualTo("req-1")
+        assertThat(roundTripped.payload).isEqualTo(payload)
+        assertThat(roundTripped.error).isEqualTo("boom")
     }
 
     @Test
-    fun `build omits null optional fields`() {
-        val json = WebViewEnvelope.build(
-            kind = WebViewEnvelope.KIND_INIT,
-            protocolVersion = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
-            componentId = componentId,
-        )
+    fun `toJsonString emits required fields`() {
+        val json = Json.parseToJsonElement(encodedInitEnvelope()).jsonObject
 
-        assertThat(json.has(WebViewMessageField.TYPE)).isFalse()
-        assertThat(json.has(WebViewMessageField.ID)).isFalse()
-        assertThat(json.has(WebViewMessageField.PAYLOAD)).isFalse()
-        assertThat(json.has(WebViewMessageField.ERROR)).isFalse()
+        assertThat(json.getValue("channel").jsonPrimitive.content).isEqualTo(WebViewEnvelope.CHANNEL)
+        assertThat(json.getValue("protocol_version").jsonPrimitive.int)
+            .isEqualTo(WebViewEnvelope.DEFAULT_PROTOCOL_VERSION)
+        assertThat(json.getValue("kind").jsonPrimitive.content).isEqualTo("init")
+        assertThat(json.getValue("component_id").jsonPrimitive.content).isEqualTo(componentId)
     }
+
+    @Test
+    fun `toJsonString omits null optional fields`() {
+        val json = Json.parseToJsonElement(encodedInitEnvelope()).jsonObject
+
+        assertThat(json.keys).doesNotContain("type", "id", "payload", "error")
+    }
+
+    private fun encodedInitEnvelope(): String = WebViewEnvelope(
+        kind = WebViewEnvelope.Kind.INIT,
+        protocolVersion = WebViewEnvelope.DEFAULT_PROTOCOL_VERSION,
+        componentId = componentId,
+    ).toJsonString()
 
     private fun envelope(
         kind: String,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -113,7 +113,7 @@ internal class WebViewJavaScriptBridgeTest {
     private fun appMessage(
         type: String,
         payload: String? = null,
-        kind: String = WebViewEnvelope.KIND_MESSAGE,
+        kind: String = "message",
         id: String? = null,
         componentId: String = this.componentId,
     ): String {
@@ -481,7 +481,7 @@ internal class WebViewJavaScriptBridgeTest {
             appMessage(
                 type = WebViewMessageType.RESIZE,
                 payload = """{"height":250}""",
-                kind = WebViewEnvelope.KIND_REQUEST,
+                kind = "request",
                 id = "resize-1",
             ),
         )
@@ -498,7 +498,7 @@ internal class WebViewJavaScriptBridgeTest {
             appMessage(
                 type = WebViewMessageType.RESIZE,
                 payload = """{"height":250}""",
-                kind = WebViewEnvelope.KIND_REQUEST,
+                kind = "request",
                 // no id → must be dropped for response-correlation safety
             ),
         )


### PR DESCRIPTION
### Motivation

The web_view transport envelope (#3782, #3798) does serialization by hand with org.json. Replace it with kotlinx.serialization, which the module already uses.

### Description

- `WebViewEnvelope` is now a `@Serializable` data class with a `Kind` enum; validation happens at decode time. The `WebViewMessageField` constants are replaced by `@SerialName` annotations.
- The bridge builds and reads payloads as kotlinx `JsonObject` instead of `JSONObject`.
- `WebViewEnvelopeTest` no longer needs Robolectric (kotlinx is pure JVM).

Behavior changes vs the hand-rolled parser, all affecting only out-of-contract frames (the content side always emits `JSON.stringify` output):

- Non-integer `protocol_version` is rejected instead of truncated. Protocol versions are exact-match integers per workflow-web-components-sdk.
- Explicit `null` in optional fields parses as absent instead of rejecting the frame.

Closes SDK-4402


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of JSON wire format handling in an already origin-gated WebView bridge; intentional tightening applies only to invalid frames, with expanded unit tests.
> 
> **Overview**
> Replaces hand-rolled **org.json** parsing and building for Paywalls V2 `web_view` transport frames with **kotlinx.serialization**, aligned with the rest of the module.
> 
> **`WebViewEnvelope`** is now a `@Serializable` data class with a `Kind` enum (`@SerialName` wire values). Inbound frames decode via `parse()`; outbound frames use `toJsonString()` instead of `build()` + `JSONObject`. **`WebViewMessageField`** is removed. **`WebViewJavaScriptBridge`** constructs envelopes as data classes, uses `buildJsonObject` for payloads, and reads resize dimensions from `JsonObject` with stricter numeric typing (no string/boolean coercion).
> 
> **Tests:** `WebViewEnvelopeTest` drops Robolectric; coverage adds missing `channel`, explicit `null` optionals, and non-integer `protocol_version`.
> 
> **Behavior vs the old parser** (only for out-of-contract frames): non-integer `protocol_version` is rejected instead of truncated; explicit `null` on optional fields is treated as absent instead of failing the frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c497efbdf0167e883c357e0f1c18edfc4518571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->