### PR TITLE
fix: render default paywall when workflow config is transiently unavailable

### DIFF
--- a/maestro/workflows/no_workflow_default_paywall.yaml
+++ b/maestro/workflows/no_workflow_default_paywall.yaml
@@ -1,0 +1,27 @@
+# Opens an offering with no paywall and no workflow attached (`no_paywall`). The SDK falls back to
+# rendering the default paywall (same as the classic offerings path), not an error.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/no_workflow_default_paywall.yaml
+
+appId: com.revenuecat.e2etests
+name: Offering with no paywall or workflow renders the default paywall
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_no_paywall
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# The default paywall renders (has a Restore purchases control); no error alert.
+- extendedWaitUntil:
+    visible: "Restore purchases"
+    timeout: 15000
+- takeScreenshot: "no_workflow_default_paywall"

--- a/maestro/workflows/workflow_config_fallback.yaml
+++ b/maestro/workflows/workflow_config_fallback.yaml
@@ -1,0 +1,31 @@
+# Forces a 4xx on /v1/config (remote_config_not_found kill-switch). The SDK falls back to the classic
+# single-page paywall (the workflow's last page), never crashing. The force_server_error_strategy
+# launch argument is read in E2ETestsApplication (onActivityPreCreated) and applied via DangerousSettings.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_config_fallback.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow offering falls back to the classic paywall on config failure
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow
+      force_server_error_strategy: remote_config_not_found
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# With /v1/config failing, the classic single-page paywall is shown directly.
+- extendedWaitUntil:
+    visible: "People Who Meditate Daily Sleep 40% Better"
+    timeout: 15000
+# The multipage workflow entry screen is never rendered in the fallback path.
+- assertNotVisible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+- takeScreenshot: "workflow_config_fallback - classic paywall"

--- a/maestro/workflows/workflow_custom_variable_default.yaml
+++ b/maestro/workflows/workflow_custom_variable_default.yaml
@@ -1,0 +1,29 @@
+# Opens the workflow paywall (offering `default_workflows`) and asserts the custom variable
+# `{{ custom.users_count }}` is replaced with its dashboard default value (50000), not rendered raw.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_custom_variable_default.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow paywall renders the custom variable default value
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# The `{{ custom.users_count }}` template renders its default (50000). Leading `.*` tolerates the
+# leading space in the source string " {{ custom.users_count }} Users".
+- extendedWaitUntil:
+    visible: ".*50000 Users"
+    timeout: 15000
+- assertNotVisible: ".*users_count"
+- takeScreenshot: "workflow_custom_variable_default"

--- a/maestro/workflows/workflow_custom_variable_override.yaml
+++ b/maestro/workflows/workflow_custom_variable_override.yaml
@@ -1,0 +1,30 @@
+# Opens the workflow paywall (offering `default_workflows`) with a runtime custom-variable override
+# (custom_users_count launch arg -> PaywallOptions.setCustomVariables) and asserts the overridden
+# value (12345) renders instead of the dashboard default (50000).
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_custom_variable_override.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow paywall renders an overridden custom variable value
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow
+      custom_users_count: "12345"
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# The runtime override wins over the dashboard default: 12345 renders, 50000 does not.
+- extendedWaitUntil:
+    visible: ".*12345 Users"
+    timeout: 15000
+- assertNotVisible: ".*50000 Users"
+- takeScreenshot: "workflow_custom_variable_override"

--- a/maestro/workflows/workflow_exit_offer_not_on_first_page.yaml
+++ b/maestro/workflows/workflow_exit_offer_not_on_first_page.yaml
@@ -1,0 +1,33 @@
+# Closing the FIRST workflow page must NOT surface the exit offer: the exit offer is gated to the
+# last (exit-offer) step. Closing page 1 dismisses the workflow back to the launcher. Presented via
+# PaywallActivityLauncher (the exit-offer-aware Activity path). The close control is an unlabeled
+# icon tapped by coordinate (top-left).
+#
+# NOTE: the close-icon coordinate below is from the workflow paywall's top-left close control
+# ([0,0][168,300] observed on a Pixel 6a). Re-confirm on the target device/emulator if it fails.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_exit_offer_not_on_first_page.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow exit offer is not shown when closing the first page
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow_presented
+- extendedWaitUntil: { visible: "Present Paywall", timeout: 15000 }
+- tapOn: { text: "Present Paywall" }
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+# Close the first page (unlabeled close icon, top-left).
+- tapOn: { point: "8%,6%" }
+- waitForAnimationToEnd: { timeout: 8000 }
+# Dismissed back to the launcher; the exit offer is NOT presented.
+- assertVisible: "Present Paywall"
+- assertNotVisible: "Paywall V2"
+- takeScreenshot: "workflow_exit_offer_not_on_first_page"

--- a/maestro/workflows/workflow_exit_offer_on_last_page.yaml
+++ b/maestro/workflows/workflow_exit_offer_on_last_page.yaml
@@ -1,0 +1,40 @@
+# Navigates a workflow to its last page (the exit-offer step) and closes it; the configured exit
+# offer (offering `default`) must be presented. Presented via PaywallActivityLauncher (the
+# exit-offer-aware Activity path; the embedded Paywall composable does not surface exit offers).
+# The close control is an unlabeled icon tapped by coordinate (top-left).
+#
+# NOTE: the close-icon coordinate below is from the workflow paywall's top-left close control
+# ([0,0][168,300] observed on a Pixel 6a). Re-confirm on the target device/emulator if it fails.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_exit_offer_on_last_page.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow exit offer is shown when closing the last page
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow_presented
+- extendedWaitUntil: { visible: "Present Paywall", timeout: 15000 }
+- tapOn: { text: "Present Paywall" }
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+- tapOn: { text: "Continue" }
+- extendedWaitUntil:
+    visible: "Most People Feel Calmer After Just 3 Sessions"
+    timeout: 15000
+- tapOn: { text: "Continue" }
+- extendedWaitUntil:
+    visible: "People Who Meditate Daily Sleep 40% Better"
+    timeout: 15000
+# Close the last page (unlabeled close icon, top-left) -> the exit offer paywall is presented.
+- tapOn: { point: "8%,6%" }
+- extendedWaitUntil:
+    visible: "Paywall V2"
+    timeout: 15000
+- takeScreenshot: "workflow_exit_offer_on_last_page"

--- a/maestro/workflows/workflow_localized_spanish.yaml
+++ b/maestro/workflows/workflow_localized_spanish.yaml
@@ -1,0 +1,39 @@
+# Opens the workflow paywall (offering `default_workflows`) with a Spanish locale and asserts the
+# workflow renders its Spanish localizations (from /v1/config) on the first and second steps,
+# including the CTA. The app_locale launch argument is read in E2ETestsApplication and applied via
+# Locale.setDefault before configure, so the SDK requests Spanish localizations.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_localized_spanish.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow paywall renders Spanish localizations
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow
+      app_locale: "es-ES"
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# Screen 1: Spanish headline + localized CTA.
+- extendedWaitUntil:
+    visible: "Empieza tu semana gratis y recupera más de 30 minutos al día"
+    timeout: 15000
+- assertVisible: "Continuar"
+- takeScreenshot: "workflow_localized_spanish - screen 1"
+- tapOn:
+    text: "Continuar"
+
+# Screen 2: Spanish headline persists across navigation.
+- extendedWaitUntil:
+    visible: "La mayoría de las personas se sienten más tranquilas después de solo 3 sesiones"
+    timeout: 15000
+- takeScreenshot: "workflow_localized_spanish - screen 2"

--- a/maestro/workflows/workflow_offline_cached.yaml
+++ b/maestro/workflows/workflow_offline_cached.yaml
@@ -1,0 +1,50 @@
+# Reopening a workflow offering while /v1/config is unreachable, AFTER a prior successful load warmed
+# the cache, renders the cached multipage workflow (not the default paywall). Phase 1 loads online so
+# config/workflow/blobs persist; phase 2 relaunches with config offline WITHOUT clearing state, so the
+# disk cache survives. stopApp kills the process, so phase 2 gets a fresh configure that reads the arg.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_offline_cached.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow offering renders from cache when reopened offline after a prior load
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+# Phase 1: load online so config, workflow and blobs get cached to disk.
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 20000
+- tapOn:
+    text: "Present Paywall"
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+# Give the config/blob persist a moment to finish before killing the app.
+- waitForAnimationToEnd:
+    timeout: 5000
+- stopApp
+
+# Phase 2: reopen with /v1/config unreachable and WITHOUT clearing state, so the disk cache survives.
+- launchApp:
+    arguments:
+      e2e_test_flow: open_workflow
+      force_server_error_strategy: remote_config_network_error
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 20000
+- tapOn:
+    text: "Present Paywall"
+
+# The cached multipage workflow renders from disk even though config is offline.
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+# The default paywall (cold-cache fallback) must NOT appear here.
+- assertNotVisible: "No Paywall configured"
+- takeScreenshot: "workflow_offline_cached - workflow from cache"

--- a/maestro/workflows/workflow_offline_fallback.yaml
+++ b/maestro/workflows/workflow_offline_fallback.yaml
@@ -1,0 +1,32 @@
+# Config endpoint unreachable (remote_config_network_error) on a cold cache. With nothing cached and
+# workflows enabled, the SDK falls back to the offering's default paywall (matching iOS) instead of
+# surfacing an error.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_offline_fallback.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow offering renders the default paywall when config is offline with nothing cached
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow
+      force_server_error_strategy: remote_config_network_error
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 20000
+- tapOn:
+    text: "Present Paywall"
+
+# Config unreachable + nothing cached -> the SDK default paywall (has a Restore purchases control).
+- extendedWaitUntil:
+    visible: "Restore purchases"
+    timeout: 15000
+# The multipage workflow entry screen is never rendered, and no error dialog appears.
+- assertNotVisible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+- assertNotVisible: "OK"
+- takeScreenshot: "workflow_offline_fallback - default paywall"

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -89,8 +89,10 @@ package com.revenuecat.purchases {
   @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize public final class DangerousSettings implements android.os.Parcelable {
     ctor public DangerousSettings(optional boolean autoSyncPurchases);
     method public boolean getAutoSyncPurchases();
+    method public com.revenuecat.purchases.ForceServerErrorMode? getForceServerErrorMode();
     method public boolean getUseWorkflows();
     property public final boolean autoSyncPurchases;
+    property public final com.revenuecat.purchases.ForceServerErrorMode? forceServerErrorMode;
     property public final boolean useWorkflows;
     field public static final com.revenuecat.purchases.DangerousSettings.Companion Companion;
   }

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -76,8 +76,10 @@ package com.revenuecat.purchases {
   @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize public final class DangerousSettings implements android.os.Parcelable {
     ctor public DangerousSettings(optional boolean autoSyncPurchases);
     method public boolean getAutoSyncPurchases();
+    method public com.revenuecat.purchases.ForceServerErrorMode? getForceServerErrorMode();
     method public boolean getUseWorkflows();
     property public final boolean autoSyncPurchases;
+    property public final com.revenuecat.purchases.ForceServerErrorMode? forceServerErrorMode;
     property public final boolean useWorkflows;
     field public static final com.revenuecat.purchases.DangerousSettings.Companion Companion;
   }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
@@ -9,7 +9,9 @@ import kotlinx.parcelize.Parcelize
  */
 @Parcelize
 @Poko
-public class DangerousSettings internal constructor(
+public class DangerousSettings
+@OptIn(InternalRevenueCatAPI::class)
+internal constructor(
     /**
      * Disable or enable syncing purchases automatically. If this is disabled, RevenueCat will not sync any purchase
      * automatically, and you will have to call syncPurchases whenever a new purchase is completed in order to send it
@@ -35,6 +37,13 @@ public class DangerousSettings internal constructor(
      */
     @InternalRevenueCatAPI
     public val useWorkflows: Boolean = false,
+
+    /**
+     * Test-only: forces server errors on the remote-config endpoint so workflow fallback paths can be
+     * exercised in E2E tests. Internal RevenueCat use only.
+     */
+    @InternalRevenueCatAPI
+    public val forceServerErrorMode: ForceServerErrorMode? = null,
 ) : Parcelable {
     @OptIn(InternalRevenueCatAPI::class)
     public constructor(autoSyncPurchases: Boolean = true) : this(
@@ -67,12 +76,16 @@ public class DangerousSettings internal constructor(
          */
         @InternalRevenueCatAPI
         @JvmStatic
-        public fun forWorkflows(autoSyncPurchases: Boolean = true): DangerousSettings = DangerousSettings(
+        public fun forWorkflows(
+            autoSyncPurchases: Boolean = true,
+            forceServerErrorMode: ForceServerErrorMode? = null,
+        ): DangerousSettings = DangerousSettings(
             autoSyncPurchases = autoSyncPurchases,
             customEntitlementComputation = false,
             uiPreviewMode = false,
             applyObfuscatedAccountIdToSubscriptionChanges = false,
             useWorkflows = true,
+            forceServerErrorMode = forceServerErrorMode,
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ForceServerErrorMode.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ForceServerErrorMode.kt
@@ -1,0 +1,23 @@
+package com.revenuecat.purchases
+
+/**
+ * Test-only server-error injection for RevenueCat internal E2E tests. Internal RevenueCat use only;
+ * behavior may change without warning.
+ *
+ * Set via [DangerousSettings.forWorkflows] to force failures on the remote-config endpoint so the
+ * SDK's workflow fallback paths can be exercised end-to-end.
+ */
+@InternalRevenueCatAPI
+public enum class ForceServerErrorMode {
+    /**
+     * Forces the remote-config endpoint to return not-found (4xx), so a workflow offering falls back
+     * to its classic single-page paywall (the kill-switch path).
+     */
+    REMOTE_CONFIG_NOT_FOUND,
+
+    /**
+     * Routes remote-config requests to an unreachable host, simulating no network. With nothing cached
+     * the SDK renders its default paywall; with a warm cache it renders the cached workflow.
+     */
+    REMOTE_CONFIG_NETWORK_ERROR,
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ForceServerErrorStrategy.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ForceServerErrorStrategy.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import java.net.URL
 
 internal fun interface ForceServerErrorStrategy {
@@ -21,5 +22,38 @@ internal fun interface ForceServerErrorStrategy {
     @OptIn(InternalRevenueCatAPI::class)
     fun fakeResponseWithoutPerformingRequest(baseURL: URL, endpoint: Endpoint): HTTPResult? {
         return null
+    }
+}
+
+private fun Endpoint.isRemoteConfig(): Boolean =
+    this is Endpoint.GetRemoteConfig || this is Endpoint.GetRemoteConfigFallback
+
+/**
+ * Maps the public [ForceServerErrorMode] to a concrete internal [ForceServerErrorStrategy] scoped to
+ * the remote-config endpoint. Kept internal so [Endpoint]/[HTTPResult] stay out of the public API.
+ */
+@OptIn(InternalRevenueCatAPI::class)
+internal fun ForceServerErrorMode.toForceServerErrorStrategy(): ForceServerErrorStrategy = when (this) {
+    ForceServerErrorMode.REMOTE_CONFIG_NOT_FOUND -> object : ForceServerErrorStrategy {
+        override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean = false
+        override fun fakeResponseWithoutPerformingRequest(baseURL: URL, endpoint: Endpoint): HTTPResult? =
+            if (endpoint.isRemoteConfig()) {
+                HTTPResult(
+                    responseCode = RCHTTPStatusCodes.NOT_FOUND,
+                    payload = "{}",
+                    origin = HTTPResult.Origin.BACKEND,
+                    requestDate = null,
+                    verificationResult = VerificationResult.NOT_REQUESTED,
+                    isLoadShedderResponse = false,
+                    isFallbackURL = false,
+                )
+            } else {
+                null
+            }
+    }
+    ForceServerErrorMode.REMOTE_CONFIG_NETWORK_ERROR -> object : ForceServerErrorStrategy {
+        // A `.invalid` TLD never resolves (RFC 2606), so the config request raises an UnknownHostException.
+        override val serverErrorURL: String = "https://config-offline.invalid/"
+        override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean = endpoint.isRemoteConfig()
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -212,6 +212,11 @@ internal class PurchasesFactory(
             }
             val apiSourceProvider = DefaultRemoteConfigSourceProvider(remoteConfigTopicStore)
 
+            // The explicit param (integration tests) wins; otherwise honor a mode set via
+            // DangerousSettings (used by the workflow E2E app, which configures via the public API).
+            val effectiveForceServerErrorStrategy =
+                forceServerErrorStrategy ?: dangerousSettings.forceServerErrorMode?.toForceServerErrorStrategy()
+
             val httpClient = HTTPClient(
                 appConfig,
                 eTagManager,
@@ -220,7 +225,7 @@ internal class PurchasesFactory(
                 cache,
                 apiSourceProvider,
                 localeProvider = localeProvider,
-                forceServerErrorStrategy = forceServerErrorStrategy,
+                forceServerErrorStrategy = effectiveForceServerErrorStrategy,
             )
             val backendHelper = BackendHelper(apiKey, backendDispatcher, appConfig, httpClient)
             val backend = Backend(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -303,7 +303,10 @@ internal class HTTPClient(
         val postFieldsToSignHeader: String?
         val fullURL: URL
 
-        if (appConfig.runningTests) {
+        // Gate on the strategy being present (not just runningTests): the workflow E2E app injects a
+        // strategy via DangerousSettings through the public configure path, where runningTests is false.
+        // In production the strategy is always null, so this stays inert.
+        if (appConfig.runningTests || forceServerErrorStrategy != null) {
             forceServerErrorStrategy?.fakeResponseWithoutPerformingRequest(baseURL, endpoint)?.let {
                 warnLog { "Faking response for request to ${endpoint.getPath()}" }
                 return it
@@ -311,7 +314,7 @@ internal class HTTPClient(
         }
 
         try {
-            fullURL = if (appConfig.runningTests &&
+            fullURL = if ((appConfig.runningTests || forceServerErrorStrategy != null) &&
                 forceServerErrorStrategy?.shouldForceServerError(baseURL, endpoint) == true
             ) {
                 warnLog { "Forcing server error for request to ${URL(baseURL, path)}" }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
@@ -14,7 +14,8 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
  *   4xx kill switch. The offering was parsed with its paywall components skipped while workflows were enabled,
  *   so the caller should reload offerings — which now re-parse with those components — to recover its paywall.
  * - [Unavailable]: the topic could not be read for some other (transient) reason, so whether the offering has a
- *   workflow is unknown and reloading would not recover anything. The caller should surface an error.
+ *   workflow is unknown and reloading would not recover anything. The caller should fall back to the offering's
+ *   default paywall (matching iOS), not surface an error.
  */
 @InternalRevenueCatAPI
 public sealed class WorkflowResolution {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -101,8 +101,8 @@ internal class WorkflowsConfigProvider(
         verboseLog { "workflows topic ${if (topic == null) "is absent" else "has ${topic.size} item(s)"}" }
         // A null topic means it could not be read. If the /v1/config endpoint is disabled (4xx kill switch) the
         // offering was parsed with its components skipped, so the caller can reload offerings to recover them;
-        // any other (transient) failure is unrecoverable and should surface an error. Either way this is not the
-        // same as a genuinely workflowless offering.
+        // any other (transient) failure should fall back to the offering's default paywall. Either way this is not
+        // the same as a genuinely workflowless offering.
         return if (topic == null) {
             if (manager.isDisabled) {
                 verboseLog { "Workflows topic unavailable (remote config disabled) resolving offering '$offeringId'" }

--- a/purchases/src/test/java/com/revenuecat/purchases/ForceServerErrorModeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/ForceServerErrorModeTest.kt
@@ -1,0 +1,50 @@
+package com.revenuecat.purchases
+
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.net.URL
+
+@OptIn(InternalRevenueCatAPI::class)
+@RunWith(RobolectricTestRunner::class)
+class ForceServerErrorModeTest {
+
+    private val baseURL = URL("https://api.revenuecat.com")
+    private val remoteConfig = Endpoint.GetRemoteConfig(domain = "acme")
+    private val remoteConfigFallback = Endpoint.GetRemoteConfigFallback(domain = "acme")
+    private val unrelatedEndpoint = Endpoint.LogIn
+
+    @Test
+    fun `REMOTE_CONFIG_NOT_FOUND fakes a 404 for the remote-config endpoints`() {
+        val strategy = ForceServerErrorMode.REMOTE_CONFIG_NOT_FOUND.toForceServerErrorStrategy()
+
+        val configResult = strategy.fakeResponseWithoutPerformingRequest(baseURL, remoteConfig)
+        val fallbackResult = strategy.fakeResponseWithoutPerformingRequest(baseURL, remoteConfigFallback)
+
+        assertThat(configResult?.responseCode).isEqualTo(RCHTTPStatusCodes.NOT_FOUND)
+        assertThat(fallbackResult?.responseCode).isEqualTo(RCHTTPStatusCodes.NOT_FOUND)
+    }
+
+    @Test
+    fun `REMOTE_CONFIG_NOT_FOUND does not touch unrelated endpoints`() {
+        val strategy = ForceServerErrorMode.REMOTE_CONFIG_NOT_FOUND.toForceServerErrorStrategy()
+
+        assertThat(strategy.fakeResponseWithoutPerformingRequest(baseURL, unrelatedEndpoint)).isNull()
+        assertThat(strategy.shouldForceServerError(baseURL, remoteConfig)).isFalse()
+    }
+
+    @Test
+    fun `REMOTE_CONFIG_NETWORK_ERROR forces an error only for the remote-config endpoints`() {
+        val strategy = ForceServerErrorMode.REMOTE_CONFIG_NETWORK_ERROR.toForceServerErrorStrategy()
+
+        assertThat(strategy.shouldForceServerError(baseURL, remoteConfig)).isTrue()
+        assertThat(strategy.shouldForceServerError(baseURL, remoteConfigFallback)).isTrue()
+        assertThat(strategy.shouldForceServerError(baseURL, unrelatedEndpoint)).isFalse()
+        // Routes to an unreachable host so the request raises a transport error.
+        assertThat(strategy.serverErrorURL).endsWith(".invalid/")
+        assertThat(strategy.fakeResponseWithoutPerformingRequest(baseURL, remoteConfig)).isNull()
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -509,7 +509,8 @@ class AppConfigTest {
                 "uiPreviewMode=false, " +
                 "applyObfuscatedAccountIdToSubscriptionChanges=false, " +
                 "usesRemoteConfigAPISources=false, " +
-                "useWorkflows=false), " +
+                "useWorkflows=false, " +
+                "forceServerErrorMode=null), " +
                 "languageTag='', " +
                 "versionName='', " +
                 "packageName='', " +

--- a/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -100,6 +100,7 @@ internal abstract class BaseHTTPClientTest {
         uiPreviewMode: Boolean = false,
         usesRemoteConfigAPISources: Boolean = false,
         forceSigningErrors: Boolean = false,
+        runningTests: Boolean = true,
         baseUrlString: String = AppConfig.baseUrlString
     ): AppConfig {
         return AppConfig(
@@ -116,7 +117,7 @@ internal abstract class BaseHTTPClientTest {
                 uiPreviewMode = uiPreviewMode,
                 usesRemoteConfigAPISources = usesRemoteConfigAPISources,
             ),
-            runningTests = true,
+            runningTests = runningTests,
             forceSigningErrors = forceSigningErrors,
             baseUrlString = baseUrlString,
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -422,6 +422,37 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         assertThat(result.payloadText).isEqualTo("{'response': 'OK'}")
     }
 
+    @Test
+    fun `forceServerErrorStrategy applies even when runningTests is false`() {
+        val client = createClient(
+            appConfig = createAppConfig(runningTests = false),
+            forceServerErrorStrategy = object : ForceServerErrorStrategy {
+                override val serverErrorURL: String
+                    get() = server.url("force-server-error").toString()
+                override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean {
+                    return true
+                }
+            },
+        )
+
+        val endpoint = Endpoint.LogIn
+        enqueue(
+            endpoint.getPath(),
+            expectedResult = HTTPResult.createResult(responseCode = 502, payload = "Some error xml")
+        )
+        enqueue(
+            "force-server-error",
+            expectedResult = HTTPResult.createResult(responseCode = 502, payload = "Some error xml")
+        )
+
+        val result = client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
+
+        val request = server.takeRequest()
+
+        assertThat(request.requestUrl?.toString()).isEqualTo("${server.url("")}force-server-error")
+        assertThat(result.responseCode).isEqualTo(502)
+    }
+
     // endregion forceServerErrors
 
     // Headers

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestFlow.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestFlow.kt
@@ -6,6 +6,8 @@ package com.revenuecat.e2etests
  */
 internal enum class E2ETestFlow(val rawValue: String) {
     OPEN_WORKFLOW("open_workflow"),
+    OPEN_WORKFLOW_PRESENTED("open_workflow_presented"),
+    OPEN_NO_PAYWALL("open_no_paywall"),
     ;
 
     companion object {

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
+import java.util.Locale
 
 class E2ETestsApplication : Application() {
 
@@ -35,6 +36,11 @@ class E2ETestsApplication : Application() {
         @OptIn(InternalRevenueCatAPI::class)
         override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
             if (Purchases.isConfigured) return
+            // Set the app locale before configuring so the SDK (which reads the default locale list
+            // dynamically) requests localized workflow config. Works on all API levels, no appcompat.
+            activity.intent?.getStringExtra(APP_LOCALE_EXTRA_KEY)?.let { tag ->
+                Locale.setDefault(Locale.forLanguageTag(tag))
+            }
             val mode = when (activity.intent?.getStringExtra(FORCE_SERVER_ERROR_EXTRA_KEY)) {
                 "remote_config_not_found" -> ForceServerErrorMode.REMOTE_CONFIG_NOT_FOUND
                 "remote_config_network_error" -> ForceServerErrorMode.REMOTE_CONFIG_NETWORK_ERROR
@@ -54,6 +60,7 @@ class E2ETestsApplication : Application() {
     private companion object {
         const val WORKFLOWS_API_KEY_PLACEHOLDER = "workflows_api_key_to_replace"
         const val FORCE_SERVER_ERROR_EXTRA_KEY = "force_server_error_strategy"
+        const val APP_LOCALE_EXTRA_KEY = "app_locale"
     }
 }
 

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
@@ -1,7 +1,10 @@
 package com.revenuecat.e2etests
 
+import android.app.Activity
 import android.app.Application
+import android.os.Bundle
 import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.ForceServerErrorMode
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
@@ -9,27 +12,58 @@ import com.revenuecat.purchases.PurchasesConfiguration
 
 class E2ETestsApplication : Application() {
 
-    @OptIn(InternalRevenueCatAPI::class)
     override fun onCreate() {
         super.onCreate()
         Purchases.logLevel = LogLevel.DEBUG
 
         // The workflow E2E flows are built with E2E_WORKFLOWS_API_KEY set (surfaced as
-        // BuildConfig.WORKFLOWS_API_KEY). When it's present we point at that project and enable
-        // workflows; otherwise we keep the default configuration used by the CI
-        // test_store_annual_purchase flow untouched. The Maestro launch argument only selects the
-        // screen (in MainActivity), so configuration stays here in the Application.
-        val builder = if (BuildConfig.WORKFLOWS_API_KEY != WORKFLOWS_API_KEY_PLACEHOLDER) {
-            PurchasesConfiguration.Builder(context = this, apiKey = BuildConfig.WORKFLOWS_API_KEY)
-                .dangerousSettings(DangerousSettings.forWorkflows())
+        // BuildConfig.WORKFLOWS_API_KEY). That build defers configure to onActivityPreCreated so the
+        // force_server_error_strategy Maestro launch argument (delivered as an intent extra on the
+        // first Activity, unreadable here) can shape DangerousSettings. The default build configures
+        // eagerly, keeping the CI test_store_annual_purchase flow untouched. Configure stays in the
+        // Application either way.
+        if (BuildConfig.WORKFLOWS_API_KEY != WORKFLOWS_API_KEY_PLACEHOLDER) {
+            registerActivityLifecycleCallbacks(ConfigureOnFirstActivity())
         } else {
-            PurchasesConfiguration.Builder(context = this, apiKey = Constants.API_KEY)
+            Purchases.configure(
+                PurchasesConfiguration.Builder(context = this, apiKey = Constants.API_KEY).build(),
+            )
         }
+    }
 
-        Purchases.configure(builder.build())
+    private inner class ConfigureOnFirstActivity : ActivityLifecycleCallbacksAdapter() {
+        @OptIn(InternalRevenueCatAPI::class)
+        override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
+            if (Purchases.isConfigured) return
+            val mode = when (activity.intent?.getStringExtra(FORCE_SERVER_ERROR_EXTRA_KEY)) {
+                "remote_config_not_found" -> ForceServerErrorMode.REMOTE_CONFIG_NOT_FOUND
+                "remote_config_network_error" -> ForceServerErrorMode.REMOTE_CONFIG_NETWORK_ERROR
+                else -> null
+            }
+            Purchases.configure(
+                PurchasesConfiguration.Builder(
+                    context = this@E2ETestsApplication,
+                    apiKey = BuildConfig.WORKFLOWS_API_KEY,
+                )
+                    .dangerousSettings(DangerousSettings.forWorkflows(forceServerErrorMode = mode))
+                    .build(),
+            )
+        }
     }
 
     private companion object {
         const val WORKFLOWS_API_KEY_PLACEHOLDER = "workflows_api_key_to_replace"
+        const val FORCE_SERVER_ERROR_EXTRA_KEY = "force_server_error_strategy"
     }
+}
+
+/** No-op base so [E2ETestsApplication] only overrides the lifecycle callback it needs. */
+private open class ActivityLifecycleCallbacksAdapter : Application.ActivityLifecycleCallbacks {
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+    override fun onActivityStarted(activity: Activity) = Unit
+    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+    override fun onActivityDestroyed(activity: Activity) = Unit
 }

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/MainActivity.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.revenuecat.e2etests.main.MainPage
+import com.revenuecat.e2etests.main.NoPaywallScreen
 import com.revenuecat.e2etests.ui.theme.PurchasesandroidTheme
 import com.revenuecat.e2etests.workflow.WorkflowScreen
 
@@ -14,16 +15,24 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        // Maestro delivers launch arguments as Activity intent extras; here we only use the flow to
-        // pick which screen to show. Purchases is configured in E2ETestsApplication.
+        // Maestro delivers launch arguments as Activity intent extras; here we only use them to
+        // pick which screen to show and to pass a custom-variable override. Purchases is configured
+        // in E2ETestsApplication.
         val flow = E2ETestFlow.fromRawValue(intent.getStringExtra(E2ETestFlow.INTENT_EXTRA_KEY))
+        val usersCountOverride = intent.getStringExtra(CUSTOM_USERS_COUNT_EXTRA_KEY)?.toIntOrNull()
         setContent {
             PurchasesandroidTheme {
                 when (flow) {
-                    E2ETestFlow.OPEN_WORKFLOW -> WorkflowScreen()
+                    E2ETestFlow.OPEN_WORKFLOW -> WorkflowScreen(usersCountOverride = usersCountOverride)
+                    E2ETestFlow.OPEN_WORKFLOW_PRESENTED -> WorkflowScreen()
+                    E2ETestFlow.OPEN_NO_PAYWALL -> NoPaywallScreen()
                     null -> MainPage()
                 }
             }
         }
+    }
+
+    private companion object {
+        const val CUSTOM_USERS_COUNT_EXTRA_KEY = "custom_users_count"
     }
 }

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/MainActivity.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/MainActivity.kt
@@ -7,13 +7,23 @@ import androidx.activity.enableEdgeToEdge
 import com.revenuecat.e2etests.main.MainPage
 import com.revenuecat.e2etests.main.NoPaywallScreen
 import com.revenuecat.e2etests.ui.theme.PurchasesandroidTheme
+import com.revenuecat.e2etests.workflow.PresentedWorkflowScreen
 import com.revenuecat.e2etests.workflow.WorkflowScreen
+import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
+import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
+import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler
 
-class MainActivity : ComponentActivity() {
+class MainActivity : ComponentActivity(), PaywallResultHandler {
+
+    private lateinit var paywallLauncher: PaywallActivityLauncher
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        // Registered before the activity is started, per ActivityResultLauncher rules. Used by the
+        // presented-workflow flow to exercise the exit-offer-aware Activity path.
+        paywallLauncher = PaywallActivityLauncher(this, this)
 
         // Maestro delivers launch arguments as Activity intent extras; here we only use them to
         // pick which screen to show and to pass a custom-variable override. Purchases is configured
@@ -24,12 +34,18 @@ class MainActivity : ComponentActivity() {
             PurchasesandroidTheme {
                 when (flow) {
                     E2ETestFlow.OPEN_WORKFLOW -> WorkflowScreen(usersCountOverride = usersCountOverride)
-                    E2ETestFlow.OPEN_WORKFLOW_PRESENTED -> WorkflowScreen()
+                    E2ETestFlow.OPEN_WORKFLOW_PRESENTED -> PresentedWorkflowScreen(
+                        onPresentPaywall = { paywallLauncher.launch(it) },
+                    )
                     E2ETestFlow.OPEN_NO_PAYWALL -> NoPaywallScreen()
                     null -> MainPage()
                 }
             }
         }
+    }
+
+    override fun onActivityResult(result: PaywallResult) {
+        // No-op: dismissing the presented paywall returns here and shows the launcher screen again.
     }
 
     private companion object {

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/main/NoPaywallScreen.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/main/NoPaywallScreen.kt
@@ -1,0 +1,73 @@
+package com.revenuecat.e2etests.main
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.awaitOfferings
+import com.revenuecat.purchases.ui.revenuecatui.Paywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+
+private const val NO_PAYWALL_OFFERING_ID = "no_paywall"
+
+@Composable
+fun NoPaywallScreen(modifier: Modifier = Modifier) {
+    var offering by remember { mutableStateOf<Offering?>(null) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var showPaywall by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        try {
+            offering = Purchases.sharedInstance.awaitOfferings().getOffering(NO_PAYWALL_OFFERING_ID)
+            if (offering == null) error = "Offering '$NO_PAYWALL_OFFERING_ID' not found"
+        } catch (e: PurchasesException) {
+            error = e.message ?: "Failed to load offerings"
+        }
+    }
+
+    val loaded = offering
+    if (showPaywall && loaded != null) {
+        Paywall(
+            options = PaywallOptions.Builder(dismissRequest = { showPaywall = false })
+                .setOffering(loaded)
+                .build(),
+        )
+        return
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+    ) {
+        Text(text = "No paywall offering", style = MaterialTheme.typography.headlineMedium)
+        when {
+            error != null -> Text(
+                text = "Error: $error",
+                color = MaterialTheme.colorScheme.error,
+            )
+            loaded != null -> Button(onClick = { showPaywall = true }) {
+                Text("Present Paywall")
+            }
+            else -> CircularProgressIndicator()
+        }
+    }
+}

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/PresentedWorkflowScreen.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/PresentedWorkflowScreen.kt
@@ -1,0 +1,66 @@
+package com.revenuecat.e2etests.workflow
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.awaitOfferings
+
+private const val WORKFLOW_OFFERING_ID = "default_workflows"
+
+/**
+ * Presents the workflow paywall via [com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher]
+ * (the Activity-based, exit-offer-aware path) rather than the embedded [WorkflowScreen] composable, which does
+ * not surface exit offers. [onPresentPaywall] hands the loaded offering back to the Activity's launcher.
+ */
+@Composable
+fun PresentedWorkflowScreen(
+    onPresentPaywall: (Offering) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var offering by remember { mutableStateOf<Offering?>(null) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        try {
+            offering = Purchases.sharedInstance.awaitOfferings().getOffering(WORKFLOW_OFFERING_ID)
+            if (offering == null) error = "Offering '$WORKFLOW_OFFERING_ID' not found"
+        } catch (e: PurchasesException) {
+            error = e.message ?: "Failed to load offerings"
+        }
+    }
+
+    val loaded = offering
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+    ) {
+        Text(text = "Workflow paywall", style = MaterialTheme.typography.headlineMedium)
+        when {
+            error != null -> Text("Error: $error", color = MaterialTheme.colorScheme.error)
+            loaded != null -> Button(onClick = { onPresentPaywall(loaded) }) {
+                Text("Present Paywall")
+            }
+            else -> CircularProgressIndicator()
+        }
+    }
+}

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/WorkflowScreen.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/WorkflowScreen.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.awaitCustomerInfo
 import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -40,7 +41,10 @@ private sealed interface OfferingState {
 }
 
 @Composable
-fun WorkflowScreen(modifier: Modifier = Modifier) {
+fun WorkflowScreen(
+    modifier: Modifier = Modifier,
+    usersCountOverride: Int? = null,
+) {
     var offeringState by remember { mutableStateOf<OfferingState>(OfferingState.Loading) }
     var showPaywall by remember { mutableStateOf(false) }
     var customerInfo by remember { mutableStateOf<CustomerInfo?>(null) }
@@ -73,18 +77,10 @@ fun WorkflowScreen(modifier: Modifier = Modifier) {
 
     val loaded = offeringState
     if (showPaywall && loaded is OfferingState.Loaded) {
-        Paywall(
-            options = PaywallOptions.Builder(dismissRequest = { showPaywall = false })
-                .setOffering(loaded.offering)
-                .setListener(object : PaywallListener {
-                    override fun onPurchaseCompleted(
-                        customerInfo: CustomerInfo,
-                        storeTransaction: StoreTransaction,
-                    ) {
-                        showPaywall = false
-                    }
-                })
-                .build(),
+        WorkflowPaywall(
+            offering = loaded.offering,
+            usersCountOverride = usersCountOverride,
+            onDismiss = { showPaywall = false },
         )
         return
     }
@@ -111,6 +107,34 @@ fun WorkflowScreen(modifier: Modifier = Modifier) {
 
         Text(text = "entitlement ($ENTITLEMENT_ID): ${entitlementStatus(customerInfo)}")
     }
+}
+
+@Composable
+private fun WorkflowPaywall(
+    offering: Offering,
+    usersCountOverride: Int?,
+    onDismiss: () -> Unit,
+) {
+    Paywall(
+        options = PaywallOptions.Builder(dismissRequest = onDismiss)
+            .setOffering(offering)
+            .apply {
+                if (usersCountOverride != null) {
+                    setCustomVariables(
+                        mapOf("users_count" to CustomVariableValue.Number(usersCountOverride.toDouble())),
+                    )
+                }
+            }
+            .setListener(object : PaywallListener {
+                override fun onPurchaseCompleted(
+                    customerInfo: CustomerInfo,
+                    storeTransaction: StoreTransaction,
+                ) {
+                    onDismiss()
+                }
+            })
+            .build(),
+    )
 }
 
 private fun entitlementStatus(customerInfo: CustomerInfo?): String {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -877,7 +877,8 @@ internal class PaywallViewModelImpl(
     /**
      * Resolves [workflowOffering] to its workflow and either presents it or decides how to fall back: a
      * workflowless offering renders its own paywall, a 4xx kill switch reloads offerings to recover the
-     * components skipped during the workflows-enabled parse, and any other failure throws (→ error state).
+     * components skipped during the workflows-enabled parse, and a transient topic failure renders the default
+     * paywall.
      */
     @Suppress("ReturnCount")
     private suspend fun presentWorkflowOrResolveFallback(
@@ -923,15 +924,16 @@ internal class PaywallViewModelImpl(
                 return WorkflowOutcome.Fallback(reloaded.offering, reloaded.offerings)
             }
             WorkflowResolution.Unavailable -> {
-                // The workflows topic could not be read and remote config is not disabled (a transient failure),
-                // so whether this offering has a workflow is unknown and reloading would recover nothing. Surface
-                // an error rather than silently degrading to the default paywall.
-                throw PurchasesException(
-                    PurchasesError(
-                        PurchasesErrorCode.UnknownError,
-                        "Could not resolve the workflow for offering '${workflowOffering.identifier}'.",
-                    ),
+                // The workflows topic could not be read for a transient reason (e.g. a network failure) with
+                // nothing cached, so whether this offering has a workflow is unknown. Rather than surfacing an
+                // error, degrade to the offering's default paywall — matching iOS. The offering's components were
+                // skipped during the workflows-enabled parse, so validatedPaywall renders the default template.
+                Logger.w(
+                    "Paywalls: Workflows topic unavailable for offering '${workflowOffering.identifier}' " +
+                        "(transient failure). Falling back to the default paywall.",
                 )
+                clearWorkflowState()
+                return WorkflowOutcome.Fallback(workflowOffering, preloadedOfferings)
             }
         }
     }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -3351,31 +3351,6 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and the workflows topic is unavailable, surfaces the error`() {
-        // The workflows topic could not be read and remote config is not disabled (a transient failure), so
-        // reloading offerings would recover nothing — surface the error instead of degrading to the default.
-        val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
-        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Unavailable
-
-        val model = PaywallViewModelImpl(
-            MockResourceProvider(),
-            purchases,
-            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
-                .setListener(listener)
-                .setOffering(offeringWithoutComponents)
-                .build(),
-            TestData.Constants.currentColorScheme,
-            isDarkMode = false,
-            shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
-        )
-
-        assertThat(model.state.value).isInstanceOf(PaywallState.Error::class.java)
-        coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
-        coVerify(exactly = 0) { purchases.awaitOfferings() }
-    }
-
-    @Test
     fun `when useWorkflows is true and no workflow is mapped with no paywall data, renders the default paywall`() {
         val offeringWithoutPaywallData = Offering(
             identifier = "offering-no-paywall-data",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -932,6 +932,21 @@ class PaywallViewModelWorkflowTest {
     // region memory-first single-path (no Loading flash)
 
     @Test
+    fun `Unavailable workflow resolution falls back to the default paywall instead of erroring`() = runTest {
+        // This models a workflow offering whose paywall data was skipped during the workflows-enabled parse,
+        // with no cached workflows topic available.
+        coEvery { purchases.resolveWorkflow(offeringId) } returns WorkflowResolution.Unavailable
+
+        val vm = createVm()
+        advanceUntilIdle()
+
+        assertThat(vm.state.value).isInstanceOf(PaywallState.Loaded.Legacy::class.java)
+        assertThat(vm.state.value).isNotInstanceOf(PaywallState.Error::class.java)
+        assertThat(vm.workflowState.value).isNull()
+        coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
+    }
+
+    @Test
     fun `warm cache renders the workflow on the first composition with no Loading state`() {
         // Model Dispatchers.Main.immediate with an unconfined main dispatcher so viewModelScope.launch runs
         // eagerly, as in production. On a warm cache every suspend read resolves without suspending (mockk


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

Match iOS by rendering the offering's default paywall when the workflows topic is unavailable instead of surfacing an error. Includes unit and Maestro coverage for the cold-cache offline case.