### PR TITLE
Fix crash when a paywall component tree fails to decode

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -158,11 +158,11 @@ private fun OfferingsListScreen(
             allOfferings.filter { offering ->
                 offering.identifier.lowercase().contains(query) ||
                     offering.paywall?.templateName?.lowercase()?.contains(query) == true ||
-                    offering.paywallComponents?.data?.templateName?.lowercase()?.contains(query) == true
+                    offering.paywallComponents?.dataOrNull?.templateName?.lowercase()?.contains(query) == true
             }
         }
         filtered.groupBy { offering ->
-            offering.paywallComponents?.data?.templateName?.let { "V2 — $it" }
+            offering.paywallComponents?.dataOrNull?.templateName?.let { "V2 — $it" }
                 ?: offering.paywall?.templateName?.let { "Template $it" }
                 ?: "No paywall"
         }.toSortedMap(

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -422,7 +422,7 @@ private fun OfferingRow(
 ) {
     val subtitle = if (showSubtitle) {
         offering.paywall?.let { "Template ${it.templateName}" }
-            ?: offering.paywallComponents?.let { "Components ${it.data.templateName}" }
+            ?: offering.paywallComponents?.dataOrNull?.templateName?.let { "Components $it" }
             ?: "No paywall"
     } else {
         null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -83,9 +83,11 @@ constructor(
             dataProvider: () -> PaywallComponentsData,
         ) : this(uiConfig, componentsHash, lazy(LazyThreadSafetyMode.SYNCHRONIZED) { runCatching(dataProvider) })
 
-        // Decoded once on first access; the outcome (success or failure) is memoized. [data] re-throws the
-        // cached failure; [dataOrNull] returns null instead, for best-effort reads that must not crash.
-        public val data: PaywallComponentsData get() = dataResult.value.getOrThrow()
+        // Decoded once on first access; the outcome (success or failure) is memoized. [data] exposes that
+        // outcome as a [Result] so callers must handle a decode failure explicitly (there is deliberately no
+        // throwing accessor to reach for by mistake). [dataOrNull] is the convenience for best-effort reads
+        // that treat a failure as absence.
+        public val data: Result<PaywallComponentsData> get() = dataResult.value
 
         public val dataOrNull: PaywallComponentsData? get() = dataResult.value.getOrNull()
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -66,14 +66,14 @@ constructor(
         // Offering.equals/hashCode/toString — which are @Poko-generated over `paywallComponents` — from forcing
         // a decode of every offering's component tree (e.g. when the cache compares cached vs network offerings).
         private val componentsHash: String,
-        dataProvider: Lazy<PaywallComponentsData>,
+        private val dataResult: Lazy<Result<PaywallComponentsData>>,
     ) {
         /**
          * Constructor for callers that already hold decoded [PaywallComponentsData] (e.g. previews, tests,
          * hybrid SDKs).
          */
         public constructor(uiConfig: UiConfig, data: PaywallComponentsData) :
-            this(uiConfig, data.hashCode().toString(), lazyOf(data))
+            this(uiConfig, data.hashCode().toString(), lazyOf(Result.success(data)))
 
         // Used by the parser: the component tree is decoded lazily on first [data] access, not at load time.
         // [componentsHash] is a cheap content hash of the raw JSON, used for equality so comparisons never decode.
@@ -81,9 +81,13 @@ constructor(
             uiConfig: UiConfig,
             componentsHash: String,
             dataProvider: () -> PaywallComponentsData,
-        ) : this(uiConfig, componentsHash, lazy(LazyThreadSafetyMode.SYNCHRONIZED, dataProvider))
+        ) : this(uiConfig, componentsHash, lazy(LazyThreadSafetyMode.SYNCHRONIZED) { runCatching(dataProvider) })
 
-        public val data: PaywallComponentsData by dataProvider
+        // Decoded once on first access; the outcome (success or failure) is memoized. [data] re-throws the
+        // cached failure; [dataOrNull] returns null instead, for best-effort reads that must not crash.
+        public val data: PaywallComponentsData get() = dataResult.value.getOrThrow()
+
+        public val dataOrNull: PaywallComponentsData? get() = dataResult.value.getOrNull()
 
         // Hand-written instead of @Poko so equality/hash/toString compare [componentsHash], never the lazy [data].
         override fun equals(other: Any?): Boolean =

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -44,18 +44,15 @@ internal class OfferingImagePreDownloader(
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
     private fun downloadV2Images(offering: Offering) {
         offering.paywallComponents?.let { paywallComponents ->
-            // `paywallComponents.data` is decoded lazily on first access and can throw if the component tree passed
+            // `paywallComponents.data` is decoded lazily on first access and fails if the component tree passed
             // the cheap parse-time shape check but is structurally invalid. Pre-downloading is best-effort, so a
             // decode failure here must not abort the offerings success/caching path — log and skip instead.
-            val componentsConfig = try {
-                paywallComponents.data.componentsConfig.base
-            } catch (e: Throwable) {
-                errorLog(e) { "Error deserializing paywall components data. Skipping V2 image pre-download." }
+            val componentsConfig = paywallComponents.data.getOrElse { error ->
+                errorLog(error) { "Error deserializing paywall components data. Skipping V2 image pre-download." }
                 return
-            }
+            }.componentsConfig.base
             paywallComponentsImagePreDownloader.preDownloadImages(componentsConfig)
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingVideoPredownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingVideoPredownloader.kt
@@ -21,19 +21,16 @@ internal class OfferingVideoPredownloader(
 ) {
     private val shouldPredownload: Boolean = canShowPaywalls
 
-    @Suppress("TooGenericExceptionCaught")
     fun downloadVideos(offering: Offering) {
         if (shouldPredownload) {
             val paywallComponents = offering.paywallComponents ?: return
-            // `paywallComponents.data` is decoded lazily on first access and can throw if the component tree passed
+            // `paywallComponents.data` is decoded lazily on first access and fails if the component tree passed
             // the cheap parse-time shape check but is structurally invalid. Pre-downloading is best-effort, so a
             // decode failure here must not abort the offerings success/caching path that invokes this.
-            val stack = try {
-                paywallComponents.data.componentsConfig.base.stack
-            } catch (e: Throwable) {
-                errorLog(e) { "Error deserializing paywall components data. Skipping video pre-download." }
+            val stack = paywallComponents.data.getOrElse { error ->
+                errorLog(error) { "Error deserializing paywall components data. Skipping video pre-download." }
                 return
-            }
+            }.componentsConfig.base.stack
             // WIP: We will add a remote flag in the offering metadata that will indicate if we should
             // pre-download videos or not. For now, we want to only download the low-res to ensure we
             // don't rack up high cloudfront costs

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
@@ -2,6 +2,8 @@ package com.revenuecat.purchases
 
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import io.mockk.mockk
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -159,5 +161,55 @@ internal class OfferingPaywallComponentsLazyTest {
         val second = Offering.PaywallComponents(uiConfig = uiConfig, data = mockk())
 
         assertThat(first == second).isFalse()
+    }
+
+    @Test
+    fun `data re-throws the decode failure while dataOrNull returns null, decoding only once`() {
+        var decodeCount = 0
+        val components = Offering.PaywallComponents(uiConfig = mockk(), componentsHash = "hash") {
+            decodeCount++
+            JsonTools.json.decodeFromString<PaywallComponentsData>(COMPONENTS_JSON_UNKNOWN_TYPE_NO_FALLBACK)
+        }
+
+        val firstThrow = runCatching { components.data }.exceptionOrNull()
+        val secondThrow = runCatching { components.data }.exceptionOrNull()
+
+        // `data` surfaces the real deserializer failure (production behavior for intentional catchers)...
+        assertThat(firstThrow).isInstanceOf(SerializationException::class.java)
+        assertThat(firstThrow?.message).isEqualTo("No fallback provided for unknown type: fake_unknown_type_for_test")
+        assertThat(secondThrow).isInstanceOf(SerializationException::class.java)
+        // ...while `dataOrNull` returns null, so best-effort readers can't crash.
+        assertThat(components.dataOrNull).isNull()
+        // The failing decode is memoized: it runs once, not on every access.
+        assertThat(decodeCount).isEqualTo(1)
+    }
+
+    private companion object {
+        // A component tree whose stack holds an unknown component type with no `fallback`, so the real
+        // PaywallComponentSerializer throws exactly as in production. The type name is deliberately synthetic
+        // (not a real-but-unreleased one) so the test stays valid as new component types ship.
+        val COMPONENTS_JSON_UNKNOWN_TYPE_NO_FALLBACK = """
+            {
+              "id": "paywall_id",
+              "template_name": "components",
+              "asset_base_url": "https://assets.pawwalls.com",
+              "components_config": {
+                "base": {
+                  "stack": {
+                    "type": "stack",
+                    "components": [
+                      { "type": "fake_unknown_type_for_test" }
+                    ]
+                  },
+                  "background": {
+                    "type": "color",
+                    "value": { "light": { "type": "alias", "value": "primary" } }
+                  }
+                }
+              },
+              "components_localizations": { "en_US": { "ZvS4Ck5hGM": "Hello" } },
+              "default_locale": "en_US"
+            }
+        """.trimIndent()
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
@@ -176,7 +176,7 @@ internal class OfferingPaywallComponentsLazyTest {
 
         // `data` surfaces the real deserializer failure (production behavior for intentional catchers)...
         assertThat(firstThrow).isInstanceOf(SerializationException::class.java)
-        assertThat(firstThrow?.message).isEqualTo("No fallback provided for unknown type: fake_unknown_type_for_test")
+        assertThat(firstThrow?.message).contains("fake_unknown_type_for_test")
         assertThat(secondThrow).isInstanceOf(SerializationException::class.java)
         // ...while `dataOrNull` returns null, so best-effort readers can't crash.
         assertThat(components.dataOrNull).isNull()

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
@@ -169,24 +169,24 @@ internal class OfferingPaywallComponentsLazyTest {
         val components = Offering.PaywallComponents(uiConfig = mockk(), data = data)
 
         assertThat(components.dataOrNull).isSameAs(data)
-        assertThat(components.data).isSameAs(data)
+        assertThat(components.data.getOrNull()).isSameAs(data)
     }
 
     @Test
-    fun `data re-throws the decode failure while dataOrNull returns null, decoding only once`() {
+    fun `data surfaces the decode failure as a failed Result while dataOrNull returns null, decoding only once`() {
         var decodeCount = 0
         val components = Offering.PaywallComponents(uiConfig = mockk(), componentsHash = "hash") {
             decodeCount++
             JsonTools.json.decodeFromString<PaywallComponentsData>(COMPONENTS_JSON_UNKNOWN_TYPE_NO_FALLBACK)
         }
 
-        val firstThrow = runCatching { components.data }.exceptionOrNull()
-        val secondThrow = runCatching { components.data }.exceptionOrNull()
+        val firstResult = components.data
+        val secondResult = components.data
 
-        // `data` surfaces the real deserializer failure (production behavior for intentional catchers)...
-        assertThat(firstThrow).isInstanceOf(SerializationException::class.java)
-        assertThat(firstThrow?.message).contains("fake_unknown_type_for_test")
-        assertThat(secondThrow).isInstanceOf(SerializationException::class.java)
+        // `data` surfaces the real deserializer failure as a Result.failure (no throwing accessor to misuse)...
+        assertThat(firstResult.exceptionOrNull()).isInstanceOf(SerializationException::class.java)
+        assertThat(firstResult.exceptionOrNull()?.message).contains("fake_unknown_type_for_test")
+        assertThat(secondResult.exceptionOrNull()).isInstanceOf(SerializationException::class.java)
         // ...while `dataOrNull` returns null, so best-effort readers can't crash.
         assertThat(components.dataOrNull).isNull()
         // The failing decode is memoized: it runs once, not on every access.

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingPaywallComponentsLazyTest.kt
@@ -164,6 +164,15 @@ internal class OfferingPaywallComponentsLazyTest {
     }
 
     @Test
+    fun `dataOrNull returns the decoded data on success`() {
+        val data = mockk<PaywallComponentsData>()
+        val components = Offering.PaywallComponents(uiConfig = mockk(), data = data)
+
+        assertThat(components.dataOrNull).isSameAs(data)
+        assertThat(components.data).isSameAs(data)
+    }
+
+    @Test
     fun `data re-throws the decode failure while dataOrNull returns null, decoding only once`() {
         var decodeCount = 0
         val components = Offering.PaywallComponents(uiConfig = mockk(), componentsHash = "hash") {

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
@@ -711,7 +711,7 @@ class OfferingsTest {
         // Assert
         val paywallComponents = offerings.all.values.first().paywallComponents ?: fail("paywallComponents is null")
         // Accessing `data` forces the deferred decode of the raw JSON captured at parse time.
-        assertThat(paywallComponents.data.defaultLocaleIdentifier).isEqualTo(LocaleId("en_US"))
+        assertThat(paywallComponents.data.getOrThrow().defaultLocaleIdentifier).isEqualTo(LocaleId("en_US"))
     }
 
     @Test

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -232,8 +232,8 @@ private fun LoadedPaywall(
     val configuration = LocalConfiguration.current
     val localeLanguageTags = configuration.locales.toLanguageTags()
     val offering = state.offering
-    val paywallRevision = offering.paywall?.revision ?: offering.paywallComponents?.data?.revision
-    val paywallIdentifier = offering.paywall?.id ?: offering.paywallComponents?.data?.id
+    val paywallRevision = offering.paywall?.revision ?: offering.paywallComponents?.dataOrNull?.revision
+    val paywallIdentifier = offering.paywall?.id ?: offering.paywallComponents?.dataOrNull?.id
     LaunchedEffect(
         offering.identifier,
         paywallIdentifier,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -157,8 +157,8 @@ internal fun InternalPaywall(
             if (paywallComponents != null) {
                 LaunchedEffect(
                     state.offering.identifier,
-                    paywallComponents.data.id,
-                    paywallComponents.data.revision,
+                    paywallComponents.dataOrNull?.id,
+                    paywallComponents.dataOrNull?.revision,
                     options.mode,
                     state.locale.toString(),
                     isDark,
@@ -167,7 +167,7 @@ internal fun InternalPaywall(
                 }
             }
             PaywallFontScaling(
-                automaticallyScaleFontSize = state.offering.paywallComponents?.data?.automaticallyScaleFontSize ?: true,
+                automaticallyScaleFontSize = paywallComponents?.dataOrNull?.automaticallyScaleFontSize ?: true,
             ) {
                 val workflowState = viewModel.workflowState.value
                 if (workflowState != null) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -632,7 +632,7 @@ internal class PaywallViewModelImpl(
                         offerEligibility = calculateOfferEligibility(resolvedOffer, it),
                     )
                 } ?: currentState.selectedPackageInfo
-                val productChangeConfig = currentState.offering.paywallComponents?.data?.productChangeConfig
+                val productChangeConfig = currentState.offering.paywallComponents?.dataOrNull?.productChangeConfig
                 performPurchaseIfNecessary(activity, selectedPackageInfo, productChangeConfig)
             }
             is PaywallState.Error,
@@ -972,7 +972,7 @@ internal class PaywallViewModelImpl(
         when (offeringSelection) {
             is OfferingSelection.OfferingType -> {
                 val hasExitOffer = offeringSelection.offeringType.paywallComponents
-                    ?.data?.exitOffers?.dismiss?.offeringId != null
+                    ?.dataOrNull?.exitOffers?.dismiss?.offeringId != null
                 val offerings = if (hasExitOffer) {
                     try {
                         purchases.awaitOfferings()
@@ -1696,14 +1696,14 @@ internal class PaywallViewModelImpl(
         stepId: String?,
     ): PaywallEvent.Data? {
         val offering = offering
-        val paywallData = this.offering.paywallComponents ?: run {
+        val paywallData = this.offering.paywallComponents?.dataOrNull ?: run {
             Logger.e("Null paywall revision trying to create event data")
             return null
         }
         return PaywallEvent.Data(
-            paywallIdentifier = paywallData.data.id,
+            paywallIdentifier = paywallData.id,
             presentedOfferingContext = offering.presentedOfferingContextOrDefault,
-            paywallRevision = paywallData.data.revision,
+            paywallRevision = paywallData.revision,
             sessionIdentifier = UUID.randomUUID(),
             displayMode = mode.name.lowercase(),
             localeIdentifier = locale.toString(),
@@ -1753,11 +1753,11 @@ internal class PaywallViewModelImpl(
         mode: PaywallMode,
         darkMode: Boolean,
     ): PaywallPresentationFingerprint? {
-        val paywallData = offering.paywallComponents ?: return null
+        val paywallData = offering.paywallComponents?.dataOrNull ?: return null
         return PaywallPresentationFingerprint(
-            paywallIdentifier = paywallData.data.id,
+            paywallIdentifier = paywallData.id,
             presentedOfferingContext = offering.presentedOfferingContextOrDefault,
-            paywallRevision = paywallData.data.revision,
+            paywallRevision = paywallData.revision,
             displayMode = mode.name.lowercase(),
             localeIdentifier = locale.toString(),
             darkMode = darkMode,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -828,7 +828,7 @@ internal class PaywallViewModelImpl(
             }
         }
 
-        val exitOfferingId = selectedOffering?.paywallComponents?.data?.exitOffers?.dismiss?.offeringId
+        val exitOfferingId = selectedOffering?.paywallComponents?.dataOrNull?.exitOffers?.dismiss?.offeringId
 
         val offerings = offeringsForExitOfferLookup
         updateExitOfferData(
@@ -1672,11 +1672,11 @@ internal class PaywallViewModelImpl(
 
     private fun PaywallState.Loaded.Legacy.createEventData(workflowId: String?, stepId: String?): PaywallEvent.Data? {
         val offering = offering
-        val revision = this.offering.paywall?.revision ?: this.offering.paywallComponents?.data?.revision ?: run {
+        val revision = this.offering.paywall?.revision ?: this.offering.paywallComponents?.dataOrNull?.revision ?: run {
             Logger.e("Null paywall revision trying to create event data")
             return null
         }
-        val paywallId = this.offering.paywall?.id ?: this.offering.paywallComponents?.data?.id
+        val paywallId = this.offering.paywall?.id ?: this.offering.paywallComponents?.dataOrNull?.id
         val locale = _lastLocaleList.value.get(0) ?: Locale.getDefault()
         return PaywallEvent.Data(
             paywallIdentifier = paywallId,
@@ -1735,9 +1735,9 @@ internal class PaywallViewModelImpl(
         darkMode: Boolean,
     ): PaywallPresentationFingerprint? {
         val revision = offering.paywall?.revision
-            ?: offering.paywallComponents?.data?.revision
+            ?: offering.paywallComponents?.dataOrNull?.revision
             ?: return null
-        val paywallId = offering.paywall?.id ?: offering.paywallComponents?.data?.id
+        val paywallId = offering.paywall?.id ?: offering.paywallComponents?.dataOrNull?.id
         val locale = localeList.get(0) ?: Locale.getDefault()
         return PaywallPresentationFingerprint(
             paywallIdentifier = paywallId,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -129,11 +129,8 @@ internal fun Offering.validatePaywallComponentsDataOrNull(
     // Force the (lazily-decoded) component tree up front. If decoding fails — e.g. a tree that passed the cheap
     // shape check at parse time but is structurally invalid — treat it as "no components paywall" so the caller
     // falls back, mirroring the previous eager-parse behavior where a decode failure yielded null paywallComponents.
-    @Suppress("TooGenericExceptionCaught")
-    val componentsData: PaywallComponentsData = try {
-        paywallComponents.data
-    } catch (e: Throwable) {
-        Logger.e("Error deserializing paywall components data. Falling back to default paywall.", e)
+    val componentsData: PaywallComponentsData = paywallComponents.data.getOrElse { error ->
+        Logger.e("Error deserializing paywall components data. Falling back to default paywall.", error)
         return null
     }
 
@@ -462,7 +459,7 @@ private val PaywallComponentsData.defaultLocalization: Map<LocalizationKey, Loca
     get() = componentsLocalizations.getBestMatch(defaultLocaleIdentifier)
 
 private val Offering.PaywallComponents.defaultVariableLocalization: Map<VariableLocalizationKey, String>?
-    get() = uiConfig.localizations.getBestMatch(data.defaultLocaleIdentifier)
+    get() = dataOrNull?.defaultLocaleIdentifier?.let { uiConfig.localizations.getBestMatch(it) }
 
 /**
  * Recursively checks whether any component override in the paywall config contains an

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallComponentDataValidationTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallComponentDataValidationTests.kt
@@ -191,8 +191,7 @@ class PaywallComponentDataValidationTests {
     @Test
     fun `Should fall back to the default paywall when the component tree fails to decode`() {
         val failingComponents = mockk<Offering.PaywallComponents>(relaxed = true) {
-            every { data } throws SerializationException("decode failed")
-            every { dataOrNull } returns null
+            every { data } returns Result.failure(SerializationException("decode failed"))
         }
         val offering = Offering(
             identifier = "identifier",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallComponentDataValidationTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallComponentDataValidationTests.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonPrimitive
 import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
@@ -55,6 +56,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallValidationResult
 import com.revenuecat.purchases.ui.revenuecatui.helpers.UiConfig
 import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
 import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedPaywall
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -184,6 +186,26 @@ class PaywallComponentDataValidationTests {
         assertNotNull(validated.errors)
         assertEquals(validated.errors?.size, 1)
         assertEquals(validated.errors?.first(), AllLocalizationsMissing(defaultLocale))
+    }
+
+    @Test
+    fun `Should fall back to the default paywall when the component tree fails to decode`() {
+        val failingComponents = mockk<Offering.PaywallComponents>(relaxed = true) {
+            every { data } throws SerializationException("decode failed")
+            every { dataOrNull } returns null
+        }
+        val offering = Offering(
+            identifier = "identifier",
+            serverDescription = "serverDescription",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly),
+            paywallComponents = failingComponents,
+        )
+
+        val validated = offering.validatedPaywall(TestData.Constants.currentColorScheme, MockResourceProvider())
+
+        // A tree that can't decode must degrade to the default paywall, not surface as a Components result.
+        check(validated is PaywallValidationResult.Legacy)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentViewTests.kt
@@ -1204,7 +1204,7 @@ class TabsComponentViewTests {
         StyleFactory(
             offering = offering,
             localizations = offering.paywallComponents
-                ?.data
+                ?.dataOrNull
                 ?.componentsLocalizations
                 ?.toNonEmptyMapOrNull()!!.mapValues { it.value.toNonEmptyMapOrNull()!! }
         )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -1832,7 +1832,7 @@ class PaywallViewModelTest {
             eventType = PaywallEventType.CANCEL,
             times = 1,
             offeringIdentifier = offering.identifier,
-            paywallRevision = offering.paywallComponents!!.data.revision,
+            paywallRevision = offering.paywallComponents!!.data.getOrThrow().revision,
         )
         assertThat(model.actionError.value).isNull()
         verify(exactly = 0) { listener.onPurchaseError(any()) }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
@@ -70,6 +70,6 @@ class WorkflowScreenMapperTest {
         val paywallComponents = WorkflowScreenMapper.toPaywallComponents(screen, screenId, uiConfig)
 
         assertThat(paywallComponents.uiConfig).isEqualTo(uiConfig)
-        assertThat(paywallComponents.data).isEqualTo(WorkflowScreenMapper.toPaywallComponentsData(screen, screenId))
+        assertThat(paywallComponents.data.getOrThrow()).isEqualTo(WorkflowScreenMapper.toPaywallComponentsData(screen, screenId))
     }
 }


### PR DESCRIPTION
### Motivation

`Offering.PaywallComponents.data` decodes the component tree lazily, and Kotlin's `lazy` does not cache a *thrown* initializer, so it re-throws (and re-decodes) on every access after a failure. Since the lazy-parse change (#3589, already released), a decode failure yields a non-null holder that throws on access instead of a null `paywallComponents`. 

Unguarded readers (notably the fallback paywall render, impression fingerprint) therefore crash on the main thread for a components-only offering whose tree can't decode, e.g. an unknown component type with no `fallback` reaching an SDK that doesn't know it.

### Description

- Memoize the decode outcome in `PaywallComponents` (`Lazy<Result<…>>`): the tree decodes once, and success *or* failure is cached.
- Add a non-throwing `dataOrNull`; keep `data` throwing for the one intentional catcher (`validatePaywallComponentsDataOrNull`), which still degrades to the default paywall.
- Route best-effort readers (fallback render, fingerprint, event data, exit offers, tester list) through `dataOrNull`.
- Test: decode a real tree with a synthetic unknown type and no fallback; assert `data` throws, `dataOrNull` is null, and the tree decodes only once.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API change (`data` is now `Result` instead of throwing `PaywallComponentsData`) and broad paywall UI/SDK touchpoints; behavior is defensive but integrators must adopt the new accessors.
> 
> **Overview**
> **Fixes main-thread crashes** when a V2 offering has `paywallComponents` present but the component tree fails to decode (e.g. unknown component type with no fallback). Lazy decode no longer re-throws on every access; success and failure are cached once.
> 
> `Offering.PaywallComponents` now backs lazy decode with `Lazy<Result<PaywallComponentsData>>`: **`data`** is a **`Result`** (callers use `getOrThrow()` / `getOrElse`), and **`dataOrNull`** is added for best-effort reads that treat failure as absence.
> 
> Call sites are updated so optional paths (image/video pre-download, paywall tester listing, impression fingerprints, exit offers, analytics) use **`dataOrNull`** or **`data.getOrElse`**, while validation still handles failure and falls back to the default paywall. Tests cover memoized failure and decode-fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 504eedcc2b448fa2a99472971f44c20d4366ecf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->