### PR TITLE
fix(paywalls): prewarm the current offering's workflow assets on load

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -138,6 +138,9 @@ internal class WorkflowManager(
      * cache next reads committed data.
      */
     fun onPaywallConfigReady(onComplete: () -> Unit) {
+        // warm() may already have run with no current offering (config commits before offerings land), and the
+        // fast path below would then never re-run it. Deduped by workflow id, so a repeat call is free.
+        workflowsConfigProvider.prewarmCurrentOfferingAssets()
         if (uiConfigProvider.isWarm() && workflowsConfigProvider.isWarmForCurrentOffering()) {
             onComplete()
             return

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -250,21 +250,30 @@ internal class WorkflowsConfigProvider(
         }
         cache.store(generation, Cached(workflows, offeringToWorkflowId))
 
-        // Warm the current offering's workflow assets (images + ui_config fonts) at load time — mirrors the
-        // offerings path, which pre-downloads only the current offering's assets, never other offerings'. So a
-        // prefetch-flagged workflow that isn't the current offering's has its bytes cached (above) but not its
-        // assets: it isn't the paywall about to be shown. Fire-and-forget so it never blocks warm() or the
-        // getOfferings readiness gate. resolveWorkflowBody decodes transiently: it reads bytes + parses without
-        // touching the retained Lazy above, so prewarming keeps the cache raw-bytes-only.
-        onCurrentWorkflowLoaded?.let { notify ->
-            // Notify whenever the current offering maps to a workflow — do NOT gate on `workflows` (the byte-warm
-            // map), whose parallel preload can miss a body that hasn't finished its LOW-priority prefetch yet.
-            // resolveWorkflowBody fetches the body on demand, so gating here would drop the current offering's
-            // asset prewarm purely on preload timing.
-            currentOfferingId?.let { offeringToWorkflowId[it] }?.let { currentWorkflowId ->
-                scope.launch { notify(currentWorkflowId, ::resolveWorkflowBody) }
-            }
-        }
+        announceCurrentWorkflow(offeringToWorkflowId)
+    }
+
+    /** Announces against the already-warmed cache, for callers that learn the current offering after [warm]. */
+    fun prewarmCurrentOfferingAssets() {
+        announceCurrentWorkflow(cache.cached?.offeringToWorkflowId)
+    }
+
+    // Warm the current offering's workflow assets (images + ui_config fonts) at load time — mirrors the
+    // offerings path, which pre-downloads only the current offering's assets, never other offerings'. So a
+    // prefetch-flagged workflow that isn't the current offering's has its bytes cached but not its assets: it
+    // isn't the paywall about to be shown. Fire-and-forget so it never blocks warm() or the getOfferings
+    // readiness gate. resolveWorkflowBody decodes transiently: it reads bytes + parses without touching the
+    // retained Lazy, so prewarming keeps the cache raw-bytes-only.
+    private fun announceCurrentWorkflow(offeringToWorkflowId: Map<String, String>?) {
+        val notify = onCurrentWorkflowLoaded ?: return
+        // Notify whenever the current offering maps to a workflow — do NOT gate on `workflows` (the byte-warm
+        // map), whose parallel preload can miss a body that hasn't finished its LOW-priority prefetch yet.
+        // resolveWorkflowBody fetches the body on demand, so gating here would drop the current offering's
+        // asset prewarm purely on preload timing.
+        val currentWorkflowId = currentOfferingIdProvider()
+            ?.let { offeringToWorkflowId?.get(it) }
+            ?: return
+        scope.launch { notify(currentWorkflowId, ::resolveWorkflowBody) }
     }
 
     /** Warms at the current config generation; used by the offerings readiness gate. */

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -207,6 +207,7 @@ class WorkflowManagerTest {
     @Test
     fun `onPaywallConfigReady fires onComplete synchronously when both caches are already warm`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
+        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns true
         every { mockUiConfigProvider.isWarm() } returns true
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
@@ -220,9 +221,24 @@ class WorkflowManagerTest {
         coVerify(exactly = 0) { mockUiConfigProvider.resolveUiConfig() }
     }
 
+    // The fast path returns before warm(), so the prewarm must not sit behind it.
+    @Test
+    fun `onPaywallConfigReady prewarms the current offering's assets even on the warm fast path`() {
+        val mockProvider = mockk<WorkflowsConfigProvider>()
+        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
+        every { mockProvider.isWarmForCurrentOffering() } returns true
+        every { mockUiConfigProvider.isWarm() } returns true
+        val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
+
+        manager.onPaywallConfigReady { }
+
+        verify(exactly = 1) { mockProvider.prewarmCurrentOfferingAssets() }
+    }
+
     @Test
     fun `onPaywallConfigReady warms both providers and invokes onComplete when cold`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
+        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } just Runs
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
@@ -239,6 +255,7 @@ class WorkflowManagerTest {
     @Test
     fun `onPaywallConfigReady still completes and error-logs when ui_config resolution throws`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
+        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } just Runs
         coEvery { mockUiConfigProvider.resolveUiConfig() } throws RuntimeException("boom")
@@ -255,6 +272,7 @@ class WorkflowManagerTest {
     @Test
     fun `onPaywallConfigReady still completes and error-logs when a published ui_config is unavailable`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
+        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } just Runs
         coEvery { mockUiConfigProvider.resolveUiConfig() } returns UiConfigResolution.Unavailable
@@ -281,6 +299,7 @@ class WorkflowManagerTest {
 
         validOutcomes.forEach { outcome ->
             val mockProvider = mockk<WorkflowsConfigProvider>()
+        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
             every { mockProvider.isWarmForCurrentOffering() } returns false
             coEvery { mockProvider.warm() } just Runs
             coEvery { mockUiConfigProvider.resolveUiConfig() } returns outcome
@@ -298,6 +317,7 @@ class WorkflowManagerTest {
     @Test
     fun `onPaywallConfigReady still completes when warming the workflows cache fails`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
+        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } throws RuntimeException("boom")
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
@@ -315,6 +335,7 @@ class WorkflowManagerTest {
     fun `onPaywallConfigReady coalesces overlapping calls so readiness work runs only once and both callbacks fire`() {
         val gate = CompletableDeferred<Unit>()
         val mockProvider = mockk<WorkflowsConfigProvider>()
+        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } coAnswers { gate.await() }
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
@@ -344,6 +365,7 @@ class WorkflowManagerTest {
         // Use a dedicated scope so closing the manager doesn't cancel the shared testScope.
         val managerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
         val mockProvider = mockk<WorkflowsConfigProvider>()
+        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } coAnswers { gate.await() }
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = managerScope)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
@@ -400,6 +400,47 @@ internal class WorkflowsConfigProviderTest {
         assertThat(announcedId).isEqualTo(WF_CURRENT)
     }
 
+    // Cold start: warm() runs before the offerings response, so it has no current offering to announce.
+    @Test
+    fun `prewarmCurrentOfferingAssets announces once the offering is known after a warm that had none`() = runTest {
+        var announcedId: String? = null
+        currentOfferingId = null
+        val providerWithListener = WorkflowsConfigProvider(
+            manager,
+            currentOfferingIdProvider = { currentOfferingId },
+            onCurrentWorkflowLoaded = { workflowId, _ -> announcedId = workflowId },
+            scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        stubTopic()
+        stubWorkflowBody(WF_PREFETCH)
+        stubWorkflowBody(WF_CURRENT)
+
+        providerWithListener.warm(generation = 0)
+        assertThat(announcedId).isNull()
+        // Bytes are warm, so the guards would now short-circuit any further warm().
+        assertThat(providerWithListener.isWarmForCurrentOffering()).isTrue
+
+        currentOfferingId = CURRENT_OFFERING
+        providerWithListener.prewarmCurrentOfferingAssets()
+
+        assertThat(announcedId).isEqualTo(WF_CURRENT)
+    }
+
+    @Test
+    fun `prewarmCurrentOfferingAssets does not announce when nothing has been warmed yet`() = runTest {
+        var announced = false
+        val providerWithListener = WorkflowsConfigProvider(
+            manager,
+            currentOfferingIdProvider = { currentOfferingId },
+            onCurrentWorkflowLoaded = { _, _ -> announced = true },
+            scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+
+        providerWithListener.prewarmCurrentOfferingAssets()
+
+        assertThat(announced).isFalse
+    }
+
     @Test
     fun `warm does not notify onCurrentWorkflowLoaded when the current offering has no workflow`() = runTest {
         var announced = false


### PR DESCRIPTION
TL;DR: for workflows paywalls, we were prefetching the data but not prewarming images/fonts/etc until we actually launched the paywall. This is a bug, since it differs from iOS and from the offerings paywalls.

- The prewarm is announced at the end of `WorkflowsConfigProvider.warm`, but `warm` runs on config commit, which on a cold start finishes before the offerings response lands. `currentOfferingIdProvider` reads the in-memory offerings cache, so it is null and nothing is announced.
- Then `isWarmForCurrentOffering` is true because the _data_ is there, so the `warm` guard and the `onPaywallConfigReady` fast path short-circuit every later attempt: the announce is never reached again, on cold or warm launch.
- Split the announce out as `prewarmCurrentOfferingAssets` and drive it from `onPaywallConfigReady`, which `OfferingsManager` calls right after caching the offerings: the first point where the current offering is known.
- **This shifts asset downloads earlier for every workflows app.** Images and fonts that used to be fetched at paywall-open are now fetched shortly after offerings resolve. That is the intended design and matches both the non-workflows path and iOS, but it is a runtime behavior change.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

Asset prewarming exists so a paywall does not fetch its own images and fonts while rendering. On projects using workflows that never happened: nothing was warmed until a paywall was opened, at which point the render path warmed everything at once. The first screen the user sees was always uncached.

The cause is an ordering race with no recovery. `WorkflowsConfigProvider.warm` byte-caches eligible workflows and then announces the current offering's workflow for asset prewarming. It is driven by `onConfigCommitted`, and on a cold start config commit wins: measured on device, config persisted at `:52.262` and warmed at `:52.291`, while the offerings response only landed at `:52.453`. `currentOfferingIdProvider` reads `offeringsCache.cachedOfferings`, which is in-memory only and therefore empty at process start, so the announce is skipped.

Nothing retries, because the warmth guards measure the wrong thing. `isWarmForCurrentOffering` reports whether the workflow's *bytes* are cached; it says nothing about whether its assets were prewarmed. Those bytes are warm after that first pass, so `warm`'s own guard and `WorkflowManager.onPaywallConfigReady`'s fast path both return before reaching the announce. `warm` ran exactly once in a 75 second session. A warm relaunch is no better: `/v1/config` returns 304, so there is no commit and no warm at all.

iOS does not have this problem because it pushes the offering id in rather than reading it from a cache: `OfferingsManager` passes `includingOfferingId: offerings.current?.identifier` into `scheduleAssetPrewarmingForPrefetchedWorkflows`, so there is no race to lose. It also tracks asset-prewarm state separately from byte state, which is the distinction the Android guard collapses.

### Description

- Extract the announce from `WorkflowsConfigProvider.warm` into `prewarmCurrentOfferingAssets`, which resolves the offering to workflow mapping from the cache rather than requiring a fresh `warm` pass. `warm` calls the same private helper, so its behavior is unchanged.
- Call it from `WorkflowManager.onPaywallConfigReady`, before the warm fast path. `OfferingsManager` already calls that right after `cacheOfferings`, so no change to `OfferingsManager` was needed.
- `WorkflowAssetPrewarmer` already dedups by workflow id, so the already-warmed case costs nothing and the render path cannot double-download.

Measured on a Pixel 7a, cold launch with no paywall opened, on a workflows project whose current offering has a V2 paywall:

| | before | after |
| --- | --- | --- |
| workflow decodes | 0 | 1 |
| image pre-downloads | 0 | 7 |

Ordering after the fix: config warm `:24.790` (no current offering yet), offerings cached `:25.208`, prewarm decode `:25.333`, images from `:25.334`.

The regression gate is `WorkflowManagerTest > onPaywallConfigReady prewarms the current offering's assets even on the warm fast path`: it fails with the `prewarmCurrentOfferingAssets` call removed and passes with it. `WorkflowsConfigProviderTest > prewarmCurrentOfferingAssets announces once the offering is known after a warm that had none` covers the provider half, reproducing the cold-start ordering directly.

Known limitation: only the current offering's assets are warmed, matching the existing offerings path. iOS additionally warms all prefetch-flagged workflows; Android still only byte-caches those. Not changed here.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shifts network work earlier for all workflows apps after offerings load; behavior is intentional but increases background downloads and touches the offerings readiness path.
> 
> **Overview**
> Fixes a cold-start race where workflow **byte** caches looked warm but **images/fonts** for the current offering were never pre-downloaded until paywall open.
> 
> On cold launch, `WorkflowsConfigProvider.warm()` often runs from config commit **before** offerings are cached, so `currentOfferingId` is null and asset prewarm is skipped. Later, `isWarmForCurrentOffering()` and `onPaywallConfigReady`'s fast path never retry the announce.
> 
> **Changes:** Asset announce logic is centralized in `announceCurrentWorkflow`, exposed as `prewarmCurrentOfferingAssets()` for callers that learn the current offering later. `WorkflowManager.onPaywallConfigReady` invokes it **before** the warm fast path (after `OfferingsManager` caches offerings). `warm()` still calls the same helper; `WorkflowAssetPrewarmer` dedupes by workflow id.
> 
> **Runtime effect:** Workflows apps now fetch current-offering paywall assets shortly after offerings resolve (aligned with offerings paywalls and iOS), not only at paywall launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 026d3cbf1b16731c26499913965b45f7f6082d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->