### PR TITLE
fix(paywalls): render price for products with no billing period

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensions.kt
@@ -7,7 +7,14 @@ import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationK
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 internal val Package.isLifetime: Boolean
-    get() = packageType == PackageType.LIFETIME || product.period == null
+    get() = packageType == PackageType.LIFETIME
+
+/**
+ * Whether the product has no billing period, which is the case for all non-subscription products.
+ * Price variables render the plain price for these instead of appending a period.
+ */
+internal val Package.hasNoBillingPeriod: Boolean
+    get() = product.period == null
 
 internal val Package.periodUnitLocalizationKey: VariableLocalizationKey?
     get() = if (isLifetime) VariableLocalizationKey.LIFETIME else product.period?.periodUnitLocalizationKey

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensions.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationK
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 internal val Package.isLifetime: Boolean
-    get() = packageType == PackageType.LIFETIME
+    get() = packageType == PackageType.LIFETIME || product.period == null
 
 internal val Package.periodUnitLocalizationKey: VariableLocalizationKey?
     get() = if (isLifetime) VariableLocalizationKey.LIFETIME else product.period?.periodUnitLocalizationKey

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -133,20 +133,19 @@ internal class VariableDataProvider(
     }
 
     fun periodName(rcPackage: Package): String? {
-        if (rcPackage.packageType == PackageType.CUSTOM ||
-            rcPackage.packageType == PackageType.UNKNOWN
-        ) {
-            return rcPackage.identifier
-        }
-        val stringId = when (rcPackage.packageType) {
-            PackageType.LIFETIME -> R.string.lifetime
-            PackageType.ANNUAL -> R.string.annual
-            PackageType.SIX_MONTH -> R.string.semester
-            PackageType.THREE_MONTH -> R.string.quarter
-            PackageType.TWO_MONTH -> R.string.bimonthly
-            PackageType.MONTHLY -> R.string.monthly
-            PackageType.WEEKLY -> R.string.weekly
-            PackageType.UNKNOWN, PackageType.CUSTOM -> null
+        val stringId = when {
+            rcPackage.isLifetime -> R.string.lifetime
+            rcPackage.packageType == PackageType.CUSTOM ||
+                rcPackage.packageType == PackageType.UNKNOWN -> return rcPackage.identifier
+            else -> when (rcPackage.packageType) {
+                PackageType.ANNUAL -> R.string.annual
+                PackageType.SIX_MONTH -> R.string.semester
+                PackageType.THREE_MONTH -> R.string.quarter
+                PackageType.TWO_MONTH -> R.string.bimonthly
+                PackageType.MONTHLY -> R.string.monthly
+                PackageType.WEEKLY -> R.string.weekly
+                PackageType.LIFETIME, PackageType.UNKNOWN, PackageType.CUSTOM -> null
+            }
         }
         return stringId?.let { resourceProvider.getString(it) }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -133,19 +133,20 @@ internal class VariableDataProvider(
     }
 
     fun periodName(rcPackage: Package): String? {
-        val stringId = when {
-            rcPackage.isLifetime -> R.string.lifetime
-            rcPackage.packageType == PackageType.CUSTOM ||
-                rcPackage.packageType == PackageType.UNKNOWN -> return rcPackage.identifier
-            else -> when (rcPackage.packageType) {
-                PackageType.ANNUAL -> R.string.annual
-                PackageType.SIX_MONTH -> R.string.semester
-                PackageType.THREE_MONTH -> R.string.quarter
-                PackageType.TWO_MONTH -> R.string.bimonthly
-                PackageType.MONTHLY -> R.string.monthly
-                PackageType.WEEKLY -> R.string.weekly
-                PackageType.LIFETIME, PackageType.UNKNOWN, PackageType.CUSTOM -> null
-            }
+        if (rcPackage.packageType == PackageType.CUSTOM ||
+            rcPackage.packageType == PackageType.UNKNOWN
+        ) {
+            return rcPackage.identifier
+        }
+        val stringId = when (rcPackage.packageType) {
+            PackageType.LIFETIME -> R.string.lifetime
+            PackageType.ANNUAL -> R.string.annual
+            PackageType.SIX_MONTH -> R.string.semester
+            PackageType.THREE_MONTH -> R.string.quarter
+            PackageType.TWO_MONTH -> R.string.bimonthly
+            PackageType.MONTHLY -> R.string.monthly
+            PackageType.WEEKLY -> R.string.weekly
+            PackageType.UNKNOWN, PackageType.CUSTOM -> null
         }
         return stringId?.let { resourceProvider.getString(it) }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorV2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorV2.kt
@@ -408,7 +408,7 @@ internal object VariableProcessorV2 {
             )?.let { price ->
                 val period = pkg.productPeriod(localizedVariableKeys)
                 when {
-                    pkg.isLifetime -> price
+                    pkg.hasNoBillingPeriod -> price
                     period != null -> "$price/$period"
                     else -> null
                 }
@@ -423,7 +423,7 @@ internal object VariableProcessorV2 {
             )?.let { price ->
                 val period = pkg.productPeriodAbbreviated(localizedVariableKeys)
                 when {
-                    pkg.isLifetime -> price
+                    pkg.hasNoBillingPeriod -> price
                     period != null -> "$price/$period"
                     else -> null
                 }
@@ -433,7 +433,8 @@ internal object VariableProcessorV2 {
         Variable.PRODUCT_PRICE_PER_DAY -> rcPackage?.let { pkg ->
             val showZeroDecimalPlacePrices = packageContext?.showZeroDecimalPlacePrices ?: false
             when {
-                pkg.isLifetime -> variableDataProvider?.localizedPrice(pkg, currencyLocale, showZeroDecimalPlacePrices)
+                pkg.hasNoBillingPeriod ->
+                    variableDataProvider?.localizedPrice(pkg, currencyLocale, showZeroDecimalPlacePrices)
                 else -> variableDataProvider?.localizedPricePerDay(pkg, currencyLocale, showZeroDecimalPlacePrices)
             }
         }
@@ -441,7 +442,8 @@ internal object VariableProcessorV2 {
         Variable.PRODUCT_PRICE_PER_WEEK -> rcPackage?.let { pkg ->
             val showZeroDecimalPlacePrices = packageContext?.showZeroDecimalPlacePrices ?: false
             when {
-                pkg.isLifetime -> variableDataProvider?.localizedPrice(pkg, currencyLocale, showZeroDecimalPlacePrices)
+                pkg.hasNoBillingPeriod ->
+                    variableDataProvider?.localizedPrice(pkg, currencyLocale, showZeroDecimalPlacePrices)
                 else -> variableDataProvider?.localizedPricePerWeek(pkg, currencyLocale, showZeroDecimalPlacePrices)
             }
         }
@@ -449,7 +451,8 @@ internal object VariableProcessorV2 {
         Variable.PRODUCT_PRICE_PER_MONTH -> rcPackage?.let { pkg ->
             val showZeroDecimalPlacePrices = packageContext?.showZeroDecimalPlacePrices ?: false
             when {
-                pkg.isLifetime -> variableDataProvider?.localizedPrice(pkg, currencyLocale, showZeroDecimalPlacePrices)
+                pkg.hasNoBillingPeriod ->
+                    variableDataProvider?.localizedPrice(pkg, currencyLocale, showZeroDecimalPlacePrices)
                 else -> variableDataProvider?.localizedPricePerMonth(pkg, currencyLocale, showZeroDecimalPlacePrices)
             }
         }
@@ -457,7 +460,8 @@ internal object VariableProcessorV2 {
         Variable.PRODUCT_PRICE_PER_YEAR -> rcPackage?.let { pkg ->
             val showZeroDecimalPlacePrices = packageContext?.showZeroDecimalPlacePrices ?: false
             when {
-                pkg.isLifetime -> variableDataProvider?.localizedPrice(pkg, currencyLocale, showZeroDecimalPlacePrices)
+                pkg.hasNoBillingPeriod ->
+                    variableDataProvider?.localizedPrice(pkg, currencyLocale, showZeroDecimalPlacePrices)
                 else -> variableDataProvider?.localizedPricePerYear(pkg, currencyLocale, showZeroDecimalPlacePrices)
             }
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -366,6 +366,19 @@ internal object TestData {
                 period = Period(value = 6, unit = Period.Unit.MONTH, iso8601 = "P6M"),
             ),
         )
+        val customLifetime = Package(
+            packageType = PackageType.CUSTOM,
+            identifier = "custom_lifetime",
+            offering = "offering",
+            product = TestStoreProduct(
+                id = "com.revenuecat.custom_lifetime_product",
+                name = "Custom Lifetime",
+                title = "Custom Lifetime (App name)",
+                price = Price(amountMicros = 1_000_000_000, currencyCode = "USD", formatted = "$1,000"),
+                description = "Custom Lifetime",
+                period = null,
+            ),
+        )
         val unknown = Package(
             packageType = PackageType.UNKNOWN,
             identifier = "Unknown",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewVariablesTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewVariablesTests.kt
@@ -898,7 +898,7 @@ internal class TextComponentViewVariablesTests(
                     storefrontCountryCode = "US",
                     variableLocalizations = variableLocalizationKeysForEnUs(),
                 ),
-                ""
+                "\$200.00"
             ), arrayOf(
                 "{{ ${Variable.PRODUCT_PRICE_PER_PERIOD_ABBREVIATED.identifier} }}",
                 Args(
@@ -907,7 +907,7 @@ internal class TextComponentViewVariablesTests(
                     storefrontCountryCode = "US",
                     variableLocalizations = variableLocalizationKeysForEnUs(),
                 ),
-                ""
+                "\$200.00"
             ), arrayOf(
                 "{{ ${Variable.PRODUCT_PRICE_PER_DAY.identifier} }}",
                 Args(
@@ -916,7 +916,7 @@ internal class TextComponentViewVariablesTests(
                     storefrontCountryCode = "US",
                     variableLocalizations = variableLocalizationKeysForEnUs(),
                 ),
-                ""
+                "\$200.00"
             ), arrayOf(
                 "{{ ${Variable.PRODUCT_PRICE_PER_WEEK.identifier} }}",
                 Args(
@@ -925,7 +925,7 @@ internal class TextComponentViewVariablesTests(
                     storefrontCountryCode = "US",
                     variableLocalizations = variableLocalizationKeysForEnUs(),
                 ),
-                ""
+                "\$200.00"
             ), arrayOf(
                 "{{ ${Variable.PRODUCT_PRICE_PER_MONTH.identifier} }}",
                 Args(
@@ -934,7 +934,7 @@ internal class TextComponentViewVariablesTests(
                     storefrontCountryCode = "US",
                     variableLocalizations = variableLocalizationKeysForEnUs(),
                 ),
-                ""
+                "\$200.00"
             ), arrayOf(
                 "{{ ${Variable.PRODUCT_PRICE_PER_YEAR.identifier} }}",
                 Args(
@@ -943,7 +943,7 @@ internal class TextComponentViewVariablesTests(
                     storefrontCountryCode = "US",
                     variableLocalizations = variableLocalizationKeysForEnUs(),
                 ),
-                ""
+                "\$200.00"
             ), arrayOf(
                 "{{ ${Variable.PRODUCT_PERIOD.identifier} }}",
                 Args(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/NonSubscriptionVariableProcessingTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/NonSubscriptionVariableProcessingTests.kt
@@ -1,0 +1,134 @@
+package com.revenuecat.purchases.ui.revenuecatui.data.processed
+
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.TestStoreProduct
+import com.revenuecat.purchases.ui.revenuecatui.components.variableLocalizationKeysForEnUs
+import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableProcessor.PackageContext
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockResourceProvider
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Price variables render the plain price for products with no billing period, regardless of the
+ * package identifier. Mirrors the behaviour of `VariableHandlerV2` on iOS.
+ */
+@Suppress("DEPRECATION")
+class NonSubscriptionVariableProcessingTests {
+
+    private val customLifetimePackage = nonSubscriptionPackage(
+        packageType = PackageType.CUSTOM,
+        identifier = "custom_lifetime_tier_1",
+    )
+
+    private val predefinedLifetimePackage = nonSubscriptionPackage(
+        packageType = PackageType.LIFETIME,
+        identifier = PackageType.LIFETIME.identifier!!,
+    )
+
+    @Before
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.w(any()) } returns Unit
+        every { Logger.e(any()) } returns Unit
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(Logger)
+    }
+
+    @Test
+    fun `price per period abbreviated renders the price for a custom-identifier lifetime package`() {
+        assertThat(processTemplate("{{ product.price_per_period_abbreviated }}", customLifetimePackage))
+            .isEqualTo("$49.99")
+    }
+
+    @Test
+    fun `price per period renders the price for a custom-identifier lifetime package`() {
+        assertThat(processTemplate("{{ product.price_per_period }}", customLifetimePackage))
+            .isEqualTo("$49.99")
+    }
+
+    @Test
+    fun `price per period abbreviated renders the price for the predefined lifetime package`() {
+        assertThat(processTemplate("{{ product.price_per_period_abbreviated }}", predefinedLifetimePackage))
+            .isEqualTo("$49.99")
+    }
+
+    @Test
+    fun `price per day renders the full price for a custom-identifier lifetime package`() {
+        assertThat(processTemplate("{{ product.price_per_day }}", customLifetimePackage)).isEqualTo("$49.99")
+    }
+
+    @Test
+    fun `price per week renders the full price for a custom-identifier lifetime package`() {
+        assertThat(processTemplate("{{ product.price_per_week }}", customLifetimePackage)).isEqualTo("$49.99")
+    }
+
+    @Test
+    fun `price per month renders the full price for a custom-identifier lifetime package`() {
+        assertThat(processTemplate("{{ product.price_per_month }}", customLifetimePackage)).isEqualTo("$49.99")
+    }
+
+    @Test
+    fun `price per year renders the full price for a custom-identifier lifetime package`() {
+        assertThat(processTemplate("{{ product.price_per_year }}", customLifetimePackage)).isEqualTo("$49.99")
+    }
+
+    @Test
+    fun `period is empty for a custom-identifier lifetime package`() {
+        assertThat(processTemplate("{{ product.period }}", customLifetimePackage)).isEmpty()
+    }
+
+    @Test
+    fun `period abbreviated is empty for a custom-identifier lifetime package`() {
+        assertThat(processTemplate("{{ product.period_abbreviated }}", customLifetimePackage)).isEmpty()
+    }
+
+    private fun nonSubscriptionPackage(packageType: PackageType, identifier: String) =
+        Package(
+            packageType = packageType,
+            identifier = identifier,
+            offering = "offering",
+            product = TestStoreProduct(
+                id = "com.revenuecat.lifetime_product",
+                name = "Lifetime",
+                title = "Lifetime (App name)",
+                price = Price(amountMicros = 49_990_000, currencyCode = "USD", formatted = "$49.99"),
+                description = "Lifetime",
+                period = null,
+            ),
+        )
+
+    private fun processTemplate(template: String, rcPackage: Package): String {
+        return VariableProcessorV2.processVariables(
+            template = template,
+            localizedVariableKeys = variableLocalizationKeysForEnUs(),
+            variableConfig = UiConfig.VariableConfig(
+                variableCompatibilityMap = emptyMap(),
+                functionCompatibilityMap = emptyMap(),
+            ),
+            variableDataProvider = VariableDataProvider(MockResourceProvider()),
+            packageContext = PackageContext(
+                discountRelativeToMostExpensivePerMonth = null,
+                showZeroDecimalPlacePrices = false,
+            ),
+            rcPackage = rcPackage,
+            subscriptionOption = null,
+            currencyLocale = Locale.US,
+            dateLocale = Locale.US,
+            date = Date(),
+        )
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensionsTest.kt
@@ -29,13 +29,13 @@ internal class PackagePeriodExtensionsTest {
     }
 
     @Test
-    fun `isLifetime is true for a non-subscription product in a custom-identifier package`() {
+    fun `isLifetime is false for a non-subscription product in a custom-identifier package`() {
         val pkg = lifetimePackage(
             packageType = PackageType.CUSTOM,
             identifier = "custom_lifetime_tier_1",
         )
 
-        assertThat(pkg.isLifetime).isTrue()
+        assertThat(pkg.isLifetime).isFalse()
     }
 
     @Test
@@ -44,10 +44,35 @@ internal class PackagePeriodExtensionsTest {
     }
 
     @Test
-    fun `productPeriodAbbreviated returns the lifetime string for a custom-identifier lifetime package`() {
+    fun `hasNoBillingPeriod is true for a non-subscription product in a custom-identifier package`() {
         val pkg = lifetimePackage(
             packageType = PackageType.CUSTOM,
             identifier = "custom_lifetime_tier_1",
+        )
+
+        assertThat(pkg.hasNoBillingPeriod).isTrue()
+    }
+
+    @Test
+    fun `hasNoBillingPeriod is false for a subscription product`() {
+        assertThat(monthlyPackage().hasNoBillingPeriod).isFalse()
+    }
+
+    @Test
+    fun `productPeriodAbbreviated returns null for a custom-identifier lifetime package`() {
+        val pkg = lifetimePackage(
+            packageType = PackageType.CUSTOM,
+            identifier = "custom_lifetime_tier_1",
+        )
+
+        assertThat(pkg.productPeriodAbbreviated(localizedVariableKeys)).isNull()
+    }
+
+    @Test
+    fun `productPeriodAbbreviated returns the lifetime string for the predefined lifetime package`() {
+        val pkg = lifetimePackage(
+            packageType = PackageType.LIFETIME,
+            identifier = PackageType.LIFETIME.identifier!!,
         )
 
         assertThat(pkg.productPeriodAbbreviated(localizedVariableKeys)).isEqualTo("Lifetime")

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackagePeriodExtensionsTest.kt
@@ -1,0 +1,90 @@
+package com.revenuecat.purchases.ui.revenuecatui.data.processed
+
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.TestStoreProduct
+import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationKey
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@Suppress("DEPRECATION")
+internal class PackagePeriodExtensionsTest {
+
+    private val localizedVariableKeys: Map<VariableLocalizationKey, String> = mapOf(
+        VariableLocalizationKey.LIFETIME to "Lifetime",
+        VariableLocalizationKey.MONTHLY to "monthly",
+        VariableLocalizationKey.MONTH_SHORT to "mo",
+    )
+
+    @Test
+    fun `isLifetime is true for the predefined lifetime package`() {
+        val pkg = lifetimePackage(
+            packageType = PackageType.LIFETIME,
+            identifier = PackageType.LIFETIME.identifier!!,
+        )
+
+        assertThat(pkg.isLifetime).isTrue()
+    }
+
+    @Test
+    fun `isLifetime is true for a non-subscription product in a custom-identifier package`() {
+        val pkg = lifetimePackage(
+            packageType = PackageType.CUSTOM,
+            identifier = "custom_lifetime_tier_1",
+        )
+
+        assertThat(pkg.isLifetime).isTrue()
+    }
+
+    @Test
+    fun `isLifetime is false for a subscription product`() {
+        assertThat(monthlyPackage().isLifetime).isFalse()
+    }
+
+    @Test
+    fun `productPeriodAbbreviated returns the lifetime string for a custom-identifier lifetime package`() {
+        val pkg = lifetimePackage(
+            packageType = PackageType.CUSTOM,
+            identifier = "custom_lifetime_tier_1",
+        )
+
+        assertThat(pkg.productPeriodAbbreviated(localizedVariableKeys)).isEqualTo("Lifetime")
+    }
+
+    @Test
+    fun `productPeriodAbbreviated returns the abbreviated period for a subscription product`() {
+        assertThat(monthlyPackage().productPeriodAbbreviated(localizedVariableKeys)).isEqualTo("mo")
+    }
+
+    private fun lifetimePackage(packageType: PackageType, identifier: String) =
+        Package(
+            packageType = packageType,
+            identifier = identifier,
+            offering = "offering",
+            product = TestStoreProduct(
+                id = "com.revenuecat.lifetime_product",
+                name = "Lifetime",
+                title = "Lifetime (App name)",
+                price = Price(amountMicros = 49_990_000, currencyCode = "USD", formatted = "$49.99"),
+                description = "Lifetime",
+                period = null,
+            ),
+        )
+
+    private fun monthlyPackage() =
+        Package(
+            packageType = PackageType.MONTHLY,
+            identifier = PackageType.MONTHLY.identifier!!,
+            offering = "offering",
+            product = TestStoreProduct(
+                id = "com.revenuecat.monthly_product",
+                name = "Monthly",
+                title = "Monthly (App name)",
+                price = Price(amountMicros = 9_990_000, currencyCode = "USD", formatted = "$9.99"),
+                description = "Monthly",
+                period = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+            ),
+        )
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
@@ -228,7 +228,7 @@ class VariableProcessorTest {
 
     @Test
     fun `process variables processes sub_period for lifetime product with custom identifier`() {
-        expectVariablesResult("{{ sub_period }}", "Lifetime", rcPackage = TestData.Packages.customLifetime)
+        expectVariablesResult("{{ sub_period }}", "custom_lifetime", rcPackage = TestData.Packages.customLifetime)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
@@ -227,6 +227,11 @@ class VariableProcessorTest {
     }
 
     @Test
+    fun `process variables processes sub_period for lifetime product with custom identifier`() {
+        expectVariablesResult("{{ sub_period }}", "Lifetime", rcPackage = TestData.Packages.customLifetime)
+    }
+
+    @Test
     fun `process variables processes sub_period unknown period`() {
         expectVariablesResult("{{ sub_period }}", "Unknown", rcPackage = TestData.Packages.unknown)
     }


### PR DESCRIPTION

Splits the approach from #3844 into two, because it was doing two jobs: deciding whether to append a period to the price, and deciding whether to render the word "Lifetime". I checked iOS and it only does the first.

This also fixes `price_per_day/week/month/year`, which returned an empty string for the same packages because `localizedPricePerDay` and friends return null with no period. iOS falls back to the full price there.

Also iOS returns the package identifier for custom packages, which is what this function already did.

#### Behaviour

`PackageType.CUSTOM`, `identifier = "custom_lifetime"`, `product.period = null` — the customer's case:

| Variable | Android today | PR #3844 as-is | With this change | iOS |
|---|---|---|---|---|
| `price_per_period` | *(empty)* | `$1,000` | `$1,000` | `$1,000` |
| `price_per_period_abbreviated` | *(empty)* | `$1,000` | `$1,000` | `$1,000` |
| `price_per_day` | *(empty)* | `$1,000` | `$1,000` | `$1,000` |
| `price_per_week` | *(empty)* | `$1,000` | `$1,000` | `$1,000` |
| `price_per_month` | *(empty)* | `$1,000` | `$1,000` | `$1,000` |
| `price_per_year` | *(empty)* | `$1,000` | `$1,000` | `$1,000` |
| `period` | *(empty)* | **`Lifetime`** | *(empty)* | *(empty)* |
| `period_abbreviated` | *(empty)* | **`Lifetime`** | *(empty)* | *(empty)* |
| `periodly` | *(empty)* | **`Lifetime`** | *(empty)* | *(empty)* |
| `period_with_unit` | *(empty)* | **`Lifetime`** | *(empty)* | *(empty)* |
| `sub_period` (V1) | `custom_lifetime` | **`Lifetime`** | `custom_lifetime` | `custom_lifetime` |

The "With this change" column matches iOS on every row. Bold marks where #3844 as-written moves away from iOS.

`$rc_lifetime` packages (`PackageType.LIFETIME`, `product.period = null`) are unaffected by either PR:

| Variable | Android today | PR #3844 as-is | With this change | iOS |
|---|---|---|---|---|
| `price_per_period` / `_abbreviated` | `$49.99` | `$49.99` | `$49.99` | `$49.99` |
| `price_per_day/week/month/year` | `$49.99` | `$49.99` | `$49.99` | `$49.99` |
| `period` / `_abbreviated` / `periodly` / `period_with_unit` | `Lifetime` | `Lifetime` | `Lifetime` | *(empty)* |
| `sub_period` (V1) | `Lifetime` | `Lifetime` | `Lifetime` | `Lifetime` |

That last-but-one row is the one divergence left in place. It predates both PRs, and closing it means adding a `lifetime` key to iOS's variable localizations plus the backend payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible paywall text for custom non-subscription packages (prices and period labels), which is product-facing but scoped to variable processing with broad test coverage.
> 
> **Overview**
> Paywall variable rendering on Android now treats **“no billing period”** (`product.period == null`) separately from **“lifetime package type”** (`PackageType.LIFETIME`), aligning price-related variables with iOS.
> 
> **`Package.isLifetime`** is limited to `PackageType.LIFETIME` only. A new **`hasNoBillingPeriod`** flag covers any non-subscription product with no period (including custom-identifier lifetime SKUs). Price variables in **`VariableProcessorV2`** (`price_per_period`, abbreviated variants, and `price_per_day/week/month/year`) use **`hasNoBillingPeriod`** to show the **plain formatted price** instead of empty strings or a `/period` suffix. Period-style variables stay empty for custom non-subscription packages; predefined `$rc_lifetime` packages still show “Lifetime” where **`isLifetime`** applies.
> 
> **`VariableDataProvider.periodName`** is refactored so CUSTOM/UNKNOWN packages return the package identifier first; lifetime naming is no longer inferred from a null period on custom packages (V1 **`sub_period`** for custom lifetime now matches the identifier, e.g. `custom_lifetime`).
> 
> Tests add **`NonSubscriptionVariableProcessingTests`** and update expectations for one-time/custom packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf5b213aa2283c37530411c82eac8ff745b7d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->