### PR TITLE
fix: exclude pending purchases from offline entitlements calculation

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcher.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
 import java.util.Date
@@ -39,6 +40,7 @@ internal class PurchasedProductsFetcher(
             appUserID,
             onSuccess = { activePurchasesByHashedToken ->
                 val activePurchases = activePurchasesByHashedToken.values
+                    .filter { it.purchaseState != PurchaseState.PENDING }
                 val purchasedProducts = activePurchases.flatMap {
                     createPurchasedProducts(it, productEntitlementMapping)
                 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcherTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.offlineentitlements
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.billingclient.api.Purchase
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -9,6 +10,8 @@ import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.toStoreTransaction
+import com.revenuecat.purchases.models.PurchaseState
+import com.revenuecat.purchases.models.PurchaseType
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
 import com.revenuecat.purchases.utils.stubGooglePurchase
@@ -17,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -312,6 +316,87 @@ class PurchasedProductsFetcherTest {
             annualProduct,
             activePurchaseAnnual,
             mapOfEntitlements,
+        )
+    }
+
+    @Test
+    fun `pending purchases are excluded from purchased products`() {
+        val pendingProductIdentifier = "monthly"
+        val purchasedProductIdentifier = "annual"
+        val mapOfEntitlements = mapOf(
+            pendingProductIdentifier to listOf("pro"),
+            purchasedProductIdentifier to listOf("premium"),
+        )
+        mockEntitlementMapping(mapOfEntitlements)
+        val pendingPurchase = stubStoreTransactionFromGooglePurchase(
+            productIds = listOf(pendingProductIdentifier),
+            purchaseTime = testDate.time,
+            purchaseToken = "test-token-1",
+            purchaseState = Purchase.PurchaseState.PENDING,
+        )
+        val activePurchase = stubStoreTransactionFromGooglePurchase(
+            productIds = listOf(purchasedProductIdentifier),
+            purchaseTime = testDate.time,
+            purchaseToken = "test-token-2",
+        )
+        mockActivePurchases(listOf(pendingPurchase, activePurchase))
+        var receivedListOfPurchasedProducts: List<PurchasedProduct> = emptyList()
+
+        fetcher.queryActiveProducts(
+            appUserID = "appUserID",
+            onSuccess = {
+                receivedListOfPurchasedProducts = it
+            },
+            unexpectedOnError,
+        )
+
+        assertThat(receivedListOfPurchasedProducts.size).isEqualTo(1)
+        assertPurchasedProduct(
+            receivedListOfPurchasedProducts[0],
+            activePurchase,
+            mapOfEntitlements,
+        )
+    }
+
+    @Test
+    fun `purchases with unspecified state are included in purchased products`() {
+        // Amazon transactions always have UNSPECIFIED_STATE, so they must not be filtered out.
+        val productIdentifier = "monthly"
+        val productIdentifierToEntitlements = mapOf(productIdentifier to listOf("pro"))
+        mockEntitlementMapping(productIdentifierToEntitlements)
+        val unspecifiedStatePurchase = StoreTransaction(
+            orderId = null,
+            productIds = listOf(productIdentifier),
+            type = ProductType.SUBS,
+            purchaseTime = testDate.time,
+            purchaseToken = "test-token-1",
+            purchaseState = PurchaseState.UNSPECIFIED_STATE,
+            isAutoRenewing = null,
+            signature = null,
+            originalJson = JSONObject(),
+            presentedOfferingContext = null,
+            storeUserID = null,
+            purchaseType = PurchaseType.AMAZON_PURCHASE,
+            marketplace = null,
+            subscriptionOptionId = null,
+            replacementMode = null,
+        )
+        mockActivePurchases(listOf(unspecifiedStatePurchase))
+        var receivedListOfPurchasedProducts: List<PurchasedProduct> = emptyList()
+
+        fetcher.queryActiveProducts(
+            appUserID = "appUserID",
+            onSuccess = {
+                receivedListOfPurchasedProducts = it
+            },
+            unexpectedOnError,
+        )
+
+        assertThat(receivedListOfPurchasedProducts.size).isEqualTo(1)
+        assertPurchasedProduct(
+            receivedListOfPurchasedProducts[0],
+            unspecifiedStatePurchase,
+            productIdentifierToEntitlements,
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubs.kt
@@ -165,11 +165,13 @@ fun stubStoreTransactionFromGooglePurchase(
     purchaseTime: Long,
     purchaseToken: String = "abcdefghijipehfnbbnldmai.AO-J1OxqriTepvB7suzlIhxqPIveA0IHtX9amMedK0KK9CsO0S3Zk5H6gdwvV" +
         "7HzZIJeTzqkY4okyVk8XKTmK1WZKAKSNTKop4dgwSmFnLWsCxYbahUmADg",
+    purchaseState: Int = Purchase.PurchaseState.PURCHASED,
 ): StoreTransaction {
     return stubGooglePurchase(
         productIds,
         purchaseTime,
         purchaseToken = purchaseToken,
+        purchaseState = purchaseState,
     ).toStoreTransaction(ProductType.SUBS, null)
 }
 


### PR DESCRIPTION
### Description

When computing CustomerInfo offline, purchases in `PENDING` state returned by `queryPurchases` were treated like any other purchase. This aligns the offline calculation with the post-receipt path, which already skips pending purchases. `PurchasedProductsFetcher` now filters out `PENDING` transactions before mapping them to purchased products. Transactions with `UNSPECIFIED_STATE` are still included, since Amazon purchases always have that state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline entitlement computation, which can affect what users see when the network is unavailable; scope is narrow (pending-only filter) and aligned with existing receipt handling.
> 
> **Overview**
> Offline **CustomerInfo** could grant entitlements from store purchases still in **`PENDING`** state because `PurchasedProductsFetcher` treated every `queryPurchases` result equally. The fetcher now **drops `PENDING` transactions** before building purchased products, matching the post-receipt path (`PostReceiptHelper` already refuses pending receipts).
> 
> **`UNSPECIFIED_STATE`** purchases are still included so Amazon transactions (which always use that state) are not affected. Tests cover pending exclusion and unspecified-state inclusion; test stubs accept a configurable `purchaseState`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e173c9eb1cc12112f466dc651b93fc2b5b6f395b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->