### PR TITLE
Only error-log an unresolvable ui_config when one is published

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.common.remoteconfig.GenerationGuardedCache
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigCommitListener
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import com.revenuecat.purchases.common.verboseLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -23,7 +24,9 @@ import kotlinx.coroutines.launch
  *
  * The merge is all-or-nothing: if any part is missing, unresolvable, or the merged object doesn't decode, no
  * [UiConfig] is returned. Callers that need UI config to render should fail instead of using a partial/default
- * configuration.
+ * configuration. [resolveUiConfig] classifies *why* nothing was returned — an absent/empty topic (a project
+ * with no paywalls) is a valid outcome, not a failure — while [getUiConfig] is the plain
+ * [UiConfigResolution.Found]-only view of it.
  *
  * `ui_config` is always kept in memory once resolved, so [getUiConfig] is memory-first: a warm read returns
  * synchronously (the suspend fn never suspends, so it resumes on the caller's thread with no dispatch) and only
@@ -32,6 +35,7 @@ import kotlinx.coroutines.launch
  * makes sure a slower disk warm never clobbers a fresher network commit (store-if-newer).
  */
 @OptIn(InternalRevenueCatAPI::class)
+@Suppress("TooManyFunctions")
 internal class UiConfigProvider(
     private val manager: RemoteConfigManager,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
@@ -44,17 +48,34 @@ internal class UiConfigProvider(
 
     /**
      * Returns the in-memory [UiConfig] if present, else resolves it from the config layer (which may wait for or
-     * trigger a `/v1/config` sync on a cold cache), caches it, and returns it. `null` when it can't be resolved.
-     *
-     * On a miss the resolved value is only returned via the cache (store-if-newer): if an identity-change
-     * invalidation advanced the generation while [resolve] was in flight, [GenerationGuardedCache.store] drops
-     * it and [GenerationGuardedCache.cached] is `null`, so the previous user's config is never served.
+     * trigger a `/v1/config` sync on a cold cache), caches it, and returns it. `null` when it can't be resolved —
+     * use [resolveUiConfig] when the reason matters.
      */
-    suspend fun getUiConfig(): UiConfig? {
-        cache.cached?.let { return it }
+    suspend fun getUiConfig(): UiConfig? = (resolveUiConfig() as? UiConfigResolution.Found)?.uiConfig
+
+    /**
+     * Like [getUiConfig], but reports *why* no [UiConfig] came back, so a caller can tell a project that simply
+     * has no `ui_config` (no paywalls configured) from one whose published `ui_config` couldn't be resolved. See
+     * [UiConfigResolution] for what each outcome means.
+     *
+     * A resolved value is only returned via the cache (store-if-newer): if an identity-change invalidation
+     * advanced the generation while [resolve] was in flight, [GenerationGuardedCache.store] drops it and
+     * [GenerationGuardedCache.cached] is `null`, so the previous user's config is never served.
+     */
+    @Suppress("ReturnCount")
+    suspend fun resolveUiConfig(): UiConfigResolution {
+        cache.cached?.let { return UiConfigResolution.Found(it) }
         val generation = manager.configGeneration
-        resolve()?.let { cache.store(generation, it) }
-        return cache.cached
+        val resolved = resolve()
+        if (resolved != null) cache.store(generation, resolved)
+        // Read back through the cache, never `resolved` itself: store-if-newer drops a value whose generation was
+        // overtaken mid-resolve, and that value may belong to the previous user.
+        cache.cached?.let { return UiConfigResolution.Found(it) }
+        // Still nothing in memory. A value that resolved but lost the store-if-newer race is not a failure, and
+        // must not reach [classifyUnresolved]: an identity change wipes the disk cache (which would read back as
+        // NotConfigured), while a newer commit's own failed warm leaves the topic intact (Unavailable) — both
+        // misreporting a resolve that actually worked.
+        return if (resolved != null) UiConfigResolution.Superseded else classifyUnresolved()
     }
 
     /**
@@ -99,6 +120,36 @@ internal class UiConfigProvider(
 
     private suspend fun resolve(): UiConfig? =
         manager.mergeItemsBlobData<UiConfig>(RemoteConfigTopic.UiConfig, ITEM_KEYS)
+
+    /**
+     * Tells "there is nothing to resolve" apart from "resolving what is published failed". Only ever called
+     * **after** a [resolve] attempt: a resolve on a cold cache waits for (or triggers) a `/v1/config` sync, so
+     * the committed state read here is post-sync. Checking before resolving would see the cold cache and report
+     * [UiConfigResolution.NotConfigured] for a project that does have a `ui_config`.
+     */
+    private suspend fun classifyUnresolved(): UiConfigResolution {
+        // First: committedTopicOrNull also returns null when the endpoint is disabled, which would otherwise be
+        // indistinguishable from an absent topic.
+        if (manager.isDisabled) {
+            verboseLog { "Remote config is disabled (4xx); there is no ui_config to resolve." }
+            return UiConfigResolution.Disabled
+        }
+        val topic = manager.committedTopicOrNull(RemoteConfigTopic.UiConfig)
+        val presentKeys = ITEM_KEYS.filter { topic?.containsKey(it) == true }
+        return if (presentKeys.isEmpty()) {
+            verboseLog {
+                val state = if (topic == null) "is absent" else "carries no ui_config part"
+                "The ui_config topic $state; nothing to resolve."
+            }
+            UiConfigResolution.NotConfigured
+        } else {
+            verboseLog {
+                "The ui_config topic carries ${presentKeys.size} of ${ITEM_KEYS.size} part(s) $presentKeys, " +
+                    "but they could not be resolved into a UiConfig."
+            }
+            UiConfigResolution.Unavailable
+        }
+    }
 
     private companion object {
         private val ITEM_KEYS = listOf("app", "localizations", "variable_config", "custom_variables")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
@@ -57,25 +57,24 @@ internal class UiConfigProvider(
      * Like [getUiConfig], but reports *why* no [UiConfig] came back, so a caller can tell a project that simply
      * has no `ui_config` (no paywalls configured) from one whose published `ui_config` couldn't be resolved. See
      * [UiConfigResolution] for what each outcome means.
-     *
-     * A resolved value is only returned via the cache (store-if-newer): if an identity-change invalidation
-     * advanced the generation while [resolve] was in flight, [GenerationGuardedCache.store] drops it and
-     * [GenerationGuardedCache.cached] is `null`, so the previous user's config is never served.
      */
-    @Suppress("ReturnCount")
     suspend fun resolveUiConfig(): UiConfigResolution {
         cache.cached?.let { return UiConfigResolution.Found(it) }
+
         val generation = manager.configGeneration
         val resolved = resolve()
         if (resolved != null) cache.store(generation, resolved)
-        // Read back through the cache, never `resolved` itself: store-if-newer drops a value whose generation was
-        // overtaken mid-resolve, and that value may belong to the previous user.
-        cache.cached?.let { return UiConfigResolution.Found(it) }
-        // Still nothing in memory. A value that resolved but lost the store-if-newer race is not a failure, and
-        // must not reach [classifyUnresolved]: an identity change wipes the disk cache (which would read back as
-        // NotConfigured), while a newer commit's own failed warm leaves the topic intact (Unavailable) — both
-        // misreporting a resolve that actually worked.
-        return if (resolved != null) UiConfigResolution.Superseded else classifyUnresolved()
+
+        // What the cache accepted is what can be served, never `resolved` itself: store-if-newer drops a value
+        // whose generation was overtaken mid-resolve, and that value may belong to the previous user.
+        val served = cache.cached
+        return when {
+            served != null -> UiConfigResolution.Found(served)
+            // Resolved fine, but the generation guard dropped it — not a failure, and it must not be classified
+            // from the committed state (an identity change has already wiped it). The next read re-resolves.
+            resolved != null -> UiConfigResolution.Superseded
+            else -> classifyUnresolved()
+        }
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigResolution.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigResolution.kt
@@ -1,0 +1,33 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.uiconfig
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.UiConfig
+
+/**
+ * Outcome of resolving `ui_config` through the `/v1/config` ui_config topic. It lets a caller tell apart the
+ * situations a bare `UiConfig?` conflates, so only a genuine failure is reported as one:
+ *
+ * - [Found]: the [UiConfig] is resolved and in memory.
+ * - [NotConfigured]: the topic is absent, or carries none of the ui_config parts. A project with no paywalls
+ *   configured legitimately has no `ui_config` at all, so there is nothing to resolve — not a failure.
+ * - [Disabled]: the `/v1/config` endpoint is disabled for the session by the 4xx kill switch, so no topic can
+ *   be read at all.
+ * - [Superseded]: a [UiConfig] **was** resolved, but a newer config commit or an identity change advanced the
+ *   config generation while it was in flight, so it was dropped instead of served (store-if-newer). The next
+ *   read re-resolves against the fresher config.
+ * - [Unavailable]: the topic carries ui_config parts but they could not be resolved into one [UiConfig] (an
+ *   unresolvable blob, or a merged object that doesn't decode). The only outcome worth reporting as an error.
+ */
+internal sealed interface UiConfigResolution {
+    data class Found(val uiConfig: UiConfig) : UiConfigResolution
+
+    object NotConfigured : UiConfigResolution
+
+    object Disabled : UiConfigResolution
+
+    object Superseded : UiConfigResolution
+
+    object Unavailable : UiConfigResolution
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -172,7 +172,7 @@ internal class WorkflowManager(
         when (uiConfigProvider.resolveUiConfig()) {
             is UiConfigResolution.Found -> Unit
             UiConfigResolution.NotConfigured -> verboseLog {
-                "No ui_config in remote config before getOfferings; nothing to ready."
+                "Remote config has no ui_config to resolve before getOfferings."
             }
             UiConfigResolution.Disabled -> debugLog {
                 "Remote config is disabled for this session; skipping ui_config readiness before getOfferings."

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -7,8 +7,11 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
+import com.revenuecat.purchases.common.uiconfig.UiConfigResolution
+import com.revenuecat.purchases.common.verboseLog
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -116,7 +119,8 @@ internal class WorkflowManager(
      * - the workflows topic is synced, so [workflowIdForOfferingId] resolves; and
      * - the `ui_config` body is resolved, so a workflow render — and, once `ui_config`/paywall components stop
      *   shipping inline in `/offerings` and move to the config endpoint, the offering itself — has its styling
-     *   in hand without a further round-trip.
+     *   in hand without a further round-trip. A project with no paywalls configured publishes no `ui_config` at
+     *   all, which is a valid ready outcome rather than a failure (see [UiConfigResolution]).
      *
      * Both steps are best-effort: a failure to ready either one is swallowed (logged) and never propagates,
      * so [onComplete] always runs and `getOfferings` can never be stranded waiting on it — if config data
@@ -140,7 +144,7 @@ internal class WorkflowManager(
         }
         val readiness: Deferred<Unit> = synchronized(readinessLock) {
             inFlightReadiness ?: scope.async {
-                awaitBestEffort("ui_config") { checkNotNull(uiConfigProvider.getUiConfig()) }
+                awaitBestEffort("ui_config") { readyUiConfig() }
                 awaitBestEffort("workflows") { workflowsConfigProvider.warm() }
             }.also { deferred ->
                 inFlightReadiness = deferred
@@ -160,6 +164,27 @@ internal class WorkflowManager(
     }
 
     /**
+     * Resolves `ui_config` for the gate and reports the outcome at the level it deserves. Only a topic that
+     * actually publishes ui_config parts and still can't be resolved is a failure: a project with no paywalls
+     * configured has no `ui_config` at all, and error-logging that was pure noise.
+     */
+    private suspend fun readyUiConfig() {
+        when (uiConfigProvider.resolveUiConfig()) {
+            is UiConfigResolution.Found -> Unit
+            UiConfigResolution.NotConfigured -> verboseLog {
+                "No ui_config in remote config before getOfferings; nothing to ready."
+            }
+            UiConfigResolution.Disabled -> debugLog {
+                "Remote config is disabled for this session; skipping ui_config readiness before getOfferings."
+            }
+            UiConfigResolution.Superseded -> verboseLog {
+                "ui_config was superseded by a newer config commit before getOfferings; the next read re-resolves it."
+            }
+            UiConfigResolution.Unavailable -> errorLog { readinessFailureMessage("ui_config") }
+        }
+    }
+
+    /**
      * Runs a best-effort readiness step: swallows and logs any failure so it can't strand the gate, but lets
      * [kotlinx.coroutines.CancellationException] propagate so real cancellation still tears the gate down
      * instead of being reported as a completed step. (Plain `runCatching` would swallow cancellation too.)
@@ -170,7 +195,10 @@ internal class WorkflowManager(
         } catch (e: CancellationException) {
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            errorLog(e) { "Failed to ready $what before getOfferings; proceeding without it." }
+            errorLog(e) { readinessFailureMessage(what) }
         }
     }
+
+    private fun readinessFailureMessage(what: String) =
+        "Failed to ready $what before getOfferings; proceeding without it."
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
@@ -5,14 +5,17 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.currentLogHandler
+import com.revenuecat.purchases.common.remoteconfig.ConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationKey
 import com.revenuecat.purchases.paywalls.components.properties.FontStyle
 import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -41,6 +44,9 @@ internal class UiConfigProviderTest {
     @Before
     fun setUp() {
         every { manager.configGeneration } returns 0
+        // Defaults for the outcome classification a failed resolve now runs; per-test stubs override them.
+        every { manager.isDisabled } returns false
+        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns null
         currentLogHandler = object : LogHandler {
             override fun v(tag: String, msg: String) {}
             override fun d(tag: String, msg: String) {}
@@ -181,8 +187,100 @@ internal class UiConfigProviderTest {
     }
 
     @Test
+    fun `resolveUiConfig serves Found from the in-memory cache without touching the config layer`() = runTest {
+        stubMergedRead(minimalUiConfigJson())
+        val first = provider.resolveUiConfig()
+
+        val second = provider.resolveUiConfig()
+
+        assertThat(first).isInstanceOf(UiConfigResolution.Found::class.java)
+        assertThat((second as UiConfigResolution.Found).uiConfig)
+            .isSameAs((first as UiConfigResolution.Found).uiConfig)
+        coVerify(exactly = 1) {
+            manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
+        }
+        coVerify(exactly = 0) { manager.committedTopicOrNull(any()) }
+    }
+
+    @Test
+    fun `resolveUiConfig returns NotConfigured when the ui_config topic is absent`() = runTest {
+        // A project with no paywalls configured publishes no ui_config topic at all. That is a valid state, not
+        // a failure the caller should report as an error.
+        stubUnresolvableMergedRead()
+        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns null
+
+        assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.NotConfigured)
+    }
+
+    @Test
+    fun `resolveUiConfig returns NotConfigured when the committed topic carries no ui_config part`() = runTest {
+        stubUnresolvableMergedRead()
+        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns ConfigTopic(emptyMap())
+
+        assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.NotConfigured)
+
+        // Same for a topic that only carries items the ui_config merge doesn't read.
+        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns uiConfigTopic("something_else")
+
+        assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.NotConfigured)
+    }
+
+    @Test
+    fun `resolveUiConfig returns Unavailable when published ui_config parts cannot be resolved`() = runTest {
+        // The topic does carry ui_config parts, so failing to assemble them into a UiConfig is a real failure —
+        // including a partially published topic, since the merge is all-or-nothing.
+        stubUnresolvableMergedRead()
+        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns uiConfigTopic("app")
+
+        assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.Unavailable)
+    }
+
+    @Test
+    fun `resolveUiConfig returns Disabled without reading the topic when remote config is disabled`() = runTest {
+        // committedTopicOrNull also returns null when disabled, so the disabled check has to come first or a
+        // killed session would look like a project with no ui_config.
+        stubUnresolvableMergedRead()
+        every { manager.isDisabled } returns true
+
+        assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.Disabled)
+        coVerify(exactly = 0) { manager.committedTopicOrNull(any()) }
+    }
+
+    @Test
+    fun `resolveUiConfig classifies only after attempting the resolve`() = runTest {
+        // A resolve on a cold cache waits for (or triggers) a /v1/config sync, so the committed topic must only
+        // be inspected afterwards; checking first would report NotConfigured for a project that has a ui_config.
+        stubUnresolvableMergedRead()
+
+        provider.resolveUiConfig()
+
+        coVerifyOrder {
+            manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
+            manager.committedTopicOrNull(RemoteConfigTopic.UiConfig)
+        }
+    }
+
+    @Test
+    fun `resolveUiConfig returns Superseded when a newer invalidation lands mid-resolve`() = runTest {
+        // The value resolved fine but belongs to a superseded generation, so it is dropped rather than served.
+        // That is not a resolution failure, and must not be classified from the (already wiped) committed state.
+        every { manager.configGeneration } returns 0
+        val merged = minimalUiConfigJson()
+        coEvery {
+            manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
+        } answers {
+            provider.onConfigInvalidated(generation = 5)
+            thirdArg<(JsonObject) -> UiConfig?>().invoke(merged)
+        }
+
+        assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.Superseded)
+        assertThat(provider.isWarm()).isFalse
+        coVerify(exactly = 0) { manager.committedTopicOrNull(any()) }
+    }
+
+    @Test
     fun `isWarm is false before warm and true after`() = runTest {
-        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns mockk()
+        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns uiConfigTopic()
         stubMergedRead(minimalUiConfigJson())
 
         assertThat(provider.isWarm()).isFalse
@@ -205,7 +303,7 @@ internal class UiConfigProviderTest {
 
     @Test
     fun `warm is a no-op when already warm at or above the generation`() = runTest {
-        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns mockk()
+        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns uiConfigTopic()
         stubMergedRead(minimalUiConfigJson())
         provider.warm(generation = 3)
         val warmed = requireNotNull(provider.getUiConfig())
@@ -248,7 +346,7 @@ internal class UiConfigProviderTest {
 
     @Test
     fun `a lower-generation warm does not clobber a higher-generation value`() = runTest {
-        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns mockk()
+        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns uiConfigTopic()
         stubMergedRead(minimalUiConfigJson())
 
         // A fresh (higher-generation) commit warmed the cache.
@@ -266,7 +364,7 @@ internal class UiConfigProviderTest {
         // Regression: onConfigCommitted re-warms asynchronously and doesn't pre-invalidate. If that warm can't
         // resolve the body (e.g. a transient blob read) it must not leave the previous snapshot behind tagged
         // with an older generation — memory-first getUiConfig would keep serving it after the config advanced.
-        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns mockk()
+        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns uiConfigTopic()
         stubMergedRead(minimalUiConfigJson())
         val original = requireNotNull(provider.getUiConfig())
 
@@ -287,7 +385,7 @@ internal class UiConfigProviderTest {
 
     @Test
     fun `a stale warm cannot repopulate the cache after a newer invalidation`() = runTest {
-        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns mockk()
+        coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns uiConfigTopic()
         stubMergedRead(minimalUiConfigJson())
 
         // Identity change / disable invalidated at a newer generation.
@@ -317,6 +415,16 @@ internal class UiConfigProviderTest {
         assertThat(uiConfig).isNull()
         assertThat(provider.isWarm()).isFalse
     }
+
+    private fun stubUnresolvableMergedRead() {
+        coEvery {
+            manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
+        } returns null
+    }
+
+    private fun uiConfigTopic(
+        vararg parts: String = arrayOf("app", "localizations", "variable_config", "custom_variables"),
+    ): ConfigTopic = ConfigTopic(parts.associateWith { RemoteConfiguration.ConfigItem(blobRef = "ref-$it") })
 
     private fun minimalUiConfigJson(): JsonObject = buildJsonObject {
         putJsonObject("app") {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.emptyUiConfig
 import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
+import com.revenuecat.purchases.common.uiconfig.UiConfigResolution
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -43,19 +44,25 @@ class WorkflowManagerTest {
     private lateinit var workflowManager: WorkflowManager
 
     // This is a plain JUnit test (no Robolectric), so the default log handler's android.util.Log calls aren't
-    // mocked. Swap in a no-op handler so the prewarm-failure path can log without blowing up.
+    // mocked. Swap in a recording handler so the prewarm-failure path can log without blowing up, and so the
+    // readiness gate's error logging can be asserted — including its absence, which assertLogs can't express.
     private val originalLogHandler = currentLogHandler
+    private val errorLogs = mutableListOf<String>()
 
     @Before
     fun setUp() {
+        errorLogs.clear()
         currentLogHandler = object : LogHandler {
             override fun v(tag: String, msg: String) {}
             override fun d(tag: String, msg: String) {}
             override fun i(tag: String, msg: String) {}
             override fun w(tag: String, msg: String) {}
-            override fun e(tag: String, msg: String, throwable: Throwable?) {}
+            override fun e(tag: String, msg: String, throwable: Throwable?) {
+                errorLogs += msg
+            }
         }
         coEvery { mockUiConfigProvider.getUiConfig() } returns uiConfig
+        coEvery { mockUiConfigProvider.resolveUiConfig() } returns UiConfigResolution.Found(uiConfig)
         every { mockUiConfigProvider.isWarm() } returns false
         every { mockAssetPreDownloader.preDownloadWorkflowAssets(any(), any()) } just Runs
         workflowManager = WorkflowManager(
@@ -210,7 +217,7 @@ class WorkflowManagerTest {
 
         assertThat(completed).isTrue()
         coVerify(exactly = 0) { mockProvider.warm() }
-        coVerify(exactly = 0) { mockUiConfigProvider.getUiConfig() }
+        coVerify(exactly = 0) { mockUiConfigProvider.resolveUiConfig() }
     }
 
     @Test
@@ -226,15 +233,15 @@ class WorkflowManagerTest {
 
         assertThat(completed).isTrue()
         coVerify(exactly = 1) { mockProvider.warm() }
-        coVerify(exactly = 1) { mockUiConfigProvider.getUiConfig() }
+        coVerify(exactly = 1) { mockUiConfigProvider.resolveUiConfig() }
     }
 
     @Test
-    fun `onPaywallConfigReady still completes when ui_config resolution fails`() {
+    fun `onPaywallConfigReady still completes and error-logs when ui_config resolution throws`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } just Runs
-        coEvery { mockUiConfigProvider.getUiConfig() } throws RuntimeException("boom")
+        coEvery { mockUiConfigProvider.resolveUiConfig() } throws RuntimeException("boom")
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
 
         var completed = false
@@ -242,14 +249,15 @@ class WorkflowManagerTest {
         testScope.testScheduler.advanceUntilIdle()
 
         assertThat(completed).isTrue()
+        assertThat(errorLogs).anyMatch { it.contains("Failed to ready ui_config before getOfferings") }
     }
 
     @Test
-    fun `onPaywallConfigReady still completes when ui_config is unavailable`() {
+    fun `onPaywallConfigReady still completes and error-logs when a published ui_config is unavailable`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } just Runs
-        coEvery { mockUiConfigProvider.getUiConfig() } returns null
+        coEvery { mockUiConfigProvider.resolveUiConfig() } returns UiConfigResolution.Unavailable
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
 
         var completed = false
@@ -257,6 +265,34 @@ class WorkflowManagerTest {
         testScope.testScheduler.advanceUntilIdle()
 
         assertThat(completed).isTrue()
+        assertThat(errorLogs).anyMatch { it.contains("Failed to ready ui_config before getOfferings") }
+    }
+
+    @Test
+    fun `onPaywallConfigReady completes without error-logging when there is no ui_config to ready`() {
+        // A project with no paywalls configured has no ui_config at all, and neither does a session whose
+        // /v1/config endpoint was killed, or one whose resolve was superseded by a newer commit. None of those
+        // is a failure, so none may reach the developer's log as an error.
+        val validOutcomes = listOf(
+            UiConfigResolution.NotConfigured,
+            UiConfigResolution.Disabled,
+            UiConfigResolution.Superseded,
+        )
+
+        validOutcomes.forEach { outcome ->
+            val mockProvider = mockk<WorkflowsConfigProvider>()
+            every { mockProvider.isWarmForCurrentOffering() } returns false
+            coEvery { mockProvider.warm() } just Runs
+            coEvery { mockUiConfigProvider.resolveUiConfig() } returns outcome
+            val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
+
+            var completed = false
+            manager.onPaywallConfigReady { completed = true }
+            testScope.testScheduler.advanceUntilIdle()
+
+            assertThat(completed).describedAs("completed for $outcome").isTrue()
+            assertThat(errorLogs).describedAs("error logs for $outcome").isEmpty()
+        }
     }
 
     @Test
@@ -272,7 +308,7 @@ class WorkflowManagerTest {
 
         assertThat(completed).isTrue()
         // A failure to ready one step must not cancel the other.
-        coVerify(exactly = 1) { mockUiConfigProvider.getUiConfig() }
+        coVerify(exactly = 1) { mockUiConfigProvider.resolveUiConfig() }
     }
 
     @Test
@@ -299,7 +335,7 @@ class WorkflowManagerTest {
         assertThat(completed2).isTrue()
         // The underlying work must have run exactly once despite two concurrent callers.
         coVerify(exactly = 1) { mockProvider.warm() }
-        coVerify(exactly = 1) { mockUiConfigProvider.getUiConfig() }
+        coVerify(exactly = 1) { mockUiConfigProvider.resolveUiConfig() }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -23,6 +23,7 @@ import com.revenuecat.purchases.common.remoteconfig.RemoteConfigSourceProvider
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopicStore
+import com.revenuecat.purchases.common.uiconfig.UiConfigResolution
 import com.revenuecat.purchases.utils.UrlConnection
 import com.revenuecat.purchases.utils.UrlConnectionFactory
 import io.mockk.coEvery
@@ -369,6 +370,7 @@ class WorkflowsConfigIntegrationTest {
         uiConfigProvider = mockk {
             every { isWarm() } returns false
             coEvery { getUiConfig() } returns emptyUiConfig()
+            coEvery { resolveUiConfig() } returns UiConfigResolution.Found(emptyUiConfig())
         },
         workflowAssetPrewarmer = mockk(relaxed = true),
         scope = testScope,


### PR DESCRIPTION
### Motivation

A project with no paywalls configured legitimately publishes no `ui_config` at all. The offerings readiness gate treated any missing `ui_config` as a failure, so developers not using paywalls/workflows got a spurious ERROR log on every cold `getOfferings`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and internal resolution classification only; getOfferings still completes best-effort and existing getUiConfig behavior for successful resolves is preserved.
> 
> **Overview**
> Stops spurious **ERROR** logs on cold `getOfferings` when a project has no paywalls and never publishes `ui_config`.
> 
> **`UiConfigProvider`** now exposes `resolveUiConfig()` with a `UiConfigResolution` outcome (`Found`, `NotConfigured`, `Disabled`, `Superseded`, `Unavailable`). Missing or empty topics are treated as valid “nothing to resolve,” not failures; only published parts that still won’t merge/decode map to `Unavailable`. `getUiConfig()` stays a `UiConfig?` view of `Found` only.
> 
> **`WorkflowManager.onPaywallConfigReady`** uses that classification in `readyUiConfig()`: it error-logs only `Unavailable` (and thrown errors); `NotConfigured`, disabled remote config, and superseded resolves log at verbose/debug and still complete the gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ded9aaf1e0ba1cb0e07a8fc69dc50510f3c29003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->