### PR TITLE
Hide autoplay web_view video until it plays

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -237,6 +237,41 @@ private fun WebView.configure(
         }
     }
     disableTapHighlight(expectedOrigin)
+    hideAutoplayVideoUntilPlaying(expectedOrigin)
+}
+
+// Fallback reveal for an autoplay <video> that never emits `playing`; long enough that a normal clip plays first.
+private const val AUTOPLAY_REVEAL_FALLBACK_MS = 5000
+
+// Android WebView flashes a play-button placeholder over an autoplay <video> until its first frame
+// paints. The placeholder isn't a stable UA element across Chromium versions, so rather than target it
+// we hide autoplay videos until they emit `playing`, with a fallback reveal so one that never plays
+// can't stay hidden.
+@Suppress("TooGenericExceptionCaught")
+internal fun WebView.hideAutoplayVideoUntilPlaying(expectedOrigin: String?) {
+    if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) return
+    try {
+        WebViewCompat.addDocumentStartJavaScript(
+            this,
+            """
+            (function () {
+              var style = document.createElement('style');
+              style.textContent = 'video[autoplay]:not([data-rc-playing]){opacity:0!important}';
+              document.documentElement.appendChild(style);
+              function reveal(video) { video.setAttribute('data-rc-playing', ''); }
+              document.addEventListener('playing', function (event) { reveal(event.target); }, true);
+              // Armed per element on `loadstart` so videos added after load are covered too.
+              document.addEventListener('loadstart', function (event) {
+                var video = event.target;
+                setTimeout(function () { reveal(video); }, $AUTOPLAY_REVEAL_FALLBACK_MS);
+              }, true);
+            })();
+            """.trimIndent(),
+            setOf(expectedOrigin ?: "*"),
+        )
+    } catch (error: RuntimeException) {
+        Logger.w("Failed to install web_view autoplay video reveal: $error")
+    }
 }
 
 // Android draws a translucent tap-highlight scrim (blue on most themes) over tapped clickable content;

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewAutoplayVideoTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewAutoplayVideoTest.kt
@@ -1,0 +1,84 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class WebViewAutoplayVideoTest {
+
+    private val webView = mockk<WebView>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        mockkStatic(WebViewFeature::class, WebViewCompat::class)
+        every { WebViewCompat.addDocumentStartJavaScript(any(), any(), any()) } returns mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `injects the autoplay reveal script scoped to the bundle origin when supported`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT) } returns true
+
+        webView.hideAutoplayVideoUntilPlaying("https://bundle.example.com")
+
+        verify {
+            WebViewCompat.addDocumentStartJavaScript(
+                webView,
+                match {
+                    it.contains("video[autoplay]:not([data-rc-playing])") &&
+                        it.contains("'playing'") &&
+                        it.contains("data-rc-playing")
+                },
+                setOf("https://bundle.example.com"),
+            )
+        }
+    }
+
+    @Test
+    fun `arms a fallback reveal so a video that never plays cannot stay hidden`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT) } returns true
+
+        webView.hideAutoplayVideoUntilPlaying("https://bundle.example.com")
+
+        verify {
+            WebViewCompat.addDocumentStartJavaScript(
+                webView,
+                match { it.contains("loadstart") && it.contains("setTimeout") && it.contains("5000") },
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `falls back to any origin when the expected origin is unknown`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT) } returns true
+
+        webView.hideAutoplayVideoUntilPlaying(null)
+
+        verify { WebViewCompat.addDocumentStartJavaScript(webView, any(), setOf("*")) }
+    }
+
+    @Test
+    fun `does nothing when document-start scripts are unsupported`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT) } returns false
+
+        webView.hideAutoplayVideoUntilPlaying("https://bundle.example.com")
+
+        verify(exactly = 0) { WebViewCompat.addDocumentStartJavaScript(any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
### Motivation

Android WebView paints a play-button placeholder over an autoplay `<video>` before its first frame paints, so a muted autoplay clip flashes a play button for a moment.

### Description

Hide `video[autoplay]` until it emits `playing`, so the transparent WebView background shows during buffering and the clip appears the instant it plays. A 5s fallback reveal ensures a video that never starts (autoplay blocked, decode error) can't stay hidden. Element-agnostic: the placeholder isn't a stable UA pseudo-element across Chromium versions, so we don't target it.

Adds `WebViewAutoplayVideoTest`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Paywall WebView presentation-only change with origin-scoped document-start scripts and graceful fallback when unsupported; no auth or purchase logic touched.
> 
> **Overview**
> Fixes a brief **play-button flash** on muted autoplay clips in Paywalls V2 **web_view** on Android by injecting a document-start script during WebView setup (alongside the existing tap-highlight workaround).
> 
> The script keeps `video[autoplay]` at **opacity 0** until a `playing` event sets `data-rc-playing`, then reveals the element. A **5s `loadstart` timeout** still reveals videos that never start (blocked autoplay, decode errors). Injection uses `WebViewCompat.addDocumentStartJavaScript`, scoped to the bundle origin when known or `*` otherwise, and is skipped when `DOCUMENT_START_SCRIPT` is unsupported.
> 
> Adds **`WebViewAutoplayVideoTest`** to verify script content, origin scoping, fallback behavior, and the no-op path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c35f0dea5d93c421d85c31c323c7365944a0262c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->