### PR TITLE
refactor(ads): expose Outcome from the reward-verification poller

### DIFF
--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesServiceDispatcher
 import com.revenuecat.purchases.admob.enableRewardVerification
 import com.revenuecat.purchases.admob.show as showWithRewardVerification
+import com.revenuecat.purchases.ads.rewardverification.Outcome
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
@@ -71,7 +72,7 @@ internal class RewardVerificationManagerTest {
         coEvery {
             mockPurchases.pollRewardVerification(
                 capture(polledClientTransactionId),
-                any<suspend (String) -> RewardVerificationResult>(),
+                any<suspend (String) -> Outcome>(),
             )
         } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 7))
 
@@ -131,7 +132,7 @@ internal class RewardVerificationManagerTest {
         coEvery {
             mockPurchases.pollRewardVerification(
                 capture(polledClientTransactionId),
-                any<suspend (String) -> RewardVerificationResult>(),
+                any<suspend (String) -> Outcome>(),
             )
         } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 3))
 

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -9,11 +9,13 @@ import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.Purchases.Companion.configure
 import com.revenuecat.purchases.Purchases.Companion.debugLogsEnabled
 import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.rewardverification.Outcome
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationPollLauncher
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import com.revenuecat.purchases.ads.rewardverification.rewardVerificationRetryDelay
+import com.revenuecat.purchases.ads.rewardverification.toResult
 import com.revenuecat.purchases.checkpoints.CheckpointResolution
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
@@ -845,12 +847,12 @@ public class Purchases internal constructor(
         )
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
     internal suspend fun pollRewardVerification(
         clientTransactionId: String,
-        poll: suspend (String) -> RewardVerificationResult,
+        poll: suspend (String) -> Outcome,
     ): RewardVerificationResult {
-        val result = poll(clientTransactionId)
+        val result = poll(clientTransactionId).toResult()
         val rewards = result.verifiedReward?.let { listOf(it) + result.moreRewards } ?: return result
 
         if (rewards.any { it is VerifiedReward.VirtualCurrency }) {

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Poller.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Poller.kt
@@ -51,7 +51,7 @@ internal object Poller {
         jitterSeconds: () -> Double = defaultJitterSeconds,
         maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
         logFailure: (message: String, isError: Boolean) -> Unit = ::logFailureToLogcat,
-    ): RewardVerificationResult {
+    ): Outcome {
         val outcome = pollOutcome(
             clientTransactionId = clientTransactionId,
             fetcher = fetcher,
@@ -62,7 +62,7 @@ internal object Poller {
         if (outcome is Outcome.Failed) {
             logFailure(outcome.logMessage, outcome.isUnexpected)
         }
-        return outcome.toResult()
+        return outcome
     }
 
     private suspend fun pollOutcome(

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -57,6 +57,7 @@ import io.mockk.verify
 import io.mockk.verifyAll
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import com.revenuecat.purchases.ads.rewardverification.Outcome
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult as PollResult
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward as PollReward
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationPollLauncher
@@ -1989,7 +1990,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         val result = runBlocking {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
-                poll = { PollResult.verified(PollReward.VirtualCurrency(code = "gems", amount = 5)) },
+                poll = { Outcome.Verified(PollReward.VirtualCurrency(code = "gems", amount = 5), moreRewards = emptyList()) },
             )
         }
 
@@ -2003,11 +2004,11 @@ internal class PurchasesTest : BasePurchasesTest() {
         runBlocking {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
-                poll = { PollResult.verified(PollReward.NoReward) },
+                poll = { Outcome.Verified(PollReward.NoReward, moreRewards = emptyList()) },
             )
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_2",
-                poll = { PollResult.failed },
+                poll = { Outcome.Failed.ExhaustedWhilePending },
             )
         }
 
@@ -2068,7 +2069,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
                 poll = {
-                    PollResult.verified(
+                    Outcome.Verified(
                         reward = PollReward.NoReward,
                         moreRewards = listOf(PollReward.VirtualCurrency(code = "gems", amount = 5)),
                     )
@@ -2088,8 +2089,9 @@ internal class PurchasesTest : BasePurchasesTest() {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
                 poll = {
-                    PollResult.verified(
-                        PollReward.Entitlement(identifier = "pro", expiresAt = Date(1_800_000_000_000L)),
+                    Outcome.Verified(
+                        reward = PollReward.Entitlement(identifier = "pro", expiresAt = Date(1_800_000_000_000L)),
+                        moreRewards = emptyList(),
                     )
                 },
             )
@@ -2119,8 +2121,9 @@ internal class PurchasesTest : BasePurchasesTest() {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
                 poll = {
-                    PollResult.verified(
-                        PollReward.Entitlement(identifier = "pro", expiresAt = Date(1_800_000_000_000L)),
+                    Outcome.Verified(
+                        reward = PollReward.Entitlement(identifier = "pro", expiresAt = Date(1_800_000_000_000L)),
+                        moreRewards = emptyList(),
                     )
                 },
             )

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/ads/rewardverification/PollerTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/ads/rewardverification/PollerTest.kt
@@ -51,7 +51,7 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
-        )
+        ).toResult()
 
         assertEquals("ct_1", receivedClientTransactionId)
         assertNotNull(result.verifiedReward)
@@ -72,7 +72,7 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
-        )
+        ).toResult()
 
         assertEquals(1, attempts)
         assertFalse(result.failed)
@@ -93,7 +93,7 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
-        )
+        ).toResult()
 
         assertFalse(result.failed)
         assertEquals(VerifiedReward.VirtualCurrency(code = "gems", amount = 10), result.verifiedReward)
@@ -117,7 +117,7 @@ class PollerTest {
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
             logFailure = captureFailure,
-        )
+        ).toResult()
 
         assertEquals(1, attempts)
         assertTrue(result.failed)
@@ -142,7 +142,7 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
-        )
+        ).toResult()
 
         assertEquals(3, attempts)
         // A backoff between each attempt: two sleeps for three reads.
@@ -165,7 +165,7 @@ class PollerTest {
             jitterSeconds = fixedJitter,
             maxAttempts = 4,
             logFailure = captureFailure,
-        )
+        ).toResult()
 
         assertEquals(4, attempts)
         assertEquals(3, recordedSleeps.size)
@@ -189,7 +189,7 @@ class PollerTest {
             jitterSeconds = fixedJitter,
             maxAttempts = 3,
             logFailure = captureFailure,
-        )
+        ).toResult()
 
         assertEquals(3, attempts)
         assertTrue(result.failed)
@@ -220,7 +220,7 @@ class PollerTest {
             jitterSeconds = fixedJitter,
             maxAttempts = 3,
             logFailure = captureFailure,
-        )
+        ).toResult()
 
         assertTrue(result.failed)
         // Unknown status wins over transient exhaustion: logged at error level.
@@ -241,7 +241,7 @@ class PollerTest {
             jitterSeconds = fixedJitter,
             maxAttempts = 3,
             logFailure = captureFailure,
-        )
+        ).toResult()
 
         assertTrue(result.failed)
         // Repeated transient errors exhaust to a failure logged at warning level.
@@ -266,7 +266,7 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
-        )
+        ).toResult()
 
         assertEquals(2, attempts)
         assertFalse(result.failed)
@@ -291,7 +291,7 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
-        )
+        ).toResult()
 
         assertEquals(2, attempts)
         assertFalse(result.failed)
@@ -312,7 +312,7 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
-        )
+        ).toResult()
 
         assertEquals(1, attempts)
         assertTrue(result.failed)
@@ -335,7 +335,7 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
-        )
+        ).toResult()
 
         assertEquals(1, attempts)
         assertTrue(result.failed)
@@ -362,7 +362,7 @@ class PollerTest {
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
-        )
+        ).toResult()
 
         assertEquals(2, attempts)
         assertFalse(result.failed)
@@ -384,7 +384,7 @@ class PollerTest {
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
             logFailure = captureFailure,
-        )
+        ).toResult()
 
         assertEquals(1, attempts)
         assertTrue(result.failed)
@@ -406,7 +406,7 @@ class PollerTest {
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
             logFailure = captureFailure,
-        )
+        ).toResult()
 
         assertEquals(1, attempts)
         assertTrue(result.failed)
@@ -428,7 +428,7 @@ class PollerTest {
             sleepSeconds = { throw IllegalStateException("scheduler down") },
             jitterSeconds = fixedJitter,
             logFailure = captureFailure,
-        )
+        ).toResult()
 
         // First read returns pending, scheduling the backoff fails before the second read.
         assertEquals(1, attempts)


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Description

This is only a refactor for the ad reward tracking feature, without any behavior or API change. 

This change moves where do we map `Outcome` to `RewardVerificationResult`\- and we do this so we can capture the failure reason in the automatic tracking later.

<!-- Describe your changes in detail -->

<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor only; public callbacks still receive RewardVerificationResult with unchanged post-poll side effects.
> 
> **Overview**
> **Refactors reward verification polling** so the internal poll pipeline works with **`Outcome`** (verified vs typed failures) instead of collapsing to **`RewardVerificationResult`** inside **`Poller`**. **`Poller.poll`** now returns **`Outcome`** after logging failures; **`Purchases`**’ internal **`pollRewardVerification`** accepts a **`suspend (String) -> Outcome`** injectable and applies **`toResult()`** before cache invalidation and entitlement customer-info refresh—same public behavior as before.
> 
> Tests in **`PollerTest`**, **`PurchasesTest`**, and AdMob **`RewardVerificationManagerTest`** were updated to stub **`Outcome`** (or call **`toResult()`** where asserting on **`RewardVerificationResult`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ff4020e9c4935995e18ebfcf92000a8f9d48588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->