### PR TITLE
feat(ads): wire-encode reward-verification events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -355,6 +355,20 @@ internal sealed class BackendEvent : Event {
         // Failed to load event only fields
         @SerialName("mediator_error_code")
         val mediatorErrorCode: Int? = null,
+
+        // Reward event only fields
+        @SerialName("reward_verification_enabled")
+        val rewardVerificationEnabled: Boolean? = null,
+        @SerialName("reward_type")
+        val rewardType: String? = null,
+        @SerialName("reward_virtual_currency_code")
+        val rewardVirtualCurrencyCode: String? = null,
+        @SerialName("reward_virtual_currency_amount")
+        val rewardVirtualCurrencyAmount: Int? = null,
+        @SerialName("reward_entitlement_id")
+        val rewardEntitlementId: String? = null,
+        @SerialName("reward_failure_reason")
+        val rewardFailureReason: String? = null,
     ) : BackendEvent()
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -4,6 +4,7 @@ package com.revenuecat.purchases.common.events
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.VerifiedReward
 import com.revenuecat.purchases.ads.events.AdEvent
 import com.revenuecat.purchases.common.workflows.events.WorkflowEvent
 import com.revenuecat.purchases.customercenter.events.CustomerCenterImpressionEvent
@@ -335,6 +336,133 @@ internal fun AdEvent.FailedToLoad.toBackendStoredEvent(
             appSessionID = appSessionID,
             captureMethod = captureMethod.value,
             mediatorErrorCode = mediatorErrorCode,
+        ),
+    )
+}
+
+@OptIn(InternalRevenueCatAPI::class)
+private val VerifiedReward.wireType: String
+    get() = when (this) {
+        is VerifiedReward.VirtualCurrency -> "virtual_currency"
+        is VerifiedReward.Entitlement -> "entitlement"
+        VerifiedReward.NoReward -> "no_reward"
+        VerifiedReward.UnsupportedReward -> "unsupported_reward"
+    }
+
+@OptIn(InternalRevenueCatAPI::class)
+private val VerifiedReward.wireVirtualCurrencyCode: String?
+    get() = (this as? VerifiedReward.VirtualCurrency)?.code
+
+@OptIn(InternalRevenueCatAPI::class)
+private val VerifiedReward.wireVirtualCurrencyAmount: Int?
+    get() = (this as? VerifiedReward.VirtualCurrency)?.amount
+
+@OptIn(InternalRevenueCatAPI::class)
+private val VerifiedReward.wireEntitlementId: String?
+    get() = (this as? VerifiedReward.Entitlement)?.identifier
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+@JvmSynthetic
+internal fun AdEvent.RewardEarnedUnverified.toBackendStoredEvent(
+    appUserID: String,
+    appSessionID: String,
+): BackendStoredEvent {
+    return BackendStoredEvent.Ad(
+        BackendEvent.Ad(
+            id = id,
+            version = eventVersion,
+            type = type.value,
+            timestamp = timestamp,
+            networkName = networkName,
+            mediatorName = mediatorName.value,
+            adFormat = adFormat.value,
+            placement = placement,
+            adUnitId = adUnitId,
+            impressionId = impressionId,
+            appUserID = appUserID,
+            appSessionID = appSessionID,
+            captureMethod = captureMethod.value,
+            rewardVerificationEnabled = rewardVerificationEnabled,
+        ),
+    )
+}
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+@JvmSynthetic
+internal fun AdEvent.RewardVerified.toBackendStoredEvent(
+    appUserID: String,
+    appSessionID: String,
+): BackendStoredEvent {
+    return BackendStoredEvent.Ad(
+        BackendEvent.Ad(
+            id = id,
+            version = eventVersion,
+            type = type.value,
+            timestamp = timestamp,
+            networkName = networkName,
+            mediatorName = mediatorName.value,
+            adFormat = adFormat.value,
+            placement = placement,
+            adUnitId = adUnitId,
+            impressionId = impressionId,
+            appUserID = appUserID,
+            appSessionID = appSessionID,
+            captureMethod = captureMethod.value,
+        ),
+    )
+}
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+@JvmSynthetic
+internal fun AdEvent.RewardGranted.toBackendStoredEvent(
+    appUserID: String,
+    appSessionID: String,
+): BackendStoredEvent {
+    return BackendStoredEvent.Ad(
+        BackendEvent.Ad(
+            id = id,
+            version = eventVersion,
+            type = type.value,
+            timestamp = timestamp,
+            networkName = networkName,
+            mediatorName = mediatorName.value,
+            adFormat = adFormat.value,
+            placement = placement,
+            adUnitId = adUnitId,
+            impressionId = impressionId,
+            appUserID = appUserID,
+            appSessionID = appSessionID,
+            captureMethod = captureMethod.value,
+            rewardType = reward.wireType,
+            rewardVirtualCurrencyCode = reward.wireVirtualCurrencyCode,
+            rewardVirtualCurrencyAmount = reward.wireVirtualCurrencyAmount,
+            rewardEntitlementId = reward.wireEntitlementId,
+        ),
+    )
+}
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+@JvmSynthetic
+internal fun AdEvent.RewardFailedToVerify.toBackendStoredEvent(
+    appUserID: String,
+    appSessionID: String,
+): BackendStoredEvent {
+    return BackendStoredEvent.Ad(
+        BackendEvent.Ad(
+            id = id,
+            version = eventVersion,
+            type = type.value,
+            timestamp = timestamp,
+            networkName = networkName,
+            mediatorName = mediatorName.value,
+            adFormat = adFormat.value,
+            placement = placement,
+            adUnitId = adUnitId,
+            impressionId = impressionId,
+            appUserID = appUserID,
+            appSessionID = appSessionID,
+            captureMethod = captureMethod.value,
+            rewardFailureReason = failureReason.value,
         ),
     )
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/ads/events/BackendStoredEventAdTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/ads/events/BackendStoredEventAdTest.kt
@@ -441,7 +441,7 @@ class BackendStoredEventAdTest {
             adUnitId = "ad-unit-999",
             impressionId = "impression-789",
             captureMethod = AdCaptureMethod.MANUAL,
-            failureReason = AdRewardFailureReason.backendError("no_reward_rule"),
+            failureReason = AdRewardFailureReason.BackendError("no_reward_rule"),
         )
 
         val storedEvent = failedEvent.toBackendStoredEvent(appUserID, appSessionID)

--- a/purchases/src/test/java/com/revenuecat/purchases/ads/events/BackendStoredEventAdTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/ads/events/BackendStoredEventAdTest.kt
@@ -2,12 +2,15 @@
 
 package com.revenuecat.purchases.ads.events
 
+import com.revenuecat.purchases.VerifiedReward
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.events.types.AdRevenuePrecision
+import com.revenuecat.purchases.ads.events.types.AdRewardFailureReason
 import com.revenuecat.purchases.common.events.BackendEvent
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.toBackendStoredEvent
+import java.util.Date
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -297,5 +300,156 @@ class BackendStoredEventAdTest {
         assertThat(adStoredEvent.event.appUserID).isEqualTo(appUserID)
         assertThat(adStoredEvent.event.appSessionID).isEqualTo(appSessionID)
         assertThat(adStoredEvent.event.captureMethod).isEqualTo("adapter")
+    }
+
+    @Test
+    fun `AdEvent RewardEarnedUnverified converts to BackendStoredEvent Ad correctly`() {
+        val earnedEvent = AdEvent.RewardEarnedUnverified(
+            id = "event-id-reward-earned",
+            timestamp = 1111111111L,
+            networkName = "Google AdMob",
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = AdFormat.REWARDED,
+            placement = "rewarded_video",
+            adUnitId = "ad-unit-999",
+            impressionId = "impression-789",
+            captureMethod = AdCaptureMethod.MANUAL,
+            rewardVerificationEnabled = true,
+        )
+
+        val storedEvent = earnedEvent.toBackendStoredEvent(appUserID, appSessionID)
+
+        assertThat(storedEvent).isInstanceOf(BackendStoredEvent.Ad::class.java)
+        val adStoredEvent = storedEvent as BackendStoredEvent.Ad
+        assertThat(adStoredEvent.event.type).isEqualTo("rc_ads_ad_reward_sdk_earned")
+        assertThat(adStoredEvent.event.impressionId).isEqualTo("impression-789")
+        assertThat(adStoredEvent.event.rewardVerificationEnabled).isTrue()
+        assertThat(adStoredEvent.event.rewardType).isNull()
+        assertThat(adStoredEvent.event.rewardFailureReason).isNull()
+    }
+
+    @Test
+    fun `AdEvent RewardVerified converts to BackendStoredEvent Ad correctly`() {
+        val verifiedEvent = AdEvent.RewardVerified(
+            id = "event-id-reward-verified",
+            timestamp = 1111111111L,
+            networkName = "Google AdMob",
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = AdFormat.REWARDED,
+            placement = "rewarded_video",
+            adUnitId = "ad-unit-999",
+            impressionId = "impression-789",
+            captureMethod = AdCaptureMethod.MANUAL,
+        )
+
+        val storedEvent = verifiedEvent.toBackendStoredEvent(appUserID, appSessionID)
+
+        assertThat(storedEvent).isInstanceOf(BackendStoredEvent.Ad::class.java)
+        val adStoredEvent = storedEvent as BackendStoredEvent.Ad
+        assertThat(adStoredEvent.event.type).isEqualTo("rc_ads_ad_reward_sdk_verified")
+        assertThat(adStoredEvent.event.impressionId).isEqualTo("impression-789")
+        assertThat(adStoredEvent.event.rewardVerificationEnabled).isNull()
+        assertThat(adStoredEvent.event.rewardType).isNull()
+        assertThat(adStoredEvent.event.rewardFailureReason).isNull()
+    }
+
+    @Test
+    fun `AdEvent RewardGranted with virtual currency converts to BackendStoredEvent Ad correctly`() {
+        val grantedEvent = AdEvent.RewardGranted(
+            id = "event-id-reward-granted",
+            timestamp = 1111111111L,
+            networkName = "Google AdMob",
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = AdFormat.REWARDED,
+            placement = "rewarded_video",
+            adUnitId = "ad-unit-999",
+            impressionId = "impression-789",
+            captureMethod = AdCaptureMethod.MANUAL,
+            reward = VerifiedReward.VirtualCurrency(code = "GLD", amount = 100),
+        )
+
+        val storedEvent = grantedEvent.toBackendStoredEvent(appUserID, appSessionID)
+
+        assertThat(storedEvent).isInstanceOf(BackendStoredEvent.Ad::class.java)
+        val adStoredEvent = storedEvent as BackendStoredEvent.Ad
+        assertThat(adStoredEvent.event.type).isEqualTo("rc_ads_ad_reward_sdk_granted")
+        assertThat(adStoredEvent.event.rewardType).isEqualTo("virtual_currency")
+        assertThat(adStoredEvent.event.rewardVirtualCurrencyCode).isEqualTo("GLD")
+        assertThat(adStoredEvent.event.rewardVirtualCurrencyAmount).isEqualTo(100)
+        assertThat(adStoredEvent.event.rewardEntitlementId).isNull()
+    }
+
+    @Test
+    fun `AdEvent RewardGranted with entitlement converts to BackendStoredEvent Ad correctly`() {
+        val grantedEvent = AdEvent.RewardGranted(
+            id = "event-id-reward-granted-entitlement",
+            timestamp = 1111111111L,
+            networkName = "Google AdMob",
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = AdFormat.REWARDED,
+            placement = "rewarded_video",
+            adUnitId = "ad-unit-999",
+            impressionId = "impression-789",
+            captureMethod = AdCaptureMethod.MANUAL,
+            reward = VerifiedReward.Entitlement(identifier = "premium", expiresAt = Date(0)),
+        )
+
+        val storedEvent = grantedEvent.toBackendStoredEvent(appUserID, appSessionID)
+
+        assertThat(storedEvent).isInstanceOf(BackendStoredEvent.Ad::class.java)
+        val adStoredEvent = storedEvent as BackendStoredEvent.Ad
+        assertThat(adStoredEvent.event.rewardType).isEqualTo("entitlement")
+        assertThat(adStoredEvent.event.rewardEntitlementId).isEqualTo("premium")
+        assertThat(adStoredEvent.event.rewardVirtualCurrencyCode).isNull()
+        assertThat(adStoredEvent.event.rewardVirtualCurrencyAmount).isNull()
+    }
+
+    @Test
+    fun `AdEvent RewardGranted with unsupported reward converts to BackendStoredEvent Ad correctly`() {
+        val grantedEvent = AdEvent.RewardGranted(
+            id = "event-id-reward-granted-unsupported",
+            timestamp = 1111111111L,
+            networkName = "Google AdMob",
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = AdFormat.REWARDED,
+            placement = "rewarded_video",
+            adUnitId = "ad-unit-999",
+            impressionId = "impression-789",
+            captureMethod = AdCaptureMethod.MANUAL,
+            reward = VerifiedReward.UnsupportedReward,
+        )
+
+        val storedEvent = grantedEvent.toBackendStoredEvent(appUserID, appSessionID)
+
+        assertThat(storedEvent).isInstanceOf(BackendStoredEvent.Ad::class.java)
+        val adStoredEvent = storedEvent as BackendStoredEvent.Ad
+        assertThat(adStoredEvent.event.rewardType).isEqualTo("unsupported_reward")
+        assertThat(adStoredEvent.event.rewardEntitlementId).isNull()
+        assertThat(adStoredEvent.event.rewardVirtualCurrencyCode).isNull()
+        assertThat(adStoredEvent.event.rewardVirtualCurrencyAmount).isNull()
+    }
+
+    @Test
+    fun `AdEvent RewardFailedToVerify converts to BackendStoredEvent Ad correctly`() {
+        val failedEvent = AdEvent.RewardFailedToVerify(
+            id = "event-id-reward-failed",
+            timestamp = 1111111111L,
+            networkName = "Google AdMob",
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = AdFormat.REWARDED,
+            placement = "rewarded_video",
+            adUnitId = "ad-unit-999",
+            impressionId = "impression-789",
+            captureMethod = AdCaptureMethod.MANUAL,
+            failureReason = AdRewardFailureReason.backendError("no_reward_rule"),
+        )
+
+        val storedEvent = failedEvent.toBackendStoredEvent(appUserID, appSessionID)
+
+        assertThat(storedEvent).isInstanceOf(BackendStoredEvent.Ad::class.java)
+        val adStoredEvent = storedEvent as BackendStoredEvent.Ad
+        assertThat(adStoredEvent.event.type).isEqualTo("rc_ads_ad_reward_sdk_failed_to_verify")
+        assertThat(adStoredEvent.event.rewardFailureReason).isEqualTo("no_reward_rule")
+        assertThat(adStoredEvent.event.rewardType).isNull()
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Description

This is a technical groundwork for ad reward tracking. It adds the serialization wiring for the 4 new ad event classes which we added in the previous branch of this stack.

<!-- Describe your changes in detail -->

<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Serialization and mapping only; no changes to reward verification logic or entitlement granting at runtime.
> 
> **Overview**
> Extends the **ad backend event wire schema** and **stored-event converters** so the four reward-verification `AdEvent` types can be serialized and flushed like other ad events.
> 
> `BackendEvent.Ad` gains optional reward fields (`reward_verification_enabled`, `reward_type`, virtual-currency and entitlement details, `reward_failure_reason`). `BackendStoredEvent.kt` adds `toBackendStoredEvent` for `RewardEarnedUnverified`, `RewardVerified`, `RewardGranted`, and `RewardFailedToVerify`, mapping `VerifiedReward` variants to the wire `reward_type` strings and populating only the fields relevant to each event type.
> 
> Unit tests in `BackendStoredEventAdTest` cover each reward event path, including virtual currency, entitlement, unsupported reward, and failed verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a86bf804e8bcd235f281ac250debfb0797d2863a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->