### PR TITLE
fix: avoid OutOfMemoryError when caching large offerings responses

### DIFF
--- a/purchases/src/main/baseline-prof.txt
+++ b/purchases/src/main/baseline-prof.txt
@@ -628,7 +628,7 @@ HSPLcom/revenuecat/purchases/common/Backend;->addCallback(Ljava/util/Map;Lcom/re
 HSPLcom/revenuecat/purchases/common/Backend;->getCallbacks()Ljava/util/Map;
 HSPLcom/revenuecat/purchases/common/Backend;->getCustomerInfo(Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 PLcom/revenuecat/purchases/common/Backend;->getDiagnosticsCallbacks()Ljava/util/Map;
-HSPLcom/revenuecat/purchases/common/Backend;->getOfferings(Ljava/lang/String;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
+HSPLcom/revenuecat/purchases/common/Backend;->getOfferings(Ljava/lang/String;ZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;)V
 HSPLcom/revenuecat/purchases/common/Backend;->getOfferingsCallbacks()Ljava/util/Map;
 HSPLcom/revenuecat/purchases/common/Backend;->getPaywallEventsCallbacks()Ljava/util/Map;
 PLcom/revenuecat/purchases/common/Backend;->getProductEntitlementCallbacks()Ljava/util/Map;

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -17,7 +17,7 @@ internal constructor(
     public val all: Map<String, Offering>,
     internal val placements: Placements? = null,
     internal val targeting: Targeting? = null,
-    internal val originalSource: HTTPResponseOriginalSource = HTTPResponseOriginalSource.MAIN,
+    internal val originalSource: HTTPResponseOriginalSource? = null,
     internal val loadedFromDiskCache: Boolean = false,
 ) {
     public constructor(current: Offering?, all: Map<String, Offering>) : this(current, all, null, null)
@@ -82,7 +82,7 @@ internal constructor(
         all: Map<String, Offering> = this.all,
         placements: Placements? = this.placements,
         targeting: Targeting? = this.targeting,
-        originalSource: HTTPResponseOriginalSource = this.originalSource,
+        originalSource: HTTPResponseOriginalSource? = this.originalSource,
         loadedFromDiskCache: Boolean = this.loadedFromDiskCache,
     ): Offerings {
         return Offerings(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -65,8 +65,12 @@ internal typealias CallbackCacheKey = List<String>
 
 /** @suppress */
 @OptIn(InternalRevenueCatAPI::class)
+internal typealias OfferingsSuccessCallback = (JSONObject, HTTPResponseOriginalSource, responsePayload: String) -> Unit
+
+/** @suppress */
+@OptIn(InternalRevenueCatAPI::class)
 internal typealias OfferingsCallback = Pair<
-    (JSONObject, HTTPResponseOriginalSource) -> Unit,
+    OfferingsSuccessCallback,
     (PurchasesError, errorHandlingBehavior: GetOfferingsErrorHandlingBehavior) -> Unit,
     >
 
@@ -422,7 +426,7 @@ internal class Backend(
     fun getOfferings(
         appUserID: String,
         appInBackground: Boolean,
-        onSuccess: (JSONObject, HTTPResponseOriginalSource) -> Unit,
+        onSuccess: OfferingsSuccessCallback,
         onError: (PurchasesError, GetOfferingsErrorHandlingBehavior) -> Unit,
     ) {
         val endpoint = Endpoint.GetOfferings(appUserID)
@@ -454,7 +458,7 @@ internal class Backend(
                 }?.forEach { (onSuccess, onError) ->
                     if (result.isSuccessful()) {
                         try {
-                            onSuccess(result.body, result.originalDataSource)
+                            onSuccess(result.body, result.originalDataSource, result.payloadText)
                         } catch (e: JSONException) {
                             val errorBehavior = GetOfferingsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_OFFERINGS
                             onError(e.toPurchasesError().also { errorLog(it) }, errorBehavior)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -45,7 +45,7 @@ internal abstract class OfferingParser(
     fun createOfferings(
         offeringsJson: JSONObject,
         productsById: Map<String, List<StoreProduct>>,
-        originalSource: HTTPResponseOriginalSource = HTTPResponseOriginalSource.MAIN,
+        originalSource: HTTPResponseOriginalSource? = null,
         loadedFromDiskCache: Boolean = false,
         configuredStore: Store = Store.PLAY_STORE,
     ): Offerings {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -593,13 +593,15 @@ public open class DeviceCache(
         return getJSONObjectOrNull(offeringsResponseCacheKey)
     }
 
+    /**
+     * Serializing a [JSONObject] here instead of storing [offeringsResponse] as received would cost a
+     * contiguous allocation of several times the response size, which OOMs on low-heap devices.
+     */
     @Synchronized
-    internal fun cacheOfferingsResponse(offeringsResponse: JSONObject) {
+    internal fun cacheOfferingsResponse(offeringsResponse: String) {
         preferences.edit()
-            .putString(
-                offeringsResponseCacheKey,
-                offeringsResponse.toString(),
-            ).apply()
+            .putString(offeringsResponseCacheKey, offeringsResponse)
+            .apply()
     }
 
     @Synchronized

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
@@ -8,7 +8,6 @@ import com.revenuecat.purchases.common.LocaleProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.caching.InMemoryCachedObject
 import com.revenuecat.purchases.common.caching.isCacheStale
-import com.revenuecat.purchases.utils.copy
 import org.json.JSONObject
 
 @OptIn(InternalRevenueCatAPI::class)
@@ -20,10 +19,6 @@ internal class OfferingsCache(
     ),
     private val localeProvider: LocaleProvider,
 ) {
-    companion object {
-        const val ORIGINAL_SOURCE_KEY = "rc_original_source"
-    }
-
     private var cachedLanguageTags: String? = null
 
     @Synchronized
@@ -33,13 +28,14 @@ internal class OfferingsCache(
         cachedLanguageTags = null
     }
 
+    /**
+     * [responsePayload] is null when [offerings] was parsed from the disk cache, whose response is already
+     * on disk: re-writing it would re-serialize a multi-MB payload on every failed fetch.
+     */
     @Synchronized
-    fun cacheOfferings(offerings: Offerings, offeringsResponse: JSONObject) {
-        val finalJsonToCache = offeringsResponse.copy(deep = false).apply {
-            put(ORIGINAL_SOURCE_KEY, offerings.originalSource)
-        }
+    fun cacheOfferings(offerings: Offerings, responsePayload: String?) {
         offeringsCachedObject.cacheInstance(offerings)
-        deviceCache.cacheOfferingsResponse(finalJsonToCache)
+        responsePayload?.let { deviceCache.cacheOfferingsResponse(it) }
         offeringsCachedObject.updateCacheTimestamp(dateProvider.now)
         cachedLanguageTags = String(localeProvider.currentLocalesLanguageTags.toCharArray())
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
@@ -30,7 +30,7 @@ internal class OfferingsFactory(
     @SuppressWarnings("TooGenericExceptionCaught", "LongMethod")
     fun createOfferings(
         offeringsJSON: JSONObject,
-        originalDataSource: HTTPResponseOriginalSource,
+        originalDataSource: HTTPResponseOriginalSource?,
         loadedFromDiskCache: Boolean,
         onError: (PurchasesError) -> Unit,
         onSuccess: (OfferingsResultData) -> Unit,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -14,14 +14,12 @@ import com.revenuecat.purchases.common.HTTPResponseOriginalSource
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.between
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
-import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.strings.OfferingStrings
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
-import com.revenuecat.purchases.utils.optNullableString
 import org.json.JSONObject
 import java.util.Date
 import java.util.concurrent.atomic.AtomicInteger
@@ -219,11 +217,11 @@ internal class OfferingsManager(
         backend.getOfferings(
             appUserID,
             appInBackground,
-            { body, originalDataSource ->
+            { body, originalDataSource, responsePayload ->
                 createAndCacheOfferings(
                     offeringsJSON = body,
                     originalDataSource = originalDataSource,
-                    loadedFromDiskCache = false,
+                    responsePayloadToCache = responsePayload,
                     fetchGeneration = fetchGeneration,
                     onError,
                     onSuccess,
@@ -237,20 +235,13 @@ internal class OfferingsManager(
                             handleErrorFetchingOfferings(backendError, onError)
                         } else {
                             warnLog { OfferingStrings.ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE }
-                            val originalDataSource = cachedOfferingsResponse.optNullableString(
-                                OfferingsCache.ORIGINAL_SOURCE_KEY,
-                            )?.let {
-                                try {
-                                    HTTPResponseOriginalSource.valueOf(it)
-                                } catch (e: IllegalArgumentException) {
-                                    errorLog(e) { "Invalid original data source for cached offerings" }
-                                    null
-                                }
-                            } ?: HTTPResponseOriginalSource.MAIN
                             createAndCacheOfferings(
                                 offeringsJSON = cachedOfferingsResponse,
-                                originalDataSource = originalDataSource,
-                                loadedFromDiskCache = true,
+                                // Unknown: the source of the response that originally populated the
+                                // disk cache is not persisted, because persisting it is what forced the
+                                // response body to be re-serialized on every write.
+                                originalDataSource = null,
+                                responsePayloadToCache = null,
                                 fetchGeneration = fetchGeneration,
                                 onError,
                                 onSuccess,
@@ -267,12 +258,14 @@ internal class OfferingsManager(
 
     private fun createAndCacheOfferings(
         offeringsJSON: JSONObject,
-        originalDataSource: HTTPResponseOriginalSource,
-        loadedFromDiskCache: Boolean,
+        originalDataSource: HTTPResponseOriginalSource?,
+        /** Null when this parse came from the disk cache; see [OfferingsCache.cacheOfferings]. */
+        responsePayloadToCache: String?,
         fetchGeneration: Int,
         onError: ((PurchasesError) -> Unit)? = null,
         onSuccess: ((OfferingsResultData) -> Unit)? = null,
     ) {
+        val loadedFromDiskCache = responsePayloadToCache == null
         offeringsFactory.createOfferings(
             offeringsJSON,
             originalDataSource,
@@ -294,7 +287,7 @@ internal class OfferingsManager(
                         offeringImagePreDownloader.preDownloadOfferingImages(it)
                     }
                     offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
-                    offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
+                    offeringsCache.cacheOfferings(offeringsResultData.offerings, responsePayloadToCache)
                     val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
                     workflowManager?.onPaywallConfigReady(onComplete = dispatchSuccess) ?: dispatchSuccess()
                 } else {
@@ -302,7 +295,7 @@ internal class OfferingsManager(
                     createAndCacheOfferings(
                         offeringsJSON = offeringsJSON,
                         originalDataSource = originalDataSource,
-                        loadedFromDiskCache = loadedFromDiskCache,
+                        responsePayloadToCache = responsePayloadToCache,
                         fetchGeneration = cacheGeneration.get(),
                         onError = onError,
                         onSuccess = onSuccess,

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsSourceTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsSourceTest.kt
@@ -14,6 +14,7 @@ import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
 import com.revenuecat.purchases.utils.stubStoreProduct
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
 import org.junit.Before
@@ -102,7 +103,7 @@ class OfferingsSourceTest {
     }
 
     @Test
-    fun `offerings cache stores and restores originalSource`() {
+    fun `caching offerings stores the response body as received`() {
         val offeringsJson = JSONObject(ONE_OFFERINGS_RESPONSE)
         val productsById = mapOf(STUB_PRODUCT_IDENTIFIER to listOf(stubStoreProduct(STUB_PRODUCT_IDENTIFIER)))
 
@@ -121,11 +122,10 @@ class OfferingsSourceTest {
 
         // Cache the offerings
         every { deviceCache.cacheOfferingsResponse(any()) } returns Unit
-        offeringsCache.cacheOfferings(originalOfferings, offeringsJson)
+        offeringsCache.cacheOfferings(originalOfferings, ONE_OFFERINGS_RESPONSE)
 
-        // Verify originalSource was stored in JSON
-        io.mockk.verify(exactly = 1) {
-            deviceCache.cacheOfferingsResponse(any())
+        verify(exactly = 1) {
+            deviceCache.cacheOfferingsResponse(ONE_OFFERINGS_RESPONSE)
         }
     }
 
@@ -148,12 +148,7 @@ class OfferingsSourceTest {
         )
 
         every { deviceCache.cacheOfferingsResponse(any()) } returns Unit
-        // Mock cached response with originalSource in JSON
-        val cachedJsonWithSource = JSONObject(ONE_OFFERINGS_RESPONSE).apply {
-            put(OfferingsCache.ORIGINAL_SOURCE_KEY, HTTPResponseOriginalSource.FALLBACK.name)
-        }
-        every { deviceCache.getOfferingsResponseCache() } returns cachedJsonWithSource
-        offeringsCache.cacheOfferings(originalOfferings, offeringsJson)
+        offeringsCache.cacheOfferings(originalOfferings, ONE_OFFERINGS_RESPONSE)
 
         // Retrieve from cache - originalSource should be preserved
         val cachedOfferings = offeringsCache.cachedOfferings
@@ -164,19 +159,20 @@ class OfferingsSourceTest {
     }
 
     @Test
-    fun `offerings defaults to MAIN when no source information provided`() {
+    fun `offerings source is null when not known`() {
         val offeringsJson = JSONObject(ONE_OFFERINGS_RESPONSE)
         val productsById = mapOf(STUB_PRODUCT_IDENTIFIER to listOf(stubStoreProduct(STUB_PRODUCT_IDENTIFIER)))
 
-        // Create offerings without specifying source (should default to MAIN)
+        // Null rather than MAIN: a caller that does not say where the response came from must not have
+        // the main API asserted on its behalf. The disk-cache path is the real case.
         val offerings = offeringParser.createOfferings(offeringsJson, productsById)
 
-        assertThat(offerings.originalSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
+        assertThat(offerings.originalSource).isNull()
         assertThat(offerings.loadedFromDiskCache).isFalse
     }
 
     @Test
-    fun `offerings cache handles missing originalSource gracefully`() {
+    fun `the cached offerings instance keeps the source it was built with`() {
         val offeringsJson = JSONObject(ONE_OFFERINGS_RESPONSE)
         val productsById = mapOf(STUB_PRODUCT_IDENTIFIER to listOf(stubStoreProduct(STUB_PRODUCT_IDENTIFIER)))
 
@@ -188,13 +184,9 @@ class OfferingsSourceTest {
             loadedFromDiskCache = true,
         )
 
-        // Cache without storing originalSource (simulating old cache)
         every { deviceCache.cacheOfferingsResponse(any()) } returns Unit
-        // Mock cached response without originalSource field (old cache format)
-        every { deviceCache.getOfferingsResponseCache() } returns JSONObject(ONE_OFFERINGS_RESPONSE)
-        offeringsCache.cacheOfferings(originalOfferings, offeringsJson)
+        offeringsCache.cacheOfferings(originalOfferings, ONE_OFFERINGS_RESPONSE)
 
-        // Retrieve from cache - should use cached instance's originalSource
         val cachedOfferings = offeringsCache.cachedOfferings
 
         assertThat(cachedOfferings).isNotNull
@@ -219,7 +211,6 @@ class OfferingsSourceTest {
             loadedFromDiskCache = false,
         )
 
-        // LOAD_SHEDDER should take precedence
         assertThat(offerings.originalSource).isEqualTo(HTTPResponseOriginalSource.FALLBACK)
         assertThat(offerings.loadedFromDiskCache).isFalse
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
@@ -851,7 +851,7 @@ class OfferingsTest {
                 JSONObject("{'offerings': [], 'current_offering_id': 'offering_with_broken_product'}"),
                 emptyMap()
             )
-        assertThat(offerings.originalSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
+        assertThat(offerings.originalSource).isNull()
         assertThat(offerings.loadedFromDiskCache).isFalse
 
         val offeringsWithDifferentMetadata = offerings.copy(
@@ -888,7 +888,7 @@ class OfferingsTest {
             products
         )
 
-        assertThat(offerings.originalSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
+        assertThat(offerings.originalSource).isNull()
         assertThat(offerings.loadedFromDiskCache).isFalse
 
         val offeringsWithDifferentData = offerings.copy(

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/FallbackURLBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/FallbackURLBackendIntegrationTest.kt
@@ -82,7 +82,7 @@ internal class FallbackURLBackendIntegrationTest: BaseBackendIntegrationTest() {
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource ->
+                onSuccess = { offeringsResponse, originalDataSource, _ ->
                     assertThat(offeringsResponse.getJSONArray("offerings").length()).isGreaterThan(0)
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.FALLBACK)
                     latch.countDown()
@@ -110,7 +110,7 @@ internal class FallbackURLBackendIntegrationTest: BaseBackendIntegrationTest() {
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource ->
+                onSuccess = { offeringsResponse, originalDataSource, _ ->
                     assertThat(offeringsResponse.getJSONArray("offerings").length()).isGreaterThan(0)
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.FALLBACK)
                     latch.countDown()

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderUSEast1BackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderUSEast1BackendIntegrationTest.kt
@@ -132,7 +132,7 @@ internal open class LoadShedderUSEast1BackendIntegrationTest: BaseBackendIntegra
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource ->
+                onSuccess = { offeringsResponse, originalDataSource, _ ->
                     assertThat(offeringsResponse.getString("current_offering_id")).isEqualTo("default")
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.LOAD_SHEDDER)
                     latch.countDown()
@@ -158,7 +158,7 @@ internal open class LoadShedderUSEast1BackendIntegrationTest: BaseBackendIntegra
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource ->
+                onSuccess = { offeringsResponse, originalDataSource, _ ->
                     assertThat(offeringsResponse.getString("current_offering_id")).isEqualTo("default")
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.LOAD_SHEDDER)
                     latch.countDown()

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -94,7 +94,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource ->
+                onSuccess = { offeringsResponse, originalDataSource, _ ->
                     assertThat(offeringsResponse.length()).isPositive
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
                     latch.countDown()
@@ -120,7 +120,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource ->
+                onSuccess = { offeringsResponse, originalDataSource, _ ->
                     assertThat(offeringsResponse.length()).isPositive
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
                     latch.countDown()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -700,8 +700,7 @@ class DeviceCacheTest {
     @Test
     fun `cache offerings response works`() {
         val jsonSample = "{\"test-key\":\"test-value\"}"
-        val offeringsResponse = JSONObject(jsonSample)
-        cache.cacheOfferingsResponse(offeringsResponse)
+        cache.cacheOfferingsResponse(jsonSample)
         verifyAll {
             mockEditor.putString(offeringsResponseCacheKey, jsonSample)
             mockEditor.apply()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -102,6 +102,7 @@ class BackendTest {
         receivedWebBillingProductsResponse = null
         receivedAliasUsersCallCount = 0
         receivedOriginalDataSource = null
+        receivedOfferingsPayload = null
     }
 
     @After
@@ -175,6 +176,7 @@ class BackendTest {
     private var receivedAliasUsersCallCount: Int = 0
     private var receivedOfferingsJSON: JSONObject? = null
     private var receivedOriginalDataSource: HTTPResponseOriginalSource? = null
+    private var receivedOfferingsPayload: String? = null
     private var receivedError: PurchasesError? = null
     private var receivedPostReceiptErrorHandlingBehavior: PostReceiptErrorHandlingBehavior? = null
     private var receivedGetOfferingsErrorHandlingBehavior: GetOfferingsErrorHandlingBehavior? = null
@@ -204,10 +206,12 @@ class BackendTest {
         this@BackendTest.receivedIsServerError = isServerError
     }
 
-    private val onReceiveOfferingsResponseSuccessHandler: (JSONObject, HTTPResponseOriginalSource) -> Unit = { offeringsJSON, originalDataSource ->
-        this@BackendTest.receivedOfferingsJSON = offeringsJSON
-        this@BackendTest.receivedOriginalDataSource = originalDataSource
-    }
+    private val onReceiveOfferingsResponseSuccessHandler: (JSONObject, HTTPResponseOriginalSource, String) -> Unit =
+        { offeringsJSON, originalDataSource, responsePayload ->
+            this@BackendTest.receivedOfferingsJSON = offeringsJSON
+            this@BackendTest.receivedOriginalDataSource = originalDataSource
+            this@BackendTest.receivedOfferingsPayload = responsePayload
+        }
 
     private val onReceiveOfferingsErrorHandler: (PurchasesError, GetOfferingsErrorHandlingBehavior) -> Unit =
         { error, errorBehavior ->
@@ -327,7 +331,7 @@ class BackendTest {
         backend.getOfferings(
             appUserID = "id",
             appInBackground = false,
-            onSuccess = { _, _ -> },
+            onSuccess = { _, _, _ -> },
             onError = { _, _ -> }
         )
 
@@ -336,7 +340,7 @@ class BackendTest {
         backend.getOfferings(
             appUserID = "id",
             appInBackground = false,
-            onSuccess = { _, _ -> },
+            onSuccess = { _, _, _ -> },
             onError = { _, _ -> }
         )
     }
@@ -1621,13 +1625,29 @@ class BackendTest {
     }
 
     @Test
+    fun `getOfferings passes the raw response body to the success callback`() {
+        mockResponse(Endpoint.GetOfferings(appUserID), null, 200, null, noOfferingsResponse)
+
+        backend.getOfferings(
+            appUserID,
+            appInBackground = false,
+            onSuccess = onReceiveOfferingsResponseSuccessHandler,
+            onError = { _, _ -> fail("Should be success") }
+        )
+
+        // Callers cache this verbatim, so it must be the body as received rather than a
+        // re-serialization of the parsed JSON.
+        assertThat(receivedOfferingsPayload).isEqualTo(noOfferingsResponse)
+    }
+
+    @Test
     fun `given a 5xx error, correct callback values are given`() {
         mockResponse(Endpoint.GetOfferings(appUserID), null, RCHTTPStatusCodes.ERROR, null, null)
 
         backend.getOfferings(
             appUserID,
             appInBackground = false,
-            onSuccess = { _, _ -> fail("Should be error") },
+            onSuccess = { _, _, _ -> fail("Should be error") },
             onError = onReceiveOfferingsErrorHandler
         )
 
@@ -1642,7 +1662,7 @@ class BackendTest {
         backend.getOfferings(
             appUserID,
             appInBackground = false,
-            onSuccess = { _, _ -> fail("Should be error") },
+            onSuccess = { _, _, _ -> fail("Should be error") },
             onError = onReceiveOfferingsErrorHandler
         )
 
@@ -1661,10 +1681,10 @@ class BackendTest {
             true
         )
         val lock = CountDownLatch(2)
-        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
-        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
@@ -1691,10 +1711,10 @@ class BackendTest {
             true
         )
         val lock = CountDownLatch(2)
-        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
-        asyncBackend.getOfferings("anotherUser", appInBackground = false, onSuccess = { _, _ ->
+        asyncBackend.getOfferings("anotherUser", appInBackground = false, onSuccess = { _, _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
@@ -1730,10 +1750,10 @@ class BackendTest {
             true
         )
         val lock = CountDownLatch(2)
-        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
-        asyncBackend.getOfferings(appUserID, appInBackground = true, onSuccess = { _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = true, onSuccess = { _, _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
@@ -1754,10 +1774,10 @@ class BackendTest {
             true
         )
         val lock = CountDownLatch(2)
-        asyncBackend.getOfferings(appUserID, appInBackground = true, onSuccess = { _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = true, onSuccess = { _, _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
-        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.common.DefaultLocaleProvider
 import com.revenuecat.purchases.common.FakeLocaleProvider
 import com.revenuecat.purchases.common.HTTPResponseOriginalSource
 import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.utils.ONE_OFFERINGS_RESPONSE
 import com.revenuecat.purchases.utils.add
 import com.revenuecat.purchases.utils.copy
 import io.mockk.InternalPlatformDsl.toArray
@@ -50,12 +51,11 @@ class OfferingsCacheTest {
 
     @Test
     fun `clear cache clears offerings cache and offerings response cache`() {
-        val offeringsResponse = JSONObject()
         every { deviceCache.clearOfferingsResponseCache() } just Runs
         every { deviceCache.cacheOfferingsResponse(any()) } just Runs
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, offeringsResponse)
+        }, ONE_OFFERINGS_RESPONSE)
         assertThat(offeringsCache.cachedOfferings).isNotNull
         offeringsCache.clearCache()
         assertThat(offeringsCache.cachedOfferings).isNull()
@@ -69,18 +69,27 @@ class OfferingsCacheTest {
         val offerings = mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
         }
-        val offeringsResponse = JSONObject()
         every { deviceCache.cacheOfferingsResponse(any()) } just Runs
         assertThat(offeringsCache.cachedOfferings).isNull()
-        offeringsCache.cacheOfferings(offerings, offeringsResponse)
+        offeringsCache.cacheOfferings(offerings, ONE_OFFERINGS_RESPONSE)
         assertThat(offeringsCache.cachedOfferings).isEqualTo(offerings)
         verify(exactly = 1) {
-            deviceCache.cacheOfferingsResponse(
-                match {
-                    it.getString(OfferingsCache.ORIGINAL_SOURCE_KEY) == HTTPResponseOriginalSource.MAIN.name
-                }
-            )
+            deviceCache.cacheOfferingsResponse(ONE_OFFERINGS_RESPONSE)
         }
+    }
+
+    @Test
+    fun `caching offerings from the disk cache does not write the response back to disk`() {
+        // The response is already on disk, so re-writing it re-serializes a multi-MB payload on
+        // every failed fetch.
+        val offerings = mockk<Offerings>()
+
+        offeringsCache.cacheOfferings(offerings, responsePayload = null)
+
+        verify(exactly = 0) { deviceCache.cacheOfferingsResponse(any()) }
+        // The in-memory cache must still be populated, or every later getOfferings re-parses the disk blob.
+        assertThat(offeringsCache.cachedOfferings).isEqualTo(offerings)
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isFalse
     }
 
     // region offerings cache
@@ -101,7 +110,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isFalse
     }
 
@@ -110,7 +119,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
         currentDate = currentDate.add(6.minutes)
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isTrue
     }
@@ -120,7 +129,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
         offeringsCache.forceCacheStale()
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isTrue
     }
@@ -130,7 +139,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
         assertThat(offeringsCache.cachedOfferings).isNotNull
         offeringsCache.clearInMemoryOfferingsCache()
         assertThat(offeringsCache.cachedOfferings).isNull()
@@ -141,7 +150,7 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isFalse
         offeringsCache.clearInMemoryOfferingsCache()
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isTrue
@@ -153,19 +162,18 @@ class OfferingsCacheTest {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
         offeringsCache.clearInMemoryOfferingsCache()
         verify(exactly = 0) { deviceCache.clearOfferingsResponseCache() }
     }
 
     @Test
     fun `clearInMemoryOfferingsCache preserves disk cache for fallback`() {
-        val offeringsResponse = JSONObject().apply { put("test", "value") }
         mockDeviceCacheOfferingResponse()
-        every { deviceCache.getOfferingsResponseCache() } returns offeringsResponse
+        every { deviceCache.getOfferingsResponseCache() } returns JSONObject(ONE_OFFERINGS_RESPONSE)
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, offeringsResponse)
+        }, ONE_OFFERINGS_RESPONSE)
 
         offeringsCache.clearInMemoryOfferingsCache()
 
@@ -187,7 +195,7 @@ class OfferingsCacheTest {
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
 
         // Assert
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isFalse
@@ -203,7 +211,7 @@ class OfferingsCacheTest {
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
         localeProvider.languageTags = listOf("fr-FR", "de-DE")
 
         // Assert
@@ -221,7 +229,7 @@ class OfferingsCacheTest {
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
         localeProvider.languageTags = listOf("fr-FR")
 
         // Assert
@@ -239,7 +247,7 @@ class OfferingsCacheTest {
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
         localeProvider.languageTags = listOf("es-ES", "en-US")
 
         // Assert
@@ -258,7 +266,7 @@ class OfferingsCacheTest {
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
-        }, JSONObject())
+        }, ONE_OFFERINGS_RESPONSE)
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isFalse
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isFalse
         offeringsCache.clearCache()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -160,6 +160,18 @@ class OfferingsManagerTest {
     }
 
     @Test
+    fun `a network fetch caches the response body as received`() {
+        mockDeviceCache()
+        mockOfferingsFactory()
+        mockBackendResponseSuccess()
+
+        offeringsManager.fetchAndCacheOfferings(appUserId, appInBackground = false)
+
+        // Verbatim, not a re-serialization of the parsed JSON: that allocation is what OOMed.
+        verify(exactly = 1) { cache.cacheOfferings(testOfferings, ONE_OFFERINGS_RESPONSE) }
+    }
+
+    @Test
     fun `in-flight fetch write lands after a non-invalidating clear (previous behavior preserved)`() {
         every { cache.clearInMemoryOfferingsCache() } just Runs
         mockDeviceCache()
@@ -467,11 +479,13 @@ class OfferingsManagerTest {
 
         assertThat(receivedOfferings).isEqualTo(testOfferings)
 
-        verify(exactly = 1) { cache.cacheOfferings(testOfferings, backendResponse) }
+        // Null payload: the response came from the disk cache, so it must not be re-serialized and
+        // written back on every failed fetch.
+        verify(exactly = 1) { cache.cacheOfferings(testOfferings, null) }
         verify(exactly = 1) {
             offeringsFactory.createOfferings(
                 offeringsJSON = backendResponse,
-                originalDataSource = HTTPResponseOriginalSource.MAIN,
+                originalDataSource = null,
                 loadedFromDiskCache = true,
                 onError = any(),
                 onSuccess = any(),
@@ -1009,7 +1023,11 @@ class OfferingsManagerTest {
         every {
             backend.getOfferings(any(), any(), captureLambda(), any())
         } answers {
-            lambda<(JSONObject, HTTPResponseOriginalSource) -> Unit>().captured.invoke(JSONObject(response), HTTPResponseOriginalSource.MAIN)
+            lambda<(JSONObject, HTTPResponseOriginalSource, String) -> Unit>().captured.invoke(
+                JSONObject(response),
+                HTTPResponseOriginalSource.MAIN,
+                response,
+            )
         }
     }
 


### PR DESCRIPTION
- Fixes an `OutOfMemoryError` when caching a large offerings response: `cacheOfferingsResponse`
  serialized a `JSONObject`, a contiguous allocation of several times the payload size. The raw
  response body is now stored as received.
- Stops re-writing the response when it was just read from the disk cache, which made the crash
  repeat on every failed fetch with no network involved.
- `Offerings.originalSource` is no longer persisted, since injecting it into the cached body is what
  forced the re-serialization. It is now nullable, and offerings from the disk cache report null.
- Fixes a stale `baseline-prof.txt` descriptor for `getOfferings` that the callback change
  invalidated.
- The response still lives in SharedPreferences, so ~1x payload stays retained for the process
  lifetime. Only the serialization is gone.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details>
<summary>Agent description</summary>

Part of #3867 (the `DeviceCache.cacheOfferingsResponse` crash; `ETagPayloadStore.read` is #3873).

**Two causes**

- `cacheOfferingsResponse` took a `JSONObject` and called `toString()`. `StringBuilder` grows by
  `(cap << 1) + 2`, so the reported 37,748,744-byte failure is the doubling step to
  `char[18,874,364]`, reached once the serialized response passes ~9.44M chars.
- `OfferingsManager` re-cached the response even when it had just been read from the disk cache, so
  an offline device re-serialized and re-wrote the same JSON on every `getOfferings`.

**Changes**

- The raw response body is threaded through `Backend.getOfferings`' callback and stored as received.
  No payload-sized allocation on the write path.
- `Offerings.originalSource` is no longer persisted. The field has no runtime consumer. SDK-4408
  tracks the two sibling caches that persist the same field.
- `originalSource` is now nullable; offerings rebuilt from the disk cache report null rather than
  claiming `MAIN`.
- The disk-cache path skips only the disk write, so the in-memory cache is still populated.
- Fixed the `baseline-prof.txt` descriptor for `getOfferings` (`Function2` to `Function3`).

**Measured**

Caller-thread allocation (where the crash was) on a 5.24MB offerings-like payload, via
`ThreadMXBean#getThreadAllocatedBytes`:

| | Allocated |
|---|---|
| `cacheOfferings`, after | 147 KB |
| serialize-then-store, before | 28,595 KB (~5.5x the payload) |

The response is parsed either way to build the offerings, so the tree is built outside the measured
window on both sides: this compares only what the caching step itself adds.

**Notes**

- No new prefs keys and nothing to migrate. Old cached bodies still parse and are still served.
- Regression gates: `DeviceCacheTest` pins the stored string; `OfferingsManagerTest` asserts the
  network path caches verbatim and the disk path caches nothing.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core offerings fetch/cache/fallback behavior and changes semantics of internal `originalSource` on disk-cache paths; mitigated by tests and no migration of existing cached bodies.
> 
> **Overview**
> Fixes **`OutOfMemoryError`** on low-heap devices when caching large offerings payloads by **storing the raw HTTP body** instead of re-serializing a `JSONObject`, and by **not writing disk again** when offerings were parsed from the existing disk cache (e.g. repeated failed fetches offline).
> 
> `Backend.getOfferings` now passes **`result.payloadText`** through the success callback so `DeviceCache.cacheOfferingsResponse` can persist the response verbatim. `OfferingsCache` no longer injects `rc_original_source` into the JSON (that mutation forced the expensive `toString()` path).
> 
> **`Offerings.originalSource`** is now **nullable** and defaults to **null** when unknown; disk-cache fallbacks use **null** instead of inferring `MAIN`. In-memory cached instances still keep the source from the build that populated them. **`baseline-prof.txt`** is updated for the `getOfferings` callback signature change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2d2b5008869fcc0e0148ec3470aa7db10d61266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
