### PR TITLE
refactor(remote-config): increase API failover restart interval to 2 hours

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProvider.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.intOrNull
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.hours
 
 /** A remote config source: a URL plus the metadata used to order sources. */
 internal data class RemoteConfigSource(
@@ -81,7 +82,7 @@ internal interface RemoteConfigSourceProvider {
  * sources have no embedded default: they are only useful alongside a fetched config, which carries
  * its own. Sources are deduped by url and ordered via [WeightedSourceSelector].
  *
- * The api list additionally restarts on its own once [API_FAILOVER_RESTART_INTERVAL_MS] has elapsed
+ * The api list additionally restarts on its own once [API_FAILOVER_RESTART_INTERVAL] has elapsed
  * since it first failed over, so the SDK periodically returns to the primary source (or re-arms an
  * exhausted list) instead of sticking on a backup forever. During a persistent outage this retries
  * the primary at most once per interval. Blob failover has no such timer: it is restarted per fetch
@@ -181,14 +182,14 @@ internal class DefaultRemoteConfigSourceProvider(
         }
 
     /**
-     * Restarts the api failover once [API_FAILOVER_RESTART_INTERVAL_MS] has elapsed since it first
+     * Restarts the api failover once [API_FAILOVER_RESTART_INTERVAL] has elapsed since it first
      * advanced, so a backup (or an exhausted list) periodically retries the primary source. The
      * restart bumps the token, so handles from before it can no longer advance the list. Callers
      * must hold [lock].
      */
     private fun restartAPIIfExpired() {
         val startedAtMs = apiFailoverStartedAtMs ?: return
-        if (dateProvider.now.time - startedAtMs >= API_FAILOVER_RESTART_INTERVAL_MS) {
+        if (dateProvider.now.time - startedAtMs >= API_FAILOVER_RESTART_INTERVAL.inWholeMilliseconds) {
             api.restart()
             apiFailoverStartedAtMs = null
         }
@@ -227,7 +228,7 @@ internal class DefaultRemoteConfigSourceProvider(
     }
 
     private companion object {
-        private const val API_FAILOVER_RESTART_INTERVAL_MS = 600_000L
+        private val API_FAILOVER_RESTART_INTERVAL = 2.hours
         private const val API_ITEM = "api"
         private const val BLOB_ITEM = "blob"
         private const val SOURCES_KEY = "sources"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigSourceProviderTest.kt
@@ -18,6 +18,10 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -379,7 +383,7 @@ class RemoteConfigSourceProviderTest {
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // a -> b
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("b"))
 
-        dateProvider.advanceTime(600_000L)
+        dateProvider.advanceTime(2.hours)
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("a"))
     }
 
@@ -390,7 +394,7 @@ class RemoteConfigSourceProviderTest {
 
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // a -> b
 
-        dateProvider.advanceTime(599_999L)
+        dateProvider.advanceTime(2.hours - 1.milliseconds)
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("b"))
     }
 
@@ -403,10 +407,10 @@ class RemoteConfigSourceProviderTest {
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // b -> exhausted
         assertThat(provider.getCurrent(Purpose.API)).isNull()
 
-        dateProvider.advanceTime(599_999L)
+        dateProvider.advanceTime(2.hours - 1.milliseconds)
         assertThat(provider.getCurrent(Purpose.API)).isNull()
 
-        dateProvider.advanceTime(1L)
+        dateProvider.advanceTime(1.milliseconds)
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("a"))
     }
 
@@ -418,10 +422,10 @@ class RemoteConfigSourceProviderTest {
         val provider = apiProvider(listOf(source("a"), source("b"), source("c")), dateProvider)
 
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // a -> b, timer starts
-        dateProvider.advanceTime(500_000L)
+        dateProvider.advanceTime(90.minutes)
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // b -> c, timer unchanged
 
-        dateProvider.advanceTime(100_000L) // 600s since the first advance
+        dateProvider.advanceTime(30.minutes) // 2h since the first advance
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("a"))
     }
 
@@ -434,7 +438,7 @@ class RemoteConfigSourceProviderTest {
         val stale = provider.getCurrent(Purpose.API)
         assertThat(stale?.url).isEqualTo(url("b"))
 
-        dateProvider.advanceTime(600_000L)
+        dateProvider.advanceTime(2.hours)
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("a"))
 
         // The pre-restart handle belongs to the previous cycle, so it must not advance the list.
@@ -448,14 +452,14 @@ class RemoteConfigSourceProviderTest {
         val provider = apiProvider(listOf(source("a"), source("b")), dateProvider)
 
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // a -> b
-        dateProvider.advanceTime(600_000L)
+        dateProvider.advanceTime(2.hours)
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("a"))
 
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // a -> b, new timer
-        dateProvider.advanceTime(599_999L)
+        dateProvider.advanceTime(2.hours - 1.milliseconds)
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("b"))
 
-        dateProvider.advanceTime(1L)
+        dateProvider.advanceTime(1.milliseconds)
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("a"))
     }
 
@@ -465,11 +469,11 @@ class RemoteConfigSourceProviderTest {
         val provider = apiProvider(listOf(source("a"), source("b")), dateProvider)
 
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // a -> b, timer starts
-        dateProvider.advanceTime(500_000L)
+        dateProvider.advanceTime(90.minutes)
         provider.restart(Purpose.API) // timer cleared
 
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // a -> b, fresh timer
-        dateProvider.advanceTime(599_999L) // over 600s since the ORIGINAL advance, under since the fresh one
+        dateProvider.advanceTime(2.hours - 1.milliseconds) // over 2h since the ORIGINAL advance, under since the fresh one
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("b"))
     }
 
@@ -480,15 +484,15 @@ class RemoteConfigSourceProviderTest {
         val provider = DefaultRemoteConfigSourceProvider(store, FakeRandom(0), dateProvider)
 
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // a -> b, timer starts
-        dateProvider.advanceTime(500_000L)
+        dateProvider.advanceTime(90.minutes)
 
         store.sources = sourcesTopic(api = listOf(source("x"), source("y")), blob = emptyList())
         provider.reportUnhealthy(provider.getCurrent(Purpose.API)!!) // x -> y, fresh timer
 
-        dateProvider.advanceTime(599_999L)
+        dateProvider.advanceTime(2.hours - 1.milliseconds)
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("y"))
 
-        dateProvider.advanceTime(1L)
+        dateProvider.advanceTime(1.milliseconds)
         assertThat(provider.getCurrent(Purpose.API)?.url).isEqualTo(url("x"))
     }
 
@@ -502,7 +506,7 @@ class RemoteConfigSourceProviderTest {
         )
 
         provider.reportUnhealthy(provider.getCurrent(Purpose.BLOB)!!) // blob1 -> blob2
-        dateProvider.advanceTime(600_000L)
+        dateProvider.advanceTime(2.hours)
         assertThat(provider.getCurrent(Purpose.BLOB)?.url).isEqualTo(url("blob2"))
     }
 
@@ -670,8 +674,8 @@ class RemoteConfigSourceProviderTest {
         override val now: Date
             get() = Date(currentTime.get())
 
-        fun advanceTime(millis: Long) {
-            currentTime.addAndGet(millis)
+        fun advanceTime(duration: Duration) {
+            currentTime.addAndGet(duration.inWholeMilliseconds)
         }
     }
 


### PR DESCRIPTION
Bumps the API source failover restart interval from 10 minutes to 2 hours, so during an outage the SDK retries the primary source at most once every 2 hours instead of every 10 minutes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timing-only change to remote-config API failover retry cadence; no auth or data-path changes, but it slows how often the primary API is retried during outages.
> 
> **Overview**
> Raises the **API remote-config source failover restart interval** from **10 minutes** to **2 hours**, so after failover the SDK returns to the primary API source (or re-arms an exhausted list) at most once every two hours instead of every ten minutes during a sustained outage.
> 
> The constant is expressed as **`2.hours`** via `kotlin.time.Duration` instead of raw milliseconds; **`restartAPIIfExpired`** still compares against elapsed wall-clock time in milliseconds. Blob failover behavior is unchanged (no TTL restart).
> 
> Tests and **`FakeDateProvider.advanceTime`** were updated to use **`Duration`** (e.g. `2.hours`, `2.hours - 1.milliseconds`) so TTL re-arm cases stay aligned with the new interval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af6169912de971bd03bc3298e1333e32ab4cfa06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->