### PR TITLE
Update exit offer Maestro assertions

### DIFF
--- a/maestro/workflows/workflow_exit_offer_not_on_first_page.yaml
+++ b/maestro/workflows/workflow_exit_offer_not_on_first_page.yaml
@@ -30,5 +30,5 @@ env:
 - waitForAnimationToEnd: { timeout: 8000 }
 # Dismissed back to the launcher; the exit offer is NOT presented.
 - assertVisible: "Present Paywall"
-- assertNotVisible: "Paywall V2"
+- assertNotVisible: "Unlock full access"
 - takeScreenshot: "workflow_exit_offer_not_on_first_page"

--- a/maestro/workflows/workflow_exit_offer_on_last_page.yaml
+++ b/maestro/workflows/workflow_exit_offer_on_last_page.yaml
@@ -35,6 +35,6 @@ env:
 # Close the last page (unlabeled close icon, top-left) -> the exit offer paywall is presented.
 - tapOn: { point: "8%,6%" }
 - extendedWaitUntil:
-    visible: "Paywall V2"
+    visible: "Unlock full access"
     timeout: 15000
 - takeScreenshot: "workflow_exit_offer_on_last_page"


### PR DESCRIPTION
The exit offer fixture changed, so the Maestro flows were still checking the old `Paywall V2` text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E workflow assertion text only; no production or payment logic changes.
> 
> **Overview**
> Updates two Maestro workflow files so exit-offer checks use the paywall headline **"Unlock full access"** instead of **"Paywall V2"**, matching the changed exit-offer fixture in purchases-ios.
> 
> In `workflow_exit_offer_on_last_page.yaml`, the post-close wait now expects that text when the exit offer should appear. In `workflow_exit_offer_not_on_first_page.yaml`, `assertNotVisible` uses the same string so closing the first page still does not show the exit offer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4caca66efe6a9eb8caaaa79a3ed81784058fd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->