### PR TITLE
Fix: Fill for Web View components

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/GrowableVerticalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/GrowableVerticalStack.kt
@@ -1,0 +1,166 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.stack
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import com.revenuecat.purchases.paywalls.components.properties.Dimension
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toAlignment
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
+
+/**
+ * A vertical stack used when a child is on a fill-height web view chain (see
+ * [growsToWebViewContentHeight]). [VerticalStack] sizes fill-height children with
+ * `Modifier.weight`, which measures them at an exact share of the available space — a size they can
+ * never exceed, because Compose clamps a child's reported size to the constraints it was measured
+ * under. Web content taller than that share then has nowhere to go and the outer scroll never
+ * engages. This layout hands each fill-height child its share as a *minimum* instead:
+ *
+ * - With a bounded height, children are measured with `min = max = share` — identical to weight.
+ * - With an unbounded maximum (an ancestor scrolls), children are measured with
+ *   `min = share, max = ∞`: the share is the space weight would have given them, computed against
+ *   the minimum height this stack was asked to keep (the viewport, under the root paywall scroll).
+ *   A child whose content fits its share stretches to it (fill), and one whose content is taller
+ *   grows past it, pushing this stack — and the scroll around it — beyond the viewport.
+ *
+ * The floor survives nesting without any signaling: a fill-height child stack's `fillMaxHeight`
+ * passes an unbounded constraint through unchanged, and if that child is itself on the chain it
+ * uses this layout too, subdividing the floor it received among its own children.
+ *
+ * [itemContent] must apply the provided item modifier to the item's single root layout node: it
+ * carries the [layoutId] this layout uses to map measurables back to [children], which keeps the
+ * mapping correct when some children compose to nothing (e.g. not visible).
+ */
+@Composable
+internal fun GrowableVerticalStack(
+    children: List<ComponentStyle>,
+    dimension: Dimension.Vertical,
+    spacing: Dp,
+    modifier: Modifier = Modifier,
+    itemContent: @Composable (index: Int, item: ComponentStyle, itemModifier: Modifier) -> Unit,
+) {
+    val alignment = dimension.alignment.toAlignment()
+    Layout(
+        content = {
+            children.forEachIndexed { index, child ->
+                itemContent(index, child, Modifier.layoutId(index))
+            }
+        },
+        modifier = modifier,
+    ) { measurables, constraints ->
+        measureGrowableColumn(
+            measurables = measurables,
+            constraints = constraints,
+            isFillHeight = measurables.map { measurable ->
+                (measurable.layoutId as? Int)
+                    ?.let { children.getOrNull(it)?.size?.height == Fill }
+                    ?: false
+            },
+            spacingPx = spacing.roundToPx(),
+            distribution = dimension.distribution,
+            alignment = alignment,
+        )
+    }
+}
+
+@Suppress("LongParameterList")
+private fun MeasureScope.measureGrowableColumn(
+    measurables: List<Measurable>,
+    constraints: Constraints,
+    isFillHeight: List<Boolean>,
+    spacingPx: Int,
+    distribution: FlexDistribution,
+    alignment: Alignment.Horizontal,
+): MeasureResult {
+    val totalSpacing = spacingPx * (measurables.size - 1).coerceAtLeast(0)
+    val placeables = arrayOfNulls<Placeable>(measurables.size)
+
+    // Fit/fixed children first: their natural heights determine the space left for fill children.
+    var nonFillHeight = 0
+    measurables.forEachIndexed { index, measurable ->
+        if (!isFillHeight[index]) {
+            val placeable = measurable.measure(
+                Constraints(maxWidth = constraints.maxWidth, maxHeight = constraints.maxHeight),
+            )
+            placeables[index] = placeable
+            nonFillHeight += placeable.height
+        }
+    }
+
+    // Each fill child's share of the space this stack has to hand out: the full bounded height, or
+    // the minimum it was asked to keep when the maximum is unbounded.
+    val fillCount = isFillHeight.count { it }
+    val budget = if (constraints.hasBoundedHeight) constraints.maxHeight else constraints.minHeight
+    val available = (budget - nonFillHeight - totalSpacing).coerceAtLeast(0)
+    val baseShare = if (fillCount > 0) available / fillCount else 0
+    var shareRemainder = if (fillCount > 0) available % fillCount else 0
+
+    var fillHeight = 0
+    measurables.forEachIndexed { index, measurable ->
+        if (isFillHeight[index]) {
+            val share = baseShare + if (shareRemainder-- > 0) 1 else 0
+            val placeable = measurable.measure(
+                if (constraints.hasBoundedHeight) {
+                    Constraints(maxWidth = constraints.maxWidth, minHeight = share, maxHeight = share)
+                } else {
+                    // The share is a floor, not a ceiling: content that reports its own height (a
+                    // web view) may measure taller and push this stack past its minimum.
+                    Constraints(maxWidth = constraints.maxWidth, minHeight = share)
+                },
+            )
+            placeables[index] = placeable
+            fillHeight += placeable.height
+        }
+    }
+
+    val contentHeight = nonFillHeight + fillHeight + totalSpacing
+    val height = contentHeight.coerceIn(constraints.minHeight, constraints.maxHeight)
+    val width = (placeables.maxOfOrNull { it?.width ?: 0 } ?: 0)
+        .coerceIn(constraints.minWidth, constraints.maxWidth)
+
+    // Leftover is zero whenever a fill child is present (the shares consume it by construction);
+    // the distribution only decides placement in the degenerate cases (e.g. every fill child
+    // composed to nothing).
+    val leftover = (height - contentHeight).coerceAtLeast(0)
+    val gapCount = (measurables.size - 1).coerceAtLeast(0)
+    val (leadingSpace, extraGap) = distribution.distributeLeftover(leftover, gapCount)
+
+    return layout(width, height) {
+        var y = leadingSpace
+        placeables.forEach { placeable ->
+            if (placeable == null) return@forEach
+            val x = alignment.align(placeable.width, width, layoutDirection)
+            placeable.place(x, y)
+            y += placeable.height + spacingPx + extraGap
+        }
+    }
+}
+
+/** Splits [leftover] main-axis space into (space before the first child, extra space per gap). */
+private fun FlexDistribution.distributeLeftover(leftover: Int, gapCount: Int): Pair<Int, Int> =
+    when (this) {
+        FlexDistribution.START -> 0 to 0
+        FlexDistribution.CENTER -> leftover / 2 to 0
+        FlexDistribution.END -> leftover to 0
+        FlexDistribution.SPACE_BETWEEN ->
+            if (gapCount > 0) 0 to leftover / gapCount else leftover / 2 to 0
+        FlexDistribution.SPACE_AROUND -> {
+            val gap = leftover / (gapCount + 1)
+            gap / 2 to gap
+        }
+        FlexDistribution.SPACE_EVENLY -> {
+            val gap = leftover / (gapCount + 2)
+            gap to gap
+        }
+    }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -659,33 +659,28 @@ private fun MainStackComponent(
                 }
 
                 is Dimension.Vertical -> {
-                    // See the Horizontal branch above for why this exists.
-                    val hasFillHeightChild = stackState.children.any { it.size.height == Fill }
-                    val mainAxisUnbounded = remember { mutableStateOf(false) }
-                    VerticalStack(
-                        size = stackState.size,
-                        dimension = dimension,
-                        spacing = stackState.spacing,
-                        modifier = outerModifier
-                            .size(stackState.size, horizontalAlignment = dimension.alignment.toAlignment())
-                            .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
-                                scrollable(state, orientation)
-                            }
-                            .then(rootModifier)
-                            .conditional(hasFillHeightChild) {
-                                trackMainAxisUnbounded(isHorizontal = false, unboundedState = mainAxisUnbounded)
-                            },
-                    ) {
-                        items(stackState.children) { index, child ->
+                    // Fill-height children on a web view chain need their share of the space as a floor
+                    // rather than a weight: web content taller than the share must be able to push this
+                    // stack — and the scroll around it — past its minimum. GrowableVerticalStack hands
+                    // out floors; all other stacks keep the Column + weight path below.
+                    if (stackState.children.any { it.growsToWebViewContentHeight }) {
+                        GrowableVerticalStack(
+                            children = stackState.children,
+                            dimension = dimension,
+                            spacing = stackState.spacing,
+                            modifier = outerModifier
+                                .size(stackState.size, horizontalAlignment = dimension.alignment.toAlignment())
+                                .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
+                                    scrollable(state, orientation)
+                                }
+                                .then(rootModifier),
+                        ) { index, child, itemModifier ->
                             ComponentView(
                                 style = child,
                                 state = state,
                                 onClick = clickHandler,
                                 componentInteractionTracker = componentInteractionTracker,
-                                modifier = Modifier
-                                    .conditional(child.size.height == Fill && !mainAxisUnbounded.value) {
-                                        Modifier.weight(1f)
-                                    }
+                                modifier = itemModifier
                                     .conditional(
                                         // In a Vertical container, we only want to apply topSystemBarsPadding to the
                                         // first child, except when that child has `ignoreTopWindowInsets` set to true.
@@ -697,6 +692,48 @@ private fun MainStackComponent(
                                     }
                                     .alpha(contentAlpha),
                             )
+                        }
+                    } else {
+                        // See the Horizontal branch above for why this exists.
+                        val hasFillHeightChild = stackState.children.any { it.size.height == Fill }
+                        val mainAxisUnbounded = remember { mutableStateOf(false) }
+                        VerticalStack(
+                            size = stackState.size,
+                            dimension = dimension,
+                            spacing = stackState.spacing,
+                            modifier = outerModifier
+                                .size(stackState.size, horizontalAlignment = dimension.alignment.toAlignment())
+                                .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
+                                    scrollable(state, orientation)
+                                }
+                                .then(rootModifier)
+                                .conditional(hasFillHeightChild) {
+                                    trackMainAxisUnbounded(isHorizontal = false, unboundedState = mainAxisUnbounded)
+                                },
+                        ) {
+                            items(stackState.children) { index, child ->
+                                ComponentView(
+                                    style = child,
+                                    state = state,
+                                    onClick = clickHandler,
+                                    componentInteractionTracker = componentInteractionTracker,
+                                    modifier = Modifier
+                                        .conditional(child.size.height == Fill && !mainAxisUnbounded.value) {
+                                            Modifier.weight(1f)
+                                        }
+                                        .conditional(
+                                            // In a Vertical container, we only want to apply topSystemBarsPadding to
+                                            // the first child, except when that child has `ignoreTopWindowInsets` set
+                                            // to true.
+                                            stackState.applyTopWindowInsets &&
+                                                index == 0 &&
+                                                !child.shouldIgnoreTopWindowInsets,
+                                        ) {
+                                            windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
+                                        }
+                                        .alpha(contentAlpha),
+                                )
+                            }
                         }
                     }
                 }
@@ -975,6 +1012,24 @@ internal val FlexDistribution.usesAllAvailableSpace: Boolean
         FlexDistribution.END,
         FlexDistribution.CENTER,
         -> false
+    }
+
+/**
+ * Whether this component, given an unbounded height constraint, grows to the height of web content:
+ * a fill-height web view, or a fill-height stack that (recursively) contains one. Fill height passes
+ * an unbounded height constraint through, so the whole chain sizes to the web content. Stacks with
+ * such a child use [GrowableVerticalStack], which hands fill children their share of the space as a
+ * minimum instead of a `weight` — weight would measure them at an exact bounded size, leaving web
+ * content taller than the viewport nowhere to grow and the outer scroll nothing to scroll. A stack
+ * that scrolls vertically itself terminates the chain: it handles its own overflow and should keep
+ * filling the viewport.
+ */
+internal val ComponentStyle.growsToWebViewContentHeight: Boolean
+    get() = size.height == Fill && when (this) {
+        is WebViewComponentStyle -> true
+        is StackComponentStyle ->
+            scrollOrientation != Orientation.Vertical && children.any { it.growsToWebViewContentHeight }
+        else -> false
     }
 
 private val ComponentStyle.shouldIgnoreTopWindowInsets: Boolean

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -1,4 +1,5 @@
 @file:JvmSynthetic
+@file:Suppress("TooManyFunctions")
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
@@ -21,6 +22,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.ProfileStore
 import androidx.webkit.WebViewCompat
@@ -39,6 +42,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.trackMainAxisUnbounded
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import kotlin.math.max
 
 @JvmSynthetic
 @Composable
@@ -69,7 +73,7 @@ internal fun WebViewComponentView(
     // workflow-web-components-sdk requires a host-assigned component id for the handshake.
     if (componentId.isBlank()) return
     val sizeToContentWidth = style.size.width is Fit
-    val sizeToContentHeight = style.size.height is Fit
+    val sizeToContentHeight = shouldReportContentHeight(style.size.height)
 
     val identity = WebViewIdentity(
         resolvedUrl = resolvedUrl,
@@ -176,6 +180,9 @@ internal fun WebViewComponentView(
                         trackMainAxisUnbounded(isHorizontal = false, unboundedState = heightAxisUnboundedState)
                     }
                     .size(effectiveSize)
+                    .conditional(style.size.height is Fill) {
+                        webViewFillHeight(contentHeightCssPx)
+                    }
                     .clipToBounds(),
             )
         }
@@ -189,6 +196,32 @@ internal fun WebViewComponentView(
  */
 internal const val FIT_PLACEHOLDER_HEIGHT: UInt = 100u
 internal const val FIT_PLACEHOLDER_WIDTH: UInt = 300u
+
+internal fun shouldReportContentHeight(height: SizeConstraint): Boolean =
+    height is Fit || height is Fill
+
+/**
+ * Leaves bounded height measurement unchanged. With an unbounded maximum, uses the incoming minimum
+ * as the fill floor and grows to reported content; CSS values follow the density-aware dp convention
+ * used by fixed WebView sizes.
+ */
+internal fun Modifier.webViewFillHeight(contentHeightCssPx: Int): Modifier =
+    layout { measurable, constraints ->
+        val childConstraints = if (constraints.hasBoundedHeight) {
+            constraints
+        } else {
+            val contentHeightPx = contentHeightCssPx.dp.roundToPx()
+            val targetHeight = max(constraints.minHeight, contentHeightPx)
+            constraints.copy(
+                minHeight = targetHeight,
+                maxHeight = targetHeight,
+            )
+        }
+        val placeable = measurable.measure(childConstraints)
+        layout(placeable.width, placeable.height) {
+            placeable.place(0, 0)
+        }
+    }
 
 internal fun webViewEffectiveSize(
     declaredSize: Size,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/GrowableVerticalStackTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/GrowableVerticalStackTests.kt
@@ -1,0 +1,255 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.stack
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.properties.Dimension
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.ui.revenuecatui.components.previewStackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.max
+
+@RunWith(AndroidJUnit4::class)
+class GrowableVerticalStackTests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private var stackSize: IntSize? = null
+    private val childConstraints = mutableMapOf<Int, Constraints>()
+    private val childHeights = mutableMapOf<Int, Int>()
+
+    @Test
+    fun `unbounded height hands fill children their share as a minimum, not an exact size`() {
+        setStack(
+            constraints = Constraints(maxWidth = 500, minHeight = 1000),
+            children = listOf(style(Fit()), style(Fill)),
+        ) { index, _, itemModifier ->
+            when (index) {
+                0 -> FixedHeightItem(key = 0, heightPx = 100, modifier = itemModifier)
+                else -> ContentGrowingItem(key = 1, contentPx = 200, modifier = itemModifier)
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(childConstraints[1]?.minHeight).isEqualTo(900)
+            assertThat(childConstraints[1]?.hasBoundedHeight).isFalse()
+            // Content smaller than the share: the child stretches to fill it.
+            assertThat(childHeights[1]).isEqualTo(900)
+            assertThat(stackSize?.height).isEqualTo(1000)
+        }
+    }
+
+    @Test
+    fun `content taller than the share pushes the stack past its minimum`() {
+        setStack(
+            constraints = Constraints(maxWidth = 500, minHeight = 1000),
+            children = listOf(style(Fit()), style(Fill)),
+        ) { index, _, itemModifier ->
+            when (index) {
+                0 -> FixedHeightItem(key = 0, heightPx = 100, modifier = itemModifier)
+                else -> ContentGrowingItem(key = 1, contentPx = 5000, modifier = itemModifier)
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(childHeights[1]).isEqualTo(5000)
+            assertThat(stackSize?.height).isEqualTo(5100)
+        }
+    }
+
+    @Test
+    fun `bounded height keeps exact weight-style shares`() {
+        setStack(
+            constraints = Constraints(maxWidth = 500, minHeight = 1000, maxHeight = 1000),
+            children = listOf(style(Fit()), style(Fill)),
+        ) { index, _, itemModifier ->
+            when (index) {
+                0 -> FixedHeightItem(key = 0, heightPx = 100, modifier = itemModifier)
+                else -> ContentGrowingItem(key = 1, contentPx = 5000, modifier = itemModifier)
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(childConstraints[1]?.minHeight).isEqualTo(900)
+            assertThat(childConstraints[1]?.maxHeight).isEqualTo(900)
+            // Bounded: content cannot exceed the share, matching the weight-based layout.
+            assertThat(childHeights[1]).isEqualTo(900)
+            assertThat(stackSize?.height).isEqualTo(1000)
+        }
+    }
+
+    @Test
+    fun `fill siblings share the floor equally and only tall content exceeds it`() {
+        setStack(
+            constraints = Constraints(maxWidth = 500, minHeight = 1000),
+            children = listOf(style(Fit()), style(Fill), style(Fill)),
+        ) { index, _, itemModifier ->
+            when (index) {
+                0 -> FixedHeightItem(key = 0, heightPx = 100, modifier = itemModifier)
+                1 -> ContentGrowingItem(key = 1, contentPx = 5000, modifier = itemModifier)
+                else -> ContentGrowingItem(key = 2, contentPx = 10, modifier = itemModifier)
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(childConstraints[1]?.minHeight).isEqualTo(450)
+            assertThat(childConstraints[2]?.minHeight).isEqualTo(450)
+            assertThat(childHeights[1]).isEqualTo(5000)
+            assertThat(childHeights[2]).isEqualTo(450)
+            assertThat(stackSize?.height).isEqualTo(5550)
+        }
+    }
+
+    @Test
+    fun `nested growable stacks subdivide the floor they receive`() {
+        val innerChildren = listOf(style(Fit()), style(Fill))
+        setStack(
+            constraints = Constraints(maxWidth = 500, minHeight = 1000),
+            children = listOf(style(Fit()), style(Fill)),
+        ) { index, _, itemModifier ->
+            when (index) {
+                0 -> FixedHeightItem(key = 0, heightPx = 100, modifier = itemModifier)
+                else -> GrowableVerticalStack(
+                    children = innerChildren,
+                    dimension = verticalDimension(),
+                    spacing = 0.toDp(),
+                    modifier = itemModifier,
+                ) { innerIndex, _, innerModifier ->
+                    when (innerIndex) {
+                        0 -> FixedHeightItem(key = 10, heightPx = 50, modifier = innerModifier)
+                        else -> ContentGrowingItem(key = 11, contentPx = 5000, modifier = innerModifier)
+                    }
+                }
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            // The inner stack received a 900px floor and subdivided it: 900 - 50 fixed = 850.
+            assertThat(childConstraints[11]?.minHeight).isEqualTo(850)
+            assertThat(childConstraints[11]?.hasBoundedHeight).isFalse()
+            assertThat(childHeights[11]).isEqualTo(5000)
+            assertThat(stackSize?.height).isEqualTo(5150)
+        }
+    }
+
+    @Test
+    fun `spacing is reserved before computing the shares`() {
+        setStack(
+            constraints = Constraints(maxWidth = 500, minHeight = 1000),
+            children = listOf(style(Fit()), style(Fill)),
+            spacingPx = 10,
+        ) { index, _, itemModifier ->
+            when (index) {
+                0 -> FixedHeightItem(key = 0, heightPx = 100, modifier = itemModifier)
+                else -> ContentGrowingItem(key = 1, contentPx = 200, modifier = itemModifier)
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(childConstraints[1]?.minHeight).isEqualTo(890)
+            assertThat(stackSize?.height).isEqualTo(1000)
+        }
+    }
+
+    @Test
+    fun `children that compose to nothing keep the style mapping intact`() {
+        setStack(
+            constraints = Constraints(maxWidth = 500, minHeight = 1000),
+            children = listOf(style(Fit()), style(Fit()), style(Fill)),
+        ) { index, _, itemModifier ->
+            when (index) {
+                0 -> FixedHeightItem(key = 0, heightPx = 100, modifier = itemModifier)
+                1 -> Unit // Not visible: emits no layout node.
+                else -> ContentGrowingItem(key = 2, contentPx = 200, modifier = itemModifier)
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(childConstraints[2]?.minHeight).isEqualTo(900)
+            assertThat(stackSize?.height).isEqualTo(1000)
+        }
+    }
+
+    private fun setStack(
+        constraints: Constraints,
+        children: List<ComponentStyle>,
+        spacingPx: Int = 0,
+        itemContent: @Composable (index: Int, item: ComponentStyle, itemModifier: Modifier) -> Unit,
+    ) {
+        composeTestRule.setContent {
+            Layout(
+                content = {
+                    GrowableVerticalStack(
+                        children = children,
+                        dimension = verticalDimension(),
+                        spacing = spacingPx.toDp(),
+                        itemContent = itemContent,
+                    )
+                },
+            ) { measurables, _ ->
+                val placeable = measurables.single().measure(constraints)
+                stackSize = IntSize(placeable.width, placeable.height)
+                layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+            }
+        }
+    }
+
+    /** Reports a fixed height regardless of available space, like a Fit or Fixed child. */
+    @Composable
+    private fun FixedHeightItem(key: Int, heightPx: Int, modifier: Modifier) {
+        Layout(modifier = modifier) { _, constraints ->
+            childConstraints[key] = constraints
+            val height = heightPx.coerceIn(constraints.minHeight, constraints.maxHeight)
+            childHeights[key] = height
+            layout(ITEM_WIDTH, height) {}
+        }
+    }
+
+    /**
+     * Fills bounded space exactly; when the maximum is unbounded, takes max(minimum, content) —
+     * the same behavior as a fill-height web view with [contentPx] of reported content.
+     */
+    @Composable
+    private fun ContentGrowingItem(key: Int, contentPx: Int, modifier: Modifier) {
+        Layout(modifier = modifier) { _, constraints ->
+            childConstraints[key] = constraints
+            val height = if (constraints.hasBoundedHeight) {
+                constraints.maxHeight
+            } else {
+                max(constraints.minHeight, contentPx)
+            }
+            childHeights[key] = height
+            layout(ITEM_WIDTH, height) {}
+        }
+    }
+
+    @Composable
+    private fun Int.toDp() = with(LocalDensity.current) { this@toDp.toDp() }
+
+    private fun verticalDimension() = Dimension.Vertical(
+        alignment = HorizontalAlignment.LEADING,
+        distribution = FlexDistribution.START,
+    )
+
+    private fun style(height: SizeConstraint): ComponentStyle =
+        previewStackComponentStyle(children = emptyList(), size = Size(width = Fit(), height = height))
+
+    private companion object {
+        const val ITEM_WIDTH = 10
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/GrowsToWebViewContentHeightTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/GrowsToWebViewContentHeightTests.kt
@@ -1,0 +1,83 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.stack
+
+import androidx.compose.foundation.gestures.Orientation
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.ui.revenuecatui.components.previewStackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class GrowsToWebViewContentHeightTests {
+
+    @Test
+    fun `fill-height web view grows to content height`() {
+        assertThat(webView(height = Fill).growsToWebViewContentHeight).isTrue()
+    }
+
+    @Test
+    fun `fit-height web view does not grow to content height`() {
+        assertThat(webView(height = Fit()).growsToWebViewContentHeight).isFalse()
+    }
+
+    @Test
+    fun `fill-height stack containing a fill-height web view grows to content height`() {
+        val stack = fillHeightStack(webView(height = Fill))
+
+        assertThat(stack.growsToWebViewContentHeight).isTrue()
+    }
+
+    @Test
+    fun `chain of fill-height stacks ending in a fill-height web view grows to content height`() {
+        val stack = fillHeightStack(fillHeightStack(fillHeightStack(webView(height = Fill))))
+
+        assertThat(stack.growsToWebViewContentHeight).isTrue()
+    }
+
+    @Test
+    fun `fit-height stack breaks the chain`() {
+        val stack = previewStackComponentStyle(
+            children = listOf(webView(height = Fill)),
+            size = Size(width = Fill, height = Fit()),
+        )
+
+        assertThat(stack.growsToWebViewContentHeight).isFalse()
+    }
+
+    @Test
+    fun `vertically scrolling stack breaks the chain`() {
+        val stack = previewStackComponentStyle(
+            children = listOf(webView(height = Fill)),
+            size = Size(width = Fill, height = Fill),
+            scrollOrientation = Orientation.Vertical,
+        )
+
+        assertThat(stack.growsToWebViewContentHeight).isFalse()
+    }
+
+    @Test
+    fun `fill-height stack containing only a fit-height web view does not grow to content height`() {
+        val stack = fillHeightStack(webView(height = Fit()))
+
+        assertThat(stack.growsToWebViewContentHeight).isFalse()
+    }
+
+    private fun fillHeightStack(child: ComponentStyle) = previewStackComponentStyle(
+        children = listOf(child),
+        size = Size(width = Fill, height = Fill),
+    )
+
+    private fun webView(height: SizeConstraint) =
+        WebViewComponentStyle(
+            url = "https://paywalls.revenuecat.com/index.html",
+            visible = true,
+            size = Size(width = Fill, height = height),
+            componentId = "web_view",
+            overrides = emptyList(),
+            rcPackage = null,
+            tabIndex = null,
+        )
+}


### PR DESCRIPTION


<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

> [!IMPORTANT]
> Do not merge yet. This fixes one thing but breaks others, still working through the problem

[Ticket](https://linear.app/revenuecat/issue/FUN-2262/fix-fill-height-discrepencies)


The WebView if in a fill stack when also the WebView is set to fill and the WebView would overflow the size of the parent of the stack, it does not force push that stack to be larger than the parent Even if the parent would allow it.. This means that scrolling doesn't work in this case.





|Before (iOS scrolls, android doesn't) | After (Android works!) |
|:--:|:--:|
| https://github.com/user-attachments/assets/a6392871-9887-46f9-8bd4-4d8afc09bcaf | https://github.com/user-attachments/assets/09d6ed31-4aeb-4e5b-8927-e0a29fd74bc0 |

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->


My initial thought was I could Simply allow fill stacks to resize when the web view resized, That was wrong. Because it treated fill web views like fit web views. We need those two things to be distinct. This will look through the descendant tree of a stack and report back if there is a WebView descendant, Allowing us to respond to its changes.

supersedes #3849 