### PR TITLE
feat(remote-config): use the server clock for X-RC-Last-Refresh-Time

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -112,7 +112,7 @@ internal typealias RewardVerificationResultCallback =
     Pair<(RewardVerificationPollStatus) -> Unit, (RewardVerificationError) -> Unit>
 
 internal typealias RemoteConfigCallback = Pair<
-    (RCContainer?, VerificationResult) -> Unit,
+    (RCContainer?, requestDate: Date?, VerificationResult) -> Unit,
     (PurchasesError, errorHandlingBehavior: GetRemoteConfigErrorHandlingBehavior) -> Unit,
     >
 
@@ -1169,7 +1169,8 @@ internal class Backend(
         manifest: String?,
         lastRefreshTime: Date?,
         prefetchedBlobs: List<String>,
-        onSuccess: (RCContainer?, VerificationResult) -> Unit,
+        // The server's own request time, so the caller can replay it rather than a device-clock value.
+        onSuccess: (RCContainer?, Date?, VerificationResult) -> Unit,
         onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit,
     ) {
         val endpoint = Endpoint.GetRemoteConfig(domain)
@@ -1220,7 +1221,7 @@ internal class Backend(
                     if (result.isSuccessful()) {
                         if (result.responseCode == RCHTTPStatusCodes.NO_CONTENT) {
                             // 204: nothing changed, no container to parse.
-                            onSuccessHandler(null, result.verificationResult)
+                            onSuccessHandler(null, result.requestDate, result.verificationResult)
                             return@forEach
                         }
                         val payload = result.payload
@@ -1236,7 +1237,11 @@ internal class Backend(
                             return@forEach
                         }
                         try {
-                            onSuccessHandler(RCContainer.parse(payload.bytes), result.verificationResult)
+                            onSuccessHandler(
+                                RCContainer.parse(payload.bytes),
+                                result.requestDate,
+                                result.verificationResult,
+                            )
                         } catch (e: RCContainerFormatException) {
                             // Parse failure of an otherwise-successful response; keep retrying.
                             onErrorHandler(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -772,7 +772,9 @@ internal class HTTPClient(
     }
 
     private fun getRequestDateHeader(connection: URLConnection): Date? {
-        return getRequestTimeHeader(connection)?.toLong()?.let {
+        // toLongOrNull: a non-numeric header degrades to no date. Throwing here would escape every catch on the
+        // request path (they cover IOException and friends) and be rethrown on the main thread by the Dispatcher.
+        return getRequestTimeHeader(connection)?.toLongOrNull()?.let {
             Date(it)
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -26,6 +26,10 @@ import java.io.IOException
  * the server can optimize its response, which is why it is persisted next to the [manifest] it pairs with: an
  * app-start request must carry it too. Unlike the topic index it is recoverable metadata, not source of truth, so a
  * failed write only costs the next request a staler value.
+ *
+ * The value is always the **server's** own `X-RevenueCat-Request-Time`, never a device-clock reading: the server
+ * compares it against its own clock, so a skewed device would silently corrupt that comparison. A response without
+ * the header leaves the previous value in place rather than substituting local time.
  */
 @Serializable
 internal data class PersistedRemoteConfigurationState(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -250,7 +250,9 @@ internal class RemoteConfigManager(
             lastRefreshTime = persisted?.lastRefreshTime?.let(::Date),
             // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
             prefetchedBlobs = persisted?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
-            onSuccess = { container, _ -> handleMainRefreshSuccess(requestEpoch, persisted, container) },
+            onSuccess = { container, requestDate, _ ->
+                handleMainRefreshSuccess(requestEpoch, persisted, container, requestDate)
+            },
             onError = { error, behavior ->
                 handleMainRefreshError(
                     requestEpoch,
@@ -279,11 +281,15 @@ internal class RemoteConfigManager(
      * Handles a successful **main** `/v1/config` response: a `204` keeps the cache (bookkeeping only), a `200`
      * parses the config element and commits it (on [scope] so [clearCache] can cancel the parse/persist). Drops
      * the result if the epoch changed meanwhile (an identity change already reset the guard via [clearCache]).
+     *
+     * [requestDate] is the server's own request time, which is what gets persisted and replayed as the refresh
+     * time — never a device-clock value the server cannot interpret. Null when the response carried no such header.
      */
     private fun handleMainRefreshSuccess(
         requestEpoch: Int,
         persisted: PersistedRemoteConfigurationState?,
         container: RCContainer?,
+        requestDate: Date?,
     ) {
         if (epoch.get() != requestEpoch) {
             // The cache was cleared (identity change) after this request started. Drop the stale
@@ -291,7 +297,7 @@ internal class RemoteConfigManager(
             return
         }
         if (container == null) {
-            handleNotModified(requestEpoch)
+            handleNotModified(requestEpoch, requestDate)
             return
         }
         scope.launch {
@@ -299,7 +305,12 @@ internal class RemoteConfigManager(
                 val response = RemoteConfiguration.parse(container.config)
                 synchronized(cacheLock) {
                     if (epoch.get() != requestEpoch) return@launch
-                    persist(previous = persisted, response = response, container = container)
+                    persist(
+                        previous = persisted,
+                        response = response,
+                        container = container,
+                        requestDate = requestDate,
+                    )
                 }
             } catch (e: SerializationException) {
                 errorLog(e) {
@@ -364,8 +375,10 @@ internal class RemoteConfigManager(
                     try {
                         synchronized(cacheLock) {
                             if (epoch.get() != requestEpoch) return@launch
-                            // No persisted state exists on the fallback path (it only runs on a cold start).
-                            persist(previous = null, response = response, container = null)
+                            // No persisted state exists on the fallback path (it only runs on a cold start). The
+                            // fallback host is not the main API, so its request time is not borrowed as the refresh
+                            // time: the value is only meaningful to the endpoint that issued it.
+                            persist(previous = null, response = response, container = null, requestDate = null)
                         }
                     } finally {
                         releaseGuardIfOwned(requestEpoch)
@@ -385,18 +398,20 @@ internal class RemoteConfigManager(
      * request, so a failed timestamp write must not hold back [hasCommittedInitialConfig], nor [lastRefreshedAt]
      * (which would re-arm the staleness gate immediately). It only costs the next request a staler header value.
      */
-    private fun handleNotModified(requestEpoch: Int) {
+    private fun handleNotModified(requestEpoch: Int, requestDate: Date?) {
         debugLog { "Remote config unchanged (204 Not Modified)." }
         scope.launch {
             try {
                 synchronized(cacheLock) {
                     if (epoch.get() != requestEpoch) return@launch
-                    val now = dateProvider.now
-                    lastRefreshedAt = now
+                    lastRefreshedAt = dateProvider.now
                     hasCommittedInitialConfig = true
-                    // Re-read instead of reusing the request's snapshot, and skip when nothing is persisted: a 204
-                    // must never write back state that was wiped, or resurrect a cleared cache.
-                    diskCache.read()?.let { diskCache.write(it.copy(lastRefreshTime = now.time)) }
+                    // Only the server's own time is worth persisting, so a response without it writes nothing and
+                    // the previous value carries forward. Re-read instead of reusing the request's snapshot, and
+                    // skip when nothing is persisted: a 204 must never resurrect a cache that was wiped meanwhile.
+                    if (requestDate != null) {
+                        diskCache.read()?.let { diskCache.write(it.copy(lastRefreshTime = requestDate.time)) }
+                    }
                 }
             } finally {
                 releaseGuardIfOwned(requestEpoch)
@@ -813,6 +828,8 @@ internal class RemoteConfigManager(
         // Null on the fallback path (plain-JSON response with no inlined blob elements to extract); the wanted
         // blobs are then fetched over the network by prefetchBlobs instead.
         container: RCContainer?,
+        // The server's own request time. Null when the response carried no such header, or on the fallback path.
+        requestDate: Date?,
     ) {
         debugLog {
             val changed = response.topics.entries.joinToString { (name, topic) ->
@@ -834,9 +851,6 @@ internal class RemoteConfigManager(
         // manifest the server diffs against is the source of truth, and persisting it IS the entire commit (the
         // manifest advances unconditionally). Inline blobs are recoverable over the network, so only touch the
         // blob store once the state is durably committed — a failed persist never orphans or evicts blobs.
-        // One instant for both the persisted refresh time (replayed in the request header) and the in-memory
-        // staleness gate, so they can never disagree about when this refresh happened.
-        val now = dateProvider.now
         val persisted = diskCache.write(
             PersistedRemoteConfigurationState(
                 domain = response.domain,
@@ -844,12 +858,16 @@ internal class RemoteConfigManager(
                 activeTopics = response.activeTopics,
                 prefetchBlobs = response.prefetchBlobs,
                 topics = mergedTopics,
-                lastRefreshTime = now.time,
+                // Server time only: a response without it carries the last server-supplied value forward rather
+                // than substituting a device-clock reading the server cannot compare against its own.
+                lastRefreshTime = requestDate?.time ?: previous?.lastRefreshTime,
             ),
         )
 
         if (persisted) {
-            lastRefreshedAt = now
+            // The staleness gate measures elapsed *local* time (isCacheStale subtracts from dateProvider.now), so
+            // it stays on the device clock and is deliberately not the value persisted above.
+            lastRefreshedAt = dateProvider.now
             hasCommittedInitialConfig = true
             debugLog {
                 "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.common.between
 import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerFormatException
 import com.revenuecat.purchases.common.verboseLog
@@ -295,6 +296,15 @@ internal class RemoteConfigManager(
             // The cache was cleared (identity change) after this request started. Drop the stale
             // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
             return
+        }
+        if (requestDate == null) {
+            // Not fatal — the previous value carries forward — but it means the server stopped telling us its own
+            // time, so the refresh time replayed on later requests is frozen. Surfaced here rather than swallowed
+            // because nothing else makes this observable in the field.
+            warnLog {
+                "Remote config response carried no ${HTTPResult.REQUEST_TIME_HEADER_NAME} header. Keeping the " +
+                    "previous refresh time; the server cannot see how fresh this client's configuration is."
+            }
         }
         if (container == null) {
             handleNotModified(requestEpoch, requestDate)

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -270,7 +270,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
                 manifest = manifest,
                 lastRefreshTime = lastRefreshTime,
                 prefetchedBlobs = prefetchedBlobs,
-                onSuccess = { rcContainer, verificationResult ->
+                onSuccess = { rcContainer, _, verificationResult ->
                     container = rcContainer
                     verification = verificationResult
                     latch.countDown()

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -212,6 +212,53 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         assertThat(secondVerification).isEqualTo(VerificationResult.VERIFIED)
     }
 
+    /**
+     * The refresh time replayed in `X-RC-Last-Refresh-Time` is the server's own `X-RevenueCat-Request-Time`, so the
+     * whole mechanism goes inert if the backend stops sending that header — and every unit test would still pass,
+     * since they all inject the date. This is the canary for that.
+     *
+     * Informational verification on purpose: [SigningManager] already fails a signed response whose request time is
+     * missing, so under enforcement a missing header would surface as a verification error and mask what is being
+     * checked here.
+     */
+    @Test
+    fun `the backend returns its request time on both a 200 and a 204`() {
+        setupTest(SignatureVerificationMode.Informational())
+
+        val first = fetchRemoteConfig(manifest = null)
+        assertThat(first.error).isNull()
+        val rcContainer = requireNotNull(first.container) { "Expected a 200 container on the first run." }
+        assertServerRequestTime(first.requestDate, "200")
+
+        // Replay the manifest for a 204, feeding back the first response's own time as the refresh time — the exact
+        // round trip production performs. A non-`app_start` context is required: an `app_start` request is always
+        // fully resolved, so it never answers 204.
+        val second = fetchRemoteConfig(
+            manifest = RemoteConfiguration.parse(rcContainer.config).manifest,
+            fetchContext = RemoteConfigFetchContext.Foreground,
+            lastRefreshTime = first.requestDate,
+        )
+        assertThat(second.error).isNull()
+        assertThat(second.container).isNull()
+        assertServerRequestTime(second.requestDate, "204")
+    }
+
+    /**
+     * A null check alone would not catch a format change: epoch *seconds* still parse as a `Long` and yield a 1970
+     * date, so the floor is what makes this meaningful. An ISO-8601 switch degrades to null via `toLongOrNull`.
+     * Deliberately not compared against device time — that would couple the assertion to CI clock accuracy.
+     */
+    private fun assertServerRequestTime(requestDate: Date?, responseKind: String) {
+        assertThat(requestDate)
+            .withFailMessage(
+                "Expected the $responseKind response to carry an X-RevenueCat-Request-Time header in epoch millis, " +
+                    "but got %s. X-RC-Last-Refresh-Time cannot be populated without it.",
+                requestDate,
+            )
+            .isNotNull
+            .isAfter(EPOCH_MILLIS_FLOOR)
+    }
+
     @Test
     fun `verifies the signed response when verification is enforced`() {
         setupTest(SignatureVerificationMode.Enforced())
@@ -247,20 +294,33 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
     }
 
     /**
+     * The outcome of one `/v1/config` request. [requestDate] is last so the existing three-component destructuring
+     * call sites keep working.
+     */
+    private data class RemoteConfigFetchResult(
+        val error: PurchasesError?,
+        val container: RCContainer?,
+        val verification: VerificationResult?,
+        val requestDate: Date?,
+    )
+
+    /**
      * Performs a single `/v1/config` request and blocks until it completes, returning the error (or `null`), the
-     * container (`null` on a `204`), and the verification result (`null` on error).
+     * container (`null` on a `204`), the verification result (`null` on error), and the server's own request time
+     * (`null` when the response carried no `X-RevenueCat-Request-Time` header).
      */
     private fun fetchRemoteConfig(
         manifest: String?,
         prefetchedBlobs: List<String> = emptyList(),
         fetchContext: RemoteConfigFetchContext = RemoteConfigFetchContext.AppStart,
         lastRefreshTime: Date? = null,
-    ): Triple<PurchasesError?, RCContainer?, VerificationResult?> {
+    ): RemoteConfigFetchResult {
         every { appConfig.isDebugBuild } returns false
 
         var error: PurchasesError? = null
         var container: RCContainer? = null
         var verification: VerificationResult? = null
+        var requestDate: Date? = null
         ensureBlockFinishes { latch ->
             backend.getRemoteConfig(
                 appInBackground = false,
@@ -270,9 +330,10 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
                 manifest = manifest,
                 lastRefreshTime = lastRefreshTime,
                 prefetchedBlobs = prefetchedBlobs,
-                onSuccess = { rcContainer, _, verificationResult ->
+                onSuccess = { rcContainer, serverRequestDate, verificationResult ->
                     container = rcContainer
                     verification = verificationResult
+                    requestDate = serverRequestDate
                     latch.countDown()
                 },
                 onError = { purchasesError, _ ->
@@ -281,7 +342,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
                 },
             )
         }
-        return Triple(error, container, verification)
+        return RemoteConfigFetchResult(error, container, verification, requestDate)
     }
 
     /**
@@ -314,5 +375,9 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
 
     private companion object {
         private const val REMOTE_CONFIG_USER = "integrationTestRemoteConfigUser"
+
+        // 2023-11-14. Any real epoch-millis instant is well past this, while a value sent in epoch *seconds* lands
+        // in 1970 and fails, which is the format regression a null check would miss.
+        private val EPOCH_MILLIS_FLOOR = Date(1_700_000_000_000L)
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -651,6 +651,49 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
     }
 
     @Test
+    fun `an RC format response exposes the server request date, including on a 204`() {
+        val serverMillis = 1785161502351L
+        listOf(200, RCHTTPStatusCodes.NO_CONTENT).forEach { responseCode ->
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(responseCode)
+                    .setHeader(HTTPResult.REQUEST_TIME_HEADER_NAME, serverMillis)
+                    .setBody(Buffer().write(byteArrayOf('R'.code.toByte(), 'C'.code.toByte(), 1, 0, 0, 0, 0, 0))),
+            )
+
+            val result = client.performRequest(
+                baseURL,
+                Endpoint.GetRemoteConfig("app"),
+                body = null,
+                postFieldsToSign = null,
+                mapOf("" to ""),
+            )
+
+            assertThat(result.requestDate).isEqualTo(Date(serverMillis))
+        }
+    }
+
+    @Test
+    fun `a non-numeric request time header yields no request date instead of throwing`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader(HTTPResult.REQUEST_TIME_HEADER_NAME, "not-a-number")
+                .setBody(Buffer().write(byteArrayOf('R'.code.toByte(), 'C'.code.toByte(), 1, 0, 0, 0, 0, 0))),
+        )
+
+        val result = client.performRequest(
+            baseURL,
+            Endpoint.GetRemoteConfig("app"),
+            body = null,
+            postFieldsToSign = null,
+            mapOf("" to ""),
+        )
+
+        assertThat(result.requestDate).isNull()
+    }
+
+    @Test
     fun `GetRemoteConfig with a 204 and a missing body stream returns an empty payload instead of throwing`() {
         // On some Android devices a 204 yields no readable body stream (getInputStream returns null).
         // This must surface as a 204 with an empty payload, not as a network IOException.

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRemoteConfigTest.kt
@@ -106,7 +106,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { result, verificationResult ->
+            onSuccess = { result, _, verificationResult ->
                 container = result
                 verification = verificationResult
             },
@@ -156,7 +156,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { result, _ -> container = result },
+            onSuccess = { result, _, _ -> container = result },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
@@ -180,7 +180,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> fail("Expected error. Got success") },
+            onSuccess = { _, _, _ -> fail("Expected error. Got success") },
             onError = { error, behavior ->
                 obtainedError = error
                 obtainedBehavior = behavior
@@ -204,7 +204,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> fail("Expected error. Got success") },
+            onSuccess = { _, _, _ -> fail("Expected error. Got success") },
             onError = { error, _ -> obtainedError = error },
         )
         assertThat(obtainedError).isNotNull
@@ -229,7 +229,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { result, verificationResult ->
+            onSuccess = { result, _, verificationResult ->
                 callbackCount++
                 container = result
                 verification = verificationResult
@@ -240,6 +240,84 @@ class BackendGetRemoteConfigTest {
         assertThat(callbackCount).isEqualTo(1)
         assertThat(container).isNull()
         assertThat(verification).isEqualTo(VerificationResult.VERIFIED)
+    }
+
+    @Test
+    fun `getRemoteConfig hands the server request date to the success callback on a 200`() {
+        val serverDate = Date(1785161502351L)
+        mockHttpResult(
+            payload = HTTPResult.Payload.RCFormat(buildContainer(config = "{}".toByteArray())),
+            requestDate = serverDate,
+        )
+
+        var obtained: Date? = null
+        backend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
+            domain = testDomain,
+            manifest = testManifest,
+            lastRefreshTime = null,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, requestDate, _ -> obtained = requestDate },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+
+        assertThat(obtained).isEqualTo(serverDate)
+    }
+
+    @Test
+    fun `getRemoteConfig hands the server request date to the success callback on a 204`() {
+        val serverDate = Date(1785161502351L)
+        mockHttpResult(
+            responseCode = RCHTTPStatusCodes.NO_CONTENT,
+            payload = HTTPResult.Payload.RCFormat(ByteArray(0)),
+            requestDate = serverDate,
+        )
+
+        var obtained: Date? = null
+        backend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
+            domain = testDomain,
+            manifest = testManifest,
+            lastRefreshTime = null,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, requestDate, _ -> obtained = requestDate },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+
+        assertThat(obtained).isEqualTo(serverDate)
+    }
+
+    @Test
+    fun `getRemoteConfig reports a null request date when the response carried no such header`() {
+        mockHttpResult(
+            responseCode = RCHTTPStatusCodes.NO_CONTENT,
+            payload = HTTPResult.Payload.RCFormat(ByteArray(0)),
+            requestDate = null,
+        )
+
+        var callbackCount = 0
+        var obtained: Date? = Date()
+        backend.getRemoteConfig(
+            appInBackground = false,
+            appUserID = testAppUserID,
+            fetchContext = RemoteConfigFetchContext.AppStart,
+            domain = testDomain,
+            manifest = testManifest,
+            lastRefreshTime = null,
+            prefetchedBlobs = testPrefetchedBlobs,
+            onSuccess = { _, requestDate, _ ->
+                callbackCount++
+                obtained = requestDate
+            },
+            onError = { error, _ -> fail("Expected success. Got error: $error") },
+        )
+
+        assertThat(callbackCount).isEqualTo(1)
+        assertThat(obtained).isNull()
     }
 
     @Test
@@ -255,7 +333,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> },
+            onSuccess = { _, _, _ -> },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
@@ -299,7 +377,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> },
+            onSuccess = { _, _, _ -> },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
@@ -320,7 +398,7 @@ class BackendGetRemoteConfigTest {
             manifest = null,
             lastRefreshTime = null,
             prefetchedBlobs = emptyList(),
-            onSuccess = { _, _ -> },
+            onSuccess = { _, _, _ -> },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
@@ -342,7 +420,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = Date(1785161502351L),
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> },
+            onSuccess = { _, _, _ -> },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
@@ -364,7 +442,7 @@ class BackendGetRemoteConfigTest {
             manifest = null,
             lastRefreshTime = null,
             prefetchedBlobs = emptyList(),
-            onSuccess = { _, _ -> },
+            onSuccess = { _, _, _ -> },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
 
@@ -421,7 +499,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> fail("Expected error. Got success") },
+            onSuccess = { _, _, _ -> fail("Expected error. Got success") },
             onError = { error, behavior ->
                 obtainedError = error
                 obtainedBehavior = behavior
@@ -448,7 +526,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> fail("Expected error. Got success") },
+            onSuccess = { _, _, _ -> fail("Expected error. Got success") },
             onError = { error, behavior ->
                 obtainedError = error
                 obtainedBehavior = behavior
@@ -471,7 +549,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> lock.countDown() },
+            onSuccess = { _, _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
         asyncBackend.getRemoteConfig(
@@ -482,7 +560,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> lock.countDown() },
+            onSuccess = { _, _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
@@ -510,7 +588,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> lock.countDown() },
+            onSuccess = { _, _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
         asyncBackend.getRemoteConfig(
@@ -521,7 +599,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> lock.countDown() },
+            onSuccess = { _, _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
@@ -550,7 +628,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> lock.countDown() },
+            onSuccess = { _, _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
         asyncBackend.getRemoteConfig(
@@ -561,7 +639,7 @@ class BackendGetRemoteConfigTest {
             manifest = testManifest,
             lastRefreshTime = null,
             prefetchedBlobs = testPrefetchedBlobs,
-            onSuccess = { _, _ -> lock.countDown() },
+            onSuccess = { _, _, _ -> lock.countDown() },
             onError = { error, _ -> fail("Expected success. Got error: $error") },
         )
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
@@ -743,6 +821,7 @@ class BackendGetRemoteConfigTest {
         payload: HTTPResult.Payload,
         delayMs: Long? = null,
         verificationResult: VerificationResult = VerificationResult.NOT_REQUESTED,
+        requestDate: Date? = null,
     ) {
         every {
             httpClient.performRequest(
@@ -761,7 +840,7 @@ class BackendGetRemoteConfigTest {
                 responseCode,
                 payload,
                 HTTPResult.Origin.BACKEND,
-                requestDate = null,
+                requestDate = requestDate,
                 verificationResult,
                 isLoadShedderResponse = false,
                 isFallbackURL = false,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
@@ -53,7 +53,7 @@ class RemoteConfigManagerIntegrationTest {
     private var capturedManifest: String? = null
     private var capturedLastRefreshTime: Date? = null
     private var capturedPrefetchedBlobs: List<String>? = null
-    private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
+    private lateinit var onSuccess: (RCContainer?, Date?, VerificationResult) -> Unit
 
     @Before
     fun setup() {
@@ -351,7 +351,7 @@ class RemoteConfigManagerIntegrationTest {
     }
 
     private fun settle(container: RCContainer?) {
-        onSuccess.invoke(container, VerificationResult.VERIFIED)
+        onSuccess.invoke(container, Date(), VerificationResult.VERIFIED)
     }
 
     private companion object {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -802,6 +802,20 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `a response with no server time warns that the refresh time is frozen`() {
+        every { diskCache.read() } returns persisted(manifest = "v1.1.", lastRefreshTime = SERVER_MILLIS)
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+
+        assertWarnLog(
+            "Remote config response carried no X-RevenueCat-Request-Time header. Keeping the previous refresh " +
+                "time; the server cannot see how fresh this client's configuration is.",
+        ) {
+            deliverSuccess(null, requestDate = null)
+        }
+    }
+
+    @Test
     fun `a 204 response with nothing persisted does not resurrect the cache`() {
         every { diskCache.read() } returns null
 
@@ -1252,6 +1266,32 @@ class RemoteConfigManagerTest {
         assertThat(written.captured.manifest).isEqualTo("v1.fallback.sources:etag")
         assertThat(written.captured.activeTopics).containsExactly("sources")
         assertThat(written.captured.topics["sources"]!!["default"]!!.blobRef).isEqualTo("newBlob")
+        // The fallback host is not the main API, so its clock is never borrowed as the refresh time.
+        assertThat(written.captured.lastRefreshTime).isNull()
+    }
+
+    @Test
+    fun `a fallback-only session sends no refresh time on its next request`() {
+        every { diskCache.read() } returns null
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.UnknownBackendError, "server error"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        val committed = slot<PersistedRemoteConfigurationState>()
+        every { diskCache.write(capture(committed)) } returns true
+        onFallbackSuccess.invoke(
+            remoteConfiguration("""{"domain":"app","manifest":"v1.fallback."}"""),
+            VerificationResult.VERIFIED,
+        )
+
+        // The committed state has no refresh time, so the following request has nothing to replay.
+        every { diskCache.read() } returns committed.captured
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+
+        assertThat(capturedManifest).isEqualTo("v1.fallback.")
+        assertThat(capturedLastRefreshTime).isNull()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -72,7 +72,7 @@ class RemoteConfigManagerTest {
     private var capturedLastRefreshTime: Date? = null
     private var capturedFetchContext: RemoteConfigFetchContext? = null
     private var capturedPrefetchedBlobs: List<String>? = null
-    private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
+    private lateinit var onSuccess: (RCContainer?, Date?, VerificationResult) -> Unit
     private lateinit var onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit
 
     private lateinit var onFallbackSuccess: (RemoteConfiguration, VerificationResult) -> Unit
@@ -170,7 +170,7 @@ class RemoteConfigManagerTest {
             fetchContext = RemoteConfigFetchContext.IdentityChange,
         )
         assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
 
         // The next committed request reports its own context.
         manager.refreshRemoteConfig(
@@ -211,7 +211,7 @@ class RemoteConfigManagerTest {
         assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
 
         // Once a request succeeds, the forcing stops and later requests report their own context.
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
         manager.refreshRemoteConfig(
             appInBackground = false,
             appUserID = TEST_APP_USER_ID,
@@ -238,7 +238,7 @@ class RemoteConfigManagerTest {
             fetchContext = RemoteConfigFetchContext.IdentityChange,
         )
         assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         manager.refreshRemoteConfig(
             appInBackground = false,
@@ -259,7 +259,7 @@ class RemoteConfigManagerTest {
         )
         assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
         // A 200 whose body fails to parse commits nothing, so the initial config is still not committed.
-        onSuccess.invoke(containerWithConfig("{ not valid json"), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig("{ not valid json"))
 
         // The next request must still be forced to AppStart, since no config landed yet.
         manager.refreshRemoteConfig(
@@ -324,7 +324,7 @@ class RemoteConfigManagerTest {
 
         // First refresh completes (204), stamping the in-memory last-sync time.
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
 
         // Same clock: still within the foreground window, so no new request.
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
@@ -337,7 +337,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
 
         currentTimeMillis = FIXED_MILLIS + STALE_FOREGROUND_AGE_MILLIS
 
@@ -351,7 +351,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
 
         // Identity change wipes the cache and the in-memory marker, so the next user refreshes immediately.
         manager.clearCache(TEST_APP_USER_ID)
@@ -467,7 +467,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         val written = slot<PersistedRemoteConfigurationState>()
         verify(exactly = 1) { diskCache.write(capture(written)) }
@@ -501,7 +501,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         val written = slot<PersistedRemoteConfigurationState>()
         verify(exactly = 1) { diskCache.write(capture(written)) }
@@ -527,7 +527,7 @@ class RemoteConfigManagerTest {
         val validData = byteArrayOf(1, 2, 3)
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(
+        deliverSuccess(
             containerWithConfig(
                 response,
                 blobs = listOf(
@@ -535,9 +535,7 @@ class RemoteConfigManagerTest {
                     // A tampered blob fails verification: its decode() throws, so it is skipped.
                     inlineElement(REF_TAMPERED, decoded = null),
                 ),
-            ),
-            VerificationResult.VERIFIED,
-        )
+            ))
 
         verify(exactly = 1) { blobStore.write(REF_VALID, validData) }
         verify(exactly = 0) { blobStore.write(REF_TAMPERED, any()) }
@@ -558,7 +556,7 @@ class RemoteConfigManagerTest {
         val wantedData = byteArrayOf(1, 2, 3)
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(
+        deliverSuccess(
             containerWithConfig(
                 response,
                 blobs = listOf(
@@ -566,9 +564,7 @@ class RemoteConfigManagerTest {
                     // Valid bytes, but not in prefetch_blobs nor referenced by any active topic (never decoded).
                     inlineElement(REF_UNWANTED, byteArrayOf(7)),
                 ),
-            ),
-            VerificationResult.VERIFIED,
-        )
+            ))
 
         verify(exactly = 1) { blobStore.write(REF_VALID, wantedData) }
         verify(exactly = 0) { blobStore.write(REF_UNWANTED, any()) }
@@ -589,13 +585,11 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(
+        deliverSuccess(
             containerWithConfig(
                 response,
                 blobs = listOf(inlineElement(REF_VALID, byteArrayOf(1, 2, 3))),
-            ),
-            VerificationResult.VERIFIED,
-        )
+            ))
 
         // Both blob-store mutations are gated on a successful persist.
         verify(exactly = 0) { blobStore.write(any(), any()) }
@@ -616,7 +610,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         val retained = slot<Set<String>>()
         verify(exactly = 1) { blobStore.retainOnly(capture(retained)) }
@@ -641,7 +635,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         val written = slot<PersistedRemoteConfigurationState>()
         verify(exactly = 1) { diskCache.write(capture(written)) }
@@ -670,7 +664,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         // Re-arm the blob sources before fetching, but only if a prior cycle exhausted them.
         verify(exactly = 1) { sourceProvider.restartIfExhausted(RemoteConfigSourceHandle.Purpose.BLOB) }
@@ -700,7 +694,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         val prefetched = slot<List<String>>()
         verify(exactly = 1) { blobFetcher.prefetch(capture(prefetched)) }
@@ -723,7 +717,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         val prefetched = slot<List<String>>()
         verify(exactly = 1) { blobFetcher.prefetch(capture(prefetched)) }
@@ -745,7 +739,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         verify(exactly = 0) { sourceProvider.restartIfExhausted(any()) }
         verify(exactly = 0) { blobFetcher.prefetch(any()) }
@@ -756,7 +750,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
 
         verify(exactly = 0) { sourceProvider.restartIfExhausted(any()) }
         verify(exactly = 0) { blobFetcher.prefetch(any()) }
@@ -773,23 +767,38 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns cached
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
 
         // The only thing a 204 rewrites is the refresh time; the configuration itself carries forward verbatim.
-        verify(exactly = 1) { diskCache.write(cached.copy(lastRefreshTime = FIXED_MILLIS)) }
+        verify(exactly = 1) { diskCache.write(cached.copy(lastRefreshTime = SERVER_MILLIS)) }
         verify(exactly = 0) { blobStore.write(any(), any()) }
         verify(exactly = 0) { blobStore.retainOnly(any()) }
     }
 
     @Test
-    fun `a 204 response advances the persisted refresh time`() {
-        val cached = persisted(manifest = "v1.1.sources:etag1", lastRefreshTime = FIXED_MILLIS - 10_000L)
+    fun `a 204 response advances the persisted refresh time to the server time`() {
+        val cached = persisted(manifest = "v1.1.sources:etag1", lastRefreshTime = SERVER_MILLIS - 10_000L)
         every { diskCache.read() } returns cached
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
 
-        verify(exactly = 1) { diskCache.write(cached.copy(lastRefreshTime = FIXED_MILLIS)) }
+        // SERVER_MILLIS, not the FIXED_MILLIS device clock: the server's own time is what gets replayed.
+        verify(exactly = 1) { diskCache.write(cached.copy(lastRefreshTime = SERVER_MILLIS)) }
+    }
+
+    @Test
+    fun `a 204 response with no server time leaves the persisted refresh time alone`() {
+        every { diskCache.read() } returns persisted(
+            manifest = "v1.1.sources:etag1",
+            lastRefreshTime = SERVER_MILLIS - 10_000L,
+        )
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccess(null, requestDate = null)
+
+        // No device-clock substitute, and no pointless rewrite of an unchanged value.
+        verify(exactly = 0) { diskCache.write(any()) }
     }
 
     @Test
@@ -797,33 +806,59 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
 
         verify(exactly = 0) { diskCache.write(any()) }
     }
 
     @Test
-    fun `a 200 response persists the refresh time`() {
+    fun `a 200 response persists the server time as the refresh time`() {
         every { diskCache.read() } returns null
         val slot = slot<PersistedRemoteConfigurationState>()
         every { diskCache.write(capture(slot)) } returns true
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig("""{"domain":"app","manifest":"v1.2."}"""), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig("""{"domain":"app","manifest":"v1.2."}"""))
 
-        assertThat(slot.captured.lastRefreshTime).isEqualTo(FIXED_MILLIS)
+        assertThat(slot.captured.lastRefreshTime).isEqualTo(SERVER_MILLIS)
+    }
+
+    @Test
+    fun `a 200 response with no server time carries the previous refresh time forward`() {
+        every { diskCache.read() } returns persisted(manifest = "v1.1.", lastRefreshTime = SERVER_MILLIS - 10_000L)
+        val slot = slot<PersistedRemoteConfigurationState>()
+        every { diskCache.write(capture(slot)) } returns true
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccess(containerWithConfig("""{"domain":"app","manifest":"v1.2."}"""), requestDate = null)
+
+        // The manifest advances, but the refresh time holds at the last value the server actually supplied.
+        assertThat(slot.captured.manifest).isEqualTo("v1.2.")
+        assertThat(slot.captured.lastRefreshTime).isEqualTo(SERVER_MILLIS - 10_000L)
+    }
+
+    @Test
+    fun `a first-ever 200 with no server time persists no refresh time`() {
+        every { diskCache.read() } returns null
+        val slot = slot<PersistedRemoteConfigurationState>()
+        every { diskCache.write(capture(slot)) } returns true
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccess(containerWithConfig("""{"domain":"app","manifest":"v1.2."}"""), requestDate = null)
+
+        assertThat(slot.captured.lastRefreshTime).isNull()
     }
 
     @Test
     fun `the persisted refresh time is sent on the next request`() {
         every { diskCache.read() } returns persisted(
             manifest = "v1.1.sources:etag1",
-            lastRefreshTime = FIXED_MILLIS - 60_000L,
+            lastRefreshTime = SERVER_MILLIS,
         )
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
-        assertThat(capturedLastRefreshTime).isEqualTo(Date(FIXED_MILLIS - 60_000L))
+        assertThat(capturedLastRefreshTime).isEqualTo(Date(SERVER_MILLIS))
     }
 
     @Test
@@ -837,7 +872,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `an identity change drops the refresh time along with the cache`() {
-        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1", lastRefreshTime = FIXED_MILLIS)
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1", lastRefreshTime = SERVER_MILLIS)
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         assertThat(capturedLastRefreshTime).isNotNull
 
@@ -900,7 +935,7 @@ class RemoteConfigManagerTest {
             appUserID = TEST_APP_USER_ID,
             fetchContext = DEFAULT_FETCH_CONTEXT,
         )
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         assertThat(manager.configGeneration).isEqualTo(1)
         assertThat(recorder.committed).containsExactly(1)
@@ -982,7 +1017,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         assertThat(recorder.disabled).isEmpty()
     }
@@ -1373,7 +1408,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
@@ -1399,7 +1434,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig("{ not valid json"), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig("{ not valid json"))
 
         verify(exactly = 0) { diskCache.write(any()) }
     }
@@ -1420,7 +1455,7 @@ class RemoteConfigManagerTest {
         """.trimIndent()
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(config), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(config))
 
         // The parse failure is caught: nothing is persisted and the cache is left intact.
         verify(exactly = 0) { diskCache.write(any()) }
@@ -1435,7 +1470,7 @@ class RemoteConfigManagerTest {
         every { diskCache.read() } returns null
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithUndecodableConfig(), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithUndecodableConfig())
 
         // The decode failure is caught: nothing is persisted and the cache is left intact.
         verify(exactly = 0) { diskCache.write(any()) }
@@ -1469,7 +1504,7 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         // Identity change wipes the cache before the in-flight request settles.
         manager.clearCache(TEST_APP_USER_ID)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         // The stale response is dropped (epoch guard): nothing is written over the wiped cache.
         verify(exactly = 0) { diskCache.write(any()) }
@@ -1500,7 +1535,7 @@ class RemoteConfigManagerTest {
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         // Run the 200 path on its own thread: it enters the lock and parks inside diskCache.write.
-        val persistThread = thread { onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED) }
+        val persistThread = thread { deliverSuccess(containerWithConfig(response)) }
         check(writeEntered.await(WAIT_SECONDS, TimeUnit.SECONDS)) { "persist did not reach diskCache.write" }
 
         // Identity change mid-persist: clearCache must block on the lock persist is holding.
@@ -1534,7 +1569,7 @@ class RemoteConfigManagerTest {
         manager.clearCache(TEST_APP_USER_ID)
         // A brand-new sync (e.g. for the new user) proceeds normally: the guard was released by clearCache.
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         verify(exactly = 1) { diskCache.write(any()) }
     }
@@ -1577,7 +1612,7 @@ class RemoteConfigManagerTest {
             appUserID = TEST_APP_USER_ID,
             fetchContext = RemoteConfigFetchContext.AppStart,
         )
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
 
         // Nothing is in flight and nothing is cached: the read triggers its own sync and waits for it.
         var result: ConfigTopic? = null
@@ -1598,7 +1633,7 @@ class RemoteConfigManagerTest {
               "topics": { "workflows": { "wf1": { "blob_ref": "$REF_VALID" } } }
             }
         """.trimIndent()
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         assertThat(read.isCompleted).isTrue()
         assertThat(result).containsKey("wf1")
@@ -1661,7 +1696,7 @@ class RemoteConfigManagerTest {
         assertThat(capturedAppUserID).isEqualTo("new-user")
 
         // Settle the triggered sync so the parked read completes cleanly.
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
         assertThat(read.isCompleted).isTrue()
     }
 
@@ -1689,7 +1724,7 @@ class RemoteConfigManagerTest {
             verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
             assertThat(capturedAppUserID).isEqualTo("new-user")
 
-            onSuccess.invoke(null, VerificationResult.VERIFIED)
+            deliverSuccess(null)
             assertThat(read.isCompleted).isTrue()
         }
 
@@ -1706,7 +1741,7 @@ class RemoteConfigManagerTest {
         verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         assertThat(capturedAppUserID).isEqualTo("bootstrap-user")
 
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
         assertThat(read.isCompleted).isTrue()
     }
 
@@ -1736,7 +1771,7 @@ class RemoteConfigManagerTest {
               "topics": { "workflows": { "wf1": { "blob_ref": "$REF_VALID" } } }
             }
         """.trimIndent()
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         assertThat(read.isCompleted).isTrue()
         assertThat(result).containsKey("wf1")
@@ -1898,7 +1933,7 @@ class RemoteConfigManagerTest {
               "topics": { "workflows": { "wf1": { "blob_ref": "$REF_VALID" } } }
             }
         """.trimIndent()
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         assertThat(read.isCompleted).isTrue()
         assertThat(result).isEqualTo(byteArrayOf(4, 2))
@@ -1955,7 +1990,7 @@ class RemoteConfigManagerTest {
               "topics": { "workflows": { "wf1": { "blob_ref": "$REF_VALID" } } }
             }
         """.trimIndent()
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         assertThat(read.isCompleted).isTrue()
         assertThat(result).isEqualTo(byteArrayOf(4, 2))
@@ -2209,7 +2244,7 @@ class RemoteConfigManagerTest {
               }
             }
         """.trimIndent()
-        onSuccess.invoke(containerWithConfig(response), VerificationResult.VERIFIED)
+        deliverSuccess(containerWithConfig(response))
 
         assertThat(read.isCompleted).isTrue()
         assertThat(result).isEqualTo(MergedBlob(wf1 = Section("x"), wf2 = Section("y")))
@@ -2265,7 +2300,7 @@ class RemoteConfigManagerTest {
         }
         assertThat(read.isActive).isTrue()
 
-        onSuccess.invoke(null, VerificationResult.VERIFIED)
+        deliverSuccess(null)
 
         assertThat(read.isCompleted).isTrue()
         assertThat(result).isNull()
@@ -2319,8 +2354,8 @@ class RemoteConfigManagerTest {
         every {
             backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any())
         } answers {
-            arg<(RCContainer?, VerificationResult) -> Unit>(7)
-                .invoke(containerWithConfig(stressResponse), VerificationResult.VERIFIED)
+            arg<(RCContainer?, Date?, VerificationResult) -> Unit>(7)
+                .invoke(containerWithConfig(stressResponse), Date(SERVER_MILLIS), VerificationResult.VERIFIED)
         }
         val manager = RemoteConfigManager(
             backend,
@@ -2384,6 +2419,14 @@ class RemoteConfigManagerTest {
     }
 
     // endregion
+
+    /**
+     * Delivers a successful config response. [requestDate] defaults to the server's request time, deliberately a
+     * different instant from the [dateProvider] clock so an assertion on the persisted value proves which one won.
+     */
+    private fun deliverSuccess(container: RCContainer?, requestDate: Date? = Date(SERVER_MILLIS)) {
+        onSuccess.invoke(container, requestDate, VerificationResult.VERIFIED)
+    }
 
     private fun persisted(
         manifest: String,
@@ -2471,6 +2514,10 @@ class RemoteConfigManagerTest {
         private const val TEST_APP_USER_ID = "test-app-user-id"
         private val DEFAULT_FETCH_CONTEXT = RemoteConfigFetchContext.AppStart
         private const val FIXED_MILLIS = 1_710_000_000_000L
+
+        // The server's X-RevenueCat-Request-Time, offset from the device clock on purpose: the persisted refresh
+        // time must come from here, never from FIXED_MILLIS.
+        private const val SERVER_MILLIS = 1_720_000_000_000L
 
         // Older than the 5-minute foreground staleness window (see Date?.isCacheStale).
         private const val STALE_FOREGROUND_AGE_MILLIS = 6 * 60 * 1000L

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -41,6 +41,7 @@ import org.robolectric.annotation.Config
 import java.io.ByteArrayInputStream
 import java.net.HttpURLConnection
 import java.security.MessageDigest
+import java.util.Date
 
 /**
  * End-to-end: drives a fake `/v1/config` sync through the **real** [RemoteConfigManager] (the single read
@@ -59,7 +60,7 @@ class WorkflowsConfigIntegrationTest {
     private lateinit var provider: WorkflowsConfigProvider
     private lateinit var manager: RemoteConfigManager
 
-    private lateinit var onSuccess: (RCContainer?, VerificationResult) -> Unit
+    private lateinit var onSuccess: (RCContainer?, Date?, VerificationResult) -> Unit
 
     /** Stateful stand-in for the persisted config file: write stashes, read returns the latest. */
     private var persistedState: PersistedRemoteConfigurationState? = null
@@ -374,7 +375,7 @@ class WorkflowsConfigIntegrationTest {
 
     private fun sync(configJson: String, vararg blobs: Pair<String, String>) {
         manager.refreshRemoteConfig(appInBackground = false, appUserID = "user-1", fetchContext = RemoteConfigFetchContext.AppStart)
-        onSuccess.invoke(containerWith(configJson, *blobs), VerificationResult.VERIFIED)
+        onSuccess.invoke(containerWith(configJson, *blobs), Date(), VerificationResult.VERIFIED)
     }
 
     private fun minimalWorkflow(id: String) = PublishedWorkflow(


### PR DESCRIPTION
Follow-up to #3853 (merged), which sent `dateProvider.now` as the refresh time. The backend compares the replayed value against its own clock, so a skewed device clock silently corrupts the optimization. This round-trips the server's own `X-RevenueCat-Request-Time` instead.

The RC-format response path already parses that header into `HTTPResult.requestDate` (including on a 204) — `getRemoteConfig` was just discarding it before `RemoteConfigManager` could see it, so this mostly widens the success callback.

- A response with no such header carries the last server-supplied value forward, rather than substituting local time. Nothing device-derived is ever sent.
- `lastRefreshedAt` stays on the device clock: `isCacheStale` measures elapsed *local* time, so server time there would produce a bogus interval. The two timestamps now use different clocks deliberately.
- The fallback endpoint contributes no refresh time: different host, different clock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote config sync bookkeeping and request headers the server uses for freshness; scope is limited to metadata timing, not config parsing or auth.
> 
> **Overview**
> Remote config no longer persists the device clock as `lastRefreshTime` for `X-RC-Last-Refresh-Time`. It now round-trips the server’s **`X-RevenueCat-Request-Time`** from each successful `/v1/config` response (200 or 204).
> 
> **`getRemoteConfig`** passes `HTTPResult.requestDate` through its success callback (new middle parameter). **`HTTPClient`** parses that header with `toLongOrNull()` so bad values become null instead of crashing the request path.
> 
> **`RemoteConfigManager`** writes `requestDate` into persisted `lastRefreshTime` on 200 and 204; if the header is missing, the previous server value is kept and a warning is logged. **`lastRefreshedAt`** (staleness) still uses the device clock. The **fallback** config path never sets refresh time from the fallback host.
> 
> Tests and a production integration check cover header presence on 200/204 and the new persistence rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddf1b82c1a37ba60cce0787978e10638bfc253da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->