### PR TITLE
feat(remote-config): send X-RC-Last-Refresh-Time on config requests

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.backendName
 import com.revenuecat.purchases.common.caching.WorkflowMetadata
 import com.revenuecat.purchases.common.events.EventsRequest
 import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.networking.HTTPRequest
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.PostReceiptResponse
 import com.revenuecat.purchases.common.networking.RCContainer
@@ -48,6 +49,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.net.URL
+import java.util.Date
 
 internal const val ATTRIBUTES_ERROR_RESPONSE_KEY = "attributes_error_response"
 internal const val ATTRIBUTE_ERRORS_KEY = "attribute_errors"
@@ -1165,6 +1167,7 @@ internal class Backend(
         fetchContext: RemoteConfigFetchContext,
         domain: String,
         manifest: String?,
+        lastRefreshTime: Date?,
         prefetchedBlobs: List<String>,
         onSuccess: (RCContainer?, VerificationResult) -> Unit,
         onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit,
@@ -1183,6 +1186,12 @@ internal class Backend(
             manifest?.let { put("manifest", it) }
             put("prefetched_blobs", prefetchedBlobs)
         }
+        // This endpoint is not ETag-cached, but the header the ETag path uses carries exactly what the server needs
+        // here, so it is reused verbatim: epoch millis, omitted entirely when there has been no successful refresh.
+        val requestHeaders = lastRefreshTime?.let {
+            backendHelper.authenticationHeaders +
+                (HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME to it.time.toString())
+        } ?: backendHelper.authenticationHeaders
 
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
@@ -1191,7 +1200,7 @@ internal class Backend(
                     endpoint,
                     body = body,
                     postFieldsToSign = null,
-                    backendHelper.authenticationHeaders,
+                    requestHeaders,
                 )
             }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -146,7 +146,7 @@ internal class ETagManager(
         val eTagData = metadata?.eTagData?.takeIf { shouldUseETag(metadata.verificationResult, verificationRequested) }
         return mapOf(
             HTTPRequest.ETAG_HEADER_NAME to eTagData?.eTag.orEmpty(),
-            HTTPRequest.ETAG_LAST_REFRESH_NAME to eTagData?.lastRefreshTime?.time?.toString(),
+            HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME to eTagData?.lastRefreshTime?.time?.toString(),
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPRequest.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPRequest.kt
@@ -10,7 +10,7 @@ internal data class HTTPRequest(
 ) {
     companion object {
         const val ETAG_HEADER_NAME = "X-RevenueCat-ETag"
-        const val ETAG_LAST_REFRESH_NAME = "X-RC-Last-Refresh-Time"
+        const val LAST_REFRESH_TIME_HEADER_NAME = "X-RC-Last-Refresh-Time"
         const val POST_PARAMS_HASH = "X-Post-Params-Hash"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -20,6 +20,12 @@ import java.io.IOException
  * `content`), which is the **source of truth**: persisting it is the whole sync commit, and consumers read their
  * topic metadata back from it. Only the heavy blob *bytes* live elsewhere (the content-addressed blob store,
  * keyed by `blob_ref`); the index holds the small metadata map per topic (an empty map for inline-only topics).
+ *
+ * [lastRefreshTime] is the epoch-millis instant of the last successful config request — a `200` *or* a `204`, since
+ * both confirm the cached configuration is current. It is replayed in the `X-RC-Last-Refresh-Time` request header so
+ * the server can optimize its response, which is why it is persisted next to the [manifest] it pairs with: an
+ * app-start request must carry it too. Unlike the topic index it is recoverable metadata, not source of truth, so a
+ * failed write only costs the next request a staler value.
  */
 @Serializable
 internal data class PersistedRemoteConfigurationState(
@@ -28,6 +34,7 @@ internal data class PersistedRemoteConfigurationState(
     val activeTopics: List<String> = emptyList(),
     val prefetchBlobs: List<String> = emptyList(),
     val topics: Map<String, ConfigTopic> = emptyMap(),
+    val lastRefreshTime: Long? = null,
 )
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -222,6 +222,20 @@ internal class RemoteConfigManager(
         if (!shouldRefresh) {
             return
         }
+        issueConfigRequest(appInBackground, requestEpoch, requestAppUserID, requestFetchContext)
+    }
+
+    /**
+     * Issues the `/v1/config` request for a sync that already owns the in-flight guard, replaying the persisted
+     * sync bookkeeping the server diffs against: the opaque manifest, the last successful refresh time, and the
+     * prefetch blobs actually held.
+     */
+    private fun issueConfigRequest(
+        appInBackground: Boolean,
+        requestEpoch: Int,
+        requestAppUserID: String,
+        requestFetchContext: RemoteConfigFetchContext,
+    ) {
         val persisted = diskCache.read()
         val storedBlobs = blobStore.cachedRefs()
         val domain = persisted?.domain ?: DEFAULT_DOMAIN
@@ -233,6 +247,7 @@ internal class RemoteConfigManager(
             domain = domain,
             // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
             manifest = persisted?.manifest,
+            lastRefreshTime = persisted?.lastRefreshTime?.let(::Date),
             // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
             prefetchedBlobs = persisted?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
             onSuccess = { container, _ -> handleMainRefreshSuccess(requestEpoch, persisted, container) },
@@ -361,15 +376,30 @@ internal class RemoteConfigManager(
         )
     }
 
-    /** Handles a `204 Not Modified`: nothing changed, so keep the cache and just advance the refresh bookkeeping. */
+    /**
+     * Handles a `204 Not Modified`: the cached configuration is confirmed current, so keep it and advance the refresh
+     * bookkeeping — including the persisted refresh time, since a 204 is as much a successful refresh as a 200. Runs
+     * on [scope] (like the 200 path) because that persist must not happen on the backend callback thread.
+     *
+     * The in-memory bookkeeping is unconditional: the configuration is already durably committed from an earlier
+     * request, so a failed timestamp write must not hold back [hasCommittedInitialConfig], nor [lastRefreshedAt]
+     * (which would re-arm the staleness gate immediately). It only costs the next request a staler header value.
+     */
     private fun handleNotModified(requestEpoch: Int) {
         debugLog { "Remote config unchanged (204 Not Modified)." }
-        synchronized(cacheLock) {
-            if (epoch.get() == requestEpoch) {
-                lastRefreshedAt = dateProvider.now
-                hasCommittedInitialConfig = true
-                isRefreshing.set(false)
-                completeRefresh()
+        scope.launch {
+            try {
+                synchronized(cacheLock) {
+                    if (epoch.get() != requestEpoch) return@launch
+                    val now = dateProvider.now
+                    lastRefreshedAt = now
+                    hasCommittedInitialConfig = true
+                    // Re-read instead of reusing the request's snapshot, and skip when nothing is persisted: a 204
+                    // must never write back state that was wiped, or resurrect a cleared cache.
+                    diskCache.read()?.let { diskCache.write(it.copy(lastRefreshTime = now.time)) }
+                }
+            } finally {
+                releaseGuardIfOwned(requestEpoch)
             }
         }
     }
@@ -804,6 +834,9 @@ internal class RemoteConfigManager(
         // manifest the server diffs against is the source of truth, and persisting it IS the entire commit (the
         // manifest advances unconditionally). Inline blobs are recoverable over the network, so only touch the
         // blob store once the state is durably committed — a failed persist never orphans or evicts blobs.
+        // One instant for both the persisted refresh time (replayed in the request header) and the in-memory
+        // staleness gate, so they can never disagree about when this refresh happened.
+        val now = dateProvider.now
         val persisted = diskCache.write(
             PersistedRemoteConfigurationState(
                 domain = response.domain,
@@ -811,11 +844,12 @@ internal class RemoteConfigManager(
                 activeTopics = response.activeTopics,
                 prefetchBlobs = response.prefetchBlobs,
                 topics = mergedTopics,
+                lastRefreshTime = now.time,
             ),
         )
 
         if (persisted) {
-            lastRefreshedAt = dateProvider.now
+            lastRefreshedAt = now
             hasCommittedInitialConfig = true
             debugLog {
                 "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -28,6 +28,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Test
 import java.io.File
+import java.util.Date
 
 internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTest() {
     override fun apiKey() = Constants.apiKey
@@ -230,6 +231,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         manifest: String?,
         prefetchedBlobs: List<String> = emptyList(),
         fetchContext: RemoteConfigFetchContext = RemoteConfigFetchContext.AppStart,
+        lastRefreshTime: Date? = null,
     ): Triple<PurchasesError?, RCContainer?, VerificationResult?> {
         every { appConfig.isDebugBuild } returns false
 
@@ -243,6 +245,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
                 fetchContext = fetchContext,
                 domain = "app",
                 manifest = manifest,
+                lastRefreshTime = lastRefreshTime,
                 prefetchedBlobs = prefetchedBlobs,
                 onSuccess = { rcContainer, verificationResult ->
                     container = rcContainer

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -913,7 +913,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         } answers {
             mapOf(
                 HTTPRequest.ETAG_HEADER_NAME to "mock-etag",
-                HTTPRequest.ETAG_LAST_REFRESH_NAME to "1234567890"
+                HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME to "1234567890"
             )
         }
 
@@ -927,7 +927,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         val request = server.takeRequest()
 
         assertThat(request.getHeader(HTTPRequest.ETAG_HEADER_NAME)).isEqualTo("mock-etag")
-        assertThat(request.getHeader(HTTPRequest.ETAG_LAST_REFRESH_NAME)).isEqualTo("1234567890")
+        assertThat(request.getHeader(HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME)).isEqualTo("1234567890")
     }
 
     @Test
@@ -940,7 +940,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         } answers {
             mapOf(
                 HTTPRequest.ETAG_HEADER_NAME to "mock-etag",
-                HTTPRequest.ETAG_LAST_REFRESH_NAME to null
+                HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME to null
             )
         }
 
@@ -954,7 +954,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         val request = server.takeRequest()
 
         assertThat(request.getHeader(HTTPRequest.ETAG_HEADER_NAME)).isEqualTo("mock-etag")
-        assertThat(request.headers.names().contains(HTTPRequest.ETAG_LAST_REFRESH_NAME)).isFalse
+        assertThat(request.headers.names().contains(HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME)).isFalse
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -12,11 +12,13 @@ import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.SyncDispatcher
 import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.networking.HTTPRequest
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
+import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith
 import java.io.ByteArrayOutputStream
 import java.net.URL
 import java.security.MessageDigest
+import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
@@ -101,6 +104,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { result, verificationResult ->
                 container = result
@@ -150,6 +154,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { result, _ -> container = result },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
@@ -173,6 +178,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error, behavior ->
@@ -196,6 +202,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error, _ -> obtainedError = error },
@@ -220,6 +227,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { result, verificationResult ->
                 callbackCount++
@@ -245,6 +253,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
@@ -288,6 +297,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
@@ -308,6 +318,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = null,
+            lastRefreshTime = null,
             prefetchedBlobs = emptyList(),
             onSuccess = { _, _ -> },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
@@ -316,6 +327,82 @@ class BackendGetRemoteConfigTest {
         val body = bodySlot.firstOrNull()
         assertThat(body?.keys).containsExactlyInAnyOrder("app_user_id", "prefetched_blobs", "fetch_context")
         assertThat(body).doesNotContainKey("manifest")
+    }
+
+    @Test
+    fun `getRemoteConfig sends the last refresh time as epoch millis`() {
+        val headersSlot = slot<Map<String, String>>()
+        mockNoContentRequest(headersSlot = headersSlot)
+
+        backend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
+            domain = testDomain,
+            manifest = testManifest,
+            lastRefreshTime = Date(1785161502351L),
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, _ -> },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+
+        assertThat(headersSlot.captured[HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME]).isEqualTo("1785161502351")
+        // The auth header must survive alongside it.
+        assertThat(headersSlot.captured).containsKey("Authorization")
+    }
+
+    @Test
+    fun `getRemoteConfig omits the last refresh time header when there was no successful refresh`() {
+        val headersSlot = slot<Map<String, String>>()
+        mockNoContentRequest(headersSlot = headersSlot)
+
+        backend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
+            domain = testDomain,
+            manifest = null,
+            lastRefreshTime = null,
+            prefetchedBlobs = emptyList(),
+            onSuccess = { _, _ -> },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+
+        assertThat(headersSlot.captured).doesNotContainKey(HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME)
+        assertThat(headersSlot.captured).containsKey("Authorization")
+    }
+
+    @Test
+    fun `getRemoteConfigFallback does not send the last refresh time header`() {
+        every { appConfig.fallbackBaseURLs } returns listOf(mockFallbackURL)
+        val headersSlot = slot<Map<String, String>>()
+        every {
+            httpClient.performRequest(
+                any(),
+                any(),
+                body = any(),
+                postFieldsToSign = any(),
+                requestHeaders = capture(headersSlot),
+                fallbackBaseURLs = any(),
+            )
+        } returns HTTPResult(
+            RCHTTPStatusCodes.SUCCESS,
+            HTTPResult.Payload.Text("""{"domain":"app","manifest":"m1"}"""),
+            HTTPResult.Origin.BACKEND,
+            requestDate = null,
+            VerificationResult.NOT_REQUESTED,
+            isLoadShedderResponse = false,
+            isFallbackURL = true,
+        )
+
+        backend.getRemoteConfigFallback(
+            appInBackground = false,
+            domain = testDomain,
+            onSuccess = { _, _ -> },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+
+        assertThat(headersSlot.captured).doesNotContainKey(HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME)
     }
 
     @Test
@@ -332,6 +419,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error, behavior ->
@@ -358,6 +446,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> fail("Expected error. Got success") },
             onError = { error, behavior ->
@@ -380,6 +469,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
@@ -390,6 +480,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
@@ -417,6 +508,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
@@ -427,6 +519,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
@@ -455,6 +548,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.AppStart,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
@@ -465,6 +559,7 @@ class BackendGetRemoteConfigTest {
             fetchContext = RemoteConfigFetchContext.Read,
             domain = testDomain,
             manifest = testManifest,
+            lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
             onSuccess = { _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
@@ -619,14 +714,17 @@ class BackendGetRemoteConfigTest {
 
     // endregion Fallback endpoint
 
-    private fun mockNoContentRequest(bodySlot: MutableList<Map<String, Any?>?>) {
+    private fun mockNoContentRequest(
+        bodySlot: MutableList<Map<String, Any?>?> = mutableListOf(),
+        headersSlot: CapturingSlot<Map<String, String>> = slot(),
+    ) {
         every {
             httpClient.performRequest(
                 any(),
                 any(),
                 body = captureNullable(bodySlot),
                 postFieldsToSign = any(),
-                requestHeaders = any(),
+                requestHeaders = capture(headersSlot),
                 fallbackBaseURLs = any(),
             )
         } returns HTTPResult(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -85,7 +85,7 @@ class ETagManagerTest {
         mockCachedHTTPResult(expectedETag = null, urlString = urlString)
 
         val eTagHeaders = underTest.getETagHeaders(urlString, verificationRequested = false)
-        val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.ETAG_LAST_REFRESH_NAME]
+        val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME]
         assertThat(lastRefreshTimeHeader).isNull()
     }
 
@@ -98,7 +98,7 @@ class ETagManagerTest {
         val eTagHeader = eTagHeaders[HTTPRequest.ETAG_HEADER_NAME]
         assertThat(eTagHeader).isEqualTo("etag")
 
-        val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.ETAG_LAST_REFRESH_NAME]
+        val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME]
         assertThat(lastRefreshTimeHeader).isNull()
     }
 
@@ -120,7 +120,7 @@ class ETagManagerTest {
         mockCachedHTTPResult(expectedETag = "etag", expectedLastRefreshTime = testDate, urlString = urlString)
 
         val eTagHeaders = underTest.getETagHeaders(urlString, verificationRequested = false)
-        val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.ETAG_LAST_REFRESH_NAME]
+        val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME]
         assertThat(lastRefreshTimeHeader).isEqualTo("1675954145")
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
@@ -60,12 +60,26 @@ class RemoteConfigDiskCacheTest {
                     mapOf("pem" to RemoteConfiguration.ConfigItem(blobRef = "pemBlob")),
                 ),
             ),
+            lastRefreshTime = 1785161502351L,
         )
 
         diskCache.write(config)
         val read = diskCache.read()
 
         assertThat(read).isEqualTo(config)
+    }
+
+    @Test
+    fun `a file written before the last refresh time existed reads it back as null`() {
+        val parent = File(File(testFolder, "RevenueCat"), "remote_config").apply { mkdirs() }
+        File(parent, "remote_config.json").writeText(
+            """{"domain":"app","manifest":"v1.1.sources:etag1"}""",
+        )
+
+        val read = RemoteConfigDiskCache(applicationContext).read()!!
+
+        assertThat(read.lastRefreshTime).isNull()
+        assertThat(read.manifest).isEqualTo("v1.1.sources:etag1")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
@@ -51,6 +51,7 @@ class RemoteConfigManagerIntegrationTest {
     private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
     private var capturedManifest: String? = null
+    private var capturedLastRefreshTime: Date? = null
     private var capturedPrefetchedBlobs: List<String>? = null
     private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
 
@@ -83,11 +84,12 @@ class RemoteConfigManagerIntegrationTest {
         )
 
         every {
-            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any())
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any())
         } answers {
             capturedManifest = arg(4)
-            capturedPrefetchedBlobs = arg(5)
-            onSuccess = arg(6)
+            capturedLastRefreshTime = arg(5)
+            capturedPrefetchedBlobs = arg(6)
+            onSuccess = arg(7)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -69,6 +69,7 @@ class RemoteConfigManagerTest {
     private var capturedAppUserID: String? = null
     private var capturedDomain: String? = null
     private var capturedManifest: String? = null
+    private var capturedLastRefreshTime: Date? = null
     private var capturedFetchContext: RemoteConfigFetchContext? = null
     private var capturedPrefetchedBlobs: List<String>? = null
     private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
@@ -100,15 +101,16 @@ class RemoteConfigManagerTest {
         every { diskCache.write(any()) } returns true
 
         every {
-            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any())
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any())
         } answers {
             capturedAppUserID = arg(1)
             capturedFetchContext = arg(2)
             capturedDomain = arg(3)
             capturedManifest = arg(4)
-            capturedPrefetchedBlobs = arg(5)
-            onSuccess = arg(6)
-            onError = arg(7)
+            capturedLastRefreshTime = arg(5)
+            capturedPrefetchedBlobs = arg(6)
+            onSuccess = arg(7)
+            onError = arg(8)
         }
 
         every {
@@ -177,7 +179,7 @@ class RemoteConfigManagerTest {
             fetchContext = RemoteConfigFetchContext.IdentityChange,
         )
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.IdentityChange)
     }
 
@@ -313,7 +315,7 @@ class RemoteConfigManagerTest {
 
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -327,7 +329,7 @@ class RemoteConfigManagerTest {
         // Same clock: still within the foreground window, so no new request.
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -341,7 +343,7 @@ class RemoteConfigManagerTest {
 
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -355,7 +357,7 @@ class RemoteConfigManagerTest {
         manager.clearCache(TEST_APP_USER_ID)
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -371,7 +373,7 @@ class RemoteConfigManagerTest {
         manager.clearCache(TEST_APP_USER_ID)
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -389,12 +391,12 @@ class RemoteConfigManagerTest {
         // Same clock: the failure left lastRefreshedAt unset, but the recent attempt keeps stale-gated refreshes
         // from retrying on every caller.
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 
         currentTimeMillis += REFRESH_ATTEMPT_COOLDOWN_MILLIS + 1
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -410,7 +412,7 @@ class RemoteConfigManagerTest {
         )
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -425,7 +427,7 @@ class RemoteConfigManagerTest {
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -761,15 +763,90 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `a 204 response leaves the cache untouched and does no blob work`() {
-        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
+    fun `a 204 response leaves the configuration untouched and does no blob work`() {
+        val cached = persisted(
+            manifest = "v1.1.sources:etag1",
+            activeTopics = listOf("sources"),
+            prefetchBlobs = listOf("blobRefA"),
+            topics = mapOf("sources" to ConfigTopic(mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = "blobRefA")))),
+        )
+        every { diskCache.read() } returns cached
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+
+        // The only thing a 204 rewrites is the refresh time; the configuration itself carries forward verbatim.
+        verify(exactly = 1) { diskCache.write(cached.copy(lastRefreshTime = FIXED_MILLIS)) }
+        verify(exactly = 0) { blobStore.write(any(), any()) }
+        verify(exactly = 0) { blobStore.retainOnly(any()) }
+    }
+
+    @Test
+    fun `a 204 response advances the persisted refresh time`() {
+        val cached = persisted(manifest = "v1.1.sources:etag1", lastRefreshTime = FIXED_MILLIS - 10_000L)
+        every { diskCache.read() } returns cached
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        onSuccess.invoke(null, VerificationResult.VERIFIED)
+
+        verify(exactly = 1) { diskCache.write(cached.copy(lastRefreshTime = FIXED_MILLIS)) }
+    }
+
+    @Test
+    fun `a 204 response with nothing persisted does not resurrect the cache`() {
+        every { diskCache.read() } returns null
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         onSuccess.invoke(null, VerificationResult.VERIFIED)
 
         verify(exactly = 0) { diskCache.write(any()) }
-        verify(exactly = 0) { blobStore.write(any(), any()) }
-        verify(exactly = 0) { blobStore.retainOnly(any()) }
+    }
+
+    @Test
+    fun `a 200 response persists the refresh time`() {
+        every { diskCache.read() } returns null
+        val slot = slot<PersistedRemoteConfigurationState>()
+        every { diskCache.write(capture(slot)) } returns true
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        onSuccess.invoke(containerWithConfig("""{"domain":"app","manifest":"v1.2."}"""), VerificationResult.VERIFIED)
+
+        assertThat(slot.captured.lastRefreshTime).isEqualTo(FIXED_MILLIS)
+    }
+
+    @Test
+    fun `the persisted refresh time is sent on the next request`() {
+        every { diskCache.read() } returns persisted(
+            manifest = "v1.1.sources:etag1",
+            lastRefreshTime = FIXED_MILLIS - 60_000L,
+        )
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+
+        assertThat(capturedLastRefreshTime).isEqualTo(Date(FIXED_MILLIS - 60_000L))
+    }
+
+    @Test
+    fun `no refresh time is sent when nothing has been persisted yet`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+
+        assertThat(capturedLastRefreshTime).isNull()
+    }
+
+    @Test
+    fun `an identity change drops the refresh time along with the cache`() {
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1", lastRefreshTime = FIXED_MILLIS)
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        assertThat(capturedLastRefreshTime).isNotNull
+
+        // clearCache() deletes the file, so the wiped cache reads back as null and the header is dropped with it.
+        manager.clearCache("new-user")
+        every { diskCache.read() } returns null
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = "new-user", fetchContext = DEFAULT_FETCH_CONTEXT)
+
+        assertThat(capturedLastRefreshTime).isNull()
     }
 
     @Test
@@ -800,7 +877,7 @@ class RemoteConfigManagerTest {
         // No further config request and no blob fetch happen for the rest of the session.
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         verify(exactly = 0) { blobFetcher.prefetch(any()) }
     }
 
@@ -925,7 +1002,7 @@ class RemoteConfigManagerTest {
 
         assertThat(topic).isNotNull
         assertThat(topic!!["wf1"]!!.blobRef).isEqualTo(REF_VALID)
-        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -936,7 +1013,7 @@ class RemoteConfigManagerTest {
         val topic = manager.committedTopicOrNull(RemoteConfigTopic.Workflows)
 
         assertThat(topic).isNull()
-        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1101,7 +1178,7 @@ class RemoteConfigManagerTest {
 
         // The endpoint is still usable, so a subsequent refresh fires.
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     // region Fallback endpoint
@@ -1218,7 +1295,7 @@ class RemoteConfigManagerTest {
 
         // The fallback settled the sync, so a later refresh is allowed to fire again.
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1236,11 +1313,11 @@ class RemoteConfigManagerTest {
         )
 
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 
         currentTimeMillis += REFRESH_ATTEMPT_COOLDOWN_MILLIS + 1
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1277,7 +1354,7 @@ class RemoteConfigManagerTest {
 
         assertThat(manager.isDisabled).isTrue()
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1288,7 +1365,7 @@ class RemoteConfigManagerTest {
         // The first refresh has not settled yet (the stub captures callbacks without invoking them).
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1299,7 +1376,7 @@ class RemoteConfigManagerTest {
         onSuccess.invoke(null, VerificationResult.VERIFIED)
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1314,7 +1391,7 @@ class RemoteConfigManagerTest {
         )
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1350,7 +1427,7 @@ class RemoteConfigManagerTest {
 
         // The guard was released in the finally block, so a subsequent refresh is allowed to start.
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1365,7 +1442,7 @@ class RemoteConfigManagerTest {
 
         // The guard was released in the finally block, so a subsequent refresh is allowed to start.
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1484,7 +1561,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         assertThat(readManager(appUserIDProvider = { null }).topic(RemoteConfigTopic.Sources)).isNull()
-        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1507,7 +1584,7 @@ class RemoteConfigManagerTest {
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             result = manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         // The on-demand sync is issued as foreground for the current user with a read fetch context.
         assertThat(capturedAppUserID).isEqualTo(TEST_APP_USER_ID)
         assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.Read)
@@ -1542,7 +1619,7 @@ class RemoteConfigManagerTest {
         val firstRead = launch(UnconfinedTestDispatcher(testScheduler)) {
             firstResult = manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         onError.invoke(
             PurchasesError(PurchasesErrorCode.NetworkError),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -1551,13 +1628,13 @@ class RemoteConfigManagerTest {
         assertThat(firstResult).isNull()
 
         assertThat(manager.topic(RemoteConfigTopic.Workflows)).isNull()
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 
         currentTimeMillis += REFRESH_ATTEMPT_COOLDOWN_MILLIS + 1
         val retryRead = launch(UnconfinedTestDispatcher(testScheduler)) {
             manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         onError.invoke(
             PurchasesError(PurchasesErrorCode.NetworkError),
             GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
@@ -1580,7 +1657,7 @@ class RemoteConfigManagerTest {
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         assertThat(capturedAppUserID).isEqualTo("new-user")
 
         // Settle the triggered sync so the parked read completes cleanly.
@@ -1609,7 +1686,7 @@ class RemoteConfigManagerTest {
             val read = launch(UnconfinedTestDispatcher(testScheduler)) {
                 manager.topic(RemoteConfigTopic.Workflows)
             }
-            verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+            verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
             assertThat(capturedAppUserID).isEqualTo("new-user")
 
             onSuccess.invoke(null, VerificationResult.VERIFIED)
@@ -1626,7 +1703,7 @@ class RemoteConfigManagerTest {
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             manager.topic(RemoteConfigTopic.Workflows)
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         assertThat(capturedAppUserID).isEqualTo("bootstrap-user")
 
         onSuccess.invoke(null, VerificationResult.VERIFIED)
@@ -1808,7 +1885,7 @@ class RemoteConfigManagerTest {
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             result = manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         // The on-demand sync is issued as foreground for the current user.
         assertThat(capturedAppUserID).isEqualTo(TEST_APP_USER_ID)
         assertThat(read.isActive).isTrue()
@@ -1832,7 +1909,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         assertThat(readManager(appUserIDProvider = { null }).blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isNull()
-        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1847,7 +1924,7 @@ class RemoteConfigManagerTest {
         )
 
         assertThat(manager.blobData(RemoteConfigTopic.Workflows, "wf1") { it }).isNull()
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -2022,7 +2099,7 @@ class RemoteConfigManagerTest {
 
         assertThat(result).isNull()
         coVerify(exactly = 0) { blobFetcher.ensureDownloaded(any<String>()) }
-        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -2116,7 +2193,7 @@ class RemoteConfigManagerTest {
         val read = launch(UnconfinedTestDispatcher(testScheduler)) {
             result = manager.mergeItemsBlobData<MergedBlob>(RemoteConfigTopic.Workflows, listOf("wf1", "wf2"))
         }
-        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         assertThat(read.isActive).isTrue()
 
         val response = """
@@ -2240,9 +2317,9 @@ class RemoteConfigManagerTest {
         every { diskCache.clear() } answers { state.set(null) }
         every { blobStore.cachedRefs() } returns emptySet()
         every {
-            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any())
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any())
         } answers {
-            arg<(RCContainer?, VerificationResult) -> Unit>(6)
+            arg<(RCContainer?, VerificationResult) -> Unit>(7)
                 .invoke(containerWithConfig(stressResponse), VerificationResult.VERIFIED)
         }
         val manager = RemoteConfigManager(
@@ -2314,12 +2391,14 @@ class RemoteConfigManagerTest {
         activeTopics: List<String> = emptyList(),
         prefetchBlobs: List<String> = emptyList(),
         topics: Map<String, ConfigTopic> = emptyMap(),
+        lastRefreshTime: Long? = null,
     ) = PersistedRemoteConfigurationState(
         domain = domain,
         manifest = manifest,
         activeTopics = activeTopics,
         prefetchBlobs = prefetchBlobs,
         topics = topics,
+        lastRefreshTime = lastRefreshTime,
     )
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -101,9 +101,9 @@ class WorkflowsConfigIntegrationTest {
         provider = WorkflowsConfigProvider(manager)
 
         every {
-            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any())
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any())
         } answers {
-            onSuccess = arg(6)
+            onSuccess = arg(7)
         }
     }
 
@@ -357,7 +357,7 @@ class WorkflowsConfigIntegrationTest {
             assertThat(completed).isTrue()
             // The topic was already committed by the sync() above — onPaywallConfigReady must not trigger
             // another one; this is what keeps OfferingsManager's gate cheap on a warm cache.
-            verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any()) }
+            verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         }
 
     // Asset prewarming is out of scope here (covered by WorkflowManagerTest), so the manager gets a stubbed


### PR DESCRIPTION
## Description
In order to be able to leverage the load shedder functionality, the backend must be able to determine when the request was last refreshed. Other API requests that rely on ETAG caching send the `X-RC-Last-Refresh-Time` header as a unix epoch in milliseconds. With this PR we're doing the same for remote config requests.

Android equivalent of https://github.com/RevenueCat/purchases-ios/pull/7308

## Changes
- After receiving the initial remote config response, we'll now store a `lastRefreshTime` value along with the received config
  - This is only done for successful responses, determined by the `2xx` status code
- In subsequent requests we'll be including this value as a Unix epoch timestamp in milliseconds under the `X-RC-Last-Refresh-Time` header
- After the next successful response we'll update the local value again


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote config request headers and disk persistence for sync bookkeeping, but behavior mirrors the existing ETag last-refresh pattern and old cache files degrade safely to a missing header.
> 
> **Overview**
> Remote config `/v1/config` requests now send **`X-RC-Last-Refresh-Time`** (epoch millis), reusing the same header name as ETag-cached APIs (`HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME`, renamed from the ETag-only constant). The header is omitted until a prior successful refresh exists; **`getRemoteConfigFallback` does not send it**.
> 
> **Persistence and replay:** `PersistedRemoteConfigurationState` adds optional `lastRefreshTime`. On a **200**, `RemoteConfigManager` stores it with the config commit using the same clock instant as the in-memory staleness gate. On a **204**, only that timestamp is advanced (config unchanged); the write runs on the manager scope and re-reads disk so a wiped cache is not resurrected. `issueConfigRequest` passes the persisted value into `Backend.getRemoteConfig`.
> 
> **Tests** cover header presence/absence, 200/204 persistence, identity `clearCache`, and backward-compatible disk reads without the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed8f58ac04b852c7e40b717905daaeb57a237403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->