### PR TITLE
refactor(checkpoints): Checkpoints core engine - SDK-4423

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowExecutor.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowExecutor.kt
@@ -21,5 +21,5 @@ internal interface CheckpointWorkflowExecutor {
 
 /** Single case while workflows are always UI; non-UI executions will add cases (e.g. returning an offering). */
 internal sealed class CheckpointWorkflowOutcome {
-    data class PaywallFinished(val paywallResult: CheckpointPaywallResult) : CheckpointWorkflowOutcome()
+    data class PaywallFinished(val paywallOutcome: CheckpointPaywallOutcome) : CheckpointWorkflowOutcome()
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowExecutor.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowExecutor.kt
@@ -1,0 +1,25 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.checkpoints
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesException
+
+/**
+ * Runs the workflow resolved for a checkpoint. UI presentation ([UiCheckpointWorkflowExecutor]) is one execution
+ * strategy; workflows made only of non-UI steps will be run by a headless executor behind this same seam.
+ */
+internal interface CheckpointWorkflowExecutor {
+
+    /**
+     * Runs the workflow in [presentation], suspending until it reaches its terminal state.
+     *
+     * @throws PurchasesException when the workflow cannot be run.
+     */
+    suspend fun execute(presentation: CheckpointWorkflowPresentation): CheckpointWorkflowOutcome
+}
+
+/** Single case while workflows are always UI; non-UI executions will add cases (e.g. returning an offering). */
+internal sealed class CheckpointWorkflowOutcome {
+    data class PaywallFinished(val paywallResult: CheckpointPaywallResult) : CheckpointWorkflowOutcome()
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolver.kt
@@ -1,0 +1,21 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.checkpoints
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesError
+
+/**
+ * Resolves a checkpoint to the workflow that should run for it, or to the reason none should. The production
+ * implementation will read a checkpoints topic from the config endpoint; the PoC stands it in with
+ * [RandomWorkflowCheckpointResolver].
+ */
+internal interface CheckpointWorkflowResolver {
+    suspend fun resolve(checkpoint: CheckpointInfo): CheckpointWorkflowResolution
+}
+
+internal sealed class CheckpointWorkflowResolution {
+    data class Matched(val presentation: CheckpointWorkflowPresentation) : CheckpointWorkflowResolution()
+    data class NoMatch(val reason: CheckpointResult.NoAction.Reason) : CheckpointWorkflowResolution()
+    data class Failed(val error: PurchasesError) : CheckpointWorkflowResolution()
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointsManager.kt
@@ -1,0 +1,72 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.checkpoints
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.interfaces.CheckpointCallback
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Orchestrates a checkpoint hit: fires listener events, resolves the checkpoint to a workflow through
+ * [CheckpointWorkflowResolver], and runs the resolved workflow through [CheckpointWorkflowExecutor].
+ */
+internal class CheckpointsManager(
+    private val resolver: CheckpointWorkflowResolver,
+    private val executor: CheckpointWorkflowExecutor,
+    private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
+) {
+
+    @get:Synchronized
+    @set:Synchronized
+    var checkpointListener: CheckpointListener? = null
+
+    private val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
+
+    /**
+     * Runs on the main dispatcher; listener callbacks fire on the main thread. For UI outcomes,
+     * suspends until the presented workflow finishes.
+     *
+     * @throws PurchasesException if the checkpoint workflow should run but can't.
+     */
+    suspend fun checkpoint(identifier: String, params: CheckpointParams?): CheckpointResult =
+        withContext(mainDispatcher) {
+            val checkpoint = CheckpointInfo(identifier, params ?: CheckpointParams())
+            checkpointListener?.onCheckpointHit(checkpoint)
+            val result = when (val resolution = resolver.resolve(checkpoint)) {
+                is CheckpointWorkflowResolution.Matched -> execute(resolution.presentation)
+                is CheckpointWorkflowResolution.NoMatch ->
+                    CheckpointResult.NoAction(checkpoint, resolution.reason)
+                is CheckpointWorkflowResolution.Failed -> {
+                    errorLog(resolution.error)
+                    throw PurchasesException(resolution.error)
+                }
+            }
+            checkpointListener?.onCheckpointResolved(checkpoint, result)
+            result
+        }
+
+    fun checkpoint(identifier: String, params: CheckpointParams?, callback: CheckpointCallback) {
+        scope.launch {
+            try {
+                callback.onResult(checkpoint(identifier, params))
+            } catch (e: PurchasesException) {
+                callback.onError(e.error)
+            }
+        }
+    }
+
+    private suspend fun execute(presentation: CheckpointWorkflowPresentation): CheckpointResult =
+        when (val outcome = executor.execute(presentation)) {
+            is CheckpointWorkflowOutcome.PaywallFinished -> {
+                checkpointListener?.onCheckpointPaywallFinished(presentation.checkpoint, outcome.paywallResult)
+                CheckpointResult.PaywallPresented(presentation.checkpoint, outcome.paywallResult)
+            }
+        }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointsManager.kt
@@ -5,12 +5,8 @@ package com.revenuecat.purchases.checkpoints
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.common.errorLog
-import com.revenuecat.purchases.interfaces.CheckpointCallback
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
@@ -26,8 +22,6 @@ internal class CheckpointsManager(
     @get:Synchronized
     @set:Synchronized
     var checkpointListener: CheckpointListener? = null
-
-    private val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
 
     /**
      * Runs on the main dispatcher; listener callbacks fire on the main thread. For UI outcomes,
@@ -51,16 +45,6 @@ internal class CheckpointsManager(
             checkpointListener?.onCheckpointResolved(checkpoint, result)
             result
         }
-
-    fun checkpoint(identifier: String, params: CheckpointParams?, callback: CheckpointCallback) {
-        scope.launch {
-            try {
-                callback.onResult(checkpoint(identifier, params))
-            } catch (e: PurchasesException) {
-                callback.onError(e.error)
-            }
-        }
-    }
 
     private suspend fun execute(presentation: CheckpointWorkflowPresentation): CheckpointResult =
         when (val outcome = executor.execute(presentation)) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointsManager.kt
@@ -49,8 +49,8 @@ internal class CheckpointsManager(
     private suspend fun execute(presentation: CheckpointWorkflowPresentation): CheckpointResult =
         when (val outcome = executor.execute(presentation)) {
             is CheckpointWorkflowOutcome.PaywallFinished -> {
-                checkpointListener?.onCheckpointPaywallFinished(presentation.checkpoint, outcome.paywallResult)
-                CheckpointResult.PaywallPresented(presentation.checkpoint, outcome.paywallResult)
+                checkpointListener?.onCheckpointPaywallFinished(presentation.checkpoint, outcome.paywallOutcome)
+                CheckpointResult.PaywallPresented(presentation.checkpoint, outcome.paywallOutcome)
             }
         }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointsManager.kt
@@ -42,15 +42,13 @@ internal class CheckpointsManager(
                     throw PurchasesException(resolution.error)
                 }
             }
-            checkpointListener?.onCheckpointResolved(checkpoint, result)
+            checkpointListener?.onCheckpointCompleted(checkpoint, result)
             result
         }
 
     private suspend fun execute(presentation: CheckpointWorkflowPresentation): CheckpointResult =
         when (val outcome = executor.execute(presentation)) {
-            is CheckpointWorkflowOutcome.PaywallFinished -> {
-                checkpointListener?.onCheckpointPaywallFinished(presentation.checkpoint, outcome.paywallOutcome)
+            is CheckpointWorkflowOutcome.PaywallFinished ->
                 CheckpointResult.PaywallPresented(presentation.checkpoint, outcome.paywallOutcome)
-            }
         }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
@@ -13,8 +13,9 @@ import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.common.workflows.WorkflowManager
 
 /**
- * PoC [CheckpointWorkflowResolver]: a hardcoded allowlist stands in for the future checkpoints config topic, and
- * a matched checkpoint resolves to a workflow picked at random from the workflows topic.
+ * PoC [CheckpointWorkflowResolver]: every checkpoint matches and resolves to a workflow picked at random from
+ * the workflows topic, except two hardcoded identifiers that simulate the no-match and error outcomes the
+ * future checkpoints config topic will produce.
  */
 internal class RandomWorkflowCheckpointResolver(
     private val workflowManager: WorkflowManager?,
@@ -30,8 +31,9 @@ internal class RandomWorkflowCheckpointResolver(
                     "Simulated error: checkpoint workflow not presentable.",
                 ),
             )
-            in WORKFLOW_CHECKPOINT_ALLOWLIST -> resolveRandomWorkflow(checkpoint)
-            else -> CheckpointWorkflowResolution.NoMatch(CheckpointResult.NoAction.Reason.NO_MATCH)
+            SIMULATED_NO_MATCH_CHECKPOINT_ID ->
+                CheckpointWorkflowResolution.NoMatch(CheckpointResult.NoAction.Reason.NO_MATCH)
+            else -> resolveRandomWorkflow(checkpoint)
         }
 
     @Suppress("ReturnCount")
@@ -66,7 +68,7 @@ internal class RandomWorkflowCheckpointResolver(
     }
 
     private companion object {
-        val WORKFLOW_CHECKPOINT_ALLOWLIST = setOf("test_checkpoint", "finished_onboarding")
+        const val SIMULATED_NO_MATCH_CHECKPOINT_ID = "unknown_checkpoint"
         const val SIMULATED_ERROR_CHECKPOINT_ID = "error_checkpoint"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
@@ -20,7 +20,7 @@ import com.revenuecat.purchases.common.workflows.WorkflowManager
 internal class RandomWorkflowCheckpointResolver(
     private val workflowManager: WorkflowManager?,
     private val uiConfigProvider: UiConfigProvider?,
-    private val cachedOfferingsProvider: () -> Offerings?,
+    private val getOfferings: suspend () -> Offerings,
 ) : CheckpointWorkflowResolver {
 
     override suspend fun resolve(checkpoint: CheckpointInfo): CheckpointWorkflowResolution =
@@ -52,7 +52,14 @@ internal class RandomWorkflowCheckpointResolver(
         }
         val uiConfig = uiConfigProvider.getUiConfig()
             ?: return configurationUnavailable("UI config is unavailable for workflow '$workflowId'.")
-        val offering = offeringId?.let { cachedOfferingsProvider()?.all?.get(it) }
+        val offering = offeringId?.let { id ->
+            val offerings = try {
+                getOfferings()
+            } catch (e: PurchasesException) {
+                return configurationUnavailable("Offerings could not be fetched for workflow '$workflowId': ${e.error}")
+            }
+            offerings.all[id]
+        }
         debugLog {
             "Checkpoint '${checkpoint.identifier}' resolved to random workflow '$workflowId' " +
                 "(offering: ${offering?.identifier})"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
@@ -43,8 +43,13 @@ internal class RandomWorkflowCheckpointResolver(
         if (workflowManager == null || uiConfigProvider == null) {
             return CheckpointWorkflowResolution.NoMatch(CheckpointResult.NoAction.Reason.DISABLED)
         }
-        val (workflowId, offeringId) = workflowManager.availableWorkflows().entries.randomOrNull()
-            ?: return configurationUnavailable("No workflows available for checkpoint '${checkpoint.identifier}'.")
+        // Only workflows tied to an offering are presentable for now: the presentation requires one.
+        val (workflowId, offeringId) = workflowManager.availableWorkflows().entries
+            .filter { it.value != null }
+            .randomOrNull()
+            ?: return configurationUnavailable(
+                "No presentable workflows available for checkpoint '${checkpoint.identifier}'.",
+            )
         val workflow = try {
             workflowManager.getWorkflow(workflowId)
         } catch (e: PurchasesException) {
@@ -52,20 +57,18 @@ internal class RandomWorkflowCheckpointResolver(
         }
         val uiConfig = uiConfigProvider.getUiConfig()
             ?: return configurationUnavailable("UI config is unavailable for workflow '$workflowId'.")
-        val offering = offeringId?.let { id ->
-            val offerings = try {
-                getOfferings()
-            } catch (e: PurchasesException) {
-                return configurationUnavailable("Offerings could not be fetched for workflow '$workflowId': ${e.error}")
-            }
-            offerings.all[id]
-                ?: return configurationUnavailable(
-                    "Offering '$id' referenced by workflow '$workflowId' was not found in offerings.",
-                )
+        val offerings = try {
+            getOfferings()
+        } catch (e: PurchasesException) {
+            return configurationUnavailable("Offerings could not be fetched for workflow '$workflowId': ${e.error}")
         }
+        val offering = offerings.all[offeringId]
+            ?: return configurationUnavailable(
+                "Offering '$offeringId' referenced by workflow '$workflowId' was not found in offerings.",
+            )
         debugLog {
             "Checkpoint '${checkpoint.identifier}' resolved to random workflow '$workflowId' " +
-                "(offering: ${offering?.identifier})"
+                "(offering: ${offering.identifier})"
         }
         return CheckpointWorkflowResolution.Matched(
             CheckpointWorkflowPresentation(checkpoint, workflow, uiConfig, offering),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
@@ -59,6 +59,9 @@ internal class RandomWorkflowCheckpointResolver(
                 return configurationUnavailable("Offerings could not be fetched for workflow '$workflowId': ${e.error}")
             }
             offerings.all[id]
+                ?: return configurationUnavailable(
+                    "Offering '$id' referenced by workflow '$workflowId' was not found in offerings.",
+                )
         }
         debugLog {
             "Checkpoint '${checkpoint.identifier}' resolved to random workflow '$workflowId' " +

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
@@ -44,7 +44,7 @@ internal class RandomWorkflowCheckpointResolver(
             return CheckpointWorkflowResolution.NoMatch(CheckpointResult.NoAction.Reason.DISABLED)
         }
         // Only workflows tied to an offering are presentable for now: the presentation requires one.
-        val (workflowId, offeringId) = workflowManager.availableWorkflows().entries
+        val (workflowId, offeringId) = workflowManager.offeringIdByWorkflowId().entries
             .filter { it.value != null }
             .randomOrNull()
             ?: return configurationUnavailable(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolver.kt
@@ -1,0 +1,72 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.checkpoints
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
+import com.revenuecat.purchases.common.workflows.WorkflowManager
+
+/**
+ * PoC [CheckpointWorkflowResolver]: a hardcoded allowlist stands in for the future checkpoints config topic, and
+ * a matched checkpoint resolves to a workflow picked at random from the workflows topic.
+ */
+internal class RandomWorkflowCheckpointResolver(
+    private val workflowManager: WorkflowManager?,
+    private val uiConfigProvider: UiConfigProvider?,
+    private val cachedOfferingsProvider: () -> Offerings?,
+) : CheckpointWorkflowResolver {
+
+    override suspend fun resolve(checkpoint: CheckpointInfo): CheckpointWorkflowResolution =
+        when (checkpoint.identifier) {
+            SIMULATED_ERROR_CHECKPOINT_ID -> CheckpointWorkflowResolution.Failed(
+                PurchasesError(
+                    PurchasesErrorCode.ConfigurationError,
+                    "Simulated error: checkpoint workflow not presentable.",
+                ),
+            )
+            in WORKFLOW_CHECKPOINT_ALLOWLIST -> resolveRandomWorkflow(checkpoint)
+            else -> CheckpointWorkflowResolution.NoMatch(CheckpointResult.NoAction.Reason.NO_MATCH)
+        }
+
+    @Suppress("ReturnCount")
+    private suspend fun resolveRandomWorkflow(checkpoint: CheckpointInfo): CheckpointWorkflowResolution {
+        val workflowManager = workflowManager
+        val uiConfigProvider = uiConfigProvider
+        if (workflowManager == null || uiConfigProvider == null) {
+            return CheckpointWorkflowResolution.NoMatch(CheckpointResult.NoAction.Reason.DISABLED)
+        }
+        val (workflowId, offeringId) = workflowManager.availableWorkflows().entries.randomOrNull()
+            ?: return configurationUnavailable("No workflows available for checkpoint '${checkpoint.identifier}'.")
+        val workflow = try {
+            workflowManager.getWorkflow(workflowId)
+        } catch (e: PurchasesException) {
+            return configurationUnavailable("Workflow '$workflowId' could not be loaded: ${e.error}")
+        }
+        val uiConfig = uiConfigProvider.getUiConfig()
+            ?: return configurationUnavailable("UI config is unavailable for workflow '$workflowId'.")
+        val offering = offeringId?.let { cachedOfferingsProvider()?.all?.get(it) }
+        debugLog {
+            "Checkpoint '${checkpoint.identifier}' resolved to random workflow '$workflowId' " +
+                "(offering: ${offering?.identifier})"
+        }
+        return CheckpointWorkflowResolution.Matched(
+            CheckpointWorkflowPresentation(checkpoint, workflow, uiConfig, offering),
+        )
+    }
+
+    private fun configurationUnavailable(message: String): CheckpointWorkflowResolution.NoMatch {
+        errorLog { message }
+        return CheckpointWorkflowResolution.NoMatch(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+    }
+
+    private companion object {
+        val WORKFLOW_CHECKPOINT_ALLOWLIST = setOf("test_checkpoint", "finished_onboarding")
+        const val SIMULATED_ERROR_CHECKPOINT_ID = "error_checkpoint"
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutor.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutor.kt
@@ -25,7 +25,7 @@ internal class UiCheckpointWorkflowExecutor(
 ) : CheckpointWorkflowExecutor, CheckpointPresenterDelegate {
 
     private val presenter: CheckpointPresenter? by lazy { presenterProvider() }
-    private val pendingCalls = mutableMapOf<String, CompletableDeferred<CheckpointPaywallResult>>()
+    private val pendingCalls = mutableMapOf<String, CompletableDeferred<CheckpointPaywallOutcome>>()
     private val presenting = AtomicBoolean(false)
 
     override suspend fun execute(presentation: CheckpointWorkflowPresentation): CheckpointWorkflowOutcome {
@@ -43,17 +43,17 @@ internal class UiCheckpointWorkflowExecutor(
                 "Another checkpoint workflow is already being presented.",
             )
         }
-        val paywallFinished = CompletableDeferred<CheckpointPaywallResult>()
+        val paywallFinished = CompletableDeferred<CheckpointPaywallOutcome>()
         val callId = UUID.randomUUID().toString()
         synchronized(this) { pendingCalls[callId] = paywallFinished }
         presenter.present(activity, callId, presentation, this)
         return CheckpointWorkflowOutcome.PaywallFinished(paywallFinished.await())
     }
 
-    override fun onCheckpointPaywallFinished(callId: String, paywallResult: CheckpointPaywallResult) {
+    override fun onCheckpointPaywallFinished(callId: String, paywallOutcome: CheckpointPaywallOutcome) {
         val pendingCall = synchronized(this) { pendingCalls.remove(callId) } ?: return
         presenting.set(false)
-        pendingCall.complete(paywallResult)
+        pendingCall.complete(paywallOutcome)
     }
 
     private fun executionError(code: PurchasesErrorCode, message: String): Nothing {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutor.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutor.kt
@@ -1,0 +1,76 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.checkpoints
+
+import android.app.Activity
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.common.errorLog
+import kotlinx.coroutines.CompletableDeferred
+import java.util.ServiceConfigurationError
+import java.util.ServiceLoader
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Runs a checkpoint workflow by presenting it as UI through the [CheckpointPresenter] the RevenueCat UI module
+ * registers via [ServiceLoader]. Owns the one-presentation-at-a-time constraint and the pending-call registry
+ * that routes the presenter's terminal report back to the suspended [execute] call.
+ */
+internal class UiCheckpointWorkflowExecutor(
+    private val currentActivityProvider: () -> Activity?,
+    private val presenterProvider: () -> CheckpointPresenter? = ::loadPresenter,
+) : CheckpointWorkflowExecutor, CheckpointPresenterDelegate {
+
+    private val presenter: CheckpointPresenter? by lazy { presenterProvider() }
+    private val pendingCalls = mutableMapOf<String, CompletableDeferred<CheckpointPaywallResult>>()
+    private val presenting = AtomicBoolean(false)
+
+    override suspend fun execute(presentation: CheckpointWorkflowPresentation): CheckpointWorkflowOutcome {
+        val presenter = presenter ?: executionError(
+            PurchasesErrorCode.ConfigurationError,
+            "Cannot present checkpoint workflow: the RevenueCat UI module is not present.",
+        )
+        val activity = currentActivityProvider() ?: executionError(
+            PurchasesErrorCode.ConfigurationError,
+            "Cannot present checkpoint workflow: no started Activity found.",
+        )
+        if (!presenting.compareAndSet(false, true)) {
+            executionError(
+                PurchasesErrorCode.OperationAlreadyInProgressError,
+                "Another checkpoint workflow is already being presented.",
+            )
+        }
+        val paywallFinished = CompletableDeferred<CheckpointPaywallResult>()
+        val callId = UUID.randomUUID().toString()
+        synchronized(this) { pendingCalls[callId] = paywallFinished }
+        presenter.present(activity, callId, presentation, this)
+        return CheckpointWorkflowOutcome.PaywallFinished(paywallFinished.await())
+    }
+
+    override fun onCheckpointPaywallFinished(callId: String, paywallResult: CheckpointPaywallResult) {
+        val pendingCall = synchronized(this) { pendingCalls.remove(callId) } ?: return
+        presenting.set(false)
+        pendingCall.complete(paywallResult)
+    }
+
+    private fun executionError(code: PurchasesErrorCode, message: String): Nothing {
+        val error = PurchasesError(code, message)
+        errorLog(error)
+        throw PurchasesException(error)
+    }
+
+    private companion object {
+        fun loadPresenter(): CheckpointPresenter? = try {
+            ServiceLoader.load(
+                CheckpointPresenter::class.java,
+                CheckpointPresenter::class.java.classLoader,
+            ).firstOrNull()
+        } catch (e: ServiceConfigurationError) {
+            errorLog { "Error loading CheckpointPresenter: $e" }
+            null
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutor.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutor.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.common.errorLog
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import java.util.ServiceConfigurationError
 import java.util.ServiceLoader
@@ -46,14 +47,32 @@ internal class UiCheckpointWorkflowExecutor(
         val paywallFinished = CompletableDeferred<CheckpointPaywallOutcome>()
         val callId = UUID.randomUUID().toString()
         synchronized(this) { pendingCalls[callId] = paywallFinished }
-        presenter.present(activity, callId, presentation, this)
-        return CheckpointWorkflowOutcome.PaywallFinished(paywallFinished.await())
+        try {
+            presenter.present(activity, callId, presentation, this)
+            return CheckpointWorkflowOutcome.PaywallFinished(paywallFinished.await())
+        } catch (e: CancellationException) {
+            abandonPendingCall(callId)
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            abandonPendingCall(callId)
+            executionError(
+                PurchasesErrorCode.ConfigurationError,
+                "Failed to present checkpoint workflow: $e",
+            )
+        }
     }
 
     override fun onCheckpointPaywallFinished(callId: String, paywallOutcome: CheckpointPaywallOutcome) {
         val pendingCall = synchronized(this) { pendingCalls.remove(callId) } ?: return
         presenting.set(false)
         pendingCall.complete(paywallOutcome)
+    }
+
+    // Idempotent counterpart of onCheckpointPaywallFinished for calls that fail or get cancelled before the
+    // presenter reports: only the side that actually removes the pending call releases the presenting gate.
+    private fun abandonPendingCall(callId: String) {
+        synchronized(this) { pendingCalls.remove(callId) } ?: return
+        presenting.set(false)
     }
 
     private fun executionError(code: PurchasesErrorCode, message: String): Nothing {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -103,9 +103,9 @@ internal class WorkflowManager(
     suspend fun resolveWorkflow(offeringId: String): WorkflowResolution =
         workflowsConfigProvider.resolveWorkflow(offeringId)
 
-    /** See [WorkflowsConfigProvider.availableWorkflows]. */
-    suspend fun availableWorkflows(): Map<String, String?> =
-        workflowsConfigProvider.availableWorkflows()
+    /** See [WorkflowsConfigProvider.offeringIdByWorkflowId]. */
+    suspend fun offeringIdByWorkflowId(): Map<String, String?> =
+        workflowsConfigProvider.offeringIdByWorkflowId()
 
     /**
      * Invokes [onComplete] once the config-endpoint paywall data `getOfferings` depends on is ready — the

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -103,6 +103,10 @@ internal class WorkflowManager(
     suspend fun resolveWorkflow(offeringId: String): WorkflowResolution =
         workflowsConfigProvider.resolveWorkflow(offeringId)
 
+    /** See [WorkflowsConfigProvider.availableWorkflows]. */
+    suspend fun availableWorkflows(): Map<String, String?> =
+        workflowsConfigProvider.availableWorkflows()
+
     /**
      * Invokes [onComplete] once the config-endpoint paywall data `getOfferings` depends on is ready — the
      * config-topic replacement for the old `getWorkflowsList(onComplete=)` gate `OfferingsManager` used to

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -142,6 +142,15 @@ internal class WorkflowsConfigProvider(
         (resolveWorkflow(offeringId) as? WorkflowResolution.Found)?.workflowId
 
     /**
+     * Every workflow id in the `workflows` topic, mapped to its `offering_identifier` (or `null` when the item
+     * has none). Empty when the topic is unavailable. May trigger a `/v1/config` sync on a cold cache.
+     */
+    suspend fun availableWorkflows(): Map<String, String?> =
+        manager.topic(RemoteConfigTopic.Workflows)
+            ?.mapValues { (_, item) -> item.metadata.stringOrNull(KEY_OFFERING_IDENTIFIER) }
+            .orEmpty()
+
+    /**
      * Resolves [workflowId] into a [PublishedWorkflow], or `null` when the item is unknown, its body can be
      * neither read nor downloaded, or the body fails to parse. Memory-first: a cached workflow returns
      * synchronously — the body bytes are already in memory, so the [Lazy] decode runs on this (caller) thread

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -145,7 +145,7 @@ internal class WorkflowsConfigProvider(
      * Every workflow id in the `workflows` topic, mapped to its `offering_identifier` (or `null` when the item
      * has none). Empty when the topic is unavailable. May trigger a `/v1/config` sync on a cold cache.
      */
-    suspend fun availableWorkflows(): Map<String, String?> =
+    suspend fun offeringIdByWorkflowId(): Map<String, String?> =
         manager.topic(RemoteConfigTopic.Workflows)
             ?.mapValues { (_, item) -> item.metadata.stringOrNull(KEY_OFFERING_IDENTIFIER) }
             .orEmpty()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CurrentActivityTracker.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CurrentActivityTracker.kt
@@ -1,0 +1,28 @@
+package com.revenuecat.purchases.utils
+
+import android.app.Activity
+import java.lang.ref.WeakReference
+
+/**
+ * Tracks the currently started [Activity], fed from the SDK's activity lifecycle callbacks, so components
+ * that need to present UI (e.g. checkpoints) can obtain it without tracking lifecycle themselves.
+ */
+internal class CurrentActivityTracker {
+
+    private var currentActivityRef: WeakReference<Activity>? = null
+
+    val currentActivity: Activity?
+        @Synchronized get() = currentActivityRef?.get()
+
+    @Synchronized
+    fun onActivityStarted(activity: Activity) {
+        currentActivityRef = WeakReference(activity)
+    }
+
+    @Synchronized
+    fun onActivityStopped(activity: Activity) {
+        if (currentActivityRef?.get() == activity) {
+            currentActivityRef = null
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CurrentActivityTracker.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CurrentActivityTracker.kt
@@ -5,7 +5,8 @@ import java.lang.ref.WeakReference
 
 /**
  * Tracks the started [Activity]s, fed from the SDK's activity lifecycle callbacks, so components that need to
- * present UI (e.g. checkpoints) can obtain the most recently started one without tracking lifecycle themselves.
+ * present UI (e.g. checkpoints) can obtain the most recently started usable (not finishing/destroyed) one
+ * without tracking lifecycle themselves.
  * Keeping every started activity (not just the last) preserves the current activity when a dialog-themed or
  * translucent activity on top of it stops: the one below never restarted, but it is still started and visible.
  */
@@ -14,7 +15,9 @@ internal class CurrentActivityTracker {
     private val startedActivities = mutableListOf<WeakReference<Activity>>()
 
     val currentActivity: Activity?
-        @Synchronized get() = startedActivities.lastOrNull { it.get() != null }?.get()
+        @Synchronized get() = startedActivities.asReversed().firstNotNullOfOrNull { ref ->
+            ref.get()?.takeIf { !it.isFinishing && !it.isDestroyed }
+        }
 
     @Synchronized
     fun onActivityStarted(activity: Activity) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CurrentActivityTracker.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CurrentActivityTracker.kt
@@ -4,25 +4,26 @@ import android.app.Activity
 import java.lang.ref.WeakReference
 
 /**
- * Tracks the currently started [Activity], fed from the SDK's activity lifecycle callbacks, so components
- * that need to present UI (e.g. checkpoints) can obtain it without tracking lifecycle themselves.
+ * Tracks the started [Activity]s, fed from the SDK's activity lifecycle callbacks, so components that need to
+ * present UI (e.g. checkpoints) can obtain the most recently started one without tracking lifecycle themselves.
+ * Keeping every started activity (not just the last) preserves the current activity when a dialog-themed or
+ * translucent activity on top of it stops: the one below never restarted, but it is still started and visible.
  */
 internal class CurrentActivityTracker {
 
-    private var currentActivityRef: WeakReference<Activity>? = null
+    private val startedActivities = mutableListOf<WeakReference<Activity>>()
 
     val currentActivity: Activity?
-        @Synchronized get() = currentActivityRef?.get()
+        @Synchronized get() = startedActivities.lastOrNull { it.get() != null }?.get()
 
     @Synchronized
     fun onActivityStarted(activity: Activity) {
-        currentActivityRef = WeakReference(activity)
+        startedActivities.removeAll { it.get() == null || it.get() == activity }
+        startedActivities.add(WeakReference(activity))
     }
 
     @Synchronized
     fun onActivityStopped(activity: Activity) {
-        if (currentActivityRef?.get() == activity) {
-            currentActivityRef = null
-        }
+        startedActivities.removeAll { it.get() == null || it.get() == activity }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointsManagerTest.kt
@@ -7,17 +7,12 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
-import com.revenuecat.purchases.interfaces.CheckpointCallback
 import io.mockk.coEvery
-import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
-import io.mockk.slot
-import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -36,7 +31,6 @@ class CheckpointsManagerTest {
     private lateinit var dispatcher: TestDispatcher
     private lateinit var mockResolver: CheckpointWorkflowResolver
     private lateinit var mockExecutor: CheckpointWorkflowExecutor
-    private lateinit var mockCallback: CheckpointCallback
     private lateinit var mockListener: CheckpointListener
 
     private lateinit var manager: CheckpointsManager
@@ -46,113 +40,71 @@ class CheckpointsManagerTest {
         dispatcher = UnconfinedTestDispatcher()
         mockResolver = mockk()
         mockExecutor = mockk()
-        mockCallback = mockk(relaxed = true)
         mockListener = mockk(relaxed = true)
         manager = CheckpointsManager(resolver = mockResolver, executor = mockExecutor, mainDispatcher = dispatcher)
         manager.checkpointListener = mockListener
     }
 
     @Test
-    fun `unmatched checkpoint resolves NoAction with the resolver's reason`() {
+    fun `unmatched checkpoint resolves NoAction with the resolver's reason`() = runTest(dispatcher) {
         coEvery { mockResolver.resolve(any()) } returns
             CheckpointWorkflowResolution.NoMatch(CheckpointResult.NoAction.Reason.NO_MATCH)
-        val resultSlot = slot<CheckpointResult>()
-        every { mockCallback.onResult(capture(resultSlot)) } just runs
 
-        manager.checkpoint(checkpointId, null, mockCallback)
+        val result = manager.checkpoint(checkpointId, null) as CheckpointResult.NoAction
 
-        val result = resultSlot.captured as CheckpointResult.NoAction
         assertThat(result.reason).isEqualTo(CheckpointResult.NoAction.Reason.NO_MATCH)
         assertThat(result.checkpoint.identifier).isEqualTo(checkpointId)
         verifyOrder {
             mockListener.onCheckpointHit(result.checkpoint)
             mockListener.onCheckpointResolved(result.checkpoint, result)
-            mockCallback.onResult(result)
         }
     }
 
     @Test
-    fun `failed resolution errors with the resolver's error`() {
-        coEvery { mockResolver.resolve(any()) } returns CheckpointWorkflowResolution.Failed(
-            PurchasesError(PurchasesErrorCode.ConfigurationError, "Simulated."),
-        )
-        val errorSlot = slot<PurchasesError>()
-        every { mockCallback.onError(capture(errorSlot)) } just runs
-
-        manager.checkpoint(checkpointId, null, mockCallback)
-
-        assertThat(errorSlot.captured.code).isEqualTo(PurchasesErrorCode.ConfigurationError)
-        verify(exactly = 0) { mockCallback.onResult(any()) }
-    }
-
-    @Test
-    fun `awaiting a failed resolution throws PurchasesException`() = runTest(dispatcher) {
+    fun `failed resolution throws PurchasesException with the resolver's error`() = runTest(dispatcher) {
         coEvery { mockResolver.resolve(any()) } returns CheckpointWorkflowResolution.Failed(
             PurchasesError(PurchasesErrorCode.ConfigurationError, "Simulated."),
         )
 
-        val exception = try {
-            manager.checkpoint(checkpointId, null)
-            null
-        } catch (e: PurchasesException) {
-            e
-        }
-
-        assertThat(exception?.code).isEqualTo(PurchasesErrorCode.ConfigurationError)
+        assertThat(checkpointErrorCode()).isEqualTo(PurchasesErrorCode.ConfigurationError)
     }
 
     @Test
-    fun `executor failure errors the callback`() {
+    fun `executor failure propagates to the caller`() = runTest(dispatcher) {
         matchCheckpointToWorkflow()
         coEvery { mockExecutor.execute(any()) } throws PurchasesException(
             PurchasesError(PurchasesErrorCode.OperationAlreadyInProgressError, "Already presenting."),
         )
-        val errorSlot = slot<PurchasesError>()
-        every { mockCallback.onError(capture(errorSlot)) } just runs
 
-        manager.checkpoint(checkpointId, null, mockCallback)
-
-        assertThat(errorSlot.captured.code).isEqualTo(PurchasesErrorCode.OperationAlreadyInProgressError)
+        assertThat(checkpointErrorCode()).isEqualTo(PurchasesErrorCode.OperationAlreadyInProgressError)
     }
 
     @Test
-    fun `matched checkpoint resolves PaywallPresented when the workflow finishes`() {
+    fun `matched checkpoint resolves PaywallPresented when the workflow finishes`() = runTest(dispatcher) {
         matchCheckpointToWorkflow()
         val paywallFinished = CompletableDeferred<CheckpointPaywallResult>()
         coEvery { mockExecutor.execute(any()) } coAnswers {
             CheckpointWorkflowOutcome.PaywallFinished(paywallFinished.await())
         }
 
-        manager.checkpoint(checkpointId, CheckpointParams("goal" to "test"), mockCallback)
+        var result: CheckpointResult? = null
+        val call = launch { result = manager.checkpoint(checkpointId, CheckpointParams("goal" to "test")) }
 
-        verify(exactly = 0) { mockCallback.onResult(any()) }
+        assertThat(result).isNull()
 
         val paywallResult = CheckpointPaywallResult.Dismissed
         paywallFinished.complete(paywallResult)
+        call.join()
 
-        val resultSlot = slot<CheckpointResult>()
-        verify { mockCallback.onResult(capture(resultSlot)) }
-        val result = resultSlot.captured as CheckpointResult.PaywallPresented
-        assertThat(result.paywallResult).isEqualTo(paywallResult)
-        assertThat(result.checkpoint.identifier).isEqualTo(checkpointId)
-        assertThat(result.checkpoint.params.customProperties).isEqualTo(mapOf("goal" to "test"))
+        val presented = result as CheckpointResult.PaywallPresented
+        assertThat(presented.paywallResult).isEqualTo(paywallResult)
+        assertThat(presented.checkpoint.identifier).isEqualTo(checkpointId)
+        assertThat(presented.checkpoint.params.customProperties).isEqualTo(mapOf("goal" to "test"))
         verifyOrder {
             mockListener.onCheckpointHit(any())
-            mockListener.onCheckpointPaywallFinished(result.checkpoint, paywallResult)
-            mockListener.onCheckpointResolved(result.checkpoint, result)
-            mockCallback.onResult(result)
+            mockListener.onCheckpointPaywallFinished(presented.checkpoint, paywallResult)
+            mockListener.onCheckpointResolved(presented.checkpoint, presented)
         }
-    }
-
-    @Test
-    fun `awaiting matched checkpoint resolves PaywallPresented when the workflow finishes`() = runTest(dispatcher) {
-        matchCheckpointToWorkflow()
-        coEvery { mockExecutor.execute(any()) } returns
-            CheckpointWorkflowOutcome.PaywallFinished(CheckpointPaywallResult.Dismissed)
-
-        val result = manager.checkpoint(checkpointId, null)
-
-        assertThat(result).isInstanceOf(CheckpointResult.PaywallPresented::class.java)
     }
 
     private fun matchCheckpointToWorkflow() {
@@ -166,5 +118,12 @@ class CheckpointsManagerTest {
                 ),
             )
         }
+    }
+
+    private suspend fun checkpointErrorCode(): PurchasesErrorCode? = try {
+        manager.checkpoint(checkpointId, null)
+        null
+    } catch (e: PurchasesException) {
+        e.code
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointsManagerTest.kt
@@ -1,0 +1,170 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.checkpoints
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.interfaces.CheckpointCallback
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class CheckpointsManagerTest {
+
+    private val checkpointId = "test_checkpoint"
+
+    private lateinit var dispatcher: TestDispatcher
+    private lateinit var mockResolver: CheckpointWorkflowResolver
+    private lateinit var mockExecutor: CheckpointWorkflowExecutor
+    private lateinit var mockCallback: CheckpointCallback
+    private lateinit var mockListener: CheckpointListener
+
+    private lateinit var manager: CheckpointsManager
+
+    @Before
+    fun setup() {
+        dispatcher = UnconfinedTestDispatcher()
+        mockResolver = mockk()
+        mockExecutor = mockk()
+        mockCallback = mockk(relaxed = true)
+        mockListener = mockk(relaxed = true)
+        manager = CheckpointsManager(resolver = mockResolver, executor = mockExecutor, mainDispatcher = dispatcher)
+        manager.checkpointListener = mockListener
+    }
+
+    @Test
+    fun `unmatched checkpoint resolves NoAction with the resolver's reason`() {
+        coEvery { mockResolver.resolve(any()) } returns
+            CheckpointWorkflowResolution.NoMatch(CheckpointResult.NoAction.Reason.NO_MATCH)
+        val resultSlot = slot<CheckpointResult>()
+        every { mockCallback.onResult(capture(resultSlot)) } just runs
+
+        manager.checkpoint(checkpointId, null, mockCallback)
+
+        val result = resultSlot.captured as CheckpointResult.NoAction
+        assertThat(result.reason).isEqualTo(CheckpointResult.NoAction.Reason.NO_MATCH)
+        assertThat(result.checkpoint.identifier).isEqualTo(checkpointId)
+        verifyOrder {
+            mockListener.onCheckpointHit(result.checkpoint)
+            mockListener.onCheckpointResolved(result.checkpoint, result)
+            mockCallback.onResult(result)
+        }
+    }
+
+    @Test
+    fun `failed resolution errors with the resolver's error`() {
+        coEvery { mockResolver.resolve(any()) } returns CheckpointWorkflowResolution.Failed(
+            PurchasesError(PurchasesErrorCode.ConfigurationError, "Simulated."),
+        )
+        val errorSlot = slot<PurchasesError>()
+        every { mockCallback.onError(capture(errorSlot)) } just runs
+
+        manager.checkpoint(checkpointId, null, mockCallback)
+
+        assertThat(errorSlot.captured.code).isEqualTo(PurchasesErrorCode.ConfigurationError)
+        verify(exactly = 0) { mockCallback.onResult(any()) }
+    }
+
+    @Test
+    fun `awaiting a failed resolution throws PurchasesException`() = runTest(dispatcher) {
+        coEvery { mockResolver.resolve(any()) } returns CheckpointWorkflowResolution.Failed(
+            PurchasesError(PurchasesErrorCode.ConfigurationError, "Simulated."),
+        )
+
+        val exception = try {
+            manager.checkpoint(checkpointId, null)
+            null
+        } catch (e: PurchasesException) {
+            e
+        }
+
+        assertThat(exception?.code).isEqualTo(PurchasesErrorCode.ConfigurationError)
+    }
+
+    @Test
+    fun `executor failure errors the callback`() {
+        matchCheckpointToWorkflow()
+        coEvery { mockExecutor.execute(any()) } throws PurchasesException(
+            PurchasesError(PurchasesErrorCode.OperationAlreadyInProgressError, "Already presenting."),
+        )
+        val errorSlot = slot<PurchasesError>()
+        every { mockCallback.onError(capture(errorSlot)) } just runs
+
+        manager.checkpoint(checkpointId, null, mockCallback)
+
+        assertThat(errorSlot.captured.code).isEqualTo(PurchasesErrorCode.OperationAlreadyInProgressError)
+    }
+
+    @Test
+    fun `matched checkpoint resolves PaywallPresented when the workflow finishes`() {
+        matchCheckpointToWorkflow()
+        val paywallFinished = CompletableDeferred<CheckpointPaywallResult>()
+        coEvery { mockExecutor.execute(any()) } coAnswers {
+            CheckpointWorkflowOutcome.PaywallFinished(paywallFinished.await())
+        }
+
+        manager.checkpoint(checkpointId, CheckpointParams("goal" to "test"), mockCallback)
+
+        verify(exactly = 0) { mockCallback.onResult(any()) }
+
+        val paywallResult = CheckpointPaywallResult.Dismissed()
+        paywallFinished.complete(paywallResult)
+
+        val resultSlot = slot<CheckpointResult>()
+        verify { mockCallback.onResult(capture(resultSlot)) }
+        val result = resultSlot.captured as CheckpointResult.PaywallPresented
+        assertThat(result.paywallResult).isEqualTo(paywallResult)
+        assertThat(result.checkpoint.identifier).isEqualTo(checkpointId)
+        assertThat(result.checkpoint.params.customProperties).isEqualTo(mapOf("goal" to "test"))
+        verifyOrder {
+            mockListener.onCheckpointHit(any())
+            mockListener.onCheckpointPaywallFinished(result.checkpoint, paywallResult)
+            mockListener.onCheckpointResolved(result.checkpoint, result)
+            mockCallback.onResult(result)
+        }
+    }
+
+    @Test
+    fun `awaiting matched checkpoint resolves PaywallPresented when the workflow finishes`() = runTest(dispatcher) {
+        matchCheckpointToWorkflow()
+        coEvery { mockExecutor.execute(any()) } returns
+            CheckpointWorkflowOutcome.PaywallFinished(CheckpointPaywallResult.Dismissed())
+
+        val result = manager.checkpoint(checkpointId, null)
+
+        assertThat(result).isInstanceOf(CheckpointResult.PaywallPresented::class.java)
+    }
+
+    private fun matchCheckpointToWorkflow() {
+        coEvery { mockResolver.resolve(any()) } answers {
+            CheckpointWorkflowResolution.Matched(
+                CheckpointWorkflowPresentation(
+                    checkpoint = firstArg(),
+                    workflow = mockk(),
+                    uiConfig = mockk(),
+                    offering = null,
+                ),
+            )
+        }
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointsManagerTest.kt
@@ -82,7 +82,7 @@ class CheckpointsManagerTest {
     @Test
     fun `matched checkpoint resolves PaywallPresented when the workflow finishes`() = runTest(dispatcher) {
         matchCheckpointToWorkflow()
-        val paywallFinished = CompletableDeferred<CheckpointPaywallResult>()
+        val paywallFinished = CompletableDeferred<CheckpointPaywallOutcome>()
         coEvery { mockExecutor.execute(any()) } coAnswers {
             CheckpointWorkflowOutcome.PaywallFinished(paywallFinished.await())
         }
@@ -92,17 +92,17 @@ class CheckpointsManagerTest {
 
         assertThat(result).isNull()
 
-        val paywallResult = CheckpointPaywallResult.Dismissed
-        paywallFinished.complete(paywallResult)
+        val paywallOutcome = CheckpointPaywallOutcome.Dismissed
+        paywallFinished.complete(paywallOutcome)
         call.join()
 
         val presented = result as CheckpointResult.PaywallPresented
-        assertThat(presented.paywallResult).isEqualTo(paywallResult)
+        assertThat(presented.paywallOutcome).isEqualTo(paywallOutcome)
         assertThat(presented.checkpoint.identifier).isEqualTo(checkpointId)
         assertThat(presented.checkpoint.params.customProperties).isEqualTo(mapOf("goal" to "test"))
         verifyOrder {
             mockListener.onCheckpointHit(any())
-            mockListener.onCheckpointPaywallFinished(presented.checkpoint, paywallResult)
+            mockListener.onCheckpointPaywallFinished(presented.checkpoint, paywallOutcome)
             mockListener.onCheckpointResolved(presented.checkpoint, presented)
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointsManagerTest.kt
@@ -56,7 +56,7 @@ class CheckpointsManagerTest {
         assertThat(result.checkpoint.identifier).isEqualTo(checkpointId)
         verifyOrder {
             mockListener.onCheckpointHit(result.checkpoint)
-            mockListener.onCheckpointResolved(result.checkpoint, result)
+            mockListener.onCheckpointCompleted(result.checkpoint, result)
         }
     }
 
@@ -102,8 +102,7 @@ class CheckpointsManagerTest {
         assertThat(presented.checkpoint.params.customProperties).isEqualTo(mapOf("goal" to "test"))
         verifyOrder {
             mockListener.onCheckpointHit(any())
-            mockListener.onCheckpointPaywallFinished(presented.checkpoint, paywallOutcome)
-            mockListener.onCheckpointResolved(presented.checkpoint, presented)
+            mockListener.onCheckpointCompleted(presented.checkpoint, presented)
         }
     }
 
@@ -114,7 +113,7 @@ class CheckpointsManagerTest {
                     checkpoint = firstArg(),
                     workflow = mockk(),
                     uiConfig = mockk(),
-                    offering = null,
+                    offering = mockk(),
                 ),
             )
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointsManagerTest.kt
@@ -127,7 +127,7 @@ class CheckpointsManagerTest {
 
         verify(exactly = 0) { mockCallback.onResult(any()) }
 
-        val paywallResult = CheckpointPaywallResult.Dismissed()
+        val paywallResult = CheckpointPaywallResult.Dismissed
         paywallFinished.complete(paywallResult)
 
         val resultSlot = slot<CheckpointResult>()
@@ -148,7 +148,7 @@ class CheckpointsManagerTest {
     fun `awaiting matched checkpoint resolves PaywallPresented when the workflow finishes`() = runTest(dispatcher) {
         matchCheckpointToWorkflow()
         coEvery { mockExecutor.execute(any()) } returns
-            CheckpointWorkflowOutcome.PaywallFinished(CheckpointPaywallResult.Dismissed())
+            CheckpointWorkflowOutcome.PaywallFinished(CheckpointPaywallResult.Dismissed)
 
         val result = manager.checkpoint(checkpointId, null)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
@@ -69,14 +69,14 @@ class RandomWorkflowCheckpointResolverTest {
     }
 
     @Test
-    fun `checkpoint outside the allowlist resolves NoMatch with NO_MATCH`() = runTest {
-        val resolution = resolver.resolve(CheckpointInfo("some_unknown_checkpoint", CheckpointParams()))
+    fun `simulated unknown checkpoint resolves NoMatch with NO_MATCH`() = runTest {
+        val resolution = resolver.resolve(CheckpointInfo("unknown_checkpoint", CheckpointParams()))
 
         assertThat(noMatchReason(resolution)).isEqualTo(CheckpointResult.NoAction.Reason.NO_MATCH)
     }
 
     @Test
-    fun `allowlisted checkpoint resolves NoMatch with DISABLED when workflows are disabled`() = runTest {
+    fun `checkpoint resolves NoMatch with DISABLED when workflows are disabled`() = runTest {
         resolver = RandomWorkflowCheckpointResolver(
             workflowManager = null,
             uiConfigProvider = null,
@@ -88,7 +88,7 @@ class RandomWorkflowCheckpointResolverTest {
     }
 
     @Test
-    fun `allowlisted checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when no workflows exist`() =
+    fun `checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when no workflows exist`() =
         runTest {
             coEvery { mockWorkflowManager.availableWorkflows() } returns emptyMap()
 
@@ -97,7 +97,7 @@ class RandomWorkflowCheckpointResolverTest {
         }
 
     @Test
-    fun `allowlisted checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when the workflow fails to load`() =
+    fun `checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when the workflow fails to load`() =
         runTest {
             coEvery { mockWorkflowManager.getWorkflow("wf1234") } throws PurchasesException(
                 PurchasesError(PurchasesErrorCode.UnknownError, "Workflow unavailable."),
@@ -108,7 +108,7 @@ class RandomWorkflowCheckpointResolverTest {
         }
 
     @Test
-    fun `allowlisted checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when ui config is unavailable`() =
+    fun `checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when ui config is unavailable`() =
         runTest {
             coEvery { mockUiConfigProvider.getUiConfig() } returns null
 
@@ -117,7 +117,7 @@ class RandomWorkflowCheckpointResolverTest {
         }
 
     @Test
-    fun `allowlisted checkpoint resolves Matched with the workflow and its offering`() = runTest {
+    fun `checkpoint resolves Matched with the workflow and its offering`() = runTest {
         val resolution = resolver.resolve(checkpoint)
 
         val presentation = (resolution as CheckpointWorkflowResolution.Matched).presentation
@@ -128,7 +128,7 @@ class RandomWorkflowCheckpointResolverTest {
     }
 
     @Test
-    fun `allowlisted checkpoint resolves Matched with null offering when the workflow has none`() = runTest {
+    fun `checkpoint resolves Matched with null offering when the workflow has none`() = runTest {
         coEvery { mockWorkflowManager.availableWorkflows() } returns mapOf("wf1234" to null)
 
         val resolution = resolver.resolve(checkpoint)

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
@@ -134,16 +134,13 @@ class RandomWorkflowCheckpointResolverTest {
     }
 
     @Test
-    fun `checkpoint resolves Matched with null offering when the workflow has none, without fetching offerings`() =
-        runTest {
-            coEvery { mockWorkflowManager.availableWorkflows() } returns mapOf("wf1234" to null)
+    fun `workflows without an offering identifier are not picked`() = runTest {
+        coEvery { mockWorkflowManager.availableWorkflows() } returns mapOf("wf1234" to null)
 
-            val resolution = resolver.resolve(checkpoint)
-
-            val presentation = (resolution as CheckpointWorkflowResolution.Matched).presentation
-            assertThat(presentation.offering).isNull()
-            assertThat(offeringsFetched).isFalse()
-        }
+        assertThat(noMatchReason(resolver.resolve(checkpoint)))
+            .isEqualTo(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        assertThat(offeringsFetched).isFalse()
+    }
 
     @Test
     fun `checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when the offerings fetch fails`() = runTest {

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
@@ -154,14 +154,13 @@ class RandomWorkflowCheckpointResolverTest {
     }
 
     @Test
-    fun `checkpoint resolves Matched with null offering when the fetched offerings lack the identifier`() = runTest {
-        every { mockOfferings.all } returns emptyMap()
+    fun `checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when the fetched offerings lack the identifier`() =
+        runTest {
+            every { mockOfferings.all } returns emptyMap()
 
-        val resolution = resolver.resolve(checkpoint)
-
-        val presentation = (resolution as CheckpointWorkflowResolution.Matched).presentation
-        assertThat(presentation.offering).isNull()
-    }
+            assertThat(noMatchReason(resolver.resolve(checkpoint)))
+                .isEqualTo(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        }
 
     private fun noMatchReason(resolution: CheckpointWorkflowResolution): CheckpointResult.NoAction.Reason =
         (resolution as CheckpointWorkflowResolution.NoMatch).reason

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
@@ -51,7 +51,7 @@ class RandomWorkflowCheckpointResolverTest {
             every { identifier } returns "default"
         }
         mockOfferings = mockk()
-        coEvery { mockWorkflowManager.availableWorkflows() } returns mapOf("wf1234" to "default")
+        coEvery { mockWorkflowManager.offeringIdByWorkflowId() } returns mapOf("wf1234" to "default")
         coEvery { mockWorkflowManager.getWorkflow("wf1234") } returns mockWorkflow
         coEvery { mockUiConfigProvider.getUiConfig() } returns mockUiConfig
         every { mockOfferings.all } returns mapOf("default" to mockOffering)
@@ -96,7 +96,7 @@ class RandomWorkflowCheckpointResolverTest {
     @Test
     fun `checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when no workflows exist`() =
         runTest {
-            coEvery { mockWorkflowManager.availableWorkflows() } returns emptyMap()
+            coEvery { mockWorkflowManager.offeringIdByWorkflowId() } returns emptyMap()
 
             assertThat(noMatchReason(resolver.resolve(checkpoint)))
                 .isEqualTo(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
@@ -135,7 +135,7 @@ class RandomWorkflowCheckpointResolverTest {
 
     @Test
     fun `workflows without an offering identifier are not picked`() = runTest {
-        coEvery { mockWorkflowManager.availableWorkflows() } returns mapOf("wf1234" to null)
+        coEvery { mockWorkflowManager.offeringIdByWorkflowId() } returns mapOf("wf1234" to null)
 
         assertThat(noMatchReason(resolver.resolve(checkpoint)))
             .isEqualTo(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
@@ -1,0 +1,142 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.checkpoints
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowManager
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class RandomWorkflowCheckpointResolverTest {
+
+    private val checkpoint = CheckpointInfo("test_checkpoint", CheckpointParams())
+
+    private lateinit var mockWorkflowManager: WorkflowManager
+    private lateinit var mockUiConfigProvider: UiConfigProvider
+    private lateinit var mockWorkflow: PublishedWorkflow
+    private lateinit var mockUiConfig: UiConfig
+    private lateinit var mockOffering: Offering
+    private lateinit var mockOfferings: Offerings
+
+    private lateinit var resolver: RandomWorkflowCheckpointResolver
+
+    @Before
+    fun setup() {
+        mockWorkflowManager = mockk()
+        mockUiConfigProvider = mockk()
+        mockWorkflow = mockk()
+        mockUiConfig = mockk()
+        mockOffering = mockk {
+            every { identifier } returns "default"
+        }
+        mockOfferings = mockk()
+        coEvery { mockWorkflowManager.availableWorkflows() } returns mapOf("wf1234" to "default")
+        coEvery { mockWorkflowManager.getWorkflow("wf1234") } returns mockWorkflow
+        coEvery { mockUiConfigProvider.getUiConfig() } returns mockUiConfig
+        every { mockOfferings.all } returns mapOf("default" to mockOffering)
+        resolver = RandomWorkflowCheckpointResolver(
+            workflowManager = mockWorkflowManager,
+            uiConfigProvider = mockUiConfigProvider,
+            cachedOfferingsProvider = { mockOfferings },
+        )
+    }
+
+    @Test
+    fun `simulated error checkpoint fails with ConfigurationError`() = runTest {
+        val resolution = resolver.resolve(CheckpointInfo("error_checkpoint", CheckpointParams()))
+
+        val failed = resolution as CheckpointWorkflowResolution.Failed
+        assertThat(failed.error.code).isEqualTo(PurchasesErrorCode.ConfigurationError)
+    }
+
+    @Test
+    fun `checkpoint outside the allowlist resolves NoMatch with NO_MATCH`() = runTest {
+        val resolution = resolver.resolve(CheckpointInfo("some_unknown_checkpoint", CheckpointParams()))
+
+        assertThat(noMatchReason(resolution)).isEqualTo(CheckpointResult.NoAction.Reason.NO_MATCH)
+    }
+
+    @Test
+    fun `allowlisted checkpoint resolves NoMatch with DISABLED when workflows are disabled`() = runTest {
+        resolver = RandomWorkflowCheckpointResolver(
+            workflowManager = null,
+            uiConfigProvider = null,
+            cachedOfferingsProvider = { null },
+        )
+
+        assertThat(noMatchReason(resolver.resolve(checkpoint)))
+            .isEqualTo(CheckpointResult.NoAction.Reason.DISABLED)
+    }
+
+    @Test
+    fun `allowlisted checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when no workflows exist`() =
+        runTest {
+            coEvery { mockWorkflowManager.availableWorkflows() } returns emptyMap()
+
+            assertThat(noMatchReason(resolver.resolve(checkpoint)))
+                .isEqualTo(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        }
+
+    @Test
+    fun `allowlisted checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when the workflow fails to load`() =
+        runTest {
+            coEvery { mockWorkflowManager.getWorkflow("wf1234") } throws PurchasesException(
+                PurchasesError(PurchasesErrorCode.UnknownError, "Workflow unavailable."),
+            )
+
+            assertThat(noMatchReason(resolver.resolve(checkpoint)))
+                .isEqualTo(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        }
+
+    @Test
+    fun `allowlisted checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when ui config is unavailable`() =
+        runTest {
+            coEvery { mockUiConfigProvider.getUiConfig() } returns null
+
+            assertThat(noMatchReason(resolver.resolve(checkpoint)))
+                .isEqualTo(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        }
+
+    @Test
+    fun `allowlisted checkpoint resolves Matched with the workflow and its offering`() = runTest {
+        val resolution = resolver.resolve(checkpoint)
+
+        val presentation = (resolution as CheckpointWorkflowResolution.Matched).presentation
+        assertThat(presentation.checkpoint).isEqualTo(checkpoint)
+        assertThat(presentation.workflow).isEqualTo(mockWorkflow)
+        assertThat(presentation.uiConfig).isEqualTo(mockUiConfig)
+        assertThat(presentation.offering).isEqualTo(mockOffering)
+    }
+
+    @Test
+    fun `allowlisted checkpoint resolves Matched with null offering when the workflow has none`() = runTest {
+        coEvery { mockWorkflowManager.availableWorkflows() } returns mapOf("wf1234" to null)
+
+        val resolution = resolver.resolve(checkpoint)
+
+        val presentation = (resolution as CheckpointWorkflowResolution.Matched).presentation
+        assertThat(presentation.offering).isNull()
+    }
+
+    private fun noMatchReason(resolution: CheckpointWorkflowResolution): CheckpointResult.NoAction.Reason =
+        (resolution as CheckpointWorkflowResolution.NoMatch).reason
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/RandomWorkflowCheckpointResolverTest.kt
@@ -36,6 +36,8 @@ class RandomWorkflowCheckpointResolverTest {
     private lateinit var mockUiConfig: UiConfig
     private lateinit var mockOffering: Offering
     private lateinit var mockOfferings: Offerings
+    private var offeringsFetchError: PurchasesError? = null
+    private var offeringsFetched = false
 
     private lateinit var resolver: RandomWorkflowCheckpointResolver
 
@@ -56,7 +58,11 @@ class RandomWorkflowCheckpointResolverTest {
         resolver = RandomWorkflowCheckpointResolver(
             workflowManager = mockWorkflowManager,
             uiConfigProvider = mockUiConfigProvider,
-            cachedOfferingsProvider = { mockOfferings },
+            getOfferings = {
+                offeringsFetched = true
+                offeringsFetchError?.let { throw PurchasesException(it) }
+                mockOfferings
+            },
         )
     }
 
@@ -80,7 +86,7 @@ class RandomWorkflowCheckpointResolverTest {
         resolver = RandomWorkflowCheckpointResolver(
             workflowManager = null,
             uiConfigProvider = null,
-            cachedOfferingsProvider = { null },
+            getOfferings = { mockOfferings },
         )
 
         assertThat(noMatchReason(resolver.resolve(checkpoint)))
@@ -128,8 +134,28 @@ class RandomWorkflowCheckpointResolverTest {
     }
 
     @Test
-    fun `checkpoint resolves Matched with null offering when the workflow has none`() = runTest {
-        coEvery { mockWorkflowManager.availableWorkflows() } returns mapOf("wf1234" to null)
+    fun `checkpoint resolves Matched with null offering when the workflow has none, without fetching offerings`() =
+        runTest {
+            coEvery { mockWorkflowManager.availableWorkflows() } returns mapOf("wf1234" to null)
+
+            val resolution = resolver.resolve(checkpoint)
+
+            val presentation = (resolution as CheckpointWorkflowResolution.Matched).presentation
+            assertThat(presentation.offering).isNull()
+            assertThat(offeringsFetched).isFalse()
+        }
+
+    @Test
+    fun `checkpoint resolves NoMatch with CONFIGURATION_UNAVAILABLE when the offerings fetch fails`() = runTest {
+        offeringsFetchError = PurchasesError(PurchasesErrorCode.NetworkError, "Offline.")
+
+        assertThat(noMatchReason(resolver.resolve(checkpoint)))
+            .isEqualTo(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+    }
+
+    @Test
+    fun `checkpoint resolves Matched with null offering when the fetched offerings lack the identifier`() = runTest {
+        every { mockOfferings.all } returns emptyMap()
 
         val resolution = resolver.resolve(checkpoint)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutorTest.kt
@@ -44,7 +44,7 @@ class UiCheckpointWorkflowExecutorTest {
             checkpoint = CheckpointInfo("test_checkpoint", CheckpointParams()),
             workflow = mockk(),
             uiConfig = mockk(),
-            offering = null,
+            offering = mockk(),
         )
         executor = UiCheckpointWorkflowExecutor(
             currentActivityProvider = { currentActivity },

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutorTest.kt
@@ -71,12 +71,12 @@ class UiCheckpointWorkflowExecutorTest {
 
     @Test
     fun `execute returns PaywallFinished with the delegate-reported result`() = runTest(dispatcher) {
-        val paywallResult = CheckpointPaywallResult.Dismissed
-        presenterReportsImmediately(paywallResult)
+        val paywallOutcome = CheckpointPaywallOutcome.Dismissed
+        presenterReportsImmediately(paywallOutcome)
 
         val outcome = executor.execute(presentation) as CheckpointWorkflowOutcome.PaywallFinished
 
-        assertThat(outcome.paywallResult).isEqualTo(paywallResult)
+        assertThat(outcome.paywallOutcome).isEqualTo(paywallOutcome)
         verify { mockPresenter.present(mockActivity, any(), presentation, executor) }
     }
 
@@ -92,7 +92,7 @@ class UiCheckpointWorkflowExecutorTest {
 
     @Test
     fun `execute can present again after the previous workflow finishes`() = runTest(dispatcher) {
-        presenterReportsImmediately(CheckpointPaywallResult.Dismissed)
+        presenterReportsImmediately(CheckpointPaywallOutcome.Dismissed)
 
         executor.execute(presentation)
         executor.execute(presentation)
@@ -102,16 +102,16 @@ class UiCheckpointWorkflowExecutorTest {
 
     @Test
     fun `report for unknown callId is a no-op`() = runTest(dispatcher) {
-        executor.onCheckpointPaywallFinished("unknown-call-id", CheckpointPaywallResult.Dismissed)
+        executor.onCheckpointPaywallFinished("unknown-call-id", CheckpointPaywallOutcome.Dismissed)
 
-        presenterReportsImmediately(CheckpointPaywallResult.Dismissed)
+        presenterReportsImmediately(CheckpointPaywallOutcome.Dismissed)
         assertThat(executor.execute(presentation))
             .isInstanceOf(CheckpointWorkflowOutcome.PaywallFinished::class.java)
     }
 
-    private fun presenterReportsImmediately(paywallResult: CheckpointPaywallResult) {
+    private fun presenterReportsImmediately(paywallOutcome: CheckpointPaywallOutcome) {
         every { mockPresenter.present(mockActivity, any(), any(), any()) } answers {
-            lastArg<CheckpointPresenterDelegate>().onCheckpointPaywallFinished(secondArg(), paywallResult)
+            lastArg<CheckpointPresenterDelegate>().onCheckpointPaywallFinished(secondArg(), paywallOutcome)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutorTest.kt
@@ -101,6 +101,29 @@ class UiCheckpointWorkflowExecutorTest {
     }
 
     @Test
+    fun `execute can present again after the presenter throws`() = runTest(dispatcher) {
+        every { mockPresenter.present(any(), any(), any(), any()) } throws RuntimeException("startActivity failed")
+
+        assertThat(executionErrorCode()).isEqualTo(PurchasesErrorCode.ConfigurationError)
+
+        presenterReportsImmediately(CheckpointPaywallOutcome.Dismissed)
+        assertThat(executor.execute(presentation))
+            .isInstanceOf(CheckpointWorkflowOutcome.PaywallFinished::class.java)
+    }
+
+    @Test
+    fun `execute can present again after being cancelled`() = runTest(dispatcher) {
+        every { mockPresenter.present(any(), any(), any(), any()) } just runs
+        val firstCall = launch { executor.execute(presentation) }
+
+        firstCall.cancel()
+
+        presenterReportsImmediately(CheckpointPaywallOutcome.Dismissed)
+        assertThat(executor.execute(presentation))
+            .isInstanceOf(CheckpointWorkflowOutcome.PaywallFinished::class.java)
+    }
+
+    @Test
     fun `report for unknown callId is a no-op`() = runTest(dispatcher) {
         executor.onCheckpointPaywallFinished("unknown-call-id", CheckpointPaywallOutcome.Dismissed)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutorTest.kt
@@ -1,0 +1,124 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.checkpoints
+
+import android.app.Activity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class UiCheckpointWorkflowExecutorTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var mockPresenter: CheckpointPresenter
+    private lateinit var mockActivity: Activity
+    private var currentActivity: Activity? = null
+    private lateinit var presentation: CheckpointWorkflowPresentation
+
+    private lateinit var executor: UiCheckpointWorkflowExecutor
+
+    @Before
+    fun setup() {
+        mockPresenter = mockk()
+        mockActivity = mockk()
+        currentActivity = mockActivity
+        presentation = CheckpointWorkflowPresentation(
+            checkpoint = CheckpointInfo("test_checkpoint", CheckpointParams()),
+            workflow = mockk(),
+            uiConfig = mockk(),
+            offering = null,
+        )
+        executor = UiCheckpointWorkflowExecutor(
+            currentActivityProvider = { currentActivity },
+            presenterProvider = { mockPresenter },
+        )
+    }
+
+    @Test
+    fun `execute errors with ConfigurationError when presenter is missing`() = runTest(dispatcher) {
+        executor = UiCheckpointWorkflowExecutor(
+            currentActivityProvider = { currentActivity },
+            presenterProvider = { null },
+        )
+
+        assertThat(executionErrorCode()).isEqualTo(PurchasesErrorCode.ConfigurationError)
+    }
+
+    @Test
+    fun `execute errors with ConfigurationError when no activity is available`() = runTest(dispatcher) {
+        currentActivity = null
+
+        assertThat(executionErrorCode()).isEqualTo(PurchasesErrorCode.ConfigurationError)
+    }
+
+    @Test
+    fun `execute returns PaywallFinished with the delegate-reported result`() = runTest(dispatcher) {
+        val paywallResult = CheckpointPaywallResult.Dismissed()
+        presenterReportsImmediately(paywallResult)
+
+        val outcome = executor.execute(presentation) as CheckpointWorkflowOutcome.PaywallFinished
+
+        assertThat(outcome.paywallResult).isEqualTo(paywallResult)
+        verify { mockPresenter.present(mockActivity, any(), presentation, executor) }
+    }
+
+    @Test
+    fun `concurrent execute errors with OperationAlreadyInProgressError`() = runTest(dispatcher) {
+        every { mockPresenter.present(any(), any(), any(), any()) } just runs
+        val firstCall = launch { executor.execute(presentation) }
+
+        assertThat(executionErrorCode()).isEqualTo(PurchasesErrorCode.OperationAlreadyInProgressError)
+
+        firstCall.cancel()
+    }
+
+    @Test
+    fun `execute can present again after the previous workflow finishes`() = runTest(dispatcher) {
+        presenterReportsImmediately(CheckpointPaywallResult.Dismissed())
+
+        executor.execute(presentation)
+        executor.execute(presentation)
+
+        verify(exactly = 2) { mockPresenter.present(mockActivity, any(), presentation, executor) }
+    }
+
+    @Test
+    fun `report for unknown callId is a no-op`() = runTest(dispatcher) {
+        executor.onCheckpointPaywallFinished("unknown-call-id", CheckpointPaywallResult.Dismissed())
+
+        presenterReportsImmediately(CheckpointPaywallResult.Dismissed())
+        assertThat(executor.execute(presentation))
+            .isInstanceOf(CheckpointWorkflowOutcome.PaywallFinished::class.java)
+    }
+
+    private fun presenterReportsImmediately(paywallResult: CheckpointPaywallResult) {
+        every { mockPresenter.present(mockActivity, any(), any(), any()) } answers {
+            lastArg<CheckpointPresenterDelegate>().onCheckpointPaywallFinished(secondArg(), paywallResult)
+        }
+    }
+
+    private suspend fun executionErrorCode(): PurchasesErrorCode? = try {
+        executor.execute(presentation)
+        null
+    } catch (e: PurchasesException) {
+        e.code
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/UiCheckpointWorkflowExecutorTest.kt
@@ -71,7 +71,7 @@ class UiCheckpointWorkflowExecutorTest {
 
     @Test
     fun `execute returns PaywallFinished with the delegate-reported result`() = runTest(dispatcher) {
-        val paywallResult = CheckpointPaywallResult.Dismissed()
+        val paywallResult = CheckpointPaywallResult.Dismissed
         presenterReportsImmediately(paywallResult)
 
         val outcome = executor.execute(presentation) as CheckpointWorkflowOutcome.PaywallFinished
@@ -92,7 +92,7 @@ class UiCheckpointWorkflowExecutorTest {
 
     @Test
     fun `execute can present again after the previous workflow finishes`() = runTest(dispatcher) {
-        presenterReportsImmediately(CheckpointPaywallResult.Dismissed())
+        presenterReportsImmediately(CheckpointPaywallResult.Dismissed)
 
         executor.execute(presentation)
         executor.execute(presentation)
@@ -102,9 +102,9 @@ class UiCheckpointWorkflowExecutorTest {
 
     @Test
     fun `report for unknown callId is a no-op`() = runTest(dispatcher) {
-        executor.onCheckpointPaywallFinished("unknown-call-id", CheckpointPaywallResult.Dismissed())
+        executor.onCheckpointPaywallFinished("unknown-call-id", CheckpointPaywallResult.Dismissed)
 
-        presenterReportsImmediately(CheckpointPaywallResult.Dismissed())
+        presenterReportsImmediately(CheckpointPaywallResult.Dismissed)
         assertThat(executor.execute(presentation))
             .isInstanceOf(CheckpointWorkflowOutcome.PaywallFinished::class.java)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/CurrentActivityTrackerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/CurrentActivityTrackerTest.kt
@@ -1,0 +1,47 @@
+package com.revenuecat.purchases.utils
+
+import android.app.Activity
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class CurrentActivityTrackerTest {
+
+    private val tracker = CurrentActivityTracker()
+
+    @Test
+    fun `currentActivity is null before any activity starts`() {
+        assertThat(tracker.currentActivity).isNull()
+    }
+
+    @Test
+    fun `currentActivity is the last started activity`() {
+        val firstActivity = mockk<Activity>()
+        val secondActivity = mockk<Activity>()
+
+        tracker.onActivityStarted(firstActivity)
+        tracker.onActivityStarted(secondActivity)
+
+        assertThat(tracker.currentActivity).isEqualTo(secondActivity)
+    }
+
+    @Test
+    fun `currentActivity is null after the tracked activity stops`() {
+        val activity = mockk<Activity>()
+        tracker.onActivityStarted(activity)
+
+        tracker.onActivityStopped(activity)
+
+        assertThat(tracker.currentActivity).isNull()
+    }
+
+    @Test
+    fun `stopping a different activity keeps the tracked one`() {
+        val activity = mockk<Activity>()
+        tracker.onActivityStarted(activity)
+
+        tracker.onActivityStopped(mockk<Activity>())
+
+        assertThat(tracker.currentActivity).isEqualTo(activity)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/CurrentActivityTrackerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/CurrentActivityTrackerTest.kt
@@ -44,4 +44,16 @@ class CurrentActivityTrackerTest {
 
         assertThat(tracker.currentActivity).isEqualTo(activity)
     }
+
+    @Test
+    fun `stopping an overlay activity restores the previously started one`() {
+        val activity = mockk<Activity>()
+        val overlayActivity = mockk<Activity>()
+        tracker.onActivityStarted(activity)
+        tracker.onActivityStarted(overlayActivity)
+
+        tracker.onActivityStopped(overlayActivity)
+
+        assertThat(tracker.currentActivity).isEqualTo(activity)
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/CurrentActivityTrackerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/CurrentActivityTrackerTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.utils
 
 import android.app.Activity
+import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -16,8 +17,8 @@ class CurrentActivityTrackerTest {
 
     @Test
     fun `currentActivity is the last started activity`() {
-        val firstActivity = mockk<Activity>()
-        val secondActivity = mockk<Activity>()
+        val firstActivity = mockActivity()
+        val secondActivity = mockActivity()
 
         tracker.onActivityStarted(firstActivity)
         tracker.onActivityStarted(secondActivity)
@@ -27,7 +28,7 @@ class CurrentActivityTrackerTest {
 
     @Test
     fun `currentActivity is null after the tracked activity stops`() {
-        val activity = mockk<Activity>()
+        val activity = mockActivity()
         tracker.onActivityStarted(activity)
 
         tracker.onActivityStopped(activity)
@@ -37,23 +38,55 @@ class CurrentActivityTrackerTest {
 
     @Test
     fun `stopping a different activity keeps the tracked one`() {
-        val activity = mockk<Activity>()
+        val activity = mockActivity()
         tracker.onActivityStarted(activity)
 
-        tracker.onActivityStopped(mockk<Activity>())
+        tracker.onActivityStopped(mockActivity())
 
         assertThat(tracker.currentActivity).isEqualTo(activity)
     }
 
     @Test
     fun `stopping an overlay activity restores the previously started one`() {
-        val activity = mockk<Activity>()
-        val overlayActivity = mockk<Activity>()
+        val activity = mockActivity()
+        val overlayActivity = mockActivity()
         tracker.onActivityStarted(activity)
         tracker.onActivityStarted(overlayActivity)
 
         tracker.onActivityStopped(overlayActivity)
 
         assertThat(tracker.currentActivity).isEqualTo(activity)
+    }
+
+    @Test
+    fun `a finishing activity is skipped in favor of the usable one underneath`() {
+        val activity = mockActivity()
+        val finishingActivity = mockActivity(finishing = true)
+        tracker.onActivityStarted(activity)
+        tracker.onActivityStarted(finishingActivity)
+
+        assertThat(tracker.currentActivity).isEqualTo(activity)
+    }
+
+    @Test
+    fun `a destroyed activity is skipped in favor of the usable one underneath`() {
+        val activity = mockActivity()
+        val destroyedActivity = mockActivity(destroyed = true)
+        tracker.onActivityStarted(activity)
+        tracker.onActivityStarted(destroyedActivity)
+
+        assertThat(tracker.currentActivity).isEqualTo(activity)
+    }
+
+    @Test
+    fun `currentActivity is null when the only started activity is finishing`() {
+        tracker.onActivityStarted(mockActivity(finishing = true))
+
+        assertThat(tracker.currentActivity).isNull()
+    }
+
+    private fun mockActivity(finishing: Boolean = false, destroyed: Boolean = false): Activity = mockk {
+        every { isFinishing } returns finishing
+        every { isDestroyed } returns destroyed
     }
 }


### PR DESCRIPTION
Stacked on top of RevenueCat/purchases-android#3887

This implements the internal engine that processes a checkpoint: deciding which workflow (if any) should run for it and running it. For this PoC, checkpoint matching is mocked and a random workflow is picked from those available. Note that none of this code is yet used, and will be in the follow-up PRs.

```mermaid
flowchart TD
    Entry["checkpoint() entry points<br/>(wired in #3863)"] --> Manager[CheckpointsManager]
    Manager -- "1. resolve(checkpoint)" --> Resolver[CheckpointWorkflowResolver]
    Resolver -. PoC impl .-> Random[RandomWorkflowCheckpointResolver]
    Random --> WM["WorkflowManager<br/>(workflows config topic)"]
    Random --> UCP[UiConfigProvider]
    Random --> Off[cached Offerings]
    Manager -- "2. execute(presentation)" --> Executor[CheckpointWorkflowExecutor]
    Executor -. PoC impl .-> UiExec[UiCheckpointWorkflowExecutor]
    UiExec --> Tracker[CurrentActivityTracker]
    UiExec -- ServiceLoader --> Presenter["CheckpointPresenter<br/>(implemented by the UI module in #3889)"]
```

---

> [!NOTE]
> **Medium Risk**<br>New paywall presentation path with concurrency and Activity lifecycle assumptions, but internal-only and not yet connected to the public API.
>
> **Overview**<br>Adds the **internal checkpoints engine** that resolves a checkpoint to a workflow and runs it. Nothing in this PR wires it to public `checkpoint()` entry points yet.
>
> `CheckpointsManager` orchestrates hits on the main dispatcher: listener `onCheckpointHit` / `onCheckpointCompleted`, `CheckpointWorkflowResolver`, then `CheckpointWorkflowExecutor`, mapping outcomes to `CheckpointResult` (`NoAction`, `PaywallPresented`, or thrown `PurchasesException` on failed resolution).
>
> **PoC resolution and execution:** `RandomWorkflowCheckpointResolver` picks a random offering-linked workflow from remote config (with hardcoded `unknown_checkpoint` / `error_checkpoint` for no-match and error paths). `UiCheckpointWorkflowExecutor` presents via `ServiceLoader`-loaded `CheckpointPresenter`, enforces one presentation at a time, and suspends until paywall completion.
>
> **Supporting changes:** `WorkflowsConfigProvider.offeringIdByWorkflowId()` (exposed through `WorkflowManager`) for listing workflows with offering metadata; `CurrentActivityTracker` for choosing a usable Activity when overlays stop.
>
> Unit tests cover the manager, resolver, executor, and activity tracker.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit c15717ba64cfc9548dff08273572ceba9c764b6c. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).