### PR TITLE
fix(remote-config): clear last attempt timestamp for cooldown after successful response

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DateExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DateExtensions.kt
@@ -15,16 +15,22 @@ import kotlin.time.Duration.Companion.minutes
 private val CACHE_REFRESH_PERIOD_IN_FOREGROUND = 5.minutes
 private val CACHE_REFRESH_PERIOD_IN_BACKGROUND = 25.hours
 
+internal fun cacheDuration(appInBackground: Boolean): Duration {
+    return when {
+        appInBackground -> CACHE_REFRESH_PERIOD_IN_BACKGROUND
+        else -> CACHE_REFRESH_PERIOD_IN_FOREGROUND
+    }
+}
+
 @OptIn(InternalRevenueCatAPI::class)
-internal fun Date?.isCacheStale(appInBackground: Boolean, dateProvider: DateProvider = DefaultDateProvider()): Boolean {
+internal fun Date?.isCacheStale(
+    appInBackground: Boolean,
+    dateProvider: DateProvider = DefaultDateProvider(),
+    cacheDurationProvider: (Boolean) -> Duration = ::cacheDuration,
+): Boolean {
     return this?.let {
         log(LogIntent.DEBUG) { ReceiptStrings.CHECKING_IF_CACHE_STALE.format(appInBackground) }
-        val cacheDuration = when {
-            appInBackground -> CACHE_REFRESH_PERIOD_IN_BACKGROUND
-            else -> CACHE_REFRESH_PERIOD_IN_FOREGROUND
-        }
-
-        isCacheStale(cacheDuration, dateProvider)
+        isCacheStale(cacheDurationProvider(appInBackground), dateProvider)
     } ?: true
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
 import com.revenuecat.purchases.common.JsonProvider
 import com.revenuecat.purchases.common.between
+import com.revenuecat.purchases.common.caching.cacheDuration
 import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
@@ -85,6 +86,7 @@ internal class RemoteConfigManager(
     private val sourceProvider: RemoteConfigSourceProvider,
     private val blobFetcher: RemoteConfigBlobFetcher = RemoteConfigBlobFetcher(blobStore, sourceProvider),
     private val appUserIDProvider: () -> String? = { null },
+    private val cacheDurationProvider: (Boolean) -> Duration = ::cacheDuration,
 ) {
     private val isRefreshing = AtomicBoolean(false)
 
@@ -160,7 +162,7 @@ internal class RemoteConfigManager(
         appUserID: String,
         fetchContext: RemoteConfigFetchContext,
     ) {
-        if (lastRefreshedAt.isCacheStale(appInBackground, dateProvider)) {
+        if (lastRefreshedAt.isCacheStale(appInBackground, dateProvider, cacheDurationProvider)) {
             refreshRemoteConfig(appInBackground, appUserID, fetchContext, staleGated = true)
         }
     }
@@ -415,6 +417,7 @@ internal class RemoteConfigManager(
                 synchronized(cacheLock) {
                     if (epoch.get() != requestEpoch) return@launch
                     lastRefreshedAt = dateProvider.now
+                    lastRefreshAttemptAt = null
                     hasCommittedInitialConfig = true
                     // Only the server's own time is worth persisting, so a response without it writes nothing and
                     // the previous value carries forward. Re-read instead of reusing the request's snapshot, and
@@ -878,6 +881,7 @@ internal class RemoteConfigManager(
             // The staleness gate measures elapsed *local* time (isCacheStale subtracts from dateProvider.now), so
             // it stays on the device clock and is deliberately not the value persisted above.
             lastRefreshedAt = dateProvider.now
+            lastRefreshAttemptAt = null
             hasCommittedInitialConfig = true
             debugLog {
                 "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -9,6 +9,8 @@ import com.revenuecat.purchases.assertWarnLog
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
+import com.revenuecat.purchases.common.caching.cacheDuration
+import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerFormatException
 import com.revenuecat.purchases.common.networking.RCElement
@@ -43,6 +45,8 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -65,6 +69,7 @@ class RemoteConfigManagerTest {
     private val dateProvider = object : DateProvider {
         override val now: Date get() = Date(currentTimeMillis)
     }
+    private var cacheDurationProvider: (Boolean) -> Duration = ::cacheDuration
 
     private var capturedAppUserID: String? = null
     private var capturedDomain: String? = null
@@ -95,6 +100,7 @@ class RemoteConfigManagerTest {
             topicStore = topicStore,
             sourceProvider = sourceProvider,
             blobFetcher = blobFetcher,
+            cacheDurationProvider = { appInBackground -> cacheDurationProvider(appInBackground) },
         )
 
         // Persist succeeds by default; the blob store is only touched once the configuration is persisted.
@@ -344,6 +350,54 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
 
         verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `successful 200 does not apply the failed refresh cooldown`() {
+        every { diskCache.read() } returns null
+        cacheDurationProvider = { 5.seconds }
+
+        manager.refreshRemoteConfigIfStale(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = DEFAULT_FETCH_CONTEXT,
+        )
+        deliverSuccess(containerWithConfig("""{"domain":"app","manifest":"v1.2."}"""))
+
+        currentTimeMillis += 5.seconds.inWholeMilliseconds
+        manager.refreshRemoteConfigIfStale(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = DEFAULT_FETCH_CONTEXT,
+        )
+
+        verify(exactly = 2) {
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `successful 204 does not apply the failed refresh cooldown`() {
+        every { diskCache.read() } returns null
+        cacheDurationProvider = { 5.seconds }
+
+        manager.refreshRemoteConfigIfStale(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = DEFAULT_FETCH_CONTEXT,
+        )
+        deliverSuccess(null)
+
+        currentTimeMillis += 5.seconds.inWholeMilliseconds
+        manager.refreshRemoteConfigIfStale(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = DEFAULT_FETCH_CONTEXT,
+        )
+
+        verify(exactly = 2) {
+            backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
     }
 
     @Test


### PR DESCRIPTION
The `lastRefreshAttemptAt` cooldown functionality was designed to ensure that the `RemoteConfigManager` would not immediately allow another request to be sent if a request failed, because the cache wouldn't be updated and thus still be stale.

However `lastRefreshAttemptAt` was never reset on a successful 200 or 204 response, which caused the logic to also kick in after successful responses. This was fine in production code, since the cache was only considered stale after 5 minutes, and the cooldown was just 1 minute.

However during manual testing (in which I lowered the cache staleness expiration time) this means that we can never really lower the value below the cooldown time (1 minute).

Also added test coverage for this, because this should've been caught really.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to clearing attempt timestamps after successful remote-config responses; production staleness (5 minutes) already dwarfed the 1-minute cooldown, so risk is mainly correctness for shorter windows and testability.
> 
> **Overview**
> Fixes **remote config refresh throttling** so a successful sync does not keep the failed-attempt cooldown active.
> 
> `RemoteConfigManager` sets `lastRefreshAttemptAt` on stale-gated refreshes to avoid hammering the API after failures, but it was **never cleared** on successful **200** or **204** responses. After a good response, the 1-minute cooldown could still block `refreshRemoteConfigIfStale` when the cache window is shorter (e.g. in tests or tuned staleness), effectively capping how often refreshes can run below the real cache TTL.
> 
> The fix **resets `lastRefreshAttemptAt` to null** when config is committed on **200** persist and when **204** bookkeeping completes. **`cacheDuration`** is extracted in `DateExtensions` with an injectable **`cacheDurationProvider`** on the manager so tests can use a short staleness window and assert a second refresh fires after success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b212d443f47be11009b22db56ef727eda1c0b2f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->