### PR TITLE
feat(ads): ad reward tracking with admob adapter

### DIFF
--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManager.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManager.kt
@@ -10,8 +10,10 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.Logger
 import com.revenuecat.purchases.admob.threading.runOnMainIfPresent
+import com.revenuecat.purchases.admob.tracking.TrackingFullScreenContentCallback
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 internal object RewardVerificationManager {
@@ -39,6 +41,7 @@ internal object RewardVerificationManager {
         rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
     ) = handleRewardEarnedInternal(
         ad.responseInfo?.responseId,
+        ad.rewardTrackingMetadata(),
         rewardVerificationStarted,
         rewardVerificationCompleted,
     )
@@ -49,9 +52,18 @@ internal object RewardVerificationManager {
         rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
     ) = handleRewardEarnedInternal(
         ad.responseInfo?.responseId,
+        ad.rewardTrackingMetadata(),
         rewardVerificationStarted,
         rewardVerificationCompleted,
     )
+
+    // Null when the ad wasn't loaded via loadAndTrackRewardedAd/loadAndTrackRewardedInterstitialAd (its
+    // fullScreenContentCallback was never wrapped, so there is nothing to track).
+    private fun RewardedAd.rewardTrackingMetadata(): RewardedAdTrackingMetadata? =
+        (fullScreenContentCallback as? TrackingFullScreenContentCallback)?.rewardTrackingMetadata()
+
+    private fun RewardedInterstitialAd.rewardTrackingMetadata(): RewardedAdTrackingMetadata? =
+        (fullScreenContentCallback as? TrackingFullScreenContentCallback)?.rewardTrackingMetadata()
 
     private fun installInternal(adResponseId: String?, attachOptions: (ServerSideVerificationOptions) -> Unit) {
         val runtime = runtime
@@ -89,6 +101,7 @@ internal object RewardVerificationManager {
 
     private fun handleRewardEarnedInternal(
         adResponseId: String?,
+        trackingMetadata: RewardedAdTrackingMetadata?,
         rewardVerificationStarted: (() -> Unit)?,
         rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
     ) {
@@ -100,6 +113,7 @@ internal object RewardVerificationManager {
         }
         runtime.handleRewardEarned(
             adResponseId = adResponseId,
+            trackingMetadata = trackingMetadata,
             rewardVerificationStarted = rewardVerificationStarted,
             rewardVerificationCompleted = rewardVerificationCompleted,
         )

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntime.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntime.kt
@@ -3,10 +3,13 @@ package com.revenuecat.purchases.admob.rewardverification
 import android.os.Handler
 import android.os.Looper
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.Logger
 import com.revenuecat.purchases.admob.threading.runOnMainIfPresent
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 import com.revenuecat.purchases.awaitPollRewardVerification
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -20,15 +23,20 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Holds the per-configuration reward verification state. A fresh instance is created when [Purchases] is
  * configured and discarded with [close] when it closes, so no verification state outlives a configuration.
  */
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 internal class RewardVerificationRuntime(
     private val mainHandler: Handler = Handler(Looper.getMainLooper()),
     createVerificationScope: () -> CoroutineScope = {
         CoroutineScope(SupervisorJob() + Dispatchers.IO)
     },
-    private val poll: suspend (String) -> RewardVerificationResult = { clientTransactionId ->
-        Purchases.sharedInstance.awaitPollRewardVerification(clientTransactionId)
-    },
+    private val poll: suspend (String, RewardedAdTrackingMetadata?) -> RewardVerificationResult =
+        { clientTransactionId, trackingMetadata ->
+            Purchases.sharedInstance.awaitPollRewardVerification(
+                clientTransactionId,
+                trackingMetadata,
+                AdCaptureMethod.ADAPTER,
+            )
+        },
 ) {
     private val clientTransactionIdByAdResponseId = mutableMapOf<String, String>()
     private val verificationScope: CoroutineScope = createVerificationScope()
@@ -40,6 +48,7 @@ internal class RewardVerificationRuntime(
 
     fun handleRewardEarned(
         adResponseId: String?,
+        trackingMetadata: RewardedAdTrackingMetadata?,
         rewardVerificationStarted: (() -> Unit)?,
         rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
     ) {
@@ -63,7 +72,7 @@ internal class RewardVerificationRuntime(
         notifyStarted(rewardVerificationStarted)
 
         val verificationTask = verificationScope.launch {
-            val result = poll(clientTransactionId)
+            val result = poll(clientTransactionId, trackingMetadata)
             deliverOnce(result)
         }
 

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/tracking/TrackingFullScreenContentCallback.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/tracking/TrackingFullScreenContentCallback.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.events.types.AdOpenedData
 import com.revenuecat.purchases.ads.events.types.AdRevenueData
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 
 /**
  * A [FullScreenContentCallback] wrapper that injects RevenueCat ad-event tracking
@@ -75,6 +76,22 @@ internal class TrackingFullScreenContentCallback(
 
     override fun onAdImpression() {
         delegate?.onAdImpression()
+    }
+
+    /**
+     * Reward-verification tracking metadata for the ad this callback is attached to, reading
+     * [placement] at call time so a show-time override is reflected.
+     */
+    fun rewardTrackingMetadata(): RewardedAdTrackingMetadata {
+        val responseInfo = responseInfoProvider()
+        return RewardedAdTrackingMetadata(
+            networkName = responseInfo.mediationAdapterClassName,
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = adFormat,
+            placement = placement,
+            adUnitId = adUnitId,
+            impressionId = responseInfo.responseId.orEmpty(),
+        )
     }
 }
 

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
@@ -16,7 +16,10 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesServiceDispatcher
 import com.revenuecat.purchases.admob.enableRewardVerification
 import com.revenuecat.purchases.admob.show as showWithRewardVerification
+import com.revenuecat.purchases.admob.tracking.TrackingFullScreenContentCallback
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.rewardverification.Outcome
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
@@ -32,6 +35,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -71,11 +75,13 @@ internal class RewardVerificationManagerTest {
         val mockPurchases = mockk<Purchases>(relaxed = true)
         every { mockPurchases.generateRewardVerificationToken("ad-response-id") } returns token
         val polledClientTransactionId = slot<String>()
+        val polledTrackingMetadata = slot<RewardedAdTrackingMetadata?>()
+        val polledCaptureMethod = slot<AdCaptureMethod>()
         coEvery {
             mockPurchases.pollRewardVerification(
                 capture(polledClientTransactionId),
-                isNull<RewardedAdTrackingMetadata>(),
-                eq(AdCaptureMethod.MANUAL),
+                captureNullable(polledTrackingMetadata),
+                capture(polledCaptureMethod),
                 any<suspend (String) -> Outcome>(),
             )
         } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 7))
@@ -121,6 +127,10 @@ internal class RewardVerificationManagerTest {
         )
         // The id polled from the backend must match the token's client transaction id so correlation round-trips.
         assertEquals("client-transaction-id", polledClientTransactionId.captured)
+        // The ad was never loaded via loadAndTrackRewardedAd, so it has no TrackingFullScreenContentCallback
+        // to read metadata from.
+        assertNull(polledTrackingMetadata.captured)
+        assertEquals(AdCaptureMethod.ADAPTER, polledCaptureMethod.captured)
     }
 
     @Test
@@ -133,11 +143,13 @@ internal class RewardVerificationManagerTest {
         val mockPurchases = mockk<Purchases>(relaxed = true)
         every { mockPurchases.generateRewardVerificationToken("interstitial-response-id") } returns token
         val polledClientTransactionId = slot<String>()
+        val polledTrackingMetadata = slot<RewardedAdTrackingMetadata?>()
+        val polledCaptureMethod = slot<AdCaptureMethod>()
         coEvery {
             mockPurchases.pollRewardVerification(
                 capture(polledClientTransactionId),
-                isNull<RewardedAdTrackingMetadata>(),
-                eq(AdCaptureMethod.MANUAL),
+                captureNullable(polledTrackingMetadata),
+                capture(polledCaptureMethod),
                 any<suspend (String) -> Outcome>(),
             )
         } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 3))
@@ -176,6 +188,63 @@ internal class RewardVerificationManagerTest {
         assertNotNull(completedResult)
         assertFalse(completedResult!!.failed)
         assertEquals("client-transaction-id", polledClientTransactionId.captured)
+        assertNull(polledTrackingMetadata.captured)
+        assertEquals(AdCaptureMethod.ADAPTER, polledCaptureMethod.captured)
+    }
+
+    @Test
+    fun `tracked ad forwards its reward tracking metadata to the poll, reflecting a show-time placement override`() {
+        val token = RewardVerificationToken(
+            customData = "custom-data",
+            clientTransactionId = "client-transaction-id",
+            appUserID = "app-user-id",
+        )
+        val mockPurchases = mockk<Purchases>(relaxed = true)
+        every { mockPurchases.generateRewardVerificationToken("ad-response-id") } returns token
+        val polledTrackingMetadata = slot<RewardedAdTrackingMetadata?>()
+        coEvery {
+            mockPurchases.pollRewardVerification(
+                any(),
+                captureNullable(polledTrackingMetadata),
+                any(),
+                any<suspend (String) -> Outcome>(),
+            )
+        } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 7))
+
+        Purchases.backingFieldSharedInstance = mockPurchases
+        originalServiceDispatcher.initialize(mockPurchases)
+
+        val ad = mockk<RewardedAd>(relaxed = true)
+        every { ad.responseInfo.responseId } returns "ad-response-id"
+        every { ad.responseInfo.mediationAdapterClassName } returns "com.example.SomeAdapter"
+        val trackingCallback = TrackingFullScreenContentCallback(
+            delegate = null,
+            adFormat = AdFormat.REWARDED,
+            placement = "load-time-placement",
+            adUnitId = "ad-unit-id",
+            responseInfoProvider = { ad.responseInfo },
+        )
+        every { ad.fullScreenContentCallback } returns trackingCallback
+        val activity = mockk<Activity>(relaxed = true)
+        val rewardListenerSlot = slot<OnUserEarnedRewardListener>()
+        every { ad.show(activity, capture(rewardListenerSlot)) } answers {}
+
+        ad.enableRewardVerification()
+        trackingCallback.placement = "show-time-placement"
+
+        ad.showWithRewardVerification(activity = activity) { }
+        rewardListenerSlot.captured.onUserEarnedReward(mockk<RewardItem>(relaxed = true))
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val metadata = polledTrackingMetadata.captured
+        assertNotNull(metadata)
+        assertEquals("com.example.SomeAdapter", metadata!!.networkName)
+        assertEquals(AdMediatorName.AD_MOB, metadata.mediatorName)
+        assertEquals(AdFormat.REWARDED, metadata.adFormat)
+        assertEquals("ad-unit-id", metadata.adUnitId)
+        assertEquals("ad-response-id", metadata.impressionId)
+        // The override applied after enableRewardVerification() (but before show) must win.
+        assertEquals("show-time-placement", metadata.placement)
     }
 
     @Test

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
@@ -232,10 +232,16 @@ internal class RewardVerificationManagerTest {
         ad.enableRewardVerification()
         trackingCallback.placement = "show-time-placement"
 
-        ad.showWithRewardVerification(activity = activity) { }
+        val completed = CountDownLatch(1)
+        ad.showWithRewardVerification(activity = activity) { completed.countDown() }
         rewardListenerSlot.captured.onUserEarnedReward(mockk<RewardItem>(relaxed = true))
-        shadowOf(Looper.getMainLooper()).idle()
 
+        val delivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(delivered)
         val metadata = polledTrackingMetadata.captured
         assertNotNull(metadata)
         assertEquals("com.example.SomeAdapter", metadata!!.networkName)

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntimeTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationRuntimeTest.kt
@@ -4,7 +4,10 @@ import android.os.Handler
 import android.os.Looper
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,6 +18,7 @@ import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -35,7 +39,7 @@ internal class RewardVerificationRuntimeTest {
             createVerificationScope = {
                 CoroutineScope(SupervisorJob() + Dispatchers.Default)
             },
-            poll = {
+            poll = { _, _ ->
                 pollStarted.countDown()
                 awaitCancellation()
             },
@@ -49,6 +53,7 @@ internal class RewardVerificationRuntimeTest {
 
         runtime.handleRewardEarned(
             adResponseId = adResponseId,
+            trackingMetadata = null,
             rewardVerificationStarted = { started = true },
             rewardVerificationCompleted = {
                 completedResult = it
@@ -78,7 +83,7 @@ internal class RewardVerificationRuntimeTest {
             createVerificationScope = {
                 CoroutineScope(SupervisorJob() + Dispatchers.Default)
             },
-            poll = { RewardVerificationResult.verified(verifiedReward) },
+            poll = { _, _ -> RewardVerificationResult.verified(verifiedReward) },
         )
         val adResponseId = "ad-response-id"
         var startedThread: Thread? = null
@@ -90,6 +95,7 @@ internal class RewardVerificationRuntimeTest {
 
         runtime.handleRewardEarned(
             adResponseId = adResponseId,
+            trackingMetadata = null,
             rewardVerificationStarted = { startedThread = Thread.currentThread() },
             rewardVerificationCompleted = {
                 completedThread = Thread.currentThread()
@@ -117,7 +123,7 @@ internal class RewardVerificationRuntimeTest {
             createVerificationScope = {
                 CoroutineScope(SupervisorJob() + Dispatchers.Default)
             },
-            poll = { error("poll should not run when no client transaction id is registered") },
+            poll = { _, _ -> error("poll should not run when no client transaction id is registered") },
         )
         val adResponseId = "ad-response-id"
         var startedCount = 0
@@ -128,6 +134,7 @@ internal class RewardVerificationRuntimeTest {
 
         runtime.handleRewardEarned(
             adResponseId = adResponseId,
+            trackingMetadata = null,
             rewardVerificationStarted = { startedCount++ },
             rewardVerificationCompleted = {
                 completedResult = it
@@ -143,5 +150,86 @@ internal class RewardVerificationRuntimeTest {
         assertEquals(0, startedCount)
         assertNotNull(completedResult)
         assertTrue(completedResult!!.failed)
+    }
+
+    @Test
+    fun `handleRewardEarned forwards tracking metadata to poll`() {
+        val trackingMetadata = RewardedAdTrackingMetadata(
+            networkName = "Google AdMob",
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = AdFormat.REWARDED,
+            placement = "rewarded_video",
+            adUnitId = "ad-unit-999",
+            impressionId = "impression-789",
+        )
+        var receivedTrackingMetadata: RewardedAdTrackingMetadata? = null
+        val runtime = RewardVerificationRuntime(
+            mainHandler = Handler(Looper.getMainLooper()),
+            createVerificationScope = {
+                CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            },
+            poll = { _, metadata ->
+                receivedTrackingMetadata = metadata
+                RewardVerificationResult.failed
+            },
+        )
+        val adResponseId = "ad-response-id"
+        val completed = CountDownLatch(1)
+
+        runtime.setClientTransactionId(adResponseId, "client-transaction-id")
+
+        runtime.handleRewardEarned(
+            adResponseId = adResponseId,
+            trackingMetadata = trackingMetadata,
+            rewardVerificationStarted = null,
+            rewardVerificationCompleted = { completed.countDown() },
+        )
+        val completionDelivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(completionDelivered)
+        assertSame(trackingMetadata, receivedTrackingMetadata)
+    }
+
+    @Test
+    fun `handleRewardEarned forwards null tracking metadata when the ad was not tracked`() {
+        var receivedTrackingMetadata: RewardedAdTrackingMetadata? = RewardedAdTrackingMetadata(
+            networkName = null,
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = AdFormat.REWARDED,
+            placement = null,
+            adUnitId = "sentinel",
+            impressionId = "sentinel",
+        )
+        val runtime = RewardVerificationRuntime(
+            mainHandler = Handler(Looper.getMainLooper()),
+            createVerificationScope = {
+                CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            },
+            poll = { _, metadata ->
+                receivedTrackingMetadata = metadata
+                RewardVerificationResult.failed
+            },
+        )
+        val adResponseId = "ad-response-id"
+        val completed = CountDownLatch(1)
+
+        runtime.setClientTransactionId(adResponseId, "client-transaction-id")
+
+        runtime.handleRewardEarned(
+            adResponseId = adResponseId,
+            trackingMetadata = null,
+            rewardVerificationStarted = null,
+            rewardVerificationCompleted = { completed.countDown() },
+        )
+        val completionDelivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(completionDelivered)
+        assertNull(receivedTrackingMetadata)
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Description

This change is the admob adapter wiring for ad reward tracking. AdMob adapter automatically manages polling of the result and so we wire up the tracking metadata automatically here.

<!-- Describe your changes in detail -->

<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches reward verification and ad event correlation paths; behavior change for poll parameters (metadata + ADAPTER) but scoped to AdMob adapter wiring with test coverage.
> 
> **Overview**
> When a rewarded ad earns a reward through the AdMob adapter’s verification flow, **reward verification polling** now includes **ad tracking metadata** and marks capture as **adapter-driven** (`AdCaptureMethod.ADAPTER`).
> 
> For ads loaded via `loadAndTrackRewardedAd` / `loadAndTrackRewardedInterstitialAd`, metadata is read from the wrapped `TrackingFullScreenContentCallback` (network, mediator, format, unit id, impression id, and **placement at reward time**). Untracked ads still poll with **null** metadata.
> 
> `TrackingFullScreenContentCallback` adds `rewardTrackingMetadata()` so placement overrides applied before show are reflected in verification tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9cdd404221bb58f083f9b39776bb35ce96cee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->