### PR TITLE
fix(paywalls): misc webviewComponent bug fixes and debug improvements

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -4,6 +4,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.graphics.Bitmap
 import android.net.http.SslError
+import android.os.Build
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
@@ -11,6 +12,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.annotation.RequiresApi
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 /**
@@ -93,6 +95,8 @@ internal class PaywallWebViewClient(
         }
     }
 
+    // RenderProcessGoneDetail and this callback exist only on API 26+; the framework never invokes it below.
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
         markFailed("render process gone (didCrash=${detail.didCrash()})")
         // true = handled; the dead WebView must not be reused (removed via the failure path).

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -11,6 +11,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 /**
  * [WebViewClient] for Paywalls V2 `web_view` components. Owns navigation policy, main-frame document
@@ -26,9 +27,10 @@ internal class PaywallWebViewClient(
     @Volatile
     private var failed: Boolean = false
 
-    private fun markFailed() {
+    private fun markFailed(reason: String) {
         if (failed) return
         failed = true
+        Logger.w("Paywalls V2 web_view load failed terminally, removing the component: $reason")
         onMainFrameLoadFailed()
     }
 
@@ -49,7 +51,7 @@ internal class PaywallWebViewClient(
             )
         ) {
             view.stopLoading()
-            markFailed()
+            markFailed("blocked main-frame navigation to '$url' (expectedOrigin=$expectedOrigin)")
             return
         }
         onMainFrameNavigationStarted()
@@ -69,7 +71,7 @@ internal class PaywallWebViewClient(
         error: WebResourceError,
     ) {
         if (request.isForMainFrame) {
-            markFailed()
+            markFailed("resource error code=${error.errorCode} '${error.description}'")
         }
     }
 
@@ -78,7 +80,7 @@ internal class PaywallWebViewClient(
     // content over a bad certificate) and fail terminally so the WebView is removed deterministically.
     override fun onReceivedSslError(view: WebView, handler: SslErrorHandler, error: SslError) {
         handler.cancel()
-        markFailed()
+        markFailed("SSL error: $error")
     }
 
     override fun onReceivedHttpError(
@@ -87,12 +89,12 @@ internal class PaywallWebViewClient(
         errorResponse: WebResourceResponse,
     ) {
         if (request.isForMainFrame) {
-            markFailed()
+            markFailed("HTTP error status=${errorResponse.statusCode}")
         }
     }
 
     override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
-        markFailed()
+        markFailed("render process gone (didCrash=${detail.didCrash()})")
         // true = handled; the dead WebView must not be reused (removed via the failure path).
         return true
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -3,7 +3,9 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.graphics.Bitmap
+import android.net.http.SslError
 import android.webkit.RenderProcessGoneDetail
+import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -69,6 +71,14 @@ internal class PaywallWebViewClient(
         if (request.isForMainFrame) {
             markFailed()
         }
+    }
+
+    // The default implementation cancels the load but leaves the component mounted and blank; whether
+    // a subsequent onReceivedError fires is undocumented and provider-dependent. Cancel (never show
+    // content over a bad certificate) and fail terminally so the WebView is removed deterministically.
+    override fun onReceivedSslError(view: WebView, handler: SslErrorHandler, error: SslError) {
+        handler.cancel()
+        markFailed()
     }
 
     override fun onReceivedHttpError(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -122,7 +122,9 @@ internal fun WebViewComponentView(
                     webView.destroy()
                 },
                 // Clip: content can briefly overflow while a fit axis animates placeholder -> measured.
-                modifier = modifier.size(effectiveSize).clipToBounds(),
+                modifier = modifier
+                    .size(effectiveSize)
+                    .clipToBounds(),
             )
         }
         // Terminal failure renders nothing; there is intentionally no native fallback.
@@ -187,6 +189,23 @@ private fun WebView.configure(
         onMainFrameNavigationStarted = onMainFrameNavigationStarted,
         onMainFrameLoadFailed = onMainFrameLoadFailed,
     )
+    disableTapHighlight(expectedOrigin)
+}
+
+// Android draws a translucent tap-highlight scrim (blue on most themes) over tapped clickable content;
+// iOS WKWebView does not. Set `-webkit-tap-highlight-color: transparent` as an inherited default at the
+// document root. A bundle can still override it per element (inheritance loses to any explicit value).
+internal fun WebView.disableTapHighlight(expectedOrigin: String?) {
+    if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) return
+    try {
+        WebViewCompat.addDocumentStartJavaScript(
+            this,
+            "document.documentElement.style.webkitTapHighlightColor = 'transparent';",
+            setOf(expectedOrigin ?: "*"),
+        )
+    } catch (error: RuntimeException) {
+        Logger.w("Failed to disable webkit tap highlight: $error")
+    }
 }
 
 // Dedicated persistent profile isolating paywall WebView storage from the host app; shared across paywalls.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -4,6 +4,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.graphics.Color
 import android.view.View
+import android.view.ViewGroup
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -79,6 +80,7 @@ internal fun WebViewComponentView(
             AndroidView(
                 factory = { context ->
                     WebView(context).apply {
+                        applyFullSizeLayoutParams()
                         // Must precede attach()/loadUrl: setProfile throws once the WebView has been used.
                         applyPaywallProfile()
                         val bridge = WebViewJavaScriptBridge(
@@ -160,6 +162,16 @@ private fun resolveFitAxis(constraint: SizeConstraint, contentCssPx: Int, placeh
 /** Holds the per-WebView bridge so factory and onRelease share one instance. */
 internal class WebViewBridgeHolder {
     var bridge: WebViewJavaScriptBridge? = null
+}
+
+// WebView drives Chromium's force_zero_layout_height off its LayoutParams: with the WRAP_CONTENT
+// defaults AndroidView assigns, CSS % and vh heights resolve to 0 and content renders blank. Compose
+// sizes the view from exact constraints, so MATCH_PARENT is safe and only flips the Chromium flag.
+internal fun WebView.applyFullSizeLayoutParams() {
+    layoutParams = ViewGroup.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.MATCH_PARENT,
+    )
 }
 
 private fun WebView.configure(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -195,6 +195,7 @@ private fun WebView.configure(
 // Android draws a translucent tap-highlight scrim (blue on most themes) over tapped clickable content;
 // iOS WKWebView does not. Set `-webkit-tap-highlight-color: transparent` as an inherited default at the
 // document root. A bundle can still override it per element (inheritance loses to any explicit value).
+@Suppress("TooGenericExceptionCaught")
 internal fun WebView.disableTapHighlight(expectedOrigin: String?) {
     if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) return
     try {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -11,6 +11,7 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
@@ -49,17 +50,20 @@ internal fun WebViewComponentView(
     val resolvedUrl = remember(style.url) {
         WebViewUrlResolver.resolve(style.url)
     }
-    if (resolvedUrl == null) {
-        Logger.w("Paywalls V2 web_view not rendered: URL must be https with no '{{' markers: '${style.url}'")
-        return
+    val componentId = style.componentId
+
+    LaunchedEffect(style.url, componentId) {
+        when {
+            resolvedUrl == null ->
+                Logger.w("Paywalls V2 web_view not rendered: URL must be https with no '{{' markers: '${style.url}'")
+            componentId.isBlank() ->
+                Logger.w("Paywalls V2 web_view not rendered: componentId is blank.")
+        }
     }
 
-    val componentId = style.componentId
+    if (resolvedUrl == null) return
     // workflow-web-components-sdk requires a host-assigned component id for the handshake.
-    if (componentId.isBlank()) {
-        Logger.w("Paywalls V2 web_view not rendered: componentId is blank.")
-        return
-    }
+    if (componentId.isBlank()) return
     val sizeToContentWidth = style.size.width is Fit
     val sizeToContentHeight = style.size.height is Fit
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -5,6 +5,8 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 import android.graphics.Color
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.ConsoleMessage
+import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -21,10 +23,13 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.ProfileStore
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
+import com.revenuecat.purchases.LogLevel
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import com.revenuecat.purchases.ui.revenuecatui.BuildConfig
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
@@ -44,11 +49,17 @@ internal fun WebViewComponentView(
     val resolvedUrl = remember(style.url) {
         WebViewUrlResolver.resolve(style.url)
     }
-    if (resolvedUrl == null) return
+    if (resolvedUrl == null) {
+        Logger.w("Paywalls V2 web_view not rendered: URL must be https with no '{{' markers: '${style.url}'")
+        return
+    }
 
     val componentId = style.componentId
     // workflow-web-components-sdk requires a host-assigned component id for the handshake.
-    if (componentId.isBlank()) return
+    if (componentId.isBlank()) {
+        Logger.w("Paywalls V2 web_view not rendered: componentId is blank.")
+        return
+    }
     val sizeToContentWidth = style.size.width is Fit
     val sizeToContentHeight = style.size.height is Fit
 
@@ -201,6 +212,21 @@ private fun WebView.configure(
         onMainFrameNavigationStarted = onMainFrameNavigationStarted,
         onMainFrameLoadFailed = onMainFrameLoadFailed,
     )
+    // Inspect the bundle from Chrome DevTools in debug builds only; process-global, never in release.
+    if (BuildConfig.DEBUG) WebView.setWebContentsDebuggingEnabled(true)
+    // Surface the bundle's own JS console in logcat when the SDK is on DEBUG/VERBOSE, so authors can
+    // diagnose their content without a debugger attached.
+    if (Purchases.logLevel <= LogLevel.DEBUG) {
+        webChromeClient = object : WebChromeClient() {
+            override fun onConsoleMessage(message: ConsoleMessage): Boolean {
+                Logger.d(
+                    "Paywalls V2 web_view console [${message.messageLevel()}] ${message.message()} " +
+                        "(${message.sourceId()}:${message.lineNumber()})",
+                )
+                return true
+            }
+        }
+    }
     disableTapHighlight(expectedOrigin)
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -207,6 +207,7 @@ private fun WebView.configure(
     settings.setSupportZoom(false)
     settings.builtInZoomControls = false
     settings.displayZoomControls = false
+    settings.mediaPlaybackRequiresUserGesture = false
     webViewClient = PaywallWebViewClient(
         expectedOrigin = expectedOrigin,
         onMainFrameNavigationStarted = onMainFrameNavigationStarted,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -82,12 +82,13 @@ internal class WebViewJavaScriptBridge(
 
     /**
      * Registers the secure message listener. Idempotent once installed; a no-op on later calls after
-     * success. If installation fails — invalid expected origin (a config error) or missing
-     * [WebViewFeature.WEB_MESSAGE_LISTENER] (an old System WebView) — it falls back to
-     * [onSecureMessagingUnsupported], logged distinctly, and a later call will retry.
+     * success. If installation fails — invalid expected origin (a config error), missing
+     * [WebViewFeature.WEB_MESSAGE_LISTENER] (an old System WebView), or the provider rejecting the
+     * registration — it falls back to [onSecureMessagingUnsupported], logged distinctly, and a later
+     * call will retry.
      */
     @MainThread
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
     fun attach() {
         if (messageListenerInstalled) return
         val webView = webViewRef.get() ?: return
@@ -108,12 +109,20 @@ internal class WebViewJavaScriptBridge(
             onSecureMessagingUnsupported()
             return
         }
-        WebViewCompat.addWebMessageListener(
-            webView,
-            WebViewEnvelope.NATIVE_OBJECT_NAME,
-            setOf(origin),
-            webMessageListener,
-        )
+        try {
+            WebViewCompat.addWebMessageListener(
+                webView,
+                WebViewEnvelope.NATIVE_OBJECT_NAME,
+                setOf(origin),
+                webMessageListener,
+            )
+        } catch (error: RuntimeException) {
+            // E.g. IllegalArgumentException: the resolved origin passed our lenient Uri parsing but is
+            // rejected by the WebView provider's stricter origin-rule parser. Never crash the host app.
+            Logger.w("Paywalls V2 web_view could not install the secure message listener; falling back. $error")
+            onSecureMessagingUnsupported()
+            return
+        }
         messageListenerInstalled = true
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -220,6 +220,7 @@ internal class WebViewJavaScriptBridge(
         if (!initDelivered) return
 
         channelOpen = true
+        Logger.d("Paywalls V2 web_view handshake complete, channel open (componentId='$componentId').")
         sendFitIfNeeded()
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.content.Context
 import android.webkit.RenderProcessGoneDetail
+import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -9,6 +10,7 @@ import android.webkit.WebView
 import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -114,6 +116,17 @@ internal class PaywallWebViewClientTest {
 
         assertThat(first).isTrue()
         assertThat(second).isTrue()
+        assertThat(failureCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `onReceivedSslError cancels the load and activates the terminal failure path`() {
+        val handler = mockk<SslErrorHandler>(relaxed = true)
+
+        client.onReceivedSslError(webView, handler, mockk(relaxed = true))
+
+        verify(exactly = 1) { handler.cancel() }
+        verify(exactly = 0) { handler.proceed() }
         assertThat(failureCount).isEqualTo(1)
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -343,6 +343,22 @@ internal class WebViewJavaScriptBridgeTest {
     }
 
     @Test
+    fun `attach reports unsupported secure messaging when listener installation throws`() {
+        every {
+            WebViewCompat.addWebMessageListener(any(), any(), any(), any())
+        } throws IllegalArgumentException("invalid origin rule")
+        var unsupportedCount = 0
+
+        val bridge = bridge(onSecureMessagingUnsupported = { unsupportedCount += 1 })
+        assertThat(unsupportedCount).isEqualTo(1)
+
+        // Installation did not latch as successful: a later attach retries (and fails again here).
+        bridge.attach()
+        assertThat(unsupportedCount).isEqualTo(2)
+        verify(exactly = 2) { WebViewCompat.addWebMessageListener(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `release removes the web message listener`() {
         val bridge = bridge()
         verify(exactly = 1) {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewTapHighlightTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewTapHighlightTest.kt
@@ -1,0 +1,65 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class WebViewTapHighlightTest {
+
+    private val webView = mockk<WebView>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        mockkStatic(WebViewFeature::class, WebViewCompat::class)
+        every { WebViewCompat.addDocumentStartJavaScript(any(), any(), any()) } returns mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `injects the tap-highlight override scoped to the bundle origin when supported`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT) } returns true
+
+        webView.disableTapHighlight("https://bundle.example.com")
+
+        verify {
+            WebViewCompat.addDocumentStartJavaScript(
+                webView,
+                match { it.contains("webkitTapHighlightColor") && it.contains("transparent") },
+                setOf("https://bundle.example.com"),
+            )
+        }
+    }
+
+    @Test
+    fun `falls back to any origin when the expected origin is unknown`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT) } returns true
+
+        webView.disableTapHighlight(null)
+
+        verify { WebViewCompat.addDocumentStartJavaScript(webView, any(), setOf("*")) }
+    }
+
+    @Test
+    fun `does nothing when document-start scripts are unsupported`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT) } returns false
+
+        webView.disableTapHighlight("https://bundle.example.com")
+
+        verify(exactly = 0) { WebViewCompat.addDocumentStartJavaScript(any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
See commit list, each is an independent fix, but I didn't think they warranted separate PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are scoped to Paywalls V2 WebView UI, improve failure handling and iOS parity, and avoid crashes on bridge setup; no auth or purchase logic touched.
> 
> **Overview**
> Hardens Paywalls V2 **`web_view`** behavior with several independent fixes and better diagnostics.
> 
> **Load failures** now log a specific reason and treat **SSL certificate errors** like other terminal failures: cancel the load and remove the component instead of leaving a blank WebView. **`onRenderProcessGone`** is annotated for API 26+.
> 
> **Rendering and UX:** WebViews get **`MATCH_PARENT`** layout params so percentage/`vh` CSS heights no longer collapse to zero under Compose’s default `WRAP_CONTENT`. **Tap highlight** is disabled via a document-start script (iOS parity). **Media** can autoplay without a user gesture.
> 
> **Bridge robustness:** **`addWebMessageListener`** is wrapped in try/catch so invalid origin rules from the WebView provider fall back to unsupported messaging instead of crashing the host app. A debug log marks successful handshakes.
> 
> **Author/debug tooling:** Invalid URL or blank `componentId` cases emit **warnings** when the component is skipped. **DEBUG** builds enable WebView remote debugging; at SDK **DEBUG/VERBOSE**, bundle **console** output is forwarded to logcat.
> 
> Tests cover SSL failure, listener install throws, and tap-highlight injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11038f51d11342dfd79738f24a4f7a921ef12752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->