### PR TITLE
feat(ads): fire reward-verification tracking events from the poll

### DIFF
--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -74,7 +74,6 @@
     <ID>ForbiddenPublicSealedClass:PurchaseLogic.kt$PurchaseLogicResult</ID>
     <ID>ForbiddenPublicSealedClass:Purchases.kt$Purchases$DeepLink</ID>
     <ID>ForbiddenPublicSealedClass:RedeemWebPurchaseListener.kt$RedeemWebPurchaseListener$Result</ID>
-    <ID>LargeClass:Purchases.kt$Purchases : LifecycleDelegate</ID>
     <ID>MagicNumber:SampleWeatherData.kt$SampleWeatherData.Companion$120</ID>
     <ID>MagicNumber:SampleWeatherData.kt$SampleWeatherData.Companion$20</ID>
     <ID>MagicNumber:SampleWeatherData.kt$SampleWeatherData.Companion$32</ID>

--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -74,6 +74,7 @@
     <ID>ForbiddenPublicSealedClass:PurchaseLogic.kt$PurchaseLogicResult</ID>
     <ID>ForbiddenPublicSealedClass:Purchases.kt$Purchases$DeepLink</ID>
     <ID>ForbiddenPublicSealedClass:RedeemWebPurchaseListener.kt$RedeemWebPurchaseListener$Result</ID>
+    <ID>LargeClass:Purchases.kt$Purchases : LifecycleDelegate</ID>
     <ID>MagicNumber:SampleWeatherData.kt$SampleWeatherData.Companion$120</ID>
     <ID>MagicNumber:SampleWeatherData.kt$SampleWeatherData.Companion$20</ID>
     <ID>MagicNumber:SampleWeatherData.kt$SampleWeatherData.Companion$32</ID>

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
@@ -16,9 +16,11 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesServiceDispatcher
 import com.revenuecat.purchases.admob.enableRewardVerification
 import com.revenuecat.purchases.admob.show as showWithRewardVerification
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.rewardverification.Outcome
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import io.mockk.coEvery
 import io.mockk.every
@@ -72,6 +74,8 @@ internal class RewardVerificationManagerTest {
         coEvery {
             mockPurchases.pollRewardVerification(
                 capture(polledClientTransactionId),
+                isNull<RewardedAdTrackingMetadata>(),
+                eq(AdCaptureMethod.MANUAL),
                 any<suspend (String) -> Outcome>(),
             )
         } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 7))
@@ -132,6 +136,8 @@ internal class RewardVerificationManagerTest {
         coEvery {
             mockPurchases.pollRewardVerification(
                 capture(polledClientTransactionId),
+                isNull<RewardedAdTrackingMetadata>(),
+                eq(AdCaptureMethod.MANUAL),
                 any<suspend (String) -> Outcome>(),
             )
         } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 3))

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -36,7 +36,7 @@ package com.revenuecat.purchases {
     method @KotlinOnly @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitGetVirtualCurrencies(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies>) throws com.revenuecat.purchases.PurchasesException;
     method @KotlinOnly @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesTransactionException.class}) public static suspend Object? awaitLogIn(com.revenuecat.purchases.Purchases, String appUserID, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.data.LogInResult>) throws com.revenuecat.purchases.PurchasesTransactionException;
     method @KotlinOnly @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesTransactionException.class}) public static suspend Object? awaitLogOut(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.CustomerInfo>) throws com.revenuecat.purchases.PurchasesTransactionException;
-    method @KotlinOnly @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static suspend Object? awaitPollRewardVerification(com.revenuecat.purchases.Purchases, String clientTransactionId, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult>);
+    method @KotlinOnly @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static suspend Object? awaitPollRewardVerification(com.revenuecat.purchases.Purchases, String clientTransactionId, optional com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata? trackingMetadata, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult>);
     method @KotlinOnly @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitSetAppstackAttributionParams(com.revenuecat.purchases.Purchases, java.util.Map<java.lang.String,java.lang.String> data, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.Offerings>) throws com.revenuecat.purchases.PurchasesException;
     method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitStorefrontLocale(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.util.Locale>) throws com.revenuecat.purchases.PurchasesException;
     method @KotlinOnly @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitSyncAttributesAndOfferingsIfNeeded(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.Offerings>) throws com.revenuecat.purchases.PurchasesException;
@@ -420,6 +420,7 @@ package com.revenuecat.purchases {
     method public static com.revenuecat.purchases.WebPurchaseRedemption? parseAsWebPurchaseRedemption(android.content.Intent intent);
     method public static com.revenuecat.purchases.WebPurchaseRedemption? parseAsWebPurchaseRedemption(String string);
     method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public void pollRewardVerification(String clientTransactionId, com.revenuecat.purchases.interfaces.PollRewardVerificationCallback callback);
+    method @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public void pollRewardVerification(String clientTransactionId, com.revenuecat.purchases.interfaces.PollRewardVerificationCallback callback, optional com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata? trackingMetadata);
     method public void purchase(com.revenuecat.purchases.PurchaseParams purchaseParams, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
     method @Deprecated public void purchasePackage(android.app.Activity activity, com.revenuecat.purchases.Package packageToPurchase, com.revenuecat.purchases.interfaces.PurchaseCallback listener);
     method @Deprecated public void purchaseProduct(android.app.Activity activity, com.revenuecat.purchases.models.StoreProduct storeProduct, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
@@ -883,6 +884,20 @@ package com.revenuecat.purchases.ads.rewardverification {
     property public String appUserID;
     property public String clientTransactionId;
     property public String customData;
+  }
+
+  @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @dev.drewhamilton.poko.Poko public final class RewardedAdTrackingMetadata {
+    ctor @KotlinOnly public RewardedAdTrackingMetadata(String? networkName, com.revenuecat.purchases.ads.events.types.AdMediatorName mediatorName, com.revenuecat.purchases.ads.events.types.AdFormat adFormat, String? placement, String adUnitId, String impressionId);
+    method @InaccessibleFromKotlin public String getAdUnitId();
+    method @InaccessibleFromKotlin public String getImpressionId();
+    method @InaccessibleFromKotlin public String? getNetworkName();
+    method @InaccessibleFromKotlin public String? getPlacement();
+    property public com.revenuecat.purchases.ads.events.types.AdFormat adFormat;
+    property public String adUnitId;
+    property public String impressionId;
+    property public com.revenuecat.purchases.ads.events.types.AdMediatorName mediatorName;
+    property public String? networkName;
+    property public String? placement;
   }
 
   @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI public interface VerifiedReward {

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -79,6 +79,7 @@ import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
  * guide to setup your RevenueCat account.
  * @warning Only one instance of Purchases should be instantiated at a time!
  */
+@Suppress("LargeClass")
 public class Purchases internal constructor(
     @get:JvmSynthetic internal val purchasesOrchestrator: PurchasesOrchestrator,
 ) : LifecycleDelegate {

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -8,11 +8,17 @@ import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.Purchases.Companion.configure
 import com.revenuecat.purchases.Purchases.Companion.debugLogsEnabled
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.events.types.AdRewardEarnedUnverifiedData
+import com.revenuecat.purchases.ads.events.types.AdRewardFailedToVerifyData
+import com.revenuecat.purchases.ads.events.types.AdRewardGrantedData
+import com.revenuecat.purchases.ads.events.types.AdRewardVerifiedData
 import com.revenuecat.purchases.ads.rewardverification.Outcome
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationPollLauncher
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import com.revenuecat.purchases.ads.rewardverification.rewardVerificationRetryDelay
 import com.revenuecat.purchases.ads.rewardverification.toResult
@@ -62,6 +68,7 @@ import org.json.JSONObject
 import java.net.URL
 import java.util.Locale
 import java.util.UUID
+import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
 
 /**
  * Entry point for Purchases. It should be instantiated as soon as your app has a unique user id
@@ -834,15 +841,20 @@ public class Purchases internal constructor(
      * [generateRewardVerificationToken]. Reflects any verified reward locally before returning. The
      * [callback] is invoked on the main thread.
      *
+     * Pass [trackingMetadata] to track reward-verification events (see [adTracker]) for the ad it belongs
+     * to; omit it to poll without tracking.
+     *
      * For coroutines, use the `awaitPollRewardVerification` suspend extension instead.
      */
+    @JvmOverloads
     @ExperimentalPreviewRevenueCatPurchasesAPI
     public fun pollRewardVerification(
         clientTransactionId: String,
         callback: PollRewardVerificationCallback,
+        trackingMetadata: RewardedAdTrackingMetadata? = null,
     ) {
         rewardVerificationPollLauncher.launch(
-            poll = { awaitPollRewardVerification(clientTransactionId) },
+            poll = { awaitPollRewardVerification(clientTransactionId, trackingMetadata) },
             onCompleted = { callback.onCompleted(it) },
         )
     }
@@ -850,9 +862,31 @@ public class Purchases internal constructor(
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
     internal suspend fun pollRewardVerification(
         clientTransactionId: String,
+        trackingMetadata: RewardedAdTrackingMetadata?,
+        captureMethod: AdCaptureMethod,
         poll: suspend (String) -> Outcome,
     ): RewardVerificationResult {
-        val result = poll(clientTransactionId).toResult()
+        if (trackingMetadata != null) {
+            adTracker.trackAdRewardEarnedUnverified(
+                data = AdRewardEarnedUnverifiedData(
+                    networkName = trackingMetadata.networkName,
+                    mediatorName = trackingMetadata.mediatorName,
+                    adFormat = trackingMetadata.adFormat,
+                    placement = trackingMetadata.placement,
+                    adUnitId = trackingMetadata.adUnitId,
+                    impressionId = trackingMetadata.impressionId,
+                    rewardVerificationEnabled = true,
+                ),
+                captureMethod = captureMethod,
+            )
+        }
+
+        val outcome = poll(clientTransactionId)
+        if (trackingMetadata != null) {
+            trackRewardOutcome(trackingMetadata, outcome, captureMethod)
+        }
+
+        val result = outcome.toResult()
         val rewards = result.verifiedReward?.let { listOf(it) + result.moreRewards } ?: return result
 
         if (rewards.any { it is VerifiedReward.VirtualCurrency }) {
@@ -863,6 +897,72 @@ public class Purchases internal constructor(
         val entitlementReflected = rewards.none { it is VerifiedReward.Entitlement } ||
             refreshCustomerInfoAfterEntitlementGrant(clientTransactionId)
         return if (entitlementReflected) result else RewardVerificationResult.failed
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+    private fun trackRewardOutcome(
+        trackingMetadata: RewardedAdTrackingMetadata,
+        outcome: Outcome,
+        captureMethod: AdCaptureMethod,
+    ) {
+        when (outcome) {
+            is Outcome.Verified -> {
+                adTracker.trackAdRewardVerified(
+                    data = AdRewardVerifiedData(
+                        networkName = trackingMetadata.networkName,
+                        mediatorName = trackingMetadata.mediatorName,
+                        adFormat = trackingMetadata.adFormat,
+                        placement = trackingMetadata.placement,
+                        adUnitId = trackingMetadata.adUnitId,
+                        impressionId = trackingMetadata.impressionId,
+                    ),
+                    captureMethod = captureMethod,
+                )
+                // A grant is never reported as NoReward: that value means "verified, nothing configured",
+                // and the absence of a granted event already conveys that.
+                (listOf(outcome.reward) + outcome.moreRewards)
+                    .filterNot { it is VerifiedReward.NoReward }
+                    .forEach { reward ->
+                        adTracker.trackAdRewardGranted(
+                            data = AdRewardGrantedData(
+                                networkName = trackingMetadata.networkName,
+                                mediatorName = trackingMetadata.mediatorName,
+                                adFormat = trackingMetadata.adFormat,
+                                placement = trackingMetadata.placement,
+                                adUnitId = trackingMetadata.adUnitId,
+                                impressionId = trackingMetadata.impressionId,
+                                reward = reward.toCoreVerifiedReward(),
+                            ),
+                            captureMethod = captureMethod,
+                        )
+                    }
+            }
+            is Outcome.Failed -> {
+                adTracker.trackAdRewardFailedToVerify(
+                    data = AdRewardFailedToVerifyData(
+                        networkName = trackingMetadata.networkName,
+                        mediatorName = trackingMetadata.mediatorName,
+                        adFormat = trackingMetadata.adFormat,
+                        placement = trackingMetadata.placement,
+                        adUnitId = trackingMetadata.adUnitId,
+                        impressionId = trackingMetadata.impressionId,
+                        failureReason = outcome.trackingFailureReason,
+                    ),
+                    captureMethod = captureMethod,
+                )
+            }
+        }
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+    private fun VerifiedReward.toCoreVerifiedReward(): CoreVerifiedReward {
+        return when (this) {
+            is VerifiedReward.VirtualCurrency -> CoreVerifiedReward.VirtualCurrency(code = code, amount = amount)
+            is VerifiedReward.Entitlement ->
+                CoreVerifiedReward.Entitlement(identifier = identifier, expiresAt = expiresAt)
+            VerifiedReward.NoReward -> CoreVerifiedReward.NoReward
+            else -> CoreVerifiedReward.UnsupportedReward
+        }
     }
 
     // getCustomerInfo has no built-in retry, so retry transient (network) failures (with a short delay

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -64,6 +64,7 @@ import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.utils.DefaultIsDebugBuildProvider
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
+import kotlinx.coroutines.CancellationException
 import org.json.JSONObject
 import java.net.URL
 import java.util.Locale
@@ -881,7 +882,14 @@ public class Purchases internal constructor(
             )
         }
 
-        val outcome = poll(clientTransactionId)
+        val outcome = try {
+            poll(clientTransactionId)
+        } catch (e: CancellationException) {
+            if (trackingMetadata != null) {
+                trackRewardOutcome(trackingMetadata, Outcome.Failed.Cancelled, captureMethod)
+            }
+            throw e
+        }
         if (trackingMetadata != null) {
             trackRewardOutcome(trackingMetadata, outcome, captureMethod)
         }

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Outcome.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Outcome.kt
@@ -1,11 +1,13 @@
+@file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+
 package com.revenuecat.purchases.ads.rewardverification
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ads.events.types.AdRewardFailureReason
 
 // Internal poll result. The public [RewardVerificationResult] stays binary (verified/failed); these subtypes
 // capture *why* polling ended so the poller can log an actionable reason without adding public cases.
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal sealed interface Outcome {
     class Verified(val reward: VerifiedReward, val moreRewards: List<VerifiedReward>) : Outcome
 
@@ -13,6 +15,9 @@ internal sealed interface Outcome {
         val logMessage: String
 
         val isUnexpected: Boolean
+
+        // The reward-tracking equivalent of this failure, forwarded verbatim into AdRewardFailedToVerifyData.
+        val trackingFailureReason: AdRewardFailureReason
 
         // Logs the backend-provided message verbatim, falling back to the machine-readable failure
         // reason when no message is present so the actionable signal isn't lost.
@@ -26,6 +31,8 @@ internal sealed interface Outcome {
                         ?.let { "Reward verification was rejected by AdMob server-side verification (reason: $it)." }
                     ?: "Reward verification was rejected by AdMob server-side verification."
             override val isUnexpected: Boolean get() = false
+            override val trackingFailureReason: AdRewardFailureReason
+                get() = AdRewardFailureReason.BackendError(failureReason)
         }
 
         object ExhaustedWhilePending : Failed {
@@ -35,6 +42,7 @@ internal sealed interface Outcome {
                     "the AdMob Dashboard, the SSV callback URL is misconfigured in the AdMob Dashboard, AdMob " +
                     "delayed delivering the callback, or RevenueCat failed to process the SSV webhook."
             override val isUnexpected: Boolean get() = false
+            override val trackingFailureReason: AdRewardFailureReason get() = AdRewardFailureReason.Timeout
         }
 
         object ExhaustedWhileTransientErroring : Failed {
@@ -42,6 +50,7 @@ internal sealed interface Outcome {
                 get() = "Reward verification timed out after repeated transient errors while polling — " +
                     "typically unstable device network connectivity. The reward couldn't be verified."
             override val isUnexpected: Boolean get() = false
+            override val trackingFailureReason: AdRewardFailureReason get() = AdRewardFailureReason.NetworkError
         }
 
         object UnexpectedResponse : Failed {
@@ -50,6 +59,7 @@ internal sealed interface Outcome {
                     "doesn't recognize. Update to the latest SDK version; if you're already on the latest, " +
                     "contact RevenueCat support."
             override val isUnexpected: Boolean get() = true
+            override val trackingFailureReason: AdRewardFailureReason get() = AdRewardFailureReason.Unknown
         }
 
         class TerminalError(private val error: String) : Failed {
@@ -57,11 +67,11 @@ internal sealed interface Outcome {
                 get() = "Reward verification stopped after an unrecoverable error: $error. This is " +
                     "unexpected; if it persists, contact RevenueCat support with the error above."
             override val isUnexpected: Boolean get() = true
+            override val trackingFailureReason: AdRewardFailureReason get() = AdRewardFailureReason.Unknown
         }
     }
 }
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 internal fun Outcome.toResult(): RewardVerificationResult {
     return when (this) {
         is Outcome.Verified -> RewardVerificationResult.verified(reward, moreRewards)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Outcome.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/Outcome.kt
@@ -69,6 +69,16 @@ internal sealed interface Outcome {
             override val isUnexpected: Boolean get() = true
             override val trackingFailureReason: AdRewardFailureReason get() = AdRewardFailureReason.Unknown
         }
+
+        // The poll was cancelled before reaching a terminal status — e.g. the ad was dismissed or the SDK
+        // closed while polling was in flight. Never returned by Poller itself (cancellation propagates as a
+        // thrown CancellationException); callers that catch it synthesize this Outcome to track the attempt.
+        object Cancelled : Failed {
+            override val logMessage: String
+                get() = "Reward verification was cancelled before it could complete."
+            override val isUnexpected: Boolean get() = false
+            override val trackingFailureReason: AdRewardFailureReason get() = AdRewardFailureReason.Cancelled
+        }
     }
 }
 

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardedAdTrackingMetadata.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/ads/rewardverification/RewardedAdTrackingMetadata.kt
@@ -1,0 +1,29 @@
+package com.revenuecat.purchases.ads.rewardverification
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdMediatorName
+import dev.drewhamilton.poko.Poko
+
+/**
+ * Identifies the ad a reward-verification poll belongs to, so [Purchases.pollRewardVerification] can track
+ * reward events for it. Omit this parameter (or pass null) to poll without tracking.
+ *
+ * @property networkName The name of the ad network, or null if unknown.
+ * @property mediatorName The name of the ad mediator. See [AdMediatorName] for common values.
+ * @property adFormat The format of the ad. See [AdFormat] for common values.
+ * @property placement The placement of the ad, if available.
+ * @property adUnitId The ad unit ID.
+ * @property impressionId The impression ID.
+ */
+@ExperimentalPreviewRevenueCatPurchasesAPI
+@Poko
+public class RewardedAdTrackingMetadata(
+    public val networkName: String?,
+    public val mediatorName: AdMediatorName,
+    public val adFormat: AdFormat,
+    public val placement: String?,
+    public val adUnitId: String,
+    public val impressionId: String,
+)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -1,8 +1,10 @@
 package com.revenuecat.purchases
 
 import com.revenuecat.purchases.CacheFetchPolicy.CACHED_OR_FETCHED
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.rewardverification.Poller
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.safeResumeWithException
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
@@ -42,14 +44,33 @@ public suspend fun Purchases.awaitCustomerInfo(
  *
  * Coroutine friendly version of [Purchases.pollRewardVerification].
  *
+ * Pass [trackingMetadata] to track reward-verification events for the ad it belongs to; omit it to
+ * poll without tracking.
+ *
  * @return The [RewardVerificationResult] (verified reward or a failed result).
  */
 @JvmSynthetic
 @ExperimentalPreviewRevenueCatPurchasesAPI
+@OptIn(InternalRevenueCatAPI::class)
 public suspend fun Purchases.awaitPollRewardVerification(
     clientTransactionId: String,
+    trackingMetadata: RewardedAdTrackingMetadata? = null,
 ): RewardVerificationResult {
-    return pollRewardVerification(clientTransactionId) { Poller.poll(it) }
+    return awaitPollRewardVerification(clientTransactionId, trackingMetadata, AdCaptureMethod.MANUAL)
+}
+
+/**
+ * [awaitPollRewardVerification] overload that stamps the capture method that initiated the poll.
+ */
+@JvmSynthetic
+@InternalRevenueCatAPI
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+public suspend fun Purchases.awaitPollRewardVerification(
+    clientTransactionId: String,
+    trackingMetadata: RewardedAdTrackingMetadata?,
+    captureMethod: AdCaptureMethod,
+): RewardVerificationResult {
+    return pollRewardVerification(clientTransactionId, trackingMetadata, captureMethod) { Poller.poll(it) }
 }
 
 /**

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -57,10 +57,15 @@ import io.mockk.verify
 import io.mockk.verifyAll
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
+import com.revenuecat.purchases.ads.events.AdEvent
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.rewardverification.Outcome
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult as PollResult
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward as PollReward
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationPollLauncher
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -1990,6 +1995,8 @@ internal class PurchasesTest : BasePurchasesTest() {
         val result = runBlocking {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
+                trackingMetadata = null,
+                captureMethod = AdCaptureMethod.MANUAL,
                 poll = { Outcome.Verified(PollReward.VirtualCurrency(code = "gems", amount = 5), moreRewards = emptyList()) },
             )
         }
@@ -2004,10 +2011,14 @@ internal class PurchasesTest : BasePurchasesTest() {
         runBlocking {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
+                trackingMetadata = null,
+                captureMethod = AdCaptureMethod.MANUAL,
                 poll = { Outcome.Verified(PollReward.NoReward, moreRewards = emptyList()) },
             )
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_2",
+                trackingMetadata = null,
+                captureMethod = AdCaptureMethod.MANUAL,
                 poll = { Outcome.Failed.ExhaustedWhilePending },
             )
         }
@@ -2068,6 +2079,8 @@ internal class PurchasesTest : BasePurchasesTest() {
         runBlocking {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
+                trackingMetadata = null,
+                captureMethod = AdCaptureMethod.MANUAL,
                 poll = {
                     Outcome.Verified(
                         reward = PollReward.NoReward,
@@ -2088,6 +2101,8 @@ internal class PurchasesTest : BasePurchasesTest() {
         val result = runBlocking {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
+                trackingMetadata = null,
+                captureMethod = AdCaptureMethod.MANUAL,
                 poll = {
                     Outcome.Verified(
                         reward = PollReward.Entitlement(identifier = "pro", expiresAt = Date(1_800_000_000_000L)),
@@ -2120,6 +2135,8 @@ internal class PurchasesTest : BasePurchasesTest() {
         val result = runBlocking {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
+                trackingMetadata = null,
+                captureMethod = AdCaptureMethod.MANUAL,
                 poll = {
                     Outcome.Verified(
                         reward = PollReward.Entitlement(identifier = "pro", expiresAt = Date(1_800_000_000_000L)),
@@ -2130,6 +2147,102 @@ internal class PurchasesTest : BasePurchasesTest() {
         }
 
         assertThat(result.failed).isTrue
+    }
+
+    private val testTrackingMetadata = RewardedAdTrackingMetadata(
+        networkName = "Google AdMob",
+        mediatorName = AdMediatorName.AD_MOB,
+        adFormat = AdFormat.REWARDED,
+        placement = "rewarded_video",
+        adUnitId = "ad-unit-999",
+        impressionId = "impression-789",
+    )
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+    private fun pollWithTracking(poll: suspend (String) -> Outcome): List<AdEvent> {
+        val trackedEvents = mutableListOf<AdEvent>()
+        every { mockAdEventsManager.track(any()) } answers { trackedEvents.add(firstArg<AdEvent>()) }
+        runBlocking {
+            purchases.pollRewardVerification(
+                clientTransactionId = "ct_1",
+                trackingMetadata = testTrackingMetadata,
+                captureMethod = AdCaptureMethod.MANUAL,
+                poll = poll,
+            )
+        }
+        return trackedEvents
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    @Test
+    fun `pollRewardVerification with tracking metadata fires earned then verified when nothing is granted`() {
+        val tracked = pollWithTracking { Outcome.Verified(PollReward.NoReward, moreRewards = emptyList()) }
+
+        assertThat(tracked).hasSize(2)
+        assertThat(tracked[0]).isInstanceOf(AdEvent.RewardEarnedUnverified::class.java)
+        assertThat(tracked[1]).isInstanceOf(AdEvent.RewardVerified::class.java)
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    @Test
+    fun `pollRewardVerification with tracking metadata fires one granted event for a single reward`() {
+        val tracked = pollWithTracking {
+            Outcome.Verified(PollReward.VirtualCurrency(code = "gems", amount = 5), moreRewards = emptyList())
+        }
+
+        assertThat(tracked).hasSize(3)
+        assertThat(tracked[0]).isInstanceOf(AdEvent.RewardEarnedUnverified::class.java)
+        assertThat(tracked[1]).isInstanceOf(AdEvent.RewardVerified::class.java)
+        val granted = tracked[2] as AdEvent.RewardGranted
+        assertThat(granted.reward).isEqualTo(VerifiedReward.VirtualCurrency(code = "gems", amount = 5))
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    @Test
+    fun `pollRewardVerification with tracking metadata fires one granted event per reward on multi-grant`() {
+        val tracked = pollWithTracking {
+            Outcome.Verified(
+                reward = PollReward.VirtualCurrency(code = "gems", amount = 5),
+                moreRewards = listOf(PollReward.Entitlement(identifier = "pro", expiresAt = Date(1_800_000_000_000L))),
+            )
+        }
+
+        assertThat(tracked).hasSize(4)
+        val grantedRewards = tracked.filterIsInstance<AdEvent.RewardGranted>().map { it.reward }
+        assertThat(grantedRewards).containsExactly(
+            VerifiedReward.VirtualCurrency(code = "gems", amount = 5),
+            VerifiedReward.Entitlement(identifier = "pro", expiresAt = Date(1_800_000_000_000L)),
+        )
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    @Test
+    fun `pollRewardVerification with tracking metadata fires failed to verify with the mapped reason`() {
+        val tracked = pollWithTracking { Outcome.Failed.BackendRejected("rejected", "no_reward_rule") }
+
+        assertThat(tracked).hasSize(2)
+        assertThat(tracked[0]).isInstanceOf(AdEvent.RewardEarnedUnverified::class.java)
+        val failed = tracked[1] as AdEvent.RewardFailedToVerify
+        assertThat(failed.failureReason.value).isEqualTo("no_reward_rule")
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    @Test
+    fun `pollRewardVerification tracks nothing when trackingMetadata is absent`() {
+        every { mockAdEventsManager.track(any()) } just Runs
+
+        runBlocking {
+            purchases.pollRewardVerification(
+                clientTransactionId = "ct_1",
+                trackingMetadata = null,
+                captureMethod = AdCaptureMethod.MANUAL,
+                poll = { Outcome.Verified(PollReward.VirtualCurrency(code = "gems", amount = 5), moreRewards = emptyList()) },
+            )
+        }
+
+        verify(exactly = 0) { mockAdEventsManager.track(any<AdEvent.RewardEarnedUnverified>()) }
+        verify(exactly = 0) { mockAdEventsManager.track(any<AdEvent.RewardVerified>()) }
+        verify(exactly = 0) { mockAdEventsManager.track(any<AdEvent.RewardGranted>()) }
     }
 
     @OptIn(InternalRevenueCatAPI::class)

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -2162,6 +2162,7 @@ internal class PurchasesTest : BasePurchasesTest() {
     private fun pollWithTracking(poll: suspend (String) -> Outcome): List<AdEvent> {
         val trackedEvents = mutableListOf<AdEvent>()
         every { mockAdEventsManager.track(any()) } answers { trackedEvents.add(firstArg<AdEvent>()) }
+        every { mockVirtualCurrencyManager.invalidateVirtualCurrenciesCache() } returns Unit
         runBlocking {
             purchases.pollRewardVerification(
                 clientTransactionId = "ct_1",
@@ -2230,6 +2231,7 @@ internal class PurchasesTest : BasePurchasesTest() {
     @Test
     fun `pollRewardVerification tracks nothing when trackingMetadata is absent`() {
         every { mockAdEventsManager.track(any()) } just Runs
+        every { mockVirtualCurrencyManager.invalidateVirtualCurrenciesCache() } returns Unit
 
         runBlocking {
             purchases.pollRewardVerification(

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -57,15 +57,18 @@ import io.mockk.verify
 import io.mockk.verifyAll
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdEvent
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdMediatorName
+import com.revenuecat.purchases.ads.events.types.AdRewardFailureReason
 import com.revenuecat.purchases.ads.rewardverification.Outcome
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult as PollResult
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward as PollReward
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationPollLauncher
 import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -2225,6 +2228,29 @@ internal class PurchasesTest : BasePurchasesTest() {
         assertThat(tracked[0]).isInstanceOf(AdEvent.RewardEarnedUnverified::class.java)
         val failed = tracked[1] as AdEvent.RewardFailedToVerify
         assertThat(failed.failureReason.value).isEqualTo("no_reward_rule")
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+    @Test
+    fun `pollRewardVerification tracks failed to verify with Cancelled reason when poll is cancelled`() {
+        val tracked = mutableListOf<AdEvent>()
+        every { mockAdEventsManager.track(any()) } answers { tracked.add(firstArg<AdEvent>()) }
+
+        assertThatThrownBy {
+            runBlocking {
+                purchases.pollRewardVerification(
+                    clientTransactionId = "ct_1",
+                    trackingMetadata = testTrackingMetadata,
+                    captureMethod = AdCaptureMethod.MANUAL,
+                    poll = { throw CancellationException() },
+                )
+            }
+        }.isInstanceOf(CancellationException::class.java)
+
+        assertThat(tracked).hasSize(2)
+        assertThat(tracked[0]).isInstanceOf(AdEvent.RewardEarnedUnverified::class.java)
+        val failed = tracked[1] as AdEvent.RewardFailedToVerify
+        assertThat(failed.failureReason).isEqualTo(AdRewardFailureReason.Cancelled)
     }
 
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Description

This change introduces a new `RewardedAdTrackingMetadata` class as a way to pass ad information to the reward polling function - and so to make it possible to _actually_ track the lifecycle of rewarded ads.

The metadata is optional and it is driving if the tracking is happening or not (someone can simply omit it like today to not have tracking).

<!-- Describe your changes in detail -->

<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the reward-verification poll path and ties it to ad analytics, but optional metadata and default-null preserve existing callers; mis-typed metadata could skew event attribution.
> 
> **Overview**
> **Reward polling can now emit ad lifecycle analytics** when callers pass optional **`RewardedAdTrackingMetadata`** (network, mediator, format, placement, ad unit, impression id). **`pollRewardVerification`** and **`awaitPollRewardVerification`** accept this metadata; omitting it keeps today’s behavior with **no reward-tracking events**.
> 
> During a tracked poll, **`Purchases`** fires **`AdTracker`** events: earned-unverified at start, then verified / per-grant granted / failed-to-verify based on the poll **`Outcome`**. **`NoReward`** does not produce a granted event. Poll **cancellation** still propagates **`CancellationException`** but records a failed-to-verify with a **Cancelled** reason when metadata was provided.
> 
> Internal **`Outcome.Failed`** cases now map to **`AdRewardFailureReason`** for analytics, including a new **`Cancelled`** failure type. Public API surface and AdMob integration tests were updated for the expanded **`pollRewardVerification`** signature (**`AdCaptureMethod.MANUAL`** on manual polls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5559b3b96dd41122c2527b2e67c85b8f59484693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->