### PR TITLE
Fix: Fill expanding to Custom Component size after layout measure pass

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -661,11 +661,10 @@ private fun MainStackComponent(
                 is Dimension.Vertical -> {
                     // See the Horizontal branch above for why this exists.
                     val hasFillHeightChild = stackState.children.any { it.size.height == Fill }
-                    // web component views that are set to fill height need to be able to push the bounds
-                    // of the containing stack. If they cannot, we don't get the scrollability that is expected.
-                    val hasFillHeightWebViewChild = stackState.children.any {
-                        it is WebViewComponentStyle && it.size.height == Fill
-                    }
+                    // Web component views that are set to fill height — directly or through a chain of
+                    // fill-height stacks — need to be able to push the bounds of the containing stack.
+                    // If they cannot, we don't get the scrollability that is expected.
+                    val hasFillHeightWebViewChild = stackState.children.any { it.growsToWebViewContentHeight }
                     val mainAxisUnbounded = remember { mutableStateOf(false) }
                     val webViewHeightAxisUnbounded = remember { mutableStateOf(false) }
                     VerticalStack(
@@ -699,7 +698,7 @@ private fun MainStackComponent(
                                     .conditional(
                                         child.size.height == Fill &&
                                             !mainAxisUnbounded.value &&
-                                            !(child is WebViewComponentStyle && webViewHeightAxisUnbounded.value),
+                                            !(child.growsToWebViewContentHeight && webViewHeightAxisUnbounded.value),
                                     ) {
                                         Modifier.weight(1f)
                                     }
@@ -992,6 +991,23 @@ internal val FlexDistribution.usesAllAvailableSpace: Boolean
         FlexDistribution.END,
         FlexDistribution.CENTER,
         -> false
+    }
+
+/**
+ * Whether this component, given an unbounded height constraint, grows to the height of web content:
+ * a fill-height web view, or a fill-height stack that (recursively) contains one. Fill height passes
+ * an unbounded height constraint through, so the whole chain sizes to the web content. Callers skip
+ * `weight` for such children when the main axis is unbounded — weight would measure them at a
+ * bounded share of the viewport, hiding the unbounded constraint from the web view and preventing
+ * the outer scroll from reaching taller-than-screen content. A stack that scrolls vertically itself
+ * terminates the chain: it handles its own overflow and should keep filling the viewport.
+ */
+internal val ComponentStyle.growsToWebViewContentHeight: Boolean
+    get() = size.height == Fill && when (this) {
+        is WebViewComponentStyle -> true
+        is StackComponentStyle ->
+            scrollOrientation != Orientation.Vertical && children.any { it.growsToWebViewContentHeight }
+        else -> false
     }
 
 private val ComponentStyle.shouldIgnoreTopWindowInsets: Boolean

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -661,7 +661,13 @@ private fun MainStackComponent(
                 is Dimension.Vertical -> {
                     // See the Horizontal branch above for why this exists.
                     val hasFillHeightChild = stackState.children.any { it.size.height == Fill }
+                    // web component views that are set to fill height need to be able to push the bounds
+                    // of the containing stack. If they cannot, we don't get the scrollability that is expected.
+                    val hasFillHeightWebViewChild = stackState.children.any {
+                        it is WebViewComponentStyle && it.size.height == Fill
+                    }
                     val mainAxisUnbounded = remember { mutableStateOf(false) }
+                    val webViewHeightAxisUnbounded = remember { mutableStateOf(false) }
                     VerticalStack(
                         size = stackState.size,
                         dimension = dimension,
@@ -674,6 +680,13 @@ private fun MainStackComponent(
                             .then(rootModifier)
                             .conditional(hasFillHeightChild) {
                                 trackMainAxisUnbounded(isHorizontal = false, unboundedState = mainAxisUnbounded)
+                            }
+                            .conditional(hasFillHeightWebViewChild) {
+                                trackMainAxisUnbounded(
+                                    isHorizontal = false,
+                                    unboundedState = webViewHeightAxisUnbounded,
+                                    includeNonZeroMinimum = true,
+                                )
                             },
                     ) {
                         items(stackState.children) { index, child ->
@@ -683,7 +696,11 @@ private fun MainStackComponent(
                                 onClick = clickHandler,
                                 componentInteractionTracker = componentInteractionTracker,
                                 modifier = Modifier
-                                    .conditional(child.size.height == Fill && !mainAxisUnbounded.value) {
+                                    .conditional(
+                                        child.size.height == Fill &&
+                                            !mainAxisUnbounded.value &&
+                                            !(child is WebViewComponentStyle && webViewHeightAxisUnbounded.value),
+                                    ) {
                                         Modifier.weight(1f)
                                     }
                                     .conditional(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -1,4 +1,5 @@
 @file:JvmSynthetic
+@file:Suppress("TooManyFunctions")
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
@@ -21,6 +22,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.ProfileStore
 import androidx.webkit.WebViewCompat
@@ -39,6 +42,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.trackMainAxisUnbounded
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import kotlin.math.max
 
 @JvmSynthetic
 @Composable
@@ -69,7 +73,7 @@ internal fun WebViewComponentView(
     // workflow-web-components-sdk requires a host-assigned component id for the handshake.
     if (componentId.isBlank()) return
     val sizeToContentWidth = style.size.width is Fit
-    val sizeToContentHeight = style.size.height is Fit
+    val sizeToContentHeight = shouldReportContentHeight(style.size.height)
 
     val identity = WebViewIdentity(
         resolvedUrl = resolvedUrl,
@@ -176,6 +180,9 @@ internal fun WebViewComponentView(
                         trackMainAxisUnbounded(isHorizontal = false, unboundedState = heightAxisUnboundedState)
                     }
                     .size(effectiveSize)
+                    .conditional(style.size.height is Fill) {
+                        webViewFillHeight(contentHeightCssPx)
+                    }
                     .clipToBounds(),
             )
         }
@@ -189,6 +196,32 @@ internal fun WebViewComponentView(
  */
 internal const val FIT_PLACEHOLDER_HEIGHT: UInt = 100u
 internal const val FIT_PLACEHOLDER_WIDTH: UInt = 300u
+
+internal fun shouldReportContentHeight(height: SizeConstraint): Boolean =
+    height is Fit || height is Fill
+
+/**
+ * Leaves bounded height measurement unchanged. With an unbounded maximum, uses the incoming minimum
+ * as the fill floor and grows to reported content; CSS values follow the density-aware dp convention
+ * used by fixed WebView sizes.
+ */
+internal fun Modifier.webViewFillHeight(contentHeightCssPx: Int): Modifier =
+    layout { measurable, constraints ->
+        val childConstraints = if (constraints.hasBoundedHeight) {
+            constraints
+        } else {
+            val contentHeightPx = contentHeightCssPx.dp.roundToPx()
+            val targetHeight = max(constraints.minHeight, contentHeightPx)
+            constraints.copy(
+                minHeight = targetHeight,
+                maxHeight = targetHeight,
+            )
+        }
+        val placeable = measurable.measure(childConstraints)
+        layout(placeable.width, placeable.height) {
+            placeable.place(0, 0)
+        }
+    }
 
 internal fun webViewEffectiveSize(
     declaredSize: Size,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
@@ -9,20 +9,20 @@ import androidx.compose.ui.layout.layout
  * distribute. Place it last in a Row/Column chain to observe the constraint after the container's own
  * sizing/scroll, or before a leaf's `.size()` to observe the raw incoming one.
  *
- * That means max == Infinity *and* min == 0: Compose distributes `mainAxisMax`, or `mainAxisMin` when
- * max is Infinity (see RowColumnMeasurePolicy), so weight only collapses a child to zero when both
- * are gone. A scroll that keeps a non-zero min (the default root paywall scroll does) still leaves
- * weight working and must not count here. Callers skip `weight` when this is true, letting the child
- * take its natural size instead of collapsing.
+ * By default that means max == Infinity *and* min == 0: Compose distributes `mainAxisMax`, or
+ * `mainAxisMin` when max is Infinity (see RowColumnMeasurePolicy), so weight only collapses a child
+ * to zero when both are gone. Set [includeNonZeroMinimum] when content also needs to grow beyond a
+ * finite minimum under an infinite maximum.
  */
 internal fun Modifier.trackMainAxisUnbounded(
     isHorizontal: Boolean,
     unboundedState: MutableState<Boolean>,
+    includeNonZeroMinimum: Boolean = false,
 ): Modifier = this.layout { measurable, constraints ->
     unboundedState.value = if (isHorizontal) {
-        !constraints.hasBoundedWidth && constraints.minWidth == 0
+        !constraints.hasBoundedWidth && (includeNonZeroMinimum || constraints.minWidth == 0)
     } else {
-        !constraints.hasBoundedHeight && constraints.minHeight == 0
+        !constraints.hasBoundedHeight && (includeNonZeroMinimum || constraints.minHeight == 0)
     }
     val placeable = measurable.measure(constraints)
     layout(placeable.width, placeable.height) {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/GrowsToWebViewContentHeightTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/GrowsToWebViewContentHeightTests.kt
@@ -1,0 +1,83 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.stack
+
+import androidx.compose.foundation.gestures.Orientation
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.ui.revenuecatui.components.previewStackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class GrowsToWebViewContentHeightTests {
+
+    @Test
+    fun `fill-height web view grows to content height`() {
+        assertThat(webView(height = Fill).growsToWebViewContentHeight).isTrue()
+    }
+
+    @Test
+    fun `fit-height web view does not grow to content height`() {
+        assertThat(webView(height = Fit()).growsToWebViewContentHeight).isFalse()
+    }
+
+    @Test
+    fun `fill-height stack containing a fill-height web view grows to content height`() {
+        val stack = fillHeightStack(webView(height = Fill))
+
+        assertThat(stack.growsToWebViewContentHeight).isTrue()
+    }
+
+    @Test
+    fun `chain of fill-height stacks ending in a fill-height web view grows to content height`() {
+        val stack = fillHeightStack(fillHeightStack(fillHeightStack(webView(height = Fill))))
+
+        assertThat(stack.growsToWebViewContentHeight).isTrue()
+    }
+
+    @Test
+    fun `fit-height stack breaks the chain`() {
+        val stack = previewStackComponentStyle(
+            children = listOf(webView(height = Fill)),
+            size = Size(width = Fill, height = Fit()),
+        )
+
+        assertThat(stack.growsToWebViewContentHeight).isFalse()
+    }
+
+    @Test
+    fun `vertically scrolling stack breaks the chain`() {
+        val stack = previewStackComponentStyle(
+            children = listOf(webView(height = Fill)),
+            size = Size(width = Fill, height = Fill),
+            scrollOrientation = Orientation.Vertical,
+        )
+
+        assertThat(stack.growsToWebViewContentHeight).isFalse()
+    }
+
+    @Test
+    fun `fill-height stack containing only a fit-height web view does not grow to content height`() {
+        val stack = fillHeightStack(webView(height = Fit()))
+
+        assertThat(stack.growsToWebViewContentHeight).isFalse()
+    }
+
+    private fun fillHeightStack(child: ComponentStyle) = previewStackComponentStyle(
+        children = listOf(child),
+        size = Size(width = Fill, height = Fill),
+    )
+
+    private fun webView(height: SizeConstraint) =
+        WebViewComponentStyle(
+            url = "https://paywalls.revenuecat.com/index.html",
+            visible = true,
+            size = Size(width = Fill, height = height),
+            componentId = "web_view",
+            overrides = emptyList(),
+            rcPackage = null,
+            tabIndex = null,
+        )
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensionsTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensionsTests.kt
@@ -1,0 +1,56 @@
+package com.revenuecat.purchases.ui.revenuecatui.extensions
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.Constraints
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ModifierExtensionsTests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `tracks an infinite maximum height with a non-zero minimum as unbounded`() {
+        lateinit var unboundedState: MutableState<Boolean>
+
+        composeTestRule.setContent {
+            unboundedState = remember { mutableStateOf(false) }
+            Layout(
+                content = {
+                    Box(
+                        modifier = Modifier.trackMainAxisUnbounded(
+                            isHorizontal = false,
+                            unboundedState = unboundedState,
+                            includeNonZeroMinimum = true,
+                        ),
+                    )
+                },
+            ) { measurables, _ ->
+                val placeable = measurables.single().measure(
+                    Constraints(
+                        minHeight = 100,
+                        maxHeight = Constraints.Infinity,
+                    ),
+                )
+                layout(placeable.width, placeable.height) {
+                    placeable.place(0, 0)
+                }
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(unboundedState.value).isTrue()
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
