### PR TITLE
fix(RevenueCatUI): host web_view in a FrameLayout to prevent off-screen RenderThread crash

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -10,6 +10,7 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.FrameLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -94,7 +95,7 @@ internal fun WebViewComponentView(
         if (!loadFailed) {
             AndroidView(
                 factory = { context ->
-                    PaywallWebView(context).apply {
+                    val webView = PaywallWebView(context).apply {
                         applyFullSizeLayoutParams()
                         // Must precede attach()/loadUrl: setProfile throws once the WebView has been used.
                         applyPaywallProfile()
@@ -131,8 +132,10 @@ internal fun WebViewComponentView(
                             loadUrl(resolvedUrl)
                         }
                     }
+                    webView.hostedInFrameLayout()
                 },
-                onRelease = { webView ->
+                onRelease = { container ->
+                    val webView = (container as FrameLayout).getChildAt(0) as WebView
                     // Only release the bridge that this view installed into this holder.
                     val bridge = bridgeHolder.bridge
                     bridgeHolder.bridge = null
@@ -182,6 +185,20 @@ private fun resolveFitAxis(constraint: SizeConstraint, contentCssPx: Int, placeh
 internal class WebViewBridgeHolder {
     var bridge: WebViewJavaScriptBridge? = null
 }
+
+// A hardware WebView drawn while fully off-screen (e.g. a non-visible carousel page) composites its GL
+// functor into an offscreen layer that has no surface, crashing the RenderThread in
+// SkSurface::getCanvas(). Hosting it inside a FrameLayout rather than directly in the AndroidView
+// isolates the functor from Compose's offscreen compositing while keeping hardware acceleration (a
+// software layer would avoid the crash but break video and WebGL).
+internal fun WebView.hostedInFrameLayout(): FrameLayout =
+    FrameLayout(context).apply {
+        layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT,
+        )
+        addView(this@hostedInFrameLayout)
+    }
 
 // WebView drives Chromium's force_zero_layout_height off its LayoutParams: with the WRAP_CONTENT
 // defaults AndroidView assigns, CSS % and vh heights resolve to 0 and content renders blank. Compose

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewFrameLayoutHostTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewFrameLayoutHostTest.kt
@@ -1,0 +1,33 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.content.Context
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression guard for the RenderThread `SkSurface::getCanvas()` crash: a hardware WebView drawn while
+ * fully off-screen (e.g. a non-visible carousel page) must be hosted inside a FrameLayout so its GL
+ * functor is not composited into a surfaceless offscreen layer. See [WebView.hostedInFrameLayout].
+ */
+@RunWith(AndroidJUnit4::class)
+internal class WebViewFrameLayoutHostTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `hosts the web view as the single child of a full-size frame layout`() {
+        val webView = WebView(context)
+
+        val container = webView.hostedInFrameLayout()
+
+        assertThat(container.childCount).isEqualTo(1)
+        assertThat(container.getChildAt(0)).isSameAs(webView)
+        assertThat(container.layoutParams.width).isEqualTo(ViewGroup.LayoutParams.MATCH_PARENT)
+        assertThat(container.layoutParams.height).isEqualTo(ViewGroup.LayoutParams.MATCH_PARENT)
+    }
+}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
A `web_view` inside a carousel crashes the app with a native `RenderThread` SIGSEGV (`SkSurface::getCanvas()` from `GLFunctorDrawable::onDraw`) on the first frame. A hardware WebView drawn while fully off-screen (a non-visible carousel page, composed eagerly via `beyondViewportPageCount`) composites its GL functor into a surfaceless offscreen layer. Reproduced on an emulator and a physical device.

### Description
Host the `PaywallWebView` in a `FrameLayout` inside the `AndroidView` factory. This isolates the functor from Compose's offscreen compositing while keeping hardware acceleration; a software layer would avoid the crash but break video and WebGL. Added a regression test asserting the FrameLayout hosting. Verified that a carousel of web_views no longer crashes and that video web_views still play, on both devices.

### References
- https://wbrawner.com/2024/08/28/android-webview-crash-in-jetpack-compose/
- https://github.com/react-native-webview/react-native-webview/issues/1915
- https://github.com/react-native-webview/react-native-webview/issues/623
- https://github.com/facebook/react-native/issues/34669

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the AndroidView view hierarchy and teardown path for all paywall WebViews; scope is narrow but affects rendering stability in carousels and relies on casting the released view to FrameLayout.
> 
> **Overview**
> Fixes a **native RenderThread SIGSEGV** when a paywall `web_view` is composed off-screen (e.g. a non-visible carousel page).
> 
> `AndroidView` now returns a full-size **`FrameLayout`** that wraps `PaywallWebView` via new **`WebView.hostedInFrameLayout()`**, instead of exposing the WebView directly. That keeps hardware acceleration (video/WebGL) while avoiding Compose compositing the WebView GL functor into a surfaceless off-screen layer. **`onRelease`** unwraps the child WebView from the container before teardown.
> 
> Adds **`WebViewFrameLayoutHostTest`** as a regression guard for the hosting shape (single child, `MATCH_PARENT` container).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d17f40d1e5527d8961f88493c77d29e5acbc310. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->