### PR TITLE
[EXTERNAL] Remove -dontoptimize from Amazon consumer ProGuard rules (#3646) via @tsushanth

### DIFF
--- a/feature/amazon/consumer-rules.pro
+++ b/feature/amazon/consumer-rules.pro
@@ -1,4 +1,3 @@
 -dontwarn com.amazon.**
 -keep class com.amazon.** {*;}
 -keepattributes *Annotation*
--dontoptimize


### PR DESCRIPTION
Original external PR: #3646 by @tsushanth

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ProGuard consumer-rule tweak only; no runtime Kotlin/Java logic changes, with minor risk if Amazon SDK behavior depended on optimization being disabled.
> 
> **Overview**
> Updates the Amazon feature module’s **consumer** ProGuard rules by **dropping `-dontoptimize`**, so consuming apps are no longer told to skip optimization for this artifact’s merged rules.
> 
> The diff also **deduplicates** `-keepattributes *Annotation*` (one duplicate line removed); keep/warn rules for `com.amazon.**` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58aacb42a2c2adf4e285e8264d6952af4b3f1ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->