### PR TITLE
test: cover workflow config failures before launch and after restart

### DIFF
--- a/maestro/workflows/workflow_config_fallback.yaml
+++ b/maestro/workflows/workflow_config_fallback.yaml
@@ -1,0 +1,31 @@
+# Forces a 4xx on /v1/config (remote_config_not_found kill-switch). The SDK falls back to the classic
+# single-page paywall (the workflow's last page), never crashing. The force_server_error_strategy
+# launch argument is read in E2ETestsApplication (onActivityPreCreated) and applied via DangerousSettings.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_config_fallback.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow offering falls back to the classic paywall on config failure
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow
+      force_server_error_strategy: remote_config_not_found
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# With /v1/config failing, the classic single-page paywall is shown directly.
+- extendedWaitUntil:
+    visible: "People Who Meditate Daily Sleep 40% Better"
+    timeout: 15000
+# The multipage workflow entry screen is never rendered in the fallback path.
+- assertNotVisible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+- takeScreenshot: "workflow_config_fallback - classic paywall"

--- a/maestro/workflows/workflow_config_fallback.yaml
+++ b/maestro/workflows/workflow_config_fallback.yaml
@@ -1,6 +1,6 @@
-# Forces a 4xx on /v1/config (remote_config_not_found kill-switch). The SDK falls back to the classic
+# Forces the /v1/config kill switch before SDK configuration. The SDK falls back to the classic
 # single-page paywall (the workflow's last page), never crashing. The force_server_error_strategy
-# launch argument is read in E2ETestsApplication (onActivityPreCreated) and applied via DangerousSettings.
+# launch argument is read in E2ETestsApplication and applied through the debug-only E2E configurator.
 #
 # Run locally against the test store:
 #   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_config_fallback.yaml
@@ -15,7 +15,7 @@ env:
     clearState: true
     arguments:
       e2e_test_flow: open_workflow
-      force_server_error_strategy: remote_config_not_found
+      force_server_error_strategy: remote_config_kill_switch
 - extendedWaitUntil:
     visible: "Present Paywall"
     timeout: 15000
@@ -24,8 +24,9 @@ env:
 
 # With /v1/config failing, the classic single-page paywall is shown directly.
 - extendedWaitUntil:
-    visible: "People Who Meditate Daily Sleep 40% Better"
+    visible: "Continue 3/3"
     timeout: 15000
 # The multipage workflow entry screen is never rendered in the fallback path.
-- assertNotVisible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+- assertNotVisible: "Continue 1/3"
+- assertNotVisible: "No Paywall configured"
 - takeScreenshot: "workflow_config_fallback - classic paywall"

--- a/maestro/workflows/workflow_offline_cached.yaml
+++ b/maestro/workflows/workflow_offline_cached.yaml
@@ -1,0 +1,50 @@
+# Reopening a workflow offering while /v1/config is unreachable, AFTER a prior successful load warmed
+# the cache, renders the cached multipage workflow (not the default paywall). Phase 1 loads online so
+# config/workflow/blobs persist; phase 2 relaunches with config offline WITHOUT clearing state, so the
+# disk cache survives. stopApp kills the process, so phase 2 gets a fresh configure that reads the arg.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_offline_cached.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow offering renders from cache when reopened offline after a prior load
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+# Phase 1: load online so config, workflow and blobs get cached to disk.
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 20000
+- tapOn:
+    text: "Present Paywall"
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+# Give the config/blob persist a moment to finish before killing the app.
+- waitForAnimationToEnd:
+    timeout: 5000
+- stopApp
+
+# Phase 2: reopen with /v1/config unreachable and WITHOUT clearing state, so the disk cache survives.
+- launchApp:
+    arguments:
+      e2e_test_flow: open_workflow
+      force_server_error_strategy: remote_config_network_error
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 20000
+- tapOn:
+    text: "Present Paywall"
+
+# The cached multipage workflow renders from disk even though config is offline.
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+# The default paywall (cold-cache fallback) must NOT appear here.
+- assertNotVisible: "No Paywall configured"
+- takeScreenshot: "workflow_offline_cached - workflow from cache"

--- a/maestro/workflows/workflow_offline_cached.yaml
+++ b/maestro/workflows/workflow_offline_cached.yaml
@@ -23,7 +23,7 @@ env:
 - tapOn:
     text: "Present Paywall"
 - extendedWaitUntil:
-    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    visible: "Continue 1/3"
     timeout: 15000
 # Give the config/blob persist a moment to finish before killing the app.
 - waitForAnimationToEnd:
@@ -43,7 +43,7 @@ env:
 
 # The cached multipage workflow renders from disk even though config is offline.
 - extendedWaitUntil:
-    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    visible: "Continue 1/3"
     timeout: 15000
 # The default paywall (cold-cache fallback) must NOT appear here.
 - assertNotVisible: "No Paywall configured"

--- a/purchases/src/defaultsDebug/kotlin/com/revenuecat/purchases/E2EForceServerErrorStrategy.kt
+++ b/purchases/src/defaultsDebug/kotlin/com/revenuecat/purchases/E2EForceServerErrorStrategy.kt
@@ -4,4 +4,5 @@ package com.revenuecat.purchases
 public enum class E2EForceServerErrorStrategy {
     Never,
     RemoteConfigKillSwitch,
+    RemoteConfigNetworkError,
 }

--- a/purchases/src/defaultsDebug/kotlin/com/revenuecat/purchases/PurchasesE2ETestConfiguration.kt
+++ b/purchases/src/defaultsDebug/kotlin/com/revenuecat/purchases/PurchasesE2ETestConfiguration.kt
@@ -22,6 +22,9 @@ public fun Purchases.Companion.configureForE2ETests(
                 E2EForceServerErrorStrategy.RemoteConfigKillSwitch -> {
                     if (endpoint is Endpoint.GetRemoteConfig) url.appendingRemoteConfigKillSwitch() else url
                 }
+                E2EForceServerErrorStrategy.RemoteConfigNetworkError -> {
+                    if (endpoint.isRemoteConfig()) remoteConfigOfflineURL else url
+                }
             }
         }
     }
@@ -47,3 +50,8 @@ private fun URL.appendingRemoteConfigKillSwitch(): URL = URL(
         .build()
         .toString(),
 )
+
+private fun Endpoint.isRemoteConfig(): Boolean =
+    this is Endpoint.GetRemoteConfig || this is Endpoint.GetRemoteConfigFallback
+
+private val remoteConfigOfflineURL = URL("https://config-offline.invalid/")

--- a/test-apps/e2etests/src/debug/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
+++ b/test-apps/e2etests/src/debug/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
@@ -13,11 +13,20 @@ private val forceServerErrorStrategy = AtomicReference(E2EForceServerErrorStrate
 @OptIn(InternalRevenueCatAPI::class)
 internal fun configurePurchases(
     configuration: PurchasesConfiguration,
+    initialForceServerErrorStrategy: String? = null,
 ) {
+    forceServerErrorStrategy.set(initialForceServerErrorStrategy.toForceServerErrorStrategy())
     Purchases.configureForE2ETests(configuration, forceServerErrorStrategy::get)
 }
 
 @OptIn(InternalRevenueCatAPI::class)
 internal fun armRemoteConfigKillSwitchForE2ETests() {
     forceServerErrorStrategy.set(E2EForceServerErrorStrategy.RemoteConfigKillSwitch)
+}
+
+@OptIn(InternalRevenueCatAPI::class)
+private fun String?.toForceServerErrorStrategy(): E2EForceServerErrorStrategy = when (this) {
+    "remote_config_kill_switch" -> E2EForceServerErrorStrategy.RemoteConfigKillSwitch
+    "remote_config_network_error" -> E2EForceServerErrorStrategy.RemoteConfigNetworkError
+    else -> E2EForceServerErrorStrategy.Never
 }

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
@@ -1,6 +1,8 @@
 package com.revenuecat.e2etests
 
+import android.app.Activity
 import android.app.Application
+import android.os.Bundle
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
@@ -12,24 +14,50 @@ class E2ETestsApplication : Application() {
         Purchases.logLevel = LogLevel.DEBUG
 
         // The workflow E2E flows are built with E2E_WORKFLOWS_API_KEY set (surfaced as
-        // BuildConfig.WORKFLOWS_API_KEY). When it's present we point at that project; otherwise we keep
-        // the default configuration used by the CI test_store_annual_purchase flow untouched. The Maestro
-        // launch argument only selects the screen (in MainActivity), so configuration stays here in the
-        // Application.
-        val builder = if (BuildConfig.WORKFLOWS_API_KEY != WORKFLOWS_API_KEY_PLACEHOLDER) {
-            PurchasesConfiguration.Builder(context = this, apiKey = BuildConfig.WORKFLOWS_API_KEY)
+        // BuildConfig.WORKFLOWS_API_KEY). When it's present we defer configuration until the first Activity
+        // is created, so a Maestro launch argument can select the initial debug-only failure strategy. The
+        // default build configures eagerly, keeping the CI test_store_annual_purchase flow untouched.
+        if (BuildConfig.WORKFLOWS_API_KEY != WORKFLOWS_API_KEY_PLACEHOLDER) {
+            registerActivityLifecycleCallbacks(ConfigureOnFirstActivity())
         } else {
-            PurchasesConfiguration.Builder(context = this, apiKey = Constants.API_KEY)
+            configurePurchases(
+                PurchasesConfiguration.Builder(context = this, apiKey = Constants.API_KEY).build(),
+            )
         }
+    }
 
-        configurePurchases(builder.build())
+    private inner class ConfigureOnFirstActivity : ActivityLifecycleCallbacksAdapter() {
+        override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
+            if (!Purchases.isConfigured) {
+                configurePurchases(
+                    PurchasesConfiguration.Builder(
+                        context = this@E2ETestsApplication,
+                        apiKey = BuildConfig.WORKFLOWS_API_KEY,
+                    ).build(),
+                    initialForceServerErrorStrategy = activity.intent?.getStringExtra(FORCE_SERVER_ERROR_EXTRA_KEY),
+                )
+            }
+            unregisterActivityLifecycleCallbacks(this)
+        }
     }
 
     internal companion object {
         private const val WORKFLOWS_API_KEY_PLACEHOLDER = "workflows_api_key_to_replace"
+        private const val FORCE_SERVER_ERROR_EXTRA_KEY = "force_server_error_strategy"
 
         fun forceConfigKillSwitch() {
             armRemoteConfigKillSwitchForE2ETests()
         }
     }
+}
+
+/** No-op base so [E2ETestsApplication] only overrides the lifecycle callback it needs. */
+private open class ActivityLifecycleCallbacksAdapter : Application.ActivityLifecycleCallbacks {
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+    override fun onActivityStarted(activity: Activity) = Unit
+    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+    override fun onActivityDestroyed(activity: Activity) = Unit
 }

--- a/test-apps/e2etests/src/release/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
+++ b/test-apps/e2etests/src/release/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
@@ -3,8 +3,10 @@ package com.revenuecat.e2etests
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 
+@Suppress("UNUSED_PARAMETER")
 internal fun configurePurchases(
     configuration: PurchasesConfiguration,
+    initialForceServerErrorStrategy: String? = null,
 ) {
     Purchases.configure(configuration)
 }


### PR DESCRIPTION
[#3878](https://github.com/RevenueCat/purchases-android/pull/3878) covers the config kill switch tripping mid-session. This adds the two remaining cases:

- the kill switch is active before SDK configuration
- the process restarts with config unreachable and a warm workflow cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Maestro workflows and debug/release e2e test app configuration; production SDK behavior is not modified.
> 
> **Overview**
> Adds **Maestro coverage** for two workflow remote-config failure paths that complement mid-session kill-switch tests: **kill switch active before SDK configure** (expects classic paywall `Continue 3/3`, not multipage `Continue 1/3`) and **process restart with config unreachable after a warm cache** (expects cached multipage workflow, not cold fallback).
> 
> **Debug-only E2E hooks** gain `RemoteConfigNetworkError`, which rewrites remote-config endpoints to an invalid URL (kill switch still uses the query param). The e2e test app **defers `Purchases` configuration** until the first Activity when the workflows API key is set, so Maestro `force_server_error_strategy` launch arguments apply at configure time; default/CI builds still configure eagerly in `Application.onCreate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4edbc59b2b7f6d8dc0c1fbe2887adcfd748ee509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->