### PR TITLE
fix: reduce memory reading cached responses and recover from corrupted cache entries

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -12,7 +12,6 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
-import com.revenuecat.purchases.utils.optNullableLong
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Date
@@ -40,8 +39,13 @@ internal data class ETagCacheMetadata(
     val verificationResult: VerificationResult,
     val isLoadShedderResponse: Boolean,
     val isFallbackURL: Boolean,
-    /** Verified on read to detect truncated payload files; `null` skips the check. */
-    val payloadSizeBytes: Long? = null,
+    /**
+     * CRC32 of the stored payload, verified on read. Kept here rather than inside the payload file
+     * because [ETagManager.storeResult] writes the file before committing these prefs: a
+     * self-describing file would still validate after a crash between the two, serving fresh bytes
+     * under the previous entry's eTag.
+     */
+    val payloadChecksum: Long,
 ) {
     fun serialize(): String {
         return JSONObject().apply {
@@ -52,7 +56,7 @@ internal data class ETagCacheMetadata(
             put(SERIALIZATION_NAME_VERIFICATION_RESULT, verificationResult.name)
             put(SERIALIZATION_NAME_IS_LOAD_SHEDDER_RESPONSE, isLoadShedderResponse)
             put(SERIALIZATION_NAME_IS_FALLBACK_URL, isFallbackURL)
-            payloadSizeBytes?.let { put(SERIALIZATION_NAME_PAYLOAD_SIZE_BYTES, it) }
+            put(SERIALIZATION_NAME_PAYLOAD_CHECKSUM, payloadChecksum)
         }.toString()
     }
 
@@ -76,9 +80,9 @@ internal data class ETagCacheMetadata(
         private const val SERIALIZATION_NAME_VERIFICATION_RESULT = "verificationResult"
         private const val SERIALIZATION_NAME_IS_LOAD_SHEDDER_RESPONSE = "isLoadShedderResponse"
         private const val SERIALIZATION_NAME_IS_FALLBACK_URL = "isFallbackURL"
-        private const val SERIALIZATION_NAME_PAYLOAD_SIZE_BYTES = "payloadSizeBytes"
+        private const val SERIALIZATION_NAME_PAYLOAD_CHECKSUM = "payloadChecksum"
 
-        fun fromResult(result: HTTPResult, eTagData: ETagData): ETagCacheMetadata {
+        fun fromResult(result: HTTPResult, eTagData: ETagData, payloadChecksum: Long): ETagCacheMetadata {
             return ETagCacheMetadata(
                 eTagData = eTagData,
                 responseCode = result.responseCode,
@@ -86,10 +90,14 @@ internal data class ETagCacheMetadata(
                 verificationResult = result.verificationResult,
                 isLoadShedderResponse = result.isLoadShedderResponse,
                 isFallbackURL = result.isFallbackURL,
+                payloadChecksum = payloadChecksum,
             )
         }
 
-        /** Null when [serialized] is unparseable, including entries from older SDK formats. */
+        /**
+         * Null when [serialized] is unparseable, including older formats that stored a payload size
+         * instead of a checksum, which therefore read as a miss rather than being served unverified.
+         */
         @Suppress("SwallowedException")
         fun deserialize(serialized: String): ETagCacheMetadata? {
             return try {
@@ -112,7 +120,7 @@ internal data class ETagCacheMetadata(
                     verificationResult = verificationResult,
                     isLoadShedderResponse = jsonObject.optBoolean(SERIALIZATION_NAME_IS_LOAD_SHEDDER_RESPONSE, false),
                     isFallbackURL = jsonObject.optBoolean(SERIALIZATION_NAME_IS_FALLBACK_URL, false),
-                    payloadSizeBytes = jsonObject.optNullableLong(SERIALIZATION_NAME_PAYLOAD_SIZE_BYTES),
+                    payloadChecksum = jsonObject.getLong(SERIALIZATION_NAME_PAYLOAD_CHECKSUM),
                 )
             } catch (e: JSONException) {
                 null
@@ -201,11 +209,10 @@ internal class ETagManager(
     internal fun getStoredResult(urlString: String): HTTPResult? {
         val serialized = prefs.value.getString(urlString, null) ?: return null
         val metadata = ETagCacheMetadata.deserialize(serialized) ?: return null
-        // Lock-free read: a store racing between the metadata and payload reads fails the size check,
-        // costing one spurious miss plus its refresh retry. The size check itself is what turns a
-        // truncated file into a miss here: downstream, HTTPResult.body swallows the parse failure and
-        // the server keeps answering 304 for its eTag, so a bad entry would never heal.
-        val payload = payloadStore.read(urlString, metadata.payloadSizeBytes) ?: return null
+        // Lock-free read: a store racing this fails the checksum, costing one spurious miss plus its
+        // refresh retry. Without that check a bad entry never heals, because HTTPResult.body swallows
+        // the parse failure and the server keeps answering 304 for its eTag.
+        val payload = payloadStore.read(urlString, metadata.payloadChecksum) ?: return null
         return metadata.toHTTPResult(payload)
     }
 
@@ -227,27 +234,20 @@ internal class ETagManager(
         payloadStore.clear()
     }
 
+    /**
+     * Payload file first, metadata only once that write succeeded: metadata present always implies its
+     * payload was written.
+     */
     @Synchronized
     private fun storeResult(
         urlString: String,
         result: HTTPResult,
         eTag: String,
     ) {
-        persistEntry(
-            urlString,
-            ETagCacheMetadata.fromResult(result, ETagData(eTag, dateProvider.now)),
-            result.payloadText,
-        )
-    }
-
-    /**
-     * Payload file first, metadata only once that write succeeded: metadata present always implies its
-     * payload was written.
-     */
-    private fun persistEntry(urlString: String, metadata: ETagCacheMetadata, payload: String) {
-        val payloadSizeBytes = payloadStore.write(urlString, payload) ?: return
+        val payloadChecksum = payloadStore.write(urlString, result.payloadText) ?: return
+        val metadata = ETagCacheMetadata.fromResult(result, ETagData(eTag, dateProvider.now), payloadChecksum)
         prefs.value.edit()
-            .putString(urlString, metadata.copy(payloadSizeBytes = payloadSizeBytes).serialize())
+            .putString(urlString, metadata.serialize())
             .apply()
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
@@ -15,6 +15,8 @@ import java.nio.ByteBuffer
 import java.nio.CharBuffer
 import java.nio.charset.CoderResult
 import java.nio.charset.CodingErrorAction
+import java.util.zip.CRC32
+import java.util.zip.CheckedOutputStream
 
 /**
  * Stores ETag cache payloads as one file per URL, so multi-MB payloads are neither re-encoded nor
@@ -22,9 +24,12 @@ import java.nio.charset.CodingErrorAction
  *
  * Writes stream through fixed-size buffers into a temp file committed by atomic rename (androidx
  * AtomicFile is unsafe here: its openRead deletes a concurrent writer's in-flight file and its
- * finishWrite hides rename failures). Writes are not fsynced; callers verify the size [write] returns
- * on [read] instead, turning files truncated by power loss into misses. A stale same-length file is
- * accepted: it serves the previous complete payload.
+ * finishWrite hides rename failures). Writes are not fsynced; callers verify the checksum [write]
+ * returns on [read] instead, so a file truncated by power loss, left stale by an interrupted rename,
+ * or corrupted in place all read back as misses.
+ *
+ * A [read] costs ~2x the payload size in heap (`ByteArray` plus `String`), which is structural rather
+ * than a tuning choice: [HTTPResult.Payload.Text] holds a `String`, so one has to exist.
  *
  * `null` reads are cache misses that self-heal via [ETagManager]'s refresh retry; the OS may purge
  * [Context.getCacheDir]. No eviction beyond overwrite and [clear], at parity with the prefs store.
@@ -36,8 +41,8 @@ internal class ETagPayloadStore(
     constructor(context: Context) : this(File(File(context.cacheDir, VENDOR_DIRECTORY), DIRECTORY_NAME))
 
     /**
-     * Returns the payload's size in bytes once the file is in place, or `null` when the write failed;
-     * callers must not persist metadata for a failed write.
+     * Returns the payload's CRC32 once the file is in place, or `null` when the write failed; callers
+     * must not persist metadata for a failed write.
      */
     fun write(urlString: String, payload: String): Long? {
         if (!directory.exists()) {
@@ -52,8 +57,8 @@ internal class ETagPayloadStore(
         // Same-URL writes are serialized by [ETagManager].
         val tempFile = File(directory, file.name + TEMP_SUFFIX)
         return try {
-            FileOutputStream(tempFile).use { out -> encodeTo(out, payload) }
-            if (tempFile.renameTo(file)) file.length() else null
+            val checksum = FileOutputStream(tempFile).use { out -> encodeTo(out, payload) }
+            if (tempFile.renameTo(file)) checksum else null
         } catch (e: IOException) {
             errorLog(e) { "Failed to persist ETag payload to disk." }
             null
@@ -61,29 +66,22 @@ internal class ETagPayloadStore(
     }
 
     /**
-     * Returns the payload, or `null` for a miss: no file, undecodable bytes, or a size mismatch
-     * against [expectedSizeBytes] (the size [write] returned; `null` skips the check).
+     * Returns the payload, or `null` for a miss: no file, or bytes not matching [expectedChecksum],
+     * the value [write] returned. Required, not optional: a failing payload decodes to U+FFFD garbage.
      */
     @Suppress("SwallowedException", "ReturnCount")
-    fun read(urlString: String, expectedSizeBytes: Long? = null): String? {
+    fun read(urlString: String, expectedChecksum: Long): String? {
         return try {
             FileInputStream(fileFor(urlString)).use { input ->
-                // The open descriptor pins one file identity, so a concurrent rename cannot swap the
-                // payload between the size check and the read.
                 val sizeBytes = input.channel.size()
-                val size = sizeBytes.toInt()
-                if ((expectedSizeBytes != null && sizeBytes != expectedSizeBytes) || size.toLong() != sizeBytes) {
-                    return null
-                }
-                val bytes = ByteArray(size)
+                // Not an integrity check: ByteArray would throw past the IOException catch below.
+                if (sizeBytes > Int.MAX_VALUE) return null
+                val bytes = ByteArray(sizeBytes.toInt())
                 DataInputStream(input).readFully(bytes)
-                // Strict decoding (unlike String(bytes), which silently substitutes U+FFFD) so a corrupt
-                // file reads back as a cache miss instead of serving garbage as a valid cached response.
-                Charsets.UTF_8.newDecoder()
-                    .onMalformedInput(CodingErrorAction.REPORT)
-                    .onUnmappableCharacter(CodingErrorAction.REPORT)
-                    .decode(ByteBuffer.wrap(bytes))
-                    .toString()
+                if (crc32Of(bytes) != expectedChecksum) return null
+                // Lenient decoding, which the checksum above makes safe. CharsetDecoder.decode would
+                // allocate a payload-sized char[] on top of `bytes`, OOMing on multi-MB responses.
+                String(bytes, Charsets.UTF_8)
             }
         } catch (e: FileNotFoundException) {
             // No payload for this URL: a plain cache miss, not an error.
@@ -114,15 +112,20 @@ internal class ETagPayloadStore(
         return File(directory, Checksum.generate(urlString.toByteArray(), Checksum.Algorithm.SHA256).value)
     }
 
+    private fun crc32Of(bytes: ByteArray): Long = CRC32().apply { update(bytes) }.value
+
     /**
-     * Streams [payload] to [out] via a `char[]` chunk: `CharBuffer.wrap(payload)` has no backing array,
-     * which forces the encoder off its fast path and measured a >60x slower store on ART. REPORT so an
-     * unencodable payload fails the write instead of being silently altered.
+     * Streams [payload] to [rawOut] via a `char[]` chunk, returning the CRC32 of the bytes written:
+     * `CharBuffer.wrap(payload)` has no backing array, which forces the encoder off its fast path and
+     * measured a >60x slower store on ART. REPORT so an unencodable payload fails the write instead of
+     * being silently altered.
      */
-    private fun encodeTo(out: OutputStream, payload: String) {
+    private fun encodeTo(rawOut: OutputStream, payload: String): Long {
         val encoder = Charsets.UTF_8.newEncoder()
             .onMalformedInput(CodingErrorAction.REPORT)
             .onUnmappableCharacter(CodingErrorAction.REPORT)
+        val checksum = CRC32()
+        val out = CheckedOutputStream(rawOut, checksum)
         val chunk = CharArray(CHUNK_CHARS)
         val charBuffer = CharBuffer.wrap(chunk)
         // Sized so a full chunk always encodes in one pass (UTF-8 is at most 3 bytes per UTF-16 char).
@@ -145,6 +148,7 @@ internal class ETagPayloadStore(
             }
         } while (payloadPosition < payload.length)
         drainInto(out, byteBuffer) { encoder.flush(byteBuffer) }
+        return checksum.value
     }
 
     /** Runs [step] until it reports underflow, writing whatever it put in [byteBuffer] after each round. */

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerMemoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerMemoryTest.kt
@@ -103,10 +103,10 @@ class ETagManagerMemoryTest {
         val maxAllowedBytes = 1024L * 1024L
         assertThat(storeBytes).isLessThan(maxAllowedBytes)
         assertThat(headerBytes).isLessThan(maxAllowedBytes)
-        // Deterministic (exact allocation counting, no timing): file byte[] (~1x payload.length for
-        // ASCII) + decoder char[] (2x) + String copy (up to 2x) = ~5x length, ~3.9x measured; 6x allows
-        // for JDKs without compact strings.
-        assertThat(notModifiedBytes).isLessThan(3L * payload.length * Char.SIZE_BYTES)
+        // Deterministic (exact counting, no timing): file byte[] (~1x payload.length for ASCII) + the
+        // String, stored compressed for ASCII (~1x) = ~2x, 2.0x measured. The ceiling stays below the
+        // 4x a payload-sized decoder char[] costs, so re-introducing CharsetDecoder.decode fails here.
+        assertThat(notModifiedBytes).isLessThan(5L * payload.length / 2)
 
         println("ETagManager memory profile (payload ${payload.length} chars, ~${payload.length / (1024 * 1024)}MB)")
         println("  storeBackendResultIfNoError: ${storeBytes / 1024} KB allocated")

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -17,6 +17,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -24,6 +25,7 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.Date
+import java.util.zip.CRC32
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -218,7 +220,7 @@ class ETagManagerTest {
         val eTagHeaders = underTest.getETagHeaders(urlString, verificationRequested = false)
 
         assertThat(eTagHeaders[HTTPRequest.ETAG_HEADER_NAME]).isEqualTo("etag")
-        verify(exactly = 0) { payloadStore.read(any()) }
+        verify(exactly = 0) { payloadStore.read(any(), any()) }
     }
 
     @Test
@@ -351,7 +353,7 @@ class ETagManagerTest {
 
         // Byte-for-byte what we received: never escaped, and never written into the prefs JSON.
         // (ETagManagerMemoryTest gates the allocation cost of this path.)
-        assertThat(payloadStore.read(urlString)).isEqualTo(payload)
+        assertStoredResponse(urlString, "etag", testDate, payload)
         assertThat(putStringKeys).containsExactly(urlString)
     }
 
@@ -367,11 +369,12 @@ class ETagManagerTest {
 
     @Test
     fun `Clearing caches removes all shared preferences and stored payloads`() {
-        payloadStore.write("http://localhost:100/v1/subscribers/appUserID", "payload")
+        val urlString = "http://localhost:100/v1/subscribers/appUserID"
+        val checksum = payloadStore.write(urlString, "payload")!!
 
         underTest.clearCaches()
 
-        assertThat(payloadStore.read("http://localhost:100/v1/subscribers/appUserID")).isNull()
+        assertThat(payloadStore.read(urlString, checksum)).isNull()
         verify {
             mockEditor.clear()
         }
@@ -667,7 +670,7 @@ class ETagManagerTest {
             verificationResult = VERIFIED,
             isLoadShedderResponse = true,
             isFallbackURL = true,
-            payloadSizeBytes = 12345L,
+            payloadChecksum = 12345L,
         )
 
         val deserialized = ETagCacheMetadata.deserialize(metadata.serialize())
@@ -684,6 +687,7 @@ class ETagManagerTest {
             verificationResult = NOT_REQUESTED,
             isLoadShedderResponse = false,
             isFallbackURL = false,
+            payloadChecksum = 12345L,
         )
 
         val deserialized = ETagCacheMetadata.deserialize(metadata.serialize())
@@ -702,6 +706,7 @@ class ETagManagerTest {
         val metadata = ETagCacheMetadata.fromResult(
             HTTPResult.createResult(origin = HTTPResult.Origin.CACHE),
             ETagData("etag", testDate),
+            payloadChecksum = 12345L,
         )
         val corrupted = metadata.serialize().replace("NOT_REQUESTED", "SOMETHING_UNKNOWN")
         every { mockedPrefs.getString(urlString, null) } returns corrupted
@@ -712,15 +717,42 @@ class ETagManagerTest {
     }
 
     @Test
-    fun `a payload file whose size does not match the metadata is treated as a miss`() {
+    fun `a payload file whose checksum does not match the metadata is treated as a miss`() {
         val urlString = "http://localhost:100/v1/subscribers/appUserID"
-        val payload = "{\"key\":\"value\"}"
-        val metadata = ETagCacheMetadata.fromResult(
-            HTTPResult.createResult(payload = payload, origin = HTTPResult.Origin.CACHE),
-            ETagData("etag", testDate),
-        ).copy(payloadSizeBytes = payload.length + 100L)
+        val result = HTTPResult.createResult(payload = "{\"key\":\"value\"}", origin = HTTPResult.Origin.CACHE)
+        val metadata = storeMetadataFor(urlString, result)
+            .let { it.copy(payloadChecksum = it.payloadChecksum + 1L) }
         every { mockedPrefs.getString(urlString, null) } returns metadata.serialize()
-        payloadStore.write(urlString, payload)
+
+        assertThat(underTest.getStoredResult(urlString)).isNull()
+    }
+
+    @Test
+    fun `an entry without a payload checksum sends no eTag, so the server answers in full`() {
+        // An entry that misses must also stop advertising its eTag, or the server keeps answering 304
+        // for a payload we refuse to serve.
+        val urlString = "http://localhost:100/v1/subscribers/appUserID"
+        val result = HTTPResult.createResult(payload = "{\"key\":\"value\"}", origin = HTTPResult.Origin.CACHE)
+        val legacy = JSONObject(storeMetadataFor(urlString, result).serialize())
+            .apply { remove("payloadChecksum") }
+            .toString()
+        every { mockedPrefs.getString(urlString, null) } returns legacy
+
+        val eTagHeaders = underTest.getETagHeaders(urlString, verificationRequested = false)
+
+        assertThat(eTagHeaders[HTTPRequest.ETAG_HEADER_NAME]).isEmpty()
+        assertThat(eTagHeaders[HTTPRequest.LAST_REFRESH_TIME_HEADER_NAME]).isNull()
+    }
+
+    @Test
+    fun `an entry without a payload checksum is treated as a miss`() {
+        // Older format: a payload size instead of a checksum, so serving it would go unverified.
+        val urlString = "http://localhost:100/v1/subscribers/appUserID"
+        val result = HTTPResult.createResult(payload = "{\"key\":\"value\"}", origin = HTTPResult.Origin.CACHE)
+        val legacy = JSONObject(storeMetadataFor(urlString, result).serialize())
+            .apply { remove("payloadChecksum") }
+            .toString()
+        every { mockedPrefs.getString(urlString, null) } returns legacy
 
         assertThat(underTest.getStoredResult(urlString)).isNull()
     }
@@ -731,6 +763,7 @@ class ETagManagerTest {
         val metadata = ETagCacheMetadata.fromResult(
             HTTPResult.createResult(origin = HTTPResult.Origin.CACHE),
             ETagData("etag", testDate),
+            payloadChecksum = 12345L,
         )
         every { mockedPrefs.getString(urlString, null) } returns metadata.serialize()
 
@@ -815,6 +848,7 @@ class ETagManagerTest {
                 verificationResult = VERIFIED,
             ),
             ETagData("etag", testDate),
+            payloadChecksum = 12345L,
         )
 
         val result = metadata.toHTTPResult("{\"key\":\"value\"}")
@@ -859,14 +893,25 @@ class ETagManagerTest {
         httpResult: HTTPResult = HTTPResult.createResult(origin = HTTPResult.Origin.CACHE)
     ) {
         val metadata = expectedETag?.let {
-            ETagCacheMetadata.fromResult(httpResult, ETagData(expectedETag, expectedLastRefreshTime))
+            storeMetadataFor(urlString, httpResult, expectedETag, expectedLastRefreshTime)
         }
         every {
             mockedPrefs.getString(urlString, null)
         } returns metadata?.serialize()
-        if (metadata != null) {
-            payloadStore.write(urlString, httpResult.payloadText)
-        }
+    }
+
+    /**
+     * Writes [result]'s payload to the store and returns metadata paired with it by checksum, which is
+     * what [ETagManager.storeResult] does and what [ETagManager.getStoredResult] requires to hit.
+     */
+    private fun storeMetadataFor(
+        urlString: String,
+        result: HTTPResult,
+        eTag: String = "etag",
+        lastRefreshTime: Date? = testDate,
+    ): ETagCacheMetadata {
+        val checksum = payloadStore.write(urlString, result.payloadText)!!
+        return ETagCacheMetadata.fromResult(result, ETagData(eTag, lastRefreshTime), checksum)
     }
 
     private fun assertStoredResponse(
@@ -882,8 +927,8 @@ class ETagManagerTest {
         assertThat(metadata!!.eTagData.eTag).isEqualTo(eTagInResponse)
         assertThat(metadata.eTagData.lastRefreshTime?.time).isEqualTo(lastRefreshTime?.time)
         assertThat(metadata.responseCode).isEqualTo(RCHTTPStatusCodes.SUCCESS)
-        assertThat(metadata.payloadSizeBytes).isEqualTo(responsePayload.toByteArray().size.toLong())
-
-        assertThat(payloadStore.read(urlString)).isEqualTo(responsePayload)
+        // Reading through the stored checksum asserts payload and metadata agree, the pairing
+        // getStoredResult depends on.
+        assertThat(payloadStore.read(urlString, metadata.payloadChecksum)).isEqualTo(responsePayload)
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagPayloadStoreTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagPayloadStoreTest.kt
@@ -8,6 +8,7 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.File
+import java.util.zip.CRC32
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -23,35 +24,41 @@ class ETagPayloadStoreTest {
 
     @Test
     fun `read returns null when nothing was written`() {
-        assertThat(underTest.read(url)).isNull()
+        assertThat(underTest.read(url, expectedChecksum = 0L)).isNull()
     }
 
     @Test
     fun `write and read round-trip a payload`() {
         val payload = "{\"offerings\":[{\"id\":\"premium\",\"desc\":\"a \\\"quoted\\\" name\"}]}\nwith\nnewlines"
 
-        assertThat(underTest.write(url, payload)).isNotNull
-        assertThat(underTest.read(url)).isEqualTo(payload)
+        assertThat(writeAndReadBack(payload)).isEqualTo(payload)
     }
 
     @Test
-    fun `write returns the encoded size which read verifies`() {
+    fun `write returns the payload checksum which read verifies`() {
         val payload = "ascii payload"
 
-        val sizeBytes = underTest.write(url, payload)
+        val checksum = underTest.write(url, payload)
 
-        assertThat(sizeBytes).isEqualTo(payload.length.toLong())
-        assertThat(underTest.read(url, expectedSizeBytes = sizeBytes)).isEqualTo(payload)
+        assertThat(checksum).isEqualTo(crc32Of(payload))
+        assertThat(underTest.read(url, expectedChecksum = checksum!!)).isEqualTo(payload)
     }
 
     @Test
-    fun `a payload file with an unexpected size reads back as a miss`() {
-        val sizeBytes = underTest.write(url, "the full payload")!!
-        val payloadFile = File(directory, directory.list()!!.single())
-        payloadFile.writeText("the full pay")
+    fun `a truncated payload file reads back as a miss`() {
+        val checksum = underTest.write(url, "the full payload")!!
+        overwritePayloadFile("the full pay")
 
-        assertThat(underTest.read(url, expectedSizeBytes = sizeBytes)).isNull()
-        assertThat(underTest.read(url)).isEqualTo("the full pay")
+        assertThat(underTest.read(url, expectedChecksum = checksum)).isNull()
+    }
+
+    @Test
+    fun `a payload file of the same length but different content reads back as a miss`() {
+        // Invisible to a size check, which is why the payload is checksummed instead.
+        val checksum = underTest.write(url, "the full payload")!!
+        overwritePayloadFile("the FULL payload")
+
+        assertThat(underTest.read(url, expectedChecksum = checksum)).isNull()
     }
 
     @Test
@@ -67,46 +74,45 @@ class ETagPayloadStoreTest {
             append("\"}")
         }
 
-        assertThat(underTest.write(url, payload)).isNotNull
-        assertThat(underTest.read(url)).isEqualTo(payload)
+        assertThat(writeAndReadBack(payload)).isEqualTo(payload)
     }
 
     @Test
     fun `write overwrites the previous payload for the same url`() {
         underTest.write(url, "first")
-        underTest.write(url, "second")
 
-        assertThat(underTest.read(url)).isEqualTo("second")
+        assertThat(writeAndReadBack("second")).isEqualTo("second")
     }
 
     @Test
     fun `payloads for different urls do not collide`() {
         val otherUrl = "$url#rc_payload"
-        underTest.write(url, "one")
-        underTest.write(otherUrl, "two")
 
-        assertThat(underTest.read(url)).isEqualTo("one")
-        assertThat(underTest.read(otherUrl)).isEqualTo("two")
+        // Both written before either is read, or a store mapping every url to one file would pass.
+        val checksum = underTest.write(url, "one")!!
+        val otherChecksum = underTest.write(otherUrl, "two")!!
+
+        assertThat(underTest.read(url, checksum)).isEqualTo("one")
+        assertThat(underTest.read(otherUrl, otherChecksum)).isEqualTo("two")
     }
 
     @Test
     fun `clear removes all payloads`() {
-        underTest.write(url, "payload")
+        val checksum = underTest.write(url, "payload")!!
         underTest.clear()
 
-        assertThat(underTest.read(url)).isNull()
+        assertThat(underTest.read(url, expectedChecksum = checksum)).isNull()
         assertThat(directory.exists()).isFalse
     }
 
     @Test
     fun `a leftover temp file from a crashed write does not affect reads or later writes`() {
-        underTest.write(url, "good")
+        val checksum = underTest.write(url, "good")!!
         val payloadFileName = directory.list()!!.single()
         File(directory, "$payloadFileName.tmp").writeText("partial write from a crashed process")
 
-        assertThat(underTest.read(url)).isEqualTo("good")
-        assertThat(underTest.write(url, "newer")).isNotNull
-        assertThat(underTest.read(url)).isEqualTo("newer")
+        assertThat(underTest.read(url, expectedChecksum = checksum)).isEqualTo("good")
+        assertThat(writeAndReadBack("newer")).isEqualTo("newer")
     }
 
     @Test
@@ -114,8 +120,7 @@ class ETagPayloadStoreTest {
         underTest.write(url, "payload")
         underTest.clear()
 
-        assertThat(underTest.write(url, "again")).isNotNull
-        assertThat(underTest.read(url)).isEqualTo("again")
+        assertThat(writeAndReadBack("again")).isEqualTo("again")
     }
 
     @Test
@@ -153,7 +158,7 @@ class ETagPayloadStoreTest {
     fun `clear on a store that never wrote is a no-op`() {
         underTest.clear()
 
-        assertThat(underTest.read(url)).isNull()
+        assertThat(underTest.read(url, expectedChecksum = 0L)).isNull()
     }
 
     @Test
@@ -161,19 +166,19 @@ class ETagPayloadStoreTest {
         val blockedByFile = ETagPayloadStore(temporaryFolder.newFile())
 
         assertThat(blockedByFile.write(url, "payload")).isNull()
-        assertThat(blockedByFile.read(url)).isNull()
+        assertThat(blockedByFile.read(url, expectedChecksum = 0L)).isNull()
     }
 
     @Test
-    fun `an empty payload round-trips with a zero size`() {
-        val sizeBytes = underTest.write(url, "")
+    fun `an empty payload round-trips with a zero checksum`() {
+        val checksum = underTest.write(url, "")
 
-        assertThat(sizeBytes).isEqualTo(0L)
-        assertThat(underTest.read(url, expectedSizeBytes = 0L)).isEqualTo("")
+        assertThat(checksum).isEqualTo(0L)
+        assertThat(underTest.read(url, expectedChecksum = 0L)).isEqualTo("")
 
         underTest.clear()
-        // A missing file also has length 0: the size check alone must not turn it into a hit.
-        assertThat(underTest.read(url, expectedSizeBytes = 0L)).isNull()
+        // An empty payload checksums to 0, same as no bytes at all: the missing file must still miss.
+        assertThat(underTest.read(url, expectedChecksum = 0L)).isNull()
     }
 
     @Test
@@ -181,15 +186,27 @@ class ETagPayloadStoreTest {
         val payloadWithUnpairedSurrogate = "{\"key\":\"\uD83C\"}"
 
         assertThat(underTest.write(url, payloadWithUnpairedSurrogate)).isNull()
-        assertThat(underTest.read(url)).isNull()
+        assertThat(underTest.read(url, expectedChecksum = 0L)).isNull()
     }
 
     @Test
-    fun `a corrupt payload file reads back as a miss instead of garbage`() {
-        underTest.write(url, "valid")
-        val payloadFile = File(directory, directory.list()!!.single())
-        payloadFile.writeBytes(byteArrayOf(0x7B, -1, -2, 0x22))
+    fun `a payload file corrupted into invalid UTF-8 reads back as a miss instead of garbage`() {
+        // Same length as the payload, so only the checksum catches it; lenient decoding would
+        // otherwise hand back U+FFFD substitutions as a valid response.
+        val checksum = underTest.write(url, "valid")!!
+        File(directory, directory.list()!!.single()).writeBytes(byteArrayOf(0x7B, -1, -2, 0x22, 0x7D))
 
-        assertThat(underTest.read(url)).isNull()
+        assertThat(underTest.read(url, expectedChecksum = checksum)).isNull()
     }
+
+    /** Reads back the way [ETagManager] does, with the checksum [ETagPayloadStore.write] returned. */
+    private fun writeAndReadBack(payload: String, storeUrl: String = url): String? =
+        underTest.write(storeUrl, payload)?.let { underTest.read(storeUrl, it) }
+
+    private fun overwritePayloadFile(contents: String) {
+        File(directory, directory.list()!!.single()).writeText(contents)
+    }
+
+    private fun crc32Of(payload: String): Long =
+        CRC32().apply { update(payload.toByteArray(Charsets.UTF_8)) }.value
 }


### PR DESCRIPTION
- Reduces the memory needed to read a cached HTTP response: the 304 path decoded the payload file
  with a strict `CharsetDecoder`, which allocates a `char[]` the size of the whole file. Measured 3.9x
  down to 2.0x payload bytes.
- Corrupted cache entries are now detected and recover on their own. Previously a same-length
  corruption was served as a cache hit and wedged permanently, because the server kept answering 304.
- Replaces the stored file size with a CRC32, folded into the existing write loop so it costs no
  extra pass over the payload.
- This reduces the OOM but does not eliminate it: ~2x is the floor while the payload has to exist as
  a `String`. #3867 stays open.
- ETag entries written by earlier versions miss once and refetch, one extra request per cached URL on
  the first launch after updating.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details>
<summary>Agent description</summary>

### Motivation

Part of #3867 (the `ETagPayloadStore.read` crash). Regression introduced in **10.14.1** by #3774,
which fixed #3628 by moving the allocation from the write path to the read path.

`CharsetDecoder.decode(ByteBuffer)` allocates `char[fileSizeBytes]` (UTF-8's
`averageCharsPerByte` is 1.0), i.e. 2x the file size contiguous. The reported 39,002,984 bytes
implies a ~19.5MB payload file.

The file-size check it replaces only caught truncation. Same-length corruption was served as a
hit, and that never heals: the payload fails JSON parsing, `HTTPResult.body` swallows it, and the
server keeps answering 304.

### Description

- `write` returns a CRC32 instead of the length, folded into the existing write loop via
  `CheckedOutputStream` (no extra pass, no extra buffer).
- `read` verifies before decoding, then uses `String(bytes, UTF_8)`. Verifying first means a
  mismatch skips the payload-sized `String`.
- `expectedChecksum` is required, so an unverified read is unreachable.
- Missing checksum is a miss, no migration branch.
- `java.util.zip.CRC32` because `CRC32C` is API 34 and `MessageDigest` is too slow here.

Measured by `ETagManagerMemoryTest` on 5MB: 304 read drops from ~3.9x to **2.0x** payload bytes.
Gate tightened 6x to 2.5x.

The regression gate is the new same-length-different-content case in `ETagPayloadStoreTest`, the
one thing the old size check could not catch.

### Known limitations

1. **Reduces the OOM, does not eliminate it.** ~2x is the floor while `Payload.Text` holds a
   `String`. The reported crash had 9.7MB free with the `byte[]` already resident, so a ~19.5MB
   `String` would also have failed. A size ceiling would fix it and was declined for this pass.
   #3867 stays open.
2. Entries from 10.14.1 to 10.16.0 store a size, not a checksum, so they miss and refetch once.
3. The CRC32 CPU cost (est. 5-40ms per 20MB on low-end ARM, background thread) is an estimate,
   not measured.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ETag cache read/write behavior and metadata format for all cached API responses; risk is mitigated by one-time miss/refetch for legacy entries and extensive unit/memory tests, but large-payload cache hits remain ~2× heap by design (#3867 not fully closed).
> 
> **Overview**
> Fixes a regression where **`ETagPayloadStore.read`** used strict **`CharsetDecoder`**, allocating a payload-sized `char[]` (~2× file size) and contributing to OOM on large offerings-style responses (#3867).
> 
> **Integrity:** Cache metadata now stores **`payloadChecksum`** (CRC32) instead of optional **`payloadSizeBytes`**. **`write`** returns the checksum via **`CheckedOutputStream`** on the existing encode path; **`read`** requires **`expectedChecksum`**, verifies CRC32 before decoding, then uses lenient **`String(bytes, UTF_8)`** instead of **`CharsetDecoder.decode`**. That catches truncation, stale interrupted renames, and **same-length corruption** that the size check could not—entries that previously wedged behind perpetual 304s now miss once and refetch.
> 
> **Migration:** Entries from 10.14.1–10.16.0 without **`payloadChecksum`** deserialize as misses and stop sending the stored eTag so the server returns a full body.
> 
> **Tests:** Memory gate for 304 reads tightened (~2× payload vs ~3.9×); new same-length corruption and legacy-metadata cases added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5025b614a938ce9eb68647512f5eb063d8b2c63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->