### PR TITLE
Enable support for multipage paywalls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -851,9 +851,9 @@ jobs:
       - android/start_emulator:
           avd_name: test-e2e-workflow-tester
           # The workflow project key is baked in at build time (BuildConfig.WORKFLOWS_API_KEY),
-          # which makes E2ETestsApplication configure against the workflow project with
-          # DangerousSettings.forWorkflows(). A single APK can only target one project, so this
-          # is built and run separately from run-maestro-e2e-tests.
+          # which makes E2ETestsApplication configure against the workflow project. A single APK
+          # can only target one project, so this is built and run separately from
+          # run-maestro-e2e-tests.
           post_emulator_launch_assemble_command: ./gradlew test-apps:e2etests:assembleDebug -PE2E_WORKFLOWS_API_KEY=$WORKFLOWS_TEST_STORE_API_KEY
       - android/restore_gradle_cache
       - run:

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/DangerousSettingsAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/DangerousSettingsAPI.kt
@@ -1,18 +1,10 @@
 package com.revenuecat.apitester.kotlin
 
 import com.revenuecat.purchases.DangerousSettings
-import com.revenuecat.purchases.InternalRevenueCatAPI
 
 @Suppress("unused", "UNUSED_VARIABLE")
 private class DangerousSettingsAPI {
     fun check(dangerousSettings: DangerousSettings) {
         val autoSync: Boolean = dangerousSettings.autoSyncPurchases
-    }
-
-    @OptIn(InternalRevenueCatAPI::class)
-    fun checkInternalRevenueCatAPIs() {
-        val forWorkflows: DangerousSettings = DangerousSettings.forWorkflows()
-        val forWorkflowsNoSync: DangerousSettings = DangerousSettings.forWorkflows(autoSyncPurchases = false)
-        val useWorkflows: Boolean = forWorkflows.useWorkflows
     }
 }

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -89,9 +89,7 @@ package com.revenuecat.purchases {
   @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize public final class DangerousSettings implements android.os.Parcelable {
     ctor public DangerousSettings(optional boolean autoSyncPurchases);
     method public boolean getAutoSyncPurchases();
-    method public boolean getUseWorkflows();
     property public final boolean autoSyncPurchases;
-    property public final boolean useWorkflows;
     field public static final com.revenuecat.purchases.DangerousSettings.Companion Companion;
   }
 

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -76,9 +76,7 @@ package com.revenuecat.purchases {
   @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize public final class DangerousSettings implements android.os.Parcelable {
     ctor public DangerousSettings(optional boolean autoSyncPurchases);
     method public boolean getAutoSyncPurchases();
-    method public boolean getUseWorkflows();
     property public final boolean autoSyncPurchases;
-    property public final boolean useWorkflows;
     field public static final com.revenuecat.purchases.DangerousSettings.Companion Companion;
   }
 

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/BaseIntegrationPurchasesTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/BaseIntegrationPurchasesTest.kt
@@ -140,7 +140,11 @@ abstract class BaseIntegrationPurchasesTest : BasePurchasesIntegrationTest() {
                     assertThat(offerings.current?.metadata?.get("dontdeletethis")).isEqualTo("useforintegrationtesting")
 
                     assertThat(offerings.current?.paywall).isNull()
-                    assertThat(offerings.current?.paywallComponents).isNotNull
+                    // This offering has a components paywall, but the components are served from `/v1/config`, so
+                    // they're not captured on the offering — only the cheap presence flag behind `hasPaywall` is.
+                    // Whether `paywallComponents` itself is populated depends on the remote config kill switch;
+                    // ProductionWorkflowsPaywallComponentsIntegrationTest covers both sides of that deterministically.
+                    assertThat(offerings.current?.hasPaywall).isTrue
 
                     lock.countDown()
                 },

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/workflows/ProductionWorkflowsPaywallComponentsIntegrationTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/workflows/ProductionWorkflowsPaywallComponentsIntegrationTest.kt
@@ -3,9 +3,7 @@ package com.revenuecat.purchases.integration.workflows
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.BasePurchasesIntegrationTest
 import com.revenuecat.purchases.Constants
-import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.ForceServerErrorStrategy
-import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.VerificationResult
@@ -38,12 +36,9 @@ import kotlin.time.Duration.Companion.milliseconds
  * with mocked billing; only `/v1/config` is faked, via [ForceServerErrorStrategy.fakeResponseWithoutPerformingRequest].
  */
 @RunWith(AndroidJUnit4::class)
-@OptIn(InternalRevenueCatAPI::class)
 class ProductionWorkflowsPaywallComponentsIntegrationTest : BasePurchasesIntegrationTest() {
 
     override val environmentConfig get() = Constants.production
-
-    override val dangerousSettings: DangerousSettings get() = DangerousSettings.forWorkflows()
 
     override var forceServerErrorsStrategy: ForceServerErrorStrategy? = RemoteConfigKillSwitchFake()
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
@@ -29,21 +29,13 @@ public class DangerousSettings internal constructor(
      * remote-config-driven host resolution is being validated.
      */
     internal val usesRemoteConfigAPISources: Boolean = false,
-
-    /**
-     * Enables RevenueCat Workflows (multipage paywalls). Internal RevenueCat use only.
-     */
-    @InternalRevenueCatAPI
-    public val useWorkflows: Boolean = false,
 ) : Parcelable {
-    @OptIn(InternalRevenueCatAPI::class)
     public constructor(autoSyncPurchases: Boolean = true) : this(
         autoSyncPurchases = autoSyncPurchases,
         customEntitlementComputation = false,
         uiPreviewMode = false,
         applyObfuscatedAccountIdToSubscriptionChanges = false,
         usesRemoteConfigAPISources = false,
-        useWorkflows = false,
     )
 
     public companion object {
@@ -59,20 +51,6 @@ public class DangerousSettings internal constructor(
             customEntitlementComputation = false,
             uiPreviewMode = true,
             applyObfuscatedAccountIdToSubscriptionChanges = false,
-        )
-
-        /**
-         * Creates a [DangerousSettings] with RevenueCat Workflows (multipage paywalls) enabled.
-         * Internal RevenueCat use only; behavior may change without warning.
-         */
-        @InternalRevenueCatAPI
-        @JvmStatic
-        public fun forWorkflows(autoSyncPurchases: Boolean = true): DangerousSettings = DangerousSettings(
-            autoSyncPurchases = autoSyncPurchases,
-            customEntitlementComputation = false,
-            uiPreviewMode = false,
-            applyObfuscatedAccountIdToSubscriptionChanges = false,
-            useWorkflows = true,
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -205,10 +205,10 @@ internal class PurchasesFactory(
 
             val localeProvider = DefaultLocaleProvider()
 
-            // useWorkflows implies the config layer: workflows are served from `/v1/config`, so the manager
-            // must exist whenever workflows are on. Not applicable to the customEntitlementComputation flavor,
-            // which doesn't serve paywalls this way.
-            val remoteConfigEnabled = appConfig.useWorkflows && !appConfig.customEntitlementComputation
+            // The config layer is on everywhere except the customEntitlementComputation flavor, which doesn't
+            // serve paywalls this way. Workflows (multipage paywalls) are served from `/v1/config`, so the
+            // manager exists wherever the config layer does.
+            val remoteConfigEnabled = !appConfig.customEntitlementComputation
             val remoteConfigDiskCache = if (remoteConfigEnabled) RemoteConfigDiskCache(contextForStorage) else null
             val remoteConfigTopicStore = RemoteConfigTopicStore {
                 remoteConfigDiskCache?.read()?.topics?.get(it.wireName)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases.common
 import android.content.Context
 import com.revenuecat.purchases.APIKeyValidator
 import com.revenuecat.purchases.DangerousSettings
-import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.finishTransactions
@@ -65,10 +64,6 @@ internal class AppConfig(
         get() = dangerousSettings.uiPreviewMode
     val applyObfuscatedAccountIdToSubscriptionChanges: Boolean
         get() = dangerousSettings.applyObfuscatedAccountIdToSubscriptionChanges
-
-    @OptIn(InternalRevenueCatAPI::class)
-    val useWorkflows: Boolean
-        get() = dangerousSettings.useWorkflows
 
     val usesRemoteConfigAPISources: Boolean
         get() = dangerousSettings.usesRemoteConfigAPISources

--- a/purchases/src/test/java/com/revenuecat/purchases/DangerousSettingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/DangerousSettingsTest.kt
@@ -52,22 +52,4 @@ class DangerousSettingsTest {
         assertThat(dangerousSettings.customEntitlementComputation).isFalse
         assertThat(dangerousSettings.applyObfuscatedAccountIdToSubscriptionChanges).isFalse
     }
-
-    @OptIn(InternalRevenueCatAPI::class)
-    @Test
-    fun `default useWorkflows is false`() {
-        val dangerousSettings = DangerousSettings()
-        assertThat(dangerousSettings.useWorkflows).isFalse
-    }
-
-    @OptIn(InternalRevenueCatAPI::class)
-    @Test
-    fun `forWorkflows sets useWorkflows to true and leaves other settings at defaults`() {
-        val dangerousSettings = DangerousSettings.forWorkflows()
-        assertThat(dangerousSettings.useWorkflows).isTrue
-        assertThat(dangerousSettings.autoSyncPurchases).isTrue
-        assertThat(dangerousSettings.customEntitlementComputation).isFalse
-        assertThat(dangerousSettings.uiPreviewMode).isFalse
-        assertThat(dangerousSettings.applyObfuscatedAccountIdToSubscriptionChanges).isFalse
-    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -508,8 +508,7 @@ class AppConfigTest {
                 "customEntitlementComputation=false, " +
                 "uiPreviewMode=false, " +
                 "applyObfuscatedAccountIdToSubscriptionChanges=false, " +
-                "usesRemoteConfigAPISources=false, " +
-                "useWorkflows=false), " +
+                "usesRemoteConfigAPISources=false), " +
                 "languageTag='', " +
                 "versionName='', " +
                 "packageName='', " +
@@ -552,33 +551,4 @@ class AppConfigTest {
     }
 
     // endregion Fallback API host
-
-    @OptIn(InternalRevenueCatAPI::class)
-    @Test
-    fun `useWorkflows reflects dangerousSettings`() {
-        val enabled = AppConfig(
-            context = mockk(relaxed = true),
-            purchasesAreCompletedBy = REVENUECAT,
-            showInAppMessagesAutomatically = false,
-            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
-            proxyURL = null,
-            store = Store.PLAY_STORE,
-            isDebugBuild = false,
-            apiKeyValidationResult = APIKeyValidator.ValidationResult.VALID,
-            dangerousSettings = DangerousSettings.forWorkflows(),
-        )
-        assertThat(enabled.useWorkflows).isTrue
-
-        val disabled = AppConfig(
-            context = mockk(relaxed = true),
-            purchasesAreCompletedBy = REVENUECAT,
-            showInAppMessagesAutomatically = false,
-            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
-            proxyURL = null,
-            store = Store.PLAY_STORE,
-            isDebugBuild = false,
-            apiKeyValidationResult = APIKeyValidator.ValidationResult.VALID,
-        )
-        assertThat(disabled.useWorkflows).isFalse
-    }
 }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesConfigureTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesConfigureTest.kt
@@ -191,6 +191,7 @@ internal class PurchasesConfigureTest : BasePurchasesTest() {
                 mockContext.getSharedPreferences("test", Context.MODE_PRIVATE)
             every { isDeviceProtectedStorageCompat } returns true
             every { cacheDir } returns File("test_cache_folder")
+            every { noBackupFilesDir } returns File("test_no_backup_files_folder")
         }
 
         // Act

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
@@ -1,27 +1,23 @@
 package com.revenuecat.e2etests
 
 import android.app.Application
-import com.revenuecat.purchases.DangerousSettings
-import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 
 class E2ETestsApplication : Application() {
 
-    @OptIn(InternalRevenueCatAPI::class)
     override fun onCreate() {
         super.onCreate()
         Purchases.logLevel = LogLevel.DEBUG
 
         // The workflow E2E flows are built with E2E_WORKFLOWS_API_KEY set (surfaced as
-        // BuildConfig.WORKFLOWS_API_KEY). When it's present we point at that project and enable
-        // workflows; otherwise we keep the default configuration used by the CI
-        // test_store_annual_purchase flow untouched. The Maestro launch argument only selects the
-        // screen (in MainActivity), so configuration stays here in the Application.
+        // BuildConfig.WORKFLOWS_API_KEY). When it's present we point at that project; otherwise we keep
+        // the default configuration used by the CI test_store_annual_purchase flow untouched. The Maestro
+        // launch argument only selects the screen (in MainActivity), so configuration stays here in the
+        // Application.
         val builder = if (BuildConfig.WORKFLOWS_API_KEY != WORKFLOWS_API_KEY_PLACEHOLDER) {
             PurchasesConfiguration.Builder(context = this, apiKey = BuildConfig.WORKFLOWS_API_KEY)
-                .dangerousSettings(DangerousSettings.forWorkflows())
         } else {
             PurchasesConfiguration.Builder(context = this, apiKey = Constants.API_KEY)
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -26,7 +26,6 @@ internal class MockPurchasesType(
     override val purchasesAreCompletedBy: PurchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
     override val storefrontCountryCode: String? = null,
     override val customerCenterListener: CustomerCenterListener? = null,
-    override val useWorkflows: Boolean = false,
 ) : PurchasesType {
     override suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult {
         throw NotImplementedError("Mock implementation for previews only")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -167,7 +167,6 @@ internal class PaywallViewModelImpl(
     private val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?,
     preview: Boolean = false,
     private val productChangeCalculator: ProductChangeCalculator = ProductChangeCalculator(purchases),
-    private val useWorkflowsEndpoint: Boolean = purchases.useWorkflows,
     private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel(), PaywallViewModel {
     private val variableDataProvider = VariableDataProvider(resourceProvider, preview)
@@ -828,13 +827,12 @@ internal class PaywallViewModelImpl(
         var selectedOffering = resolvedOfferingSelection.selectedOffering
         var offeringsForExitOfferLookup = resolvedOfferingSelection.offeringsForExitOfferLookup
 
-        // When workflows are enabled, every non-legacy paywall is served through the workflows
-        // path. `offering.paywall == null` is the durable marker of a non-legacy (workflow)
-        // paywall: a legacy v1 paywall always carries `offering.paywall`, and that field stays
-        // even after `paywallComponents` is removed and all V2 paywalls move to workflows. We
-        // deliberately do NOT gate on `paywallComponents`, which is going away.
+        // Every non-legacy paywall is served through the workflows path. `offering.paywall == null` is the
+        // durable marker of a non-legacy (workflow) paywall: a legacy v1 paywall always carries
+        // `offering.paywall`, and that field stays even after `paywallComponents` is removed and all V2
+        // paywalls move to workflows. We deliberately do NOT gate on `paywallComponents`, which is going away.
         val workflowOffering = selectedOffering
-        if (useWorkflowsEndpoint && workflowOffering != null && workflowOffering.paywall == null) {
+        if (workflowOffering != null && workflowOffering.paywall == null) {
             when (val outcome = presentWorkflowOrResolveFallback(workflowOffering, offeringsForExitOfferLookup)) {
                 WorkflowOutcome.Presented -> return
                 is WorkflowOutcome.Fallback -> {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -75,8 +75,6 @@ internal interface PurchasesType {
     suspend fun awaitGetUiConfig(): UiConfig
 
     suspend fun resolveWorkflow(offeringId: String): WorkflowResolution
-
-    val useWorkflows: Boolean
 }
 
 @Suppress("TooManyFunctions")
@@ -157,8 +155,4 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
     @OptIn(InternalRevenueCatAPI::class)
     override suspend fun resolveWorkflow(offeringId: String): WorkflowResolution =
         purchases.resolveWorkflow(offeringId)
-
-    @OptIn(InternalRevenueCatAPI::class)
-    override val useWorkflows: Boolean
-        get() = purchases.currentConfiguration.dangerousSettings.useWorkflows
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogTests.kt
@@ -33,10 +33,12 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConf
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.helpers.UiConfig
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
 import io.mockk.Runs
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -70,6 +72,7 @@ class PaywallDialogTests {
         every { mockPurchases.currentConfiguration } returns mockk {
             every { dangerousSettings } returns DangerousSettings()
         }
+        coEvery { mockPurchases.resolveWorkflow(any()) } returns WorkflowResolution.NoWorkflow
     }
 
     @After

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -24,7 +24,6 @@ internal class MockPurchasesType(
     override val purchasesAreCompletedBy: PurchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
     override val storefrontCountryCode: String? = null,
     override val customerCenterListener: CustomerCenterListener? = null,
-    override val useWorkflows: Boolean = false,
 ) : PurchasesType {
     override suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult {
         throw NotImplementedError("Mock implementation")

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -236,7 +236,6 @@ class PaywallViewModelTest {
         every { purchases.track(any()) } just Runs
         coEvery { purchases.awaitSyncPurchases() } returns customerInfo
         every { purchases.preferredUILocaleOverride } returns null
-        every { purchases.useWorkflows } returns false
         coEvery { purchases.resolveWorkflow(any()) } returns WorkflowResolution.NoWorkflow
         coEvery { purchases.awaitGetUiConfig() } returns UiConfig()
 
@@ -1443,7 +1442,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         assertThat(model.workflowState.value?.currentStepId).isEqualTo("step-1")
@@ -1501,7 +1499,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         coVerify(exactly = 1) { purchases.awaitGetWorkflow(any()) }
@@ -3105,7 +3102,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         assertThat(model.workflowState.value?.currentStepId).isEqualTo("step-1")
@@ -3114,7 +3110,7 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and offering has a legacy paywall, does not fetch workflow`() {
+    fun `when offering has a legacy paywall, does not fetch workflow`() {
         // defaultOffering has a legacy paywall (offering.paywall != null), so it renders through
         // the legacy path and never hits the workflows endpoint, even with workflows enabled.
         PaywallViewModelImpl(
@@ -3127,14 +3123,13 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         coVerify(exactly = 0) { purchases.awaitGetWorkflow(any()) }
     }
 
     @Test
-    fun `when useWorkflows is true and offering has a legacy paywall, renders legacy paywall`() {
+    fun `when offering has a legacy paywall, renders legacy paywall`() {
         val model = PaywallViewModelImpl(
             MockResourceProvider(),
             purchases,
@@ -3145,14 +3140,13 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Legacy::class.java)
     }
 
     @Test
-    fun `when useWorkflows is true and offering has no legacy paywall, fetches by workflow id from map`() {
+    fun `when offering has no legacy paywall, fetches by workflow id from map`() {
         // offeringWithWPL has no legacy paywall (offering.paywall == null), so it is served through
         // the workflows endpoint. With a mapped workflow id, that id (not the offering id) is used.
         val workflowId = "wfl-real-id"
@@ -3192,7 +3186,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
@@ -3201,7 +3194,7 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and offering has no mapped workflow, skips fetch and falls back`() {
+    fun `when offering has no mapped workflow, skips fetch and falls back`() {
         // The config endpoint cannot lazily convert an offering id into a workflow. A workflowless offering
         // should therefore fall back immediately to the components paywall already delivered by offerings.
         coEvery { purchases.resolveWorkflow(offeringWithWPL.identifier) } returns WorkflowResolution.NoWorkflow
@@ -3216,7 +3209,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
@@ -3224,7 +3216,7 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and the workflow fetch fails, surfaces the error`() {
+    fun `when the workflow fetch fails, surfaces the error`() {
         // The workflow id resolved but its body or ui config could not be served. Reloading offerings would only
         // yield the offering's skipped-away components, so the paywall surfaces the error instead of silently
         // degrading to a different paywall.
@@ -3245,7 +3237,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         assertThat(model.state.value).isInstanceOf(PaywallState.Error::class.java)
@@ -3253,7 +3244,7 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and the workflows topic is disabled by a 4xx, reloads its paywall from offerings`() {
+    fun `when the workflows topic is disabled by a 4xx, reloads its paywall from offerings`() {
         // A 4xx disabled the config endpoint for the session. The initial offering was parsed while workflows
         // were enabled, so it has no components. Reload it from /offerings after the disable to get its paywall.
         val offeringWithoutComponents = offeringWithWPL.copy(paywallComponents = null)
@@ -3274,7 +3265,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
@@ -3301,7 +3291,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
@@ -3339,7 +3328,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
@@ -3351,7 +3339,7 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `when useWorkflows is true and no workflow is mapped with no paywall data, renders the default paywall`() {
+    fun `when no workflow is mapped with no paywall data, renders the default paywall`() {
         val offeringWithoutPaywallData = Offering(
             identifier = "offering-no-paywall-data",
             serverDescription = "description",
@@ -3372,7 +3360,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Legacy::class.java)
@@ -3420,7 +3407,6 @@ class PaywallViewModelTest {
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
             shouldDisplayBlock = null,
-            useWorkflowsEndpoint = true,
         )
 
         // The workflow loaded — this is the state InternalPaywall would render.

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -451,7 +451,6 @@ class PaywallViewModelWorkflowTest {
             every { storefrontCountryCode } returns "US"
             every { preferredUILocaleOverride } returns null
             every { purchasesAreCompletedBy } returns PurchasesAreCompletedBy.REVENUECAT
-            every { useWorkflows } returns true
             every { track(any()) } just Runs
             coEvery { awaitOfferings() } returns testOfferings
             coEvery { awaitCustomerInfo(any()) } returns mockk {


### PR DESCRIPTION
Removes useWorkflows DangerousSettings

Equivalent PR https://github.com/RevenueCat/purchases-ios/pull/7327


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for all default-flavor apps: remote config and workflow paywall routing are always active, which affects paywall loading and memory/offering parsing; CEC flavor behavior is unchanged.
> 
> **Overview**
> **Multipage paywalls (workflows) are now always on** for the default SDK flavor—no `DangerousSettings` toggle. This removes the internal `useWorkflows` flag, `DangerousSettings.forWorkflows()`, and related public API surface from the API dumps.
> 
> **SDK wiring:** `PurchasesFactory` turns on the `/v1/config` remote-config layer whenever the app is not on the custom entitlement computation flavor (previously it also required `useWorkflows`). `AppConfig` no longer exposes `useWorkflows`.
> 
> **RevenueCat UI:** `PaywallViewModel` always routes non-legacy paywalls (`offering.paywall == null`) through the workflows path; `PurchasesType.useWorkflows` is removed from mocks and `PurchasesImpl`.
> 
> **Tests & E2E:** Integration tests drop `DangerousSettings.forWorkflows()`; offerings integration asserts `hasPaywall` instead of `paywallComponents` when components come from remote config. E2E workflow APK only swaps the API key—workflows are not enabled via dangerous settings anymore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b8c40100e90db740e671e5fdc9b7f47885fb14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->