### PR TITLE
Add a Maestro flow for the config kill switch tripping mid-session

### DIFF
--- a/maestro/workflows/workflow_config_killswitch_mid_session.yaml
+++ b/maestro/workflows/workflow_config_killswitch_mid_session.yaml
@@ -49,6 +49,7 @@ env:
 # Arm the config-only failure and drive an unconditional config refresh.
 - tapOn:
     text: "Force Config Killswitch"
+- assertVisible: "config killswitch: armed"
 - tapOn:
     text: "Sync Attributes And Offerings"
 - extendedWaitUntil:

--- a/maestro/workflows/workflow_config_killswitch_mid_session.yaml
+++ b/maestro/workflows/workflow_config_killswitch_mid_session.yaml
@@ -1,0 +1,79 @@
+# The /v1/config kill switch tripping mid-session must degrade a workflow offering to the classic
+# single-page paywall (the workflow's last screen), not the generic default paywall. The degraded
+# paywall must still complete a purchase.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store maestro/workflows/workflow_config_killswitch_mid_session.yaml
+
+appId: com.revenuecat.e2etests
+name: Workflow offering falls back to the classic paywall when the config kill switch trips mid-session
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- launchApp:
+    clearState: true
+    arguments:
+      e2e_test_flow: open_workflow
+- assertVisible: "entitlement (pro): nil"
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# Prove all three workflow screens render while config is healthy.
+- extendedWaitUntil:
+    visible: "Continue 1/3"
+    timeout: 15000
+- takeScreenshot: "workflow_config_killswitch_mid_session - screen 1"
+- tapOn:
+    text: "Continue 1/3"
+- extendedWaitUntil:
+    visible: "Continue 2/3"
+    timeout: 15000
+- tapOn:
+    text: "Continue 2/3"
+- extendedWaitUntil:
+    visible: "Continue 3/3"
+    timeout: 15000
+- takeScreenshot: "workflow_config_killswitch_mid_session - screen 3"
+
+# Return to the launcher through the dashboard-configured close action on the last screen.
+- tapOn:
+    text: "Close Paywall"
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+
+# Arm the config-only failure and drive an unconditional config refresh.
+- tapOn:
+    text: "Force Config Killswitch"
+- tapOn:
+    text: "Sync Attributes And Offerings"
+- extendedWaitUntil:
+    visible: "config killswitch: on"
+    timeout: 30000
+
+# Present the offering captured before the kill switch. It must recover the classic last page.
+- tapOn:
+    text: "Present Paywall"
+- extendedWaitUntil:
+    visible: "Continue 3/3"
+    timeout: 15000
+- assertNotVisible: "Continue 1/3"
+- assertNotVisible: "No Paywall configured"
+- takeScreenshot: "workflow_config_killswitch_mid_session - classic paywall"
+
+# Only the /v1/config request is modified, so the fallback paywall must still be able to sell.
+- tapOn:
+    text: "Continue 3/3"
+- extendedWaitUntil:
+    visible: "TEST VALID PURCHASE"
+    timeout: 15000
+- tapOn:
+    text: "TEST VALID PURCHASE"
+- extendedWaitUntil:
+    visible: "entitlement (pro): active"
+    timeout: 15000
+- takeScreenshot: "workflow_config_killswitch_mid_session - unlocked entitlement"

--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -85,6 +85,9 @@ abstract class BasePurchasesIntegrationTest {
         override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean {
             return forceServerErrorsStrategy?.shouldForceServerError(baseURL, endpoint) ?: false
         }
+        override fun modifyRequestURL(url: URL, endpoint: Endpoint): URL {
+            return forceServerErrorsStrategy?.modifyRequestURL(url, endpoint) ?: url
+        }
         override fun fakeResponseWithoutPerformingRequest(baseURL: URL, endpoint: Endpoint): HTTPResult? {
             return forceServerErrorsStrategy?.fakeResponseWithoutPerformingRequest(baseURL, endpoint)
         }

--- a/purchases/src/defaultsDebug/kotlin/com/revenuecat/purchases/E2EForceServerErrorStrategy.kt
+++ b/purchases/src/defaultsDebug/kotlin/com/revenuecat/purchases/E2EForceServerErrorStrategy.kt
@@ -1,0 +1,7 @@
+package com.revenuecat.purchases
+
+@InternalRevenueCatAPI
+public enum class E2EForceServerErrorStrategy {
+    Never,
+    RemoteConfigKillSwitch,
+}

--- a/purchases/src/defaultsDebug/kotlin/com/revenuecat/purchases/PurchasesE2ETestConfiguration.kt
+++ b/purchases/src/defaultsDebug/kotlin/com/revenuecat/purchases/PurchasesE2ETestConfiguration.kt
@@ -1,0 +1,49 @@
+package com.revenuecat.purchases
+
+import android.annotation.SuppressLint
+import android.net.Uri
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.utils.DefaultIsDebugBuildProvider
+import java.net.URL
+
+/** Debug-only configuration entry point used by the E2E test app. */
+@InternalRevenueCatAPI
+@JvmSynthetic
+public fun Purchases.Companion.configureForE2ETests(
+    configuration: PurchasesConfiguration,
+    currentForceServerErrorStrategy: () -> E2EForceServerErrorStrategy,
+): Purchases {
+    val forceServerErrorStrategy = object : ForceServerErrorStrategy {
+        override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean = false
+
+        override fun modifyRequestURL(url: URL, endpoint: Endpoint): URL {
+            return when (currentForceServerErrorStrategy()) {
+                E2EForceServerErrorStrategy.Never -> url
+                E2EForceServerErrorStrategy.RemoteConfigKillSwitch -> {
+                    if (endpoint is Endpoint.GetRemoteConfig) url.appendingRemoteConfigKillSwitch() else url
+                }
+            }
+        }
+    }
+
+    return PurchasesFactory(
+        isDebugBuild = DefaultIsDebugBuildProvider(configuration.context),
+    ).createPurchases(
+        configuration = configuration,
+        platformInfo = platformInfo,
+        proxyURL = proxyURL,
+        forceServerErrorStrategy = forceServerErrorStrategy,
+    ).also {
+        @SuppressLint("RestrictedApi")
+        sharedInstance = it
+        serviceDispatcher.initialize(it)
+    }
+}
+
+private fun URL.appendingRemoteConfigKillSwitch(): URL = URL(
+    Uri.parse(toString())
+        .buildUpon()
+        .appendQueryParameter("force_killswitch", "true")
+        .build()
+        .toString(),
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ForceServerErrorStrategy.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ForceServerErrorStrategy.kt
@@ -18,6 +18,8 @@ internal fun interface ForceServerErrorStrategy {
 
     fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean
 
+    fun modifyRequestURL(url: URL, endpoint: Endpoint): URL = url
+
     @OptIn(InternalRevenueCatAPI::class)
     fun fakeResponseWithoutPerformingRequest(baseURL: URL, endpoint: Endpoint): HTTPResult? {
         return null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -399,13 +399,14 @@ internal class HTTPClient(
         }
 
         try {
+            val requestURL = URL(baseURL, path)
             fullURL = if (appConfig.runningTests &&
                 forceServerErrorStrategy?.shouldForceServerError(baseURL, endpoint) == true
             ) {
                 warnLog { "Forcing server error for request to ${URL(baseURL, path)}" }
                 URL(forceServerErrorStrategy.serverErrorURL)
             } else {
-                URL(baseURL, path)
+                forceServerErrorStrategy?.modifyRequestURL(requestURL, endpoint) ?: requestURL
             }
 
             nonce = if (shouldAddNonce) signingManager.createRandomNonce() else null

--- a/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -111,7 +111,8 @@ internal abstract class BaseHTTPClientTest {
         uiPreviewMode: Boolean = false,
         usesRemoteConfigAPISources: Boolean = false,
         forceSigningErrors: Boolean = false,
-        baseUrlString: String = AppConfig.baseUrlString
+        baseUrlString: String = AppConfig.baseUrlString,
+        runningTests: Boolean = true,
     ): AppConfig {
         return AppConfig(
             context = context,
@@ -127,7 +128,7 @@ internal abstract class BaseHTTPClientTest {
                 uiPreviewMode = uiPreviewMode,
                 usesRemoteConfigAPISources = usesRemoteConfigAPISources,
             ),
-            runningTests = true,
+            runningTests = runningTests,
             forceSigningErrors = forceSigningErrors,
             baseUrlString = baseUrlString,
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -814,6 +814,35 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
     // region forceServerErrors
 
     @Test
+    fun `request URL strategy is honored outside integration test mode`() {
+        val endpoint = Endpoint.GetRemoteConfig("app")
+        val client = createClient(
+            appConfig = createAppConfig(runningTests = false),
+            forceServerErrorStrategy = object : ForceServerErrorStrategy {
+                override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean = false
+
+                override fun modifyRequestURL(url: URL, endpoint: Endpoint): URL {
+                    return URL("$url?force_killswitch=true")
+                }
+            },
+        )
+        enqueue(
+            "${endpoint.getPath()}?force_killswitch=true",
+            expectedResult = HTTPResult.createResult(),
+        )
+
+        client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            postFieldsToSign = null,
+            mapOf("" to ""),
+        )
+
+        assertThat(server.takeRequest().requestUrl?.queryParameter("force_killswitch")).isEqualTo("true")
+    }
+
+    @Test
     fun `when forceServerErrorsStrategy returns true, error url is used`() {
         val client = createClient(
             forceServerErrorStrategy = object : ForceServerErrorStrategy {

--- a/test-apps/e2etests/src/debug/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
+++ b/test-apps/e2etests/src/debug/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
@@ -14,6 +14,7 @@ private val forceServerErrorStrategy = AtomicReference(E2EForceServerErrorStrate
 internal fun configurePurchases(
     configuration: PurchasesConfiguration,
 ) {
+    forceServerErrorStrategy.set(E2EForceServerErrorStrategy.Never)
     Purchases.configureForE2ETests(configuration, forceServerErrorStrategy::get)
 }
 

--- a/test-apps/e2etests/src/debug/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
+++ b/test-apps/e2etests/src/debug/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
@@ -14,7 +14,6 @@ private val forceServerErrorStrategy = AtomicReference(E2EForceServerErrorStrate
 internal fun configurePurchases(
     configuration: PurchasesConfiguration,
 ) {
-    forceServerErrorStrategy.set(E2EForceServerErrorStrategy.Never)
     Purchases.configureForE2ETests(configuration, forceServerErrorStrategy::get)
 }
 

--- a/test-apps/e2etests/src/debug/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
+++ b/test-apps/e2etests/src/debug/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
@@ -1,0 +1,23 @@
+package com.revenuecat.e2etests
+
+import com.revenuecat.purchases.E2EForceServerErrorStrategy
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesConfiguration
+import com.revenuecat.purchases.configureForE2ETests
+import java.util.concurrent.atomic.AtomicReference
+
+@OptIn(InternalRevenueCatAPI::class)
+private val forceServerErrorStrategy = AtomicReference(E2EForceServerErrorStrategy.Never)
+
+@OptIn(InternalRevenueCatAPI::class)
+internal fun configurePurchases(
+    configuration: PurchasesConfiguration,
+) {
+    Purchases.configureForE2ETests(configuration, forceServerErrorStrategy::get)
+}
+
+@OptIn(InternalRevenueCatAPI::class)
+internal fun armRemoteConfigKillSwitchForE2ETests() {
+    forceServerErrorStrategy.set(E2EForceServerErrorStrategy.RemoteConfigKillSwitch)
+}

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
@@ -22,10 +22,14 @@ class E2ETestsApplication : Application() {
             PurchasesConfiguration.Builder(context = this, apiKey = Constants.API_KEY)
         }
 
-        Purchases.configure(builder.build())
+        configurePurchases(builder.build())
     }
 
-    private companion object {
-        const val WORKFLOWS_API_KEY_PLACEHOLDER = "workflows_api_key_to_replace"
+    internal companion object {
+        private const val WORKFLOWS_API_KEY_PLACEHOLDER = "workflows_api_key_to_replace"
+
+        fun forceConfigKillSwitch() {
+            armRemoteConfigKillSwitchForE2ETests()
+        }
     }
 }

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/WorkflowScreen.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/WorkflowScreen.kt
@@ -42,7 +42,10 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 private const val WORKFLOW_OFFERING_ID = "default_workflows"
 private const val ENTITLEMENT_ID = "pro"
-private const val KILL_SWITCH_TIMEOUT_MILLIS = 10_000L
+
+// Keep this longer than Maestro's 30-second wait so app-side polling cannot preempt the test timeout.
+private const val KILL_SWITCH_TIMEOUT_MILLIS = 35_000L
+
 private const val KILL_SWITCH_POLL_INTERVAL_MILLIS = 100L
 
 private sealed interface OfferingState {

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/WorkflowScreen.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/WorkflowScreen.kt
@@ -133,6 +133,7 @@ private fun WorkflowLauncher(
 
 @Composable
 private fun ConfigKillSwitchControls() {
+    var configEndpointKillSwitchArmed by remember { mutableStateOf(false) }
     var configEndpointKillSwitchOn by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
 
@@ -140,8 +141,18 @@ private fun ConfigKillSwitchControls() {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Button(onClick = E2ETestsApplication::forceConfigKillSwitch) {
+        Button(
+            onClick = {
+                E2ETestsApplication.forceConfigKillSwitch()
+                configEndpointKillSwitchArmed = true
+                configEndpointKillSwitchOn = false
+            },
+        ) {
             Text("Force Config Killswitch")
+        }
+
+        if (configEndpointKillSwitchArmed && !configEndpointKillSwitchOn) {
+            Text("config killswitch: armed")
         }
 
         Button(

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/WorkflowScreen.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/WorkflowScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
 package com.revenuecat.e2etests.workflow
 
 import androidx.compose.foundation.layout.Arrangement
@@ -14,24 +16,34 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.revenuecat.e2etests.E2ETestsApplication
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.awaitCustomerInfo
 import com.revenuecat.purchases.awaitOfferings
+import com.revenuecat.purchases.awaitSyncAttributesAndOfferingsIfNeeded
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 private const val WORKFLOW_OFFERING_ID = "default_workflows"
 private const val ENTITLEMENT_ID = "pro"
+private const val KILL_SWITCH_TIMEOUT_MILLIS = 10_000L
+private const val KILL_SWITCH_POLL_INTERVAL_MILLIS = 100L
 
 private sealed interface OfferingState {
     data object Loading : OfferingState
@@ -46,21 +58,8 @@ fun WorkflowScreen(modifier: Modifier = Modifier) {
     var customerInfo by remember { mutableStateOf<CustomerInfo?>(null) }
 
     LaunchedEffect(Unit) {
-        try {
-            customerInfo = Purchases.sharedInstance.awaitCustomerInfo()
-        } catch (@Suppress("SwallowedException") e: PurchasesException) {
-            // Ignore; the entitlement surface shows "nil" until info arrives.
-        }
-        offeringState = try {
-            val offering = Purchases.sharedInstance.awaitOfferings().getOffering(WORKFLOW_OFFERING_ID)
-            if (offering != null) {
-                OfferingState.Loaded(offering)
-            } else {
-                OfferingState.Failed("Offering '$WORKFLOW_OFFERING_ID' not found")
-            }
-        } catch (e: PurchasesException) {
-            OfferingState.Failed(e.message ?: "Failed to load offerings")
-        }
+        customerInfo = loadCustomerInfo()
+        offeringState = loadWorkflowOffering()
     }
 
     // Keep the entitlement surface live so it flips to "active" after a purchase.
@@ -73,22 +72,40 @@ fun WorkflowScreen(modifier: Modifier = Modifier) {
 
     val loaded = offeringState
     if (showPaywall && loaded is OfferingState.Loaded) {
-        Paywall(
-            options = PaywallOptions.Builder(dismissRequest = { showPaywall = false })
-                .setOffering(loaded.offering)
-                .setListener(object : PaywallListener {
-                    override fun onPurchaseCompleted(
-                        customerInfo: CustomerInfo,
-                        storeTransaction: StoreTransaction,
-                    ) {
-                        showPaywall = false
-                    }
-                })
-                .build(),
-        )
+        WorkflowPaywall(offering = loaded.offering, onDismiss = { showPaywall = false })
         return
     }
 
+    WorkflowLauncher(
+        offeringState = loaded,
+        customerInfo = customerInfo,
+        onPresentPaywall = { showPaywall = true },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun WorkflowPaywall(offering: Offering, onDismiss: () -> Unit) {
+    Paywall(
+        options = PaywallOptions.Builder(dismissRequest = onDismiss)
+            .setOffering(offering)
+            .setListener(object : PaywallListener {
+                override fun onPurchaseCompleted(
+                    customerInfo: CustomerInfo,
+                    storeTransaction: StoreTransaction,
+                ) = onDismiss()
+            })
+            .build(),
+    )
+}
+
+@Composable
+private fun WorkflowLauncher(
+    offeringState: OfferingState,
+    customerInfo: CustomerInfo?,
+    onPresentPaywall: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -98,19 +115,80 @@ fun WorkflowScreen(modifier: Modifier = Modifier) {
     ) {
         Text(text = "Workflow paywall", style = MaterialTheme.typography.headlineMedium)
 
-        when (loaded) {
+        when (offeringState) {
             is OfferingState.Loading -> CircularProgressIndicator()
-            is OfferingState.Loaded -> Button(onClick = { showPaywall = true }) {
+            is OfferingState.Loaded -> Button(onClick = onPresentPaywall) {
                 Text("Present Paywall")
             }
             is OfferingState.Failed -> Text(
-                text = "Error: ${loaded.message}",
+                text = "Error: ${offeringState.message}",
                 color = MaterialTheme.colorScheme.error,
             )
         }
 
         Text(text = "entitlement ($ENTITLEMENT_ID): ${entitlementStatus(customerInfo)}")
+        ConfigKillSwitchControls()
     }
+}
+
+@Composable
+private fun ConfigKillSwitchControls() {
+    var configEndpointKillSwitchOn by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Button(onClick = E2ETestsApplication::forceConfigKillSwitch) {
+            Text("Force Config Killswitch")
+        }
+
+        Button(
+            onClick = {
+                coroutineScope.launch {
+                    if (syncAndWaitForConfigKillSwitch()) {
+                        configEndpointKillSwitchOn = true
+                    }
+                }
+            },
+        ) {
+            Text("Sync Attributes And Offerings")
+        }
+
+        if (configEndpointKillSwitchOn) {
+            Text("config killswitch: on")
+        }
+    }
+}
+
+private suspend fun loadCustomerInfo(): CustomerInfo? = try {
+    Purchases.sharedInstance.awaitCustomerInfo()
+} catch (@Suppress("SwallowedException") e: PurchasesException) {
+    null
+}
+
+private suspend fun loadWorkflowOffering(): OfferingState = try {
+    Purchases.sharedInstance.awaitOfferings().getOffering(WORKFLOW_OFFERING_ID)?.let(OfferingState::Loaded)
+        ?: OfferingState.Failed("Offering '$WORKFLOW_OFFERING_ID' not found")
+} catch (e: PurchasesException) {
+    OfferingState.Failed(e.message ?: "Failed to load offerings")
+}
+
+private suspend fun syncAndWaitForConfigKillSwitch(): Boolean {
+    try {
+        // Intentionally discard these offerings so the screen retains its pre-switch Offering instance.
+        Purchases.sharedInstance.awaitSyncAttributesAndOfferingsIfNeeded()
+    } catch (@Suppress("SwallowedException") e: PurchasesException) {
+        // The config request intentionally fails; readiness is checked below.
+    }
+
+    return withTimeoutOrNull(KILL_SWITCH_TIMEOUT_MILLIS) {
+        while (Purchases.sharedInstance.resolveWorkflow(WORKFLOW_OFFERING_ID) !is WorkflowResolution.Disabled) {
+            delay(KILL_SWITCH_POLL_INTERVAL_MILLIS)
+        }
+        true
+    } ?: false
 }
 
 private fun entitlementStatus(customerInfo: CustomerInfo?): String {

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/WorkflowScreen.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/workflow/WorkflowScreen.kt
@@ -51,6 +51,12 @@ private sealed interface OfferingState {
     data class Failed(val message: String) : OfferingState
 }
 
+private enum class ConfigKillSwitchState {
+    Off,
+    Armed,
+    On,
+}
+
 @Composable
 fun WorkflowScreen(modifier: Modifier = Modifier) {
     var offeringState by remember { mutableStateOf<OfferingState>(OfferingState.Loading) }
@@ -133,8 +139,7 @@ private fun WorkflowLauncher(
 
 @Composable
 private fun ConfigKillSwitchControls() {
-    var configEndpointKillSwitchArmed by remember { mutableStateOf(false) }
-    var configEndpointKillSwitchOn by remember { mutableStateOf(false) }
+    var configKillSwitchState by remember { mutableStateOf(ConfigKillSwitchState.Off) }
     val coroutineScope = rememberCoroutineScope()
 
     Column(
@@ -144,22 +149,17 @@ private fun ConfigKillSwitchControls() {
         Button(
             onClick = {
                 E2ETestsApplication.forceConfigKillSwitch()
-                configEndpointKillSwitchArmed = true
-                configEndpointKillSwitchOn = false
+                configKillSwitchState = ConfigKillSwitchState.Armed
             },
         ) {
             Text("Force Config Killswitch")
-        }
-
-        if (configEndpointKillSwitchArmed && !configEndpointKillSwitchOn) {
-            Text("config killswitch: armed")
         }
 
         Button(
             onClick = {
                 coroutineScope.launch {
                     if (syncAndWaitForConfigKillSwitch()) {
-                        configEndpointKillSwitchOn = true
+                        configKillSwitchState = ConfigKillSwitchState.On
                     }
                 }
             },
@@ -167,8 +167,10 @@ private fun ConfigKillSwitchControls() {
             Text("Sync Attributes And Offerings")
         }
 
-        if (configEndpointKillSwitchOn) {
-            Text("config killswitch: on")
+        when (configKillSwitchState) {
+            ConfigKillSwitchState.Off -> Unit
+            ConfigKillSwitchState.Armed -> Text("config killswitch: armed")
+            ConfigKillSwitchState.On -> Text("config killswitch: on")
         }
     }
 }

--- a/test-apps/e2etests/src/release/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
+++ b/test-apps/e2etests/src/release/java/com/revenuecat/e2etests/PurchasesConfigurator.kt
@@ -1,0 +1,12 @@
+package com.revenuecat.e2etests
+
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesConfiguration
+
+internal fun configurePurchases(
+    configuration: PurchasesConfiguration,
+) {
+    Purchases.configure(configuration)
+}
+
+internal fun armRemoteConfigKillSwitchForE2ETests() = Unit


### PR DESCRIPTION
## Description
E2E test with coverage for the scenario of triggering the remote config kill-switch mid session.

With the remote config enabled it will first go through a multi page workflow, after which it will trigger the kill-switch and re-open the workflow, asserting that now only the last screen (the paywall) is presented as a single page fallback, and ensuring the product can be purchased on the paywall.

iOS counterpart: [RevenueCat/purchases-ios#7324](https://github.com/RevenueCat/purchases-ios/pull/7324)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly E2E and debug-only hooks; production impact is a small HTTPClient path that honors optional URL modification on all requests when a strategy is injected.
> 
> **Overview**
> Adds a **Maestro E2E workflow** that walks a three-screen workflow paywall, arms a remote-config kill switch mid-session, re-presents the same offering, and asserts degradation to the **classic last-page paywall** (not the generic default) with a successful purchase.
> 
> To drive that scenario in the test app, the PR extends **`ForceServerErrorStrategy`** with **`modifyRequestURL`** and wires **`HTTPClient`** to use it when requests are not redirected to the forced-error URL. Debug-only **`configureForE2ETests`** can append `force_killswitch=true` on **`GetRemoteConfig`** when armed.
> 
> The workflow E2E screen gains **Force Config Killswitch** / **Sync Attributes And Offerings** controls, sync + polling until **`resolveWorkflow`** reports **`WorkflowResolution.Disabled`**, while keeping the pre-switch **`Offering`** instance for paywall presentation. Release builds keep normal **`Purchases.configure`** via a stub configurator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e64fdf1a7e52fe4b199d0d2e1791fc655e5aac02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->