### PR TITLE
Exclude nested agent worktrees from detekt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,19 @@ dokka {
     }
 }
 
+// Shared by detektAll and detektAllBaseline: both analyze the whole rootDir, so they must skip the same paths.
+// `.claude` and `.conductor` hold nested checkouts of this repo created by agent tooling (git worktrees, so they
+// contain full copies of every source file). Without these excludes, detekt reports issues from other branches that
+// aren't in the developer's working tree at all, failing detektAll and the detekt pre-commit hook for clean changes.
+val detektExcludes = listOf(
+    "**/build/**",
+    "**/test/**/*.kt",
+    "**/testDefaults/**/*.kt",
+    "**/testCustomEntitlementComputation/**/*.kt",
+    "**/.claude/**",
+    "**/.conductor/**",
+)
+
 tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detektAll") {
     description = "Runs over the whole codebase without the startup overhead for each module."
     buildUponDefaultConfig = true
@@ -51,12 +64,7 @@ tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detektAll") {
     parallel = true
     setSource(files(rootDir))
     include("**/*.kt", "**/*.kts")
-    exclude(
-        "**/build/**",
-        "**/test/**/*.kt",
-        "**/testDefaults/**/*.kt",
-        "**/testCustomEntitlementComputation/**/*.kt",
-    )
+    exclude(detektExcludes)
     config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
     baseline.set(file("$rootDir/config/detekt/detekt-baseline.xml"))
     reports {
@@ -76,10 +84,5 @@ tasks.register<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>("detektAllB
     config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
     baseline.set(file("$rootDir/config/detekt/detekt-baseline.xml"))
     include("**/*.kt", "**/*.kts")
-    exclude(
-        "**/build/**",
-        "**/test/**/*.kt",
-        "**/testDefaults/**/*.kt",
-        "**/testCustomEntitlementComputation/**/*.kt",
-    )
+    exclude(detektExcludes)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,9 +45,11 @@ dokka {
 }
 
 // Shared by detektAll and detektAllBaseline: both analyze the whole rootDir, so they must skip the same paths.
-// `.claude` and `.conductor` hold nested checkouts of this repo created by agent tooling (git worktrees, so they
-// contain full copies of every source file). Without these excludes, detekt reports issues from other branches that
-// aren't in the developer's working tree at all, failing detektAll and the detekt pre-commit hook for clean changes.
+// `.claude`, `.conductor` and `.codex` hold nested checkouts of this repo created by agent tooling (git worktrees, so
+// they contain full copies of every source file). Without these excludes, detekt reports issues from other branches
+// that aren't in the developer's working tree at all, failing detektAll and the detekt pre-commit hook for clean
+// changes. These only match nested copies: a worktree analyzes its own sources normally, because the patterns are
+// relative to the rootDir you run Gradle from.
 val detektExcludes = listOf(
     "**/build/**",
     "**/test/**/*.kt",
@@ -55,6 +57,7 @@ val detektExcludes = listOf(
     "**/testCustomEntitlementComputation/**/*.kt",
     "**/.claude/**",
     "**/.conductor/**",
+    "**/.codex/**",
 )
 
 tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detektAll") {


### PR DESCRIPTION
`detektAll` runs over all of `rootDir`, and that includes `.claude/worktrees/**`, or other folders where agents create git worktrees. Those are full checkouts of the repo, so detekt was reporting issues from other worktrees. Locally I get 15 weighted issues from files that aren't in my working tree at all:

```
.claude/worktrees/perf-ci-network-test/rules-engine-internal/src/main/kotlin/com/revenuecat/purchases/rules/Value.kt  ForbiddenPublicDataClass
.claude/worktrees/agent-a29059a0cf46e6d14/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt                ForbiddenPublicEnum
```

That also blocks the pre-commit hook.

#### This doesn't stop detekt from checking a worktree you're working in

The excludes resolve relative to `rootDir`, and `rootDir` is whichever checkout you run Gradle from. So each worktree still gets fully analyzed when you run `detektAll` inside it. A file at `.claude/worktrees/my-branch/purchases/src/…` seen from the main checkout is just `purchases/src/…` when you run from `my-branch`, so it doesn't match `**/.claude/**`.

What gets skipped is only the nested copy as seen from the outside. Every worktree checks itself, nobody checks the others. The pre-commit hook runs from the worktree you're in, so it behaves the same. The first commit in this PR passed the hook without `--no-verify`.

Verified both directions by planting a public enum, in a worktree that had no nested checkouts of its own:

| Step | Result |
|------|--------|
| Offending files under `.claude/worktrees/probe/…`, before the fix | `FAILED — Analysis failed with 1 weighted issues` |
| Same, after the fix | `BUILD SUCCESSFUL`, `:detektAll UP-TO-DATE` |
| Enum under `.codex/worktrees/probe/…`, after the fix | `BUILD SUCCESSFUL` |
| Enum in the worktree's own `purchases/src/main/kotlin/…`, after the fix | `FAILED — Analysis failed with 1 weighted issues` |
| Probes removed, `detektAll --rerun-tasks` on the rebased branch | `BUILD SUCCESSFUL in 22s` |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gradle/detekt configuration only; narrows static analysis scope and does not change app or library runtime behavior.
> 
> **Overview**
> **Detekt** was failing on clean local changes because `detektAll` and `detektAllBaseline` scan all of `rootDir`, including full repo copies under agent tooling dirs (`.claude`, `.conductor`, `.codex`).
> 
> This PR pulls the exclude list into a shared `detektExcludes` value and adds `**/.claude/**`, `**/.conductor/**`, and `**/.codex/**` so nested worktrees are skipped when Gradle runs from the main checkout. Running Gradle from inside a worktree still analyzes that checkout’s sources normally, since excludes are relative to that `rootDir`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7ad9943a62becce99168b621e90e3234d5171a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->