### PR TITLE
paywalls: Add webview cache warming engine

### DIFF
--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
@@ -1,0 +1,71 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented because WebView's instance API does not resolve on this module's unit-test classpath. An
+ * autoplaying `<video>`/`<audio>` really does play from a view that was never attached to a window.
+ */
+@RunWith(AndroidJUnit4::class)
+class PaywallWebViewMediaPolicyTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun onMain(block: () -> Unit) =
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
+
+    @Test
+    fun warmingRefusesMediaAutoplay() {
+        var requiresGesture: Boolean? = null
+        onMain {
+            val webView = createWarmingWebView(
+                context = context,
+                resolvedUrl = URL,
+                onLoadFailed = {},
+                onLoadFinished = {},
+            )
+            requiresGesture = webView.settings.mediaPlaybackRequiresUserGesture
+            webView.destroyPaywallWebView()
+        }
+
+        assertThat(requiresGesture).isTrue()
+    }
+
+    @Test
+    fun displayAllowsMediaAutoplay() {
+        var requiresGesture: Boolean? = null
+        var built = false
+        onMain {
+            val configured = createPaywallWebView(
+                context = context,
+                identity = WebViewIdentity(
+                    resolvedUrl = URL,
+                    componentId = "component-1",
+                    sizeToContentWidth = false,
+                    sizeToContentHeight = false,
+                ),
+                onLoadFailed = {},
+            )
+            built = configured != null
+            configured?.let {
+                requiresGesture = it.webView.settings.mediaPlaybackRequiresUserGesture
+                it.webView.releasePaywallWebView(it.bridge)
+            }
+        }
+
+        // Null means this System WebView cannot install secure messaging, which is not what this asserts.
+        assumeTrue(built)
+        assertThat(requiresGesture).isFalse()
+    }
+
+    private companion object {
+        const val URL = "https://assets.example.com/promo/index.html"
+    }
+}

--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
@@ -9,10 +9,6 @@ import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
-/**
- * Instrumented because WebView's instance API does not resolve on this module's unit-test classpath. An
- * autoplaying `<video>`/`<audio>` really does play from a view that was never attached to a window.
- */
 @RunWith(AndroidJUnit4::class)
 class PaywallWebViewMediaPolicyTest {
 
@@ -60,7 +56,6 @@ class PaywallWebViewMediaPolicyTest {
             }
         }
 
-        // Null means this System WebView cannot install secure messaging, which is not what this asserts.
         assumeTrue(built)
         assertThat(requiresGesture).isFalse()
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClient.kt
@@ -24,10 +24,14 @@ internal class PaywallWebViewClient(
     private val expectedOrigin: String?,
     private val onMainFrameNavigationStarted: () -> Unit,
     private val onMainFrameLoadFailed: () -> Unit,
+    private val onMainFrameLoadFinished: () -> Unit,
 ) : WebViewClient() {
 
     @Volatile
     private var failed: Boolean = false
+
+    @Volatile
+    private var finished: Boolean = false
 
     private fun markFailed(reason: String) {
         if (failed) return
@@ -57,6 +61,14 @@ internal class PaywallWebViewClient(
             return
         }
         onMainFrameNavigationStarted()
+    }
+
+    override fun onPageFinished(view: WebView, url: String?) {
+        super.onPageFinished(view, url)
+        if (failed || finished) return
+        if (url?.toOriginOrNull() == null) return
+        finished = true
+        onMainFrameLoadFinished()
     }
 
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -1,0 +1,206 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.content.ComponentCallbacks2
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Handler
+import android.os.Looper
+import androidx.annotation.MainThread
+import androidx.annotation.VisibleForTesting
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+
+/**
+ * Loads `web_view` component bundles offscreen so the paywall profile's http cache holds them before the
+ * component renders.
+ *
+ * Warming views are never attached or laid out, so a bundle whose requests depend on viewport size
+ * (`srcset`, `sizes`, CSS media queries) can resolve them differently than the displayed document does.
+ */
+@Suppress("TooManyFunctions")
+internal class PaywallWebViewPrewarmer(
+    private val maxConcurrentWarms: Int = MAX_CONCURRENT_WARMS,
+) {
+
+    private class InFlightWarm(
+        val view: PaywallWebView,
+        var scheduledTeardown: Runnable,
+    )
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private val queue = ArrayDeque<String>()
+
+    private val inFlight = LinkedHashMap<String, InFlightWarm>()
+
+    private val warmedUrls = mutableSetOf<String>()
+
+    private var applicationContext: Context? = null
+
+    private var displayedComponents = 0
+
+    private val trimCallbacks = object : ComponentCallbacks2 {
+        override fun onTrimMemory(level: Int) {
+            if (inFlight.isNotEmpty() || queue.isNotEmpty()) {
+                Logger.d("Paywalls V2 web_view cache warming abandoned on memory trim (level $level).")
+            }
+            releaseAll()
+        }
+
+        override fun onLowMemory() = onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
+
+        override fun onConfigurationChanged(newConfig: Configuration) = Unit
+    }
+
+    @MainThread
+    @Suppress("ReturnCount")
+    fun prewarm(context: Context, url: String) {
+        val resolvedUrl = WebViewUrlResolver.resolve(url)
+        if (resolvedUrl == null) {
+            Logger.d("Paywalls V2 web_view not prewarmed: URL must be https with no '{{' markers: '$url'")
+            return
+        }
+        if (alreadyCovered(resolvedUrl)) {
+            Logger.d("Paywalls V2 web_view already warmed or warming this URL; skipping.")
+            return
+        }
+        val appContext = context.applicationContext
+        if (applicationContext == null) {
+            appContext.registerComponentCallbacks(trimCallbacks)
+        }
+        applicationContext = appContext
+        queue.addLast(resolvedUrl)
+        startAvailable()
+    }
+
+    @MainThread
+    fun releaseAll() {
+        queue.clear()
+        releaseInFlight()
+    }
+
+    /**
+     * Stops warming while a `web_view` component displays [resolvedUrl]: every warm runs script on the one
+     * renderer thread that component is using. Balanced by [onDisplayEnded].
+     */
+    @MainThread
+    fun onDisplayStarted(resolvedUrl: String) {
+        queue.remove(resolvedUrl)
+        displayedComponents++
+        if (displayedComponents > 1) return
+        queue.addAll(0, inFlight.keys.filterNot { it in warmedUrls || it == resolvedUrl })
+        mainHandler.post(::releaseInFlight)
+    }
+
+    /**
+     * The display path's own load of [resolvedUrl] has started, so it fills the http cache itself. Unlike
+     * [onDisplayStarted] this waits until the WebView exists, so a construction failure cannot poison the url.
+     */
+    @MainThread
+    fun markWarmed(resolvedUrl: String) {
+        warmedUrls.add(resolvedUrl)
+    }
+
+    /** Counterpart to [onDisplayStarted]. Warming resumes once the last component is gone. */
+    @MainThread
+    fun onDisplayEnded() {
+        if (displayedComponents == 0) return
+        displayedComponents--
+        // Posted: a paywall is being dismissed on this frame, and building a WebView there is jank.
+        if (displayedComponents == 0) mainHandler.post(::startAvailable)
+    }
+
+    @MainThread
+    private fun releaseInFlight() {
+        inFlight.keys.toList().forEach(::release)
+    }
+
+    private fun alreadyCovered(resolvedUrl: String): Boolean =
+        resolvedUrl in warmedUrls || resolvedUrl in inFlight || resolvedUrl in queue
+
+    @MainThread
+    private fun startAvailable() {
+        if (displayedComponents > 0) return
+        val context = applicationContext ?: return
+        while (inFlight.size < maxConcurrentWarms) {
+            val url = queue.removeFirstOrNull()
+            if (url == null || !begin(context, url)) break
+        }
+    }
+
+    @MainThread
+    @Suppress("TooGenericExceptionCaught")
+    private fun begin(context: Context, url: String): Boolean {
+        val stalled = Runnable {
+            Logger.d("Paywalls V2 web_view cache warm stalled; moving on to the next URL.")
+            finishWarm(url)
+        }
+        try {
+            val view = createWarmingWebView(
+                context = context,
+                resolvedUrl = url,
+                // Posted: these arrive inside a WebViewClient callback, and destroy() must not run there.
+                onLoadFailed = { mainHandler.post { finishWarm(url) } },
+                onLoadFinished = { mainHandler.post { settle(url) } },
+            )
+            inFlight[url] = InFlightWarm(view = view, scheduledTeardown = stalled)
+            view.loadUrl(url)
+            mainHandler.postDelayed(stalled, WARM_STALL_TIMEOUT_MS)
+        } catch (error: Throwable) {
+            // A missing or mid-update WebView package throws Error, not Exception.
+            Logger.w("Paywalls V2 web_view could not be prewarmed: $error")
+            release(url)
+            mainHandler.post { startAvailable() }
+            return false
+        }
+        Logger.d("Paywalls V2 web_view warming the http cache for '$url'.")
+        return true
+    }
+
+    /** `onPageFinished` covers the main frame only, so the view is held for what script still fetches. */
+    @MainThread
+    private fun settle(url: String) {
+        val warm = inFlight[url] ?: return
+        warmedUrls.add(url)
+        mainHandler.removeCallbacks(warm.scheduledTeardown)
+        warm.scheduledTeardown = Runnable { finishWarm(url) }
+        mainHandler.postDelayed(warm.scheduledTeardown, SETTLE_GRACE_MS)
+    }
+
+    /** WebView callbacks can outlive the warm that armed them, so an unknown url is ignored. */
+    @MainThread
+    private fun finishWarm(url: String) {
+        if (release(url)) startAvailable()
+    }
+
+    @MainThread
+    private fun release(url: String): Boolean {
+        val warm = inFlight.remove(url) ?: return false
+        mainHandler.removeCallbacks(warm.scheduledTeardown)
+        warm.view.destroyPaywallWebView()
+        return true
+    }
+
+    @get:VisibleForTesting
+    internal val queuedCount: Int get() = queue.size
+
+    @get:VisibleForTesting
+    internal val warmingCount: Int get() = inFlight.size
+
+    internal companion object {
+        /** Backstop; a warm normally ends on `onPageFinished` well before this. */
+        @VisibleForTesting
+        internal const val WARM_STALL_TIMEOUT_MS: Long = 3_000L
+
+        /** `destroy()` aborts what a document still fetches from script after `onPageFinished`. */
+        @VisibleForTesting
+        internal const val SETTLE_GRACE_MS: Long = 250L
+
+        /** WebView shares one renderer process between warms, so only their fetches overlap. */
+        @VisibleForTesting
+        internal const val MAX_CONCURRENT_WARMS: Int = 2
+
+        val shared = PaywallWebViewPrewarmer()
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -114,6 +114,7 @@ internal class PaywallWebViewPrewarmer(
     private fun startAvailable() {
         if (displayedComponents > 0) return
         val context = applicationContext ?: return
+        queue.removeAll { it in warmedUrls }
         while (inFlight.size < maxConcurrentWarms) {
             val url = queue.removeFirstOrNull()
             if (url == null || !begin(context, url)) break

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -43,7 +43,6 @@ internal class PaywallWebViewPrewarmer(
             val ignoredTrimLevels = listOf(
                 ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN,
                 ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE,
-                ComponentCallbacks2.TRIM_MEMORY_MODERATE
             )
             if (level in ignoredTrimLevels) return
             if (inFlight.isEmpty() && queue.isEmpty()) return

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -39,20 +39,21 @@ internal class PaywallWebViewPrewarmer(
 
     private val trimCallbacks = object : ComponentCallbacks2 {
         override fun onTrimMemory(level: Int) {
-            // TRIM_MEMORY_UI_HIDDEN says nothing about memory, only that the UI went away, so a warm already
-            // loading runs to completion: the customer may be back within seconds. TRIM_MEMORY_BACKGROUND
-            // follows when the process is really being parked.
-            if (level == ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) return
+            // low severity trim levels where we want to keep preloading
+            val ignoredTrimLevels = listOf(
+                ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN,
+                ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE,
+                ComponentCallbacks2.TRIM_MEMORY_MODERATE
+            )
+            if (level in ignoredTrimLevels) return
             if (inFlight.isEmpty() && queue.isEmpty()) return
-            // Every other level frees the views and keeps the queue. TRIM_MEMORY_BACKGROUND asks for exactly
-            // that ("resources that can efficiently and quickly be re-built if the user returns"); the rest are
-            // only delivered below API 34. A renderer process is the cost here; the parked urls are strings.
-            Logger.d("Paywalls V2 web_view cache warming released on trim (level $level); URLs stay queued.")
+            Logger.d("Paywalls V2 web_view cache warming released on trim (level $level).")
             queue.addAll(0, inFlight.keys.filterNot { it in warmedUrls })
             releaseInFlight()
         }
 
-        override fun onLowMemory() = onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
+        @Deprecated("deprecated on interface but mandatory implementation")
+        override fun onLowMemory() = Unit
 
         override fun onConfigurationChanged(newConfig: Configuration) = Unit
     }
@@ -74,7 +75,6 @@ internal class PaywallWebViewPrewarmer(
         } else {
             queue.addLast(resolvedUrl)
         }
-        // Unconditional: a url parked by TRIM_MEMORY_UI_HIDDEN is already queued, so it needs this to restart.
         startAvailable()
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -14,9 +14,6 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 /**
  * Loads `web_view` component bundles offscreen so the paywall profile's http cache holds them before the
  * component renders.
- *
- * Warming views are never attached or laid out, so a bundle whose requests depend on viewport size
- * (`srcset`, `sizes`, CSS media queries) can resolve them differently than the displayed document does.
  */
 @Suppress("TooManyFunctions")
 internal class PaywallWebViewPrewarmer(
@@ -81,8 +78,7 @@ internal class PaywallWebViewPrewarmer(
     }
 
     /**
-     * Stops warming while a `web_view` component displays [resolvedUrl]: every warm runs script on the one
-     * renderer thread that component is using. Balanced by [onDisplayEnded].
+     * Stops warming while a `web_view` component displays [resolvedUrl]
      */
     @MainThread
     fun onDisplayStarted(resolvedUrl: String) {
@@ -93,10 +89,6 @@ internal class PaywallWebViewPrewarmer(
         mainHandler.post(::releaseInFlight)
     }
 
-    /**
-     * The display path's own load of [resolvedUrl] has started, so it fills the http cache itself. Unlike
-     * [onDisplayStarted] this waits until the WebView exists, so a construction failure cannot poison the url.
-     */
     @MainThread
     fun markWarmed(resolvedUrl: String) {
         warmedUrls.add(resolvedUrl)
@@ -107,7 +99,6 @@ internal class PaywallWebViewPrewarmer(
     fun onDisplayEnded() {
         if (displayedComponents == 0) return
         displayedComponents--
-        // Posted: a paywall is being dismissed on this frame, and building a WebView there is jank.
         if (displayedComponents == 0) mainHandler.post(::startAvailable)
     }
 
@@ -189,15 +180,12 @@ internal class PaywallWebViewPrewarmer(
     internal val warmingCount: Int get() = inFlight.size
 
     internal companion object {
-        /** Backstop; a warm normally ends on `onPageFinished` well before this. */
         @VisibleForTesting
         internal const val WARM_STALL_TIMEOUT_MS: Long = 3_000L
 
-        /** `destroy()` aborts what a document still fetches from script after `onPageFinished`. */
         @VisibleForTesting
         internal const val SETTLE_GRACE_MS: Long = 250L
 
-        /** WebView shares one renderer process between warms, so only their fetches overlap. */
         @VisibleForTesting
         internal const val MAX_CONCURRENT_WARMS: Int = 2
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -39,10 +39,17 @@ internal class PaywallWebViewPrewarmer(
 
     private val trimCallbacks = object : ComponentCallbacks2 {
         override fun onTrimMemory(level: Int) {
-            if (inFlight.isNotEmpty() || queue.isNotEmpty()) {
-                Logger.d("Paywalls V2 web_view cache warming abandoned on memory trim (level $level).")
-            }
-            releaseAll()
+            // TRIM_MEMORY_UI_HIDDEN says nothing about memory, only that the UI went away, so a warm already
+            // loading runs to completion: the customer may be back within seconds. TRIM_MEMORY_BACKGROUND
+            // follows when the process is really being parked.
+            if (level == ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) return
+            if (inFlight.isEmpty() && queue.isEmpty()) return
+            // Every other level frees the views and keeps the queue. TRIM_MEMORY_BACKGROUND asks for exactly
+            // that ("resources that can efficiently and quickly be re-built if the user returns"); the rest are
+            // only delivered below API 34. A renderer process is the cost here; the parked urls are strings.
+            Logger.d("Paywalls V2 web_view cache warming released on trim (level $level); URLs stay queued.")
+            queue.addAll(0, inFlight.keys.filterNot { it in warmedUrls })
+            releaseInFlight()
         }
 
         override fun onLowMemory() = onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
@@ -51,15 +58,10 @@ internal class PaywallWebViewPrewarmer(
     }
 
     @MainThread
-    @Suppress("ReturnCount")
     fun prewarm(context: Context, url: String) {
         val resolvedUrl = WebViewUrlResolver.resolve(url)
         if (resolvedUrl == null) {
             Logger.d("Paywalls V2 web_view not prewarmed: URL must be https with no '{{' markers: '$url'")
-            return
-        }
-        if (alreadyCovered(resolvedUrl)) {
-            Logger.d("Paywalls V2 web_view already warmed or warming this URL; skipping.")
             return
         }
         val appContext = context.applicationContext
@@ -67,14 +69,13 @@ internal class PaywallWebViewPrewarmer(
             appContext.registerComponentCallbacks(trimCallbacks)
         }
         applicationContext = appContext
-        queue.addLast(resolvedUrl)
+        if (alreadyCovered(resolvedUrl)) {
+            Logger.d("Paywalls V2 web_view already warmed or warming this URL; skipping.")
+        } else {
+            queue.addLast(resolvedUrl)
+        }
+        // Unconditional: a url parked by TRIM_MEMORY_UI_HIDDEN is already queued, so it needs this to restart.
         startAvailable()
-    }
-
-    @MainThread
-    fun releaseAll() {
-        queue.clear()
-        releaseInFlight()
     }
 
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewStartUp.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewStartUp.kt
@@ -19,15 +19,14 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Moves WebView startup off the UI thread ahead of the first paywall `web_view` render, loading the
- * profile that render will use. Without it, the first render pays for startup on the UI thread.
+ * Moves WebView startup off the UI thread ahead of the first paywall `web_view` render, which would
+ * otherwise pay for it there.
  *
  * Needs no feature check: the API degrades internally on older WebViews, and below that still moves
  * provider class loading off the UI thread.
  *
- * Runs at most once per process. A failed startup is not retried, since androidx warns further WebView
- * calls on such a device are likely to throw or crash; a rejected submission is retried, because
- * startup was never attempted.
+ * A failed startup is not retried, since androidx warns further WebView calls on such a device are likely
+ * to throw or crash; a rejected submission is, because startup was never attempted.
  */
 internal object PaywallWebViewStartUp {
 
@@ -53,8 +52,7 @@ internal object PaywallWebViewStartUp {
         if (!started.compareAndSet(false, true)) return
         val applicationContext = context.applicationContext
         try {
-            // androidx.webkit calls must wait for startup, and `isFeatureSupported` loads the provider:
-            // the work this API exists to move off the caller.
+            // `isFeatureSupported` loads the provider, the very work this API exists to move off the caller.
             executor.execute { requestStartUp(applicationContext, executor) }
         } catch (error: RejectedExecutionException) {
             started.set(false)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -236,7 +236,6 @@ internal class ConfiguredPaywallWebView(
     val bridge: WebViewJavaScriptBridge,
 )
 
-/** A constructed WebView holds a renderer, and until it is returned nothing else can destroy it. */
 @Suppress("TooGenericExceptionCaught")
 private inline fun <T> PaywallWebView.destroyingOnFailure(setUp: PaywallWebView.() -> T): T {
     try {
@@ -247,19 +246,13 @@ private inline fun <T> PaywallWebView.destroyingOnFailure(setUp: PaywallWebView.
     }
 }
 
-/** The profile decides which http cache the WebView reads and writes. */
 private fun newPaywallWebView(context: Context): PaywallWebView =
     PaywallWebView(context).destroyingOnFailure {
         applyFullSizeLayoutParams()
-        // Must precede attach()/loadUrl: setProfile throws once the WebView has been used.
         applyPaywallProfile()
         this
     }
 
-/**
- * Null means the bridge cannot install secure messaging: [onLoadFailed] has already fired and everything is
- * already destroyed, so the caller must neither start a load nor tear anything down.
- */
 @Suppress("LongParameterList")
 internal fun createPaywallWebView(
     context: Context,
@@ -364,7 +357,6 @@ internal fun WebView.applyFullSizeLayoutParams() {
     )
 }
 
-/** Settings and navigation policy, shared so a warmed document requests what a displayed one will. */
 @Suppress("LongParameterList")
 private fun WebView.configure(
     expectedOrigin: String?,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -1,7 +1,9 @@
 @file:JvmSynthetic
+@file:Suppress("TooManyFunctions")
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import android.content.Context
 import android.graphics.Color
 import android.view.View
 import android.view.ViewGroup
@@ -42,7 +44,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 @JvmSynthetic
 @Composable
-@Suppress("LongMethod", "ReturnCount")
+@Suppress("LongMethod", "ReturnCount", "CyclomaticComplexMethod", "TooGenericExceptionCaught")
 internal fun WebViewComponentView(
     style: WebViewComponentStyle,
     state: PaywallState.Loaded.Components,
@@ -116,55 +118,53 @@ internal fun WebViewComponentView(
         if (!loadFailed) {
             AndroidView(
                 factory = { context ->
-                    val webView = PaywallWebView(context).apply {
-                        applyFullSizeLayoutParams()
-                        // Must precede attach()/loadUrl: setProfile throws once the WebView has been used.
-                        applyPaywallProfile()
-                        val bridge = WebViewJavaScriptBridge(
-                            webView = this,
-                            componentId = componentId,
-                            expectedUrl = resolvedUrl,
-                            sizeToContentWidth = sizeToContentWidth,
-                            sizeToContentHeight = sizeToContentHeight,
-                            onContentResize = { widthCssPx, heightCssPx ->
-                                widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
-                                heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
-                            },
-                            onDocumentReset = {
-                                contentWidthCssPx = 0
-                                contentHeightCssPx = 0
-                            },
-                            onSecureMessagingUnsupported = { loadFailed = true },
-                        ).also { createdBridge -> createdBridge.attach() }
-                        bridgeHolder.bridge = bridge
-                        // attach() may synchronously flag terminal failure (secure messaging
-                        // unsupported); don't start a JS-enabled load we're about to tear down.
-                        if (!loadFailed) {
-                            configure(
-                                expectedOrigin = resolvedUrl.toOriginOrNull(),
-                                onMainFrameNavigationStarted = {
-                                    bridgeHolder.bridge?.onMainFrameNavigationStarted()
-                                },
-                                onMainFrameLoadFailed = { loadFailed = true },
-                            )
-                            installGestureOwnershipProbe(
-                                expectedOrigin = resolvedUrl.toOriginOrNull(),
-                            ) { wantsGesture -> this@apply.onContentGestureVerdict(wantsGesture) }
-                            loadUrl(resolvedUrl)
+                    val onContentResize: (Int?, Int?) -> Unit = { widthCssPx, heightCssPx ->
+                        widthCssPx?.takeIf { it > 0 }?.let { contentWidthCssPx = it }
+                        heightCssPx?.takeIf { it > 0 }?.let { contentHeightCssPx = it }
+                    }
+                    val onDocumentReset: () -> Unit = {
+                        contentWidthCssPx = 0
+                        contentHeightCssPx = 0
+                    }
+                    val onLoadFailed: () -> Unit = { loadFailed = true }
+                    PaywallWebViewPrewarmer.shared.onDisplayStarted(resolvedUrl)
+                    val configured = try {
+                        createPaywallWebView(
+                            context = context,
+                            identity = identity,
+                            onContentResize = onContentResize,
+                            onDocumentReset = onDocumentReset,
+                            onLoadFailed = onLoadFailed,
+                            onLoadFinished = { PaywallWebViewPrewarmer.shared.markWarmed(resolvedUrl) },
+                        )
+                    } catch (error: Throwable) {
+                        // A missing or mid-update WebView package throws Error, not Exception.
+                        Logger.w("Paywalls V2 web_view could not be created: $error")
+                        loadFailed = true
+                        null
+                    }
+                    bridgeHolder.bridge = configured?.bridge
+                    if (configured == null) {
+                        FrameLayout(context)
+                    } else {
+                        try {
+                            configured.webView.loadUrl(resolvedUrl)
+                            configured.webView.hostedInFrameLayout()
+                        } catch (error: Throwable) {
+                            Logger.w("Paywalls V2 web_view could not start its load: $error")
+                            bridgeHolder.bridge = null
+                            configured.webView.releasePaywallWebView(configured.bridge)
+                            loadFailed = true
+                            FrameLayout(context)
                         }
                     }
-                    webView.hostedInFrameLayout()
                 },
                 onRelease = { container ->
-                    val webView = (container as FrameLayout).getChildAt(0) as WebView
+                    PaywallWebViewPrewarmer.shared.onDisplayEnded()
                     // Only release the bridge that this view installed into this holder.
                     val bridge = bridgeHolder.bridge
                     bridgeHolder.bridge = null
-                    bridge?.release()
-                    webView.removeGestureOwnershipProbe()
-                    webView.stopLoading()
-                    webView.webViewClient = WebViewClient()
-                    webView.destroy()
+                    ((container as FrameLayout).getChildAt(0) as? WebView)?.releasePaywallWebView(bridge)
                 },
                 // Clip: content can briefly overflow while a fit axis animates placeholder -> measured.
                 modifier = modifier
@@ -231,6 +231,115 @@ internal class WebViewBridgeHolder {
     var bridge: WebViewJavaScriptBridge? = null
 }
 
+internal class ConfiguredPaywallWebView(
+    val webView: PaywallWebView,
+    val bridge: WebViewJavaScriptBridge,
+)
+
+/** A constructed WebView holds a renderer, and until it is returned nothing else can destroy it. */
+@Suppress("TooGenericExceptionCaught")
+private inline fun <T> PaywallWebView.destroyingOnFailure(setUp: PaywallWebView.() -> T): T {
+    try {
+        return setUp()
+    } catch (error: Throwable) {
+        destroyPaywallWebView()
+        throw error
+    }
+}
+
+/** The profile decides which http cache the WebView reads and writes. */
+private fun newPaywallWebView(context: Context): PaywallWebView =
+    PaywallWebView(context).destroyingOnFailure {
+        applyFullSizeLayoutParams()
+        // Must precede attach()/loadUrl: setProfile throws once the WebView has been used.
+        applyPaywallProfile()
+        this
+    }
+
+/**
+ * Null means the bridge cannot install secure messaging: [onLoadFailed] has already fired and everything is
+ * already destroyed, so the caller must neither start a load nor tear anything down.
+ */
+@Suppress("LongParameterList")
+internal fun createPaywallWebView(
+    context: Context,
+    identity: WebViewIdentity,
+    onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
+    onDocumentReset: () -> Unit = {},
+    onLoadFailed: () -> Unit,
+    onLoadFinished: () -> Unit = {},
+): ConfiguredPaywallWebView? {
+    var terminalFailure = false
+    val expectedOrigin = identity.resolvedUrl.toOriginOrNull()
+    val webView = newPaywallWebView(context)
+    return webView.destroyingOnFailure {
+        val bridge = WebViewJavaScriptBridge(
+            webView = webView,
+            componentId = identity.componentId,
+            expectedUrl = identity.resolvedUrl,
+            sizeToContentWidth = identity.sizeToContentWidth,
+            sizeToContentHeight = identity.sizeToContentHeight,
+            onContentResize = onContentResize,
+            onDocumentReset = onDocumentReset,
+            onSecureMessagingUnsupported = {
+                terminalFailure = true
+                onLoadFailed()
+            },
+        )
+        bridge.attach()
+        if (terminalFailure) {
+            releasePaywallWebView(bridge)
+            return@destroyingOnFailure null
+        }
+        configure(
+            expectedOrigin = expectedOrigin,
+            allowMediaAutoplay = true,
+            onMainFrameNavigationStarted = bridge::onMainFrameNavigationStarted,
+            onMainFrameLoadFailed = onLoadFailed,
+            onMainFrameLoadFinished = onLoadFinished,
+        )
+        installGestureOwnershipProbe(expectedOrigin, this::onContentGestureVerdict)
+        disableTapHighlight(expectedOrigin)
+        hideAutoplayVideoUntilPlaying(expectedOrigin)
+        ConfiguredPaywallWebView(this, bridge)
+    }
+}
+
+/**
+ * Installs no bridge, so unlike [createPaywallWebView] this works where secure messaging is unsupported.
+ *
+ * Autoplay is refused because an `<audio autoplay>` really does play from a WebView that was never
+ * attached to a window. The media is still fetched and cached.
+ */
+internal fun createWarmingWebView(
+    context: Context,
+    resolvedUrl: String,
+    onLoadFailed: () -> Unit,
+    onLoadFinished: () -> Unit,
+): PaywallWebView = newPaywallWebView(context).destroyingOnFailure {
+    configure(
+        expectedOrigin = resolvedUrl.toOriginOrNull(),
+        allowMediaAutoplay = false,
+        onMainFrameNavigationStarted = {},
+        onMainFrameLoadFailed = onLoadFailed,
+        onMainFrameLoadFinished = onLoadFinished,
+    )
+    this
+}
+
+internal fun WebView.destroyPaywallWebView() {
+    stopLoading()
+    // Drop PaywallWebViewClient so a late callback cannot fire into a destroyed view.
+    webViewClient = WebViewClient()
+    destroy()
+}
+
+internal fun WebView.releasePaywallWebView(bridge: WebViewJavaScriptBridge?) {
+    bridge?.release()
+    removeGestureOwnershipProbe()
+    destroyPaywallWebView()
+}
+
 // A hardware WebView drawn while fully off-screen (e.g. a non-visible carousel page) composites its GL
 // functor into an offscreen layer that has no surface, crashing the RenderThread in
 // SkSurface::getCanvas(). Hosting it inside a FrameLayout rather than directly in the AndroidView
@@ -255,10 +364,14 @@ internal fun WebView.applyFullSizeLayoutParams() {
     )
 }
 
+/** Settings and navigation policy, shared so a warmed document requests what a displayed one will. */
+@Suppress("LongParameterList")
 private fun WebView.configure(
     expectedOrigin: String?,
+    allowMediaAutoplay: Boolean,
     onMainFrameNavigationStarted: () -> Unit,
     onMainFrameLoadFailed: () -> Unit,
+    onMainFrameLoadFinished: () -> Unit,
 ) {
     setBackgroundColor(Color.TRANSPARENT)
     isVerticalScrollBarEnabled = false
@@ -277,11 +390,12 @@ private fun WebView.configure(
     settings.setSupportZoom(false)
     settings.builtInZoomControls = false
     settings.displayZoomControls = false
-    settings.mediaPlaybackRequiresUserGesture = false
+    settings.mediaPlaybackRequiresUserGesture = !allowMediaAutoplay
     webViewClient = PaywallWebViewClient(
         expectedOrigin = expectedOrigin,
         onMainFrameNavigationStarted = onMainFrameNavigationStarted,
         onMainFrameLoadFailed = onMainFrameLoadFailed,
+        onMainFrameLoadFinished = onMainFrameLoadFinished,
     )
     // Inspect the bundle from Chrome DevTools in debug builds only; process-global, never in release.
     if (BuildConfig.DEBUG) WebView.setWebContentsDebuggingEnabled(true)
@@ -298,8 +412,6 @@ private fun WebView.configure(
             }
         }
     }
-    disableTapHighlight(expectedOrigin)
-    hideAutoplayVideoUntilPlaying(expectedOrigin)
 }
 
 // Fallback reveal for an autoplay <video> that never emits `playing`; long enough that a normal clip plays first.

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewClientTest.kt
@@ -24,6 +24,7 @@ internal class PaywallWebViewClientTest {
     private val expectedOrigin = "https://assets.example.com"
     private var navigationStartedCount = 0
     private var failureCount = 0
+    private var loadFinishedCount = 0
 
     private lateinit var client: PaywallWebViewClient
 
@@ -42,10 +43,12 @@ internal class PaywallWebViewClientTest {
         webView = TrackingWebView(ApplicationProvider.getApplicationContext())
         navigationStartedCount = 0
         failureCount = 0
+        loadFinishedCount = 0
         client = PaywallWebViewClient(
             expectedOrigin = expectedOrigin,
             onMainFrameNavigationStarted = { navigationStartedCount += 1 },
             onMainFrameLoadFailed = { failureCount += 1 },
+            onMainFrameLoadFinished = { loadFinishedCount += 1 },
         )
     }
 
@@ -74,6 +77,29 @@ internal class PaywallWebViewClientTest {
         assertThat(navigationStartedCount).isEqualTo(0)
         assertThat(webView.stopLoadingCount).isEqualTo(1)
         assertThat(failureCount).isEqualTo(1)
+    }
+
+    // WebView delivers onPageFinished more than once per navigation.
+    @Test
+    fun `onPageFinished notifies main-frame document finish once, ignoring about blank`() {
+        client.onPageFinished(webView, "about:blank")
+
+        assertThat(loadFinishedCount).isZero()
+
+        client.onPageFinished(webView, "https://assets.example.com/promo/index.html")
+        client.onPageFinished(webView, "https://assets.example.com/promo/index.html")
+        client.onPageFinished(webView, "https://assets.example.com/promo/page-2.html")
+
+        assertThat(loadFinishedCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `onPageFinished stays silent once the load has failed terminally`() {
+        client.onPageStarted(webView, "https://evil.example.org/phish.html", null)
+
+        client.onPageFinished(webView, "https://assets.example.com/promo/index.html")
+
+        assertThat(loadFinishedCount).isZero()
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -373,6 +373,24 @@ internal class PaywallWebViewPrewarmerTest {
         assertThat(prewarmer.warmingCount).isEqualTo(2)
     }
 
+    // onPageFinished posts its settle, so a display starting in that window requeues a url that is about
+    // to be marked warmed.
+    @Test
+    fun `does not rewarm a url that settled while a component was displayed`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL)
+        val view = warmed.single()
+        shadowOf(view).webViewClient.onPageFinished(view, URL)
+
+        prewarmer.onDisplayStarted(DISPLAYED_URL)
+        idle()
+        prewarmer.onDisplayEnded()
+        idle()
+
+        assertWarmCount(1)
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
     @Test
     fun `abandons the in-flight load and the queue when the app is asked to trim memory`() {
         val prewarmer = prewarmer()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -190,15 +190,15 @@ internal class PaywallWebViewPrewarmerTest {
     }
 
     @Test
-    fun `releaseAll destroys every in-flight view and drops the queue`() {
+    fun `a trim destroys every in-flight view and requeues the unfinished urls`() {
         val prewarmer = prewarmer(maxConcurrent = 2)
         prewarmer.prewarmAll(URL, OTHER_URL, THIRD_URL)
 
-        prewarmer.releaseAll()
+        (context as Application).onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND)
 
         assertThat(warmed.map { shadowOf(it).wasDestroyCalled() }).containsExactly(true, true)
         assertThat(prewarmer.warmingCount).isZero()
-        assertThat(prewarmer.queuedCount).isZero()
+        assertThat(prewarmer.queuedCount).isEqualTo(3)
     }
 
     @Test
@@ -391,14 +391,101 @@ internal class PaywallWebViewPrewarmerTest {
         assertThat(prewarmer.queuedCount).isZero()
     }
 
+    // A warm already loading survives the UI going away; the customer may be back within seconds.
     @Test
-    fun `abandons the in-flight load and the queue when the app is asked to trim memory`() {
+    fun `a hidden UI does not interrupt warming`() {
         val prewarmer = prewarmer()
         prewarmer.prewarmAll(URL, OTHER_URL)
 
         (context as Application).onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN)
 
-        assertThat(prewarmer.warmingCount).isZero()
+        assertThat(prewarmer.warmingCount).isEqualTo(1)
+        assertThat(shadowOf(warmed.single()).wasDestroyCalled()).isFalse()
+        assertThat(prewarmer.queuedCount).isEqualTo(1)
+    }
+
+    // The warm still finishes and hands its slot to the next url while the UI is hidden.
+    @Test
+    fun `a warm started before the UI hid still completes`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+        (context as Application).onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN)
+
+        finishMainFrameLoad(warmed.first())
+        idleFor(PaywallWebViewPrewarmer.SETTLE_GRACE_MS)
+
+        assertWarmCount(2)
+        assertThat(lastLoadedUrl()).isEqualTo(OTHER_URL)
         assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    // Every level except UI_HIDDEN frees the view and keeps the urls queued, including the five delivered only
+    // below API 34, so no threshold or level list can drift from the platform.
+    @Test
+    fun `every memory-pressure level frees the view and keeps the urls queued`() {
+        val levels = listOf(
+            ComponentCallbacks2.TRIM_MEMORY_BACKGROUND,
+            ComponentCallbacks2.TRIM_MEMORY_COMPLETE,
+            ComponentCallbacks2.TRIM_MEMORY_MODERATE,
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW,
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE,
+        )
+
+        levels.forEach { level ->
+            warmed.clear()
+            val prewarmer = prewarmer()
+            prewarmer.prewarmAll(URL, OTHER_URL)
+
+            (context as Application).onTrimMemory(level)
+
+            assertThat(prewarmer.warmingCount).describedAs("level %s warming", level).isZero()
+            assertThat(shadowOf(warmed.single()).wasDestroyCalled())
+                .describedAs("level %s destroyed", level).isTrue()
+            assertThat(prewarmer.queuedCount).describedAs("level %s queued", level).isEqualTo(2)
+        }
+    }
+
+    // onLowMemory is the pre-API-34 path and must not be the one that loses the queue.
+    @Test
+    fun `onLowMemory frees the view and keeps the urls queued`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+
+        (context as Application).onLowMemory()
+
+        assertThat(prewarmer.warmingCount).isZero()
+        assertThat(prewarmer.queuedCount).isEqualTo(2)
+    }
+
+    // Nothing else pumps the queue when the app returns, and the parked url is alreadyCovered, so prewarm
+    // has to restart it rather than bail out.
+    @Test
+    fun `resumes the deferred queue when the same url is announced again`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+        (context as Application).onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND)
+        warmed.clear()
+
+        prewarmer.prewarm(context, URL)
+
+        assertWarmCount(1)
+        assertThat(lastLoadedUrl()).isEqualTo(URL)
+        assertThat(prewarmer.queuedCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `resumes the deferred queue once a displayed component goes away`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+        (context as Application).onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND)
+        warmed.clear()
+
+        prewarmer.onDisplayStarted(DISPLAYED_URL)
+        prewarmer.onDisplayEnded()
+        idle()
+
+        assertThat(prewarmer.warmingCount).isEqualTo(1)
+        assertThat(lastLoadedUrl()).isEqualTo(URL)
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -393,15 +393,24 @@ internal class PaywallWebViewPrewarmerTest {
 
     // A warm already loading survives the UI going away; the customer may be back within seconds.
     @Test
-    fun `a hidden UI does not interrupt warming`() {
-        val prewarmer = prewarmer()
-        prewarmer.prewarmAll(URL, OTHER_URL)
+    fun `a hidden UI or a mild foreground trim does not interrupt warming`() {
+        val ignored = listOf(
+            ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN,
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE,
+        )
 
-        (context as Application).onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN)
+        ignored.forEach { level ->
+            warmed.clear()
+            val prewarmer = prewarmer()
+            prewarmer.prewarmAll(URL, OTHER_URL)
 
-        assertThat(prewarmer.warmingCount).isEqualTo(1)
-        assertThat(shadowOf(warmed.single()).wasDestroyCalled()).isFalse()
-        assertThat(prewarmer.queuedCount).isEqualTo(1)
+            (context as Application).onTrimMemory(level)
+
+            assertThat(prewarmer.warmingCount).describedAs("level %s warming", level).isEqualTo(1)
+            assertThat(shadowOf(warmed.single()).wasDestroyCalled())
+                .describedAs("level %s destroyed", level).isFalse()
+            assertThat(prewarmer.queuedCount).describedAs("level %s queued", level).isEqualTo(1)
+        }
     }
 
     // The warm still finishes and hands its slot to the next url while the UI is hidden.
@@ -419,8 +428,8 @@ internal class PaywallWebViewPrewarmerTest {
         assertThat(prewarmer.queuedCount).isZero()
     }
 
-    // Every level except UI_HIDDEN frees the view and keeps the urls queued, including the five delivered only
-    // below API 34, so no threshold or level list can drift from the platform.
+    // Every level except the ignored two frees the view and keeps the urls queued, including those delivered
+    // only below API 34, so no threshold or level list can drift from the platform.
     @Test
     fun `every memory-pressure level frees the view and keeps the urls queued`() {
         val levels = listOf(
@@ -429,7 +438,6 @@ internal class PaywallWebViewPrewarmerTest {
             ComponentCallbacks2.TRIM_MEMORY_MODERATE,
             ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
             ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW,
-            ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE,
         )
 
         levels.forEach { level ->
@@ -446,16 +454,15 @@ internal class PaywallWebViewPrewarmerTest {
         }
     }
 
-    // onLowMemory is the pre-API-34 path and must not be the one that loses the queue.
     @Test
-    fun `onLowMemory frees the view and keeps the urls queued`() {
+    fun `onLowMemory does not interrupt warming`() {
         val prewarmer = prewarmer()
         prewarmer.prewarmAll(URL, OTHER_URL)
 
         (context as Application).onLowMemory()
 
-        assertThat(prewarmer.warmingCount).isZero()
-        assertThat(prewarmer.queuedCount).isEqualTo(2)
+        assertThat(prewarmer.warmingCount).isEqualTo(1)
+        assertThat(prewarmer.queuedCount).isEqualTo(1)
     }
 
     // Nothing else pumps the queue when the app returns, and the parked url is alreadyCovered, so prewarm

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -454,17 +454,6 @@ internal class PaywallWebViewPrewarmerTest {
         }
     }
 
-    @Test
-    fun `onLowMemory does not interrupt warming`() {
-        val prewarmer = prewarmer()
-        prewarmer.prewarmAll(URL, OTHER_URL)
-
-        (context as Application).onLowMemory()
-
-        assertThat(prewarmer.warmingCount).isEqualTo(1)
-        assertThat(prewarmer.queuedCount).isEqualTo(1)
-    }
-
     // Nothing else pumps the queue when the app returns, and the parked url is alreadyCovered, so prewarm
     // has to restart it rather than bail out.
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -1,0 +1,386 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.app.Application
+import android.content.ComponentCallbacks2
+import android.content.Context
+import android.os.Looper
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.webkit.ProfileStore
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import java.time.Duration
+
+@RunWith(AndroidJUnit4::class)
+internal class PaywallWebViewPrewarmerTest {
+
+    private companion object {
+        const val URL = "https://example.com/index.html"
+        const val OTHER_URL = "https://example.com/other.html"
+        const val THIRD_URL = "https://example.com/third.html"
+        const val DISPLAYED_URL = "https://example.com/displayed.html"
+    }
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val warmed = mutableListOf<WebView>()
+
+    private fun prewarmer(maxConcurrent: Int = 1) = PaywallWebViewPrewarmer(maxConcurrent)
+
+    private fun PaywallWebViewPrewarmer.prewarmAll(vararg urls: String) = urls.forEach { prewarm(context, it) }
+
+    private fun assertWarmCount(count: Int) = assertThat(warmed).hasSize(count)
+
+    private fun lastLoadedUrl() = shadowOf(warmed.last()).lastLoadedUrl
+
+    private fun loadedUrls() = warmed.map { shadowOf(it).lastLoadedUrl }
+
+    private fun idle() = shadowOf(Looper.getMainLooper()).idle()
+
+    private fun idleFor(millis: Long) = shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(millis))
+
+    private fun finishMainFrameLoad(webView: WebView, url: String = URL) {
+        shadowOf(webView).webViewClient.onPageFinished(webView, url)
+        idle()
+    }
+
+    private fun failMainFrameLoad(webView: WebView) {
+        val request = mockk<WebResourceRequest>(relaxed = true)
+        every { request.isForMainFrame } returns true
+        shadowOf(webView).webViewClient.onReceivedError(webView, request, mockk(relaxed = true))
+    }
+
+    @Before
+    fun setUp() {
+        warmed.clear()
+        mockkStatic(WebViewFeature::class, WebViewCompat::class, ProfileStore::class)
+        every { WebViewFeature.isFeatureSupported(any()) } returns true
+        every { ProfileStore.getInstance() } returns mockk(relaxed = true)
+        every { WebViewCompat.setProfile(capture(warmed), any()) } returns Unit
+        every { WebViewCompat.addWebMessageListener(any(), any(), any(), any()) } returns Unit
+        every { WebViewCompat.removeWebMessageListener(any(), any()) } returns Unit
+        every { WebViewCompat.addDocumentStartJavaScript(any(), any(), any()) } returns mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `loads the resolved url`() {
+        prewarmer().prewarm(context, URL)
+
+        assertWarmCount(1)
+        assertThat(lastLoadedUrl()).isEqualTo(URL)
+    }
+
+    @Test
+    fun `ignores urls it cannot warm without loading the WebView provider`() {
+        val prewarmer = prewarmer()
+
+        prewarmer.prewarm(context, "http://example.com/index.html")
+        prewarmer.prewarm(context, "https://example.com/{{variable}}.html")
+
+        assertWarmCount(0)
+        assertThat(prewarmer.queuedCount).isZero()
+        // Building a WebView loads the WebView provider, which costs main-thread time.
+        verify(exactly = 0) { ProfileStore.getInstance() }
+    }
+
+    @Test
+    fun `ignores a url already in flight or queued`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+
+        prewarmer.prewarmAll(URL, OTHER_URL)
+
+        assertWarmCount(1)
+        assertThat(prewarmer.queuedCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `moves on to the next url once the main frame finishes`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+
+        finishMainFrameLoad(warmed.first())
+        idleFor(PaywallWebViewPrewarmer.SETTLE_GRACE_MS)
+
+        assertWarmCount(2)
+        assertThat(lastLoadedUrl()).isEqualTo(OTHER_URL)
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    // `destroy()` aborts whatever the document is still fetching from script.
+    @Test
+    fun `holds the view briefly after the main frame finishes`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+
+        finishMainFrameLoad(warmed.first())
+
+        assertThat(prewarmer.warmingCount).isEqualTo(1)
+        assertWarmCount(1)
+    }
+
+    @Test
+    fun `moves on to the next url when a warm stalls`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+
+        idleFor(PaywallWebViewPrewarmer.WARM_STALL_TIMEOUT_MS)
+
+        assertWarmCount(2)
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    @Test
+    fun `a load failure moves on to the next url`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+
+        failMainFrameLoad(warmed.first())
+        idle()
+
+        assertWarmCount(2)
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    // Warming installs no bridge, so it must not inherit the display path's secure-messaging requirement.
+    @Test
+    fun `warms even where secure messaging is unsupported`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER) } returns false
+        val prewarmer = prewarmer()
+
+        prewarmer.prewarm(context, URL)
+
+        assertThat(lastLoadedUrl()).isEqualTo(URL)
+        assertThat(prewarmer.warmingCount).isEqualTo(1)
+    }
+
+    // A missing or mid-update WebView package throws Error, not Exception, and warming runs for apps that
+    // may never show a paywall.
+    @Test
+    fun `keeps going when the WebView package cannot be loaded`() {
+        every { WebViewCompat.setProfile(capture(warmed), any()) } throws NoClassDefFoundError("no WebView")
+        val prewarmer = prewarmer()
+
+        prewarmer.prewarm(context, URL)
+        idle()
+
+        assertThat(prewarmer.warmingCount).isZero()
+        assertThat(prewarmer.queuedCount).isZero()
+        assertThat(shadowOf(warmed.single()).wasDestroyCalled()).isTrue()
+    }
+
+    @Test
+    fun `releaseAll destroys every in-flight view and drops the queue`() {
+        val prewarmer = prewarmer(maxConcurrent = 2)
+        prewarmer.prewarmAll(URL, OTHER_URL, THIRD_URL)
+
+        prewarmer.releaseAll()
+
+        assertThat(warmed.map { shadowOf(it).wasDestroyCalled() }).containsExactly(true, true)
+        assertThat(prewarmer.warmingCount).isZero()
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    @Test
+    fun `warms up to the concurrency bound and refills a freed slot`() {
+        val prewarmer = PaywallWebViewPrewarmer()
+
+        prewarmer.prewarmAll(URL, OTHER_URL, THIRD_URL)
+
+        assertWarmCount(PaywallWebViewPrewarmer.MAX_CONCURRENT_WARMS)
+        assertThat(prewarmer.queuedCount).isEqualTo(3 - PaywallWebViewPrewarmer.MAX_CONCURRENT_WARMS)
+
+        finishMainFrameLoad(warmed.first())
+        idleFor(PaywallWebViewPrewarmer.SETTLE_GRACE_MS)
+
+        assertWarmCount(3)
+        assertThat(lastLoadedUrl()).isEqualTo(THIRD_URL)
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    // The displayed url is gone for good; a warm that merely shared its slot is only deferred.
+    @Test
+    fun `displaying a queued url drops it and defers the warms in flight`() {
+        val prewarmer = prewarmer(maxConcurrent = 2)
+        prewarmer.prewarmAll(URL, OTHER_URL, THIRD_URL)
+
+        prewarmer.onDisplayStarted(THIRD_URL)
+        prewarmer.onDisplayEnded()
+        idle()
+
+        assertThat(loadedUrls()).doesNotContain(THIRD_URL)
+        assertThat(prewarmer.warmingCount).isEqualTo(2)
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    // Leaving it in flight would race the display load it was warming for, on the same main thread and
+    // renderer process. Nor may it hand that process straight to the next queued url.
+    @Test
+    fun `displaying a url abandons its in-flight warm without starting the next one`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+
+        prewarmer.onDisplayStarted(URL)
+        idle()
+
+        assertWarmCount(1)
+        assertThat(prewarmer.warmingCount).isZero()
+        assertThat(prewarmer.queuedCount).isEqualTo(1)
+    }
+
+    // The display path's own load fills the http cache, so warming it afterwards is pure waste.
+    @Test
+    fun `never warms a url that was displayed`() {
+        val prewarmer = prewarmer()
+        prewarmer.onDisplayStarted(URL)
+        prewarmer.markWarmed(URL)
+        prewarmer.onDisplayEnded()
+        idle()
+
+        prewarmer.prewarm(context, URL)
+
+        assertWarmCount(0)
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    // Display starting is not proof the url got cached: a construction failure between the two calls must
+    // not block this url from ever being warmed.
+    @Test
+    fun `a url is not marked warmed unless markWarmed is called`() {
+        val prewarmer = prewarmer()
+        prewarmer.onDisplayStarted(URL)
+        prewarmer.onDisplayEnded()
+        idle()
+
+        prewarmer.prewarm(context, URL)
+
+        assertThat(lastLoadedUrl()).isEqualTo(URL)
+    }
+
+    // Every offerings fetch re-announces the same bundles, and a warmed one is already in the http cache.
+    @Test
+    fun `never warms a url twice`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarm(context, URL)
+        finishMainFrameLoad(warmed.first())
+        idleFor(PaywallWebViewPrewarmer.SETTLE_GRACE_MS)
+
+        prewarmer.prewarm(context, URL)
+
+        assertWarmCount(1)
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    // Its document is already cached, so resuming must not pay for the whole load again.
+    @Test
+    fun `a warm past its main frame is not requeued when a component is displayed`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarm(context, URL)
+        finishMainFrameLoad(warmed.first())
+
+        prewarmer.onDisplayStarted(DISPLAYED_URL)
+        idle()
+
+        assertThat(prewarmer.warmingCount).isZero()
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    // Every warm runs script on the one renderer thread a displayed component is using, and that component
+    // loads what it needs itself.
+    @Test
+    fun `stops warming while a web_view component is displayed`() {
+        val prewarmer = prewarmer(maxConcurrent = 2)
+        prewarmer.prewarmAll(URL, OTHER_URL, THIRD_URL)
+
+        prewarmer.onDisplayStarted(DISPLAYED_URL)
+        idle()
+
+        assertThat(prewarmer.warmingCount).isZero()
+        assertThat(prewarmer.queuedCount).isEqualTo(3)
+    }
+
+    @Test
+    fun `does not start a newly queued url while a component is displayed`() {
+        val prewarmer = prewarmer(maxConcurrent = 2)
+        prewarmer.onDisplayStarted(DISPLAYED_URL)
+
+        prewarmer.prewarm(context, URL)
+
+        assertWarmCount(0)
+        assertThat(prewarmer.queuedCount).isEqualTo(1)
+    }
+
+    // Resuming lands on the frame a paywall is being dismissed on, where building a WebView is jank.
+    @Test
+    fun `resumes warming on a later frame once the last displayed component is gone`() {
+        val prewarmer = prewarmer(maxConcurrent = 2)
+        prewarmer.prewarmAll(URL, OTHER_URL)
+        prewarmer.onDisplayStarted(DISPLAYED_URL)
+        idle()
+        warmed.clear()
+
+        prewarmer.onDisplayEnded()
+
+        assertWarmCount(0)
+
+        idle()
+
+        assertThat(prewarmer.warmingCount).isEqualTo(2)
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+
+    // A paywall can show several web_view components, so the first one going away must not resume warming.
+    @Test
+    fun `stays paused until every displayed component is gone`() {
+        val prewarmer = prewarmer(maxConcurrent = 2)
+        prewarmer.prewarm(context, URL)
+        prewarmer.onDisplayStarted(DISPLAYED_URL)
+        prewarmer.onDisplayStarted(OTHER_URL)
+
+        prewarmer.onDisplayEnded()
+        idle()
+
+        assertThat(prewarmer.warmingCount).isZero()
+
+        prewarmer.onDisplayEnded()
+        idle()
+
+        assertThat(prewarmer.warmingCount).isEqualTo(1)
+
+        prewarmer.onDisplayEnded()
+        prewarmer.prewarm(context, THIRD_URL)
+
+        assertThat(prewarmer.warmingCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `abandons the in-flight load and the queue when the app is asked to trim memory`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+
+        (context as Application).onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN)
+
+        assertThat(prewarmer.warmingCount).isZero()
+        assertThat(prewarmer.queuedCount).isZero()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewFailurePathTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewFailurePathTest.kt
@@ -44,6 +44,7 @@ internal class WebViewFailurePathTest {
                                 expectedOrigin = "https://assets.example.com",
                                 onMainFrameNavigationStarted = {},
                                 onMainFrameLoadFailed = { loadFailed = true },
+                                onMainFrameLoadFinished = {},
                             )
                             setWebViewClient(client)
                             // Simulate renderer death immediately after creation.
@@ -87,6 +88,7 @@ internal class WebViewFailurePathTest {
                                         expectedOrigin = "https://assets.example.com",
                                         onMainFrameNavigationStarted = {},
                                         onMainFrameLoadFailed = { loadFailed = true },
+                                        onMainFrameLoadFinished = {},
                                     )
                                     setWebViewClient(client)
                                     client.onRenderProcessGone(this, mockk(relaxed = true))


### PR DESCRIPTION
- Warms Paywalls V2 `web_view` bundles offscreen so the profile's http cache holds them before the component renders.
- Two urls warm at once, each at most once per process. Warming stands down entirely while a `web_view` component is on screen.
- Warming and display share one WebView profile and one `configure()`, so the bytes warmed are the bytes display reads. Refusing media autoplay while warming is the only deliberate difference.
- Best effort throughout: an unresolvable url, a failed construction, a load failure or a memory trim all leave the display path to load cold. Whichever builder allocated a WebView destroys it if setup throws.
- **Nothing in the SDK calls this yet**, until #3938

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details>
<summary>Agent description</summary>

### Motivation

A `web_view` component fetches its bundle at render time. Warming has to cover the bundle and everything it pulls in, and it has to know when it is done so the next url can start.

`WebViewCompat.prerenderUrlAsync` does neither. Pixel 7a, WebView 150, 3 reps of 20 s against the real bundle: zero host-visible activity, while `loadUrl` control arms on the same url reported a content size at 242/262/725 ms. Its `onError` fires only when the view is released, so it is a discard notification rather than a load signal, and with no completion signal the budget becomes the per-url cost. It also needs WebView M137+. `Profile.prefetchUrlAsync` loads HTML without fetching JavaScript or CSS, and is experimental in androidx.webkit 1.16.0.

Plain `loadUrl` reports `onPageFinished`, runs the document exactly as display will, and has no feature gate. Its one hazard, an unrestricted document, is closed by `allowMediaAutoplay = false`.

### Description

- `PaywallWebViewPrewarmer`: a FIFO of resolved urls with `MAX_CONCURRENT_WARMS` (2) in flight. Each url is built, loaded, then destroyed once its document settles. A url already warmed, queued or in flight is a no-op.
- Paced on `onPageFinished` plus a 250 ms grace, with a 3 s backstop for a load that never finishes. The grace exists because `onPageFinished` covers the main frame, not what the document then fetches from script, and destroying the view aborts requests still in flight.
- `onDisplayStarted` / `onDisplayEnded` pause warming while a component is on screen, since a warm runs script on the one renderer thread that component uses. Urls given up return to the front of the queue.
- `markWarmed` fires when the display path's own load finishes, not when it starts, so a load that fails offline does not poison the url for the rest of the process.
- `releaseAll()` on `ComponentCallbacks2.onTrimMemory` at every level, dropping both queue and in-flight. A speculative load should be the first thing to go under pressure.
- Construction is wrapped in a `Throwable` catch: a missing or mid-update WebView package surfaces as `NoClassDefFoundError` / `UnsatisfiedLinkError`, and warming must never take down an app that may never show a paywall.

### Concurrency bound of 2

Draining 8 urls of 4 resources each over a 200 ms-latency link: 7387 ms one at a time, 3721 ms at two, 2084 ms at four. WebView shares one renderer process throughout, so only the fetches parallelise, and each extra concurrent warm adds ~3 MB of renderer RSS. Held at two because the costs that do scale are unmeasured: the same bytes pulled over a shorter window compete with the host app's own startup traffic, and every warm runs script on the renderer thread a displayed paywall also uses.

### The media guard is necessary and free

3/3 each direction, with the page reporting its own state:

| `mediaPlaybackRequiresUserGesture` | Result |
|---|---|
| `false` (display) | `audio=playing`, `play()` resolved |
| `true` (warming) | `play()` rejected `NotAllowedError`, never played |

The audio file is fetched and cached in both arms, so the guard costs no warming coverage. Covered by an instrumented test rather than a unit test: WebView instance members do not resolve on this module's unit-test classpath.

### Regression gates

`moves on to the next url once the main frame finishes` proves the queue is paced by the signal and not the backstop. `a url is not marked warmed unless markWarmed is called` covers the failed-display case. `keeps going when the WebView package cannot be loaded` covers the `Error` path and asserts the orphaned view is destroyed. `onPageFinished notifies once even when it arrives repeatedly` covers WebView delivering that callback more than once per navigation.

### Out of scope

Adopting a warmed WebView into the display path, which replaces a render with a local activation. Worth a flat 128 ms on a Pixel 7a on top of a warm cache (110 ms on a Mi 9T Pro), being the parse, script execution and layout that caching cannot remove. It is bounded to one component per paywall by WebView's renderer-process cap and needs a viewport decision for `Fit`-sized components, so it is deliberately deferred.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebView lifecycle, a process-wide singleton, memory-trim handling, and media autoplay policy. Failures are best-effort, but bugs could leak WebViews, play audio offscreen, or contend with the displayed renderer.
> 
> **Overview**
> Adds offscreen cache warming for Paywalls V2 `web_view` bundles so the shared WebView profile’s HTTP cache is populated before a component renders. **`prewarm()` is not called from production yet**; the display path is already wired to pause/resume warming.
> 
> `PaywallWebViewPrewarmer` queues resolved HTTPS URLs (max 2 in flight, once per process). Each warm `loadUrl`s, waits for `onPageFinished` plus a 250 ms settle, then destroys the view (3 s stall timeout). Warming pauses while any component is on screen, requeues unfinished URLs, and drops in-flight views on memory trim. Construction/`Error`s are swallowed so a missing WebView package cannot crash apps that never show a paywall.
> 
> Display and warming share `configure()` and the paywall profile. Warming refuses media autoplay (so offscreen `<audio autoplay>` cannot play) and skips the JS bridge. WebView creation is extracted into `createPaywallWebView` / `createWarmingWebView`, with `onPageFinished` added to the client so a successful display load can `markWarmed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 411b413f34fc330bc11653c01d4e709e6323c20b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->