### PR TITLE
fix(paywalls): reject a quoted protocol_version instead of coercing it

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
@@ -65,15 +65,14 @@ internal class PaywallComponentSerializer : KSerializer<PaywallComponent> {
         }
     }
 
-    // Gate on the raw protocol_version BEFORE decoding so an absent, malformed, or unsupported
-    // (forward-incompatible) version falls back like an unrecognized component instead of failing to
-    // decode the whole paywall. The backend also guarantees protocol_version == 1 at publish time; this
-    // is client-side defense in depth.
+    // Gate on the raw protocol_version before decoding so an unsupported version falls back
+    // instead of failing to decode the whole paywall.
     private fun decodeWebViewOrFallback(
         jsonDecoder: JsonDecoder,
         json: JsonObject,
     ): PaywallComponent {
-        val declaredVersion = (json["protocol_version"] as? JsonPrimitive)?.intOrNull
+        // intOrNull parses digits regardless of quoting, so exclude string primitives first.
+        val declaredVersion = (json["protocol_version"] as? JsonPrimitive)?.takeUnless { it.isString }?.intOrNull
         return if (declaredVersion == WebViewComponent.SUPPORTED_PROTOCOL_VERSION) {
             jsonDecoder.json.decodeFromJsonElement<WebViewComponent>(json)
         } else {

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/WebViewComponentTests.kt
@@ -145,6 +145,44 @@ class WebViewComponentTests {
     }
 
     @Test
+    fun `protocol_version as a JSON string is treated as unsupported, not coerced`() {
+        // A quoted "1" must not slip past the version gate (intOrNull parses digits regardless of quoting).
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "protocol_version": "1",
+              "url": "https://paywalls.revenuecat.com/index.html",
+              "fallback": {
+                "type": "stack",
+                "name": "web_view_fallback",
+                "components": []
+              }
+            }
+            """
+
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(json)
+
+        assertThat(actual).isInstanceOf(StackComponent::class.java)
+        assertThat((actual as StackComponent).name).isEqualTo("web_view_fallback")
+    }
+
+    @Test
+    fun `supported protocol_version with another required field missing still throws`() {
+        @Language("json")
+        val json = """
+            {
+              "type": "web_view",
+              "protocol_version": 1,
+              "url": "https://paywalls.revenuecat.com/index.html"
+            }
+            """
+
+        assertThatThrownBy { JsonTools.json.decodeFromString<PaywallComponent>(json) }
+            .isInstanceOf(SerializationException::class.java)
+    }
+
+    @Test
     fun `missing protocol_version renders the fallback component`() {
         // protocol_version is required; an absent version is treated like an unsupported one and
         // routes to the author's fallback rather than decoding as a web view.


### PR DESCRIPTION
Force `protocol_version` to be an int before parsing to prevent parsing failures if backend would send e.g. a quoted number.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small deserialization guard for web_view paywalls with no auth or payment impact; behavior change only for malformed string protocol_version values.
> 
> **Overview**
> **Web_view paywall components** now treat `protocol_version` as unsupported unless it is a JSON **number**, not a string that looks like a number.
> 
> In `decodeWebViewOrFallback`, the version gate uses `takeUnless { it.isString }` before `intOrNull`, because `intOrNull` would coerce `"1"` to `1` and incorrectly decode as supported v1. Quoted or missing versions still route to the author's **fallback** stack; only a numeric `1` proceeds to full `WebViewComponent` decoding (which can still throw if required fields are missing).
> 
> Tests cover string `"1"` → fallback and supported version with an incomplete payload still throwing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 515f09cfba73f3fb78c4e73797e2e61abf67db7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->