### PR TITLE
FIX: Web View Scroll Arbitration 

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebView.kt
@@ -15,6 +15,12 @@ import kotlin.math.abs
  * inner scroller or `touch-action` map that native can't see — wins; otherwise native root
  * scrollability decides. [canScrollVertically]/[canScrollHorizontally] mirror View: `direction > 0`
  * = down/end.
+ *
+ * The native-scrollability decision fires at half of [touchSlop], not the full slop: Compose's
+ * scrollable consumes the drag on the MOVE that crosses the full slop, and interop views only receive
+ * MOVEs in the Final pointer pass — so a claim decided at the full slop always loses (that MOVE
+ * arrives as ACTION_CANCEL and the view is cut off for the rest of the gesture). Half slop is early
+ * enough to win on a pre-slop MOVE while still reading a reliable drag direction.
  */
 @Suppress("ReturnCount", "LongParameterList")
 internal fun shouldWebViewOwnGesture(
@@ -26,7 +32,8 @@ internal fun shouldWebViewOwnGesture(
     canScrollVertically: (direction: Int) -> Boolean,
 ): Boolean {
     if (webContentWantsGesture == true) return true
-    if (abs(totalDx) < touchSlop && abs(totalDy) < touchSlop) return false
+    val claimThreshold = (touchSlop / 2).coerceAtLeast(1)
+    if (abs(totalDx) < claimThreshold && abs(totalDy) < claimThreshold) return false
     return if (abs(totalDy) >= abs(totalDx)) {
         canScrollVertically(if (totalDy < 0) 1 else -1)
     } else {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/DragGestureArbitrationTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/DragGestureArbitrationTest.kt
@@ -57,8 +57,22 @@ internal class DragGestureArbitrationTest {
     }
 
     @Test
-    fun `movement within touch slop does not claim without an own verdict`() {
-        assertThat(shouldOwn(dx = 7f, dy = -7f, canScrollUp = true)).isFalse()
+    fun `movement below half the touch slop does not claim without an own verdict`() {
+        assertThat(shouldOwn(dx = 0f, dy = -3f, canScrollDown = true)).isFalse()
+    }
+
+    // Compose's scrollable consumes the drag on the MOVE that crosses the system touch slop, and interop
+    // views only receive MOVEs in the Final pointer pass — so a claim decided at the full slop always
+    // loses (that MOVE arrives as ACTION_CANCEL). The claim must fire strictly below the system slop.
+    @Test
+    fun `native scrollability claims at half the touch slop, before Compose consumes at the full slop`() {
+        assertThat(shouldOwn(dx = 0f, dy = -4f, canScrollDown = true)).isTrue()
+        assertThat(shouldOwn(dx = 0f, dy = -7f, canScrollDown = true)).isTrue()
+    }
+
+    @Test
+    fun `half-slop claim still hands off to the paywall when the root cannot scroll that direction`() {
+        assertThat(shouldOwn(dx = 0f, dy = -4f, canScrollDown = false)).isFalse()
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

Web views required 2 fingers to scroll in certain situations. We need it to be 1.

[Ticket](https://linear.app/revenuecat/issue/FUN-2262/fix-fill-height-discrepancies) linear issue FUN-2262

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

Adjust the scroll arbitration
