### PR TITLE
fix: render default paywall when workflow config is transiently unavailable

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowResolution.kt
@@ -14,7 +14,8 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
  *   4xx kill switch. The offering was parsed with its paywall components skipped while workflows were enabled,
  *   so the caller should reload offerings — which now re-parse with those components — to recover its paywall.
  * - [Unavailable]: the topic could not be read for some other (transient) reason, so whether the offering has a
- *   workflow is unknown and reloading would not recover anything. The caller should surface an error.
+ *   workflow is unknown and reloading would not recover anything. The caller should fall back to the offering's
+ *   default paywall, not surface an error.
  */
 @InternalRevenueCatAPI
 public sealed class WorkflowResolution {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -101,8 +101,8 @@ internal class WorkflowsConfigProvider(
         verboseLog { "workflows topic ${if (topic == null) "is absent" else "has ${topic.size} item(s)"}" }
         // A null topic means it could not be read. If the /v1/config endpoint is disabled (4xx kill switch) the
         // offering was parsed with its components skipped, so the caller can reload offerings to recover them;
-        // any other (transient) failure is unrecoverable and should surface an error. Either way this is not the
-        // same as a genuinely workflowless offering.
+        // any other (transient) failure should fall back to the offering's default paywall. Either way this is not
+        // the same as a genuinely workflowless offering.
         return if (topic == null) {
             if (manager.isDisabled) {
                 verboseLog { "Workflows topic unavailable (remote config disabled) resolving offering '$offeringId'" }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -877,7 +877,8 @@ internal class PaywallViewModelImpl(
     /**
      * Resolves [workflowOffering] to its workflow and either presents it or decides how to fall back: a
      * workflowless offering renders its own paywall, a 4xx kill switch reloads offerings to recover the
-     * components skipped during the workflows-enabled parse, and any other failure throws (→ error state).
+     * components skipped during the workflows-enabled parse, and a transient topic failure renders the default
+     * paywall.
      */
     @Suppress("ReturnCount")
     private suspend fun presentWorkflowOrResolveFallback(
@@ -923,15 +924,16 @@ internal class PaywallViewModelImpl(
                 return WorkflowOutcome.Fallback(reloaded.offering, reloaded.offerings)
             }
             WorkflowResolution.Unavailable -> {
-                // The workflows topic could not be read and remote config is not disabled (a transient failure),
-                // so whether this offering has a workflow is unknown and reloading would recover nothing. Surface
-                // an error rather than silently degrading to the default paywall.
-                throw PurchasesException(
-                    PurchasesError(
-                        PurchasesErrorCode.UnknownError,
-                        "Could not resolve the workflow for offering '${workflowOffering.identifier}'.",
-                    ),
+                // The workflows topic could not be read for a transient reason (e.g. a network failure) with
+                // nothing cached, so whether this offering has a workflow is unknown. Rather than surfacing an
+                // error, degrade to the offering's default paywall. The offering's components were skipped
+                // during the workflows-enabled parse, so validatedPaywall renders the default template.
+                Logger.w(
+                    "Paywalls: Workflows topic unavailable for offering '${workflowOffering.identifier}' " +
+                        "(transient failure). Falling back to the default paywall.",
                 )
+                clearWorkflowState()
+                return WorkflowOutcome.Fallback(workflowOffering, preloadedOfferings)
             }
         }
     }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -3351,31 +3351,6 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and the workflows topic is unavailable, surfaces the error`() {
-        // The workflows topic could not be read and remote config is not disabled (a transient failure), so
-        // reloading offerings would recover nothing — surface the error instead of degrading to the default.
-        val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
-        coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.Unavailable
-
-        val model = PaywallViewModelImpl(
-            MockResourceProvider(),
-            purchases,
-            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
-                .setListener(listener)
-                .setOffering(offeringWithoutComponents)
-                .build(),
-            TestData.Constants.currentColorScheme,
-            isDarkMode = false,
-            shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
-        )
-
-        assertThat(model.state.value).isInstanceOf(PaywallState.Error::class.java)
-        coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
-        coVerify(exactly = 0) { purchases.awaitOfferings() }
-    }
-
-    @Test
     fun `when useWorkflows is true and no workflow is mapped with no paywall data, renders the default paywall`() {
         val offeringWithoutPaywallData = Offering(
             identifier = "offering-no-paywall-data",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -932,6 +932,21 @@ class PaywallViewModelWorkflowTest {
     // region memory-first single-path (no Loading flash)
 
     @Test
+    fun `Unavailable workflow resolution falls back to the default paywall instead of erroring`() = runTest {
+        // This models a workflow offering whose paywall data was skipped during the workflows-enabled parse,
+        // with no cached workflows topic available.
+        coEvery { purchases.resolveWorkflow(offeringId) } returns WorkflowResolution.Unavailable
+
+        val vm = createVm()
+        advanceUntilIdle()
+
+        assertThat(vm.state.value).isInstanceOf(PaywallState.Loaded.Legacy::class.java)
+        assertThat(vm.state.value).isNotInstanceOf(PaywallState.Error::class.java)
+        assertThat(vm.workflowState.value).isNull()
+        coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
+    }
+
+    @Test
     fun `warm cache renders the workflow on the first composition with no Loading state`() {
         // Model Dispatchers.Main.immediate with an unconfined main dispatcher so viewModelScope.launch runs
         // eagerly, as in production. On a warm cache every suspend read resolves without suspending (mockk


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

When a paywall is opened for a workflow offering and the workflows topic cannot be read for a transient reason, like a network failure with nothing cached, Android surfaced an error instead of showing a paywall. On device the user got an "Error 0: Unknown error" dialog. iOS degrades to the offering's default paywall in the same situation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to the transient-unavailable workflow path and improves resilience by showing a default paywall instead of an error dialog, matching iOS with no auth or purchase-flow changes.
> 
> **Overview**
> When workflow remote config cannot be read for a **transient** reason (e.g. network failure with no cached workflows topic), Android previously threw and showed an error paywall instead of rendering anything. **iOS already degrades to the default paywall** in that case; this PR aligns Android.
> 
> `PaywallViewModel.presentWorkflowOrResolveFallback` now treats `WorkflowResolution.Unavailable` like other fallbacks: log a warning, clear workflow UI state, and return `WorkflowOutcome.Fallback` so `validatedPaywall` shows the **default legacy template** (paywall components were skipped during the workflows-enabled offering parse).
> 
> Docs/comments in `WorkflowResolution` and `WorkflowsConfigProvider` are updated to say callers should **fall back to the default paywall** rather than surface an error. Tests drop the “surfaces error” case and add coverage that `Unavailable` loads `PaywallState.Loaded.Legacy` without fetching a workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e4ec03910a34b34280f84686b63cbc07ca7b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->