### PR TITLE
fix(paywall-tester): make ApiKeyButton look and behave like a button

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
@@ -239,7 +239,7 @@ private fun ApiKeyDialog(onApiKeyClick: (String) -> Unit, onDismissed: () -> Uni
                     apiKey = Constants.GOOGLE_API_KEY_A,
                     onClick = onApiKeyClick,
                 )
-
+                Spacer(Modifier.size(8.dp))
                 ApiKeyButton(
                     label = Constants.GOOGLE_API_KEY_B_LABEL,
                     apiKey = Constants.GOOGLE_API_KEY_B,
@@ -264,8 +264,11 @@ private fun ApiKeyDialog(onApiKeyClick: (String) -> Unit, onDismissed: () -> Uni
 
 @Composable
 private fun ApiKeyButton(label: String, apiKey: String, onClick: (String) -> Unit) {
-    TextButton(onClick = { onClick(apiKey) }) {
-        Column {
+    Button(
+        onClick = { onClick(apiKey) },
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.fillMaxWidth()) {
             Text(
                 text = label,
                 style = MaterialTheme.typography.labelSmall,


### PR DESCRIPTION
The API key picker buttons in the paywall-tester's App Info screen looked like plain text, no border or press feedback so they were a bit confusing to me.

Switch `ApiKeyButton` from `TextButton` to a full-width `Button`, matching the other buttons on the screen.

<img width="2440" height="2620" alt="comp" src="https://github.com/user-attachments/assets/36aaab54-1f22-4d4b-860d-e08f104a0296" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app Compose styling only; no SDK, auth, or business logic changes.
> 
> **Overview**
> Updates the **Switch API key** dialog so each API key option reads as a real control instead of plain text.
> 
> `ApiKeyButton` is changed from `TextButton` to a full-width Material3 `Button`, aligned with the primary actions on App Info. An **8.dp** spacer is added between the two key rows for clearer separation. Selection behavior and `onApiKeyClick` wiring are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2f37d51df1a861b27bd096c4d5d4a8b34e4afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->