### PR TITLE
refactor(paywalls): collect web_view assets in the existing predownload walk

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmer.kt
@@ -4,10 +4,12 @@ package com.revenuecat.purchases.common.workflows
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.common.canUsePaywallUI
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.utils.PaywallComponentsImagePreDownloader
+import com.revenuecat.purchases.utils.collectAssets
 import kotlinx.coroutines.CancellationException
 
 /**
@@ -27,6 +29,8 @@ internal class WorkflowAssetPrewarmer(
     private val uiConfigProvider: UiConfigProvider,
     private val paywallComponentsImagePreDownloader: PaywallComponentsImagePreDownloader,
     private val offeringFontPreDownloader: OfferingFontPreDownloader,
+    /** The only consumer of the walk is a no-op without the paywalls SDK, so the walk itself is skipped. */
+    private val shouldCollectAssets: Boolean = canUsePaywallUI,
 ) {
 
     // Ids whose assets have been enqueued, so neither path warms the same workflow twice. Never reset for the
@@ -41,8 +45,10 @@ internal class WorkflowAssetPrewarmer(
         synchronized(warmedWorkflowIds) {
             if (!warmedWorkflowIds.add(workflow.id)) return
         }
-        workflow.screens.values.forEach { screen ->
-            paywallComponentsImagePreDownloader.preDownloadImages(screen.componentsConfig.base)
+        if (shouldCollectAssets) {
+            workflow.screens.values.forEach { screen ->
+                paywallComponentsImagePreDownloader.preDownloadImages(screen.componentsConfig.base.collectAssets())
+            }
         }
         offeringFontPreDownloader.preDownloadFontsIfNeeded(uiConfig.app.fonts.values)
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -53,7 +53,7 @@ internal class OfferingImagePreDownloader(
                 errorLog(error) { "Error deserializing paywall components data. Skipping V2 image pre-download." }
                 return
             }.componentsConfig.base
-            paywallComponentsImagePreDownloader.preDownloadImages(componentsConfig)
+            paywallComponentsImagePreDownloader.preDownloadImages(componentsConfig.collectAssets())
         }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentAssets.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentAssets.kt
@@ -1,0 +1,148 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.utils
+
+import android.net.Uri
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.ButtonComponent
+import com.revenuecat.purchases.paywalls.components.CarouselComponent
+import com.revenuecat.purchases.paywalls.components.CountdownComponent
+import com.revenuecat.purchases.paywalls.components.FallbackHeaderComponent
+import com.revenuecat.purchases.paywalls.components.HeaderComponent
+import com.revenuecat.purchases.paywalls.components.IconComponent
+import com.revenuecat.purchases.paywalls.components.ImageComponent
+import com.revenuecat.purchases.paywalls.components.PackageComponent
+import com.revenuecat.purchases.paywalls.components.PartialComponent
+import com.revenuecat.purchases.paywalls.components.PaywallComponent
+import com.revenuecat.purchases.paywalls.components.PurchaseButtonComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
+import com.revenuecat.purchases.paywalls.components.TabControlButtonComponent
+import com.revenuecat.purchases.paywalls.components.TabControlComponent
+import com.revenuecat.purchases.paywalls.components.TabControlToggleComponent
+import com.revenuecat.purchases.paywalls.components.TabsComponent
+import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.TimelineComponent
+import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
+import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
+
+/**
+ * Everything in a paywall's component tree that can be warmed before it is displayed, gathered in a
+ * single pass so each warming path picks what it needs instead of walking the tree again.
+ */
+internal data class PaywallComponentAssets(
+    val imageUris: Set<Uri>,
+    val webViews: Set<WebViewAsset>,
+)
+
+internal data class WebViewAsset(
+    val url: String,
+    val componentId: String,
+    val sizeToContentWidth: Boolean,
+    val sizeToContentHeight: Boolean,
+)
+
+internal fun PaywallComponentsConfig.collectAssets(): PaywallComponentAssets {
+    val imageUris = background.findImageUris().toMutableSet()
+    val webViews = mutableSetOf<WebViewAsset>()
+
+    listOfNotNull(stack, header?.stack, stickyFooter?.stack).forEach { tree ->
+        tree.flatten().forEach { component ->
+            imageUris += component.findImageUris()
+            if (component is WebViewComponent) webViews += component.toWebViewAsset()
+        }
+    }
+
+    return PaywallComponentAssets(imageUris = imageUris, webViews = webViews)
+}
+
+private fun WebViewComponent.toWebViewAsset(): WebViewAsset = WebViewAsset(
+    url = url,
+    componentId = id,
+    // Overrides can only change `visible`, so size is always the base component's. Matches how
+    // WebViewComponentView derives the same two axes at render time.
+    sizeToContentWidth = size.width is SizeConstraint.Fit,
+    sizeToContentHeight = size.height is SizeConstraint.Fit,
+)
+
+/** Image URIs this component references directly; descendants are visited separately by [flatten]. */
+@Suppress("CyclomaticComplexMethod")
+private fun PaywallComponent.findImageUris(): Set<Uri> =
+    when (this) {
+        is StackComponent -> {
+            background.findImageUris() + overrides.imageUris { it.background.findImageUris() }
+        }
+        is IconComponent -> {
+            // appendEncodedPath, not path() (which replaces the base URL's path, dropping e.g.
+            // /icons) nor appendPath (which percent-encodes the segment). The result must match
+            // the URL IconComponentState builds at render time by raw concatenation, since the
+            // image cache is keyed by the exact URL string.
+            setOf(
+                Uri.parse(baseUrl)
+                    .buildUpon()
+                    .appendEncodedPath(formats.webp)
+                    .build(),
+            )
+        }
+        is CarouselComponent -> {
+            background.findImageUris() + overrides.imageUris { it.background.findImageUris() }
+        }
+        is TabsComponent -> {
+            background.findImageUris() + overrides.imageUris { it.background.findImageUris() }
+        }
+        is ImageComponent -> {
+            source.findImageUris() + overrides.imageUris { it.source?.findImageUris().orEmpty() }
+        }
+        is VideoComponent -> {
+            fallbackSource?.findImageUris().orEmpty() +
+                overrides.imageUris { it.fallbackSource?.findImageUris().orEmpty() }
+        }
+        is ButtonComponent,
+        is CountdownComponent,
+        is FallbackHeaderComponent,
+        is HeaderComponent,
+        is PackageComponent,
+        is PurchaseButtonComponent,
+        is StickyFooterComponent,
+        is TabControlButtonComponent,
+        is TabControlComponent,
+        is TabControlToggleComponent,
+        is TextComponent,
+        is TimelineComponent,
+        // Its bundle is warmed through PaywallComponentAssets.webViews instead.
+        is WebViewComponent,
+        -> emptySet()
+    }
+
+private fun <T : PartialComponent> List<ComponentOverride<T>>?.imageUris(
+    extract: (T) -> Set<Uri>,
+): Set<Uri> = this?.flatMapTo(mutableSetOf()) { extract(it.properties) } ?: emptySet()
+
+private fun Background?.findImageUris(): Set<Uri> {
+    return when (this) {
+        is Background.Image -> setOfNotNull(
+            Uri.parse(value.light.webpLowRes.toString()),
+            value.dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
+        )
+        is Background.Video -> setOfNotNull(
+            Uri.parse(fallbackImage.light.webpLowRes.toString()),
+            fallbackImage.dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
+        )
+        is Background.Color,
+        is Background.Unknown,
+        null,
+        -> emptySet()
+    }
+}
+
+private fun ThemeImageUrls.findImageUris(): Set<Uri> {
+    return setOfNotNull(
+        light.webpLowRes.toString().let { Uri.parse(it) },
+        dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
+    )
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentFilterExtension.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentFilterExtension.kt
@@ -22,6 +22,10 @@ import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.VideoComponent
 import com.revenuecat.purchases.paywalls.components.WebViewComponent
 
+/** Returns this component and every descendant, breadth-first. */
+@OptIn(InternalRevenueCatAPI::class)
+internal fun PaywallComponent.flatten(): List<PaywallComponent> = filter { true }
+
 /**
  * Returns all PaywallComponent that satisfy the predicate.
  *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
@@ -1,36 +1,8 @@
-@file:OptIn(InternalRevenueCatAPI::class)
-
 package com.revenuecat.purchases.utils
 
-import android.net.Uri
-import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.canUsePaywallUI
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.verboseLog
-import com.revenuecat.purchases.paywalls.components.ButtonComponent
-import com.revenuecat.purchases.paywalls.components.CarouselComponent
-import com.revenuecat.purchases.paywalls.components.CountdownComponent
-import com.revenuecat.purchases.paywalls.components.FallbackHeaderComponent
-import com.revenuecat.purchases.paywalls.components.HeaderComponent
-import com.revenuecat.purchases.paywalls.components.IconComponent
-import com.revenuecat.purchases.paywalls.components.ImageComponent
-import com.revenuecat.purchases.paywalls.components.PackageComponent
-import com.revenuecat.purchases.paywalls.components.PartialComponent
-import com.revenuecat.purchases.paywalls.components.PurchaseButtonComponent
-import com.revenuecat.purchases.paywalls.components.StackComponent
-import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
-import com.revenuecat.purchases.paywalls.components.TabControlButtonComponent
-import com.revenuecat.purchases.paywalls.components.TabControlComponent
-import com.revenuecat.purchases.paywalls.components.TabControlToggleComponent
-import com.revenuecat.purchases.paywalls.components.TabsComponent
-import com.revenuecat.purchases.paywalls.components.TextComponent
-import com.revenuecat.purchases.paywalls.components.TimelineComponent
-import com.revenuecat.purchases.paywalls.components.VideoComponent
-import com.revenuecat.purchases.paywalls.components.WebViewComponent
-import com.revenuecat.purchases.paywalls.components.common.Background
-import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
-import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
-import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
 
 internal class PaywallComponentsImagePreDownloader(
     /**
@@ -41,112 +13,15 @@ internal class PaywallComponentsImagePreDownloader(
     private val coilImageDownloader: CoilImageDownloader,
 ) {
 
-    fun preDownloadImages(paywallComponentsConfig: PaywallComponentsConfig) {
+    fun preDownloadImages(assets: PaywallComponentAssets) {
         if (!shouldPredownloadImages) {
             verboseLog { "PaywallComponentsImagePreDownloader won't pre-download images" }
             return
         }
 
-        val imageUrls = findImageUrisToDownload(paywallComponentsConfig)
-        imageUrls.forEach {
+        assets.imageUris.forEach {
             debugLog { "Pre-downloading Paywall V2 image: $it" }
             coilImageDownloader.downloadImage(it)
         }
-    }
-
-    private fun findImageUrisToDownload(paywallComponentsConfig: PaywallComponentsConfig): Set<Uri> {
-        return paywallComponentsConfig.stack.findImageUrisToDownload() +
-            (paywallComponentsConfig.header?.stack?.findImageUrisToDownload().orEmpty()) +
-            (paywallComponentsConfig.stickyFooter?.stack?.findImageUrisToDownload().orEmpty()) +
-            paywallComponentsConfig.background.findImageUrisToDownload()
-    }
-
-    @Suppress("CyclomaticComplexMethod")
-    private fun StackComponent.findImageUrisToDownload(): Set<Uri> {
-        // PaywallComponent.filter is a BFS over the whole component tree. Passing { true }
-        // visits every descendant; findImageUrisToDownload is then responsible for extracting
-        // direct URIs per type (with the when expression as the single source of truth).
-        return filter { true }
-            .flatMapTo(mutableSetOf()) { component ->
-                when (component) {
-                    is StackComponent -> {
-                        component.background.findImageUrisToDownload() +
-                            component.overrides.imageUrisToDownload { it.background.findImageUrisToDownload() }
-                    }
-                    is IconComponent -> {
-                        // appendEncodedPath, not path() (which replaces the base URL's path, dropping e.g.
-                        // /icons) nor appendPath (which percent-encodes the segment). The result must match
-                        // the URL IconComponentState builds at render time by raw concatenation, since the
-                        // image cache is keyed by the exact URL string.
-                        setOf(
-                            Uri.parse(component.baseUrl)
-                                .buildUpon()
-                                .appendEncodedPath(component.formats.webp)
-                                .build(),
-                        )
-                    }
-                    is CarouselComponent -> {
-                        // pages are visited by BFS; only extract this component's own background
-                        component.background.findImageUrisToDownload() +
-                            component.overrides.imageUrisToDownload { it.background.findImageUrisToDownload() }
-                    }
-                    is TabsComponent -> {
-                        component.background.findImageUrisToDownload() +
-                            component.overrides.imageUrisToDownload { it.background.findImageUrisToDownload() }
-                    }
-                    is ImageComponent -> {
-                        component.source.findImageUrisToDownload() +
-                            component.overrides.imageUrisToDownload { it.source?.findImageUrisToDownload().orEmpty() }
-                    }
-                    is VideoComponent -> {
-                        component.fallbackSource?.findImageUrisToDownload().orEmpty() +
-                            component.overrides.imageUrisToDownload {
-                                it.fallbackSource?.findImageUrisToDownload().orEmpty()
-                            }
-                    }
-                    is ButtonComponent,
-                    is CountdownComponent, // sub-stacks visited by BFS
-                    is FallbackHeaderComponent,
-                    is HeaderComponent,
-                    is PackageComponent,
-                    is PurchaseButtonComponent,
-                    is StickyFooterComponent,
-                    is TabControlButtonComponent,
-                    is TabControlComponent,
-                    is TabControlToggleComponent,
-                    is TextComponent,
-                    is TimelineComponent,
-                    is WebViewComponent,
-                    -> emptySet()
-                }
-            }
-    }
-
-    private fun <T : PartialComponent> List<ComponentOverride<T>>?.imageUrisToDownload(
-        extract: (T) -> Set<Uri>,
-    ): Set<Uri> = this?.flatMapTo(mutableSetOf()) { extract(it.properties) } ?: emptySet()
-
-    private fun Background?.findImageUrisToDownload(): Set<Uri> {
-        return when (this) {
-            is Background.Image -> setOfNotNull(
-                Uri.parse(value.light.webpLowRes.toString()),
-                value.dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
-            )
-            is Background.Video -> setOfNotNull(
-                Uri.parse(fallbackImage.light.webpLowRes.toString()),
-                fallbackImage.dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
-            )
-            is Background.Color,
-            is Background.Unknown,
-            null,
-            -> emptySet()
-        }
-    }
-
-    private fun ThemeImageUrls.findImageUrisToDownload(): Set<Uri> {
-        return setOfNotNull(
-            light.webpLowRes.toString().let { Uri.parse(it) },
-            dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
-        )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
@@ -2,6 +2,7 @@
 
 package com.revenuecat.purchases.common.workflows
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.FontAlias
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.LogHandler
@@ -11,13 +12,18 @@ import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.emptyUiConfig
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.LocalizationData
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
 import com.revenuecat.purchases.uiConfigWithFonts
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.utils.PaywallComponentsImagePreDownloader
+import com.revenuecat.purchases.utils.collectAssets
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -46,8 +52,17 @@ class WorkflowAssetPrewarmerTest {
     fun setUp() {
         currentLogHandler = NoOpLogHandler
         coEvery { mockUiConfigProvider.getUiConfig() } returns uiConfig
-        prewarmer = WorkflowAssetPrewarmer(mockUiConfigProvider, imagePreDownloader, fontPreDownloader)
+        // canUsePaywallUI is false in this module's tests (RevenueCatUI is not on the classpath), so the
+        // walk has to be enabled explicitly.
+        prewarmer = prewarmer(shouldCollectAssets = true)
     }
+
+    private fun prewarmer(shouldCollectAssets: Boolean) = WorkflowAssetPrewarmer(
+        uiConfigProvider = mockUiConfigProvider,
+        paywallComponentsImagePreDownloader = imagePreDownloader,
+        offeringFontPreDownloader = fontPreDownloader,
+        shouldCollectAssets = shouldCollectAssets,
+    )
 
     @After
     fun tearDown() {
@@ -56,9 +71,22 @@ class WorkflowAssetPrewarmerTest {
 
     // region render path (preDownloadWorkflowAssets)
 
+    // The walk decodes every screen's component tree. Without the paywalls SDK there is nothing to warm
+    // into, so doing it anyway is pure cost on the workflow load path.
+    @Test
+    fun `preDownloadWorkflowAssets skips the component walk but still downloads fonts when disabled`() {
+        val screenConfig = emptyComponentsConfig()
+        val workflow = createWorkflow("wf_1", screens = mapOf("screen_1" to createScreen(screenConfig)))
+
+        prewarmer(shouldCollectAssets = false).preDownloadWorkflowAssets(workflow, uiConfig)
+
+        verify(exactly = 0) { imagePreDownloader.preDownloadImages(any()) }
+        verify(exactly = 1) { fontPreDownloader.preDownloadFontsIfNeeded(uiConfig.app.fonts.values) }
+    }
+
     @Test
     fun `preDownloadWorkflowAssets downloads screen images and workflow fonts`() {
-        val screenConfig = mockk<PaywallComponentsConfig>()
+        val screenConfig = emptyComponentsConfig()
         val font = UiConfig.AppConfig.FontsConfig(
             android = UiConfig.AppConfig.FontsConfig.FontInfo.GoogleFonts("Roboto"),
         )
@@ -69,7 +97,7 @@ class WorkflowAssetPrewarmerTest {
 
         val fontsSlot = slot<Collection<UiConfig.AppConfig.FontsConfig>>()
         verify(exactly = 1) {
-            imagePreDownloader.preDownloadImages(screenConfig)
+            imagePreDownloader.preDownloadImages(screenConfig.collectAssets())
             fontPreDownloader.preDownloadFontsIfNeeded(capture(fontsSlot))
         }
         assertThat(fontsSlot.captured).containsExactly(font)
@@ -77,13 +105,13 @@ class WorkflowAssetPrewarmerTest {
 
     @Test
     fun `preDownloadWorkflowAssets only downloads each workflow once`() {
-        val screenConfig = mockk<PaywallComponentsConfig>()
+        val screenConfig = emptyComponentsConfig()
         val workflow = createWorkflow("wf_1", screens = mapOf("screen_1" to createScreen(screenConfig)))
 
         prewarmer.preDownloadWorkflowAssets(workflow, uiConfig)
         prewarmer.preDownloadWorkflowAssets(workflow, uiConfig)
 
-        verify(exactly = 1) { imagePreDownloader.preDownloadImages(screenConfig) }
+        verify(exactly = 1) { imagePreDownloader.preDownloadImages(screenConfig.collectAssets()) }
     }
 
     // endregion render path
@@ -92,12 +120,12 @@ class WorkflowAssetPrewarmerTest {
 
     @Test
     fun `onCurrentWorkflowLoaded decodes and prewarms the workflow, resolving ui_config once`() = runTest {
-        val screenConfig = mockk<PaywallComponentsConfig>()
+        val screenConfig = emptyComponentsConfig()
         val workflow = createWorkflow("wf_1", screens = mapOf("screen_1" to createScreen(screenConfig)))
 
         prewarmer.onCurrentWorkflowLoaded("wf_1") { workflow }
 
-        verify(exactly = 1) { imagePreDownloader.preDownloadImages(screenConfig) }
+        verify(exactly = 1) { imagePreDownloader.preDownloadImages(screenConfig.collectAssets()) }
         verify(exactly = 1) { fontPreDownloader.preDownloadFontsIfNeeded(any()) }
         coVerify(exactly = 1) { mockUiConfigProvider.getUiConfig() }
     }
@@ -160,6 +188,14 @@ class WorkflowAssetPrewarmerTest {
             initialStepId = "step_1",
             steps = emptyMap(),
             screens = screens,
+        )
+
+    // A real config rather than a mock: the prewarmer traverses it via collectAssets().
+    private fun emptyComponentsConfig(): PaywallComponentsConfig =
+        PaywallComponentsConfig(
+            stack = StackComponent(components = emptyList()),
+            background = Background.Color(ColorScheme(light = ColorInfo.Alias(ColorAlias("")))),
+            stickyFooter = null,
         )
 
     private fun createScreen(paywallComponentsConfig: PaywallComponentsConfig): WorkflowScreen =

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/PaywallComponentAssetsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/PaywallComponentAssetsTest.kt
@@ -1,0 +1,152 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ColorAlias
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.HeaderComponent
+import com.revenuecat.purchases.paywalls.components.PaywallComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
+import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.ImageUrls
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URL
+
+@RunWith(AndroidJUnit4::class)
+class PaywallComponentAssetsTest {
+
+    @Test
+    fun `collects a web_view's url and component id`() {
+        val config = configWith(webView(url = "https://example.com/index.html", id = "component-1"))
+
+        val assets = config.collectAssets()
+
+        assertThat(assets.webViews).containsExactly(
+            WebViewAsset(
+                url = "https://example.com/index.html",
+                componentId = "component-1",
+                sizeToContentWidth = false,
+                sizeToContentHeight = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `derives each fit axis independently`() {
+        val config = configWith(
+            webView(
+                id = "fit-height-only",
+                size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()),
+            ),
+        )
+
+        val webView = config.collectAssets().webViews.single()
+
+        assertThat(webView.sizeToContentWidth).isFalse()
+        assertThat(webView.sizeToContentHeight).isTrue()
+    }
+
+    @Test
+    fun `treats a fixed axis as not sizing to content`() {
+        val config = configWith(
+            webView(size = Size(width = SizeConstraint.Fixed(320u), height = SizeConstraint.Fixed(240u))),
+        )
+
+        val webView = config.collectAssets().webViews.single()
+
+        assertThat(webView.sizeToContentWidth).isFalse()
+        assertThat(webView.sizeToContentHeight).isFalse()
+    }
+
+    @Test
+    fun `finds web_views nested anywhere in the tree`() {
+        val config = PaywallComponentsConfig(
+            stack = StackComponent(
+                components = listOf(StackComponent(components = listOf(webView(id = "nested")))),
+            ),
+            background = transparentBackground,
+            header = HeaderComponent(StackComponent(components = listOf(webView(id = "in-header")))),
+            stickyFooter = StickyFooterComponent(
+                StackComponent(components = listOf(webView(id = "in-footer"))),
+            ),
+        )
+
+        val assets = config.collectAssets()
+
+        assertThat(assets.webViews.map { it.componentId })
+            .containsExactlyInAnyOrder("nested", "in-header", "in-footer")
+    }
+
+    @Test
+    fun `keeps two components sharing a url apart by component id`() {
+        val config = configWith(
+            webView(url = "https://example.com/index.html", id = "first"),
+            webView(url = "https://example.com/index.html", id = "second"),
+        )
+
+        assertThat(config.collectAssets().webViews).hasSize(2)
+    }
+
+    @Test
+    fun `reports no web_views when the tree has none`() {
+        val config = configWith()
+
+        assertThat(config.collectAssets().webViews).isEmpty()
+    }
+
+    @Test
+    fun `collects images and web_views in the same pass`() {
+        val config = PaywallComponentsConfig(
+            stack = StackComponent(
+                components = listOf(webView(id = "component-1")),
+                background = Background.Image(
+                    value = ThemeImageUrls(light = imageUrls("https://example.com/stack.webp")),
+                ),
+            ),
+            background = transparentBackground,
+        )
+
+        val assets = config.collectAssets()
+
+        assertThat(assets.webViews.map { it.componentId }).containsExactly("component-1")
+        assertThat(assets.imageUris.map { it.toString() }).containsExactly("https://example.com/stack.webp")
+    }
+
+    private val transparentBackground =
+        Background.Color(ColorScheme(light = ColorInfo.Alias(ColorAlias(""))))
+
+    private fun configWith(vararg components: PaywallComponent) = PaywallComponentsConfig(
+        stack = StackComponent(components = components.toList()),
+        background = transparentBackground,
+    )
+
+    private fun webView(
+        url: String = "https://example.com/index.html",
+        id: String = "component-1",
+        size: Size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fill),
+    ) = WebViewComponent(
+        url = url,
+        id = id,
+        protocolVersion = WebViewComponent.SUPPORTED_PROTOCOL_VERSION,
+        size = size,
+    )
+
+    private fun imageUrls(webpLowRes: String) = ImageUrls(
+        original = URL("https://example.com/original.png"),
+        webp = URL("https://example.com/original.webp"),
+        webpLowRes = URL(webpLowRes),
+        width = 200u,
+        height = 200u,
+    )
+}


### PR DESCRIPTION
- Widens the existing paywall component walk so a single BFS collects image URIs **and** `web_view` descriptors
- **Nothing consumes the `web_view` data yet, and image pre-download behavior is unchanged**, so this is a no-op at runtime. It exists to give the next two PRs a single traversal to read from.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

Both warming paths already funnelled through one BFS over the component tree, with a `when` over component type as the single source of truth for extraction. `web_view` was the one type that returned nothing.

Adding WebView warming as its own traversal would have meant a second walk over the same tree on the offerings-load path, and a second place to keep in sync with the component model. Widening the return type of the walk that already exists costs one pass and keeps the `when` exhaustive, so a new component type still fails to compile until someone decides what it contributes.

This mirrors step 1 of the iOS plan, which consolidates image and video traversals into one. Android was already consolidated (video fallbacks are handled inside the same `when`, fonts never come from the tree), so the Android version of that step is just this widening.

### Description

- `PaywallComponentsImagePreDownloader.findImageUrisToDownload()` moves out to a top-level `PaywallComponentsConfig.collectAssets()` in a new `PaywallComponentAssets.kt`. The extraction `when` is carried over unchanged.
- Returns `PaywallComponentAssets(imageUris, webViews)`. `preDownloadImages` now takes the collected assets rather than the config, so one traversal feeds every warming path.
- `WebViewAsset` derives the Fit axes from the base component's `size`. Overrides can only change `visible`, so the base component is the right source; this matches what `WebViewComponentView` derives at render time.
- Adds `PaywallComponent.flatten()` next to the existing `filter`, so the walk reads as a flatten instead of `filter { true }`.
- Covers the walk with `PaywallComponentAssetsTest`: nesting under header and sticky footer, per-axis Fit derivation, two components sharing a URL, and images plus `web_view` collected in the same pass.

### Known limitations

- `OfferingVideoPredownloader` still does its own `filter { it is VideoComponent }` walk, over `base.stack` only rather than header and sticky footer. It has no production caller today, so it is not a second walk on any live path, but it should fold into `collectAssets()` whenever it gets wired.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of best-effort pre-download paths with new unit tests; no new consumers of WebView assets and image URL logic was carried over unchanged.
> 
> **Overview**
> Consolidates paywall **asset discovery** into a single tree walk so image pre-download and future warmers share one traversal instead of duplicating BFS logic.
> 
> **`PaywallComponentsConfig.collectAssets()`** (new `PaywallComponentAssets.kt`) returns **`PaywallComponentAssets`** with **`imageUris`** (same extraction rules as before, moved out of `PaywallComponentsImagePreDownloader`) and **`webViews`** (`WebViewAsset`: URL, component id, Fit axes from base `size`). **`flatten()`** is added on `PaywallComponent` as a clearer alias for visiting every node.
> 
> **`PaywallComponentsImagePreDownloader`** now accepts collected assets and only enqueues Coil downloads for **`imageUris`**—no config walk inside the downloader. **`OfferingImagePreDownloader`** and **`WorkflowAssetPrewarmer`** call **`collectAssets()`** before pre-download. **`WorkflowAssetPrewarmer`** skips the component walk when **`shouldCollectAssets`** is false (default **`canUsePaywallUI`**) but still pre-downloads fonts.
> 
> **Nothing consumes `webViews` yet**, so runtime image behavior should match the previous walk; this prepares follow-up WebView warming PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e973a843ab91d970b50aff7c46ef0ab2ad1eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


