### PR TITLE
test(remote-config): de-flake the inline workflows blob integration test

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.jsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
+import org.junit.Assume
 import org.junit.Test
 import java.io.File
 
@@ -87,20 +88,42 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         val rcContainer = requireNotNull(container) { "Expected a 200 container, got 204 (no content)." }
 
         val config = RemoteConfiguration.parse(rcContainer.config)
+        val diagnostics = describe(config, rcContainer)
 
-        // The refs of workflows items whose bodies the container may have inlined.
-        val workflows = requireNotNull(config.topics["workflows"]) { "Expected a workflows topic." }
-        val wantedRefs = workflows.values.mapNotNull { it.blobRef }.toSet()
-
-        // Find an inlined workflows item and capture its decoded bytes. decode() uncompresses and checks the
-        // SHA-256 against the advertised ref, so the bytes are exactly the content the backend addressed there.
-        val element = requireNotNull(rcContainer.contentElements.firstOrNull { it.checksumBase64() in wantedRefs }) {
-            "Expected a workflows item with an inlined blob_ref."
+        // Every inlined element must be one the config asks for, and must decode: decode() uncompresses per the
+        // element's codec and checks the SHA-256 against the advertised ref, so this exercises the real backend
+        // bytes end to end regardless of which blobs the backend chose to inline on this response.
+        val advertisedRefs = config.prefetchBlobs.toSet() +
+            config.topics.values.flatMap { topic -> topic.values.mapNotNull { it.blobRef } }
+        rcContainer.contentElements.forEach { element ->
+            assertThat(element.checksumBase64()).describedAs(diagnostics).isIn(advertisedRefs)
+            assertThat(element.decode()).describedAs(diagnostics).isNotEmpty()
         }
 
+        // Inlining is a backend optimization, not a contract: a blob the config advertises may be served from the
+        // CDN instead. When the workflows blob isn't inlined there is nothing to decode here, so skip rather than
+        // fail, and report what the response did carry so the reason is identifiable.
+        val workflows = requireNotNull(config.topics["workflows"]) { "Expected a workflows topic. $diagnostics" }
+        val wantedRefs = workflows.values.mapNotNull { it.blobRef }.toSet()
+        val element = rcContainer.contentElements.firstOrNull { it.checksumBase64() in wantedRefs }
+        Assume.assumeTrue(
+            "Skipping: the backend inlined no workflows blob in this response. $diagnostics",
+            element != null,
+        )
+
         // The decoded bytes are real, structured content (a non-empty JSON object), not garbage.
-        val json = JsonProvider.defaultJson.parseToJsonElement(element.decode().decodeToString())
+        val json = JsonProvider.defaultJson.parseToJsonElement(element!!.decode().decodeToString())
         assertThat(json.jsonObject).isNotEmpty()
+    }
+
+    /** The response's advertised-vs-inlined state, for classifying a missing inline blob. */
+    private fun describe(config: RemoteConfiguration, container: RCContainer): String {
+        val workflowItems = config.topics["workflows"]?.entries?.joinToString { (key, item) ->
+            "$key -> ${item.blobRef}"
+        }
+        val inlined = container.contentElements.joinToString { "${it.checksumBase64()} (${it.data.remaining()}B)" }
+        return "activeTopics=${config.activeTopics}, prefetchBlobs=${config.prefetchBlobs}, " +
+            "workflowsItems=[$workflowItems], inlinedElements=[$inlined]"
     }
 
     @Test


### PR DESCRIPTION
`ProductionRemoteConfigIntegrationTest.decodes an inline workflows content blob` intermittently failed on CI with `Expected a workflows item with an inlined blob_ref`.

The request is identical every run and this path has no cache, retry or URL fallback, so the variance is in the response: blob inlining is a backend optimization, not a contract, and a blob the config advertises may be served from the CDN instead.

The test now:
- asserts unconditionally that every inlined element's ref is advertised by the config (`prefetch_blobs` ∪ topic `blob_ref`s) and decodes to non-empty bytes, which still exercises the real backend bytes through codec + checksum verification;
- skips (with diagnostics naming the advertised refs and the inlined element refs/sizes) instead of failing when the backend inlined no workflows blob.

Note this is a valid case on the backend since in some cases the blob would need to be warmed before being inlined, so we need to handle that case as well

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code; reduces false CI failures without weakening coverage of inlined blob decoding.
> 
> **Overview**
> Stops CI flakes in **`decodes an inline workflows content blob`** by aligning the test with backend behavior: blob inlining is optional, so responses may advertise workflows refs without inline bytes.
> 
> The test now **always** checks every inlined element is advertised in config (`prefetch_blobs` plus topic `blob_ref`s) and that `decode()` yields non-empty bytes (codec + checksum path against real backend data). The workflows JSON assertion runs only when a workflows blob was inlined; otherwise **`Assume.assumeTrue`** skips with a **`describe()`** diagnostic (active topics, prefetch refs, workflows items, inlined element refs/sizes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1fad6197815d14e2c5e4b84f0745f0cd7a1efa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->