### PR TITLE
fix(paywalls): stop Fill content collapsing to zero under an unbounded ancestor

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentState.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
@@ -23,7 +22,6 @@ import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDel
 import com.revenuecat.purchases.ui.revenuecatui.components.style.CarouselComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
-import com.revenuecat.purchases.ui.revenuecatui.extensions.dpOrNull
 
 @Stable
 @JvmSynthetic
@@ -108,14 +106,6 @@ internal class CarouselComponentState(
 
     @get:JvmSynthetic
     val pages by derivedStateOf { style.pages }
-
-    // HorizontalPager only learns its own resolved height after measuring every page, too late to hand a
-    // Fixed-height sibling's bound to a Fill-height page's own measurement. Reading it from the schema up
-    // front lets a Fill page stretch to match, instead of falling back to wrapping its own content.
-    @get:JvmSynthetic
-    val maxFixedPageHeight: Dp? by derivedStateOf {
-        pages.mapNotNull { it.size.height.dpOrNull() }.maxOrNull()
-    }
 
     @get:JvmSynthetic
     val pageAlignment by derivedStateOf {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentState.kt
@@ -8,8 +8,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowWidthSizeClass
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
 import com.revenuecat.purchases.ui.revenuecatui.components.ConditionContext
@@ -106,6 +108,14 @@ internal class CarouselComponentState(
 
     @get:JvmSynthetic
     val pages by derivedStateOf { style.pages }
+
+    // HorizontalPager only learns its own resolved height after measuring every page, too late to hand a
+    // Fixed-height sibling's bound to a Fill-height page's own measurement. Reading it from the schema up
+    // front lets a Fill page stretch to match, instead of falling back to wrapping its own content.
+    @get:JvmSynthetic
+    val maxFixedPageHeight: Dp? by derivedStateOf {
+        pages.mapNotNull { (it.size.height as? SizeConstraint.Fixed)?.value }.maxOrNull()?.toInt()?.dp
+    }
 
     @get:JvmSynthetic
     val pageAlignment by derivedStateOf {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentState.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowWidthSizeClass
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
 import com.revenuecat.purchases.ui.revenuecatui.components.ConditionContext
@@ -24,6 +23,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDel
 import com.revenuecat.purchases.ui.revenuecatui.components.style.CarouselComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.extensions.dpOrNull
 
 @Stable
 @JvmSynthetic
@@ -114,7 +114,7 @@ internal class CarouselComponentState(
     // front lets a Fill page stretch to match, instead of falling back to wrapping its own content.
     @get:JvmSynthetic
     val maxFixedPageHeight: Dp? by derivedStateOf {
-        pages.mapNotNull { (it.size.height as? SizeConstraint.Fixed)?.value }.maxOrNull()?.toInt()?.dp
+        pages.mapNotNull { it.size.height.dpOrNull() }.maxOrNull()
     }
 
     @get:JvmSynthetic

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -47,6 +47,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toShape
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.border
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.shadow
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.previewEmptyState
 import com.revenuecat.purchases.ui.revenuecatui.components.previewTextComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
@@ -158,6 +159,7 @@ internal fun CarouselComponentView(
 
     Column(
         modifier = modifier
+            .size(carouselState.size)
             .padding(carouselState.margin)
             .applyIfNotNull(shadowStyle) { shadow(it, carouselState.shape) }
             .applyIfNotNull(backgroundColorStyle) { background(it, carouselState.shape) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -158,9 +158,7 @@ internal fun CarouselComponentView(
         }
     }
 
-    // Only steps in for a Fit-height carousel: an explicit Fixed/Fill declaration is a deliberate author
-    // choice and must not be overridden by this fallback.
-    val fixedSiblingHeight = carouselState.maxFixedPageHeight.takeIf { carouselState.size.height is SizeConstraint.Fit }
+    val fixedSiblingHeight = carouselState.fixedSiblingHeightOrNull()
 
     Column(
         modifier = modifier
@@ -418,6 +416,12 @@ internal fun nextAutoAdvanceTargetPage(
         currentPage + 1
     }
 }
+
+// Only applies for a Fit-height carousel: an explicit Fixed/Fill declaration is a deliberate
+// author choice and must not be overridden by this fallback. Checked first so the page scan is
+// skipped entirely for the common Fixed/Fill case.
+private fun CarouselComponentState.fixedSiblingHeightOrNull(): Dp? =
+    if (size.height is SizeConstraint.Fit) maxFixedPageHeight else null
 
 private fun getInitialPage(carouselState: CarouselComponentState) = if (carouselState.loop) {
     // When looping, we use a very large number of pages to allow for "infinite" scrolling

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
@@ -157,8 +158,13 @@ internal fun CarouselComponentView(
         }
     }
 
+    // Only steps in for a Fit-height carousel: an explicit Fixed/Fill declaration is a deliberate author
+    // choice and must not be overridden by this fallback.
+    val fixedSiblingHeight = carouselState.maxFixedPageHeight.takeIf { carouselState.size.height is SizeConstraint.Fit }
+
     Column(
         modifier = modifier
+            .applyIfNotNull(fixedSiblingHeight) { height(it) }
             .size(carouselState.size)
             .padding(carouselState.margin)
             .applyIfNotNull(shadowStyle) { shadow(it, carouselState.shape) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -167,8 +167,8 @@ internal fun CarouselComponentView(
     // known, so a Fill page wraps its own (smaller) content instead of matching. Pin the Fill pages
     // to the measured height; leave the Pager unpinned so it keeps tracking the tallest page as
     // content grows (async WebView), which avoids latching to the first frame.
-    // ponytail: a SubcomposeLayout single pass would avoid this measure -> recompose reflow, but it
-    // would compose every page (WebViews included) twice -- not worth it for one settle frame.
+    // A SubcomposeLayout single pass would avoid this measure -> recompose reflow, but it would
+    // compose every page (WebViews included) twice, so it isn't worth it for one settle frame.
     val density = LocalDensity.current
     var pagerHeightPx by remember(carouselState.pages) { mutableIntStateOf(0) }
     val fillPageModifier = fillPageModifierOrEmpty(carouselState.size.height, pagerHeightPx, density)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
@@ -172,9 +172,14 @@ internal fun CarouselComponentView(
     // tall content). Measured and applied on the same node so it converges to a fixpoint rather than
     // oscillating (measuring the outer Column instead would fold its padding/page-control back into
     // the loop each pass and never settle).
+    //
+    // ponytail: this is the measure -> state -> recompose reflow the Compose guidelines steer away
+    // from (a SubcomposeLayout single pass would avoid the extra frame), but HorizontalPager is a
+    // LazyLayout whose height only resolves after it co-measures its pages, so a single-pass wrap
+    // would have to compose every page (WebViews included) twice. Not worth it for one settle frame.
     val density = LocalDensity.current
     var pagerHeightPx by remember(carouselState.pages) { mutableIntStateOf(0) }
-    val pagerHeight = stabilizedHeightOrNull(carouselState, pagerHeightPx, density)
+    val pagerHeight = pagerHeightOrNull(carouselState.size.height, pagerHeightPx, density)
 
     Column(
         modifier = modifier
@@ -212,7 +217,7 @@ internal fun CarouselComponentView(
             verticalAlignment = carouselState.pageAlignment,
             modifier = Modifier
                 .applyIfNotNull(pagerHeight) { height(it) }
-                .onGloballyPositioned { pagerHeightPx = it.size.height },
+                .onSizeChanged { pagerHeightPx = it.height },
         ) { page ->
             StackComponentView(
                 style = carouselState.pages[page % pageCount],
@@ -435,14 +440,10 @@ internal fun nextAutoAdvanceTargetPage(
     }
 }
 
-// Only applies for a Fit-height carousel: an explicit Fixed/Fill declaration is a deliberate
-// author choice and must not be overridden by this fallback.
-private fun stabilizedHeightOrNull(
-    carouselState: CarouselComponentState,
-    measuredHeightPx: Int,
-    density: Density,
-): Dp? =
-    if (carouselState.size.height is SizeConstraint.Fit && measuredHeightPx > 0) {
+// Only a Fit height is unresolved at measure time (Fixed/Fill already give the Column a bound to
+// hand down), so only then do we pin the Pager to its measured height.
+private fun pagerHeightOrNull(heightConstraint: SizeConstraint, measuredHeightPx: Int, density: Density): Dp? =
+    if (heightConstraint is SizeConstraint.Fit && measuredHeightPx > 0) {
         with(density) { measuredHeightPx.toDp() }
     } else {
         null

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -166,12 +166,11 @@ internal fun CarouselComponentView(
     // beyondViewportPageCount = pageCount below forces every page to measure together, so the Pager
     // resolves its own height to the tallest page -- but each page is measured before that resolved
     // height is known, so a Fill-height page only wraps its own (possibly much smaller) content
-    // instead of stretching to match. Pin the Pager to its own measured height so on the next frame
-    // it hands that bound down to every page, letting a Fill page stretch to it regardless of how
-    // the tallest sibling got there (a Fixed descendant partway down its tree, or just naturally
-    // tall content). Measured and applied on the same node so it converges to a fixpoint rather than
-    // oscillating (measuring the outer Column instead would fold its padding/page-control back into
-    // the loop each pass and never settle).
+    // instead of stretching to match. Capture the Pager's resolved height and, on the next frame,
+    // pin only the Fill-height pages to it so they stretch to match the tallest sibling. The Pager
+    // itself is left unpinned so it keeps tracking that sibling's real height (async-growing
+    // content like a WebView still grows it); Fill pages never drive the max, so this converges
+    // without latching the height to the first frame.
     //
     // ponytail: this is the measure -> state -> recompose reflow the Compose guidelines steer away
     // from (a SubcomposeLayout single pass would avoid the extra frame), but HorizontalPager is a
@@ -179,7 +178,7 @@ internal fun CarouselComponentView(
     // would have to compose every page (WebViews included) twice. Not worth it for one settle frame.
     val density = LocalDensity.current
     var pagerHeightPx by remember(carouselState.pages) { mutableIntStateOf(0) }
-    val pagerHeight = pagerHeightOrNull(carouselState.size.height, pagerHeightPx, density)
+    val fillPageHeight = fillPageHeightOrNull(carouselState.size.height, pagerHeightPx, density)
 
     Column(
         modifier = modifier
@@ -215,15 +214,15 @@ internal fun CarouselComponentView(
             beyondViewportPageCount = pageCount,
             pageSpacing = carouselState.pageSpacing,
             verticalAlignment = carouselState.pageAlignment,
-            modifier = Modifier
-                .applyIfNotNull(pagerHeight) { height(it) }
-                .onSizeChanged { pagerHeightPx = it.height },
+            modifier = Modifier.onSizeChanged { pagerHeightPx = it.height },
         ) { page ->
+            val pageStyle = carouselState.pages[page % pageCount]
             StackComponentView(
-                style = carouselState.pages[page % pageCount],
+                style = pageStyle,
                 state = state,
                 clickHandler = clickHandler,
                 componentInteractionTracker = componentInteractionTracker,
+                modifier = fillPageHeightModifier(pageStyle.size.height, fillPageHeight),
             )
         }
 
@@ -440,14 +439,19 @@ internal fun nextAutoAdvanceTargetPage(
     }
 }
 
-// Only a Fit height is unresolved at measure time (Fixed/Fill already give the Column a bound to
-// hand down), so only then do we pin the Pager to its measured height.
-private fun pagerHeightOrNull(heightConstraint: SizeConstraint, measuredHeightPx: Int, density: Density): Dp? =
-    if (heightConstraint is SizeConstraint.Fit && measuredHeightPx > 0) {
+// The height to pin Fill pages to, or null. Only a Fit carousel leaves pages unbounded at measure
+// time (Fixed/Fill already give the Column a bound to hand down), so only then is a pin needed.
+private fun fillPageHeightOrNull(carouselHeight: SizeConstraint, measuredHeightPx: Int, density: Density): Dp? =
+    if (carouselHeight is SizeConstraint.Fit && measuredHeightPx > 0) {
         with(density) { measuredHeightPx.toDp() }
     } else {
         null
     }
+
+// Pin only Fill-height pages: a Fit/Fixed page already resolves to a real height on its own, and
+// pinning those would also risk feeding the tallest sibling's height back into itself.
+private fun fillPageHeightModifier(pageHeight: SizeConstraint, pinnedHeight: Dp?): Modifier =
+    if (pinnedHeight != null && pageHeight is SizeConstraint.Fill) Modifier.height(pinnedHeight) else Modifier
 
 private fun getInitialPage(carouselState: CarouselComponentState) = if (carouselState.loop) {
     // When looping, we use a very large number of pages to allow for "infinite" scrolling

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -24,14 +24,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -158,11 +163,20 @@ internal fun CarouselComponentView(
         }
     }
 
-    val fixedSiblingHeight = carouselState.fixedSiblingHeightOrNull()
+    // A Fit-height carousel wraps to the Pager's own resolved height, which (since
+    // beyondViewportPageCount = pageCount above forces every page to measure together) already
+    // reflects the tallest page -- but each page is measured before that resolved height is known,
+    // so a Fill-height page only gets to wrap its own (possibly much smaller) content instead of
+    // stretching to match. Capturing the resolved height and feeding it back as an explicit bound
+    // on the next frame lets a Fill page stretch to it, regardless of how the tallest sibling got
+    // there (a Fixed descendant partway down its tree, or just naturally tall content).
+    val density = LocalDensity.current
+    var measuredHeightPx by remember(carouselState.pages) { mutableIntStateOf(0) }
+    val stabilizedHeight = stabilizedHeightOrNull(carouselState, measuredHeightPx, density)
 
     Column(
         modifier = modifier
-            .applyIfNotNull(fixedSiblingHeight) { height(it) }
+            .applyIfNotNull(stabilizedHeight) { height(it) }
             .size(carouselState.size)
             .padding(carouselState.margin)
             .applyIfNotNull(shadowStyle) { shadow(it, carouselState.shape) }
@@ -172,7 +186,8 @@ internal fun CarouselComponentView(
                 border(it, carouselState.shape)
                     .padding(it.width)
             }
-            .padding(carouselState.padding),
+            .padding(carouselState.padding)
+            .onGloballyPositioned { measuredHeightPx = it.size.height },
     ) {
         val pageControl = @Composable {
             carouselState.pageControl?.let {
@@ -418,10 +433,17 @@ internal fun nextAutoAdvanceTargetPage(
 }
 
 // Only applies for a Fit-height carousel: an explicit Fixed/Fill declaration is a deliberate
-// author choice and must not be overridden by this fallback. Checked first so the page scan is
-// skipped entirely for the common Fixed/Fill case.
-private fun CarouselComponentState.fixedSiblingHeightOrNull(): Dp? =
-    if (size.height is SizeConstraint.Fit) maxFixedPageHeight else null
+// author choice and must not be overridden by this fallback.
+private fun stabilizedHeightOrNull(
+    carouselState: CarouselComponentState,
+    measuredHeightPx: Int,
+    density: Density,
+): Dp? =
+    if (carouselState.size.height is SizeConstraint.Fit && measuredHeightPx > 0) {
+        with(density) { measuredHeightPx.toDp() }
+    } else {
+        null
+    }
 
 private fun getInitialPage(carouselState: CarouselComponentState) = if (carouselState.loop) {
     // When looping, we use a very large number of pages to allow for "infinite" scrolling

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -178,7 +178,8 @@ internal fun CarouselComponentView(
     // would have to compose every page (WebViews included) twice. Not worth it for one settle frame.
     val density = LocalDensity.current
     var pagerHeightPx by remember(carouselState.pages) { mutableIntStateOf(0) }
-    val fillPageHeight = fillPageHeightOrNull(carouselState.size.height, pagerHeightPx, density)
+    // Built once and reused across pages: every Fill page pins to the same height.
+    val fillPageModifier = fillPageModifierOrEmpty(carouselState.size.height, pagerHeightPx, density)
 
     Column(
         modifier = modifier
@@ -222,7 +223,7 @@ internal fun CarouselComponentView(
                 state = state,
                 clickHandler = clickHandler,
                 componentInteractionTracker = componentInteractionTracker,
-                modifier = fillPageHeightModifier(pageStyle.size.height, fillPageHeight),
+                modifier = pageHeightModifier(pageStyle.size.height, fillPageModifier),
             )
         }
 
@@ -439,19 +440,21 @@ internal fun nextAutoAdvanceTargetPage(
     }
 }
 
-// The height to pin Fill pages to, or null. Only a Fit carousel leaves pages unbounded at measure
-// time (Fixed/Fill already give the Column a bound to hand down), so only then is a pin needed.
-private fun fillPageHeightOrNull(carouselHeight: SizeConstraint, measuredHeightPx: Int, density: Density): Dp? =
+// The height modifier for Fill pages, or an empty Modifier. Only a Fit carousel leaves pages
+// unbounded at measure time (Fixed/Fill already give the Column a bound to hand down), so only then
+// is a pin built.
+private fun fillPageModifierOrEmpty(carouselHeight: SizeConstraint, measuredHeightPx: Int, density: Density): Modifier =
     if (carouselHeight is SizeConstraint.Fit && measuredHeightPx > 0) {
-        with(density) { measuredHeightPx.toDp() }
+        Modifier.height(with(density) { measuredHeightPx.toDp() })
     } else {
-        null
+        Modifier
     }
 
-// Pin only Fill-height pages: a Fit/Fixed page already resolves to a real height on its own, and
-// pinning those would also risk feeding the tallest sibling's height back into itself.
-private fun fillPageHeightModifier(pageHeight: SizeConstraint, pinnedHeight: Dp?): Modifier =
-    if (pinnedHeight != null && pageHeight is SizeConstraint.Fill) Modifier.height(pinnedHeight) else Modifier
+// Apply the shared fill modifier only to Fill-height pages: a Fit/Fixed page already resolves to a
+// real height on its own, and pinning those would risk feeding the tallest sibling's height back
+// into itself.
+private fun pageHeightModifier(pageHeight: SizeConstraint, fillPageModifier: Modifier): Modifier =
+    if (pageHeight is SizeConstraint.Fill) fillPageModifier else Modifier
 
 private fun getInitialPage(carouselState: CarouselComponentState) = if (carouselState.loop) {
     // When looping, we use a very large number of pages to allow for "infinite" scrolling

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -163,20 +163,21 @@ internal fun CarouselComponentView(
         }
     }
 
-    // A Fit-height carousel wraps to the Pager's own resolved height, which (since
-    // beyondViewportPageCount = pageCount above forces every page to measure together) already
-    // reflects the tallest page -- but each page is measured before that resolved height is known,
-    // so a Fill-height page only gets to wrap its own (possibly much smaller) content instead of
-    // stretching to match. Capturing the resolved height and feeding it back as an explicit bound
-    // on the next frame lets a Fill page stretch to it, regardless of how the tallest sibling got
-    // there (a Fixed descendant partway down its tree, or just naturally tall content).
+    // beyondViewportPageCount = pageCount below forces every page to measure together, so the Pager
+    // resolves its own height to the tallest page -- but each page is measured before that resolved
+    // height is known, so a Fill-height page only wraps its own (possibly much smaller) content
+    // instead of stretching to match. Pin the Pager to its own measured height so on the next frame
+    // it hands that bound down to every page, letting a Fill page stretch to it regardless of how
+    // the tallest sibling got there (a Fixed descendant partway down its tree, or just naturally
+    // tall content). Measured and applied on the same node so it converges to a fixpoint rather than
+    // oscillating (measuring the outer Column instead would fold its padding/page-control back into
+    // the loop each pass and never settle).
     val density = LocalDensity.current
-    var measuredHeightPx by remember(carouselState.pages) { mutableIntStateOf(0) }
-    val stabilizedHeight = stabilizedHeightOrNull(carouselState, measuredHeightPx, density)
+    var pagerHeightPx by remember(carouselState.pages) { mutableIntStateOf(0) }
+    val pagerHeight = stabilizedHeightOrNull(carouselState, pagerHeightPx, density)
 
     Column(
         modifier = modifier
-            .applyIfNotNull(stabilizedHeight) { height(it) }
             .size(carouselState.size)
             .padding(carouselState.margin)
             .applyIfNotNull(shadowStyle) { shadow(it, carouselState.shape) }
@@ -186,8 +187,7 @@ internal fun CarouselComponentView(
                 border(it, carouselState.shape)
                     .padding(it.width)
             }
-            .padding(carouselState.padding)
-            .onGloballyPositioned { measuredHeightPx = it.size.height },
+            .padding(carouselState.padding),
     ) {
         val pageControl = @Composable {
             carouselState.pageControl?.let {
@@ -210,6 +210,9 @@ internal fun CarouselComponentView(
             beyondViewportPageCount = pageCount,
             pageSpacing = carouselState.pageSpacing,
             verticalAlignment = carouselState.pageAlignment,
+            modifier = Modifier
+                .applyIfNotNull(pagerHeight) { height(it) }
+                .onGloballyPositioned { pagerHeightPx = it.size.height },
         ) { page ->
             StackComponentView(
                 style = carouselState.pages[page % pageCount],

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -163,22 +163,14 @@ internal fun CarouselComponentView(
         }
     }
 
-    // beyondViewportPageCount = pageCount below forces every page to measure together, so the Pager
-    // resolves its own height to the tallest page -- but each page is measured before that resolved
-    // height is known, so a Fill-height page only wraps its own (possibly much smaller) content
-    // instead of stretching to match. Capture the Pager's resolved height and, on the next frame,
-    // pin only the Fill-height pages to it so they stretch to match the tallest sibling. The Pager
-    // itself is left unpinned so it keeps tracking that sibling's real height (async-growing
-    // content like a WebView still grows it); Fill pages never drive the max, so this converges
-    // without latching the height to the first frame.
-    //
-    // ponytail: this is the measure -> state -> recompose reflow the Compose guidelines steer away
-    // from (a SubcomposeLayout single pass would avoid the extra frame), but HorizontalPager is a
-    // LazyLayout whose height only resolves after it co-measures its pages, so a single-pass wrap
-    // would have to compose every page (WebViews included) twice. Not worth it for one settle frame.
+    // A Fit carousel sizes to its tallest page, but each page is measured before that height is
+    // known, so a Fill page wraps its own (smaller) content instead of matching. Pin the Fill pages
+    // to the measured height; leave the Pager unpinned so it keeps tracking the tallest page as
+    // content grows (async WebView), which avoids latching to the first frame.
+    // ponytail: a SubcomposeLayout single pass would avoid this measure -> recompose reflow, but it
+    // would compose every page (WebViews included) twice -- not worth it for one settle frame.
     val density = LocalDensity.current
     var pagerHeightPx by remember(carouselState.pages) { mutableIntStateOf(0) }
-    // Built once and reused across pages: every Fill page pins to the same height.
     val fillPageModifier = fillPageModifierOrEmpty(carouselState.size.height, pagerHeightPx, density)
 
     Column(
@@ -440,9 +432,7 @@ internal fun nextAutoAdvanceTargetPage(
     }
 }
 
-// The height modifier for Fill pages, or an empty Modifier. Only a Fit carousel leaves pages
-// unbounded at measure time (Fixed/Fill already give the Column a bound to hand down), so only then
-// is a pin built.
+// Only a Fit carousel leaves pages unbounded at measure time; Fixed/Fill already bound them.
 private fun fillPageModifierOrEmpty(carouselHeight: SizeConstraint, measuredHeightPx: Int, density: Density): Modifier =
     if (carouselHeight is SizeConstraint.Fit && measuredHeightPx > 0) {
         Modifier.height(with(density) { measuredHeightPx.toDp() })
@@ -450,9 +440,8 @@ private fun fillPageModifierOrEmpty(carouselHeight: SizeConstraint, measuredHeig
         Modifier
     }
 
-// Apply the shared fill modifier only to Fill-height pages: a Fit/Fixed page already resolves to a
-// real height on its own, and pinning those would risk feeding the tallest sibling's height back
-// into itself.
+// Pin only Fill pages: a Fit/Fixed page resolves its own height, and pinning it would feed a
+// sibling's height back into itself.
 private fun pageHeightModifier(pageHeight: SizeConstraint, fillPageModifier: Modifier): Modifier =
     if (pageHeight is SizeConstraint.Fill) fillPageModifier else Modifier
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -98,6 +99,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentS
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+import com.revenuecat.purchases.ui.revenuecatui.extensions.trackMainAxisUnbounded
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
 import kotlin.math.roundToInt
 import androidx.compose.ui.geometry.Size as ComposeSize
@@ -614,63 +616,83 @@ private fun MainStackComponent(
             )
         } else {
             when (val dimension = stackState.dimension) {
-                is Dimension.Horizontal -> HorizontalStack(
-                    size = stackState.size,
-                    dimension = dimension,
-                    spacing = stackState.spacing,
-                    modifier = outerModifier
-                        .size(stackState.size, verticalAlignment = dimension.alignment.toAlignment())
-                        .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
-                            scrollable(state, orientation)
+                is Dimension.Horizontal -> {
+                    // Tracks whether this Row's own main-axis (width) constraint ends up unbounded (e.g. an
+                    // ancestor scrolls, or a `Fit`-sized container sits under one that does). A `weight`-ed
+                    // Fill child would otherwise collapse to zero width in that case (Compose's weight
+                    // distribution falls back to the axis minimum, which is 0 once relaxed by scroll/Fit) — see
+                    // Modifier.trackMainAxisUnbounded for the full rationale.
+                    val mainAxisUnbounded = remember { mutableStateOf(false) }
+                    HorizontalStack(
+                        size = stackState.size,
+                        dimension = dimension,
+                        spacing = stackState.spacing,
+                        modifier = outerModifier
+                            .size(stackState.size, verticalAlignment = dimension.alignment.toAlignment())
+                            .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
+                                scrollable(state, orientation)
+                            }
+                            .then(rootModifier)
+                            .trackMainAxisUnbounded(isHorizontal = true, unboundedState = mainAxisUnbounded),
+                    ) {
+                        items(stackState.children) { _, child ->
+                            ComponentView(
+                                style = child,
+                                state = state,
+                                onClick = clickHandler,
+                                componentInteractionTracker = componentInteractionTracker,
+                                modifier = Modifier
+                                    .conditional(child.size.width == Fill && !mainAxisUnbounded.value) {
+                                        Modifier.weight(1f)
+                                    }
+                                    .conditional(
+                                        stackState.applyTopWindowInsets && !child.shouldIgnoreTopWindowInsets,
+                                    ) {
+                                        windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
+                                    }
+                                    .alpha(contentAlpha),
+                            )
                         }
-                        .then(rootModifier),
-                ) {
-                    items(stackState.children) { _, child ->
-                        ComponentView(
-                            style = child,
-                            state = state,
-                            onClick = clickHandler,
-                            componentInteractionTracker = componentInteractionTracker,
-                            modifier = Modifier
-                                .conditional(child.size.width == Fill) { Modifier.weight(1f) }
-                                .conditional(stackState.applyTopWindowInsets && !child.shouldIgnoreTopWindowInsets) {
-                                    windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
-                                }
-                                .alpha(contentAlpha),
-                        )
                     }
                 }
 
-                is Dimension.Vertical -> VerticalStack(
-                    size = stackState.size,
-                    dimension = dimension,
-                    spacing = stackState.spacing,
-                    modifier = outerModifier
-                        .size(stackState.size, horizontalAlignment = dimension.alignment.toAlignment())
-                        .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
-                            scrollable(state, orientation)
+                is Dimension.Vertical -> {
+                    // See the Horizontal branch above for why this exists.
+                    val mainAxisUnbounded = remember { mutableStateOf(false) }
+                    VerticalStack(
+                        size = stackState.size,
+                        dimension = dimension,
+                        spacing = stackState.spacing,
+                        modifier = outerModifier
+                            .size(stackState.size, horizontalAlignment = dimension.alignment.toAlignment())
+                            .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
+                                scrollable(state, orientation)
+                            }
+                            .then(rootModifier)
+                            .trackMainAxisUnbounded(isHorizontal = false, unboundedState = mainAxisUnbounded),
+                    ) {
+                        items(stackState.children) { index, child ->
+                            ComponentView(
+                                style = child,
+                                state = state,
+                                onClick = clickHandler,
+                                componentInteractionTracker = componentInteractionTracker,
+                                modifier = Modifier
+                                    .conditional(child.size.height == Fill && !mainAxisUnbounded.value) {
+                                        Modifier.weight(1f)
+                                    }
+                                    .conditional(
+                                        // In a Vertical container, we only want to apply topSystemBarsPadding to the
+                                        // first child, except when that child has `ignoreTopWindowInsets` set to true.
+                                        stackState.applyTopWindowInsets &&
+                                            index == 0 &&
+                                            !child.shouldIgnoreTopWindowInsets,
+                                    ) {
+                                        windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
+                                    }
+                                    .alpha(contentAlpha),
+                            )
                         }
-                        .then(rootModifier),
-                ) {
-                    items(stackState.children) { index, child ->
-                        ComponentView(
-                            style = child,
-                            state = state,
-                            onClick = clickHandler,
-                            componentInteractionTracker = componentInteractionTracker,
-                            modifier = Modifier
-                                .conditional(child.size.height == Fill) { Modifier.weight(1f) }
-                                .conditional(
-                                    // In a Vertical container, we only want to apply topSystemBarsPadding to the first
-                                    // child, except when that child has `ignoreTopWindowInsets` set to true.
-                                    stackState.applyTopWindowInsets &&
-                                        index == 0 &&
-                                        !child.shouldIgnoreTopWindowInsets,
-                                ) {
-                                    windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
-                                }
-                                .alpha(contentAlpha),
-                        )
                     }
                 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -621,7 +621,9 @@ private fun MainStackComponent(
                     // ancestor scrolls, or a `Fit`-sized container sits under one that does). A `weight`-ed
                     // Fill child would otherwise collapse to zero width in that case (Compose's weight
                     // distribution falls back to the axis minimum, which is 0 once relaxed by scroll/Fit) — see
-                    // Modifier.trackMainAxisUnbounded for the full rationale.
+                    // Modifier.trackMainAxisUnbounded for the full rationale. Only worth tracking (and paying
+                    // an extra measure hop for) when a Fill-width child could actually be affected.
+                    val hasFillWidthChild = stackState.children.any { it.size.width == Fill }
                     val mainAxisUnbounded = remember { mutableStateOf(false) }
                     HorizontalStack(
                         size = stackState.size,
@@ -633,7 +635,9 @@ private fun MainStackComponent(
                                 scrollable(state, orientation)
                             }
                             .then(rootModifier)
-                            .trackMainAxisUnbounded(isHorizontal = true, unboundedState = mainAxisUnbounded),
+                            .conditional(hasFillWidthChild) {
+                                trackMainAxisUnbounded(isHorizontal = true, unboundedState = mainAxisUnbounded)
+                            },
                     ) {
                         items(stackState.children) { _, child ->
                             ComponentView(
@@ -658,6 +662,7 @@ private fun MainStackComponent(
 
                 is Dimension.Vertical -> {
                     // See the Horizontal branch above for why this exists.
+                    val hasFillHeightChild = stackState.children.any { it.size.height == Fill }
                     val mainAxisUnbounded = remember { mutableStateOf(false) }
                     VerticalStack(
                         size = stackState.size,
@@ -669,7 +674,9 @@ private fun MainStackComponent(
                                 scrollable(state, orientation)
                             }
                             .then(rootModifier)
-                            .trackMainAxisUnbounded(isHorizontal = false, unboundedState = mainAxisUnbounded),
+                            .conditional(hasFillHeightChild) {
+                                trackMainAxisUnbounded(isHorizontal = false, unboundedState = mainAxisUnbounded)
+                            },
                     ) {
                         items(stackState.children) { index, child ->
                             ComponentView(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -617,12 +617,9 @@ private fun MainStackComponent(
         } else {
             when (val dimension = stackState.dimension) {
                 is Dimension.Horizontal -> {
-                    // Tracks whether this Row's own main-axis (width) constraint ends up unbounded (e.g. an
-                    // ancestor scrolls, or a `Fit`-sized container sits under one that does). A `weight`-ed
-                    // Fill child would otherwise collapse to zero width in that case (Compose's weight
-                    // distribution falls back to the axis minimum, which is 0 once relaxed by scroll/Fit) — see
-                    // Modifier.trackMainAxisUnbounded for the full rationale. Only worth tracking (and paying
-                    // an extra measure hop for) when a Fill-width child could actually be affected.
+                    // Skip weight() for a Fill child when this Row's width axis is unbounded (else it
+                    // collapses to zero). See Modifier.trackMainAxisUnbounded; only tracked when a Fill
+                    // child could be affected.
                     val hasFillWidthChild = stackState.children.any { it.size.width == Fill }
                     val mainAxisUnbounded = remember { mutableStateOf(false) }
                     HorizontalStack(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.ProfileStore
 import androidx.webkit.WebViewCompat
@@ -37,6 +36,7 @@ import com.revenuecat.purchases.ui.revenuecatui.BuildConfig
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.extensions.trackMainAxisUnbounded
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 @JvmSynthetic
@@ -89,10 +89,12 @@ internal fun WebViewComponentView(
         // A `fill` axis genuinely unbounded at measure time (e.g. an ancestor scrolls, or a `Fit`-sized
         // container sits under one that does) would otherwise collapse to zero — `fillMaxWidth/Height`
         // passes an unbounded constraint straight through, and a bare WebView has no intrinsic size to
-        // fall back on. Tracked here and fed the same content-size/placeholder fallback `fit` already
-        // uses; see the `Modifier.layout` probe below.
-        var widthAxisUnbounded by remember { mutableStateOf(false) }
-        var heightAxisUnbounded by remember { mutableStateOf(false) }
+        // fall back on. Tracked here (reusing the same probe StackComponentView uses for its main axis)
+        // and fed the same content-size/placeholder fallback `fit` already uses.
+        val widthAxisUnboundedState = remember { mutableStateOf(false) }
+        val heightAxisUnboundedState = remember { mutableStateOf(false) }
+        val widthAxisUnbounded = widthAxisUnboundedState.value
+        val heightAxisUnbounded = heightAxisUnboundedState.value
 
         val effectiveSize = remember(
             style.size,
@@ -165,16 +167,8 @@ internal fun WebViewComponentView(
                 },
                 // Clip: content can briefly overflow while a fit axis animates placeholder -> measured.
                 modifier = modifier
-                    .layout { measurable, constraints ->
-                        val newWidthUnbounded = !constraints.hasBoundedWidth
-                        val newHeightUnbounded = !constraints.hasBoundedHeight
-                        if (newWidthUnbounded != widthAxisUnbounded) widthAxisUnbounded = newWidthUnbounded
-                        if (newHeightUnbounded != heightAxisUnbounded) heightAxisUnbounded = newHeightUnbounded
-                        val placeable = measurable.measure(constraints)
-                        layout(placeable.width, placeable.height) {
-                            placeable.place(0, 0)
-                        }
-                    }
+                    .trackMainAxisUnbounded(isHorizontal = true, unboundedState = widthAxisUnboundedState)
+                    .trackMainAxisUnbounded(isHorizontal = false, unboundedState = heightAxisUnboundedState)
                     .size(effectiveSize)
                     .clipToBounds(),
             )
@@ -216,10 +210,14 @@ internal fun resolveAxis(
     placeholder: UInt,
     unbounded: Boolean,
 ): SizeConstraint =
-    when {
-        constraint is Fit -> Fixed(if (contentCssPx > 0) contentCssPx.toUInt() else constraint.default ?: placeholder)
-        constraint is Fill && unbounded -> Fixed(if (contentCssPx > 0) contentCssPx.toUInt() else placeholder)
-        else -> constraint
+    when (constraint) {
+        is Fit -> Fixed(if (contentCssPx > 0) contentCssPx.toUInt() else constraint.default ?: placeholder)
+        is Fill -> if (unbounded) {
+            Fixed(if (contentCssPx > 0) contentCssPx.toUInt() else placeholder)
+        } else {
+            constraint
+        }
+        is Fixed -> constraint
     }
 
 /** Holds the per-WebView bridge so factory and onRelease share one instance. */

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.ProfileStore
 import androidx.webkit.WebViewCompat
@@ -29,6 +30,7 @@ import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.ui.revenuecatui.BuildConfig
@@ -84,11 +86,27 @@ internal fun WebViewComponentView(
         // Remembered inside key(identity) so a stale onRelease can only release its own view's bridge.
         val bridgeHolder = remember { WebViewBridgeHolder() }
 
-        val effectiveSize = remember(style.size, contentWidthCssPx, contentHeightCssPx) {
+        // A `fill` axis genuinely unbounded at measure time (e.g. an ancestor scrolls, or a `Fit`-sized
+        // container sits under one that does) would otherwise collapse to zero — `fillMaxWidth/Height`
+        // passes an unbounded constraint straight through, and a bare WebView has no intrinsic size to
+        // fall back on. Tracked here and fed the same content-size/placeholder fallback `fit` already
+        // uses; see the `Modifier.layout` probe below.
+        var widthAxisUnbounded by remember { mutableStateOf(false) }
+        var heightAxisUnbounded by remember { mutableStateOf(false) }
+
+        val effectiveSize = remember(
+            style.size,
+            contentWidthCssPx,
+            contentHeightCssPx,
+            widthAxisUnbounded,
+            heightAxisUnbounded,
+        ) {
             webViewEffectiveSize(
                 declaredSize = style.size,
                 contentWidthCssPx = contentWidthCssPx,
                 contentHeightCssPx = contentHeightCssPx,
+                widthAxisUnbounded = widthAxisUnbounded,
+                heightAxisUnbounded = heightAxisUnbounded,
             )
         }
 
@@ -147,6 +165,16 @@ internal fun WebViewComponentView(
                 },
                 // Clip: content can briefly overflow while a fit axis animates placeholder -> measured.
                 modifier = modifier
+                    .layout { measurable, constraints ->
+                        val newWidthUnbounded = !constraints.hasBoundedWidth
+                        val newHeightUnbounded = !constraints.hasBoundedHeight
+                        if (newWidthUnbounded != widthAxisUnbounded) widthAxisUnbounded = newWidthUnbounded
+                        if (newHeightUnbounded != heightAxisUnbounded) heightAxisUnbounded = newHeightUnbounded
+                        val placeable = measurable.measure(constraints)
+                        layout(placeable.width, placeable.height) {
+                            placeable.place(0, 0)
+                        }
+                    }
                     .size(effectiveSize)
                     .clipToBounds(),
             )
@@ -166,18 +194,31 @@ internal fun webViewEffectiveSize(
     declaredSize: Size,
     contentWidthCssPx: Int,
     contentHeightCssPx: Int,
+    widthAxisUnbounded: Boolean = false,
+    heightAxisUnbounded: Boolean = false,
 ): Size = Size(
-    width = resolveFitAxis(declaredSize.width, contentWidthCssPx, FIT_PLACEHOLDER_WIDTH),
-    height = resolveFitAxis(declaredSize.height, contentHeightCssPx, FIT_PLACEHOLDER_HEIGHT),
+    width = resolveAxis(declaredSize.width, contentWidthCssPx, FIT_PLACEHOLDER_WIDTH, widthAxisUnbounded),
+    height = resolveAxis(declaredSize.height, contentHeightCssPx, FIT_PLACEHOLDER_HEIGHT, heightAxisUnbounded),
 )
 
 /**
- * A `fit` axis resolves to the content-reported size once known, else the schema's `fit.default`, else
- * [placeholder]. Non-fit axes pass through unchanged.
+ * A `fit` axis always resolves to the content-reported size once known, else the schema's
+ * `fit.default`, else [placeholder]. A `fill` axis normally passes through unchanged (it fills its
+ * parent), but a bare WebView has no intrinsic size of its own to fall back on, so a `fill` axis
+ * that turns out to be [unbounded] at measure time (an ancestor scrolls, or a `Fit`-sized container
+ * sits under one that does) gets the same content/placeholder fallback `fit` uses — otherwise it
+ * would collapse to zero, since `fillMaxWidth`/`fillMaxHeight` just pass an unbounded constraint
+ * through. `fixed` axes, and a bounded `fill` axis, are untouched either way.
  */
-private fun resolveFitAxis(constraint: SizeConstraint, contentCssPx: Int, placeholder: UInt): SizeConstraint =
-    when (constraint) {
-        is Fit -> Fixed(if (contentCssPx > 0) contentCssPx.toUInt() else constraint.default ?: placeholder)
+internal fun resolveAxis(
+    constraint: SizeConstraint,
+    contentCssPx: Int,
+    placeholder: UInt,
+    unbounded: Boolean,
+): SizeConstraint =
+    when {
+        constraint is Fit -> Fixed(if (contentCssPx > 0) contentCssPx.toUInt() else constraint.default ?: placeholder)
+        constraint is Fill && unbounded -> Fixed(if (contentCssPx > 0) contentCssPx.toUInt() else placeholder)
         else -> constraint
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -36,6 +36,7 @@ import com.revenuecat.purchases.ui.revenuecatui.BuildConfig
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.trackMainAxisUnbounded
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
@@ -167,8 +168,13 @@ internal fun WebViewComponentView(
                 },
                 // Clip: content can briefly overflow while a fit axis animates placeholder -> measured.
                 modifier = modifier
-                    .trackMainAxisUnbounded(isHorizontal = true, unboundedState = widthAxisUnboundedState)
-                    .trackMainAxisUnbounded(isHorizontal = false, unboundedState = heightAxisUnboundedState)
+                    // Only Fill axes ever consult these (resolveAxis's Fixed/Fit branches ignore them).
+                    .conditional(style.size.width is Fill) {
+                        trackMainAxisUnbounded(isHorizontal = true, unboundedState = widthAxisUnboundedState)
+                    }
+                    .conditional(style.size.height is Fill) {
+                        trackMainAxisUnbounded(isHorizontal = false, unboundedState = heightAxisUnboundedState)
+                    }
                     .size(effectiveSize)
                     .clipToBounds(),
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
@@ -5,20 +5,25 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 
 /**
- * Tracks in [unboundedState] whether this modifier's incoming main-axis constraint is unbounded (an
- * ancestor scrolls, or a `Fit` container sits under one that does). Place it last in a Row/Column
- * chain to observe the constraint after the container's own sizing/scroll, or before a leaf's
- * `.size()` to observe the raw incoming one.
+ * Tracks in [unboundedState] whether this modifier's main-axis constraint leaves `weight` no space to
+ * distribute. Place it last in a Row/Column chain to observe the constraint after the container's own
+ * sizing/scroll, or before a leaf's `.size()` to observe the raw incoming one.
  *
- * A `weight`-ed child under an unbounded main axis collapses to zero (Compose's weight distribution
- * falls back to the axis minimum), so callers skip `weight` in that case and let the child take its
- * natural size instead.
+ * That means max == Infinity *and* min == 0: Compose distributes `mainAxisMax`, or `mainAxisMin` when
+ * max is Infinity (see RowColumnMeasurePolicy), so weight only collapses a child to zero when both
+ * are gone. A scroll that keeps a non-zero min (the default root paywall scroll does) still leaves
+ * weight working and must not count here. Callers skip `weight` when this is true, letting the child
+ * take its natural size instead of collapsing.
  */
 internal fun Modifier.trackMainAxisUnbounded(
     isHorizontal: Boolean,
     unboundedState: MutableState<Boolean>,
 ): Modifier = this.layout { measurable, constraints ->
-    unboundedState.value = if (isHorizontal) !constraints.hasBoundedWidth else !constraints.hasBoundedHeight
+    unboundedState.value = if (isHorizontal) {
+        !constraints.hasBoundedWidth && constraints.minWidth == 0
+    } else {
+        !constraints.hasBoundedHeight && constraints.minHeight == 0
+    }
     val placeable = measurable.measure(constraints)
     layout(placeable.width, placeable.height) {
         placeable.place(0, 0)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
@@ -7,10 +7,11 @@ import androidx.compose.ui.layout.layout
 /**
  * Tracks, in [unboundedState], whether this modifier's incoming main-axis constraint is
  * unbounded (e.g. because an ancestor scrolls, or a `Fit`-sized container sits under one that
- * does). Meant to be the LAST modifier in a Row/Column's chain, right before the Row/Column
- * itself, so it observes the constraint the container's own sizing (and any scroll) actually
- * produces — not the raw constraint the container received from its parent, which a `Fixed` size
- * or scroll modifier further up this same chain may still turn bounded.
+ * does). Where to place it in the chain depends on what the caller needs to observe: last, right
+ * before a Row/Column, to see the constraint its own sizing (and any scroll) actually produces —
+ * not the raw constraint it received from its parent, which a `Fixed` size or scroll modifier
+ * further up this same chain may still turn bounded; or earlier, before a leaf's own `.size()`
+ * call, to see the raw incoming constraint that sizing decision needs to react to.
  *
  * A container whose main axis is unbounded can't give a `weight`-ed child a meaningful share of
  * space (Compose's weight distribution falls back to the axis minimum, which is 0 whenever an
@@ -21,10 +22,7 @@ internal fun Modifier.trackMainAxisUnbounded(
     isHorizontal: Boolean,
     unboundedState: MutableState<Boolean>,
 ): Modifier = this.layout { measurable, constraints ->
-    val unbounded = if (isHorizontal) !constraints.hasBoundedWidth else !constraints.hasBoundedHeight
-    if (unbounded != unboundedState.value) {
-        unboundedState.value = unbounded
-    }
+    unboundedState.value = if (isHorizontal) !constraints.hasBoundedWidth else !constraints.hasBoundedHeight
     val placeable = measurable.measure(constraints)
     layout(placeable.width, placeable.height) {
         placeable.place(0, 0)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
@@ -5,18 +5,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 
 /**
- * Tracks, in [unboundedState], whether this modifier's incoming main-axis constraint is
- * unbounded (e.g. because an ancestor scrolls, or a `Fit`-sized container sits under one that
- * does). Where to place it in the chain depends on what the caller needs to observe: last, right
- * before a Row/Column, to see the constraint its own sizing (and any scroll) actually produces —
- * not the raw constraint it received from its parent, which a `Fixed` size or scroll modifier
- * further up this same chain may still turn bounded; or earlier, before a leaf's own `.size()`
- * call, to see the raw incoming constraint that sizing decision needs to react to.
+ * Tracks in [unboundedState] whether this modifier's incoming main-axis constraint is unbounded (an
+ * ancestor scrolls, or a `Fit` container sits under one that does). Place it last in a Row/Column
+ * chain to observe the constraint after the container's own sizing/scroll, or before a leaf's
+ * `.size()` to observe the raw incoming one.
  *
- * A container whose main axis is unbounded can't give a `weight`-ed child a meaningful share of
- * space (Compose's weight distribution falls back to the axis minimum, which is 0 whenever an
- * ancestor scroll or `Fit` wrapping relaxed it) — callers use this to skip `weight` in that case
- * and let the child fall back to its own natural size instead of collapsing to zero.
+ * A `weight`-ed child under an unbounded main axis collapses to zero (Compose's weight distribution
+ * falls back to the axis minimum), so callers skip `weight` in that case and let the child take its
+ * natural size instead.
  */
 internal fun Modifier.trackMainAxisUnbounded(
     isHorizontal: Boolean,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
@@ -1,6 +1,35 @@
 package com.revenuecat.purchases.ui.revenuecatui.extensions
 
+import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+
+/**
+ * Tracks, in [unboundedState], whether this modifier's incoming main-axis constraint is
+ * unbounded (e.g. because an ancestor scrolls, or a `Fit`-sized container sits under one that
+ * does). Meant to be the LAST modifier in a Row/Column's chain, right before the Row/Column
+ * itself, so it observes the constraint the container's own sizing (and any scroll) actually
+ * produces — not the raw constraint the container received from its parent, which a `Fixed` size
+ * or scroll modifier further up this same chain may still turn bounded.
+ *
+ * A container whose main axis is unbounded can't give a `weight`-ed child a meaningful share of
+ * space (Compose's weight distribution falls back to the axis minimum, which is 0 whenever an
+ * ancestor scroll or `Fit` wrapping relaxed it) — callers use this to skip `weight` in that case
+ * and let the child fall back to its own natural size instead of collapsing to zero.
+ */
+internal fun Modifier.trackMainAxisUnbounded(
+    isHorizontal: Boolean,
+    unboundedState: MutableState<Boolean>,
+): Modifier = this.layout { measurable, constraints ->
+    val unbounded = if (isHorizontal) !constraints.hasBoundedWidth else !constraints.hasBoundedHeight
+    if (unbounded != unboundedState.value) {
+        unboundedState.value = unbounded
+    }
+    val placeable = measurable.measure(constraints)
+    layout(placeable.width, placeable.height) {
+        placeable.place(0, 0)
+    }
+}
 
 internal fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> Modifier): Modifier {
     return if (condition) {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselFillCollapseTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselFillCollapseTest.kt
@@ -1,0 +1,117 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.carousel
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.CarouselComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.Dimension
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.VerticalAlignment
+import com.revenuecat.purchases.ui.revenuecatui.components.style.CarouselComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Regression test for a real customer paywall (`test_k`): a `Carousel` with no explicit `size`
+ * (schema default `Fit`/`Fit`) whose page and page content are both `Fill`/`Fill` rendered
+ * completely blank on Android, because every V2 paywall's root content is wrapped in a default
+ * `verticalScroll` (`LoadedPaywallComponents.kt`) unless the root stack itself already scrolls
+ * vertically. That relaxes the ambient height constraint to unbounded by the time it reaches the
+ * carousel's `HorizontalPager`, and a `Fill`-height page (and its `Fill`-height content) collapses
+ * to exactly zero via `Modifier.weight`'s unbounded-constraint fallback — see
+ * `StackComponentView.kt`'s `mainAxisUnbounded` tracking for the fix.
+ */
+@Config(sdk = [26])
+@RunWith(AndroidJUnit4::class)
+class CarouselFillCollapseTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `carousel page and content both Fill Fill render non-zero under the default root scroll`() {
+        // A real leaf with actual content, matching test_k's [TextComponent, WebViewComponent]
+        // content: an empty decorative box has zero intrinsic size and would correctly measure to
+        // 0 under any unbounded constraint (nothing to fix there) -- the bug this test guards
+        // against is that the CONTAINING stacks (page, content) collapse the incoming constraint
+        // itself via `weight`, hiding content that would otherwise render fine. `web_view`'s own
+        // fallback for a genuinely-unbounded Fill axis is covered separately in
+        // WebViewEffectiveSizeTest; this isolates the Stack-level fix.
+        val leaf = TextComponent(
+            text = LocalizationKey("dummyKey"),
+            color = ColorScheme(light = ColorInfo.Hex(Color.Black.toArgb())),
+            size = Size(width = Fit(), height = Fit()),
+        )
+        val content = StackComponent(
+            components = listOf(leaf),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.CENTER,
+                distribution = FlexDistribution.CENTER,
+            ),
+            size = Size(width = Fill, height = Fill),
+        )
+        val page = StackComponent(
+            components = listOf(content),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.CENTER,
+                distribution = FlexDistribution.CENTER,
+            ),
+            size = Size(width = Fill, height = Fill),
+        )
+        // No explicit `size` — matches the schema default (Fit/Fit) and test_k's real config.
+        val carousel = CarouselComponent(
+            pages = listOf(page),
+            pageAlignment = VerticalAlignment.CENTER,
+        )
+
+        val state = FakePaywallState(components = listOf(carousel))
+        val rootStack = state.stack as StackComponentStyle
+        val carouselStyle = rootStack.children.filterIsInstance<CarouselComponentStyle>().single()
+
+        var measuredHeight = -1
+
+        composeTestRule.setContent {
+            // Mirrors LoadedPaywallComponents.kt's real modifier chain on the root ComponentView:
+            // Modifier.fillMaxSize().conditional(shouldWrapMainContentInVerticalScroll) { verticalScroll(...) }
+            // — the default for every V2 paywall whose root stack doesn't itself scroll vertically.
+            Box(Modifier.fillMaxSize().height(800.dp)) {
+                Box(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                    CarouselComponentView(
+                        style = carouselStyle,
+                        state = state,
+                        clickHandler = {},
+                        modifier = Modifier.onGloballyPositioned { measuredHeight = it.size.height },
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        // Before the fix, this measured exactly 0 (matching the customer's blank screenshot).
+        assertThat(measuredHeight).isGreaterThan(0)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselFillMatchesFixedSiblingTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselFillMatchesFixedSiblingTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.paywalls.components.CarouselComponent
@@ -41,10 +42,9 @@ import org.robolectric.annotation.GraphicsMode
 import org.robolectric.shadows.ShadowPixelCopy
 
 /**
- * Regression test: a Fit-height carousel (the schema default) whose pages include a Fixed-height
- * sibling should size itself to that sibling and let a Fill-height page stretch to match, instead
- * of the container ending up tall (sized by the sibling) while the Fill page only wraps its own,
- * much smaller content -- see `CarouselComponentState.maxFixedPageHeight` for the fix.
+ * Regression tests: a Fit-height carousel (the schema default) sizes itself to its tallest page,
+ * and a Fill-height page must stretch to match rather than wrapping its own (much smaller) content
+ * -- see `CarouselComponentView`'s Pager-height fixpoint for the mechanism.
  */
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(shadows = [ShadowPixelCopy::class], sdk = [26])
@@ -80,51 +80,14 @@ class CarouselFillMatchesFixedSiblingTest {
             pageAlignment = VerticalAlignment.CENTER,
         )
 
-        val state = FakePaywallState(components = listOf(carousel))
-        val rootStack = state.stack as StackComponentStyle
-        val carouselStyle = rootStack.children.filterIsInstance<CarouselComponentStyle>().single()
-
-        var measuredHeightPx = -1
-
-        composeTestRule.setContent {
-            // Mirrors LoadedPaywallComponents.kt's real modifier chain on the root ComponentView.
-            Box(Modifier.fillMaxSize().height(800.dp)) {
-                Box(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
-                    CarouselComponentView(
-                        style = carouselStyle,
-                        state = state,
-                        clickHandler = {},
-                        modifier = Modifier
-                            .testTag("carousel")
-                            .onGloballyPositioned { measuredHeightPx = it.size.height },
-                    )
-                }
-            }
-        }
-
-        composeTestRule.waitForIdle()
-
-        val expectedHeightPx = with(composeTestRule.density) { 300.dp.roundToPx() }
-        // Before the fix, this wrapped to the Fill page's own (much smaller) content height.
-        assertThat(measuredHeightPx).isEqualTo(expectedHeightPx)
-
-        // The visible page (index 0, Fill/Fill, blue) must stretch all the way to the bottom edge,
-        // not just wrap its content and leave the rest of the Fixed sibling's height blank.
-        composeTestRule.onNodeWithTag("carousel")
-            .assertPixelColorEquals(
-                color = Color.Blue,
-                startX = 10,
-                startY = expectedHeightPx - 10,
-                width = 1,
-                height = 1,
-            )
+        assertFillPageStretchesTo(carousel, expectedHeight = 300.dp)
     }
 
     @Test
     fun `Fill page stretches to match a sibling whose height comes from a nested Fixed descendant`() {
         // Matches a real customer paywall: the tall sibling page itself declares Fit/Fit, but wraps
-        // a Fixed(350)/Fixed(350) content stack -- there is no top-level Fixed page to read from the
-        // schema, only a real, naturally-tall measured page.
+        // a Fixed(350) content stack -- there is no top-level Fixed page to read from the schema,
+        // only a real, naturally-tall measured page.
         val fillPage = StackComponent(
             components = listOf(
                 StackComponent(
@@ -149,6 +112,15 @@ class CarouselFillMatchesFixedSiblingTest {
             pageAlignment = VerticalAlignment.CENTER,
         )
 
+        assertFillPageStretchesTo(carousel, expectedHeight = 350.dp)
+    }
+
+    /**
+     * Renders [carousel] under the real default root-scroll chain and asserts it measures to
+     * [expectedHeight] (the tallest page) and that the visible Fill page (blue) stretches all the
+     * way to the bottom edge, rather than wrapping its own content and leaving the rest blank.
+     */
+    private fun assertFillPageStretchesTo(carousel: CarouselComponent, expectedHeight: Dp) {
         val state = FakePaywallState(components = listOf(carousel))
         val rootStack = state.stack as StackComponentStyle
         val carouselStyle = rootStack.children.filterIsInstance<CarouselComponentStyle>().single()
@@ -156,6 +128,7 @@ class CarouselFillMatchesFixedSiblingTest {
         var measuredHeightPx = -1
 
         composeTestRule.setContent {
+            // Mirrors LoadedPaywallComponents.kt's real modifier chain on the root ComponentView.
             Box(Modifier.fillMaxSize().height(800.dp)) {
                 Box(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
                     CarouselComponentView(
@@ -172,7 +145,8 @@ class CarouselFillMatchesFixedSiblingTest {
 
         composeTestRule.waitForIdle()
 
-        val expectedHeightPx = with(composeTestRule.density) { 350.dp.roundToPx() }
+        val expectedHeightPx = with(composeTestRule.density) { expectedHeight.roundToPx() }
+        // Before the fix, this wrapped to the Fill page's own (much smaller) content height.
         assertThat(measuredHeightPx).isEqualTo(expectedHeightPx)
 
         composeTestRule.onNodeWithTag("carousel")

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselFillMatchesFixedSiblingTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselFillMatchesFixedSiblingTest.kt
@@ -119,4 +119,69 @@ class CarouselFillMatchesFixedSiblingTest {
                 height = 1,
             )
     }
+
+    @Test
+    fun `Fill page stretches to match a sibling whose height comes from a nested Fixed descendant`() {
+        // Matches a real customer paywall: the tall sibling page itself declares Fit/Fit, but wraps
+        // a Fixed(350)/Fixed(350) content stack -- there is no top-level Fixed page to read from the
+        // schema, only a real, naturally-tall measured page.
+        val fillPage = StackComponent(
+            components = listOf(
+                StackComponent(
+                    components = emptyList(),
+                    size = Size(width = Fill, height = Fill),
+                    backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                ),
+            ),
+            size = Size(width = Fill, height = Fill),
+        )
+        val nestedFixedSiblingPage = StackComponent(
+            components = listOf(
+                StackComponent(
+                    components = emptyList(),
+                    size = Size(width = Fixed(350u), height = Fixed(350u)),
+                ),
+            ),
+            size = Size(width = Fit(), height = Fit()),
+        )
+        val carousel = CarouselComponent(
+            pages = listOf(fillPage, nestedFixedSiblingPage),
+            pageAlignment = VerticalAlignment.CENTER,
+        )
+
+        val state = FakePaywallState(components = listOf(carousel))
+        val rootStack = state.stack as StackComponentStyle
+        val carouselStyle = rootStack.children.filterIsInstance<CarouselComponentStyle>().single()
+
+        var measuredHeightPx = -1
+
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize().height(800.dp)) {
+                Box(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                    CarouselComponentView(
+                        style = carouselStyle,
+                        state = state,
+                        clickHandler = {},
+                        modifier = Modifier
+                            .testTag("carousel")
+                            .onGloballyPositioned { measuredHeightPx = it.size.height },
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        val expectedHeightPx = with(composeTestRule.density) { 350.dp.roundToPx() }
+        assertThat(measuredHeightPx).isEqualTo(expectedHeightPx)
+
+        composeTestRule.onNodeWithTag("carousel")
+            .assertPixelColorEquals(
+                color = Color.Blue,
+                startX = 10,
+                startY = expectedHeightPx - 10,
+                width = 1,
+                height = 1,
+            )
+    }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselFillMatchesFixedSiblingTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselFillMatchesFixedSiblingTest.kt
@@ -1,0 +1,122 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.carousel
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.CarouselComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.Dimension
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import com.revenuecat.purchases.paywalls.components.properties.VerticalAlignment
+import com.revenuecat.purchases.ui.revenuecatui.assertions.assertPixelColorEquals
+import com.revenuecat.purchases.ui.revenuecatui.components.style.CarouselComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowPixelCopy
+
+/**
+ * Regression test: a Fit-height carousel (the schema default) whose pages include a Fixed-height
+ * sibling should size itself to that sibling and let a Fill-height page stretch to match, instead
+ * of the container ending up tall (sized by the sibling) while the Fill page only wraps its own,
+ * much smaller content -- see `CarouselComponentState.maxFixedPageHeight` for the fix.
+ */
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(shadows = [ShadowPixelCopy::class], sdk = [26])
+@RunWith(AndroidJUnit4::class)
+class CarouselFillMatchesFixedSiblingTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `Fill page stretches to match a Fixed sibling page's height`() {
+        val leaf = TextComponent(
+            text = LocalizationKey("dummyKey"),
+            color = ColorScheme(light = ColorInfo.Hex(Color.Black.toArgb())),
+            size = Size(width = Fit(), height = Fit()),
+        )
+        val fillPage = StackComponent(
+            components = listOf(leaf),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.CENTER,
+                distribution = FlexDistribution.CENTER,
+            ),
+            size = Size(width = Fill, height = Fill),
+            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+        )
+        val fixedSiblingPage = StackComponent(
+            components = emptyList(),
+            size = Size(width = Fill, height = Fixed(300u)),
+        )
+        // No explicit carousel `size` -- matches the schema default (Fit/Fit).
+        val carousel = CarouselComponent(
+            pages = listOf(fillPage, fixedSiblingPage),
+            pageAlignment = VerticalAlignment.CENTER,
+        )
+
+        val state = FakePaywallState(components = listOf(carousel))
+        val rootStack = state.stack as StackComponentStyle
+        val carouselStyle = rootStack.children.filterIsInstance<CarouselComponentStyle>().single()
+
+        var measuredHeightPx = -1
+
+        composeTestRule.setContent {
+            // Mirrors LoadedPaywallComponents.kt's real modifier chain on the root ComponentView.
+            Box(Modifier.fillMaxSize().height(800.dp)) {
+                Box(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                    CarouselComponentView(
+                        style = carouselStyle,
+                        state = state,
+                        clickHandler = {},
+                        modifier = Modifier
+                            .testTag("carousel")
+                            .onGloballyPositioned { measuredHeightPx = it.size.height },
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        val expectedHeightPx = with(composeTestRule.density) { 300.dp.roundToPx() }
+        // Before the fix, this wrapped to the Fill page's own (much smaller) content height.
+        assertThat(measuredHeightPx).isEqualTo(expectedHeightPx)
+
+        // The visible page (index 0, Fill/Fill, blue) must stretch all the way to the bottom edge,
+        // not just wrap its content and leave the rest of the Fixed sibling's height blank.
+        composeTestRule.onNodeWithTag("carousel")
+            .assertPixelColorEquals(
+                color = Color.Blue,
+                startX = 10,
+                startY = expectedHeightPx - 10,
+                width = 1,
+                height = 1,
+            )
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselFillMatchesFixedSiblingTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselFillMatchesFixedSiblingTest.kt
@@ -44,7 +44,8 @@ import org.robolectric.shadows.ShadowPixelCopy
 /**
  * Regression tests: a Fit-height carousel (the schema default) sizes itself to its tallest page,
  * and a Fill-height page must stretch to match rather than wrapping its own (much smaller) content
- * -- see `CarouselComponentView`'s Pager-height fixpoint for the mechanism.
+ * -- see `CarouselComponentView`, which leaves the Pager unpinned (so it keeps tracking the tallest
+ * page) and pins only the Fill pages to that measured height.
  */
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(shadows = [ShadowPixelCopy::class], sdk = [26])

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackFillUnboundedCollapseTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackFillUnboundedCollapseTest.kt
@@ -1,0 +1,171 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.stack
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.Dimension
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.VerticalAlignment
+import com.revenuecat.purchases.ui.revenuecatui.assertions.assertPixelColorEquals
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.StyleFactory
+import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowPixelCopy
+
+/**
+ * Regression tests for the `Fill`-child-collapses-under-an-unbounded-main-axis bug fixed via
+ * `mainAxisUnbounded` tracking in `StackComponentView.kt`. See `CarouselFillCollapseTest` for the
+ * broader real-world repro (a Carousel with no scroll declared at all); these focus on the
+ * `Stack`-level mechanism directly, including the earlier, narrower "explicit `overflow: scroll`"
+ * case this fix subsumes.
+ */
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(shadows = [ShadowPixelCopy::class], sdk = [26])
+@RunWith(AndroidJUnit4::class)
+class StackFillUnboundedCollapseTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val styleFactory = StyleFactory()
+
+    @Test
+    fun `Fit stack with explicit vertical scroll no longer collapses a Fill child`() {
+        // A real leaf with actual content: an empty decorative box has zero intrinsic size and
+        // would correctly measure to 0 under any unbounded constraint regardless of this fix
+        // (nothing to rescue there). The bug is that the CONTAINING stack collapses the incoming
+        // constraint itself via `weight`, hiding content that would otherwise render fine.
+        val child = TextComponent(
+            text = LocalizationKey("dummy"),
+            color = ColorScheme(light = ColorInfo.Hex(Color.Black.toArgb())),
+            size = Size(width = Fill, height = Fill),
+        )
+        val stack = StackComponent(
+            components = listOf(child),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.CENTER,
+                distribution = FlexDistribution.START,
+            ),
+            size = Size(width = Fit(), height = Fit()),
+            overflow = StackComponent.Overflow.SCROLL,
+        )
+        val style = styleFactory.create(stack).getOrThrow().componentStyle as StackComponentStyle
+
+        var measuredHeight = -1
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize().height(800.dp)) {
+                StackComponentView(
+                    style = style,
+                    state = FakePaywallState(components = emptyList()),
+                    clickHandler = {},
+                    modifier = Modifier.onGloballyPositioned { measuredHeight = it.size.height },
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        // Before the fix, this measured exactly 0 (Modifier.weight's unbounded-constraint fallback).
+        assertThat(measuredHeight).isGreaterThan(0)
+    }
+
+    @Test
+    fun `Fixed stack under an ambient-unbounded scroll still distributes weight between Fill siblings`() {
+        // Guards the probe's placement: it must observe the constraint AFTER this stack's own
+        // .size() is applied, not the raw incoming constraint. A Fixed-sized stack establishes its
+        // own bound regardless of what's above it, so its Fill children must keep real weight()
+        // distribution -- if the probe were placed before .size(), an ambient scroll would wrongly
+        // disable weight() even though Fixed(200) already gives the Row a real bound.
+        assertTwoFillSiblingsSplitEvenly(stackSize = Size(width = Fixed(200u), height = Fixed(50u))) { content ->
+            Box(Modifier.fillMaxSize().height(800.dp)) {
+                Box(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                    content()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `bounded Fill siblings still split proportionally, no scroll involved`() {
+        assertTwoFillSiblingsSplitEvenly(stackSize = Size(width = Fixed(200u), height = Fixed(50u))) { content ->
+            Box(Modifier.fillMaxSize().height(800.dp)) {
+                content()
+            }
+        }
+    }
+
+    /**
+     * Renders a horizontal stack of [stackSize] with two `Fill`-width children (red, then blue)
+     * wrapped in [wrapper], and asserts each occupies roughly its own half of the stack's width --
+     * i.e. that `Modifier.weight` is still doing real proportional distribution, not that one
+     * child silently took everything (which is what happens if `weight` gets disabled when it
+     * shouldn't be).
+     */
+    private fun assertTwoFillSiblingsSplitEvenly(
+        stackSize: Size,
+        wrapper: @androidx.compose.runtime.Composable (content: @androidx.compose.runtime.Composable () -> Unit) -> Unit,
+    ) {
+        val redChild = StackComponent(
+            components = emptyList(),
+            size = Size(width = Fill, height = Fill),
+            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+        )
+        val blueChild = StackComponent(
+            components = emptyList(),
+            size = Size(width = Fill, height = Fill),
+            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+        )
+        val stack = StackComponent(
+            components = listOf(redChild, blueChild),
+            dimension = Dimension.Horizontal(alignment = VerticalAlignment.CENTER, distribution = FlexDistribution.START),
+            size = stackSize,
+        )
+        val style = styleFactory.create(stack).getOrThrow().componentStyle as StackComponentStyle
+
+        composeTestRule.setContent {
+            wrapper {
+                StackComponentView(
+                    style = style,
+                    state = FakePaywallState(components = emptyList()),
+                    clickHandler = {},
+                    modifier = Modifier.testTag("stack"),
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("stack")
+            // Deep into the first quarter: must be red.
+            .assertPixelColorEquals(color = Color.Red, startX = 10, startY = 10, width = 1, height = 1)
+            // Deep into the last quarter: must be blue. Would still be red if weight() were
+            // incorrectly disabled (the first Fill child would greedily take the whole width).
+            .assertPixelColorEquals(color = Color.Blue, startX = 190, startY = 10, width = 1, height = 1)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackFillUnboundedCollapseTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackFillUnboundedCollapseTest.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.paywalls.components.StackComponent
@@ -79,11 +78,7 @@ class StackFillUnboundedCollapseTest {
         // bound, so its two Fill-height children must still split it 50/50 via weight(). If the
         // probe read the constraint BEFORE .size(), it would see the ambient unbounded axis and
         // wrongly disable weight() -- this test would then fail.
-        assertTwoFillSiblingsSplitEvenly(
-            dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
-            mainAxis = 200.dp,
-            crossAxis = 100.dp,
-        ) { content ->
+        assertTwoFillSiblingsSplitEvenly(horizontal = false) { content ->
             Box(Modifier.fillMaxSize().height(800.dp)) {
                 Box(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
                     content()
@@ -94,11 +89,7 @@ class StackFillUnboundedCollapseTest {
 
     @Test
     fun `bounded Fill siblings still split proportionally, no scroll involved`() {
-        assertTwoFillSiblingsSplitEvenly(
-            dimension = Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START),
-            mainAxis = 200.dp,
-            crossAxis = 100.dp,
-        ) { content ->
+        assertTwoFillSiblingsSplitEvenly(horizontal = true) { content ->
             Box(Modifier.fillMaxSize().height(800.dp)) {
                 content()
             }
@@ -148,20 +139,19 @@ class StackFillUnboundedCollapseTest {
     }
 
     /**
-     * Renders a [dimension] stack of [mainAxis] x [crossAxis] with two `Fill` children (red, then
-     * blue) wrapped in [wrapper], and asserts each occupies its own half of the main axis -- i.e.
-     * that `Modifier.weight` is still doing real proportional distribution, not that one child
-     * silently took everything (which is what happens if `weight` gets disabled when it shouldn't).
-     * Pixel positions are derived from [mainAxis]/[crossAxis] via the current density so the
-     * assertions hold regardless of the screen density Robolectric runs at.
+     * Renders a [horizontal] (else vertical) stack of `mainAxis` x `crossAxis` with two `Fill`
+     * children (red, then blue) wrapped in [wrapper], and asserts each occupies its own half of the
+     * main axis -- i.e. that `Modifier.weight` is still doing real proportional distribution, not
+     * that one child silently took everything (which is what happens if `weight` gets disabled when
+     * it shouldn't). Pixel positions are derived via the current density so the assertions hold
+     * regardless of the screen density Robolectric runs at.
      */
     private fun assertTwoFillSiblingsSplitEvenly(
-        dimension: Dimension,
-        mainAxis: Dp,
-        crossAxis: Dp,
+        horizontal: Boolean,
         wrapper: @Composable (content: @Composable () -> Unit) -> Unit,
     ) {
-        val horizontal = dimension is Dimension.Horizontal
+        val mainAxis = 200.dp
+        val crossAxis = 100.dp
         val redChild = StackComponent(
             components = emptyList(),
             size = Size(width = Fill, height = Fill),
@@ -174,7 +164,11 @@ class StackFillUnboundedCollapseTest {
         )
         val stack = StackComponent(
             components = listOf(redChild, blueChild),
-            dimension = dimension,
+            dimension = if (horizontal) {
+                Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START)
+            } else {
+                Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START)
+            },
             size = if (horizontal) {
                 Size(width = Fixed(mainAxis.value.toUInt()), height = Fixed(crossAxis.value.toUInt()))
             } else {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackFillUnboundedCollapseTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackFillUnboundedCollapseTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.paywalls.components.StackComponent
@@ -45,8 +46,8 @@ import org.robolectric.shadows.ShadowPixelCopy
  * Regression tests for the `Fill`-child-collapses-under-an-unbounded-main-axis bug fixed via
  * `mainAxisUnbounded` tracking in `StackComponentView.kt`. See `CarouselFillCollapseTest` for the
  * broader real-world repro (a Carousel with no scroll declared at all); these focus on the
- * `Stack`-level mechanism directly, including the earlier, narrower "explicit `overflow: scroll`"
- * case this fix subsumes.
+ * `Stack`-level mechanism directly, on both axes, including the earlier, narrower "explicit
+ * `overflow: scroll`" case this fix subsumes.
  */
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(shadows = [ShadowPixelCopy::class], sdk = [26])
@@ -60,51 +61,29 @@ class StackFillUnboundedCollapseTest {
 
     @Test
     fun `Fit stack with explicit vertical scroll no longer collapses a Fill child`() {
-        // A real leaf with actual content: an empty decorative box has zero intrinsic size and
-        // would correctly measure to 0 under any unbounded constraint regardless of this fix
-        // (nothing to rescue there). The bug is that the CONTAINING stack collapses the incoming
-        // constraint itself via `weight`, hiding content that would otherwise render fine.
-        val child = TextComponent(
-            text = LocalizationKey("dummy"),
-            color = ColorScheme(light = ColorInfo.Hex(Color.Black.toArgb())),
-            size = Size(width = Fill, height = Fill),
-        )
-        val stack = StackComponent(
-            components = listOf(child),
-            dimension = Dimension.Vertical(
-                alignment = HorizontalAlignment.CENTER,
-                distribution = FlexDistribution.START,
-            ),
-            size = Size(width = Fit(), height = Fit()),
-            overflow = StackComponent.Overflow.SCROLL,
-        )
-        val style = styleFactory.create(stack).getOrThrow().componentStyle as StackComponentStyle
-
-        var measuredHeight = -1
-        composeTestRule.setContent {
-            Box(Modifier.fillMaxSize().height(800.dp)) {
-                StackComponentView(
-                    style = style,
-                    state = FakePaywallState(components = emptyList()),
-                    clickHandler = {},
-                    modifier = Modifier.onGloballyPositioned { measuredHeight = it.size.height },
-                )
-            }
-        }
-
-        composeTestRule.waitForIdle()
-        // Before the fix, this measured exactly 0 (Modifier.weight's unbounded-constraint fallback).
-        assertThat(measuredHeight).isGreaterThan(0)
+        assertScrollingFitStackKeepsFillChild(vertical = true)
     }
 
     @Test
-    fun `Fixed stack under an ambient-unbounded scroll still distributes weight between Fill siblings`() {
+    fun `Fit stack with explicit horizontal scroll no longer collapses a Fill child`() {
+        // The horizontal counterpart of the fix path (StackComponentView's Horizontal branch): a
+        // Fill-width child under a Fit-width stack whose own width axis scrolls (so it's unbounded).
+        assertScrollingFitStackKeepsFillChild(vertical = false)
+    }
+
+    @Test
+    fun `Fixed-height vertical stack under an ambient vertical scroll still distributes weight`() {
         // Guards the probe's placement: it must observe the constraint AFTER this stack's own
-        // .size() is applied, not the raw incoming constraint. A Fixed-sized stack establishes its
-        // own bound regardless of what's above it, so its Fill children must keep real weight()
-        // distribution -- if the probe were placed before .size(), an ambient scroll would wrongly
-        // disable weight() even though Fixed(200) already gives the Row a real bound.
-        assertTwoFillSiblingsSplitEvenly(stackSize = Size(width = Fixed(200u), height = Fixed(50u))) { content ->
+        // .size() is applied, not the raw incoming one. Here the ambient verticalScroll relaxes the
+        // vertical (main) axis to unbounded, but the stack's own Fixed(200) height re-establishes a
+        // bound, so its two Fill-height children must still split it 50/50 via weight(). If the
+        // probe read the constraint BEFORE .size(), it would see the ambient unbounded axis and
+        // wrongly disable weight() -- this test would then fail.
+        assertTwoFillSiblingsSplitEvenly(
+            dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+            mainAxis = 200.dp,
+            crossAxis = 100.dp,
+        ) { content ->
             Box(Modifier.fillMaxSize().height(800.dp)) {
                 Box(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
                     content()
@@ -115,24 +94,74 @@ class StackFillUnboundedCollapseTest {
 
     @Test
     fun `bounded Fill siblings still split proportionally, no scroll involved`() {
-        assertTwoFillSiblingsSplitEvenly(stackSize = Size(width = Fixed(200u), height = Fixed(50u))) { content ->
+        assertTwoFillSiblingsSplitEvenly(
+            dimension = Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START),
+            mainAxis = 200.dp,
+            crossAxis = 100.dp,
+        ) { content ->
             Box(Modifier.fillMaxSize().height(800.dp)) {
                 content()
             }
         }
     }
 
+    private fun assertScrollingFitStackKeepsFillChild(vertical: Boolean) {
+        // A real leaf with actual content: an empty decorative box has zero intrinsic size and
+        // would correctly measure to 0 under any unbounded constraint regardless of this fix
+        // (nothing to rescue there). The bug is that the CONTAINING stack collapses the incoming
+        // constraint itself via `weight`, hiding content that would otherwise render fine.
+        val child = TextComponent(
+            text = LocalizationKey("dummy"),
+            color = ColorScheme(light = ColorInfo.Hex(Color.Black.toArgb())),
+            size = Size(width = Fill, height = Fill),
+        )
+        val dimension = if (vertical) {
+            Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START)
+        } else {
+            Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START)
+        }
+        val stack = StackComponent(
+            components = listOf(child),
+            dimension = dimension,
+            size = Size(width = Fit(), height = Fit()),
+            overflow = StackComponent.Overflow.SCROLL,
+        )
+        val style = styleFactory.create(stack).getOrThrow().componentStyle as StackComponentStyle
+
+        var measuredSize = -1
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize().height(800.dp)) {
+                StackComponentView(
+                    style = style,
+                    state = FakePaywallState(components = emptyList()),
+                    clickHandler = {},
+                    modifier = Modifier.onGloballyPositioned {
+                        measuredSize = if (vertical) it.size.height else it.size.width
+                    },
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        // Before the fix, this measured exactly 0 (Modifier.weight's unbounded-constraint fallback).
+        assertThat(measuredSize).isGreaterThan(0)
+    }
+
     /**
-     * Renders a horizontal stack of [stackSize] with two `Fill`-width children (red, then blue)
-     * wrapped in [wrapper], and asserts each occupies roughly its own half of the stack's width --
-     * i.e. that `Modifier.weight` is still doing real proportional distribution, not that one
-     * child silently took everything (which is what happens if `weight` gets disabled when it
-     * shouldn't be).
+     * Renders a [dimension] stack of [mainAxis] x [crossAxis] with two `Fill` children (red, then
+     * blue) wrapped in [wrapper], and asserts each occupies its own half of the main axis -- i.e.
+     * that `Modifier.weight` is still doing real proportional distribution, not that one child
+     * silently took everything (which is what happens if `weight` gets disabled when it shouldn't).
+     * Pixel positions are derived from [mainAxis]/[crossAxis] via the current density so the
+     * assertions hold regardless of the screen density Robolectric runs at.
      */
     private fun assertTwoFillSiblingsSplitEvenly(
-        stackSize: Size,
+        dimension: Dimension,
+        mainAxis: Dp,
+        crossAxis: Dp,
         wrapper: @Composable (content: @Composable () -> Unit) -> Unit,
     ) {
+        val horizontal = dimension is Dimension.Horizontal
         val redChild = StackComponent(
             components = emptyList(),
             size = Size(width = Fill, height = Fill),
@@ -145,8 +174,12 @@ class StackFillUnboundedCollapseTest {
         )
         val stack = StackComponent(
             components = listOf(redChild, blueChild),
-            dimension = Dimension.Horizontal(alignment = VerticalAlignment.CENTER, distribution = FlexDistribution.START),
-            size = stackSize,
+            dimension = dimension,
+            size = if (horizontal) {
+                Size(width = Fixed(mainAxis.value.toUInt()), height = Fixed(crossAxis.value.toUInt()))
+            } else {
+                Size(width = Fixed(crossAxis.value.toUInt()), height = Fixed(mainAxis.value.toUInt()))
+            },
         )
         val style = styleFactory.create(stack).getOrThrow().componentStyle as StackComponentStyle
 
@@ -162,11 +195,17 @@ class StackFillUnboundedCollapseTest {
         }
 
         composeTestRule.waitForIdle()
+        val (mainPx, crossPx) = with(composeTestRule.density) { mainAxis.roundToPx() to crossAxis.roundToPx() }
+        // Deep in the first main-axis quarter must be red, deep in the last quarter blue. If weight()
+        // were wrongly disabled the first Fill child would greedily take everything, so the last
+        // quarter would still be red.
+        val firstQuarter = mainPx / 4
+        val lastQuarter = mainPx * 3 / 4
+        val crossMid = crossPx / 2
+        val (redX, redY) = if (horizontal) firstQuarter to crossMid else crossMid to firstQuarter
+        val (blueX, blueY) = if (horizontal) lastQuarter to crossMid else crossMid to lastQuarter
         composeTestRule.onNodeWithTag("stack")
-            // Deep into the first quarter: must be red.
-            .assertPixelColorEquals(color = Color.Red, startX = 10, startY = 10, width = 1, height = 1)
-            // Deep into the last quarter: must be blue. Would still be red if weight() were
-            // incorrectly disabled (the first Fill child would greedily take the whole width).
-            .assertPixelColorEquals(color = Color.Blue, startX = 190, startY = 10, width = 1, height = 1)
+            .assertPixelColorEquals(color = Color.Red, startX = redX, startY = redY, width = 1, height = 1)
+            .assertPixelColorEquals(color = Color.Blue, startX = blueX, startY = blueY, width = 1, height = 1)
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackFillUnboundedCollapseTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackFillUnboundedCollapseTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -130,7 +131,7 @@ class StackFillUnboundedCollapseTest {
      */
     private fun assertTwoFillSiblingsSplitEvenly(
         stackSize: Size,
-        wrapper: @androidx.compose.runtime.Composable (content: @androidx.compose.runtime.Composable () -> Unit) -> Unit,
+        wrapper: @Composable (content: @Composable () -> Unit) -> Unit,
     ) {
         val redChild = StackComponent(
             components = emptyList(),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackFillUnboundedCollapseTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackFillUnboundedCollapseTest.kt
@@ -88,6 +88,51 @@ class StackFillUnboundedCollapseTest {
     }
 
     @Test
+    fun `Fill child still stretches under the real root scroll chain`() {
+        // Regression (template_019): LoadedPaywallComponents applies `fillMaxSize().verticalScroll()`
+        // to the root stack's own node, so the stack sees minHeight = viewport with maxHeight =
+        // Infinity. Compose distributes that min, so weight still works and must NOT be skipped --
+        // treating "max is Infinity" alone as unbounded made every Fill child on such a paywall wrap
+        // its content instead of stretching. (Wrapping the scroll around a parent Box does not
+        // reproduce this: Box relaxes its child's min to 0.)
+        val fillChild = StackComponent(
+            components = emptyList(),
+            size = Size(width = Fill, height = Fill),
+            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+        )
+        val root = StackComponent(
+            components = listOf(
+                StackComponent(components = emptyList(), size = Size(width = Fill, height = Fixed(100u))),
+                fillChild,
+            ),
+            dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+            size = Size(width = Fill, height = Fill),
+        )
+        val style = styleFactory.create(root).getOrThrow().componentStyle as StackComponentStyle
+
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize().height(800.dp)) {
+                StackComponentView(
+                    style = style,
+                    state = FakePaywallState(components = emptyList()),
+                    clickHandler = {},
+                    modifier = Modifier
+                        .testTag("stack")
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        // The Fill child must stretch through the remaining height, so near the bottom edge is red.
+        // Without weight it wraps its (empty) content to zero and nothing is drawn there.
+        val node = composeTestRule.onNodeWithTag("stack")
+        val bottom = node.fetchSemanticsNode().size.height - 5
+        node.assertPixelColorEquals(Color.Red, startX = 10, startY = bottom, width = 1, height = 1)
+    }
+
+    @Test
     fun `bounded Fill siblings still split proportionally, no scroll involved`() {
         assertTwoFillSiblingsSplitEvenly(horizontal = true) { content ->
             Box(Modifier.fillMaxSize().height(800.dp)) {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
@@ -76,7 +76,8 @@ internal class WebViewEffectiveSizeTest {
         // A bare WebView has no intrinsic size, so a fill axis that's genuinely unbounded at
         // measure time (an ancestor scrolls, or a Fit container sits under one that does) would
         // otherwise collapse to zero, since fillMaxWidth/Height just passes the unbounded
-        // constraint through.
+        // constraint through. Fill (unlike Fit) also carries no `default` field in the schema, so
+        // there's nothing to fall back on but the hardcoded placeholder.
         val size = webViewEffectiveSize(
             declaredSize = Size(width = Fill, height = Fill),
             contentWidthCssPx = 0,
@@ -101,22 +102,6 @@ internal class WebViewEffectiveSizeTest {
 
         assertThat(size.width).isEqualTo(Fixed(320u))
         assertThat(size.height).isEqualTo(Fixed(480u))
-    }
-
-    @Test
-    fun `unbounded fill axes have no schema default to fall back on, unlike fit`() {
-        // Fill (unlike Fit) carries no `default` field in the schema, so an unbounded Fill axis
-        // with no reported content size falls straight to the hardcoded placeholder.
-        val size = webViewEffectiveSize(
-            declaredSize = Size(width = Fill, height = Fill),
-            contentWidthCssPx = 0,
-            contentHeightCssPx = 0,
-            widthAxisUnbounded = true,
-            heightAxisUnbounded = true,
-        )
-
-        assertThat(size.width).isEqualTo(Fixed(FIT_PLACEHOLDER_WIDTH))
-        assertThat(size.height).isEqualTo(Fixed(FIT_PLACEHOLDER_HEIGHT))
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
@@ -56,4 +56,80 @@ internal class WebViewEffectiveSizeTest {
         assertThat(size.width).isEqualTo(Fill)
         assertThat(size.height).isEqualTo(Fixed(200u))
     }
+
+    @Test
+    fun `bounded fill axes are left untouched`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fill, height = Fill),
+            contentWidthCssPx = 0,
+            contentHeightCssPx = 0,
+            widthAxisUnbounded = false,
+            heightAxisUnbounded = false,
+        )
+
+        assertThat(size.width).isEqualTo(Fill)
+        assertThat(size.height).isEqualTo(Fill)
+    }
+
+    @Test
+    fun `unbounded fill axes use the placeholder until the content reports a size`() {
+        // A bare WebView has no intrinsic size, so a fill axis that's genuinely unbounded at
+        // measure time (an ancestor scrolls, or a Fit container sits under one that does) would
+        // otherwise collapse to zero, since fillMaxWidth/Height just passes the unbounded
+        // constraint through.
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fill, height = Fill),
+            contentWidthCssPx = 0,
+            contentHeightCssPx = 0,
+            widthAxisUnbounded = true,
+            heightAxisUnbounded = true,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(FIT_PLACEHOLDER_WIDTH))
+        assertThat(size.height).isEqualTo(Fixed(FIT_PLACEHOLDER_HEIGHT))
+    }
+
+    @Test
+    fun `unbounded fill axes use the reported content size once available`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fill, height = Fill),
+            contentWidthCssPx = 320,
+            contentHeightCssPx = 480,
+            widthAxisUnbounded = true,
+            heightAxisUnbounded = true,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(320u))
+        assertThat(size.height).isEqualTo(Fixed(480u))
+    }
+
+    @Test
+    fun `unbounded fill axes have no schema default to fall back on, unlike fit`() {
+        // Fill (unlike Fit) carries no `default` field in the schema, so an unbounded Fill axis
+        // with no reported content size falls straight to the hardcoded placeholder.
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fill, height = Fill),
+            contentWidthCssPx = 0,
+            contentHeightCssPx = 0,
+            widthAxisUnbounded = true,
+            heightAxisUnbounded = true,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(FIT_PLACEHOLDER_WIDTH))
+        assertThat(size.height).isEqualTo(Fixed(FIT_PLACEHOLDER_HEIGHT))
+    }
+
+    @Test
+    fun `fixed axes are never affected by unbounded tracking`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(width = Fixed(200u), height = Fixed(300u)),
+            contentWidthCssPx = 320,
+            contentHeightCssPx = 480,
+            widthAxisUnbounded = true,
+            heightAxisUnbounded = true,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(200u))
+        assertThat(size.height).isEqualTo(Fixed(300u))
+    }
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Paywalls V2 `Fill`-sized content collapsed to zero when nested under an ancestor whose main axis is unbounded (every paywall's default root vertical scroll, or a `Fit` container under one that scrolls). A real customer paywall (a Carousel of Fit/Fill pages containing a web_view) rendered blank on Android while rendering correctly on Web.

### Description
Three related fixes for `Fill` content under an unbounded main axis:

- **Stack:** skip `Modifier.weight` for a `Fill` child when the container's own main axis resolves to unbounded. Compose's weight distribution falls back to the axis minimum (0) there, collapsing the child. Boundedness is read at measure time via a small `trackMainAxisUnbounded` probe fed back into composition, and only attached when a `Fill` child could actually be affected.
- **web_view:** a `Fill` axis that is genuinely unbounded at measure time falls back to the same content/placeholder size a `Fit` axis uses, instead of passing the unbounded constraint through and measuring to zero.
- **Carousel:** a `Fit`-height carousel (the schema default) pins its `Fill` pages to the tallest page's measured height so they stretch to match. The Pager itself is left unpinned so it keeps tracking that height as content grows (e.g. an async web_view), avoiding a latch.

Tested with new Robolectric layout regression tests for each path (Stack both axes, Carousel Fill-matches-tallest including a nested-Fixed sibling, web_view effective-size resolution).


To illustrate:

<img width="2440" height="2620" alt="comp-fill" src="https://github.com/user-attachments/assets/ea5b912b-1505-4354-8a3a-9363e0956250" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Compose layout behavior for Fill/weight and carousel/WebView sizing across all V2 paywalls; well-tested but regressions could affect unrelated paywall layouts.
> 
> **Overview**
> Fixes **Paywalls V2** layouts where **`Fill`**-sized stacks, carousels, and **`web_view`** measured to **zero height** under the default root **`verticalScroll`**, producing blank carousels (customer repro).
> 
> **Stack:** Adds **`trackMainAxisUnbounded`** and only applies **`Modifier.weight`** to **`Fill`** children when the row/column main axis is actually bounded (not max infinite with min 0), so children keep natural size instead of collapsing.
> 
> **WebView:** When a **`Fill`** axis is unbounded at measure time, **`resolveAxis`** / **`webViewEffectiveSize`** use the same content-reported or placeholder sizes as **`Fit`**, since WebViews have no intrinsic size.
> 
> **Carousel:** For **`Fit`**-height carousels, **`Fill`** pages get a height pin from the pager’s measured tallest-page height (pager stays unpinned so async content can grow).
> 
> Robolectric regression tests cover stack (both axes), carousel stretch vs fixed siblings, and web_view effective sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f64d321d5fb16440fb504e21f63bfa0cefbc62a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->