### PR TITLE
fix: make interface default methods usable from Java in all published modules

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallListenerAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallListenerAPI.java
@@ -46,5 +46,9 @@ final class PaywallListenerAPI {
             @Override
             public void onUrlOpened(@NonNull String url) {}
         };
+
+        // Only compiles with -Xjvm-default=all-compatibility; guards against method additions
+        // becoming source-breaking for Java implementors.
+        PaywallListener listenerWithDefaults = new PaywallListener() {};
     }
 }

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigureAndroidLibrary.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigureAndroidLibrary.kt
@@ -60,6 +60,9 @@ internal fun Project.configureAndroidLibrary() {
         }
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
+            // Emits interface default bodies as real JVM default methods, so adding a method to a
+            // public interface is not source-breaking for Java implementors. Keeps DefaultImpls: ABI-safe.
+            freeCompilerArgs.add("-Xjvm-default=all-compatibility")
             val kotlinLanguageVersion = libs.getVersion("kotlinLanguage")
             languageVersion.set(
                 KotlinVersion.fromVersion(kotlinLanguageVersion),

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -158,10 +158,6 @@ metalava {
 }
 
 tasks.withType<KotlinCompilationTask<*>>().configureEach {
-    compilerOptions {
-        freeCompilerArgs.add("-Xjvm-default=all-compatibility")
-    }
-
     if (name.contains("UnitTest") || name.contains("AndroidTest")) {
         compilerOptions {
             freeCompilerArgs.add("-opt-in=com.revenuecat.purchases.InternalRevenueCatAPI")


### PR DESCRIPTION
- Only `:purchases` set `-Xjvm-default=all-compatibility`. Every other published module compiled interface default bodies into `DefaultImpls` only, so Java implementors saw all-abstract interfaces and had to override every method.
- Moved the flag to the shared library convention plugin: `purchases`, `ui:revenuecatui`, `ui:debugview`, `feature:{amazon,galaxy,admob}`.
- Adding a method to a public interface is no longer source-breaking for Java. Retroactively unblocks purchases-unity, which broke on `PaywallListener.onUrlOpened` in 10.16.0, with no Unity-side change.
- ABI-safe: `DefaultImpls` is retained, so consumers compiled against older versions still link. `api.txt` is unchanged, metalava already reported these methods as `default`.
- Regression gate: a no-override `new PaywallListener() {}` in `PaywallListenerAPI.java`, which fails to compile without the flag with the exact error Unity hit.


Closes SDK-4409

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details>
<summary>Agent description</summary>

### Motivation

SDK-4409. Kotlin only emits real JVM `default` methods under
`-Xjvm-default=all-compatibility`; the default (`disable`) puts the bodies in a `DefaultImpls`
class that only kotlinc can use. `:purchases` has had the flag since #2199 (March 2025, when
`CustomerCenterListener` was added); nothing else did.

So this was never specific to `onUrlOpened`, or to `PaywallListener`. Any method added to any
interface in those modules has always been source-breaking for Java implementors, and Unity
absorbed it each time by implementing every method.

### Description

One line in `configureAndroidLibrary()` instead of per-module blocks, which also covers the
"audit the other modules" half of the issue. The now-redundant module-level flag in
`purchases/build.gradle.kts` is deleted; `CustomerCenterListener` was checked with `javap` to
confirm `:purchases` still emits defaults through the convention plugin.

### Safety

- **Binary compatibility**: `all-compatibility` keeps `DefaultImpls` (confirmed via `javap`:
  `PaywallListener$DefaultImpls.class` is still emitted). Consumers compiled against 10.16.0
  that link `DefaultImpls.onX(this)` still resolve, and already-compiled Kotlin implementors
  have concrete bodies baked in, so no `AbstractMethodError`.
- **Below API 24**: default methods need D8 desugaring under 24. `:purchases` is minSdk 23 and
  has shipped real default methods for 16 months, so the consuming app's D8 has been desugaring
  ours all along. Of the newly-flagged modules, `revenuecatui` is minSdk 24; `debugview` and the
  `feature:*` modules are 23, same as `purchases`.
- **New diamond conflicts**: real defaults can cause "inherits unrelated defaults" errors for a
  Java class implementing two interfaces. Checked every method signature shared across public
  interfaces per flavor. Three real pairs, none regress: `PaywallListener` /
  `CustomerCenterListener` (`onRestoreStarted`, `onRestoreCompleted`) and the two `Resumable`
  interfaces were already abstract-plus-default, which javac also rejects, so an override was
  required before and after; `FontProvider` / `ParcelizableFontProvider` differ in return type,
  so implementing both was already impossible; `PurchaseLogic extends PaywallPurchaseLogic`.
- Minor cost: a few synthetic `access$…$jd` bridges per interface on top of the retained
  `DefaultImpls`.

### Known limitation

This is the intended tradeoff, not a defect: adding a method to a public interface will no
longer fail Java implementors' builds, they silently inherit a no-op. Same tradeoff Kotlin
consumers already have, but a new callback can now go unnoticed instead of surfacing as a
compile error.

### Verification

Locally: the Java gate fails before the change with
`is not abstract and does not override abstract method onUrlOpened(String)` and passes after;
`api-check.sh` clean; `detektAll` and release assembly of all six published modules pass;
unit tests for the five newly-flagged modules pass, including 150 Paparazzi snapshots. The one
failure, `PaywallComponentsTemplatePreviewRecorder`, is environmental: the
`upstream/paywall-preview-resources` submodule is not initialized in that worktree.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compilation output for multiple shipped artifacts (ABI retained via DefaultImpls); Java implementors may silently inherit no-op defaults instead of compile failures when interfaces grow.
> 
> **Overview**
> **`-Xjvm-default=all-compatibility`** is now applied in **`configureAndroidLibrary()`** for every module using the public library convention, not only `:purchases`. Kotlin interface bodies compile to real JVM `default` methods so **Java** `implements` can omit overrides; **`DefaultImpls`** stays for ABI compatibility.
> 
> The duplicate compiler flag on **`purchases/build.gradle.kts`** is removed. **`PaywallListenerAPI.java`** adds a no-override **`new PaywallListener() {}`** compile check so new interface methods (e.g. **`onUrlOpened`**) do not break Java consumers like Unity again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8325abf08cb6d6d1fb51548d49bb9280736ab3fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->