### PR TITLE
fix(maestro): tap the relabeled Continue buttons in the workflow flows

### DIFF
--- a/maestro/workflows/navigate_workflow_back.yaml
+++ b/maestro/workflows/navigate_workflow_back.yaml
@@ -1,6 +1,6 @@
 # Opens a workflow paywall (offering `default_workflows`), advances to screen 2, taps the back
 # button, and asserts screen 1 is shown again.
-# Local-only (not under e2e_tests/, so the CI job does not run it).
+# Run on CI by the `run-maestro-workflow-tests` job.
 #
 # Run locally against the test store:
 #   maestro test -e MAESTRO_STORE=test_store maestro/workflows/navigate_workflow_back.yaml
@@ -26,7 +26,7 @@ env:
     visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
     timeout: 15000
 - tapOn:
-    text: "Continue"
+    text: "Continue 1/3"
 
 # Screen 2
 - extendedWaitUntil:

--- a/maestro/workflows/open_workflow.yaml
+++ b/maestro/workflows/open_workflow.yaml
@@ -1,6 +1,6 @@
 # Opens a workflow paywall (offering `default_workflows`), navigates all three screens via the
 # "Continue" button, purchases on the last one, then asserts the entitlement unlocks.
-# Local-only (not under e2e_tests/, so the CI job does not run it).
+# Run on CI by the `run-maestro-workflow-tests` job.
 #
 # Run locally against the test store:
 #   maestro test -e MAESTRO_STORE=test_store maestro/workflows/open_workflow.yaml
@@ -27,7 +27,7 @@ env:
     timeout: 15000
 - takeScreenshot: "open_workflow - screen 1"
 - tapOn:
-    text: "Continue"
+    text: "Continue 1/3"
 
 # Screen 2
 - extendedWaitUntil:
@@ -35,7 +35,7 @@ env:
     timeout: 15000
 - takeScreenshot: "open_workflow - screen 2"
 - tapOn:
-    text: "Continue"
+    text: "Continue 2/3"
 
 # Paywall screen; the last Continue starts the purchase.
 - extendedWaitUntil:
@@ -43,7 +43,7 @@ env:
     timeout: 15000
 - takeScreenshot: "open_workflow - paywall screen"
 - tapOn:
-    text: "Continue"
+    text: "Continue 3/3"
 
 # Test store purchase confirmation.
 - extendedWaitUntil:


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

The `default_workflows` CTAs were relabeled to `Continue 1/3`, `2/3` and `3/3` in the dashboard, and Maestro matches `text` against the whole string, so `run-maestro-workflow-tests` is red on every PR. Android counterpart of RevenueCat/purchases-ios#7332.

### Description

- Tap labels only; the screen assertions are untouched.
- The `e2e_tests` flow drives a different offering, so its buttons didn't change.
- Also drops the stale "local-only" header note: these flows have run on CI since #3804.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML changes with no production or security impact.
> 
> **Overview**
> Updates Maestro workflow E2E flows for the `default_workflows` offering so taps match the dashboard CTA labels **`Continue 1/3`**, **`Continue 2/3`**, and **`Continue 3/3`** instead of plain **`Continue`**. Screen visibility checks are unchanged.
> 
> Comments in `navigate_workflow_back.yaml` and `open_workflow.yaml` now note these run on CI via **`run-maestro-workflow-tests`**, replacing the outdated local-only note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5034e2b499d5315eca93315b7604042660076d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->