### PR TITLE
fix(remote-config): improve logging when remote config is disabled through to killswitch

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -8,11 +8,13 @@ import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
 import com.revenuecat.purchases.common.JsonProvider
+import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.between
 import com.revenuecat.purchases.common.caching.cacheDuration
 import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerFormatException
@@ -457,7 +459,13 @@ internal class RemoteConfigManager(
             listeners.forEach { it.onRemoteConfigDisabled(invalidatedGeneration) }
         }
         if (releaseGuardIfOwned(requestEpoch)) {
-            errorLog(error)
+            if (behavior == GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE) {
+                log(LogIntent.RC_ERROR) {
+                    "Disabling remote config for this session after receiving a 4xx response. Error: $error"
+                }
+            } else {
+                errorLog(error)
+            }
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -5,6 +5,8 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.assertDebugLog
+import com.revenuecat.purchases.assertErrorLog
 import com.revenuecat.purchases.assertWarnLog
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
@@ -963,6 +965,46 @@ class RemoteConfigManagerTest {
         )
 
         verify(exactly = 0) { diskCache.write(any()) }
+    }
+
+    @Test
+    fun `a 4xx logs when remote config is disabled and when a later refresh is skipped`() {
+        every { diskCache.read() } returns null
+        val error = PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request")
+
+        assertErrorLog(
+            "😿‼️ Disabling remote config for this session after receiving a 4xx response. Error: $error",
+        ) {
+            manager.refreshRemoteConfig(
+                appInBackground = false,
+                appUserID = TEST_APP_USER_ID,
+                fetchContext = DEFAULT_FETCH_CONTEXT,
+            )
+            onError.invoke(error, GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE)
+        }
+
+        assertDebugLog("Remote config is disabled for this session (4xx). Skipping refresh.") {
+            manager.refreshRemoteConfig(
+                appInBackground = false,
+                appUserID = TEST_APP_USER_ID,
+                fetchContext = DEFAULT_FETCH_CONTEXT,
+            )
+        }
+    }
+
+    @Test
+    fun `a non-4xx refresh error keeps the generic error log`() {
+        every { diskCache.read() } returns persisted(manifest = "v1.1.sources:etag1")
+        val error = PurchasesError(PurchasesErrorCode.UnknownError, "boom")
+
+        assertErrorLog("😿‼️ $error") {
+            manager.refreshRemoteConfig(
+                appInBackground = false,
+                appUserID = TEST_APP_USER_ID,
+                fetchContext = DEFAULT_FETCH_CONTEXT,
+            )
+            onError.invoke(error, GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY)
+        }
     }
 
     @Test


### PR DESCRIPTION
# Description
We previously only logged a generic error when receiving a 4xx from the backend, and nothing to indicate that this will turn off the remote config feature. We did however log (with debug level) on subsequent requests.

# Changes
Improved the error log when the received response disables the remote config feature through the kill-switch. 

### Before
```
ERROR: 😿‼️ PurchasesError(code=UnknownBackendError, underlyingErrorMessage=Backend Code: N/A - , message='There was an unknown backend error.')
```

### After
```
ERROR: 😿‼️ Disabling remote config for this session after receiving a 4xx response. Error: PurchasesError(code=UnknownBackendError, underlyingErrorMessage=Backend Code: N/A - , message='There was an unknown backend error.')
```

And on subsequent requests
```
DEBUG: Remote config is disabled for this session (4xx). Skipping refresh.
```

This is now in line with iOS through https://github.com/RevenueCat/purchases-ios/pull/7337

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in remote config error handling; no behavior change to disable logic or network calls.
> 
> **Overview**
> When a `/v1/config` refresh fails with **4xx** (`SHOULD_DISABLE`), `RemoteConfigManager` now logs an explicit **ERROR** via `log(LogIntent.RC_ERROR)` explaining that remote config is disabled for the session, including the underlying `PurchasesError`. Other refresh errors still use the generic `errorLog(error)`.
> 
> Tests assert the new disable message, the existing debug skip log on later refreshes, and that non-4xx errors keep the generic error log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7044cb7ebd9ac10e0b55bd76583ec35f1fb2cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->