### PR TITLE
Isolate paywall web_view storage in a dedicated WebView profile

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -190,9 +190,9 @@ private fun WebView.configure(
 }
 
 // Dedicated persistent profile isolating paywall WebView storage from the host app; shared across paywalls.
-private const val PAYWALL_PROFILE_NAME: String = "com.revenuecat.paywall"
+internal const val PAYWALL_PROFILE_NAME: String = "com.revenuecat.paywall"
 
-private fun WebView.applyPaywallProfile() {
+internal fun WebView.applyPaywallProfile() {
     // Unsupported System WebViews (< 113) keep the Default profile; setProfile would otherwise throw.
     if (!WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE)) return
     // Isolation is an enhancement: on failure fall back to the Default profile rather than failing the render.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -17,6 +17,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.webkit.ProfileStore
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
@@ -24,6 +27,7 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fi
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 @JvmSynthetic
 @Composable
@@ -75,6 +79,8 @@ internal fun WebViewComponentView(
             AndroidView(
                 factory = { context ->
                     WebView(context).apply {
+                        // Must precede attach()/loadUrl: setProfile throws once the WebView has been used.
+                        applyPaywallProfile()
                         val bridge = WebViewJavaScriptBridge(
                             webView = this,
                             componentId = componentId,
@@ -181,4 +187,21 @@ private fun WebView.configure(
         onMainFrameNavigationStarted = onMainFrameNavigationStarted,
         onMainFrameLoadFailed = onMainFrameLoadFailed,
     )
+}
+
+// Dedicated persistent profile isolating paywall WebView storage from the host app; shared across paywalls.
+private const val PAYWALL_PROFILE_NAME: String = "com.revenuecat.paywall"
+
+private fun WebView.applyPaywallProfile() {
+    // Unsupported System WebViews (< 113) keep the Default profile; setProfile would otherwise throw.
+    if (!WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE)) return
+    // Isolation is an enhancement: on failure fall back to the Default profile rather than failing the render.
+    try {
+        ProfileStore.getInstance().getOrCreateProfile(PAYWALL_PROFILE_NAME)
+        WebViewCompat.setProfile(this, PAYWALL_PROFILE_NAME)
+    } catch (error: IllegalStateException) {
+        Logger.w("Paywalls V2 web_view could not use an isolated profile; using the default. $error")
+    } catch (error: UnsupportedOperationException) {
+        Logger.w("Paywalls V2 web_view could not use an isolated profile; using the default. $error")
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -192,16 +192,15 @@ private fun WebView.configure(
 // Dedicated persistent profile isolating paywall WebView storage from the host app; shared across paywalls.
 internal const val PAYWALL_PROFILE_NAME: String = "com.revenuecat.paywall"
 
+// Isolation is an enhancement: on any failure fall back to the Default profile rather than failing the render.
+@Suppress("TooGenericExceptionCaught")
 internal fun WebView.applyPaywallProfile() {
     // Unsupported System WebViews (< 113) keep the Default profile; setProfile would otherwise throw.
     if (!WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE)) return
-    // Isolation is an enhancement: on failure fall back to the Default profile rather than failing the render.
     try {
         ProfileStore.getInstance().getOrCreateProfile(PAYWALL_PROFILE_NAME)
         WebViewCompat.setProfile(this, PAYWALL_PROFILE_NAME)
-    } catch (error: IllegalStateException) {
-        Logger.w("Paywalls V2 web_view could not use an isolated profile; using the default. $error")
-    } catch (error: UnsupportedOperationException) {
+    } catch (error: RuntimeException) {
         Logger.w("Paywalls V2 web_view could not use an isolated profile; using the default. $error")
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
@@ -51,11 +51,13 @@ internal class WebViewProfileTest {
 
     @Test
     fun `does not fail the render when profile setup throws`() {
+        val profileStore = mockk<ProfileStore>()
+        every { ProfileStore.getInstance() } returns profileStore
         every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
-        every { WebViewCompat.setProfile(any(), any()) } throws IllegalStateException("WebView already used")
+        every { profileStore.getOrCreateProfile(any()) } throws IllegalArgumentException("invalid profile name")
 
         webView.applyPaywallProfile()
 
-        verify { WebViewCompat.setProfile(webView, PAYWALL_PROFILE_NAME) }
+        verify { profileStore.getOrCreateProfile(PAYWALL_PROFILE_NAME) }
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
@@ -1,0 +1,61 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.webkit.ProfileStore
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class WebViewProfileTest {
+
+    private val webView = mockk<WebView>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        mockkStatic(WebViewFeature::class, WebViewCompat::class, ProfileStore::class)
+        every { ProfileStore.getInstance() } returns mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `assigns the dedicated profile when multi-profile is supported`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
+
+        webView.applyPaywallProfile()
+
+        verify { WebViewCompat.setProfile(webView, PAYWALL_PROFILE_NAME) }
+    }
+
+    @Test
+    fun `keeps the default profile when multi-profile is unsupported`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns false
+
+        webView.applyPaywallProfile()
+
+        verify(exactly = 0) { WebViewCompat.setProfile(any(), any()) }
+    }
+
+    @Test
+    fun `does not fail the render when profile setup throws`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
+        every { WebViewCompat.setProfile(any(), any()) } throws IllegalStateException("WebView already used")
+
+        webView.applyPaywallProfile()
+
+        verify { WebViewCompat.setProfile(webView, PAYWALL_PROFILE_NAME) }
+    }
+}


### PR DESCRIPTION
Enables isolating our paywall webviews from the rest of the consuming app via profiles. This is supported on webview 113+ (2023) so it must be treated as optional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to paywall WebView creation with feature gating and try/catch fallback; no auth or purchase-flow changes.
> 
> **Overview**
> Paywalls V2 **web_view** components now assign a dedicated persistent WebView profile (`com.revenuecat.paywall`) **before** attach/`loadUrl`, so cookies, DOM storage, and other WebView data stay separate from the host app’s default profile. All paywall WebViews share this profile.
> 
> Isolation is **optional**: if `MULTI_PROFILE` isn’t supported (System WebView &lt; 113) or profile setup throws, the code logs a warning and keeps the default profile so rendering still succeeds.
> 
> Unit tests cover supported multi-profile assignment, unsupported fallback, and non-fatal errors during profile creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73f671d87f08f73b0023b0745189c6f17290bc71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->