### PR TITLE
Assume product with no billing period to be a "lifetime" offering

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensions.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationK
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 internal val Package.isLifetime: Boolean
-    get() = packageType == PackageType.LIFETIME
+    get() = packageType == PackageType.LIFETIME || product.period == null
 
 internal val Package.periodUnitLocalizationKey: VariableLocalizationKey?
     get() = if (isLifetime) VariableLocalizationKey.LIFETIME else product.period?.periodUnitLocalizationKey

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -133,20 +133,19 @@ internal class VariableDataProvider(
     }
 
     fun periodName(rcPackage: Package): String? {
-        if (rcPackage.packageType == PackageType.CUSTOM ||
-            rcPackage.packageType == PackageType.UNKNOWN
-        ) {
-            return rcPackage.identifier
-        }
-        val stringId = when (rcPackage.packageType) {
-            PackageType.LIFETIME -> R.string.lifetime
-            PackageType.ANNUAL -> R.string.annual
-            PackageType.SIX_MONTH -> R.string.semester
-            PackageType.THREE_MONTH -> R.string.quarter
-            PackageType.TWO_MONTH -> R.string.bimonthly
-            PackageType.MONTHLY -> R.string.monthly
-            PackageType.WEEKLY -> R.string.weekly
-            PackageType.UNKNOWN, PackageType.CUSTOM -> null
+        val stringId = when {
+            rcPackage.isLifetime -> R.string.lifetime
+            rcPackage.packageType == PackageType.CUSTOM ||
+                rcPackage.packageType == PackageType.UNKNOWN -> return rcPackage.identifier
+            else -> when (rcPackage.packageType) {
+                PackageType.ANNUAL -> R.string.annual
+                PackageType.SIX_MONTH -> R.string.semester
+                PackageType.THREE_MONTH -> R.string.quarter
+                PackageType.TWO_MONTH -> R.string.bimonthly
+                PackageType.MONTHLY -> R.string.monthly
+                PackageType.WEEKLY -> R.string.weekly
+                PackageType.LIFETIME, PackageType.UNKNOWN, PackageType.CUSTOM -> null
+            }
         }
         return stringId?.let { resourceProvider.getString(it) }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -366,6 +366,19 @@ internal object TestData {
                 period = Period(value = 6, unit = Period.Unit.MONTH, iso8601 = "P6M"),
             ),
         )
+        val customLifetime = Package(
+            packageType = PackageType.CUSTOM,
+            identifier = "custom_lifetime",
+            offering = "offering",
+            product = TestStoreProduct(
+                id = "com.revenuecat.custom_lifetime_product",
+                name = "Custom Lifetime",
+                title = "Custom Lifetime (App name)",
+                price = Price(amountMicros = 1_000_000_000, currencyCode = "USD", formatted = "$1,000"),
+                description = "Custom Lifetime",
+                period = null,
+            ),
+        )
         val unknown = Package(
             packageType = PackageType.UNKNOWN,
             identifier = "Unknown",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensionsTest.kt
@@ -1,0 +1,90 @@
+package com.revenuecat.purchases.ui.revenuecatui.data.processed
+
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.TestStoreProduct
+import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationKey
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@Suppress("DEPRECATION")
+internal class PackagePeriodExtensionsTest {
+
+    private val localizedVariableKeys: Map<VariableLocalizationKey, String> = mapOf(
+        VariableLocalizationKey.LIFETIME to "Lifetime",
+        VariableLocalizationKey.MONTHLY to "monthly",
+        VariableLocalizationKey.MONTH_SHORT to "mo",
+    )
+
+    @Test
+    fun `isLifetime is true for the predefined lifetime package`() {
+        val pkg = lifetimePackage(
+            packageType = PackageType.LIFETIME,
+            identifier = PackageType.LIFETIME.identifier!!,
+        )
+
+        assertThat(pkg.isLifetime).isTrue()
+    }
+
+    @Test
+    fun `isLifetime is true for a non-subscription product in a custom-identifier package`() {
+        val pkg = lifetimePackage(
+            packageType = PackageType.CUSTOM,
+            identifier = "custom_lifetime_tier_1",
+        )
+
+        assertThat(pkg.isLifetime).isTrue()
+    }
+
+    @Test
+    fun `isLifetime is false for a subscription product`() {
+        assertThat(monthlyPackage().isLifetime).isFalse()
+    }
+
+    @Test
+    fun `productPeriodAbbreviated returns the lifetime string for a custom-identifier lifetime package`() {
+        val pkg = lifetimePackage(
+            packageType = PackageType.CUSTOM,
+            identifier = "custom_lifetime_tier_1",
+        )
+
+        assertThat(pkg.productPeriodAbbreviated(localizedVariableKeys)).isEqualTo("Lifetime")
+    }
+
+    @Test
+    fun `productPeriodAbbreviated returns the abbreviated period for a subscription product`() {
+        assertThat(monthlyPackage().productPeriodAbbreviated(localizedVariableKeys)).isEqualTo("mo")
+    }
+
+    private fun lifetimePackage(packageType: PackageType, identifier: String) =
+        Package(
+            packageType = packageType,
+            identifier = identifier,
+            offering = "offering",
+            product = TestStoreProduct(
+                id = "com.revenuecat.lifetime_product",
+                name = "Lifetime",
+                title = "Lifetime (App name)",
+                price = Price(amountMicros = 49_990_000, currencyCode = "USD", formatted = "$49.99"),
+                description = "Lifetime",
+                period = null,
+            ),
+        )
+
+    private fun monthlyPackage() =
+        Package(
+            packageType = PackageType.MONTHLY,
+            identifier = PackageType.MONTHLY.identifier!!,
+            offering = "offering",
+            product = TestStoreProduct(
+                id = "com.revenuecat.monthly_product",
+                name = "Monthly",
+                title = "Monthly (App name)",
+                price = Price(amountMicros = 9_990_000, currencyCode = "USD", formatted = "$9.99"),
+                description = "Monthly",
+                period = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+            ),
+        )
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
@@ -227,6 +227,11 @@ class VariableProcessorTest {
     }
 
     @Test
+    fun `process variables processes sub_period for lifetime product with custom identifier`() {
+        expectVariablesResult("{{ sub_period }}", "Lifetime", rcPackage = TestData.Packages.customLifetime)
+    }
+
+    @Test
     fun `process variables processes sub_period unknown period`() {
         expectVariablesResult("{{ sub_period }}", "Unknown", rcPackage = TestData.Packages.unknown)
     }


### PR DESCRIPTION
### Motivation

Fixed `price_per_period_abbreviated` (and similar period variables) returning an empty string for lifetime products with custom package identifiers

### Description

This updates so we are now detecting "lifetime" via the product having no billing period (`period == null`) instead of the `$rc_lifetime` package identifier

Comparative check in purchases-ios that this change was based on: https://github.com/RevenueCat/purchases-ios/blob/48237e34209b86221aa86629befc3698df2a2640/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift#L594

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5f40e1e2b43a6f5ace8d75a2b4a5f1a3d9732586. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->