### PR TITLE
chore: stop persisting ProductEntitlementMapping.originalSource to disk

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMapping.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMapping.kt
@@ -12,7 +12,7 @@ import org.json.JSONObject
 @InternalRevenueCatAPI
 public data class ProductEntitlementMapping(
     val mappings: Map<String, Mapping>,
-    val originalSource: HTTPResponseOriginalSource = HTTPResponseOriginalSource.MAIN,
+    val originalSource: HTTPResponseOriginalSource? = null,
     val loadedFromCache: Boolean = false,
 ) {
     public companion object {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMapping.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMapping.kt
@@ -2,10 +2,8 @@ package com.revenuecat.purchases.common.offlineentitlements
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.HTTPResponseOriginalSource
-import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.originalDataSource
-import com.revenuecat.purchases.utils.copy
 import com.revenuecat.purchases.utils.optNullableString
 import org.json.JSONArray
 import org.json.JSONObject
@@ -22,7 +20,6 @@ public data class ProductEntitlementMapping(
         private const val PRODUCT_ID_KEY = "product_identifier"
         private const val BASE_PLAN_ID_KEY = "base_plan_id"
         private const val ENTITLEMENTS_KEY = "entitlements"
-        private const val ORIGINAL_SOURCE_KEY = "rc_original_source"
 
         internal fun fromJson(
             json: JSONObject,
@@ -41,21 +38,11 @@ public data class ProductEntitlementMapping(
                 }
                 mappings[mappingIdentifier] = Mapping(productIdentifier, basePlanId, entitlements)
             }
-            val originalSource = json.optNullableString(ORIGINAL_SOURCE_KEY)?.let {
-                try {
-                    HTTPResponseOriginalSource.valueOf(it)
-                } catch (e: IllegalArgumentException) {
-                    errorLog(e) { "Invalid original source when reading it from JSON: $it. Defaulting to MAIN." }
-                    null
-                }
-            } ?: HTTPResponseOriginalSource.MAIN
-            return ProductEntitlementMapping(mappings, originalSource, loadedFromCache)
+            return ProductEntitlementMapping(mappings, loadedFromCache = loadedFromCache)
         }
 
         internal fun fromNetwork(json: JSONObject, httpResult: HTTPResult): ProductEntitlementMapping {
-            val jsonCopy = json.copy(deep = false)
-            val jsonWithSource = jsonCopy.put(ORIGINAL_SOURCE_KEY, httpResult.originalDataSource.name)
-            return fromJson(jsonWithSource, loadedFromCache = false)
+            return fromJson(json, loadedFromCache = false).copy(originalSource = httpResult.originalDataSource)
         }
     }
 
@@ -76,6 +63,5 @@ public data class ProductEntitlementMapping(
             }
         }
         put(PRODUCT_ENTITLEMENT_MAPPING_KEY, JSONObject(mappingsObjects))
-        put(ORIGINAL_SOURCE_KEY, originalSource.name)
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -682,7 +682,8 @@ class DeviceCacheTest {
         every {
             mockPrefs.getString(productEntitlementMappingCacheKey, null)
         } returns expectedMappings.toJson().toString()
-        assertThat(cache.getProductEntitlementMapping()).isEqualTo(expectedMappings.copy(loadedFromCache = true))
+        assertThat(cache.getProductEntitlementMapping())
+            .isEqualTo(expectedMappings.copy(originalSource = null, loadedFromCache = true))
     }
 
     @Test
@@ -696,7 +697,7 @@ class DeviceCacheTest {
         assertThat(JSONObject(cachedJsonSlot.captured).has("rc_original_source")).isFalse
 
         every { mockPrefs.getString(productEntitlementMappingCacheKey, null) } returns cachedJsonSlot.captured
-        assertThat(cache.getProductEntitlementMapping()?.originalSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
+        assertThat(cache.getProductEntitlementMapping()?.originalSource).isNull()
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -586,7 +586,7 @@ class DeviceCacheTest {
         verify(exactly = 1) {
             mockEditor.putString(
                 productEntitlementMappingCacheKey,
-                "{\"product_entitlement_mapping\":{\"com.revenuecat.foo_1:p1m\":{\"product_identifier\":\"com.revenuecat.foo_1\",\"base_plan_id\":\"p1m\",\"entitlements\":[\"pro_1\"]},\"com.revenuecat.foo_1:p1y\":{\"product_identifier\":\"com.revenuecat.foo_1\",\"base_plan_id\":\"p1y\",\"entitlements\":[\"pro_1\",\"pro_2\"]},\"com.revenuecat.foo_1\":{\"product_identifier\":\"com.revenuecat.foo_1\",\"base_plan_id\":\"p1m\",\"entitlements\":[\"pro_1\"]},\"com.revenuecat.foo_2\":{\"product_identifier\":\"com.revenuecat.foo_2\",\"entitlements\":[\"pro_3\"]}},\"rc_original_source\":\"MAIN\"}"
+                "{\"product_entitlement_mapping\":{\"com.revenuecat.foo_1:p1m\":{\"product_identifier\":\"com.revenuecat.foo_1\",\"base_plan_id\":\"p1m\",\"entitlements\":[\"pro_1\"]},\"com.revenuecat.foo_1:p1y\":{\"product_identifier\":\"com.revenuecat.foo_1\",\"base_plan_id\":\"p1y\",\"entitlements\":[\"pro_1\",\"pro_2\"]},\"com.revenuecat.foo_1\":{\"product_identifier\":\"com.revenuecat.foo_1\",\"base_plan_id\":\"p1m\",\"entitlements\":[\"pro_1\"]},\"com.revenuecat.foo_2\":{\"product_identifier\":\"com.revenuecat.foo_2\",\"entitlements\":[\"pro_3\"]}}}"
             )
         }
         verify(exactly = 1) {
@@ -601,7 +601,7 @@ class DeviceCacheTest {
         verify(exactly = 1) {
             mockEditor.putString(
                 productEntitlementMappingCacheKey,
-                "{\"product_entitlement_mapping\":{},\"rc_original_source\":\"MAIN\"}",
+                "{\"product_entitlement_mapping\":{}}",
             )
         }
         verify(exactly = 1) {
@@ -683,6 +683,20 @@ class DeviceCacheTest {
             mockPrefs.getString(productEntitlementMappingCacheKey, null)
         } returns expectedMappings.toJson().toString()
         assertThat(cache.getProductEntitlementMapping()).isEqualTo(expectedMappings.copy(loadedFromCache = true))
+    }
+
+    @Test
+    fun `cacheProductEntitlementMapping does not persist originalSource`() {
+        val mappingFromFallbackURL = createProductEntitlementMapping(originalSource = HTTPResponseOriginalSource.FALLBACK)
+
+        cache.cacheProductEntitlementMapping(mappingFromFallbackURL)
+
+        val cachedJsonSlot = slot<String>()
+        verify(exactly = 1) { mockEditor.putString(productEntitlementMappingCacheKey, capture(cachedJsonSlot)) }
+        assertThat(JSONObject(cachedJsonSlot.captured).has("rc_original_source")).isFalse
+
+        every { mockPrefs.getString(productEntitlementMappingCacheKey, null) } returns cachedJsonSlot.captured
+        assertThat(cache.getProductEntitlementMapping()?.originalSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingSourceTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingSourceTest.kt
@@ -119,21 +119,20 @@ class ProductEntitlementMappingSourceTest {
     }
 
     @Test
-    fun `productEntitlementMapping ignores originalSource in JSON, always defaults to MAIN`() {
+    fun `productEntitlementMapping ignores originalSource in JSON, always returns null`() {
         // originalSource is intentionally not persisted, so fromJson doesn't read it back even if
         // present, e.g. from a cache file written by an older SDK version.
         val mapping = ProductEntitlementMapping.fromJson(sampleResponseJsonWithSource, loadedFromCache = true)
 
-        assertThat(mapping.originalSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
+        assertThat(mapping.originalSource).isNull()
         assertThat(mapping.loadedFromCache).isTrue
     }
 
     @Test
-    fun `productEntitlementMapping defaults to MAIN when no source information provided`() {
-        // Create mapping without specifying source (should default to MAIN)
+    fun `productEntitlementMapping originalSource is null when no source information provided`() {
         val mapping = ProductEntitlementMapping.fromJson(sampleResponseJson)
 
-        assertThat(mapping.originalSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
+        assertThat(mapping.originalSource).isNull()
         assertThat(mapping.loadedFromCache).isFalse
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingSourceTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingSourceTest.kt
@@ -119,32 +119,13 @@ class ProductEntitlementMappingSourceTest {
     }
 
     @Test
-    fun `productEntitlementMapping reads originalSource from cached JSON when present`() {
-        val httpResult = HTTPResult.createResult(
-            origin = HTTPResult.Origin.BACKEND,
-            isLoadShedderResponse = false,
-            isFallbackURL = true,
-        )
+    fun `productEntitlementMapping ignores originalSource in JSON, always defaults to MAIN`() {
+        // originalSource is intentionally not persisted, so fromJson doesn't read it back even if
+        // present, e.g. from a cache file written by an older SDK version.
+        val mapping = ProductEntitlementMapping.fromJson(sampleResponseJsonWithSource, loadedFromCache = true)
 
-        val originalMapping = ProductEntitlementMapping.fromNetwork(sampleResponseJson, httpResult)
-
-        every { deviceCache.cacheProductEntitlementMapping(any()) } returns Unit
-
-        // Cache the mapping
-        deviceCache.cacheProductEntitlementMapping(originalMapping)
-
-        // Mock retrieval with preserved originalSource
-        every { deviceCache.getProductEntitlementMapping() } returns ProductEntitlementMapping.fromJson(
-            sampleResponseJsonWithSource,
-            loadedFromCache = true,
-        )
-
-        // Retrieve from cache - originalSource should be preserved
-        val cachedMapping = deviceCache.getProductEntitlementMapping()
-
-        assertThat(cachedMapping).isNotNull
-        assertThat(cachedMapping!!.originalSource).isEqualTo(HTTPResponseOriginalSource.FALLBACK)
-        assertThat(cachedMapping.loadedFromCache).isTrue
+        assertThat(mapping.originalSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
+        assertThat(mapping.loadedFromCache).isTrue
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingTest.kt
@@ -70,7 +70,7 @@ class ProductEntitlementMappingTest {
         assertThat(productEntitlementMapping.mappings["com.revenuecat.foo_2"]).isEqualTo(
             ProductEntitlementMapping.Mapping("com.revenuecat.foo_2", null, listOf("pro_3"))
         )
-        val expectedEntitlementMapping = createProductEntitlementMapping()
+        val expectedEntitlementMapping = createProductEntitlementMapping(originalSource = null)
         assertThat(productEntitlementMapping).isEqualTo(expectedEntitlementMapping)
     }
 
@@ -107,12 +107,8 @@ class ProductEntitlementMappingTest {
     }
 
     @Test
-    fun `toJson transforms mappings back to original Json while adding original data source field`() {
+    fun `toJson transforms mappings back to original Json`() {
         val mappings = ProductEntitlementMapping.fromJson(sampleResponseJson)
-        val json = mappings.toJson()
-        val toJsonWithoutOriginalDataSource = json.apply {
-            remove("rc_original_source")
-        }
-        assertThat(toJsonWithoutOriginalDataSource.toString()).isEqualTo(sampleResponseJson.toString())
+        assertThat(mappings.toJson().toString()).isEqualTo(sampleResponseJson.toString())
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/productEntitlementMappingFactory.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/productEntitlementMappingFactory.kt
@@ -9,6 +9,6 @@ internal fun createProductEntitlementMapping(
         "com.revenuecat.foo_1" to ProductEntitlementMapping.Mapping("com.revenuecat.foo_1", "p1m", listOf("pro_1")),
         "com.revenuecat.foo_2" to ProductEntitlementMapping.Mapping("com.revenuecat.foo_2", null, listOf("pro_3")),
     ),
-    originalSource: HTTPResponseOriginalSource = HTTPResponseOriginalSource.MAIN,
+    originalSource: HTTPResponseOriginalSource? = HTTPResponseOriginalSource.MAIN,
     loadedFromCache: Boolean = false,
 ) = ProductEntitlementMapping(mappings, originalSource, loadedFromCache)


### PR DESCRIPTION
- Stops persisting `ProductEntitlementMapping.originalSource` to disk. Only used by tests, who still read it from memory.
- Fresh network fetches still set it in-memory via `fromNetwork()`. disk-cache reads now report `null` as source
- Simplified `fromJson()`/`fromNetwork()` to drop the JSON round-trip the field used to need, now that nothing persists or reads it back from disk.
- Partial fix for [SDK-4408](https://linear.app/revenuecat/issue/SDK-4408/stop-persisting-originalsource-three-android-caches-write-a-test-only), issue stays open.


### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

`ProductEntitlementMapping.originalSource` was added to support backend integration tests asserting failover behavior. It has no runtime consumer. Unlike `Offerings`/`CustomerInfo`, this class has no custom `equals()`, so the field was participating in ordinary data class equality.

Investigated together with the analogous fields on `Offerings` (already fixed in #3872, was forcing a costly JSON reserialize on every cache write) and `CustomerInfo` (left as-is: three existing androidTest assertions genuinely depend on it surviving a cache read, and there's no OOM-shaped driver to justify building an in-memory shim just for this).

### Description

- Removed the `rc_original_source` write from `ProductEntitlementMapping.toJson()`.
- `fromNetwork()` now attaches `originalSource` directly via `.copy()` instead of injecting it into a JSON copy just to re-parse it back out through `fromJson()`.
- `fromJson()` no longer reads `rc_original_source` at all. A legacy cache file from an older SDK version that still has the key is now ignored.
- Made `originalSource` nullable, defaulting to `null` instead of `MAIN`: a disk-loaded mapping no longer silently claims a source it doesn't actually know.
- Added a regression test proving the field isn't persisted (`DeviceCacheTest`), and updated the existing tests that encoded the old default-to-`MAIN` behavior.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only metadata on an internal API with no runtime consumers; entitlement mapping data itself is unchanged.
> 
> **Overview**
> Stops writing **`ProductEntitlementMapping.originalSource`** to SharedPreferences by removing `rc_original_source` from **`toJson()`** and from **`fromJson()`** parsing. Network responses still set the field in memory via **`fromNetwork()`** → **`copy(originalSource = httpResult.originalDataSource)`**, without the previous JSON inject-and-reparse path.
> 
> **`originalSource`** is now **nullable** and defaults to **`null`** instead of **`MAIN`**, so cache reads no longer imply a source the mapping never stored. Legacy cache JSON that still contains **`rc_original_source`** is ignored on load.
> 
> Tests and **`createProductEntitlementMapping`** were updated; **`DeviceCacheTest`** adds a regression that cached JSON omits the key and round-trip **`originalSource`** is null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57de5806b10b3b989cae1e2d53c35f314a94172f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->