### PR TITLE
fix: Declare kotlinx-coroutines-android as a dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -139,6 +139,7 @@ compose-window-size = { module = "androidx.compose.material3:material3-window-si
 compose-annotations = { module = "androidx.compose.runtime:runtime-annotation", version.ref = "composeAnnotation" }
 
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
 detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -198,6 +198,7 @@ dependencies {
     implementation(libs.tink)
     implementation(libs.playServices.ads.identifier)
     implementation(libs.coroutines.core)
+    implementation(libs.coroutines.android)
     api(libs.billing)
 
     compileOnly(libs.compose.annotations)


### PR DESCRIPTION
- `:purchases` uses `Dispatchers.Main` in two places but only declared `kotlinx-coroutines-core`, which does not provide it. `Dispatchers.Main` throws `IllegalStateException("Module with the Main dispatcher is missing")` without the `kotlinx-coroutines-android` artifact.
- Affected call sites: `BlockstoreHelper` (a constructor-default `CoroutineScope`) and `RewardVerificationPollLauncher` (`withContext(Dispatchers.Main)` to deliver the poll result).
- **Almost certainly unreachable in practice.** Nearly every app already brings `kotlinx-coroutines-android` transitively through `lifecycle-runtime-ktx`, `activity-compose` or similar, which is why this has gone unnoticed. An app using the SDK with no other coroutines-consuming AndroidX library would hit it.
- Adds one line to `libs.versions.toml` and one dependency. Expect a small size delta on an app that did not already have the artifact.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

Found while removing Coil from `:purchases` in a stacked PR. `coil-base` was declared `testImplementation`, and it pulls `kotlinx-coroutines-android` transitively, so the *test* classpath had `Dispatchers.Main` by accident. Dropping Coil broke two reward-verification tests with the missing-Main-dispatcher error, which is what surfaced the gap.

Checking the production side showed the same hole and no accident covering it: `kotlinx-coroutines-android` was on no RevenueCat module's runtime classpath, verified against `:purchases`, `:feature:admob` and `:ui:revenuecatui`. The SDK was relying on the consuming app to supply a dispatcher it uses itself.

### Description

- `implementation(libs.coroutines.android)` in `purchases/build.gradle.kts`, plus the version-catalog alias. Same version reference as `coroutines-core`, so the two cannot drift.

### On the missing test

There is no unit test here, deliberately. The failure mode is a missing artifact on the *published* runtime classpath, not a code path: on this branch the test classpath still gets `kotlinx-coroutines-android` transitively through `coil-base`, so any `Dispatchers.Main` test passes with or without this change and would gate nothing.

The evidence is the dependency graph. Before, `:purchases:dependencies --configuration defaultsReleaseRuntimeClasspath` had no `kotlinx-coroutines-android`; now it does.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only fix with no logic changes; slightly increases published SDK footprint for apps that lacked the artifact transitively.
> 
> **Overview**
> **`:purchases` now declares `kotlinx-coroutines-android` on its runtime classpath** so `Dispatchers.Main` is available from the SDK itself instead of depending on the host app’s transitive AndroidX/coroutines stack.
> 
> The change adds a version-catalog alias (`coroutines-android`, same `coroutines` version as `coroutines-core`) and `implementation(libs.coroutines.android)` in `purchases/build.gradle.kts`. That covers real uses of the main dispatcher in `BlockstoreHelper` (default `mainScope`) and `RewardVerificationPollLauncher` (`withContext(Dispatchers.Main)` for callbacks). Without the artifact, those paths can throw *Module with the Main dispatcher is missing* on apps that only pull `kotlinx-coroutines-core` from RevenueCat.
> 
> **Practical impact:** Low for typical apps that already get this library via `lifecycle-runtime-ktx` or similar; it fixes the edge case where RevenueCat is the only coroutines consumer and may add a small dependency footprint when the artifact wasn’t already present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f582dd7272ede916e0ca8991fd6b2735a177bee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->