### PR TITLE
feat(paywalls): apply hero top-inset treatment to full-width web_view

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -95,6 +95,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ImageComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
@@ -954,6 +955,7 @@ private val ComponentStyle.shouldIgnoreTopWindowInsets: Boolean
     get() = when (this) {
         is ImageComponentStyle -> ignoreTopWindowInsets
         is VideoComponentStyle -> ignoreTopWindowInsets
+        is WebViewComponentStyle -> ignoreTopWindowInsets
         else -> false
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -188,7 +188,8 @@ internal class StyleFactory(
             var topWindowInsetsApplied = false
 
             /**
-             * Whether the first visual component in the tree is a full-width image or video (a "hero image").
+             * Whether the first visual component in the tree is a full-width image, video or web_view (a
+             * "hero image").
              * This is tracked separately from [topWindowInsetsApplied] because a hero image can appear
              * outside a ZLayer (e.g. directly in a Vertical stack), in which case it doesn't affect
              * top window insets application but still needs to be detected for header padding logic.
@@ -201,9 +202,9 @@ internal class StyleFactory(
             private var stillLookingForHeaderMedia = true
 
             /**
-             * This will be called for every component in the tree, and will determine whether we have a header image
-             * or video that needs special top-window-insets treatment. A header image is found if the first
-             * non-container component is an image component with a Fill width and a ZLayer parent stack.
+             * This will be called for every component in the tree, and will determine whether we have header media
+             * that needs special top-window-insets treatment. Header media is found if the first non-container
+             * component is an image, video or web_view component with a Fill width and a ZLayer parent stack.
              */
             fun handleHeaderMediaViewWindowInsets(component: PaywallComponent) {
                 when (component) {
@@ -222,18 +223,14 @@ internal class StyleFactory(
                         }
                     }
 
-                    is ImageComponent -> {
+                    is ImageComponent,
+                    is VideoComponent,
+                    is WebViewComponent,
+                    -> {
                         if (stillLookingForHeaderMedia) {
-                            ignoreTopWindowInsets = component.isHeaderImage
-                            heroImageDetected = component.isHeaderImage
-                        }
-                        stillLookingForHeaderMedia = false
-                    }
-
-                    is VideoComponent -> {
-                        if (stillLookingForHeaderMedia) {
-                            ignoreTopWindowInsets = component.isHeaderVideo
-                            heroImageDetected = component.isHeaderVideo
+                            val isHero = component.isHeaderMedia
+                            ignoreTopWindowInsets = isHero
+                            heroImageDetected = isHero
                         }
                         stillLookingForHeaderMedia = false
                     }
@@ -244,25 +241,20 @@ internal class StyleFactory(
             }
 
             private val PaywallComponent.isHeaderMedia: Boolean
-                get() = isHeaderImage || isHeaderVideo
+                get() = when (this) {
+                    is ImageComponent -> size.width.isFill
+                    is VideoComponent -> size.width.isFill
+                    is WebViewComponent -> size.width.isFill
+                    else -> false
+                }
 
-            private val PaywallComponent.isHeaderImage: Boolean
-                get() = this is ImageComponent &&
-                    when (size.width) {
-                        is SizeConstraint.Fill -> true
-                        is SizeConstraint.Fit,
-                        is SizeConstraint.Fixed,
-                        -> false
-                    }
-
-            private val PaywallComponent.isHeaderVideo: Boolean
-                get() = this is VideoComponent &&
-                    when (size.width) {
-                        is SizeConstraint.Fill -> true
-                        is SizeConstraint.Fit,
-                        is SizeConstraint.Fixed,
-                        -> false
-                    }
+            private val SizeConstraint.isFill: Boolean
+                get() = when (this) {
+                    is SizeConstraint.Fill -> true
+                    is SizeConstraint.Fit,
+                    is SizeConstraint.Fixed,
+                    -> false
+                }
         }
 
         val windowInsetsState = WindowInsetsState()
@@ -590,6 +582,7 @@ internal class StyleFactory(
                 visible = component.visible ?: DEFAULT_VISIBILITY,
                 size = component.size,
                 componentId = component.id,
+                ignoreTopWindowInsets = ignoreTopWindowInsets,
             ),
         )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/WebViewComponentStyle.kt
@@ -12,4 +12,5 @@ internal data class WebViewComponentStyle(
     override val size: Size,
     /** Schema `web_view.id`, sent to the content during the handshake. A blank id renders nothing. */
     val componentId: String,
+    val ignoreTopWindowInsets: Boolean = false,
 ) : ComponentStyle

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallComponentDataValidationTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallComponentDataValidationTests.kt
@@ -18,6 +18,7 @@ import com.revenuecat.purchases.paywalls.components.PartialTextComponent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import kotlinx.serialization.SerializationException
@@ -947,6 +948,59 @@ class PaywallComponentDataValidationTests {
                                         height = 100u,
                                     ),
                                 )
+                            ),
+                            TestData.Components.monthlyPackageComponent,
+                        )
+                    ),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    header = HeaderComponent(stack = StackComponent(components = emptyList())),
+                ),
+            ),
+            componentsLocalizations = mapOf(
+                defaultLocale to mapOf(LocalizationKey("key1") to LocalizationData.Text("value1")),
+            ),
+            defaultLocaleIdentifier = defaultLocale,
+        )
+        val offering = Offering(
+            identifier = "identifier",
+            serverDescription = "serverDescription",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly),
+            paywallComponents = Offering.PaywallComponents(UiConfig(), data),
+        )
+
+        // Act
+        val validated = offering.validatedPaywall(TestData.Constants.currentColorScheme, MockResourceProvider())
+
+        // Assert
+        assertTrue(validated is PaywallValidationResult.Components)
+        assertNull(validated.errors)
+        val result = validated as PaywallValidationResult.Components
+        assertTrue(result.mainStackHasHeroImage)
+        assertNotNull(result.header)
+    }
+
+    @Test
+    fun `Should set mainStackHasHeroImage when header and full-width web_view coexist`() {
+        // Arrange - web_view directly in the root Vertical stack, not wrapped in a ZLayer
+        val defaultLocale = LocaleId("en_US")
+        val data = PaywallComponentsData(
+            id = "paywall_id",
+            templateName = "template",
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(
+                        dimension = Dimension.Vertical(HorizontalAlignment.CENTER, START),
+                        components = listOf(
+                            WebViewComponent(
+                                url = "https://bundle-hash.components.revenuecat-static.com/index.html",
+                                id = "hero_web_view",
+                                protocolVersion = 1,
+                                size = Size(
+                                    width = SizeConstraint.Fill,
+                                    height = SizeConstraint.Fit(default = 400u),
+                                ),
                             ),
                             TestData.Components.monthlyPackageComponent,
                         )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -1348,6 +1348,169 @@ class StyleFactoryTests {
         assertThat(secondImage.ignoreTopWindowInsets).isFalse()
     }
 
+    private fun heroWebViewComponent(width: SizeConstraint = SizeConstraint.Fill) = WebViewComponent(
+        url = "https://bundle-hash.components.revenuecat-static.com/index.html",
+        id = "hero_web_view",
+        protocolVersion = 1,
+        size = Size(width = width, height = SizeConstraint.Fit(default = 400u)),
+    )
+
+    private fun textComponent() = TextComponent(
+        text = LOCALIZATION_KEY_TEXT_1,
+        color = ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb())),
+    )
+
+    @Test
+    fun `Should ignore top window insets for the first full-width web_view in the first z-stack`() {
+        // Arrange
+        val stackComponent = StackComponent(
+            components = listOf(
+                StackComponent(
+                    components = listOf(heroWebViewComponent()),
+                    dimension = Dimension.ZLayer(
+                        alignment = TwoDimensionalAlignment.TOP,
+                    )
+                ),
+                textComponent(),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isTrue()
+        val style = styleResult.componentStyle as StackComponentStyle
+        // The root stack should not apply top window insets (the ZLayer child handles it).
+        assertThat(style.applyTopWindowInsets).isFalse()
+        val firstZStack = style.children[0] as StackComponentStyle
+        assertThat(firstZStack.applyTopWindowInsets).isTrue()
+        val webView = firstZStack.children[0] as WebViewComponentStyle
+        assertThat(webView.ignoreTopWindowInsets).isTrue()
+    }
+
+    @Test
+    fun `Should not ignore top window insets for the first web_view in the first z-stack if it is not full-width`() {
+        // Arrange
+        val stackComponent = StackComponent(
+            components = listOf(
+                StackComponent(
+                    components = listOf(heroWebViewComponent(width = SizeConstraint.Fixed(200u))),
+                    dimension = Dimension.ZLayer(
+                        alignment = TwoDimensionalAlignment.TOP,
+                    )
+                ),
+                textComponent(),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isFalse()
+        val style = styleResult.componentStyle as StackComponentStyle
+        assertThat(style.applyTopWindowInsets).isTrue()
+        val firstZStack = style.children[0] as StackComponentStyle
+        assertThat(firstZStack.applyTopWindowInsets).isFalse()
+        val webView = firstZStack.children[0] as WebViewComponentStyle
+        assertThat(webView.ignoreTopWindowInsets).isFalse()
+    }
+
+    @Test
+    fun `Should ignore top window insets for the first full-width web_view in the root`() {
+        // Arrange
+        val stackComponent = StackComponent(
+            components = listOf(
+                heroWebViewComponent(),
+                textComponent(),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isTrue()
+        val style = styleResult.componentStyle as StackComponentStyle
+        assertThat(style.applyTopWindowInsets).isTrue()
+        val webView = style.children[0] as WebViewComponentStyle
+        assertThat(webView.ignoreTopWindowInsets).isTrue()
+    }
+
+    @Test
+    fun `Should not ignore top window insets for a web_view that is not the first component`() {
+        // Arrange
+        val stackComponent = StackComponent(
+            components = listOf(
+                textComponent(),
+                heroWebViewComponent(),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isFalse()
+        val style = styleResult.componentStyle as StackComponentStyle
+        assertThat(style.applyTopWindowInsets).isTrue()
+        val webView = style.children[1] as WebViewComponentStyle
+        assertThat(webView.ignoreTopWindowInsets).isFalse()
+    }
+
+    @Test
+    fun `Should ignore top window insets for a full-width web_view preceded by a FallbackHeaderComponent`() {
+        // Arrange
+        // FallbackHeaderComponent is injected as the first element of the body stack by the dashboard.
+        // It should not prematurely stop hero detection.
+        val stackComponent = StackComponent(
+            components = listOf(
+                FallbackHeaderComponent,
+                heroWebViewComponent(),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            )
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isTrue()
+        val style = styleResult.componentStyle as StackComponentStyle
+        val webView = style.children[0] as WebViewComponentStyle
+        assertThat(webView.ignoreTopWindowInsets).isTrue()
+    }
+
     @Test
     fun `PackageComponentStyle visible defaults to true when component visible is null`() {
         // Arrange


### PR DESCRIPTION
Allows custom components to behave as heroes like images and videos currently do by drawing underneath the header. Only applies if the CC is the first element in the paywal and is full width.


<img width="1288" height="1339" alt="scomp-20260728-111100" src="https://github.com/user-attachments/assets/a48a7b44-4adb-4c6a-8c01-cc1e526ca833" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall window-inset and hero detection for web views; behavior is aligned with existing image/video paths and covered by new tests, but layout edge cases could still differ for embedded WebViews.
> 
> **Overview**
> Full-width **web_view** components can now act as **hero** media like images and videos, so custom components can extend under the status bar/header instead of getting top safe-area padding on the first child.
> 
> **StyleFactory** unifies header-media detection: the first non-container component that is an image, video, or web_view with **Fill** width sets `ignoreTopWindowInsets` and `heroImageDetected`, including when the web_view is first in a vertical root stack (not only inside a Z-layer). **WebViewComponentStyle** gains `ignoreTopWindowInsets`, and **StackComponentView** skips top window inset padding for web views when that flag is set.
> 
> Tests cover Z-layer heroes, non-full-width, ordering, and **FallbackHeaderComponent** before the hero web_view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4abb68bc34f9eca2a4549b7cc118db1c5ce1a955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->