### PR TITLE
refactor(checkpoints): Checkpoints workflow presenter UI - SDK-4423

### DIFF
--- a/ui/revenuecatui/consumer-rules.pro
+++ b/ui/revenuecatui/consumer-rules.pro
@@ -1,2 +1,9 @@
 -dontwarn com.emergetools.snapshots.annotations.IgnoreEmergeSnapshot
 -dontwarn com.emergetools.snapshots.annotations.EmergeSnapshotConfig
+
+# CheckpointPresenterImpl is instantiated reflectively by java.util.ServiceLoader through the
+# META-INF/services/com.revenuecat.purchases.checkpoints.CheckpointPresenter descriptor, so keep the class and
+# its no-argument constructor even though there are no direct references to it.
+-keep class com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointPresenterImpl {
+    <init>();
+}

--- a/ui/revenuecatui/src/main/AndroidManifest.xml
+++ b/ui/revenuecatui/src/main/AndroidManifest.xml
@@ -9,6 +9,9 @@
                 android:name=".customercenter.CustomerCenterActivity"
                 android:theme="@android:style/Theme.NoTitleBar"
                 android:exported="false" />
+        <activity
+                android:name=".checkpoints.CheckpointWorkflowActivity"
+                android:exported="false" />
     </application>
 
 </manifest>

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStore.kt
@@ -1,19 +1,24 @@
 package com.revenuecat.purchases.ui.revenuecatui.checkpoints
 
+import com.revenuecat.purchases.checkpoints.CheckpointPaywallOutcome
 import com.revenuecat.purchases.checkpoints.CheckpointPresenterDelegate
 import com.revenuecat.purchases.checkpoints.CheckpointWorkflowPresentation
 
 /**
  * Carries a checkpoint call's non-Parcelable payload across the Intent boundary into
  * [CheckpointWorkflowActivity], keyed by callId. Entries are removed when the terminal result is reported, so
- * a recreated activity (e.g. rotation) can still read its payload.
+ * a recreated activity (e.g. rotation) can still read its payload — including the outcome staged so far, which
+ * must outlive any single activity instance.
  */
 internal object CheckpointCallStore {
 
     class Entry(
         val delegate: CheckpointPresenterDelegate,
         val presentation: CheckpointWorkflowPresentation,
-    )
+    ) {
+        // Written/read on the main thread by the presenting activity.
+        var stagedOutcome: CheckpointPaywallOutcome = CheckpointPaywallOutcome.Dismissed
+    }
 
     private val entriesByCallId = mutableMapOf<String, Entry>()
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStore.kt
@@ -27,4 +27,9 @@ internal object CheckpointCallStore {
 
     @Synchronized
     fun remove(callId: String): Entry? = entriesByCallId.remove(callId)
+
+    @Synchronized
+    fun clear() {
+        entriesByCallId.clear()
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStore.kt
@@ -1,0 +1,30 @@
+package com.revenuecat.purchases.ui.revenuecatui.checkpoints
+
+import com.revenuecat.purchases.checkpoints.CheckpointPresenterDelegate
+import com.revenuecat.purchases.checkpoints.CheckpointWorkflowPresentation
+
+/**
+ * Carries a checkpoint call's non-Parcelable payload across the Intent boundary into
+ * [CheckpointWorkflowActivity], keyed by callId. Entries are removed when the terminal result is reported, so
+ * a recreated activity (e.g. rotation) can still read its payload.
+ */
+internal object CheckpointCallStore {
+
+    class Entry(
+        val delegate: CheckpointPresenterDelegate,
+        val presentation: CheckpointWorkflowPresentation,
+    )
+
+    private val entriesByCallId = mutableMapOf<String, Entry>()
+
+    @Synchronized
+    fun store(callId: String, entry: Entry) {
+        entriesByCallId[callId] = entry
+    }
+
+    @Synchronized
+    fun get(callId: String): Entry? = entriesByCallId[callId]
+
+    @Synchronized
+    fun remove(callId: String): Entry? = entriesByCallId.remove(callId)
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStore.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStore.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.checkpoints.CheckpointWorkflowPresentation
 /**
  * Carries a checkpoint call's non-Parcelable payload across the Intent boundary into
  * [CheckpointWorkflowActivity], keyed by callId. Entries are removed when the terminal result is reported, so
- * a recreated activity (e.g. rotation) can still read its payload — including the outcome staged so far, which
+ * a recreated activity (e.g. rotation) can still read its payload — including the outcome cached so far, which
  * must outlive any single activity instance.
  */
 internal object CheckpointCallStore {
@@ -17,7 +17,7 @@ internal object CheckpointCallStore {
         val presentation: CheckpointWorkflowPresentation,
     ) {
         // Written/read on the main thread by the presenting activity.
-        var stagedOutcome: CheckpointPaywallOutcome = CheckpointPaywallOutcome.Dismissed
+        var outcome: CheckpointPaywallOutcome = CheckpointPaywallOutcome.Dismissed
     }
 
     private val entriesByCallId = mutableMapOf<String, Entry>()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointPresenterImpl.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointPresenterImpl.kt
@@ -1,0 +1,29 @@
+package com.revenuecat.purchases.ui.revenuecatui.checkpoints
+
+import android.app.Activity
+import android.content.Intent
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.checkpoints.CheckpointPresenter
+import com.revenuecat.purchases.checkpoints.CheckpointPresenterDelegate
+import com.revenuecat.purchases.checkpoints.CheckpointWorkflowPresentation
+
+/**
+ * [CheckpointPresenter] implementation instantiated by the core module through [java.util.ServiceLoader]
+ * (registered in `META-INF/services`).
+ */
+@InternalRevenueCatAPI
+public class CheckpointPresenterImpl : CheckpointPresenter {
+
+    override fun present(
+        activity: Activity,
+        callId: String,
+        presentation: CheckpointWorkflowPresentation,
+        delegate: CheckpointPresenterDelegate,
+    ) {
+        CheckpointCallStore.store(callId, CheckpointCallStore.Entry(delegate, presentation))
+        activity.startActivity(
+            Intent(activity, CheckpointWorkflowActivity::class.java)
+                .putExtra(CheckpointWorkflowActivity.EXTRA_CALL_ID, callId),
+        )
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
@@ -16,7 +16,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 /**
  * Presents the workflow resolved for a checkpoint and reports the terminal [CheckpointPaywallOutcome] back to
- * the core module exactly once. Terminal purchase/restore events are staged as they happen and delivered when
+ * the core module exactly once. Terminal purchase/restore events are cached as they happen and delivered when
  * the paywall dismisses (or the activity is otherwise finished), mirroring
  * [com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivity]'s result handling.
  */
@@ -44,7 +44,7 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
         }
         val options = PaywallOptions.Builder(dismissRequest = ::finish)
             .injectedWorkflow(presentation.workflow, presentation.offering, presentation.uiConfig)
-            .setListener(resultStagingListener)
+            .setListener(outcomeListener)
             .build()
         setContent {
             Paywall(options)
@@ -58,24 +58,24 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
         super.onDestroy()
     }
 
-    // Outcomes are staged on the store entry (not this instance) so a configuration change doesn't reset them.
-    private val resultStagingListener = object : PaywallListener {
+    // Outcomes are cached on the store entry (not this instance) so a configuration change doesn't reset them.
+    private val outcomeListener = object : PaywallListener {
         override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
-            entry?.stagedOutcome = CheckpointPaywallOutcome.Purchased(customerInfo)
+            entry?.outcome = CheckpointPaywallOutcome.Purchased(customerInfo)
         }
 
         override fun onRestoreCompleted(customerInfo: CustomerInfo) {
-            entry?.stagedOutcome = CheckpointPaywallOutcome.Restored(customerInfo)
+            entry?.outcome = CheckpointPaywallOutcome.Restored(customerInfo)
         }
 
         override fun onPurchaseError(error: PurchasesError) {
             if (error.code != PurchasesErrorCode.PurchaseCancelledError) {
-                entry?.stagedOutcome = CheckpointPaywallOutcome.Error(error)
+                entry?.outcome = CheckpointPaywallOutcome.Error(error)
             }
         }
 
         override fun onRestoreError(error: PurchasesError) {
-            entry?.stagedOutcome = CheckpointPaywallOutcome.Error(error)
+            entry?.outcome = CheckpointPaywallOutcome.Error(error)
         }
     }
 
@@ -85,6 +85,6 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
         if (reported || callId == null || entry == null) return
         reported = true
         CheckpointCallStore.remove(callId)
-        entry.delegate.onCheckpointPaywallFinished(callId, entry.stagedOutcome)
+        entry.delegate.onCheckpointPaywallFinished(callId, entry.outcome)
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.checkpoints
 
 import android.os.Bundle
+import android.view.Window
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.revenuecat.purchases.CustomerInfo
@@ -30,6 +31,7 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
     private var reported = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
         super.onCreate(savedInstanceState)
         callId = intent.getStringExtra(EXTRA_CALL_ID)
         entry = callId?.let { CheckpointCallStore.get(it) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 /**
  * Presents the workflow resolved for a checkpoint and reports the terminal [CheckpointPaywallOutcome] back to
@@ -27,7 +28,6 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
     private var callId: String? = null
     private var entry: CheckpointCallStore.Entry? = null
     private var reported = false
-    private var stagedResult: CheckpointPaywallOutcome = CheckpointPaywallOutcome.Dismissed
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -36,6 +36,7 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
         val presentation = entry?.presentation ?: run {
             // Process death or stray relaunch: the core-side pending call died with the process, so there is
             // nothing to report to.
+            Logger.w("Checkpoint call '$callId' no longer exists. Closing the checkpoint workflow.")
             finish()
             return
         }
@@ -55,32 +56,33 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
         super.onDestroy()
     }
 
+    // Outcomes are staged on the store entry (not this instance) so a configuration change doesn't reset them.
     private val resultStagingListener = object : PaywallListener {
         override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
-            stagedResult = CheckpointPaywallOutcome.Purchased(customerInfo)
+            entry?.stagedOutcome = CheckpointPaywallOutcome.Purchased(customerInfo)
         }
 
         override fun onRestoreCompleted(customerInfo: CustomerInfo) {
-            stagedResult = CheckpointPaywallOutcome.Restored(customerInfo)
+            entry?.stagedOutcome = CheckpointPaywallOutcome.Restored(customerInfo)
         }
 
         override fun onPurchaseError(error: PurchasesError) {
             if (error.code != PurchasesErrorCode.PurchaseCancelledError) {
-                stagedResult = CheckpointPaywallOutcome.Error(error)
+                entry?.stagedOutcome = CheckpointPaywallOutcome.Error(error)
             }
         }
 
         override fun onRestoreError(error: PurchasesError) {
-            stagedResult = CheckpointPaywallOutcome.Error(error)
+            entry?.stagedOutcome = CheckpointPaywallOutcome.Error(error)
         }
     }
 
     private fun report() {
         val callId = callId
-        val delegate = entry?.delegate
-        if (reported || callId == null || delegate == null) return
+        val entry = entry
+        if (reported || callId == null || entry == null) return
         reported = true
         CheckpointCallStore.remove(callId)
-        delegate.onCheckpointPaywallFinished(callId, stagedResult)
+        entry.delegate.onCheckpointPaywallFinished(callId, entry.stagedOutcome)
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
@@ -6,14 +6,14 @@ import androidx.activity.compose.setContent
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
-import com.revenuecat.purchases.checkpoints.CheckpointPaywallResult
+import com.revenuecat.purchases.checkpoints.CheckpointPaywallOutcome
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 
 /**
- * Presents the workflow resolved for a checkpoint and reports the terminal [CheckpointPaywallResult] back to
+ * Presents the workflow resolved for a checkpoint and reports the terminal [CheckpointPaywallOutcome] back to
  * the core module exactly once. Terminal purchase/restore events are staged as they happen and delivered when
  * the paywall dismisses (or the activity is otherwise finished), mirroring
  * [com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivity]'s result handling.
@@ -27,7 +27,7 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
     private var callId: String? = null
     private var entry: CheckpointCallStore.Entry? = null
     private var reported = false
-    private var stagedResult: CheckpointPaywallResult = CheckpointPaywallResult.Dismissed
+    private var stagedResult: CheckpointPaywallOutcome = CheckpointPaywallOutcome.Dismissed
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,21 +57,21 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
 
     private val resultStagingListener = object : PaywallListener {
         override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
-            stagedResult = CheckpointPaywallResult.Purchased(customerInfo)
+            stagedResult = CheckpointPaywallOutcome.Purchased(customerInfo)
         }
 
         override fun onRestoreCompleted(customerInfo: CustomerInfo) {
-            stagedResult = CheckpointPaywallResult.Restored(customerInfo)
+            stagedResult = CheckpointPaywallOutcome.Restored(customerInfo)
         }
 
         override fun onPurchaseError(error: PurchasesError) {
             if (error.code != PurchasesErrorCode.PurchaseCancelledError) {
-                stagedResult = CheckpointPaywallResult.Error(error)
+                stagedResult = CheckpointPaywallOutcome.Error(error)
             }
         }
 
         override fun onRestoreError(error: PurchasesError) {
-            stagedResult = CheckpointPaywallResult.Error(error)
+            stagedResult = CheckpointPaywallOutcome.Error(error)
         }
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
@@ -1,0 +1,86 @@
+package com.revenuecat.purchases.ui.revenuecatui.checkpoints
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.checkpoints.CheckpointPaywallResult
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.Paywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+
+/**
+ * Presents the workflow resolved for a checkpoint and reports the terminal [CheckpointPaywallResult] back to
+ * the core module exactly once. Terminal purchase/restore events are staged as they happen and delivered when
+ * the paywall dismisses (or the activity is otherwise finished), mirroring
+ * [com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivity]'s result handling.
+ */
+internal class CheckpointWorkflowActivity : ComponentActivity() {
+
+    companion object {
+        const val EXTRA_CALL_ID = "checkpoint_call_id"
+    }
+
+    private var callId: String? = null
+    private var entry: CheckpointCallStore.Entry? = null
+    private var reported = false
+    private var stagedResult: CheckpointPaywallResult = CheckpointPaywallResult.Dismissed()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        callId = intent.getStringExtra(EXTRA_CALL_ID)
+        entry = callId?.let { CheckpointCallStore.get(it) }
+        val presentation = entry?.presentation ?: run {
+            // Process death or stray relaunch: the core-side pending call died with the process, so there is
+            // nothing to report to.
+            finish()
+            return
+        }
+        val options = PaywallOptions.Builder(dismissRequest = ::finish)
+            .injectedWorkflow(presentation.workflow, presentation.offering, presentation.uiConfig)
+            .setListener(resultStagingListener)
+            .build()
+        setContent {
+            Paywall(options)
+        }
+    }
+
+    override fun onDestroy() {
+        if (isFinishing) {
+            report()
+        }
+        super.onDestroy()
+    }
+
+    private val resultStagingListener = object : PaywallListener {
+        override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
+            stagedResult = CheckpointPaywallResult.Purchased(customerInfo)
+        }
+
+        override fun onRestoreCompleted(customerInfo: CustomerInfo) {
+            stagedResult = CheckpointPaywallResult.Restored(customerInfo)
+        }
+
+        override fun onPurchaseError(error: PurchasesError) {
+            if (error.code != PurchasesErrorCode.PurchaseCancelledError) {
+                stagedResult = CheckpointPaywallResult.Error(error)
+            }
+        }
+
+        override fun onRestoreError(error: PurchasesError) {
+            stagedResult = CheckpointPaywallResult.Error(error)
+        }
+    }
+
+    private fun report() {
+        val callId = callId
+        val delegate = entry?.delegate
+        if (reported || callId == null || delegate == null) return
+        reported = true
+        CheckpointCallStore.remove(callId)
+        delegate.onCheckpointPaywallFinished(callId, stagedResult)
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
@@ -27,7 +27,7 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
     private var callId: String? = null
     private var entry: CheckpointCallStore.Entry? = null
     private var reported = false
-    private var stagedResult: CheckpointPaywallResult = CheckpointPaywallResult.Dismissed()
+    private var stagedResult: CheckpointPaywallResult = CheckpointPaywallResult.Dismissed
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/ui/revenuecatui/src/main/resources/META-INF/services/com.revenuecat.purchases.checkpoints.CheckpointPresenter
+++ b/ui/revenuecatui/src/main/resources/META-INF/services/com.revenuecat.purchases.checkpoints.CheckpointPresenter
@@ -1,0 +1,1 @@
+com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointPresenterImpl

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStoreTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStoreTest.kt
@@ -1,0 +1,54 @@
+package com.revenuecat.purchases.ui.revenuecatui.checkpoints
+
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Test
+
+class CheckpointCallStoreTest {
+
+    @After
+    fun tearDown() {
+        CheckpointCallStore.clear()
+    }
+
+    @Test
+    fun `get retrieves the stored entry without removing it`() {
+        val entry = CheckpointCallStore.Entry(delegate = mockk(), presentation = mockk())
+        CheckpointCallStore.store("call-id", entry)
+
+        assertThat(CheckpointCallStore.get("call-id")).isSameAs(entry)
+        assertThat(CheckpointCallStore.get("call-id")).isSameAs(entry)
+    }
+
+    @Test
+    fun `get returns null for an unknown callId`() {
+        assertThat(CheckpointCallStore.get("unknown-call-id")).isNull()
+    }
+
+    @Test
+    fun `remove returns the entry and deletes it`() {
+        val entry = CheckpointCallStore.Entry(delegate = mockk(), presentation = mockk())
+        CheckpointCallStore.store("call-id", entry)
+
+        assertThat(CheckpointCallStore.remove("call-id")).isSameAs(entry)
+        assertThat(CheckpointCallStore.get("call-id")).isNull()
+    }
+
+    @Test
+    fun `remove returns null for an unknown callId`() {
+        assertThat(CheckpointCallStore.remove("unknown-call-id")).isNull()
+    }
+
+    @Test
+    fun `remove does not affect other entries`() {
+        val entry = CheckpointCallStore.Entry(delegate = mockk(), presentation = mockk())
+        val otherEntry = CheckpointCallStore.Entry(delegate = mockk(), presentation = mockk())
+        CheckpointCallStore.store("call-id", entry)
+        CheckpointCallStore.store("other-call-id", otherEntry)
+
+        CheckpointCallStore.remove("call-id")
+
+        assertThat(CheckpointCallStore.get("other-call-id")).isSameAs(otherEntry)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStoreTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStoreTest.kt
@@ -43,22 +43,22 @@ class CheckpointCallStoreTest {
     }
 
     @Test
-    fun `a stored entry's staged outcome defaults to Dismissed`() {
+    fun `a stored entry's cached outcome defaults to Dismissed`() {
         CheckpointCallStore.store("call-id", CheckpointCallStore.Entry(delegate = mockk(), presentation = mockk()))
 
-        assertThat(CheckpointCallStore.get("call-id")?.stagedOutcome)
+        assertThat(CheckpointCallStore.get("call-id")?.outcome)
             .isEqualTo(CheckpointPaywallOutcome.Dismissed)
     }
 
     @Test
-    fun `a staged outcome survives re-reading the entry`() {
+    fun `a cached outcome survives re-reading the entry`() {
         val entry = CheckpointCallStore.Entry(delegate = mockk(), presentation = mockk())
         CheckpointCallStore.store("call-id", entry)
         val customerInfo = mockk<CustomerInfo>()
 
-        entry.stagedOutcome = CheckpointPaywallOutcome.Restored(customerInfo)
+        entry.outcome = CheckpointPaywallOutcome.Restored(customerInfo)
 
-        assertThat(CheckpointCallStore.get("call-id")?.stagedOutcome)
+        assertThat(CheckpointCallStore.get("call-id")?.outcome)
             .isEqualTo(CheckpointPaywallOutcome.Restored(customerInfo))
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStoreTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointCallStoreTest.kt
@@ -1,5 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.checkpoints
 
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.checkpoints.CheckpointPaywallOutcome
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -38,6 +40,26 @@ class CheckpointCallStoreTest {
     @Test
     fun `remove returns null for an unknown callId`() {
         assertThat(CheckpointCallStore.remove("unknown-call-id")).isNull()
+    }
+
+    @Test
+    fun `a stored entry's staged outcome defaults to Dismissed`() {
+        CheckpointCallStore.store("call-id", CheckpointCallStore.Entry(delegate = mockk(), presentation = mockk()))
+
+        assertThat(CheckpointCallStore.get("call-id")?.stagedOutcome)
+            .isEqualTo(CheckpointPaywallOutcome.Dismissed)
+    }
+
+    @Test
+    fun `a staged outcome survives re-reading the entry`() {
+        val entry = CheckpointCallStore.Entry(delegate = mockk(), presentation = mockk())
+        CheckpointCallStore.store("call-id", entry)
+        val customerInfo = mockk<CustomerInfo>()
+
+        entry.stagedOutcome = CheckpointPaywallOutcome.Restored(customerInfo)
+
+        assertThat(CheckpointCallStore.get("call-id")?.stagedOutcome)
+            .isEqualTo(CheckpointPaywallOutcome.Restored(customerInfo))
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointPresenterImplTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointPresenterImplTest.kt
@@ -1,0 +1,76 @@
+package com.revenuecat.purchases.ui.revenuecatui.checkpoints
+
+import android.app.Activity
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.checkpoints.CheckpointPresenter
+import com.revenuecat.purchases.checkpoints.CheckpointPresenterDelegate
+import com.revenuecat.purchases.checkpoints.CheckpointWorkflowPresentation
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.ServiceLoader
+
+@RunWith(AndroidJUnit4::class)
+class CheckpointPresenterImplTest {
+
+    private val callId = "test-call-id"
+
+    private lateinit var mockActivity: Activity
+    private lateinit var mockDelegate: CheckpointPresenterDelegate
+    private lateinit var mockPresentation: CheckpointWorkflowPresentation
+    private val startedIntent = slot<Intent>()
+
+    private lateinit var presenter: CheckpointPresenterImpl
+
+    @Before
+    fun setup() {
+        mockActivity = mockk {
+            every { packageName } returns "com.revenuecat.test"
+            every { startActivity(capture(startedIntent)) } just runs
+        }
+        mockDelegate = mockk()
+        mockPresentation = mockk()
+        presenter = CheckpointPresenterImpl()
+    }
+
+    @After
+    fun tearDown() {
+        CheckpointCallStore.clear()
+    }
+
+    @Test
+    fun `present stores the delegate and presentation keyed by callId`() {
+        presenter.present(mockActivity, callId, mockPresentation, mockDelegate)
+
+        val entry = CheckpointCallStore.get(callId)
+        assertThat(entry?.delegate).isSameAs(mockDelegate)
+        assertThat(entry?.presentation).isSameAs(mockPresentation)
+    }
+
+    @Test
+    fun `present starts the checkpoint workflow activity carrying only the callId`() {
+        presenter.present(mockActivity, callId, mockPresentation, mockDelegate)
+
+        val intent = startedIntent.captured
+        assertThat(intent.component?.className).isEqualTo(CheckpointWorkflowActivity::class.java.name)
+        assertThat(intent.getStringExtra(CheckpointWorkflowActivity.EXTRA_CALL_ID)).isEqualTo(callId)
+    }
+
+    @Test
+    fun `presenter is discoverable through ServiceLoader`() {
+        val loadedPresenter = ServiceLoader.load(
+            CheckpointPresenter::class.java,
+            CheckpointPresenter::class.java.classLoader,
+        ).firstOrNull()
+
+        assertThat(loadedPresenter).isInstanceOf(CheckpointPresenterImpl::class.java)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivityTest.kt
@@ -1,0 +1,41 @@
+package com.revenuecat.purchases.ui.revenuecatui.checkpoints
+
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.core.app.launchActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CheckpointWorkflowActivityTest {
+
+    @Test
+    fun `activity finishes gracefully when the checkpoint call is unknown`() {
+        // Simulates process death: the task is restored with the original callId extra, but the in-process
+        // call store (delegate, pending call) died with the process.
+        val intent = Intent(
+            ApplicationProvider.getApplicationContext<Context>(),
+            CheckpointWorkflowActivity::class.java,
+        ).putExtra(CheckpointWorkflowActivity.EXTRA_CALL_ID, "call-id-from-a-previous-process")
+
+        val scenario = launchActivity<CheckpointWorkflowActivity>(intent)
+
+        assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
+    }
+
+    @Test
+    fun `activity finishes gracefully when launched without a callId`() {
+        val intent = Intent(
+            ApplicationProvider.getApplicationContext<Context>(),
+            CheckpointWorkflowActivity::class.java,
+        )
+
+        val scenario = launchActivity<CheckpointWorkflowActivity>(intent)
+
+        assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
+    }
+}


### PR DESCRIPTION
Stacked on top of #3888 

This adds the UI side of checkpoints: presenting the workflow resolved for a checkpoint full-screen and reporting the outcome back to the SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New purchase/paywall presentation path tied to checkpoint execution; outcome delivery and process-death edge cases need correct behavior, but scope is isolated to the new presenter/activity flow.
> 
> **Overview**
> Adds the **RevenueCat UI** side of checkpoint workflows: core can discover and invoke a `CheckpointPresenter` through **ServiceLoader** without a compile-time UI dependency.
> 
> **`CheckpointPresenterImpl`** stores delegate, presentation, and a mutable outcome in **`CheckpointCallStore`** (keyed by `callId`), then starts **`CheckpointWorkflowActivity`** with only the call id in the Intent. The activity shows **`Paywall`** with an **injected workflow** from the checkpoint resolution and mirrors **`PaywallActivity`** outcome handling: purchase/restore/errors update the store entry; on finish it reports **`onCheckpointPaywallFinished`** once and removes the entry. Missing or stale call ids (e.g. after process death) close the activity without reporting.
> 
> **ProGuard** keeps `CheckpointPresenterImpl` for reflective loading. Unit tests cover the call store, presenter wiring, ServiceLoader discovery, and graceful finish when the call is unknown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265cf0be932d4083feb8ae5587142bb515d1dfec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->