### PR TITLE
Send workflow `trace_id` on paywall events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -171,15 +171,19 @@ internal sealed class BackendEvent : Event {
         val paywallID: String? = null,
         @SerialName("workflow_id")
         val workflowID: String? = null,
+        @SerialName("trace_id")
+        val traceId: String? = null,
     ) {
         companion object {
             fun fromContext(
                 context: PresentedOfferingContext,
                 paywallId: String? = null,
                 workflowId: String? = null,
+                traceId: String? = null,
             ): PresentedOfferingContextData? {
                 val hasPlacement = context.placementIdentifier != null || context.targetingContext != null
-                if (!hasPlacement && paywallId == null && workflowId == null) {
+                val hasAttribution = paywallId != null || workflowId != null || traceId != null
+                if (!hasPlacement && !hasAttribution) {
                     return null
                 }
                 return PresentedOfferingContextData(
@@ -188,6 +192,7 @@ internal sealed class BackendEvent : Event {
                     targetingRuleId = context.targetingContext?.ruleId,
                     paywallID = paywallId,
                     workflowID = workflowId,
+                    traceId = traceId,
                 )
             }
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -118,6 +118,7 @@ internal fun PaywallEvent.toBackendStoredEvent(
                 context = data.presentedOfferingContext,
                 paywallId = data.paywallIdentifier,
                 workflowId = data.workflowId,
+                traceId = data.traceId,
             ),
             exitOfferType = data.exitOfferType?.value,
             exitOfferingID = data.exitOfferingIdentifier,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
@@ -41,6 +41,7 @@ internal data class PaywallStoredEvent(
                 context = event.data.presentedOfferingContext,
                 paywallId = event.data.paywallIdentifier,
                 workflowId = event.data.workflowId,
+                traceId = event.data.traceId,
             ),
             exitOfferType = event.data.exitOfferType?.value,
             exitOfferingID = event.data.exitOfferingIdentifier,

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.toBackendStoredEvent
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -646,6 +647,7 @@ class PaywallEventSerializationTests {
             BackendEvent.PresentedOfferingContextData(
                 paywallID = "paywallID",
                 workflowID = "workflow-xyz",
+                traceId = "trace-xyz",
             )
         )
     }
@@ -679,15 +681,44 @@ class PaywallEventSerializationTests {
     }
 
     @Test
-    fun `toBackendEvent does not send trace_id`() {
+    fun `toBackendEvent sends trace_id nested in presented_offering_context, not at the top level`() {
         val backendEvent = workflowImpressionEvent.toBackendEvent()
+        assertThat(backendEvent.presentedOfferingContext?.traceId).isEqualTo("trace-xyz")
 
+        // khepri treats presented_offering_context as an opaque blob and passes unknown keys through,
+        // so trace_id has to be nested there. A top-level trace_id would be dropped by the event model.
         val encoded = JsonProvider.defaultJson.encodeToJsonElement(
             BackendEvent.serializer(),
             backendEvent,
         ).jsonObject
         assertThat(encoded).doesNotContainKey("trace_id")
-        assertThat(encoded["presented_offering_context"]!!.jsonObject).doesNotContainKey("trace_id")
+        assertThat(encoded["presented_offering_context"]!!.jsonObject["trace_id"]!!.jsonPrimitive.content)
+            .isEqualTo("trace-xyz")
     }
 
+    @Test
+    fun `toBackendEvent omits trace_id when there is no workflow traversal`() {
+        val encoded = JsonProvider.defaultJson.encodeToString(
+            BackendEvent.serializer(),
+            exitOfferEvent.toBackendEvent(),
+        )
+        assertThat(encoded).doesNotContain("trace_id")
+    }
+
+    @Test
+    fun `presented_offering_context survives when traceId is the only attribution`() {
+        val context = BackendEvent.PresentedOfferingContextData.fromContext(
+            context = PresentedOfferingContext("offeringID"),
+            traceId = "trace-only",
+        )
+        assertThat(context).isEqualTo(BackendEvent.PresentedOfferingContextData(traceId = "trace-only"))
+    }
+
+    @Test
+    fun `presented_offering_context is still null when nothing is present`() {
+        val context = BackendEvent.PresentedOfferingContextData.fromContext(
+            context = PresentedOfferingContext("offeringID"),
+        )
+        assertThat(context).isNull()
+    }
 }


### PR DESCRIPTION
Paywall events already carry `paywall_id` and `workflow_id` in `presented_offering_context`, but not `trace_id`, so a paywall impression in `paywall_user_event` cannot be tied to the specific workflow traversal it came from. `workflow_id` alone cannot distinguish two traversals of the same workflow. We got a request from product to include it in `presented_offering_context`.

Khepri passes `presented_offering_context` through, so the key lands in Snowflake without a schema or dbt change.

iOS equivalent: RevenueCat/purchases-ios#7322.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics/event serialization only; backward-compatible optional field with tests for legacy payloads and omission when no workflow traversal.
> 
> **Overview**
> Paywall backend events now include workflow **`trace_id`** inside **`presented_offering_context`**, alongside existing **`paywall_id`** and **`workflow_id`**, so paywall impressions can be tied to a specific workflow traversal (not just the workflow definition).
> 
> **`PresentedOfferingContextData`** gains a serialized **`trace_id`** field and **`fromContext`** passes **`data.traceId`** from paywall events through **`PaywallStoredEvent`** and **`BackendStoredEvent`** mapping. **`trace_id`** is **not** emitted at the top level of the paywalls event—only nested in **`presented_offering_context`**, matching how khepri forwards opaque context into analytics.
> 
> **`fromContext`** now treats **`traceId`** as sufficient attribution to build a non-null context when placement/targeting are absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ead443102074807de911eba8a9a076d8726f37c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->