### PR TITLE
Fix test value for Last-Refreshed-At header

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -29,7 +29,8 @@ import java.util.Date
 @Config(manifest = Config.NONE)
 class ETagManagerTest {
 
-    private val testDate = Date(1675954145L) // Thursday, February 9, 2023 2:49:05 PM GMT
+    // Epoch millis, matching the X-RC-Last-Refresh-Time wire format.
+    private val testDate = Date(1675954145000L) // Thursday, February 9, 2023 2:49:05 PM GMT
     private val testDateProvider = object : DateProvider {
         override val now: Date
             get() = testDate
@@ -121,7 +122,7 @@ class ETagManagerTest {
 
         val eTagHeaders = underTest.getETagHeaders(urlString, verificationRequested = false)
         val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME]
-        assertThat(lastRefreshTimeHeader).isEqualTo("1675954145")
+        assertThat(lastRefreshTimeHeader).isEqualTo("1675954145000")
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only correction of fixture and expected header string; no runtime behavior changes.
> 
> **Overview**
> Aligns **ETagManagerTest** with how the SDK actually formats the last-refresh header on the wire.
> 
> The shared `testDate` is now **epoch milliseconds** (`1675954145000L`), and the assertion on `HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME` expects `"1675954145000"`, matching `ETagManager` / `Backend` usage of `Date.time.toString()`. A short comment documents that this matches the **X-RC-Last-Refresh-Time** format. No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58cfd23719406a648e9024109586d165c907ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->