### PR TITLE
fix(paywalls): Stop looping carousels redrawing their pages every few seconds

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -26,6 +27,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -76,10 +78,15 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteract
 import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallCarouselPageChange
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import kotlin.math.ceil
+import kotlin.math.max
 import androidx.compose.ui.unit.lerp as lerpUnit
 
 // Two is the minimum that keeps the trailing page_peek populated during the wrap. Matches the web SDK.
-private const val LOOP_CLONE_PAD = 2
+private const val MIN_LOOP_CLONE_PAD = 2
+
+// Eight clones a side is seven visible neighbours, past any real carousel design.
+private const val MAX_LOOP_CLONE_PAD = 8
 
 @Suppress("LongMethod")
 @JvmSynthetic
@@ -104,82 +111,8 @@ internal fun CarouselComponentView(
     val borderStyle = carouselState.border?.let { rememberBorderStyle(border = it) }
     val shadowStyle = carouselState.shadow?.let { rememberShadowStyle(shadow = it) }
 
-    val pageCount = style.pages.size
-
-    // Every pager index is a distinct LazyLayout key, so an unbounded index space would rebuild a
-    // page from scratch on every advance. Keep the ring finite.
-    val clonePad = loopClonePad(carouselState.loop, pageCount)
-    val ringCount = pageCount + 2 * clonePad
-    val initialPage = clonePad + carouselState.initialPageIndex.coerceIn(0, maxOf(pageCount - 1, 0))
-
-    val pagerState = rememberPagerState(initialPage = initialPage) { ringCount }
-
-    val currentLogicalPage by remember(pagerState, clonePad, pageCount) {
-        derivedStateOf { carouselLogicalPage(pagerState.currentPage, clonePad, pageCount) }
-    }
-
-    val skipProgrammaticPageTracking = remember { ProgrammaticPageTrackingFlag() }
-
-    RecenterLoopClones(pagerState = pagerState, clonePad = clonePad, pageCount = pageCount)
-
-    carouselState.autoAdvance?.let { autoAdvance ->
-        EnableAutoAdvance(
-            autoAdvance,
-            pagerState,
-            ringCount,
-            skipProgrammaticPageTracking,
-        )
-    }
-
-    if (pageCount > 0) {
-        LaunchedEffect(
-            pagerState,
-            pageCount,
-            clonePad,
-            style.componentName,
-            style.pageContextNames,
-            style.initialPageIndex,
-            componentInteractionTracker,
-        ) {
-            // Logical page, so the invisible clone re-centre does not emit a page change.
-            var previousPage = currentLogicalPage
-            snapshotFlow { currentLogicalPage }.collect { page ->
-                if (page != previousPage) {
-                    if (skipProgrammaticPageTracking.consumeShouldSkipPageChange()) {
-                        // Auto-advance scroll; do not emit component interaction.
-                    } else {
-                        fun pageName(logical: Int): String? =
-                            style.pageContextNames.getOrNull(logical)?.takeUnless { it.isBlank() }
-                        componentInteractionTracker.track(
-                            paywallCarouselPageChange(
-                                CarouselPageChangeInteraction(
-                                    componentName = style.componentName,
-                                    destinationPageIndex = page,
-                                    originPageIndex = previousPage,
-                                    defaultPageIndex = style.initialPageIndex,
-                                    originContextName = pageName(previousPage),
-                                    destinationContextName = pageName(page),
-                                ),
-                            ),
-                        )
-                    }
-                    previousPage = page
-                }
-            }
-        }
-    }
-
-    // A Fit carousel sizes to its tallest page, but each page is measured before that height is
-    // known, so a Fill page wraps its own (smaller) content instead of matching. Pin the Fill pages
-    // to the measured height; leave the Pager unpinned so it keeps tracking the tallest page as
-    // content grows (async WebView), which avoids latching to the first frame.
-    // A SubcomposeLayout single pass would avoid this measure -> recompose reflow, but it would
-    // compose every page (WebViews included) twice, so it isn't worth it for one settle frame.
-    val density = LocalDensity.current
-    var pagerHeightPx by remember(carouselState.pages) { mutableIntStateOf(0) }
-    val fillPageModifier = fillPageModifierOrEmpty(carouselState.size.height, pagerHeightPx, density)
-
-    Column(
+    // propagateMinConstraints, or a Fill or Fixed carousel wraps its content instead of filling.
+    BoxWithConstraints(
         modifier = modifier
             .size(carouselState.size)
             .padding(carouselState.margin)
@@ -191,43 +124,138 @@ internal fun CarouselComponentView(
                     .padding(it.width)
             }
             .padding(carouselState.padding),
+        propagateMinConstraints = true,
     ) {
-        val pageControl = @Composable {
-            carouselState.pageControl?.let {
-                PagerIndicator(
-                    pageControl = it,
-                    pageCount = pageCount,
-                    currentPage = currentLogicalPage,
-                    pagerState = pagerState,
-                )
-            }
-        }
+        val pageCount = style.pages.size
 
-        if (carouselState.pageControl?.position == CarouselComponent.PageControl.Position.TOP) {
-            pageControl()
-        }
+        val contentPadding = carouselState.pagePeek + carouselState.pageSpacing
 
-        HorizontalPager(
-            state = pagerState,
-            contentPadding = PaddingValues(horizontal = carouselState.pagePeek + carouselState.pageSpacing),
-            // Whole ring stays composed, so nothing is torn down. Ceiling: pageCount + 4 live pages.
-            beyondViewportPageCount = ringCount,
+        // Every pager index is a distinct LazyLayout key, so an unbounded index space would rebuild a
+        // page from scratch on every advance. Keep the ring finite.
+        val clonePad = loopClonePad(
+            loop = carouselState.loop,
+            pageCount = pageCount,
+            viewportWidth = maxWidth,
+            contentPadding = contentPadding,
             pageSpacing = carouselState.pageSpacing,
-            verticalAlignment = carouselState.pageAlignment,
-            modifier = Modifier.onSizeChanged { pagerHeightPx = it.height },
-        ) { page ->
-            val pageStyle = carouselState.pages[carouselLogicalPage(page, clonePad, pageCount)]
-            StackComponentView(
-                style = pageStyle,
-                state = state,
-                clickHandler = clickHandler,
-                componentInteractionTracker = componentInteractionTracker,
-                modifier = pageHeightModifier(pageStyle.size.height, fillPageModifier),
+        )
+        val ringCount = pageCount + 2 * clonePad
+        val initialPage = carouselRealZoneIndex(
+            pageIndex = carouselState.initialPageIndex.coerceIn(0, maxOf(pageCount - 1, 0)),
+            clonePad = clonePad,
+            pageCount = pageCount,
+        )
+
+        val pagerState = rememberPagerState(initialPage = initialPage) { ringCount }
+
+        val currentLogicalPage by remember(pagerState, pageCount) {
+            derivedStateOf { carouselLogicalPage(pagerState.currentPage, pageCount) }
+        }
+
+        val skipProgrammaticPageTracking = remember { ProgrammaticPageTrackingFlag() }
+
+        ReanchorOnPadChange(
+            pagerState = pagerState,
+            pageBeforeChange = currentLogicalPage,
+            clonePad = clonePad,
+            pageCount = pageCount,
+        )
+
+        RecenterLoopClones(pagerState = pagerState, clonePad = clonePad, pageCount = pageCount)
+
+        carouselState.autoAdvance?.let { autoAdvance ->
+            EnableAutoAdvance(
+                autoAdvance,
+                pagerState,
+                ringCount,
+                skipProgrammaticPageTracking,
             )
         }
 
-        if (carouselState.pageControl?.position == CarouselComponent.PageControl.Position.BOTTOM) {
-            pageControl()
+        if (pageCount > 0) {
+            LaunchedEffect(
+                pagerState,
+                pageCount,
+                style.componentName,
+                style.pageContextNames,
+                style.initialPageIndex,
+                componentInteractionTracker,
+            ) {
+                // Logical page, so the invisible clone re-centre does not emit a page change.
+                var previousPage = currentLogicalPage
+                snapshotFlow { currentLogicalPage }.collect { page ->
+                    if (page != previousPage) {
+                        if (skipProgrammaticPageTracking.consumeShouldSkipPageChange()) {
+                            // Auto-advance scroll; do not emit component interaction.
+                        } else {
+                            fun pageName(logical: Int): String? =
+                                style.pageContextNames.getOrNull(logical)?.takeUnless { it.isBlank() }
+                            componentInteractionTracker.track(
+                                paywallCarouselPageChange(
+                                    CarouselPageChangeInteraction(
+                                        componentName = style.componentName,
+                                        destinationPageIndex = page,
+                                        originPageIndex = previousPage,
+                                        defaultPageIndex = style.initialPageIndex,
+                                        originContextName = pageName(previousPage),
+                                        destinationContextName = pageName(page),
+                                    ),
+                                ),
+                            )
+                        }
+                        previousPage = page
+                    }
+                }
+            }
+        }
+
+        // A Fit carousel sizes to its tallest page, but each page is measured before that height is
+        // known, so a Fill page wraps its own (smaller) content instead of matching. Pin the Fill pages
+        // to the measured height; leave the Pager unpinned so it keeps tracking the tallest page as
+        // content grows (async WebView), which avoids latching to the first frame.
+        // A SubcomposeLayout single pass would avoid this measure -> recompose reflow, but it would
+        // compose every page (WebViews included) twice, so it isn't worth it for one settle frame.
+        val density = LocalDensity.current
+        var pagerHeightPx by remember(carouselState.pages) { mutableIntStateOf(0) }
+        val fillPageModifier = fillPageModifierOrEmpty(carouselState.size.height, pagerHeightPx, density)
+
+        Column {
+            val pageControl = @Composable {
+                carouselState.pageControl?.let {
+                    PagerIndicator(
+                        pageControl = it,
+                        pageCount = pageCount,
+                        pagerState = pagerState,
+                    )
+                }
+            }
+
+            if (carouselState.pageControl?.position == CarouselComponent.PageControl.Position.TOP) {
+                pageControl()
+            }
+
+            HorizontalPager(
+                state = pagerState,
+                contentPadding = PaddingValues(horizontal = contentPadding),
+                // Every ring index stays composed, so LazyLayout never tears a page down to rebuild it.
+                beyondViewportPageCount = ringCount,
+                pageSpacing = carouselState.pageSpacing,
+                verticalAlignment = carouselState.pageAlignment,
+                modifier = Modifier.onSizeChanged { pagerHeightPx = it.height },
+            ) { page ->
+                val pageStyle = carouselState.pages[carouselLogicalPage(page, pageCount)]
+                StackComponentView(
+                    style = pageStyle,
+                    state = state,
+                    clickHandler = clickHandler,
+                    componentInteractionTracker = componentInteractionTracker,
+                    modifier = pageHeightModifier(pageStyle.size.height, fillPageModifier),
+                )
+            }
+
+            if (carouselState.pageControl?.position == CarouselComponent.PageControl.Position.BOTTOM) {
+                pageControl()
+            }
         }
     }
 }
@@ -236,7 +264,6 @@ internal fun CarouselComponentView(
 private fun ColumnScope.PagerIndicator(
     pageControl: CarouselComponentStyle.PageControlStyles,
     pageCount: Int,
-    currentPage: Int,
     pagerState: PagerState,
     modifier: Modifier = Modifier,
 ) {
@@ -260,7 +287,7 @@ private fun ColumnScope.PagerIndicator(
             Indicator(
                 pagerState = pagerState,
                 pageIndex = iteration,
-                currentPage = currentPage,
+                pageCount = pageCount,
                 pageControl = pageControl,
             )
         }
@@ -272,11 +299,14 @@ private fun ColumnScope.PagerIndicator(
 private fun Indicator(
     pagerState: PagerState,
     pageIndex: Int,
-    currentPage: Int,
+    pageCount: Int,
     pageControl: CarouselComponentStyle.PageControlStyles,
 ) {
-    val progress by remember(pageIndex, currentPage) {
+    val progress by remember(pageIndex, pageCount) {
         derivedStateOf {
+            // Both reads have to come from one snapshot: a page hoisted into the remember key lags
+            // the offset by a frame, and the boundary frame then animates the wrong dot.
+            val currentPage = carouselLogicalPage(pagerState.currentPage, pageCount)
             when {
                 pageIndex == currentPage -> {
                     if (pagerState.currentPageOffsetFraction >= 0f) {
@@ -343,6 +373,21 @@ private fun Indicator(
     )
 }
 
+/**
+ * Puts [pageBeforeChange] back under the pager once a new pad has moved the real zone. It is passed
+ * in rather than read here: `PagerState` coerces its current page during the measure pass that
+ * follows, and a coerced index is a different page.
+ */
+@Composable
+private fun ReanchorOnPadChange(pagerState: PagerState, pageBeforeChange: Int, clonePad: Int, pageCount: Int) {
+    // Without clones there is no real zone to return to, and requestScrollToPage invalidates the
+    // pager's measure scope even when it already sits on the target page.
+    if (clonePad == 0) return
+    LaunchedEffect(clonePad, pageCount) {
+        pagerState.requestScrollToPage(carouselRealZoneIndex(pageBeforeChange, clonePad, pageCount))
+    }
+}
+
 /** Snaps back into the real zone on settling on a clone. The clone is identical, so it is invisible. */
 @Composable
 internal fun RecenterLoopClones(pagerState: PagerState, clonePad: Int, pageCount: Int) {
@@ -362,12 +407,16 @@ private fun EnableAutoAdvance(
     ringCount: Int,
     skipProgrammaticPageTracking: ProgrammaticPageTrackingFlag,
 ) {
+    // LaunchedEffect(Unit) runs once and outlives recomposition, so the ring bound and the timings
+    // have to be read live rather than captured as effect keys.
+    val currentRingCount by rememberUpdatedState(ringCount)
+    val currentAutoAdvance by rememberUpdatedState(autoAdvance)
     LaunchedEffect(Unit) {
         while (true) {
-            delay(autoAdvance.msTimePerPage.toLong())
+            delay(currentAutoAdvance.msTimePerPage.toLong())
             if (!pagerState.isScrollInProgress) {
                 val nextPage = nextAutoAdvanceTargetPage(
-                    ringCount = ringCount,
+                    ringCount = currentRingCount,
                     currentPage = pagerState.currentPage,
                 )
                 if (nextPage != null) {
@@ -376,7 +425,7 @@ private fun EnableAutoAdvance(
                         pagerState.animateScrollToPage(
                             page = nextPage,
                             animationSpec = tween(
-                                autoAdvance.msTransitionTime,
+                                currentAutoAdvance.msTransitionTime,
                             ),
                         )
                     } catch (_: CancellationException) {
@@ -406,22 +455,45 @@ private class ProgrammaticPageTrackingFlag {
     }
 }
 
-internal fun loopClonePad(loop: Boolean, pageCount: Int): Int =
-    if (loop && pageCount > 1) LOOP_CLONE_PAD else 0
+/**
+ * Clones per side. The pager cannot scroll past the ends of the ring, so anything the peek exposes
+ * beyond the last clone renders blank: a 3-across carousel already needs more than the minimum.
+ */
+internal fun loopClonePad(
+    loop: Boolean,
+    pageCount: Int,
+    viewportWidth: Dp,
+    contentPadding: Dp,
+    pageSpacing: Dp,
+): Int {
+    if (!loop || pageCount <= 1) return 0
+    // Pages are PageSize.Fill, so they get whatever the content padding leaves.
+    val pitch = viewportWidth - contentPadding * 2 + pageSpacing
+    // page_peek and page_spacing arrive unvalidated, so they can leave no room to lay a page out.
+    val visiblePerSide = if (pitch <= 0.dp) 0 else ceil(contentPadding / pitch).toInt()
+    // One clone per page the peek exposes, plus one that stays populated while the wrap animates.
+    // Capped: every ring index is composed for as long as the paywall is open, and a peek that
+    // approaches half the viewport drives this into the hundreds. Past the cap the peek gaps.
+    return max(MIN_LOOP_CLONE_PAD, visiblePerSide + 1).coerceAtMost(MAX_LOOP_CLONE_PAD)
+}
 
 internal fun nextAutoAdvanceTargetPage(ringCount: Int, currentPage: Int): Int? =
     (currentPage + 1).takeIf { it < ringCount }
 
-/** Maps the clone-padded ring back onto `0..pageCount-1`. Guards `mod(0)`: `pages` can be empty. */
-internal fun carouselLogicalPage(pagerIndex: Int, clonePad: Int, pageCount: Int): Int =
-    if (pageCount <= 0) 0 else (pagerIndex - clonePad).mod(pageCount)
+/**
+ * Maps the ring back onto `0..pageCount-1`. Independent of the pad, so a pad change leaves every
+ * index showing the page it already showed. Guards `mod(0)`: `pages` can be empty.
+ */
+internal fun carouselLogicalPage(pagerIndex: Int, pageCount: Int): Int =
+    if (pageCount <= 0) 0 else pagerIndex.mod(pageCount)
+
+/** First index in the real zone showing [pageIndex]. */
+internal fun carouselRealZoneIndex(pageIndex: Int, clonePad: Int, pageCount: Int): Int =
+    if (pageCount <= 0) 0 else clonePad + (pageIndex - clonePad).mod(pageCount)
 
 /** Index holding the same content as [settledPage] but in the real zone, or `null` if already there. */
-internal fun carouselRecenterTarget(settledPage: Int, clonePad: Int, pageCount: Int): Int? = when {
-    settledPage < clonePad -> settledPage + pageCount
-    settledPage >= clonePad + pageCount -> settledPage - pageCount
-    else -> null
-}
+internal fun carouselRecenterTarget(settledPage: Int, clonePad: Int, pageCount: Int): Int? =
+    carouselRealZoneIndex(settledPage, clonePad, pageCount).takeIf { it != settledPage }
 
 // Only a Fit carousel leaves pages unbounded at measure time; Fixed/Fill already bound them.
 private fun fillPageModifierOrEmpty(carouselHeight: SizeConstraint, measuredHeightPx: Int, density: Density): Modifier =

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -345,17 +345,14 @@ private fun Indicator(
 
 /** Snaps back into the real zone on settling on a clone. The clone is identical, so it is invisible. */
 @Composable
-private fun RecenterLoopClones(pagerState: PagerState, clonePad: Int, pageCount: Int) {
+internal fun RecenterLoopClones(pagerState: PagerState, clonePad: Int, pageCount: Int) {
     if (clonePad == 0) return
     LaunchedEffect(pagerState, clonePad, pageCount) {
         snapshotFlow { pagerState.settledPage }.collect { settledPage ->
             val target = carouselRecenterTarget(settledPage, clonePad, pageCount) ?: return@collect
-            try {
-                pagerState.scrollToPage(target)
-            } catch (_: CancellationException) {
-                // A competing scroll won the pager's mutex. Letting this out would kill the effect
-                // for good, and its keys never change, so re-centring would stop for the session.
-            }
+            // Not scrollToPage: it runs on the pager's scroll mutex, which a gesture holds at a
+            // higher (UserInput) priority and can't be interrupted by this (Default) caller.
+            pagerState.requestScrollToPage(target)
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -350,8 +350,6 @@ internal fun RecenterLoopClones(pagerState: PagerState, clonePad: Int, pageCount
     LaunchedEffect(pagerState, clonePad, pageCount) {
         snapshotFlow { pagerState.settledPage }.collect { settledPage ->
             val target = carouselRecenterTarget(settledPage, clonePad, pageCount) ?: return@collect
-            // Not scrollToPage: it runs on the pager's scroll mutex, which a gesture holds at a
-            // higher (UserInput) priority and can't be interrupted by this (Default) caller.
             pagerState.requestScrollToPage(target)
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -78,6 +78,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import androidx.compose.ui.unit.lerp as lerpUnit
 
+// Two is the minimum that keeps the trailing page_peek populated during the wrap. Matches the web SDK.
+private const val LOOP_CLONE_PAD = 2
+
 @Suppress("LongMethod")
 @JvmSynthetic
 @Composable
@@ -103,24 +106,27 @@ internal fun CarouselComponentView(
 
     val pageCount = style.pages.size
 
-    val initialPage = getInitialPage(carouselState)
+    // The ring must stay finite: every pager index is a distinct LazyLayout key, so an unbounded
+    // index space rebuilds a page from scratch on every advance.
+    val clonePad = loopClonePad(carouselState.loop, pageCount)
+    val ringCount = pageCount + 2 * clonePad
+    val initialPage = clonePad + carouselState.initialPageIndex.coerceIn(0, maxOf(pageCount - 1, 0))
 
-    val pagerState = rememberPagerState(initialPage = initialPage) {
-        if (carouselState.loop) {
-            Int.MAX_VALUE
-        } else {
-            pageCount
-        }
+    val pagerState = rememberPagerState(initialPage = initialPage) { ringCount }
+
+    val currentLogicalPage by remember(pagerState, clonePad, pageCount) {
+        derivedStateOf { carouselLogicalPage(pagerState.currentPage, clonePad, pageCount) }
     }
 
     val skipProgrammaticPageTracking = remember { ProgrammaticPageTrackingFlag() }
+
+    RecenterLoopClones(pagerState = pagerState, clonePad = clonePad, pageCount = pageCount)
 
     carouselState.autoAdvance?.let { autoAdvance ->
         EnableAutoAdvance(
             autoAdvance,
             pagerState,
-            carouselState.loop,
-            pageCount,
+            ringCount,
             skipProgrammaticPageTracking,
         )
     }
@@ -129,30 +135,30 @@ internal fun CarouselComponentView(
         LaunchedEffect(
             pagerState,
             pageCount,
+            clonePad,
             style.componentName,
             style.pageContextNames,
             style.initialPageIndex,
             componentInteractionTracker,
         ) {
-            var previousPage = pagerState.currentPage
-            snapshotFlow { pagerState.currentPage }.collect { page ->
+            // Logical page, so the invisible clone re-centre does not emit a page change.
+            var previousPage = carouselLogicalPage(pagerState.currentPage, clonePad, pageCount)
+            snapshotFlow { carouselLogicalPage(pagerState.currentPage, clonePad, pageCount) }.collect { page ->
                 if (page != previousPage) {
                     if (skipProgrammaticPageTracking.consumeShouldSkipPageChange()) {
                         // Auto-advance scroll; do not emit component interaction.
                     } else {
-                        val logicalDestination = page % pageCount
-                        val logicalOrigin = previousPage % pageCount
                         fun pageName(logical: Int): String? =
                             style.pageContextNames.getOrNull(logical)?.takeUnless { it.isBlank() }
                         componentInteractionTracker.track(
                             paywallCarouselPageChange(
                                 CarouselPageChangeInteraction(
                                     componentName = style.componentName,
-                                    destinationPageIndex = logicalDestination,
-                                    originPageIndex = logicalOrigin,
+                                    destinationPageIndex = page,
+                                    originPageIndex = previousPage,
                                     defaultPageIndex = style.initialPageIndex,
-                                    originContextName = pageName(logicalOrigin),
-                                    destinationContextName = pageName(logicalDestination),
+                                    originContextName = pageName(previousPage),
+                                    destinationContextName = pageName(page),
                                 ),
                             ),
                         )
@@ -191,6 +197,7 @@ internal fun CarouselComponentView(
                 PagerIndicator(
                     pageControl = it,
                     pageCount = pageCount,
+                    currentPage = currentLogicalPage,
                     pagerState = pagerState,
                 )
             }
@@ -203,13 +210,14 @@ internal fun CarouselComponentView(
         HorizontalPager(
             state = pagerState,
             contentPadding = PaddingValues(horizontal = carouselState.pagePeek + carouselState.pageSpacing),
-            // This will load all the pages at once, which allows the pager to always have the correct size
-            beyondViewportPageCount = pageCount,
+            // Compose the whole ring: keeps the pager correctly sized and stops pages being torn
+            // down. Ceiling: a looping carousel holds pageCount + 4 live pages, WebViews included.
+            beyondViewportPageCount = ringCount,
             pageSpacing = carouselState.pageSpacing,
             verticalAlignment = carouselState.pageAlignment,
             modifier = Modifier.onSizeChanged { pagerHeightPx = it.height },
         ) { page ->
-            val pageStyle = carouselState.pages[page % pageCount]
+            val pageStyle = carouselState.pages[carouselLogicalPage(page, clonePad, pageCount)]
             StackComponentView(
                 style = pageStyle,
                 state = state,
@@ -229,6 +237,7 @@ internal fun CarouselComponentView(
 private fun ColumnScope.PagerIndicator(
     pageControl: CarouselComponentStyle.PageControlStyles,
     pageCount: Int,
+    currentPage: Int,
     pagerState: PagerState,
     modifier: Modifier = Modifier,
 ) {
@@ -252,7 +261,7 @@ private fun ColumnScope.PagerIndicator(
             Indicator(
                 pagerState = pagerState,
                 pageIndex = iteration,
-                pageCount = pageCount,
+                currentPage = currentPage,
                 pageControl = pageControl,
             )
         }
@@ -264,24 +273,23 @@ private fun ColumnScope.PagerIndicator(
 private fun Indicator(
     pagerState: PagerState,
     pageIndex: Int,
-    pageCount: Int,
+    currentPage: Int,
     pageControl: CarouselComponentStyle.PageControlStyles,
 ) {
-    val progress by remember {
+    val progress by remember(pageIndex, currentPage) {
         derivedStateOf {
-            val processedCurrentPage = pagerState.currentPage % pageCount
             when {
-                pageIndex == processedCurrentPage -> {
+                pageIndex == currentPage -> {
                     if (pagerState.currentPageOffsetFraction >= 0f) {
                         1f - pagerState.currentPageOffsetFraction
                     } else {
                         1f + pagerState.currentPageOffsetFraction
                     }
                 }
-                pageIndex == processedCurrentPage + 1 && pagerState.currentPageOffsetFraction >= 0f -> {
+                pageIndex == currentPage + 1 && pagerState.currentPageOffsetFraction >= 0f -> {
                     pagerState.currentPageOffsetFraction
                 }
-                pageIndex == processedCurrentPage - 1 && pagerState.currentPageOffsetFraction < 0f -> {
+                pageIndex == currentPage - 1 && pagerState.currentPageOffsetFraction < 0f -> {
                     -pagerState.currentPageOffsetFraction
                 }
                 else -> 0f
@@ -289,34 +297,16 @@ private fun Indicator(
         }
     }
 
-    val targetWidth by remember {
-        derivedStateOf {
-            lerpUnit(
-                pageControl.default.width,
-                pageControl.active.width,
-                progress,
-            )
-        }
-    }
-    val targetHeight by remember {
-        derivedStateOf {
-            lerpUnit(
-                pageControl.default.height,
-                pageControl.active.height,
-                progress,
-            )
-        }
-    }
-
-    val targetStrokeWidth by remember {
-        derivedStateOf {
-            lerpUnit(
-                pageControl.default.strokeWidth ?: 0.dp,
-                pageControl.active.strokeWidth ?: 0.dp,
-                progress,
-            )
-        }
-    }
+    // Plain vals, not remembered: the body already reads `progress` on every recomposition for
+    // `color`, and a keyless remember here would pin the `progress` state object from the first
+    // composition, freezing the dot sizes on the page the carousel happened to start on.
+    val targetWidth = lerpUnit(pageControl.default.width, pageControl.active.width, progress)
+    val targetHeight = lerpUnit(pageControl.default.height, pageControl.active.height, progress)
+    val targetStrokeWidth = lerpUnit(
+        pageControl.default.strokeWidth ?: 0.dp,
+        pageControl.active.strokeWidth ?: 0.dp,
+        progress,
+    )
 
     val width by animateDpAsState(
         targetValue = targetWidth,
@@ -356,12 +346,25 @@ private fun Indicator(
     )
 }
 
+/**
+ * Snaps back into the real zone when the pager settles on a clone. The clone holds identical
+ * content, so the jump is invisible.
+ */
+@Composable
+private fun RecenterLoopClones(pagerState: PagerState, clonePad: Int, pageCount: Int) {
+    if (clonePad == 0) return
+    LaunchedEffect(pagerState, clonePad, pageCount) {
+        snapshotFlow { pagerState.settledPage }.collect { settledPage ->
+            carouselRecenterTarget(settledPage, clonePad, pageCount)?.let { pagerState.scrollToPage(it) }
+        }
+    }
+}
+
 @Composable
 private fun EnableAutoAdvance(
     autoAdvance: CarouselComponent.AutoAdvancePages,
     pagerState: PagerState,
-    shouldLoop: Boolean,
-    pageCount: Int,
+    ringCount: Int,
     skipProgrammaticPageTracking: ProgrammaticPageTrackingFlag,
 ) {
     LaunchedEffect(Unit) {
@@ -369,8 +372,7 @@ private fun EnableAutoAdvance(
             delay(autoAdvance.msTimePerPage.toLong())
             if (!pagerState.isScrollInProgress) {
                 val nextPage = nextAutoAdvanceTargetPage(
-                    shouldLoop = shouldLoop,
-                    pageCount = pageCount,
+                    ringCount = ringCount,
                     currentPage = pagerState.currentPage,
                 )
                 if (nextPage != null) {
@@ -413,23 +415,28 @@ private class ProgrammaticPageTrackingFlag {
     }
 }
 
+internal fun loopClonePad(loop: Boolean, pageCount: Int): Int =
+    if (loop && pageCount > 1) LOOP_CLONE_PAD else 0
+
+/** Next pager index for auto-advance, or `null` at the end of the index space. */
+internal fun nextAutoAdvanceTargetPage(ringCount: Int, currentPage: Int): Int? =
+    (currentPage + 1).takeIf { it < ringCount }
+
 /**
- * Next pager index for carousel auto-advance, or `null` when no scroll should run
- * (empty carousel, or non-loop already on the last page).
+ * Logical page shown at [pagerIndex], mapping the clone-padded ring back onto `0..pageCount-1`.
+ * A server-sent carousel can have no pages at all, and `mod(0)` throws.
  */
-internal fun nextAutoAdvanceTargetPage(
-    shouldLoop: Boolean,
-    pageCount: Int,
-    currentPage: Int,
-): Int? {
-    if (pageCount <= 0) return null
-    return if (shouldLoop) {
-        currentPage + 1
-    } else if (currentPage >= pageCount - 1) {
-        null
-    } else {
-        currentPage + 1
-    }
+internal fun carouselLogicalPage(pagerIndex: Int, clonePad: Int, pageCount: Int): Int =
+    if (pageCount <= 0) 0 else (pagerIndex - clonePad).mod(pageCount)
+
+/**
+ * Pager index holding the same content as [settledPage] but inside the ring's real zone, or `null`
+ * when it already is.
+ */
+internal fun carouselRecenterTarget(settledPage: Int, clonePad: Int, pageCount: Int): Int? = when {
+    settledPage < clonePad -> settledPage + pageCount
+    settledPage >= clonePad + pageCount -> settledPage - pageCount
+    else -> null
 }
 
 // Only a Fit carousel leaves pages unbounded at measure time; Fixed/Fill already bound them.
@@ -444,19 +451,6 @@ private fun fillPageModifierOrEmpty(carouselHeight: SizeConstraint, measuredHeig
 // sibling's height back into itself.
 private fun pageHeightModifier(pageHeight: SizeConstraint, fillPageModifier: Modifier): Modifier =
     if (pageHeight is SizeConstraint.Fill) fillPageModifier else Modifier
-
-private fun getInitialPage(carouselState: CarouselComponentState) = if (carouselState.loop) {
-    // When looping, we use a very large number of pages to allow for "infinite" scrolling
-    // We need to calculate the initial page index in the middle of that large number of pages to make the carousel
-    // start at the correct page
-    var currentPage = Int.MAX_VALUE / 2
-    while ((currentPage % carouselState.pages.size) != carouselState.initialPageIndex) {
-        currentPage++
-    }
-    currentPage
-} else {
-    carouselState.initialPageIndex
-}
 
 @Preview
 @Composable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -355,7 +355,14 @@ private fun RecenterLoopClones(pagerState: PagerState, clonePad: Int, pageCount:
     if (clonePad == 0) return
     LaunchedEffect(pagerState, clonePad, pageCount) {
         snapshotFlow { pagerState.settledPage }.collect { settledPage ->
-            carouselRecenterTarget(settledPage, clonePad, pageCount)?.let { pagerState.scrollToPage(it) }
+            val target = carouselRecenterTarget(settledPage, clonePad, pageCount) ?: return@collect
+            try {
+                pagerState.scrollToPage(target)
+            } catch (_: CancellationException) {
+                // A competing scroll (a swipe, or auto-advance) won the pager's mutex. Swallow it
+                // so the collector survives: letting it out would kill this effect for good, and
+                // its keys never change, so the carousel would never re-centre again.
+            }
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -142,8 +142,8 @@ internal fun CarouselComponentView(
             componentInteractionTracker,
         ) {
             // Logical page, so the invisible clone re-centre does not emit a page change.
-            var previousPage = carouselLogicalPage(pagerState.currentPage, clonePad, pageCount)
-            snapshotFlow { carouselLogicalPage(pagerState.currentPage, clonePad, pageCount) }.collect { page ->
+            var previousPage = currentLogicalPage
+            snapshotFlow { currentLogicalPage }.collect { page ->
                 if (page != previousPage) {
                     if (skipProgrammaticPageTracking.consumeShouldSkipPageChange()) {
                         // Auto-advance scroll; do not emit component interaction.
@@ -380,7 +380,7 @@ private fun EnableAutoAdvance(
                             ),
                         )
                     } catch (_: CancellationException) {
-                        skipProgrammaticPageTracking.clear()
+                        skipProgrammaticPageTracking.consumeShouldSkipPageChange()
                         // Do nothing, so we continue scrolling on the next loop
                     }
                 }
@@ -403,10 +403,6 @@ private class ProgrammaticPageTrackingFlag {
         val shouldSkip = shouldSkipNextPageChange
         shouldSkipNextPageChange = false
         return shouldSkip
-    }
-
-    fun clear() {
-        shouldSkipNextPageChange = false
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -106,8 +106,8 @@ internal fun CarouselComponentView(
 
     val pageCount = style.pages.size
 
-    // The ring must stay finite: every pager index is a distinct LazyLayout key, so an unbounded
-    // index space rebuilds a page from scratch on every advance.
+    // Every pager index is a distinct LazyLayout key, so an unbounded index space would rebuild a
+    // page from scratch on every advance. Keep the ring finite.
     val clonePad = loopClonePad(carouselState.loop, pageCount)
     val ringCount = pageCount + 2 * clonePad
     val initialPage = clonePad + carouselState.initialPageIndex.coerceIn(0, maxOf(pageCount - 1, 0))
@@ -210,8 +210,7 @@ internal fun CarouselComponentView(
         HorizontalPager(
             state = pagerState,
             contentPadding = PaddingValues(horizontal = carouselState.pagePeek + carouselState.pageSpacing),
-            // Compose the whole ring: keeps the pager correctly sized and stops pages being torn
-            // down. Ceiling: a looping carousel holds pageCount + 4 live pages, WebViews included.
+            // Whole ring stays composed, so nothing is torn down. Ceiling: pageCount + 4 live pages.
             beyondViewportPageCount = ringCount,
             pageSpacing = carouselState.pageSpacing,
             verticalAlignment = carouselState.pageAlignment,
@@ -297,9 +296,7 @@ private fun Indicator(
         }
     }
 
-    // Plain vals, not remembered: the body already reads `progress` on every recomposition for
-    // `color`, and a keyless remember here would pin the `progress` state object from the first
-    // composition, freezing the dot sizes on the page the carousel happened to start on.
+    // Not remembered: a keyless remember would pin the first `progress` state and freeze the sizes.
     val targetWidth = lerpUnit(pageControl.default.width, pageControl.active.width, progress)
     val targetHeight = lerpUnit(pageControl.default.height, pageControl.active.height, progress)
     val targetStrokeWidth = lerpUnit(
@@ -346,10 +343,7 @@ private fun Indicator(
     )
 }
 
-/**
- * Snaps back into the real zone when the pager settles on a clone. The clone holds identical
- * content, so the jump is invisible.
- */
+/** Snaps back into the real zone on settling on a clone. The clone is identical, so it is invisible. */
 @Composable
 private fun RecenterLoopClones(pagerState: PagerState, clonePad: Int, pageCount: Int) {
     if (clonePad == 0) return
@@ -359,9 +353,8 @@ private fun RecenterLoopClones(pagerState: PagerState, clonePad: Int, pageCount:
             try {
                 pagerState.scrollToPage(target)
             } catch (_: CancellationException) {
-                // A competing scroll (a swipe, or auto-advance) won the pager's mutex. Swallow it
-                // so the collector survives: letting it out would kill this effect for good, and
-                // its keys never change, so the carousel would never re-centre again.
+                // A competing scroll won the pager's mutex. Letting this out would kill the effect
+                // for good, and its keys never change, so re-centring would stop for the session.
             }
         }
     }
@@ -425,21 +418,14 @@ private class ProgrammaticPageTrackingFlag {
 internal fun loopClonePad(loop: Boolean, pageCount: Int): Int =
     if (loop && pageCount > 1) LOOP_CLONE_PAD else 0
 
-/** Next pager index for auto-advance, or `null` at the end of the index space. */
 internal fun nextAutoAdvanceTargetPage(ringCount: Int, currentPage: Int): Int? =
     (currentPage + 1).takeIf { it < ringCount }
 
-/**
- * Logical page shown at [pagerIndex], mapping the clone-padded ring back onto `0..pageCount-1`.
- * A server-sent carousel can have no pages at all, and `mod(0)` throws.
- */
+/** Maps the clone-padded ring back onto `0..pageCount-1`. Guards `mod(0)`: `pages` can be empty. */
 internal fun carouselLogicalPage(pagerIndex: Int, clonePad: Int, pageCount: Int): Int =
     if (pageCount <= 0) 0 else (pagerIndex - clonePad).mod(pageCount)
 
-/**
- * Pager index holding the same content as [settledPage] but inside the ring's real zone, or `null`
- * when it already is.
- */
+/** Index holding the same content as [settledPage] but in the real zone, or `null` if already there. */
 internal fun carouselRecenterTarget(settledPage: Int, clonePad: Int, pageCount: Int): Int? = when {
     settledPage < clonePad -> settledPage + pageCount
     settledPage >= clonePad + pageCount -> settledPage - pageCount

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselEmptyPagesTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselEmptyPagesTest.kt
@@ -18,9 +18,8 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 /**
- * `pages` is a plain list off the wire with no non-empty validation, and a page control reads the
- * carousel's logical page before anything guards on the list. The modulo behind that read throws on
- * a zero page count.
+ * `pages` arrives off the wire with no non-empty validation, and a page control reads the logical
+ * page before anything guards on the list. The modulo behind that read throws on zero pages.
  */
 @Config(sdk = [26])
 @RunWith(AndroidJUnit4::class)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselEmptyPagesTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselEmptyPagesTest.kt
@@ -1,0 +1,61 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.carousel
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.CarouselComponent
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.VerticalAlignment
+import com.revenuecat.purchases.ui.revenuecatui.components.style.CarouselComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * `pages` is a plain list off the wire with no non-empty validation, and a page control reads the
+ * carousel's logical page before anything guards on the list. The modulo behind that read throws on
+ * a zero page count.
+ */
+@Config(sdk = [26])
+@RunWith(AndroidJUnit4::class)
+class CarouselEmptyPagesTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `a carousel with no pages and a page control renders instead of crashing`() {
+        val carousel = CarouselComponent(
+            pages = emptyList(),
+            pageAlignment = VerticalAlignment.CENTER,
+            pageControl = CarouselComponent.PageControl(
+                position = CarouselComponent.PageControl.Position.BOTTOM,
+                active = indicator(),
+                default = indicator(),
+            ),
+        )
+        val state = FakePaywallState(components = listOf(carousel))
+        val rootStack = state.stack as StackComponentStyle
+        val carouselStyle = rootStack.children.filterIsInstance<CarouselComponentStyle>().single()
+
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize()) {
+                CarouselComponentView(style = carouselStyle, state = state, clickHandler = {})
+            }
+        }
+
+        composeTestRule.waitForIdle()
+    }
+
+    private fun indicator() = CarouselComponent.PageControl.Indicator(
+        width = 8u,
+        height = 8u,
+        color = ColorScheme(light = ColorInfo.Hex(0xFF000000.toInt())),
+    )
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopCompositionStabilityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopCompositionStabilityTest.kt
@@ -1,8 +1,12 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.carousel
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -11,6 +15,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.paywalls.components.CarouselComponent
@@ -36,11 +41,13 @@ import org.robolectric.annotation.Config
 import kotlin.math.abs
 
 /**
- * Regression test for SDK-4435. A `loop: true` carousel ran its pager over an unbounded index
- * space, so every auto-advance destroyed and rebuilt a page. Observed on device as a `web_view`
- * page fully reloading every ~8s for as long as the paywall was open.
+ * A `loop: true` carousel ran its pager over an unbounded index space, so every auto-advance
+ * destroyed and rebuilt a page. Observed on device as a `web_view` page fully reloading every ~8s
+ * for as long as the paywall was open.
  */
-@Config(sdk = [26])
+// Wide enough that the per-test host widths below are reachable; the default Robolectric screen
+// would coerce them all to the same value.
+@Config(sdk = [26], qualifiers = "w1200dp-h800dp")
 @RunWith(AndroidJUnit4::class)
 class CarouselLoopCompositionStabilityTest {
 
@@ -49,13 +56,19 @@ class CarouselLoopCompositionStabilityTest {
         const val PAGE_TWO_TEXT = "pageTwoText"
         const val MS_PER_PAGE = 3500
         const val MS_TRANSITION = 500
-        // Two pages plus two clones per side puts each page on three ring indices. This is the
-        // memory ceiling the ticket bounds: if the pad grows, weigh the cost, do not just bump it.
+        const val PAGE_PEEK = 28
+        // Two pages plus two clones per side puts each page on three ring indices. The pad is the
+        // minimum here because this peek exposes one neighbour per side.
         const val EXPECTED_INSTANCES_PER_PAGE = 3
+        // Against a 300dp viewport this peek leaves 80dp pages, so two neighbours show per side.
+        const val WIDE_PAGE_PEEK = 110
+        const val EXPECTED_WIDE_PEEK_INSTANCES_PER_PAGE = 4
     }
 
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    private var hostWidth by mutableStateOf<Dp?>(null)
 
     @Test
     fun `a looping carousel composes each page a bounded number of times`() {
@@ -102,6 +115,63 @@ class CarouselLoopCompositionStabilityTest {
         )
     }
 
+    @Test
+    fun `a peek wider than a page gets a clone for every page it exposes`() {
+        // With the minimum pad the pager runs out of ring before the peek is filled, and the gap
+        // is permanent: re-centring still leaves the outermost real page against the ring edge.
+        setLoopingCarouselContent(pagePeek = WIDE_PAGE_PEEK, width = 300.dp)
+
+        composeTestRule.onAllNodesWithText(PAGE_ONE_TEXT, useUnmergedTree = true)
+            .assertCountEquals(EXPECTED_WIDE_PEEK_INSTANCES_PER_PAGE)
+        composeTestRule.onAllNodesWithText(PAGE_TWO_TEXT, useUnmergedTree = true)
+            .assertCountEquals(EXPECTED_WIDE_PEEK_INSTANCES_PER_PAGE)
+    }
+
+    @Test
+    fun `a resize that changes the pad leaves the carousel on the same page`() {
+        // Pad 3 -> 2, small enough that the current index stays inside the shorter ring: this is
+        // the index-to-page mapping on its own, with no re-anchoring involved.
+        setLoopingCarouselContent(pagePeek = WIDE_PAGE_PEEK, width = 300.dp, autoAdvance = false)
+        val pageBeforeResize = centeredPageText()
+
+        hostWidth = 1000.dp
+        composeTestRule.waitForIdle()
+
+        assertThat(centeredPageText()).isEqualTo(pageBeforeResize)
+    }
+
+    @Test
+    fun `a resize that shrinks the ring leaves the carousel on the same page`() {
+        // Pad 5 -> 2, big enough to put the current index outside the shorter ring, which is the
+        // case PagerState coerces. A coerced index means a different page, so this one needs the
+        // re-anchor rather than the mapping alone.
+        setLoopingCarouselContent(pagePeek = WIDE_PAGE_PEEK, width = 250.dp, autoAdvance = false)
+        val pageBeforeResize = centeredPageText()
+
+        hostWidth = 1000.dp
+        composeTestRule.waitForIdle()
+
+        assertThat(centeredPageText()).isEqualTo(pageBeforeResize)
+    }
+
+    @Test
+    fun `a resize that changes the pad keeps auto-advancing`() {
+        // The ring grows with the pad, so an auto-advance loop holding the old ring size stops
+        // targeting anything once the real zone moves past it, and never recovers.
+        setLoopingCarouselContent(pagePeek = WIDE_PAGE_PEEK, width = 340.dp)
+
+        hostWidth = 250.dp
+        composeTestRule.waitForIdle()
+
+        val centeredPages = mutableListOf(centeredPageText())
+        repeat(2) {
+            advanceOnePage()
+            centeredPages += centeredPageText()
+        }
+
+        assertThat(centeredPages).containsExactly(PAGE_ONE_TEXT, PAGE_TWO_TEXT, PAGE_ONE_TEXT)
+    }
+
     private fun advanceOnePage() {
         composeTestRule.mainClock.advanceTimeBy((MS_PER_PAGE + MS_TRANSITION).toLong())
         composeTestRule.waitForIdle()
@@ -119,9 +189,14 @@ class CarouselLoopCompositionStabilityTest {
         composeTestRule.onAllNodesWithText(text, useUnmergedTree = true)
             .fetchSemanticsNodes(atLeastOneRootRequired = false)
 
-    private fun setLoopingCarouselContent() {
+    private fun setLoopingCarouselContent(
+        pagePeek: Int = PAGE_PEEK,
+        width: Dp? = null,
+        autoAdvance: Boolean = true,
+    ) {
+        hostWidth = width
         val state = FakePaywallState(
-            components = listOf(loopingCarousel()),
+            components = listOf(loopingCarousel(pagePeek = pagePeek, autoAdvance = autoAdvance)),
             localizations = nonEmptyMapOf(
                 LocaleId("en_US") to nonEmptyMapOf(
                     LocalizationKey("pageOneKey") to LocalizationData.Text(PAGE_ONE_TEXT),
@@ -133,7 +208,12 @@ class CarouselLoopCompositionStabilityTest {
         val carouselStyle = rootStack.children.filterIsInstance<CarouselComponentStyle>().single()
 
         composeTestRule.setContent {
-            Box(Modifier.fillMaxSize().height(800.dp)) {
+            val currentWidth = hostWidth
+            Box(
+                Modifier
+                    .height(800.dp)
+                    .then(currentWidth?.let { Modifier.width(it) } ?: Modifier.fillMaxWidth()),
+            ) {
                 CarouselComponentView(style = carouselStyle, state = state, clickHandler = {})
             }
         }
@@ -141,15 +221,15 @@ class CarouselLoopCompositionStabilityTest {
     }
 
     /** Mirrors the reported repro. */
-    private fun loopingCarousel() = CarouselComponent(
+    private fun loopingCarousel(pagePeek: Int, autoAdvance: Boolean) = CarouselComponent(
         pages = listOf(page("pageOneKey"), page("pageTwoKey")),
         pageAlignment = VerticalAlignment.CENTER,
-        pagePeek = 28,
+        pagePeek = pagePeek,
         loop = true,
         autoAdvance = CarouselComponent.AutoAdvancePages(
             msTimePerPage = MS_PER_PAGE,
             msTransitionTime = MS_TRANSITION,
-        ),
+        ).takeIf { autoAdvance },
     )
 
     private fun page(textKey: String) = StackComponent(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopCompositionStabilityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopCompositionStabilityTest.kt
@@ -49,9 +49,8 @@ class CarouselLoopCompositionStabilityTest {
         const val PAGE_TWO_TEXT = "pageTwoText"
         const val MS_PER_PAGE = 3500
         const val MS_TRANSITION = 500
-        // Two pages padded with two clones per side, so each page lands on three ring indices.
-        // This is the memory ceiling the ticket exists to bound: if the clone pad grows, weigh the
-        // extra live pages rather than just updating the number.
+        // Two pages plus two clones per side puts each page on three ring indices. This is the
+        // memory ceiling the ticket bounds: if the pad grows, weigh the cost, do not just bump it.
         const val EXPECTED_INSTANCES_PER_PAGE = 3
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopCompositionStabilityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopCompositionStabilityTest.kt
@@ -1,0 +1,166 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.carousel
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.CarouselComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.LocalizationData
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.VerticalAlignment
+import com.revenuecat.purchases.ui.revenuecatui.components.style.CarouselComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.math.abs
+
+/**
+ * Regression test for SDK-4435. A `loop: true` carousel ran its pager over an unbounded index
+ * space, so every auto-advance destroyed and rebuilt a page. Observed on device as a `web_view`
+ * page fully reloading every ~8s for as long as the paywall was open.
+ */
+@Config(sdk = [26])
+@RunWith(AndroidJUnit4::class)
+class CarouselLoopCompositionStabilityTest {
+
+    private companion object {
+        const val PAGE_ONE_TEXT = "pageOneText"
+        const val PAGE_TWO_TEXT = "pageTwoText"
+        const val MS_PER_PAGE = 3500
+        const val MS_TRANSITION = 500
+        // Two pages padded with two clones per side, so each page lands on three ring indices.
+        // This is the memory ceiling the ticket exists to bound: if the clone pad grows, weigh the
+        // extra live pages rather than just updating the number.
+        const val EXPECTED_INSTANCES_PER_PAGE = 3
+    }
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `a looping carousel composes each page a bounded number of times`() {
+        setLoopingCarouselContent()
+
+        composeTestRule.onAllNodesWithText(PAGE_ONE_TEXT, useUnmergedTree = true)
+            .assertCountEquals(EXPECTED_INSTANCES_PER_PAGE)
+        composeTestRule.onAllNodesWithText(PAGE_TWO_TEXT, useUnmergedTree = true)
+            .assertCountEquals(EXPECTED_INSTANCES_PER_PAGE)
+    }
+
+    @Test
+    fun `a looping carousel never rebuilds its pages while auto-advancing`() {
+        setLoopingCarouselContent()
+
+        val pageOneBefore = nodeIdsFor(PAGE_ONE_TEXT)
+        val pageTwoBefore = nodeIdsFor(PAGE_TWO_TEXT)
+
+        // Three full cycles: the old unbounded pager would have churned six indices by now.
+        repeat(3 * 2) { advanceOnePage() }
+
+        // Semantics ids are per LayoutNode, so a destroyed-and-recomposed page shows up as a new id.
+        assertThat(nodeIdsFor(PAGE_ONE_TEXT)).isEqualTo(pageOneBefore)
+        assertThat(nodeIdsFor(PAGE_TWO_TEXT)).isEqualTo(pageTwoBefore)
+    }
+
+    @Test
+    fun `a looping carousel keeps advancing forward past its last page`() {
+        setLoopingCarouselContent()
+
+        // Without the re-centre the pager slides into the trailing clones and sticks there.
+        val centeredPages = mutableListOf(centeredPageText())
+        repeat(4) {
+            advanceOnePage()
+            centeredPages += centeredPageText()
+        }
+
+        assertThat(centeredPages).containsExactly(
+            PAGE_ONE_TEXT,
+            PAGE_TWO_TEXT,
+            PAGE_ONE_TEXT,
+            PAGE_TWO_TEXT,
+            PAGE_ONE_TEXT,
+        )
+    }
+
+    private fun advanceOnePage() {
+        composeTestRule.mainClock.advanceTimeBy((MS_PER_PAGE + MS_TRANSITION).toLong())
+        composeTestRule.waitForIdle()
+    }
+
+    private fun nodeIdsFor(text: String): Set<Int> = nodesFor(text).map { it.id }.toSet()
+
+    private fun centeredPageText(): String {
+        val rootCenterX = composeTestRule.onRoot().fetchSemanticsNode().boundsInRoot.center.x
+        return listOf(PAGE_ONE_TEXT, PAGE_TWO_TEXT)
+            .minBy { text -> nodesFor(text).minOf { abs(it.boundsInRoot.center.x - rootCenterX) } }
+    }
+
+    private fun nodesFor(text: String): List<SemanticsNode> =
+        composeTestRule.onAllNodesWithText(text, useUnmergedTree = true)
+            .fetchSemanticsNodes(atLeastOneRootRequired = false)
+
+    private fun setLoopingCarouselContent() {
+        val state = FakePaywallState(
+            components = listOf(loopingCarousel()),
+            localizations = nonEmptyMapOf(
+                LocaleId("en_US") to nonEmptyMapOf(
+                    LocalizationKey("pageOneKey") to LocalizationData.Text(PAGE_ONE_TEXT),
+                    LocalizationKey("pageTwoKey") to LocalizationData.Text(PAGE_TWO_TEXT),
+                ),
+            ),
+        )
+        val rootStack = state.stack as StackComponentStyle
+        val carouselStyle = rootStack.children.filterIsInstance<CarouselComponentStyle>().single()
+
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize().height(800.dp)) {
+                CarouselComponentView(style = carouselStyle, state = state, clickHandler = {})
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    /** Mirrors the reported repro. */
+    private fun loopingCarousel() = CarouselComponent(
+        pages = listOf(page("pageOneKey"), page("pageTwoKey")),
+        pageAlignment = VerticalAlignment.CENTER,
+        pagePeek = 28,
+        loop = true,
+        autoAdvance = CarouselComponent.AutoAdvancePages(
+            msTimePerPage = MS_PER_PAGE,
+            msTransitionTime = MS_TRANSITION,
+        ),
+    )
+
+    private fun page(textKey: String) = StackComponent(
+        components = listOf(
+            TextComponent(
+                text = LocalizationKey(textKey),
+                color = ColorScheme(light = ColorInfo.Hex(Color.Black.toArgb())),
+                size = Size(width = Fit(), height = Fit()),
+            ),
+        ),
+        size = Size(width = Fit(), height = Fit()),
+    )
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopIndexTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopIndexTest.kt
@@ -1,0 +1,64 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.carousel
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+/** Ring index math for a looping carousel. See `CarouselComponentView`. */
+internal class CarouselLoopIndexTest {
+
+    @Test
+    fun `only a multi-page looping carousel gets clones`() {
+        assertThat(loopClonePad(loop = true, pageCount = 2)).isGreaterThan(0)
+        assertThat(loopClonePad(loop = false, pageCount = 2)).isZero()
+        // One page: nothing to loop between.
+        assertThat(loopClonePad(loop = true, pageCount = 1)).isZero()
+        assertThat(loopClonePad(loop = true, pageCount = 0)).isZero()
+    }
+
+    @Test
+    fun `the clone-padded ring maps onto the logical pages`() {
+        // Ring 0..6, real zone 2..4. Leading clones mirror the web SDK's prevPages = [last - 1,
+        // last] and trailing clones its nextPages = [0, 1]. Indices below the pad must wrap rather
+        // than go negative, so this fails if `%` replaces `mod`.
+        assertThat((0..6).map { carouselLogicalPage(it, clonePad = 2, pageCount = 3) })
+            .containsExactly(1, 2, 0, 1, 2, 0, 1)
+        // Two pages is the reported repro, and the pad then exceeds the page count.
+        assertThat((0..5).map { carouselLogicalPage(it, clonePad = 2, pageCount = 2) })
+            .containsExactly(0, 1, 0, 1, 0, 1)
+    }
+
+    @Test
+    fun `an empty carousel has no page to map to`() {
+        // A page control reads the logical page before anything guards on pages being non-empty,
+        // and `mod(0)` would throw.
+        assertThat(carouselLogicalPage(pagerIndex = 0, clonePad = 0, pageCount = 0)).isZero()
+    }
+
+    @Test
+    fun `without clones the pager index is the logical page`() {
+        assertThat((0..2).map { carouselLogicalPage(it, clonePad = 0, pageCount = 3) })
+            .containsExactly(0, 1, 2)
+    }
+
+    @Test
+    fun `settling on a clone re-centres by one full page count`() {
+        assertThat((0..6).map { carouselRecenterTarget(it, clonePad = 2, pageCount = 3) })
+            .containsExactly(3, 4, null, null, null, 2, 3)
+    }
+
+    @Test
+    fun `a re-centre target holds the same page as the clone it replaces`() {
+        for (pagerIndex in 0..6) {
+            val target = carouselRecenterTarget(pagerIndex, clonePad = 2, pageCount = 3) ?: continue
+            assertThat(carouselLogicalPage(target, clonePad = 2, pageCount = 3))
+                .isEqualTo(carouselLogicalPage(pagerIndex, clonePad = 2, pageCount = 3))
+            assertThat(target).isBetween(2, 4)
+        }
+    }
+
+    @Test
+    fun `a carousel without clones never re-centres`() {
+        assertThat((0..2).map { carouselRecenterTarget(it, clonePad = 0, pageCount = 3) })
+            .containsOnlyNulls()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopIndexTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopIndexTest.kt
@@ -1,5 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.carousel
 
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -8,34 +10,92 @@ internal class CarouselLoopIndexTest {
 
     @Test
     fun `only a multi-page looping carousel gets clones`() {
-        assertThat(loopClonePad(loop = true, pageCount = 2)).isGreaterThan(0)
-        assertThat(loopClonePad(loop = false, pageCount = 2)).isZero()
+        assertThat(clonePad(loop = true, pageCount = 2)).isGreaterThan(0)
+        assertThat(clonePad(loop = false, pageCount = 2)).isZero()
         // One page: nothing to loop between.
-        assertThat(loopClonePad(loop = true, pageCount = 1)).isZero()
-        assertThat(loopClonePad(loop = true, pageCount = 0)).isZero()
+        assertThat(clonePad(loop = true, pageCount = 1)).isZero()
+        assertThat(clonePad(loop = true, pageCount = 0)).isZero()
     }
 
     @Test
-    fun `the clone-padded ring maps onto the logical pages`() {
-        // Ring 0..6, real zone 2..4. Clones mirror the web SDK: prevPages [last - 1, last],
-        // nextPages [0, 1]. Indices below the pad must wrap, so this fails if `%` replaces `mod`.
-        assertThat((0..6).map { carouselLogicalPage(it, clonePad = 2, pageCount = 3) })
-            .containsExactly(1, 2, 0, 1, 2, 0, 1)
+    fun `an ordinary peek needs the minimum pad`() {
+        // The reported repro: one neighbour visible per side.
+        assertThat(clonePad(pagePeek = 28.dp, viewportWidth = 320.dp)).isEqualTo(2)
+        assertThat(clonePad(pagePeek = 0.dp, viewportWidth = 320.dp)).isEqualTo(2)
+        // The boundary. Peek, page and pitch are all a third of the viewport, so exactly one
+        // neighbour fits per side: a 3-across carousel.
+        assertThat(clonePad(pagePeek = 100.dp, viewportWidth = 300.dp)).isEqualTo(2)
+    }
+
+    @Test
+    fun `a peek wider than a page needs a clone for every page it exposes`() {
+        // Past the boundary the pager would run out of ring and render blank in the peek.
+        assertThat(clonePad(pagePeek = 110.dp, viewportWidth = 300.dp)).isEqualTo(3)
+        // 70dp pages behind a 165dp peek: three neighbours a side, all of them on screen anyway.
+        assertThat(clonePad(pagePeek = 165.dp, viewportWidth = 400.dp)).isEqualTo(4)
+    }
+
+    @Test
+    fun `page spacing counts towards the peek and the pitch`() {
+        assertThat(clonePad(pagePeek = 90.dp, pageSpacing = 20.dp, viewportWidth = 300.dp)).isEqualTo(3)
+    }
+
+    @Test
+    fun `the pad is capped, because every ring index stays composed`() {
+        // A 2dp pitch would otherwise ask for 101 clones a side, so 200+ live pages.
+        assertThat(clonePad(pagePeek = 199.dp, viewportWidth = 400.dp)).isEqualTo(8)
+    }
+
+    @Test
+    fun `a peek leaving no room for a page falls back to the minimum`() {
+        // Nothing renders sensibly at this point; the guard is here because the wire allows it.
+        assertThat(clonePad(pagePeek = 150.dp, viewportWidth = 300.dp)).isEqualTo(2)
+        assertThat(clonePad(viewportWidth = Dp.Infinity)).isEqualTo(2)
+    }
+
+    private fun clonePad(
+        loop: Boolean = true,
+        pageCount: Int = 3,
+        viewportWidth: Dp = 320.dp,
+        pagePeek: Dp = 28.dp,
+        pageSpacing: Dp = 0.dp,
+    ) = loopClonePad(
+        loop = loop,
+        pageCount = pageCount,
+        viewportWidth = viewportWidth,
+        contentPadding = pagePeek + pageSpacing,
+        pageSpacing = pageSpacing,
+    )
+
+    @Test
+    fun `the ring maps onto the logical pages`() {
+        // Content is periodic across the whole ring, which is what makes every clone mirror the
+        // page one page count away from it.
+        assertThat((0..6).map { carouselLogicalPage(it, pageCount = 3) })
+            .containsExactly(0, 1, 2, 0, 1, 2, 0)
         // Two pages is the reported repro, where the pad exceeds the page count.
-        assertThat((0..5).map { carouselLogicalPage(it, clonePad = 2, pageCount = 2) })
+        assertThat((0..5).map { carouselLogicalPage(it, pageCount = 2) })
             .containsExactly(0, 1, 0, 1, 0, 1)
     }
 
     @Test
     fun `an empty carousel has no page to map to`() {
         // A page control reads this before anything guards on `pages`, and `mod(0)` would throw.
-        assertThat(carouselLogicalPage(pagerIndex = 0, clonePad = 0, pageCount = 0)).isZero()
+        assertThat(carouselLogicalPage(pagerIndex = 0, pageCount = 0)).isZero()
+        assertThat(carouselRealZoneIndex(pageIndex = 0, clonePad = 2, pageCount = 0)).isZero()
     }
 
     @Test
-    fun `without clones the pager index is the logical page`() {
-        assertThat((0..2).map { carouselLogicalPage(it, clonePad = 0, pageCount = 3) })
-            .containsExactly(0, 1, 2)
+    fun `the real zone index holds the page it was asked for, whatever the pad`() {
+        // The pad tracks the viewport, so it changes on a resize or a partial that moves page_peek.
+        // A page must not move between indices when it does, or every page would be rebuilt.
+        for (clonePad in 0..4) {
+            for (pageIndex in 0..2) {
+                val index = carouselRealZoneIndex(pageIndex, clonePad, pageCount = 3)
+                assertThat(carouselLogicalPage(index, pageCount = 3)).isEqualTo(pageIndex)
+                assertThat(index).isBetween(clonePad, clonePad + 2)
+            }
+        }
     }
 
     @Test
@@ -48,10 +108,18 @@ internal class CarouselLoopIndexTest {
     fun `a re-centre target holds the same page as the clone it replaces`() {
         for (pagerIndex in 0..6) {
             val target = carouselRecenterTarget(pagerIndex, clonePad = 2, pageCount = 3) ?: continue
-            assertThat(carouselLogicalPage(target, clonePad = 2, pageCount = 3))
-                .isEqualTo(carouselLogicalPage(pagerIndex, clonePad = 2, pageCount = 3))
+            assertThat(carouselLogicalPage(target, pageCount = 3))
+                .isEqualTo(carouselLogicalPage(pagerIndex, pageCount = 3))
             assertThat(target).isBetween(2, 4)
         }
+    }
+
+    @Test
+    fun `a re-centre lands in the real zone in one hop, even with more clones than pages`() {
+        // A wide peek gives more clones per side than there are pages, so stepping by a single
+        // page count is not enough to clear the clone zone.
+        assertThat((0..7).map { carouselRecenterTarget(it, clonePad = 3, pageCount = 2) })
+            .containsExactly(4, 3, 4, null, null, 3, 4, 3)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopIndexTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselLoopIndexTest.kt
@@ -17,20 +17,18 @@ internal class CarouselLoopIndexTest {
 
     @Test
     fun `the clone-padded ring maps onto the logical pages`() {
-        // Ring 0..6, real zone 2..4. Leading clones mirror the web SDK's prevPages = [last - 1,
-        // last] and trailing clones its nextPages = [0, 1]. Indices below the pad must wrap rather
-        // than go negative, so this fails if `%` replaces `mod`.
+        // Ring 0..6, real zone 2..4. Clones mirror the web SDK: prevPages [last - 1, last],
+        // nextPages [0, 1]. Indices below the pad must wrap, so this fails if `%` replaces `mod`.
         assertThat((0..6).map { carouselLogicalPage(it, clonePad = 2, pageCount = 3) })
             .containsExactly(1, 2, 0, 1, 2, 0, 1)
-        // Two pages is the reported repro, and the pad then exceeds the page count.
+        // Two pages is the reported repro, where the pad exceeds the page count.
         assertThat((0..5).map { carouselLogicalPage(it, clonePad = 2, pageCount = 2) })
             .containsExactly(0, 1, 0, 1, 0, 1)
     }
 
     @Test
     fun `an empty carousel has no page to map to`() {
-        // A page control reads the logical page before anything guards on pages being non-empty,
-        // and `mod(0)` would throw.
+        // A page control reads this before anything guards on `pages`, and `mod(0)` would throw.
         assertThat(carouselLogicalPage(pagerIndex = 0, clonePad = 0, pageCount = 0)).isZero()
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselRecenterUnderGestureTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselRecenterUnderGestureTest.kt
@@ -30,7 +30,8 @@ class CarouselRecenterUnderGestureTest {
     @Test
     fun `a recentre started while a gesture holds the scroll mutex still lands`() {
         val pageCount = 2
-        val clonePad = loopClonePad(loop = true, pageCount = pageCount)
+        // Any non-zero pad exercises this; where it comes from is CarouselLoopIndexTest's business.
+        val clonePad = 2
         val ringCount = pageCount + 2 * clonePad
         val trailingClone = ringCount - 1
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselRecenterUnderGestureTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselRecenterUnderGestureTest.kt
@@ -24,24 +24,22 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 class CarouselRecenterUnderGestureTest {
 
-    private companion object {
-        const val CLONE_PAD = 2
-        const val PAGE_COUNT = 2
-        const val RING_COUNT = PAGE_COUNT + 2 * CLONE_PAD
-        const val TRAILING_CLONE = RING_COUNT - 1
-    }
-
     @get:Rule
     val composeTestRule = createComposeRule()
 
     @Test
     fun `a recentre started while a gesture holds the scroll mutex still lands`() {
+        val clonePad = 2
+        val pageCount = 2
+        val ringCount = pageCount + 2 * clonePad
+        val trailingClone = ringCount - 1
+
         var holdMutexWithGesture by mutableStateOf(false)
         var recenterEnabled by mutableStateOf(false)
         lateinit var pagerState: PagerState
 
         composeTestRule.setContent {
-            pagerState = rememberPagerState(initialPage = TRAILING_CLONE) { RING_COUNT }
+            pagerState = rememberPagerState(initialPage = trailingClone) { ringCount }
 
             if (holdMutexWithGesture) {
                 LaunchedEffect(pagerState) {
@@ -49,7 +47,7 @@ class CarouselRecenterUnderGestureTest {
                 }
             }
             if (recenterEnabled) {
-                RecenterLoopClones(pagerState = pagerState, clonePad = CLONE_PAD, pageCount = PAGE_COUNT)
+                RecenterLoopClones(pagerState = pagerState, clonePad = clonePad, pageCount = pageCount)
             }
 
             Box(Modifier.fillMaxSize()) {
@@ -57,7 +55,6 @@ class CarouselRecenterUnderGestureTest {
             }
         }
         composeTestRule.waitForIdle()
-        assertThat(pagerState.currentPage).isEqualTo(TRAILING_CLONE)
 
         holdMutexWithGesture = true
         composeTestRule.waitForIdle()
@@ -70,7 +67,7 @@ class CarouselRecenterUnderGestureTest {
 
         assertThat(pagerState.currentPage)
             .describedAs("requestScrollToPage bypasses the scroll mutex, so it lands even mid-gesture")
-            .isEqualTo(carouselRecenterTarget(TRAILING_CLONE, CLONE_PAD, PAGE_COUNT))
+            .isEqualTo(carouselRecenterTarget(trailingClone, clonePad, pageCount))
         assertThat(pagerState.isScrollInProgress)
             .describedAs("the re-centre must not have cancelled the gesture's hold on the mutex")
             .isTrue()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselRecenterUnderGestureTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselRecenterUnderGestureTest.kt
@@ -1,0 +1,84 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.carousel
+
+import androidx.compose.foundation.MutatePriority
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.awaitCancellation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Regression test for the Bugbot finding on purchases-android#3911: a re-centre attempted while
+ * a gesture holds the pager's scroll mutex at `UserInput` priority must still land.
+ */
+@Config(sdk = [26])
+@RunWith(AndroidJUnit4::class)
+class CarouselRecenterUnderGestureTest {
+
+    private companion object {
+        const val CLONE_PAD = 2
+        const val PAGE_COUNT = 2
+        const val RING_COUNT = PAGE_COUNT + 2 * CLONE_PAD
+        // Ring 0..5, real zone 2..3. Index 5 is the trailing clone of logical page 0.
+        const val TRAILING_CLONE = RING_COUNT - 1
+    }
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `a recentre started while a gesture holds the scroll mutex still lands`() {
+        var holdMutexWithGesture by mutableStateOf(false)
+        var recenterEnabled by mutableStateOf(false)
+        lateinit var pagerState: PagerState
+
+        composeTestRule.setContent {
+            pagerState = rememberPagerState(initialPage = TRAILING_CLONE) { RING_COUNT }
+
+            if (holdMutexWithGesture) {
+                LaunchedEffect(pagerState) {
+                    // Mirrors a drag: same priority, holds the mutex until cancelled.
+                    pagerState.scroll(MutatePriority.UserInput) { awaitCancellation() }
+                }
+            }
+            if (recenterEnabled) {
+                RecenterLoopClones(pagerState = pagerState, clonePad = CLONE_PAD, pageCount = PAGE_COUNT)
+            }
+
+            Box(Modifier.fillMaxSize()) {
+                HorizontalPager(state = pagerState) { }
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertThat(pagerState.currentPage).isEqualTo(TRAILING_CLONE)
+
+        holdMutexWithGesture = true
+        composeTestRule.waitForIdle()
+        assertThat(pagerState.isScrollInProgress)
+            .describedAs("the gesture must hold the scroll mutex before the re-centre is attempted")
+            .isTrue()
+
+        recenterEnabled = true
+        composeTestRule.waitForIdle()
+
+        assertThat(pagerState.currentPage)
+            .describedAs("requestScrollToPage bypasses the scroll mutex, so it lands even mid-gesture")
+            .isEqualTo(carouselRecenterTarget(TRAILING_CLONE, CLONE_PAD, PAGE_COUNT))
+        assertThat(pagerState.isScrollInProgress)
+            .describedAs("the re-centre must not have cancelled the gesture's hold on the mutex")
+            .isTrue()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselRecenterUnderGestureTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselRecenterUnderGestureTest.kt
@@ -20,10 +20,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
-/**
- * Regression test for the Bugbot finding on purchases-android#3911: a re-centre attempted while
- * a gesture holds the pager's scroll mutex at `UserInput` priority must still land.
- */
 @Config(sdk = [26])
 @RunWith(AndroidJUnit4::class)
 class CarouselRecenterUnderGestureTest {
@@ -32,7 +28,6 @@ class CarouselRecenterUnderGestureTest {
         const val CLONE_PAD = 2
         const val PAGE_COUNT = 2
         const val RING_COUNT = PAGE_COUNT + 2 * CLONE_PAD
-        // Ring 0..5, real zone 2..3. Index 5 is the trailing clone of logical page 0.
         const val TRAILING_CLONE = RING_COUNT - 1
     }
 
@@ -50,7 +45,6 @@ class CarouselRecenterUnderGestureTest {
 
             if (holdMutexWithGesture) {
                 LaunchedEffect(pagerState) {
-                    // Mirrors a drag: same priority, holds the mutex until cancelled.
                     pagerState.scroll(MutatePriority.UserInput) { awaitCancellation() }
                 }
             }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselRecenterUnderGestureTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselRecenterUnderGestureTest.kt
@@ -29,8 +29,8 @@ class CarouselRecenterUnderGestureTest {
 
     @Test
     fun `a recentre started while a gesture holds the scroll mutex still lands`() {
-        val clonePad = 2
         val pageCount = 2
+        val clonePad = loopClonePad(loop = true, pageCount = pageCount)
         val ringCount = pageCount + 2 * clonePad
         val trailingClone = ringCount - 1
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/NextAutoAdvanceTargetPageTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/NextAutoAdvanceTargetPageTest.kt
@@ -33,8 +33,8 @@ internal class NextAutoAdvanceTargetPageTest {
 
     @Test
     fun `single page loop never advances`() {
-        val ringCount = 1 + 2 * loopClonePad(loop = true, pageCount = 1)
-        assertThat(nextAutoAdvanceTargetPage(ringCount = ringCount, currentPage = 0)).isNull()
+        // A single page gets no clones, so its ring is just the one index.
+        assertThat(nextAutoAdvanceTargetPage(ringCount = 1, currentPage = 0)).isNull()
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/NextAutoAdvanceTargetPageTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/NextAutoAdvanceTargetPageTest.kt
@@ -19,8 +19,8 @@ internal class NextAutoAdvanceTargetPageTest {
 
     @Test
     fun `loop advances forward through the ring, including past the last real page`() {
-        // Three pages padded with two clones per side: ring 0..6, real zone 2..4. Sliding into the
-        // clone is what makes the wrap look like an ordinary forward transition.
+        // Ring 0..6, real zone 2..4. Sliding on into the clone is what makes the wrap look like an
+        // ordinary forward transition.
         assertThat(nextAutoAdvanceTargetPage(ringCount = 7, currentPage = 2)).isEqualTo(3)
         assertThat(nextAutoAdvanceTargetPage(ringCount = 7, currentPage = 4)).isEqualTo(5)
         assertThat(nextAutoAdvanceTargetPage(ringCount = 7, currentPage = 5)).isEqualTo(6)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/NextAutoAdvanceTargetPageTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/NextAutoAdvanceTargetPageTest.kt
@@ -7,25 +7,38 @@ internal class NextAutoAdvanceTargetPageTest {
 
     @Test
     fun `non-loop advances until last page then returns null`() {
-        assertThat(nextAutoAdvanceTargetPage(shouldLoop = false, pageCount = 3, currentPage = 0)).isEqualTo(1)
-        assertThat(nextAutoAdvanceTargetPage(shouldLoop = false, pageCount = 3, currentPage = 1)).isEqualTo(2)
-        assertThat(nextAutoAdvanceTargetPage(shouldLoop = false, pageCount = 3, currentPage = 2)).isNull()
+        assertThat(nextAutoAdvanceTargetPage(ringCount = 3, currentPage = 0)).isEqualTo(1)
+        assertThat(nextAutoAdvanceTargetPage(ringCount = 3, currentPage = 1)).isEqualTo(2)
+        assertThat(nextAutoAdvanceTargetPage(ringCount = 3, currentPage = 2)).isNull()
     }
 
     @Test
     fun `non-loop single page never advances`() {
-        assertThat(nextAutoAdvanceTargetPage(shouldLoop = false, pageCount = 1, currentPage = 0)).isNull()
+        assertThat(nextAutoAdvanceTargetPage(ringCount = 1, currentPage = 0)).isNull()
     }
 
     @Test
-    fun `loop always increments`() {
-        assertThat(nextAutoAdvanceTargetPage(shouldLoop = true, pageCount = 3, currentPage = 0)).isEqualTo(1)
-        assertThat(nextAutoAdvanceTargetPage(shouldLoop = true, pageCount = 3, currentPage = 2)).isEqualTo(3)
+    fun `loop advances forward through the ring, including past the last real page`() {
+        // Three pages padded with two clones per side: ring 0..6, real zone 2..4. Sliding into the
+        // clone is what makes the wrap look like an ordinary forward transition.
+        assertThat(nextAutoAdvanceTargetPage(ringCount = 7, currentPage = 2)).isEqualTo(3)
+        assertThat(nextAutoAdvanceTargetPage(ringCount = 7, currentPage = 4)).isEqualTo(5)
+        assertThat(nextAutoAdvanceTargetPage(ringCount = 7, currentPage = 5)).isEqualTo(6)
+    }
+
+    @Test
+    fun `loop never targets an index outside the ring`() {
+        assertThat(nextAutoAdvanceTargetPage(ringCount = 7, currentPage = 6)).isNull()
+    }
+
+    @Test
+    fun `single page loop never advances`() {
+        val ringCount = 1 + 2 * loopClonePad(loop = true, pageCount = 1)
+        assertThat(nextAutoAdvanceTargetPage(ringCount = ringCount, currentPage = 0)).isNull()
     }
 
     @Test
     fun `empty carousel returns null`() {
-        assertThat(nextAutoAdvanceTargetPage(shouldLoop = false, pageCount = 0, currentPage = 0)).isNull()
-        assertThat(nextAutoAdvanceTargetPage(shouldLoop = true, pageCount = 0, currentPage = 0)).isNull()
+        assertThat(nextAutoAdvanceTargetPage(ringCount = 0, currentPage = 0)).isNull()
     }
 }


### PR DESCRIPTION
- A `loop: true` carousel ran its pager over an unbounded index space starting near `Int.MAX_VALUE / 2`. Every pager index is a distinct LazyLayout key, so **each auto-advance composed a brand new page and destroyed the oldest, forever.**
- This is specially noticeable with a `web_view` component: repeated bundle downloads, and any in-page state (video position, form input, animation) reset on a timer.
- The pager now runs over a finite ring with clone pages on each side, re-centred invisibly when it settles on a clone. This is the model the web SDK's carousel already uses. Infinite forward swipe and the forward-sliding wrap are unchanged.
- **Live pages per looping carousel go from `2 x pageCount + 3` to `pageCount + 4`** for an ordinary peek. The clone count per side tracks how many pages the `page_peek` actually exposes, so a wide-peek carousel buys more; it is capped at 8 a side.
- Each logical page is still live on more than one ring index (3x for the reported 2-page carousel). This fix removes the rebuild-and-reload, not the duplication: `beyondViewportPageCount` is what keeps rebuilds at zero.
- Also fixes an unrelated `ArithmeticException: / by zero` when a carousel has no pages and a page control.

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids: [PWENG-188](https://linear.app/revenuecat/issue/PWENG-188/ios-looping-carousel-keeps-3-to-6-copies-of-every-page-alive)

<details><summary>Agent description</summary>

### Motivation

Linear: [SDK-4435](https://linear.app/revenuecat/issue/SDK-4435/looping-carousel-composes-each-page-3x-and-reloads-it-every)

`CarouselComponentView` gave a looping carousel a pager of `Int.MAX_VALUE` pages and started it near `Int.MAX_VALUE / 2`, resolving content with `pages[index % pageCount]`. Because Compose keys pager items by index, no index is ever revisited: auto-advance walked forward forever, and every `pageCount` advances pulled a fresh index into the composed window and evicted the oldest. A fresh index means a fresh composition, a fresh `AndroidView` factory, and for a `web_view` page a full reload.

Measured on a Pixel 7a with a 2-page carousel, `page_peek: 28`, `auto_advance {3500, 500}`, one `web_view`: 3 concurrent WebViews and a reload every ~8s (deltas 7602 / 8032 / 8040 / 8040 ms). With `loop: false`: 1 instance, no reloads in 45s.

The obvious fix, making the pager exactly `pageCount` pages, was rejected: it removes infinite manual swipe, which is a product requirement.

### Description

- Pager count is now `pageCount + 2 * clonePad` instead of `Int.MAX_VALUE`. `clonePad` is one clone per page the `page_peek` exposes on that side, plus one to keep the trailing peek populated while animating into the wrap, floored at 2 (web SDK parity) and capped at 8. The pager cannot scroll past the ends of the ring, so a fixed pad of 2 leaves a permanent blank gap once the peek passes roughly a third of the carousel width, which is an ordinary 3-across design. The cap is there because every ring index stays composed and a peek approaching half the viewport would otherwise ask for hundreds of live pages.
- The width comes from a `BoxWithConstraints` wrapping the carousel body, because the pad has to be known before `rememberPagerState` is constructed. `propagateMinConstraints = true` keeps a Fill or Fixed carousel filling.
- A ring index means a page only relative to the pad it was chosen under, so the index-to-page mapping is `index.mod(pageCount)`, independent of the pad: a pad change leaves every index showing the page it already showed, instead of relabelling the whole ring and rebuilding every page. `PagerState` also coerces its current page when the ring shrinks, so a pad change re-anchors to the logical page captured during composition, before the measure pass can coerce it.
- `RecenterLoopClones` watches `settledPage` and `scrollToPage`s back into the real zone whenever the pager settles on a clone. The clone holds identical content, so the jump is invisible, and it targets an already composed index, so nothing is rebuilt.
- `beyondViewportPageCount` is the ring size, which keeps every ring index composed permanently. This is what takes rebuilds to zero, and it preserves the Fit-height measurement that `CarouselFillMatchesFixedSiblingTest` covers.
- Analytics now tracks the logical page rather than the raw pager index, so the invisible re-centre emits no `carousel_page_change`.
- Removed `getInitialPage`, which scanned upward from `Int.MAX_VALUE / 2`. It divided by zero on an empty looping carousel and looped forever when `initial_page_index >= pages.size`.
- The page indicator reads its current page and its offset inside one `derivedStateOf`. Hoisting the page into the `remember` key leaves it a frame behind the offset, and the boundary frame then animates the wrong dot.
- Auto-advance reads the ring bound and its timings through `rememberUpdatedState` rather than capturing them: the loop must not restart, or every resize would reset the delay.
- `carouselLogicalPage` returns 0 for an empty carousel. `pages` arrives off the wire with no non-empty validation, and the page control reads the logical page before anything guards on it.

Behavior deliberately unchanged: infinite forward and backward swipe, the wrap as a forward slide, indicator behavior, and the non-loop path (`clonePad` is 0, so the ring is exactly `pageCount`).

Two behaviour changes worth naming. A `loop: true` carousel with a single page no longer advances or swipes, since a ring of one has nowhere to go; it previously slid between identical copies forever. And past the pad cap, or within one uninterrupted drag that reaches the outermost ring index, the peek can show a gap until the scroll settles and the re-centre fires. Permanent gaps are fixed; that transient one is the accepted ceiling.

Not addressed here, both pre-existing: the page indicator does not wrap at the loop seam, so no dot grows while crossing from the last page to the first, and `Indicator` allocates a `Shape.Pill` on every frame of a scroll.

`purchases-ios` has the same class of problem and is worse: `CarouselComponentView.swift` builds 3 full copies of every page eagerly in an `HStack`, growing to 5 or 6 via `expandDataIfNeeded`, over an unbounded index. Filed as [PWENG-188](https://linear.app/revenuecat/issue/PWENG-188/ios-looping-carousel-keeps-3-to-6-copies-of-every-page-alive); not touched here. This fix does not port to it, since iOS is not using a pager.

### Regression gates

- `CarouselLoopCompositionStabilityTest`: the real gate. Captures the semantics node ids of each page, advances three auto-advance cycles, and asserts the id set is unchanged. Semantics ids are per `LayoutNode`, so a rebuilt page shows up as a new id. Before this change the ids churn. It also asserts the instance count per page (4 before, 3 after) and that the carousel still cycles `one, two, one, two, one`, which catches a broken re-centre: without it the pager slides into the trailing clones and sticks.
- `CarouselEmptyPagesTest`: renders an empty carousel with a page control. Throws `ArithmeticException` without the guard.
- `CarouselLoopIndexTest`, `NextAutoAdvanceTargetPageTest`: the ring math, including the pad against viewport width, the cap, and that a re-centre clears the clone zone in one hop when the pad exceeds the page count. `NextAutoAdvanceTargetPageTest` previously asserted the unbounded increment, which encoded the bug; it now asserts against the ring.
- Three resize gates in `CarouselLoopCompositionStabilityTest`, each verified to fail without its fix: a wide peek composes a clone for every page it exposes; a pad change keeps the carousel on the same page (small shrink for the mapping, large shrink for the `PagerState` coercion path); and a pad change keeps auto-advancing, which a captured ring bound would stop for good.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core looping carousel paging and auto-advance behavior in paywalls, so swipe/wrap regressions are possible, but the change is well covered by new composition-stability and index tests.
> 
> **Overview**
> **Stops looping carousels from destroying and recomposing pages on every auto-advance**, which was especially visible as `web_view` reloads every few seconds.
> 
> Replaces the unbounded `Int.MAX_VALUE` pager with a finite ring (`pageCount + 4`, two clones per side). When the pager settles on a clone, `RecenterLoopClones` snaps back into the real zone invisibly via `requestScrollToPage`, keeping infinite swipe and forward-wrap behavior. Page-change analytics and indicators now use the logical page so re-centers do not emit spurious events.
> 
> Also guards empty carousels so a page control no longer crashes with divide-by-zero, and adds regression tests for composition stability, ring math, empty pages, and re-center under gesture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40fa4c34a602402184b0219f3ad005e899fd888b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




