### PR TITLE
feat: add onUrlOpened to PaywallListener

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallListenerAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallListenerAPI.java
@@ -42,6 +42,9 @@ final class PaywallListenerAPI {
 
             @Override
             public void onWebCheckoutOpened() {}
+
+            @Override
+            public void onUrlOpened(@NonNull String url) {}
         };
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallListenerAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallListenerAPI.kt
@@ -19,6 +19,8 @@ private class PaywallListenerAPI {
 
             override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {}
 
+            override fun onPurchaseCancelled() {}
+
             override fun onRestoreInitiated(resume: Resumable) {}
 
             override fun onRestoreStarted() {}
@@ -26,6 +28,10 @@ private class PaywallListenerAPI {
             override fun onRestoreError(error: PurchasesError) {}
 
             override fun onRestoreCompleted(customerInfo: CustomerInfo) {}
+
+            override fun onWebCheckoutOpened() {}
+
+            override fun onUrlOpened(url: String) {}
         }
     }
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
@@ -103,6 +103,10 @@ class MainActivity : ComponentActivity(), PaywallResultHandler {
         override fun onRestoreError(error: PurchasesError) {
             Log.d(TAG, "onRestoreError: ${error.message}")
         }
+
+        override fun onUrlOpened(url: String) {
+            Log.d(TAG, "onUrlOpened: $url")
+        }
     }
 
     fun launchCustomerCenter() {

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallFooterViewActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallFooterViewActivity.kt
@@ -26,6 +26,11 @@ class PaywallFooterViewActivity : AppCompatActivity() {
                 super.onPurchaseCompleted(customerInfo, storeTransaction)
                 Log.d("PaywallsTester", "onPurchaseCompleted")
             }
+
+            override fun onUrlOpened(url: String) {
+                super.onUrlOpened(url)
+                Log.d("PaywallsTester", "onUrlOpened: $url")
+            }
         })
         binding.paywallFooterView.setDismissHandler { finish() }
     }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallViewActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallViewActivity.kt
@@ -54,6 +54,11 @@ class PaywallViewActivity : AppCompatActivity() {
                 super.onPurchaseCompleted(customerInfo, storeTransaction)
                 Log.d("PaywallsTester", "onPurchaseCompleted")
             }
+
+            override fun onUrlOpened(url: String) {
+                super.onUrlOpened(url)
+                Log.d("PaywallsTester", "onUrlOpened: $url")
+            }
         })
         binding.paywallView.setDismissHandler { finish() }
     }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -335,6 +335,10 @@ private fun OfferingsListScreen(
                     override fun onRestoreError(error: PurchasesError) {
                         Log.e("PaywallDialog", "onRestoreError: ${error.message}")
                     }
+
+                    override fun onUrlOpened(url: String) {
+                        Log.d("PaywallDialog", "onUrlOpened: $url")
+                    }
                 })
                 .build(),
         )

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
@@ -33,6 +33,7 @@ interface PaywallScreenViewModel : PaywallListener {
     fun refreshOffering()
 }
 
+@Suppress("TooManyFunctions")
 class PaywallScreenViewModelImpl(
     application: Application,
     savedStateHandle: SavedStateHandle,
@@ -97,6 +98,17 @@ class PaywallScreenViewModelImpl(
     }
 
     override fun onPurchaseError(error: PurchasesError) = Unit
+
+    override fun onUrlOpened(url: String) {
+        val value = _state.value
+        if (value is PaywallScreenState.Loaded) {
+            _state.update {
+                value.copy(
+                    dialogText = "Opened URL: $url",
+                )
+            }
+        }
+    }
 
     override fun onDialogDismissed() {
         val value = _state.value

--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -87,6 +87,7 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method public default void onRestoreError(com.revenuecat.purchases.PurchasesError error);
     method public default void onRestoreInitiated(com.revenuecat.purchases.ui.revenuecatui.utils.Resumable resume);
     method public default void onRestoreStarted();
+    method public default void onUrlOpened(String url);
     method public default void onWebCheckoutOpened();
   }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.unit.Density
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -87,6 +89,29 @@ private fun PaywallFontScaling(
             content()
         }
     }
+}
+
+/**
+ * Provides a [UriHandler] that notifies the listener about URLs opened from within the paywall content, such as
+ * links in text components. URLs opened through [PaywallAction] are notified separately.
+ */
+@Composable
+private fun NotifyingUriHandler(
+    viewModel: PaywallViewModel,
+    content: @Composable () -> Unit,
+) {
+    val platformUriHandler = LocalUriHandler.current
+    val notifyingUriHandler = remember(platformUriHandler, viewModel) {
+        object : UriHandler {
+            override fun openUri(uri: String) {
+                // Throws if the URI cannot be opened, which skips the notification.
+                platformUriHandler.openUri(uri)
+                viewModel.notifyUrlOpened(uri)
+            }
+        }
+    }
+
+    CompositionLocalProvider(LocalUriHandler provides notifyingUriHandler, content = content)
 }
 
 @Suppress("LongMethod", "ViewModelForwarding")
@@ -170,20 +195,22 @@ internal fun InternalPaywall(
             PaywallFontScaling(
                 automaticallyScaleFontSize = paywallComponents?.dataOrNull?.automaticallyScaleFontSize ?: true,
             ) {
-                val workflowState = viewModel.workflowState.value
-                if (workflowState != null) {
-                    LoadedWorkflowPaywall(
-                        workflowState = workflowState,
-                        onTransitionComplete = viewModel::onTransitionComplete,
-                        clickHandler = rememberPaywallActionHandler(viewModel),
-                        componentInteractionTracker = componentInteractionTracker,
-                    )
-                } else {
-                    LoadedPaywallComponents(
-                        state = state,
-                        clickHandler = rememberPaywallActionHandler(viewModel),
-                        componentInteractionTracker = componentInteractionTracker,
-                    )
+                NotifyingUriHandler(viewModel) {
+                    val workflowState = viewModel.workflowState.value
+                    if (workflowState != null) {
+                        LoadedWorkflowPaywall(
+                            workflowState = workflowState,
+                            onTransitionComplete = viewModel::onTransitionComplete,
+                            clickHandler = rememberPaywallActionHandler(viewModel),
+                            componentInteractionTracker = componentInteractionTracker,
+                        )
+                    } else {
+                        LoadedPaywallComponents(
+                            state = state,
+                            clickHandler = rememberPaywallActionHandler(viewModel),
+                            componentInteractionTracker = componentInteractionTracker,
+                        )
+                    }
                 }
             }
         } else {
@@ -406,10 +433,10 @@ private fun rememberPaywallActionHandler(viewModel: PaywallViewModel): suspend (
                     is PaywallAction.External.NavigateTo.Destination.CustomerCenter ->
                         Logger.w("Customer Center is not yet implemented on Android.")
 
-                    is PaywallAction.External.NavigateTo.Destination.Url -> context.handleUrlDestination(
-                        url = destination.url,
-                        method = destination.method,
-                    )
+                    is PaywallAction.External.NavigateTo.Destination.Url ->
+                        if (context.handleUrlDestination(url = destination.url, method = destination.method)) {
+                            viewModel.notifyUrlOpened(destination.url)
+                        }
                 }
             }
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -218,6 +218,10 @@ private class LoadingViewModel(
         // no-op
     }
 
+    override fun notifyUrlOpened(url: String) {
+        // no-op
+    }
+
     override fun invalidateCustomerInfoCache() {
         // no-op
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.utils.Resumable
 
+@Suppress("TooManyFunctions")
 public interface PaywallListener {
     /**
      * Called when a package purchase is about to be initiated, before the payment sheet is displayed.
@@ -45,4 +46,14 @@ public interface PaywallListener {
      * Distinct from cancellation: the user has not cancelled, they left to pay externally.
      */
     public fun onWebCheckoutOpened() {}
+
+    /**
+     * Called after the paywall successfully opened a URL, either from a button with a URL destination or from a
+     * link inside a text component. Called for all opening methods: in-app browser, external browser and deep link.
+     *
+     * Not called for web checkout URLs. Use [onWebCheckoutOpened] for those.
+     *
+     * @param url The URL that was opened.
+     */
+    public fun onUrlOpened(url: String) {}
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -190,6 +190,10 @@ internal class PaywallActivity : ComponentActivity() {
             override fun onWebCheckoutOpened() {
                 userListener?.onWebCheckoutOpened()
             }
+
+            override fun onUrlOpened(url: String) {
+                userListener?.onUrlOpened(url)
+            }
         }
 
         val edgeToEdge = args?.edgeToEdge == true

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -140,6 +140,7 @@ internal interface PaywallViewModel {
 
     fun getWebCheckoutUrl(launchWebCheckout: PaywallAction.External.LaunchWebCheckout): String?
     fun notifyWebCheckoutOpened()
+    fun notifyUrlOpened(url: String)
     fun invalidateCustomerInfoCache()
 
     /**
@@ -426,6 +427,10 @@ internal class PaywallViewModelImpl(
 
     override fun notifyWebCheckoutOpened() {
         listener?.onWebCheckoutOpened()
+    }
+
+    override fun notifyUrlOpened(url: String) {
+        listener?.onUrlOpened(url)
     }
 
     override fun invalidateCustomerInfoCache() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -642,6 +642,12 @@ internal class MockViewModel(
         notifyWebCheckoutOpenedCallCount++
     }
 
+    var notifyUrlOpenedParams = mutableListOf<String>()
+        private set
+    override fun notifyUrlOpened(url: String) {
+        notifyUrlOpenedParams.add(url)
+    }
+
     var invalidateCustomerInfoCacheCallCount = 0
         private set
     override fun invalidateCustomerInfoCache() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/OriginalTemplatePaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/OriginalTemplatePaywallFooterView.kt
@@ -111,6 +111,8 @@ public open class OriginalTemplatePaywallFooterView : FrameLayout {
         override fun onRestoreStarted() { listener?.onRestoreStarted() }
         override fun onRestoreCompleted(customerInfo: CustomerInfo) { listener?.onRestoreCompleted(customerInfo) }
         override fun onRestoreError(error: PurchasesError) { listener?.onRestoreError(error) }
+        override fun onWebCheckoutOpened() { listener?.onWebCheckoutOpened() }
+        override fun onUrlOpened(url: String) { listener?.onUrlOpened(url) }
     }
 
     private var paywallOptions: PaywallOptions

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
@@ -108,6 +108,8 @@ public class PaywallView : CompatComposeView {
         override fun onRestoreStarted() { listener?.onRestoreStarted() }
         override fun onRestoreCompleted(customerInfo: CustomerInfo) { listener?.onRestoreCompleted(customerInfo) }
         override fun onRestoreError(error: PurchasesError) { listener?.onRestoreError(error) }
+        override fun onWebCheckoutOpened() { listener?.onWebCheckoutOpened() }
+        override fun onUrlOpened(url: String) { listener?.onUrlOpened(url) }
     }
 
     private var paywallOptions: PaywallOptions

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
@@ -3,14 +3,18 @@ package com.revenuecat.purchases.ui.revenuecatui.components
 import android.content.Context
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Offering
@@ -38,6 +42,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.UiConfig
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallWarning
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -449,6 +454,226 @@ class PaywallActionTests {
             // (no matching activity), so the listener must not be told a web checkout was launched
             assertEquals(0, viewModel.notifyWebCheckoutOpenedCallCount)
         }
+
+    @Test
+    fun `NavigateTo url with external browser notifies listener with the opened url`(): Unit =
+        with(composeTestRule) {
+            val url = "https://example.com/terms"
+
+            val viewModel = renderPaywallAndClickUrlButton(
+                method = ButtonComponent.UrlMethod.EXTERNAL_BROWSER,
+                url = url,
+            )
+
+            assertEquals(listOf(url), viewModel.notifyUrlOpenedParams)
+        }
+
+    @Test
+    fun `NavigateTo url with in-app browser notifies listener with the opened url`(): Unit =
+        with(composeTestRule) {
+            val url = "https://example.com/privacy"
+
+            val viewModel = renderPaywallAndClickUrlButton(
+                method = ButtonComponent.UrlMethod.IN_APP_BROWSER,
+                url = url,
+            )
+
+            assertEquals(listOf(url), viewModel.notifyUrlOpenedParams)
+        }
+
+    @Test
+    fun `NavigateTo url with deep link notifies listener with the opened url`(): Unit =
+        with(composeTestRule) {
+            val url = "https://example.com/deep-link"
+
+            val viewModel = renderPaywallAndClickUrlButton(
+                method = ButtonComponent.UrlMethod.DEEP_LINK,
+                url = url,
+            )
+
+            assertEquals(listOf(url), viewModel.notifyUrlOpenedParams)
+        }
+
+    @Test
+    fun `NavigateTo url with unknown method does not notify listener`(): Unit = with(composeTestRule) {
+        // Arrange
+        val textColor = ColorScheme(ColorInfo.Hex(Color.Black.toArgb()))
+        val defaultLocale = LocaleId("en_US")
+        val buttonKey = LocalizationKey("open_url")
+        val buttonText = LocalizationData.Text("open url")
+        val urlKey = LocalizationKey("url_lid")
+        val localizations = nonEmptyMapOf(
+            defaultLocale to nonEmptyMapOf(
+                buttonKey to buttonText,
+                urlKey to LocalizationData.Text("https://example.com/unknown"),
+            ),
+        )
+        val components = listOf(
+            ButtonComponent(
+                action = ButtonComponent.Action.NavigateTo(
+                    ButtonComponent.Destination.Url(
+                        urlLid = urlKey,
+                        method = ButtonComponent.UrlMethod.UNKNOWN,
+                    ),
+                ),
+                stack = StackComponent(components = listOf(TextComponent(text = buttonKey, color = textColor))),
+            ),
+        )
+        val offering = FakeOffering(components, localizations)
+        val options = PaywallOptions.Builder(dismissRequest = {}).setOffering(offering).build()
+        val viewModel = MockViewModel(offering = offering, allowsPurchases = true)
+
+        // Act
+        setContent { InternalPaywall(options, viewModel) }
+        waitForIdle()
+
+        // Assert: buttons with an unknown open method are hidden, so nothing can be opened
+        onAllNodesWithText(buttonText.value).assertCountEquals(0)
+        assertEquals(emptyList<String>(), viewModel.notifyUrlOpenedParams)
+    }
+
+    @Test
+    fun `NavigateTo url that fails to actually open does not notify listener`(): Unit = with(composeTestRule) {
+        // Robolectric's default shadow accepts any startActivity call as "successful" regardless of whether a real
+        // component could handle it. Enable strict validation so this custom scheme genuinely throws
+        // ActivityNotFoundException, like it would on a real device.
+        org.robolectric.Shadows.shadowOf(
+            ApplicationProvider.getApplicationContext<android.app.Application>(),
+        ).checkActivities(true)
+
+        val viewModel = renderPaywallAndClickUrlButton(
+            method = ButtonComponent.UrlMethod.DEEP_LINK,
+            url = "com.revenuecat.nonexistent-test-scheme://terms",
+        )
+
+        assertEquals(emptyList<String>(), viewModel.notifyUrlOpenedParams)
+    }
+
+    @Test
+    fun `LaunchWebCheckout does not notify listener about an opened url`(): Unit = with(composeTestRule) {
+        // Arrange
+        val textColor = ColorScheme(ColorInfo.Hex(Color.Black.toArgb()))
+        val defaultLocale = LocaleId("en_US")
+        val localizationKey = LocalizationKey("web_checkout")
+        val localizationData = LocalizationData.Text("web checkout")
+        val localizations = nonEmptyMapOf(
+            defaultLocale to nonEmptyMapOf(localizationKey to localizationData),
+        )
+        val components = listOf(
+            PurchaseButtonComponent(
+                stack = StackComponent(components = listOf(TextComponent(text = localizationKey, color = textColor))),
+                method = PurchaseButtonComponent.Method.WebCheckout(autoDismiss = false),
+            ),
+        )
+        val offering = FakeOffering(components, localizations)
+        val viewModel = MockViewModel(
+            offering = offering,
+            allowsPurchases = true,
+            webCheckoutUrl = "https://checkout.example.com",
+        )
+        val options = PaywallOptions.Builder(dismissRequest = {}).setOffering(offering).build()
+
+        // Act
+        setContent { InternalPaywall(options, viewModel) }
+        clickButtonsWithText(localizationData, expectedCount = 2)
+
+        // Assert: web checkout has its own callback, so onUrlOpened must not also be notified
+        assertEquals(2, viewModel.notifyWebCheckoutOpenedCallCount)
+        assertEquals(emptyList<String>(), viewModel.notifyUrlOpenedParams)
+    }
+
+    @Test
+    fun `Markdown link click in a text component notifies listener with the opened url`(): Unit =
+        with(composeTestRule) {
+            // Arrange
+            val url = "https://example.com/markdown-terms"
+            val linkText = "our terms"
+            val textColor = ColorScheme(ColorInfo.Hex(Color.Black.toArgb()))
+            val defaultLocale = LocaleId("en_US")
+            val textKey = LocalizationKey("body")
+            val localizations = nonEmptyMapOf(
+                defaultLocale to nonEmptyMapOf(
+                    textKey to LocalizationData.Text("Read [$linkText]($url) for details"),
+                ),
+            )
+            val components = listOf(TextComponent(text = textKey, color = textColor))
+            val offering = FakeOffering(components, localizations)
+            val options = PaywallOptions.Builder(dismissRequest = {}).setOffering(offering).build()
+            val viewModel = MockViewModel(offering = offering, allowsPurchases = true)
+
+            // Act
+            setContent { InternalPaywall(options, viewModel) }
+            clickMarkdownLink(linkText)
+
+            // Assert
+            assertEquals(listOf(url), viewModel.notifyUrlOpenedParams)
+        }
+
+    /**
+     * Renders a paywall with a single button navigating to [url] using [method], and clicks it.
+     */
+    private fun ComposeContentTestRule.renderPaywallAndClickUrlButton(
+        method: ButtonComponent.UrlMethod,
+        url: String,
+    ): MockViewModel {
+        val textColor = ColorScheme(ColorInfo.Hex(Color.Black.toArgb()))
+        val defaultLocale = LocaleId("en_US")
+        val buttonKey = LocalizationKey("open_url")
+        val buttonText = LocalizationData.Text("open url")
+        val urlKey = LocalizationKey("url_lid")
+        val localizations = nonEmptyMapOf(
+            defaultLocale to nonEmptyMapOf(
+                buttonKey to buttonText,
+                urlKey to LocalizationData.Text(url),
+            ),
+        )
+        val components = listOf(
+            ButtonComponent(
+                action = ButtonComponent.Action.NavigateTo(
+                    ButtonComponent.Destination.Url(urlLid = urlKey, method = method),
+                ),
+                stack = StackComponent(components = listOf(TextComponent(text = buttonKey, color = textColor))),
+            ),
+        )
+        val offering = FakeOffering(components, localizations)
+        val options = PaywallOptions.Builder(dismissRequest = {}).setOffering(offering).build()
+        val viewModel = MockViewModel(offering = offering, allowsPurchases = true)
+
+        setContent { InternalPaywall(options, viewModel) }
+        // Buttons appear once in main content and once in the sticky footer. Only click the first one.
+        onAllNodesWithText(buttonText.value)
+            .assertCountEquals(2)
+            .get(0)
+            .assertIsDisplayed()
+            .assertHasClickAction()
+            .performClick()
+        waitForIdle()
+
+        return viewModel
+    }
+
+    /**
+     * Clicks the markdown link containing [linkSubstring] in the first text node that renders it. The link is part of
+     * an [androidx.compose.ui.text.AnnotatedString], so it can only be clicked by touching its coordinates.
+     */
+    private fun ComposeContentTestRule.clickMarkdownLink(linkSubstring: String) {
+        val textNode = onAllNodesWithText(linkSubstring, substring = true, useUnmergedTree = true).get(0)
+        val layoutResults = mutableListOf<TextLayoutResult>()
+        val action = textNode.fetchSemanticsNode().config[SemanticsActions.GetTextLayoutResult].action
+            ?: error("Missing GetTextLayoutResult action")
+        action.invoke(layoutResults)
+        val layout = layoutResults.first()
+        val startIndex = layout.layoutInput.text.text.indexOf(linkSubstring)
+        assertNotEquals(-1, startIndex)
+        val charIndex = startIndex + (linkSubstring.length / 2).coerceAtMost(linkSubstring.lastIndex)
+        val box = layout.getBoundingBox(charIndex)
+
+        textNode.performTouchInput {
+            down(box.center)
+            up()
+        }
+        waitForIdle()
+    }
 
     @Suppress("TestFunctionName")
     private fun FakeOffering(data: PaywallComponentsData): Offering =


### PR DESCRIPTION
Adds `PaywallListener.onUrlOpened(url)`, called after the paywall successfully opens a URL — from a button with a URL destination (`url` / `terms` / `privacy_policy`) or from a link in a text component. Fired for all opening methods: in-app browser, external browser and deep link.

Also forwards `onUrlOpened` and the previous`onWebCheckoutOpened` through `PaywallView` / `OriginalTemplatePaywallFooterView`, which were dropping both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive default-empty listener API with notifications gated on successful URL open; no changes to purchase or auth flows.
> 
> **Overview**
> Adds **`PaywallListener.onUrlOpened(url)`**, invoked only after a URL is **successfully** opened from paywall UI—not for web checkout (still **`onWebCheckoutOpened`**).
> 
> **URL button actions** (`NavigateTo` with URL destination) now call the listener when `handleUrlDestination` succeeds (in-app, external, or deep link). Failed opens do not notify.
> 
> **Text / markdown links** are covered via a **`NotifyingUriHandler`** around loaded components paywall content: it delegates to the platform `UriHandler` and notifies only if opening does not throw.
> 
> **Forwarding fixes:** `PaywallView` and `OriginalTemplatePaywallFooterView` now pass **`onUrlOpened`** and **`onWebCheckoutOpened`** to the app listener (they were dropped before). `PaywallActivity` forwards **`onUrlOpened`** as well.
> 
> Public API (`api.txt`), api-tester stubs, paywall-tester samples, view model demo UI, and component tests for open success/failure and web-checkout separation are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a6ccc1e2fa50f9ab94fe9c7e8517b0afb28535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->