### PR TITLE
fix(paywalls): apply tab state rules on workflow-backed paywalls

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -8,6 +8,8 @@ import com.revenuecat.purchases.paywalls.components.common.ExitOffers
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.LocalizationData
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
+import com.revenuecat.purchases.paywalls.components.common.StateDeclarationMapSerializer
 import com.revenuecat.purchases.utils.serializers.EnumDeserializerWithDefault
 import com.revenuecat.purchases.utils.serializers.JsonObjectToMapSerializer
 import com.revenuecat.purchases.utils.serializers.SealedDeserializerWithDefault
@@ -127,6 +129,8 @@ public data class WorkflowScreen(
     @SerialName("config") val config: JsonObject = JsonObject(emptyMap()),
     @SerialName("offering_identifier") val offeringIdentifier: String? = null,
     @SerialName("exit_offers") val exitOffers: ExitOffers? = null,
+    @Serializable(with = StateDeclarationMapSerializer::class)
+    @SerialName("state_declarations") val stateDeclarations: Map<String, StateDeclaration>? = null,
 )
 
 /**

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -6,7 +6,8 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
-import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.elementNames
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -115,15 +116,13 @@ internal class WorkflowModelsDeserializationTest {
     }
 
     /**
-     * A workflow screen and an offering's paywall are the same backend document, but they decode
-     * through two independent field lists, so a field added to [PaywallComponentsData] alone is
-     * silently dropped on the workflow path (this is how `state_declarations` went missing, which
-     * left every state_condition override inert on funnel paywalls).
+     * A workflow screen and an offering's paywall are the same backend document decoded through two
+     * independent field lists, which is how `state_declarations` went missing.
      *
-     * Adding a field to [PaywallComponentsData] fails this test until it is either decoded by
-     * [WorkflowScreen] (and passed through by `WorkflowScreenMapper`) or listed below with a reason.
+     * Add the field to [WorkflowScreen] or allow-list it below with a reason.
      */
     @Test
+    @OptIn(ExperimentalSerializationApi::class)
     fun `WorkflowScreen decodes every PaywallComponentsData field`() {
         val notSentPerScreen = setOf(
             // Supplied by WorkflowScreenMapper from the screens map key, not by the screen body.
@@ -135,13 +134,10 @@ internal class WorkflowModelsDeserializationTest {
             "automatically_scale_font_size",
         )
 
-        val missing = PaywallComponentsData.serializer().descriptor.serialNames() -
-            WorkflowScreen.serializer().descriptor.serialNames() -
+        val missing = PaywallComponentsData.serializer().descriptor.elementNames.toSet() -
+            WorkflowScreen.serializer().descriptor.elementNames.toSet() -
             notSentPerScreen
 
         assertThat(missing).isEmpty()
     }
-
-    private fun SerialDescriptor.serialNames(): Set<String> =
-        (0 until elementsCount).map { getElementName(it) }.toSet()
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -4,6 +4,7 @@ package com.revenuecat.purchases.common.workflows
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -85,5 +86,29 @@ internal class WorkflowModelsDeserializationTest {
         """.trimIndent()
         val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
         assertThat(step.stepScreenType).isNull()
+    }
+
+    @Test
+    fun `WorkflowScreen reads state_declarations`() {
+        val json = """
+            {
+              "template_name": "components",
+              "asset_base_url": "https://assets.pawwalls.com",
+              "components_config": {
+                "base": {
+                  "stack": {"type": "stack", "components": []},
+                  "background": {"type": "color", "value": {"light": {"type": "hex", "value": "#ffffff"}}}
+                }
+              },
+              "components_localizations": {"en_US": {}},
+              "default_locale": "en_US",
+              "state_declarations": {"selected_tab": {"type": "string", "default": "monthly"}}
+            }
+        """.trimIndent()
+        val screen = JsonTools.json.decodeFromString(WorkflowScreen.serializer(), json)
+
+        val declaration = screen.stateDeclarations?.get("selected_tab")
+        assertThat(declaration?.type).isEqualTo(StateDeclaration.ValueType.STRING)
+        assertThat(declaration?.defaultValue?.content).isEqualTo("monthly")
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -130,7 +130,7 @@ internal class WorkflowModelsDeserializationTest {
             // Absent from the backend's per-screen payload (serialize_paywalls_as_screens).
             "zero_decimal_place_countries",
             "play_store_product_change_mode",
-            // Sent per screen but not wired through yet: funnel paywalls always use the default.
+            // Sent per screen but not wired through yet: workflow-backed paywalls use the default.
             "automatically_scale_font_size",
         )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -4,7 +4,9 @@ package com.revenuecat.purchases.common.workflows
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
+import kotlinx.serialization.descriptors.SerialDescriptor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -111,4 +113,35 @@ internal class WorkflowModelsDeserializationTest {
         assertThat(declaration?.type).isEqualTo(StateDeclaration.ValueType.STRING)
         assertThat(declaration?.defaultValue?.content).isEqualTo("monthly")
     }
+
+    /**
+     * A workflow screen and an offering's paywall are the same backend document, but they decode
+     * through two independent field lists, so a field added to [PaywallComponentsData] alone is
+     * silently dropped on the workflow path (this is how `state_declarations` went missing, which
+     * left every state_condition override inert on funnel paywalls).
+     *
+     * Adding a field to [PaywallComponentsData] fails this test until it is either decoded by
+     * [WorkflowScreen] (and passed through by `WorkflowScreenMapper`) or listed below with a reason.
+     */
+    @Test
+    fun `WorkflowScreen decodes every PaywallComponentsData field`() {
+        val notSentPerScreen = setOf(
+            // Supplied by WorkflowScreenMapper from the screens map key, not by the screen body.
+            "id",
+            // Absent from the backend's per-screen payload (serialize_paywalls_as_screens).
+            "zero_decimal_place_countries",
+            "play_store_product_change_mode",
+            // Sent per screen but not wired through yet: funnel paywalls always use the default.
+            "automatically_scale_font_size",
+        )
+
+        val missing = PaywallComponentsData.serializer().descriptor.serialNames() -
+            WorkflowScreen.serializer().descriptor.serialNames() -
+            notSentPerScreen
+
+        assertThat(missing).isEmpty()
+    }
+
+    private fun SerialDescriptor.serialNames(): Set<String> =
+        (0 until elementsCount).map { getElementName(it) }.toSet()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapper.kt
@@ -20,6 +20,7 @@ internal object WorkflowScreenMapper {
             defaultLocaleIdentifier = screen.defaultLocaleIdentifier,
             revision = screen.revision,
             exitOffers = screen.exitOffers,
+            stateDeclarations = screen.stateDeclarations,
         )
 
     fun toPaywallComponents(screen: WorkflowScreen, screenId: String, uiConfig: UiConfig): Offering.PaywallComponents =

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
@@ -71,7 +71,6 @@ class WorkflowScreenMapperTest {
         assertThat(data.componentsLocalizations).isEqualTo(screen.componentsLocalizations)
         assertThat(data.defaultLocaleIdentifier).isEqualTo(screen.defaultLocaleIdentifier)
         assertThat(data.revision).isEqualTo(screen.revision)
-        // Without declarations, an undeclared key never matches: every state_condition override is inert.
         assertThat(data.stateDeclarations).isEqualTo(stateDeclarations)
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
@@ -13,9 +13,11 @@ import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.LocalizationData
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.ui.revenuecatui.helpers.UiConfig
+import kotlinx.serialization.json.JsonPrimitive
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.net.URL
@@ -38,6 +40,13 @@ class WorkflowScreenMapperTest {
         ),
     )
 
+    private val stateDeclarations = mapOf(
+        "selected_tab" to StateDeclaration(
+            type = StateDeclaration.ValueType.STRING,
+            defaultValue = JsonPrimitive("monthly"),
+        ),
+    )
+
     private val screen = WorkflowScreen(
         name = "Test Screen",
         templateName = "template_v2",
@@ -46,7 +55,8 @@ class WorkflowScreenMapperTest {
         componentsConfig = componentsConfig,
         componentsLocalizations = localizations,
         defaultLocaleIdentifier = defaultLocaleId,
-        offeringIdentifier = "offering_id"
+        offeringIdentifier = "offering_id",
+        stateDeclarations = stateDeclarations,
     )
 
     @Test
@@ -61,6 +71,8 @@ class WorkflowScreenMapperTest {
         assertThat(data.componentsLocalizations).isEqualTo(screen.componentsLocalizations)
         assertThat(data.defaultLocaleIdentifier).isEqualTo(screen.defaultLocaleIdentifier)
         assertThat(data.revision).isEqualTo(screen.revision)
+        // Without declarations, an undeclared key never matches: every state_condition override is inert.
+        assertThat(data.stateDeclarations).isEqualTo(stateDeclarations)
     }
 
     @Test


### PR DESCRIPTION
- Tab state rules did nothing on a paywall built on the workflow data model: `WorkflowScreen` never decoded
  the screen's `state_declarations` and `WorkflowScreenMapper` never passed them on, so no
  `state_condition` override could match.
- Offering-served paywalls were never affected — they decode `PaywallComponentsData` directly.
- Adds a ratchet test so the next field added to `PaywallComponentsData` must be either decoded by
  `WorkflowScreen` or allow-listed with a reason.


iOS: https://github.com/RevenueCat/purchases-ios/pull/7347

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details>
<summary>Agent description</summary>

**Why nothing matched**

- `stateDeclarations` arrived at the renderer as null for every workflow-served screen, so
  `PaywallStateStore` had no declared keys.
- With no declared key, `applyUpdates` drops each entry on `declaredTypes[setUpdate.key] ?: return@forEach`,
  so a tab's `state_updates` wrote nothing, and `currentValueOrDefault` returned null.
- `Condition.State.evaluate` treats a null read as "never applies, regardless of operator", which is
  correct behavior for an undeclared key and is why there was no error to find.

**Changes**

- `WorkflowScreen` decodes `state_declarations`, reusing `StateDeclarationMapSerializer` so both
  paths interpret a malformed declaration identically.
- `WorkflowScreenMapper` passes it into `PaywallComponentsData`.

**The ratchet, and what it does not cover**

A workflow screen and an offering's paywall are the same backend document decoded through two
independent field lists, which is how the field went missing. The test diffs the two serial
descriptors. It guards the decode half only — it cannot observe the mapper — so a field added to both
models and dropped in the mapper still passes. Allow-list entries:

- `id` — supplied by the mapper from the screens map key, not the screen body.
- `zero_decimal_place_countries`, `play_store_product_change_mode` — absent from the backend's
  per-screen payload.
- `automatically_scale_font_size` — sent per screen, and `InternalPaywall` reads it off the mapper
  output, but no mapper sets it. A customer who disables Dynamic Type scaling gets it re-enabled on a
  workflow-backed paywall.

**Follow-ups**

- Wire `automatically_scale_font_size` on both platforms and drop the allow-list entry.
- Collapse `WorkflowScreen` into `PaywallComponentsData` to remove the bug class rather than guard
  it. Needs a serializer on the `screens` map, since `@Poko` has no `copy()` to stamp the screen id.
- Consider replacing the descriptor diff with a value-equality round trip (one screen JSON decoded
  through the mapper vs. straight through `PaywallComponentsData`), which would cover the mapper too.

</details>



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized deserialization and mapping fix with tests; no auth, security, or payment logic changes.
> 
> **Overview**
> Workflow-backed paywalls ignored **tab state rules** because `state_declarations` from the screen JSON never reached the renderer: `WorkflowScreen` did not decode the field and `WorkflowScreenMapper` did not pass it into `PaywallComponentsData`, so `PaywallStateStore` had no keys and `state_condition` overrides never matched. Offering-served paywalls were unaffected because they decode `PaywallComponentsData` directly.
> 
> This PR adds `state_declarations` on `WorkflowScreen` (via `StateDeclarationMapSerializer`, matching the offering path), forwards it in the mapper, and extends unit tests plus a **descriptor ratchet** so new `PaywallComponentsData` fields must appear on `WorkflowScreen` or be explicitly allow-listed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e400b192d9a9c86695458a9b8d12040c31719a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


