### PR TITLE
fix(paywalls): tighten web_view gesture-arbitration probe, track pointer id

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebView.kt
@@ -35,6 +35,23 @@ internal fun shouldWebViewOwnGesture(
 }
 
 /**
+ * The tracked finger's total drag delta from [downX]/[downY], or `null` once that finger is no longer
+ * in [event] (lifted, or another pointer's index shifted it out). Reading [MotionEvent.getX]/[getY]
+ * unconditionally (pointer index 0) would silently jump to a different finger's position once the
+ * original one lifts mid-gesture.
+ */
+internal fun trackedPointerDelta(
+    event: MotionEvent,
+    trackedPointerId: Int,
+    downX: Float,
+    downY: Float,
+): Pair<Float, Float>? {
+    val pointerIndex = event.findPointerIndex(trackedPointerId)
+    if (pointerIndex == -1) return null
+    return (event.getX(pointerIndex) - downX) to (event.getY(pointerIndex) - downY)
+}
+
+/**
  * A [WebView] that claims a drag from the paywall scroll it's embedded in, via
  * [android.view.ViewParent.requestDisallowInterceptTouchEvent]. Compose won't hand a gesture back once
  * decided, so we never pre-claim and claim exactly once, when [shouldWebViewOwnGesture] says so.
@@ -50,6 +67,7 @@ internal class PaywallWebView(context: Context) : WebView(context) {
 
     private var downX = 0f
     private var downY = 0f
+    private var trackedPointerId = MotionEvent.INVALID_POINTER_ID
     private var lastTotalDx = 0f
     private var lastTotalDy = 0f
     private var webContentWantsGesture: Boolean? = null
@@ -64,6 +82,7 @@ internal class PaywallWebView(context: Context) : WebView(context) {
             MotionEvent.ACTION_DOWN -> {
                 downX = event.x
                 downY = event.y
+                trackedPointerId = event.getPointerId(0)
                 lastTotalDx = 0f
                 lastTotalDy = 0f
                 webContentWantsGesture = null
@@ -71,8 +90,10 @@ internal class PaywallWebView(context: Context) : WebView(context) {
                 gestureActive = true
             }
             MotionEvent.ACTION_MOVE -> {
-                lastTotalDx = event.x - downX
-                lastTotalDy = event.y - downY
+                val delta = trackedPointerDelta(event, trackedPointerId, downX, downY)
+                    ?: return super.onTouchEvent(event)
+                lastTotalDx = delta.first
+                lastTotalDy = delta.second
                 claimForWebViewIfNeeded()
             }
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> gestureActive = false

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewGestureOwnershipProbe.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewGestureOwnershipProbe.kt
@@ -10,24 +10,35 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 private const val GESTURE_PROBE_OBJECT_NAME = "rcPaywallGestureProbe"
 private const val VERDICT_OWN = "own"
 
-// On each touchstart, reports "own" if the touched element or an ancestor scrolls or declares a
-// non-default `touch-action` — the per-element signals native canScroll can't see. Passive.
+// On each touchstart, reports "own" if the touched element or an inner ancestor scrolls or declares
+// `touch-action: none` — the per-element signals native canScroll can't see. Passive.
 private val GESTURE_PROBE_SCRIPT =
     """
     (function () {
       var name = '$GESTURE_PROBE_OBJECT_NAME';
       var ELEMENT_NODE = Node.ELEMENT_NODE;
+      function isRootScroller(n) {
+        return n === document.scrollingElement || n === document.documentElement || n === document.body;
+      }
       function consumesGesture(el) {
         var node = el && el.nodeType === ELEMENT_NODE ? el : (el ? el.parentElement : null);
         for (var n = node; n && n.nodeType === ELEMENT_NODE; n = n.parentElement) {
           var s = getComputedStyle(n);
-          if (s.touchAction && s.touchAction !== 'auto' && s.touchAction !== 'manipulation') return true;
+          // Only `none` means the browser won't pan this element at all (JS owns every axis). `pan-x`/
+          // `pan-y` still let native scroll handle an axis, already covered by canScroll*.
+          if (s.touchAction === 'none') return true;
+          // The root scroller is the WebView's own scroll, already tracked by canScroll* with correct
+          // edge handoff; only inner scrollers are invisible to it.
+          if (isRootScroller(n)) continue;
           if ((s.overflowY === 'auto' || s.overflowY === 'scroll') && n.scrollHeight > n.clientHeight) return true;
           if ((s.overflowX === 'auto' || s.overflowX === 'scroll') && n.scrollWidth > n.clientWidth) return true;
         }
         return false;
       }
       document.addEventListener('touchstart', function (event) {
+        // Only the first finger of a sequence: the recognizer tracks one gesture, so a second finger's
+        // verdict must not overwrite it.
+        if (event.touches.length > 1) return;
         try {
           window[name].postMessage(consumesGesture(event.target) ? '$VERDICT_OWN' : 'release');
         } catch (e) {}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/TrackedPointerDeltaTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/TrackedPointerDeltaTest.kt
@@ -1,0 +1,74 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.view.MotionEvent
+import android.view.MotionEvent.PointerCoords
+import android.view.MotionEvent.PointerProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class TrackedPointerDeltaTest {
+
+    private fun pointerEvent(action: Int, vararg pointers: Triple<Int, Float, Float>): MotionEvent {
+        val properties = pointers.map { (pointerId, _, _) ->
+            PointerProperties().apply { id = pointerId }
+        }.toTypedArray()
+        val coords = pointers.map { (_, pointerX, pointerY) ->
+            PointerCoords().apply {
+                x = pointerX
+                y = pointerY
+            }
+        }.toTypedArray()
+        return MotionEvent.obtain(
+            0L,
+            0L,
+            action,
+            pointers.size,
+            properties,
+            coords,
+            0,
+            0,
+            1f,
+            1f,
+            0,
+            0,
+            0,
+            0,
+        )
+    }
+
+    @Test
+    fun `resolves the delta of the tracked pointer when it's the only one down`() {
+        val event = pointerEvent(MotionEvent.ACTION_MOVE, Triple(0, 130f, 550f))
+
+        val delta = trackedPointerDelta(event, trackedPointerId = 0, downX = 100f, downY = 500f)
+
+        assertThat(delta).isEqualTo(30f to 50f)
+    }
+
+    @Test
+    fun `follows the tracked pointer id when a second finger shifted the index`() {
+        // Pointer 0 (the tracked finger) is now at index 1; a naive index-0 read would return pointer 1.
+        val event = pointerEvent(
+            MotionEvent.ACTION_MOVE,
+            Triple(1, 900f, 900f),
+            Triple(0, 130f, 550f),
+        )
+
+        val delta = trackedPointerDelta(event, trackedPointerId = 0, downX = 100f, downY = 500f)
+
+        assertThat(delta).isEqualTo(30f to 50f)
+    }
+
+    @Test
+    fun `returns null once the tracked pointer has lifted, even if another finger remains`() {
+        // Only pointer 1 remains; index 0 now belongs to a finger that never set downX/downY.
+        val event = pointerEvent(MotionEvent.ACTION_MOVE, Triple(1, 900f, 900f))
+
+        val delta = trackedPointerDelta(event, trackedPointerId = 0, downX = 100f, downY = 500f)
+
+        assertThat(delta).isNull()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewGestureOwnershipProbeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewGestureOwnershipProbeTest.kt
@@ -59,4 +59,48 @@ internal class WebViewGestureOwnershipProbeTest {
 
         verify(exactly = 0) { WebViewCompat.addWebMessageListener(any(), any(), any(), any()) }
     }
+
+    @Test
+    fun `probe script only claims touch-action none, not pan-x or pan-y`() {
+        webView.installGestureOwnershipProbe("https://bundle.example.com") {}
+
+        verify {
+            WebViewCompat.addDocumentStartJavaScript(
+                webView,
+                match { it.contains("s.touchAction === 'none'") && !it.contains("!== 'auto'") },
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `probe script skips the root scroller`() {
+        webView.installGestureOwnershipProbe("https://bundle.example.com") {}
+
+        verify {
+            WebViewCompat.addDocumentStartJavaScript(
+                webView,
+                match {
+                    it.contains("isRootScroller") &&
+                        it.contains("document.scrollingElement") &&
+                        it.contains("document.documentElement") &&
+                        it.contains("document.body")
+                },
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `probe script bails on a second finger`() {
+        webView.installGestureOwnershipProbe("https://bundle.example.com") {}
+
+        verify {
+            WebViewCompat.addDocumentStartJavaScript(
+                webView,
+                match { it.contains("event.touches.length > 1") },
+                any(),
+            )
+        }
+    }
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Mirrors RevenueCat/purchases-ios#7283: Cursor found gesture-arbitration bugs in that PR's web_view drag logic, shared verbatim with our #3823. Fixed here.

### Description
- Probe (`WebViewGestureOwnershipProbe.kt`): claim only `touch-action: none` (not any non-default value), skip the root scroller in the ancestor walk, ignore multi-finger touchstarts.
- `PaywallWebView.kt`: track the pointer id that started the drag instead of raw index 0, so a lifted/reindexed finger can't corrupt the delta.

Device-verified (inner list, carousel, map).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch arbitration logic in embedded paywall WebViews, which can affect scroll UX (inner lists, carousels, maps) but does not touch auth, payments, or data handling.
> 
> **Overview**
> Tightens **paywall WebView vs parent scroll** gesture arbitration so drags aren’t mis-assigned to the WebView or the outer paywall scroll.
> 
> **`PaywallWebView`** now tracks the **pointer id** from the initial touch and computes move deltas via `trackedPointerDelta`, instead of always reading pointer index 0. That avoids wrong deltas when a finger lifts mid-gesture or pointer indices reorder during multi-touch.
> 
> The injected **gesture ownership probe** is more conservative: it only treats **`touch-action: none`** as “WebView owns” (not `pan-x`/`pan-y`, which native `canScroll*` already covers), **skips the document root scroller** in the ancestor walk, and **ignores touchstarts when more than one finger** is down so a second finger can’t overwrite the first gesture’s verdict.
> 
> Unit tests cover pointer tracking and the updated probe script behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cee15c04393cd42bb8fafccf46b152df6767d33b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->