### PR TITLE
feat(paywalls): support visibility overrides for web_view component

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/WebViewComponent.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.paywalls.components
 
 import androidx.compose.runtime.Immutable
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.SerialName
@@ -34,6 +35,8 @@ public class WebViewComponent(
     public val protocolVersion: Int,
     @get:JvmSynthetic
     public val size: Size,
+    @get:JvmSynthetic
+    public val overrides: List<ComponentOverride<PartialWebViewComponent>> = emptyList(),
 ) : PaywallComponent {
 
     public companion object {
@@ -47,3 +50,17 @@ public class WebViewComponent(
         public const val SUPPORTED_PROTOCOL_VERSION: Int = 1
     }
 }
+
+/**
+ * The subset of [WebViewComponent] properties that can be adjusted by a rule-based
+ * [ComponentOverride]. Only [visible] is overridable; `url` and `size` always come from the base
+ * component.
+ */
+@InternalRevenueCatAPI
+@Poko
+@Serializable
+@Immutable
+public class PartialWebViewComponent(
+    @get:JvmSynthetic
+    public val visible: Boolean? = true,
+) : PartialComponent

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.paywalls.components
 
 import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.utils.filter
@@ -301,5 +302,51 @@ class WebViewComponentTests {
         val matches = webView.filter { it is WebViewComponent }
 
         assertThat(matches).containsExactly(webView)
+    }
+
+    @Test
+    fun `decodes with no overrides by default`() {
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(fullJson) as WebViewComponent
+
+        assertThat(actual.overrides).isEmpty()
+    }
+
+    @Test
+    fun `decodes a rule-based visibility override, matching the dashboard-published shape`() {
+        // Regression test: a dashboard rule that shows/hides a web_view previously failed SDK
+        // decoding entirely with `extra_forbidden` on `...web_view.overrides` (PWENG-152).
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "id": "promo_web_view",
+              "protocol_version": 1,
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
+              "overrides": [
+                {
+                  "conditions": [{ "type": "selected" }],
+                  "properties": { "visible": false }
+                },
+                {
+                  "conditions": [{ "type": "expanded" }],
+                  "properties": { "visible": true }
+                }
+              ]
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json) as WebViewComponent
+
+        assertThat(actual.overrides).containsExactly(
+            ComponentOverride(
+                conditions = listOf(ComponentOverride.Condition.Selected),
+                properties = PartialWebViewComponent(visible = false),
+            ),
+            ComponentOverride(
+                conditions = listOf(ComponentOverride.Condition.Expanded),
+                properties = PartialWebViewComponent(visible = true),
+            ),
+        )
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedWebViewPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedWebViewPartial.kt
@@ -1,0 +1,19 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import com.revenuecat.purchases.paywalls.components.PartialWebViewComponent
+import dev.drewhamilton.poko.Poko
+
+@Poko
+internal class PresentedWebViewPartial(
+    @get:JvmSynthetic val partial: PartialWebViewComponent,
+) : PresentedPartial<PresentedWebViewPartial> {
+    override fun combine(with: PresentedWebViewPartial?): PresentedWebViewPartial {
+        val otherPartial = with?.partial
+
+        return PresentedWebViewPartial(
+            partial = PartialWebViewComponent(
+                visible = otherPartial?.visible ?: partial.visible,
+            ),
+        )
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -48,6 +48,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.PresentedTabsPartial
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedTimelineItemPartial
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedTimelinePartial
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedVideoPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedWebViewPartial
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.LocalizationDictionary
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.imageForAllLocales
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.stringForAllLocales
@@ -576,15 +577,23 @@ internal class StyleFactory(
     private fun StyleFactoryScope.createWebViewComponentStyle(
         component: WebViewComponent,
     ): Result<WebViewComponentStyle, NonEmptyList<PaywallValidationError>> =
-        Result.Success(
-            WebViewComponentStyle(
-                url = component.url,
-                visible = component.visible ?: DEFAULT_VISIBILITY,
-                size = component.size,
-                componentId = component.id,
-                ignoreTopWindowInsets = ignoreTopWindowInsets,
-            ),
-        )
+        component.overrides
+            .toPresentedOverrides(stripRules) { partial -> Result.Success(PresentedWebViewPartial(partial)) }
+            .mapError { nonEmptyListOf(it) }
+            .map { presentedOverrides ->
+                WebViewComponentStyle(
+                    url = component.url,
+                    visible = component.visible ?: DEFAULT_VISIBILITY,
+                    size = component.size,
+                    componentId = component.id,
+                    overrides = presentedOverrides,
+                    rcPackage = rcPackage,
+                    resolvedOffer = resolvedOffer,
+                    tabIndex = tabControlIndex,
+                    offerEligibility = offerEligibility,
+                    ignoreTopWindowInsets = ignoreTopWindowInsets,
+                )
+            }
 
     private fun StyleFactoryScope.createCountdownComponentStyle(
         component: CountdownComponent,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -3,7 +3,13 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.style
 
 import androidx.compose.runtime.Immutable
+import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverride
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedWebViewPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageContext
+import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
+import com.revenuecat.purchases.ui.revenuecatui.helpers.ResolvedOffer
 
 @Immutable
 internal data class WebViewComponentStyle(
@@ -12,5 +18,32 @@ internal data class WebViewComponentStyle(
     override val size: Size,
     /** Schema `web_view.id`, sent to the content during the handshake. A blank id renders nothing. */
     val componentId: String,
+    val overrides: List<PresentedOverride<PresentedWebViewPartial>>,
+    /**
+     * If this is non-null and equal to the currently selected package, the `selected` [overrides] will be used if
+     * available.
+     */
+    @get:JvmSynthetic
+    override val rcPackage: Package?,
+    /**
+     * The resolved offer for this package, containing the subscription option and promo offer status.
+     * Used to determine offer eligibility and pricing phase information.
+     */
+    @get:JvmSynthetic
+    override val resolvedOffer: ResolvedOffer? = null,
+    /**
+     * If this is non-null and equal to the currently selected tab index, the `selected` [overrides] will be used if
+     * available. This should only be set for web views inside tab control elements. Not for all web views within a
+     * tab.
+     */
+    @get:JvmSynthetic
+    override val tabIndex: Int?,
+    /**
+     * The pre-computed offer eligibility for this component's package context.
+     * Used for applying conditional overrides based on intro/promo offer status.
+     * Null if this component is not in a package scope.
+     */
+    @get:JvmSynthetic
+    override val offerEligibility: OfferEligibility? = null,
     val ignoreTopWindowInsets: Boolean = false,
-) : ComponentStyle
+) : ComponentStyle, PackageContext

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentState.kt
@@ -1,0 +1,114 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.window.core.layout.WindowWidthSizeClass
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
+import com.revenuecat.purchases.ui.revenuecatui.components.ConditionContext
+import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
+import com.revenuecat.purchases.ui.revenuecatui.components.buildPresentedPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDelegate
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallStateStore
+
+@Stable
+@JvmSynthetic
+@Composable
+internal fun rememberUpdatedWebViewComponentState(
+    style: WebViewComponentStyle,
+    paywallState: PaywallState.Loaded.Components,
+): WebViewComponentState = rememberUpdatedWebViewComponentState(
+    style = style,
+    selectedPackageInfoProvider = { paywallState.selectedPackageInfo },
+    selectedTabIndexProvider = { paywallState.selectedTabIndex },
+    selectedOfferEligibilityProvider = { paywallState.selectedOfferEligibility },
+    customVariablesProvider = { paywallState.mergedCustomVariables },
+    stateStoreProvider = { paywallState.stateStore },
+)
+
+@Suppress("LongParameterList")
+@Stable
+@JvmSynthetic
+@Composable
+private fun rememberUpdatedWebViewComponentState(
+    style: WebViewComponentStyle,
+    selectedPackageInfoProvider: () -> PaywallState.Loaded.Components.SelectedPackageInfo?,
+    selectedTabIndexProvider: () -> Int,
+    selectedOfferEligibilityProvider: () -> OfferEligibility,
+    customVariablesProvider: () -> Map<String, CustomVariableValue>,
+    stateStoreProvider: () -> PaywallStateStore,
+): WebViewComponentState {
+    val windowSize = currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass
+
+    return remember(style) {
+        WebViewComponentState(
+            initialWindowSize = windowSize,
+            style = style,
+            selectedPackageInfoProvider = selectedPackageInfoProvider,
+            selectedTabIndexProvider = selectedTabIndexProvider,
+            selectedOfferEligibilityProvider = selectedOfferEligibilityProvider,
+            customVariablesProvider = customVariablesProvider,
+            stateStoreProvider = stateStoreProvider,
+        )
+    }.apply {
+        update(windowSize = windowSize)
+    }
+}
+
+@Suppress("LongParameterList")
+@Stable
+internal class WebViewComponentState(
+    initialWindowSize: WindowWidthSizeClass,
+    private val style: WebViewComponentStyle,
+    private val selectedPackageInfoProvider: () -> PaywallState.Loaded.Components.SelectedPackageInfo?,
+    private val selectedTabIndexProvider: () -> Int,
+    private val selectedOfferEligibilityProvider: () -> OfferEligibility,
+    private val customVariablesProvider: () -> Map<String, CustomVariableValue> = { emptyMap() },
+    private val stateStoreProvider: () -> PaywallStateStore = { PaywallStateStore(emptyMap()) },
+) {
+    private var windowSize by mutableStateOf(initialWindowSize)
+
+    private val packageAwareDelegate = PackageAwareDelegate(
+        style = style,
+        selectedPackageInfoProvider = selectedPackageInfoProvider,
+        selectedTabIndexProvider = selectedTabIndexProvider,
+        selectedOfferEligibilityProvider = selectedOfferEligibilityProvider,
+    )
+
+    private val presentedPartial by derivedStateOf {
+        val windowCondition = ScreenCondition.from(windowSize)
+        val componentState =
+            if (packageAwareDelegate.isSelected) ComponentViewState.SELECTED else ComponentViewState.DEFAULT
+
+        style.overrides.buildPresentedPartial(
+            windowCondition,
+            packageAwareDelegate.offerEligibility,
+            componentState,
+            conditionContext = ConditionContext(
+                selectedPackageId = selectedPackageInfoProvider()?.rcPackage?.identifier,
+                customVariables = customVariablesProvider(),
+                stateReader = stateStoreProvider()::currentValueOrDefault,
+            ),
+        )
+    }
+
+    // url/componentId/size always come from the base component; only visible is overridable.
+    @get:JvmSynthetic
+    val visible by derivedStateOf { presentedPartial?.partial?.visible ?: style.visible }
+
+    @JvmSynthetic
+    fun update(windowSize: WindowWidthSizeClass? = null) {
+        if (windowSize != null) this.windowSize = windowSize
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -42,14 +42,14 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 @JvmSynthetic
 @Composable
-// `state` is unused in v1 but kept for the uniform ComponentView signature (variables land later).
-@Suppress("LongMethod", "ReturnCount", "UnusedParameter")
+@Suppress("LongMethod", "ReturnCount")
 internal fun WebViewComponentView(
     style: WebViewComponentStyle,
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
 ) {
-    if (!style.visible) return
+    val webViewState = rememberUpdatedWebViewComponentState(style, state)
+    if (!webViewState.visible) return
 
     val resolvedUrl = remember(style.url) {
         WebViewUrlResolver.resolve(style.url)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -524,7 +524,7 @@ internal fun PaywallComponent.containsUnsupportedCondition(): Boolean = when (th
     is TabControlToggleComponent -> false
     is TabControlComponent -> false
     is FallbackHeaderComponent -> false
-    is WebViewComponent -> false
+    is WebViewComponent -> overrides.hasUnsupportedCondition()
 }
 
 @JvmSynthetic

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.paywalls.components.PackageComponent
 import com.revenuecat.purchases.paywalls.components.PartialImageComponent
 import com.revenuecat.purchases.paywalls.components.PartialPackageComponent
 import com.revenuecat.purchases.paywalls.components.PartialTextComponent
+import com.revenuecat.purchases.paywalls.components.PartialWebViewComponent
 import com.revenuecat.purchases.paywalls.components.PurchaseButtonComponent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.TabControlButtonComponent
@@ -138,6 +139,33 @@ class StyleFactoryTests {
         assertThat(style.visible).isFalse()
         assertThat(style.size).isEqualTo(size)
         assertThat(style.componentId).isEqualTo("promo_web_view")
+        assertThat(style.overrides).isEmpty()
+    }
+
+    @Test
+    fun `WebViewComponentStyle overrides are populated from component overrides`() {
+        // Arrange
+        val webViewComponent = WebViewComponent(
+            url = "https://paywalls.revenuecat.com/index.html",
+            id = "promo_web_view",
+            protocolVersion = 1,
+            size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()),
+            overrides = listOf(
+                ComponentOverride(
+                    conditions = listOf(ComponentOverride.Condition.Selected),
+                    properties = PartialWebViewComponent(visible = false),
+                ),
+            ),
+        )
+
+        // Act
+        val result = styleFactory.create(webViewComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as WebViewComponentStyle
+        assertThat(style.overrides).hasSize(1)
+        assertThat(style.overrides[0].properties.partial.visible).isFalse()
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentStateTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentStateTest.kt
@@ -1,0 +1,118 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.window.core.layout.WindowWidthSizeClass
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.paywalls.components.PartialWebViewComponent
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverride
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedWebViewPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallStateStore
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Only `visible` is overridable on web_view (url/size always come from the base style); these tests
+ * exercise the wiring from [WebViewComponentStyle.overrides] through [WebViewComponentState.visible].
+ */
+@RunWith(AndroidJUnit4::class)
+class WebViewComponentStateTest {
+
+    private val size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit())
+
+    private fun styleWithOverrides(
+        visible: Boolean,
+        overrides: List<PresentedOverride<PresentedWebViewPartial>>,
+        rcPackage: Package? = null,
+    ) = WebViewComponentStyle(
+        url = "https://paywalls.revenuecat.com/index.html",
+        visible = visible,
+        size = size,
+        componentId = "promo_web_view",
+        overrides = overrides,
+        rcPackage = rcPackage,
+        tabIndex = null,
+    )
+
+    private fun state(
+        style: WebViewComponentStyle,
+        windowSize: WindowWidthSizeClass = WindowWidthSizeClass.COMPACT,
+        selectedPackageInfo: PaywallState.Loaded.Components.SelectedPackageInfo? = null,
+    ) = WebViewComponentState(
+        initialWindowSize = windowSize,
+        style = style,
+        selectedPackageInfoProvider = { selectedPackageInfo },
+        selectedTabIndexProvider = { 0 },
+        selectedOfferEligibilityProvider = { OfferEligibility.Ineligible },
+        customVariablesProvider = { emptyMap() },
+        stateStoreProvider = { PaywallStateStore(emptyMap()) },
+    )
+
+    @Test
+    fun `falls back to the base component's visible when no override applies`() {
+        val style = styleWithOverrides(visible = true, overrides = emptyList())
+
+        assertThat(state(style).visible).isTrue()
+        assertThat(state(styleWithOverrides(visible = false, overrides = emptyList())).visible).isFalse()
+    }
+
+    @Test
+    fun `hides a base-visible web_view under a matching expanded override`() {
+        val overrides = listOf(
+            PresentedOverride(
+                conditions = listOf(ComponentOverride.Condition.Expanded),
+                properties = PresentedWebViewPartial(PartialWebViewComponent(visible = false)),
+            ),
+        )
+        val style = styleWithOverrides(visible = true, overrides = overrides)
+
+        assertThat(state(style, windowSize = WindowWidthSizeClass.COMPACT).visible).isTrue()
+        assertThat(state(style, windowSize = WindowWidthSizeClass.EXPANDED).visible).isFalse()
+    }
+
+    @Test
+    fun `shows a base-hidden web_view under a matching selected override`() {
+        val rcPackage = TestData.Packages.monthly
+        val overrides = listOf(
+            PresentedOverride(
+                conditions = listOf(ComponentOverride.Condition.Selected),
+                properties = PresentedWebViewPartial(PartialWebViewComponent(visible = true)),
+            ),
+        )
+        val style = styleWithOverrides(visible = false, overrides = overrides, rcPackage = rcPackage)
+        val selectedPackageInfo = PaywallState.Loaded.Components.SelectedPackageInfo(
+            rcPackage = rcPackage,
+            uniqueId = rcPackage.identifier,
+            offerEligibility = OfferEligibility.Ineligible,
+        )
+
+        // Not selected: keeps the base (hidden) value.
+        assertThat(state(style, selectedPackageInfo = null).visible).isFalse()
+        // Selected: the override applies.
+        assertThat(state(style, selectedPackageInfo = selectedPackageInfo).visible).isTrue()
+    }
+
+    @Test
+    fun `overrides never affect url, size, or componentId`() {
+        val overrides = listOf(
+            PresentedOverride(
+                conditions = listOf(ComponentOverride.Condition.Expanded),
+                properties = PresentedWebViewPartial(PartialWebViewComponent(visible = false)),
+            ),
+        )
+        val style = styleWithOverrides(visible = true, overrides = overrides)
+
+        // WebViewComponentState only ever exposes `visible`; url/size/componentId are read directly
+        // from the style by WebViewComponentView, unaffected by any override.
+        assertThat(style.url).isEqualTo("https://paywalls.revenuecat.com/index.html")
+        assertThat(style.size).isEqualTo(size)
+        assertThat(style.componentId).isEqualTo("promo_web_view")
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentStateTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentStateTest.kt
@@ -98,21 +98,4 @@ class WebViewComponentStateTest {
         // Selected: the override applies.
         assertThat(state(style, selectedPackageInfo = selectedPackageInfo).visible).isTrue()
     }
-
-    @Test
-    fun `overrides never affect url, size, or componentId`() {
-        val overrides = listOf(
-            PresentedOverride(
-                conditions = listOf(ComponentOverride.Condition.Expanded),
-                properties = PresentedWebViewPartial(PartialWebViewComponent(visible = false)),
-            ),
-        )
-        val style = styleWithOverrides(visible = true, overrides = overrides)
-
-        // WebViewComponentState only ever exposes `visible`; url/size/componentId are read directly
-        // from the style by WebViewComponentView, unaffected by any override.
-        assertThat(style.url).isEqualTo("https://paywalls.revenuecat.com/index.html")
-        assertThat(style.size).isEqualTo(size)
-        assertThat(style.componentId).isEqualTo("promo_web_view")
-    }
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
- Dashboard rules that show/hide the custom `web_view` component fail to publish: backend accepts `overrides`, SDK rejects them (`extra_forbidden`).
- Part of [PWENG-152](https://linear.app/revenuecat/issue/PWENG-152/allow-rules-for-a-custom-component-or-not-allow-creating-one). Android counterpart to [purchases-ios#7291](https://github.com/RevenueCat/purchases-ios/pull/7291).

### Description
- Adds `visible`-only `overrides` to `WebViewComponent` (via new `PartialWebViewComponent`).
- Resolves overrides through the existing `PresentedPartial`/`buildPresentedPartial` machinery, same as every other V2 component.
- `url`/`size` are never overridable, only `visible` — matches iOS scope.
- Depends on unmerged base branch #3787 (activation); stacked on top for now, will drop to sit on `main` once that merges.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, visible-only override support that mirrors existing Paywalls V2 components; covered by decode, style factory, and state tests with no auth or purchase-path changes.
> 
> **Overview**
> Fixes dashboard paywalls that attach show/hide **rules** to custom `web_view` components: the SDK previously rejected `overrides` on decode (`extra_forbidden`, PWENG-152).
> 
> **Model & decode:** `WebViewComponent` now accepts `overrides` and introduces `PartialWebViewComponent` with **only** `visible` overridable (`url` and `size` stay on the base component, iOS parity).
> 
> **Runtime:** Overrides flow through the same V2 path as other components—`PresentedWebViewPartial`, `StyleFactory.toPresentedOverrides`, `WebViewComponentStyle` + package/tab context, and new `WebViewComponentState` resolving conditions (selected, expanded, etc.). `WebViewComponentView` gates rendering on resolved `visible` instead of static style visibility.
> 
> **Validation:** Unsupported override conditions on `web_view` are included when deciding to strip rule-based overrides for the whole paywall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c3700e3bb35803f735eaf8c711c6e0cbd7f0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->