### PR TITLE
feat(paywalls): Pool prerendered web_views by url

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -50,17 +50,14 @@ internal class PaywallWebViewPrewarmer {
 
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    private var slot: PrewarmedWebView? = null
+    private val pool = LinkedHashMap<String, PrewarmedWebView>()
 
     // A prerender that is never displayed holds a renderer process at foreground priority, which
-    // Android will not reclaim on its own. Bound it.
-    private val releaseOnTimeout = Runnable {
-        Logger.d("Paywalls V2 web_view prewarm expired before display; releasing.")
-        releaseSlot()
-    }
+    // Android will not reclaim on its own. Each entry expires on its own schedule.
+    private val expiries = mutableMapOf<String, Runnable>()
 
-    // Urls the hold tier had no room for, warmed for the http cache alone. One at a time: WebView caps
-    // its own renderer processes low, so concurrent loads contend instead of overlapping.
+    // Urls the pool had no room for, warmed for the http cache alone. One at a time: WebView caps its
+    // own renderer processes low, so concurrent loads contend instead of overlapping.
     private val cacheWarmQueue = ArrayDeque<WebViewIdentity>()
     private var cacheWarmInFlight: PrewarmedWebView? = null
     private var abandonCacheWarm: Runnable? = null
@@ -78,7 +75,7 @@ internal class PaywallWebViewPrewarmer {
     @VisibleForTesting
     internal val trimCallbacks = object : ComponentCallbacks2 {
         override fun onTrimMemory(level: Int) {
-            if (slot != null || cacheWarmInFlight != null) {
+            if (pool.isNotEmpty() || cacheWarmInFlight != null) {
                 Logger.d("Paywalls V2 web_view warming abandoned on memory trim (level $level).")
             }
             releaseAll()
@@ -90,12 +87,12 @@ internal class PaywallWebViewPrewarmer {
     }
 
     /**
-     * Warms [url] for the component that will render it. [url] is resolved through [WebViewUrlResolver]
-     * so the resulting identity matches the display path's byte for byte; an unresolvable URL is a no-op.
+     * Prerenders [url] for the component that will render it. [url] is resolved through
+     * [WebViewUrlResolver] so the resulting identity matches the display path's byte for byte;
+     * an unresolvable URL is a no-op.
      *
-     * The first url is held for adoption. Later urls are queued and warmed for the http cache one at a
-     * time, since the single slot can only serve one of them. A url already held, in flight or queued is
-     * a no-op.
+     * Entries are pooled by resolved URL up to [MAX_PREWARMED]. Beyond that the url is queued and warmed
+     * for the http cache alone, one at a time. A url already held, in flight or queued is a no-op.
      */
     @MainThread
     @Suppress("ReturnCount")
@@ -119,6 +116,7 @@ internal class PaywallWebViewPrewarmer {
             Logger.d("Paywalls V2 web_view not prewarmed: this System WebView does not support prerendering.")
             return
         }
+
         if (resolvedUrl in warmingUrls) {
             Logger.d("Paywalls V2 web_view already warming this URL; keeping the existing one.")
             return
@@ -132,20 +130,21 @@ internal class PaywallWebViewPrewarmer {
         )
         applicationContext = context.applicationContext
         registerTrimCallbacks(context)
-        if (slot != null) {
+        // At capacity nothing is evicted: a held entry is worth more than a queued one, and the overflow
+        // still gets its bundle into the http cache.
+        if (pool.size >= MAX_PREWARMED) {
             cacheWarmQueue.addLast(identity)
             startNextCacheWarm()
             return
         }
-        slot = createPrerendered(context, identity) ?: return
-        mainHandler.removeCallbacks(releaseOnTimeout)
-        mainHandler.postDelayed(releaseOnTimeout, HOLD_TIMEOUT_MS)
+        pool[resolvedUrl] = createPrerendered(context, identity) ?: return
+        scheduleExpiry(resolvedUrl)
     }
 
     /** Every url this instance is already holding, loading, or about to load. */
     private val warmingUrls: Set<String>
         get() = buildSet {
-            slot?.resolvedUrl?.let(::add)
+            addAll(pool.keys)
             cacheWarmInFlight?.resolvedUrl?.let(::add)
             cacheWarmQueue.forEach { add(it.resolvedUrl) }
         }
@@ -191,6 +190,22 @@ internal class PaywallWebViewPrewarmer {
         startNextCacheWarm()
     }
 
+    private fun scheduleExpiry(resolvedUrl: String) {
+        val expiry = Runnable {
+            Logger.d("Paywalls V2 web_view prewarm expired before display; releasing it.")
+            discard(resolvedUrl)
+        }
+        expiries[resolvedUrl] = expiry
+        mainHandler.postDelayed(expiry, HOLD_TIMEOUT_MS)
+    }
+
+    /** Destroys one entry and cancels its expiry. Siblings are untouched. */
+    @MainThread
+    private fun discard(resolvedUrl: String) {
+        expiries.remove(resolvedUrl)?.let(mainHandler::removeCallbacks)
+        pool.remove(resolvedUrl)?.destroy()
+    }
+
     // Registered on first hold rather than on construction, so an SDK that never prewarms adds no
     // callback to the host application. Kept for the process lifetime: this instance is a singleton.
     private fun registerTrimCallbacks(context: Context) {
@@ -219,7 +234,7 @@ internal class PaywallWebViewPrewarmer {
             onLoadFailed = {
                 callbacks.dispatchLoadFailed()
                 // Posted: this arrives inside a WebViewClient callback, and destroy() must not run there.
-                entry?.let { failed -> mainHandler.post { releaseIfHeld(failed) } }
+                entry?.let { failed -> mainHandler.post { discardIfHeld(failed) } }
             },
             onLoadFinished = onDocumentFinished,
         ) ?: return null
@@ -249,52 +264,46 @@ internal class PaywallWebViewPrewarmer {
     }
 
     /**
-     * Hands the prewarmed WebView to the display factory, clearing the slot either way. Matching is
-     * on resolved URL alone, matching iOS: the component id and `Fit` axes are rebound at activation,
-     * so a view warmed for one component can serve any component pointing at the same bundle. A view
-     * held for a different URL, or one whose document failed to load, is destroyed instead of handed
-     * over so the caller loads cold.
+     * Hands the prewarmed WebView for [resolvedUrl] to the display factory, removing it from the pool.
+     * Matching is on resolved URL alone, matching iOS: the component id and `Fit` axes are rebound at
+     * activation, so a view warmed for one component serves any component pointing at the same bundle.
+     *
+     * An entry whose document failed to load is destroyed instead of handed over, so the caller loads
+     * cold rather than rendering nothing.
+     *
+     * A miss leaves the pool untouched. Sibling entries belong to other components on the same paywall
+     * and are very likely about to be taken themselves.
      */
     @MainThread
     fun take(resolvedUrl: String): PrewarmedWebView? {
         // Whatever the outcome, this url is being displayed now, and that load fills the http cache by
         // itself. A queued warm for it would be pure waste.
         cacheWarmQueue.removeAll { it.resolvedUrl == resolvedUrl }
-        val current = slot ?: return null
-        slot = null
-        mainHandler.removeCallbacks(releaseOnTimeout)
-        val rejection = when {
-            current.resolvedUrl != resolvedUrl -> "it was held for a different URL"
-            current.loadFailed -> "its document failed to load while prewarming"
-            else -> null
+        val taken = pool.remove(resolvedUrl)
+        if (taken == null) {
+            Logger.d("Paywalls V2 web_view not prewarmed for this URL; loading it cold.")
+            return null
         }
-        return if (rejection == null) {
-            current
-        } else {
-            Logger.d("Paywalls V2 web_view prewarm discarded: $rejection.")
-            current.destroy()
-            null
+        expiries.remove(resolvedUrl)?.let(mainHandler::removeCallbacks)
+        if (taken.loadFailed) {
+            Logger.d("Paywalls V2 web_view prewarm discarded: its document failed to load while prewarming.")
+            taken.destroy()
+            return null
         }
+        return taken
     }
 
     /**
-     * Drops [entry], whichever tier it belongs to. Compared by instance, not by URL: a later prewarm of
-     * the same URL is a different view, and an async failure from this one must not take it down. A
-     * hold-tier failure leaves the cache-warm queue alone, since those are other urls still worth warming.
+     * Discards [entry], whichever tier it belongs to. Compared by instance, not by URL: a later prewarm
+     * of the same URL is a different view, and an async failure from this one must not take it down (nor
+     * touch one that [take] has already handed to a composition). Siblings are left alone.
      */
     @MainThread
-    private fun releaseIfHeld(entry: PrewarmedWebView) {
+    private fun discardIfHeld(entry: PrewarmedWebView) {
         when {
-            slot === entry -> releaseSlot()
+            pool[entry.resolvedUrl] === entry -> discard(entry.resolvedUrl)
             cacheWarmInFlight === entry -> finishCacheWarm()
         }
-    }
-
-    @MainThread
-    private fun releaseSlot() {
-        mainHandler.removeCallbacks(releaseOnTimeout)
-        slot?.destroy()
-        slot = null
     }
 
     @MainThread
@@ -304,8 +313,20 @@ internal class PaywallWebViewPrewarmer {
         abandonCacheWarm = null
         cacheWarmInFlight?.destroy()
         cacheWarmInFlight = null
-        releaseSlot()
+        expiries.values.forEach(mainHandler::removeCallbacks)
+        expiries.clear()
+        pool.values.forEach { it.destroy() }
+        pool.clear()
     }
+
+    @get:VisibleForTesting
+    internal val heldCount: Int get() = pool.size
+
+    @get:VisibleForTesting
+    internal val queuedCacheWarmCount: Int get() = cacheWarmQueue.size
+
+    @get:VisibleForTesting
+    internal val isWarmingCache: Boolean get() = cacheWarmInFlight != null
 
     private inner class PrerenderLogger(private val entry: PrewarmedWebView) : PrerenderOperationCallback {
         override fun onPrerenderActivated() {
@@ -314,15 +335,9 @@ internal class PaywallWebViewPrewarmer {
 
         override fun onError(exception: PrerenderException) {
             Logger.d("Paywalls V2 web_view prerender failed for '${entry.resolvedUrl}': $exception")
-            releaseIfHeld(entry)
+            discardIfHeld(entry)
         }
     }
-
-    @get:VisibleForTesting
-    internal val queuedCacheWarmCount: Int get() = cacheWarmQueue.size
-
-    @get:VisibleForTesting
-    internal val isWarmingCache: Boolean get() = cacheWarmInFlight != null
 
     internal companion object {
         /**
@@ -332,6 +347,16 @@ internal class PaywallWebViewPrewarmer {
          */
         @VisibleForTesting
         internal const val HOLD_TIMEOUT_MS: Long = 30_000L
+
+        /**
+         * Pool bound. Measured on device, the cost of holding prerenders is dominated by the renderer
+         * processes WebView spawns, which it caps low on its own (2 on a 5.6 GB device, 1 on 4 GB):
+         * the first held view cost ~104 MB there, the second ~104 MB, and the third through fifth
+         * ~1-6 MB each. So a small pool is nearly free once the first entry is paid for, while still
+         * covering paywalls that carry several web_view components.
+         */
+        @VisibleForTesting
+        internal const val MAX_PREWARMED: Int = 3
 
         /**
          * How long one cache warm may run before the next url starts instead. Well above the 200-850 ms

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -145,8 +145,8 @@ internal class PaywallWebViewPrewarmer {
     /** Every url this instance is already holding, loading, or about to load. */
     private val warmingUrls: Set<String>
         get() = buildSet {
-            slot?.identity?.resolvedUrl?.let(::add)
-            cacheWarmInFlight?.identity?.resolvedUrl?.let(::add)
+            slot?.resolvedUrl?.let(::add)
+            cacheWarmInFlight?.resolvedUrl?.let(::add)
             cacheWarmQueue.forEach { add(it.resolvedUrl) }
         }
 
@@ -206,6 +206,8 @@ internal class PaywallWebViewPrewarmer {
         onDocumentFinished: () -> Unit = {},
     ): PrewarmedWebView? {
         val callbacks = PrewarmBridgeCallbacks()
+        // Assigned below, before any load can start: the failure callback needs the entry it belongs to.
+        var entry: PrewarmedWebView? = null
         // Application context: prewarm has no Activity to borrow, and this view must not outlive the one
         // that happens to be showing. The cost is that it cannot host JS dialogs, <select> popups, file
         // choosers or fullscreen video, unlike a view the display path builds from an Activity.
@@ -217,7 +219,7 @@ internal class PaywallWebViewPrewarmer {
             onLoadFailed = {
                 callbacks.dispatchLoadFailed()
                 // Posted: this arrives inside a WebViewClient callback, and destroy() must not run there.
-                mainHandler.post { releaseIfHeld(identity) }
+                entry?.let { failed -> mainHandler.post { releaseIfHeld(failed) } }
             },
             onLoadFinished = onDocumentFinished,
         ) ?: return null
@@ -226,16 +228,17 @@ internal class PaywallWebViewPrewarmer {
             webView = configured.webView,
             bridge = configured.bridge,
             callbacks = callbacks,
-            identity = identity,
+            resolvedUrl = identity.resolvedUrl,
             cancellationSignal = CancellationSignal(),
         )
+        entry = prewarmed
         return try {
             WebViewCompat.prerenderUrlAsync(
                 configured.webView,
                 identity.resolvedUrl,
                 prewarmed.cancellationSignal,
                 ContextCompat.getMainExecutor(context),
-                PrerenderLogger(identity),
+                PrerenderLogger(prewarmed),
             )
             prewarmed
         } catch (error: RuntimeException) {
@@ -246,20 +249,22 @@ internal class PaywallWebViewPrewarmer {
     }
 
     /**
-     * Hands the prewarmed WebView to the display factory, clearing the slot either way. A view warmed for
-     * a different component, or one whose document failed to load, is destroyed instead of handed over so
-     * the caller loads cold.
+     * Hands the prewarmed WebView to the display factory, clearing the slot either way. Matching is
+     * on resolved URL alone, matching iOS: the component id and `Fit` axes are rebound at activation,
+     * so a view warmed for one component can serve any component pointing at the same bundle. A view
+     * held for a different URL, or one whose document failed to load, is destroyed instead of handed
+     * over so the caller loads cold.
      */
     @MainThread
-    fun take(identity: WebViewIdentity): PrewarmedWebView? {
+    fun take(resolvedUrl: String): PrewarmedWebView? {
         // Whatever the outcome, this url is being displayed now, and that load fills the http cache by
         // itself. A queued warm for it would be pure waste.
-        cacheWarmQueue.removeAll { it.resolvedUrl == identity.resolvedUrl }
+        cacheWarmQueue.removeAll { it.resolvedUrl == resolvedUrl }
         val current = slot ?: return null
         slot = null
         mainHandler.removeCallbacks(releaseOnTimeout)
         val rejection = when {
-            current.identity != identity -> "it was held for a different component"
+            current.resolvedUrl != resolvedUrl -> "it was held for a different URL"
             current.loadFailed -> "its document failed to load while prewarming"
             else -> null
         }
@@ -273,14 +278,15 @@ internal class PaywallWebViewPrewarmer {
     }
 
     /**
-     * Drops whichever view [identity] was warmed for. A hold-tier failure leaves the cache-warm queue
-     * alone: those are other urls, and they are still worth warming.
+     * Drops [entry], whichever tier it belongs to. Compared by instance, not by URL: a later prewarm of
+     * the same URL is a different view, and an async failure from this one must not take it down. A
+     * hold-tier failure leaves the cache-warm queue alone, since those are other urls still worth warming.
      */
     @MainThread
-    private fun releaseIfHeld(identity: WebViewIdentity) {
+    private fun releaseIfHeld(entry: PrewarmedWebView) {
         when {
-            slot?.identity == identity -> releaseSlot()
-            cacheWarmInFlight?.identity == identity -> finishCacheWarm()
+            slot === entry -> releaseSlot()
+            cacheWarmInFlight === entry -> finishCacheWarm()
         }
     }
 
@@ -301,14 +307,14 @@ internal class PaywallWebViewPrewarmer {
         releaseSlot()
     }
 
-    private inner class PrerenderLogger(private val identity: WebViewIdentity) : PrerenderOperationCallback {
+    private inner class PrerenderLogger(private val entry: PrewarmedWebView) : PrerenderOperationCallback {
         override fun onPrerenderActivated() {
-            Logger.d("Paywalls V2 web_view prerender activated for component '${identity.componentId}'.")
+            Logger.d("Paywalls V2 web_view prerender activated for '${entry.resolvedUrl}'.")
         }
 
         override fun onError(exception: PrerenderException) {
-            Logger.d("Paywalls V2 web_view prerender failed for component '${identity.componentId}': $exception")
-            releaseIfHeld(identity)
+            Logger.d("Paywalls V2 web_view prerender failed for '${entry.resolvedUrl}': $exception")
+            releaseIfHeld(entry)
         }
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -129,7 +129,12 @@ internal class PaywallWebViewPrewarmer {
             sizeToContentHeight = sizeToContentHeight,
         )
         applicationContext = context.applicationContext
-        registerTrimCallbacks(context)
+        // Registered on first hold rather than on construction, so an SDK that never prewarms adds no
+        // callback to the host application. Kept for the process lifetime: this instance is a singleton.
+        if (!trimCallbacksRegistered) {
+            trimCallbacksRegistered = true
+            context.applicationContext.registerComponentCallbacks(trimCallbacks)
+        }
         // At capacity nothing is evicted: a held entry is worth more than a queued one, and the overflow
         // still gets its bundle into the http cache.
         if (pool.size >= MAX_PREWARMED) {
@@ -204,14 +209,6 @@ internal class PaywallWebViewPrewarmer {
     private fun discard(resolvedUrl: String) {
         expiries.remove(resolvedUrl)?.let(mainHandler::removeCallbacks)
         pool.remove(resolvedUrl)?.destroy()
-    }
-
-    // Registered on first hold rather than on construction, so an SDK that never prewarms adds no
-    // callback to the host application. Kept for the process lifetime: this instance is a singleton.
-    private fun registerTrimCallbacks(context: Context) {
-        if (trimCallbacksRegistered) return
-        trimCallbacksRegistered = true
-        context.applicationContext.registerComponentCallbacks(trimCallbacks)
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -285,12 +285,11 @@ internal class PaywallWebViewPrewarmer {
             return null
         }
         expiries.remove(resolvedUrl)?.let(mainHandler::removeCallbacks)
-        if (taken.loadFailed) {
+        return taken.takeUnless { it.loadFailed } ?: run {
             Logger.d("Paywalls V2 web_view prewarm discarded: its document failed to load while prewarming.")
             taken.destroy()
-            return null
+            null
         }
-        return taken
     }
 
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PrewarmedWebView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PrewarmedWebView.kt
@@ -14,7 +14,7 @@ internal class PrewarmedWebView(
     private val webView: PaywallWebView,
     val bridge: WebViewJavaScriptBridge,
     private val callbacks: PrewarmBridgeCallbacks,
-    val identity: WebViewIdentity,
+    val resolvedUrl: String,
     val cancellationSignal: CancellationSignal,
 ) {
 
@@ -24,18 +24,27 @@ internal class PrewarmedWebView(
 
     /**
      * Hands this view to the composition adopting it. It is already configured down to its
-     * document-start scripts, so only the callbacks need repointing; loading the prerendered URL
-     * activates the prerender rather than starting a fresh load.
+     * document-start scripts, so only the callbacks and the component config need repointing;
+     * loading the prerendered URL activates the prerender rather than starting a fresh load.
+     *
+     * The component config is applied *before* the load, because that load resets the handshake and
+     * the following `init`/`fit` must carry the adopting component's values, not the warmed one's.
      */
     @MainThread
     fun activateIn(
+        identity: WebViewIdentity,
         onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit,
         onDocumentReset: () -> Unit,
         onLoadFailed: () -> Unit,
     ): FrameLayout {
         callbacks.rebind(onContentResize, onDocumentReset, onLoadFailed)
+        bridge.rebindComponent(
+            componentId = identity.componentId,
+            sizeToContentWidth = identity.sizeToContentWidth,
+            sizeToContentHeight = identity.sizeToContentHeight,
+        )
         callbacks.ignoreDocumentResetFromActivation()
-        webView.loadUrl(identity.resolvedUrl)
+        webView.loadUrl(resolvedUrl)
         return webView.hostedInFrameLayout()
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -127,10 +127,10 @@ internal fun WebViewComponentView(
                         contentHeightCssPx = 0
                     }
                     val onLoadFailed: () -> Unit = { loadFailed = true }
-                    val prewarmed = PaywallWebViewPrewarmer.shared.take(identity)
+                    val prewarmed = PaywallWebViewPrewarmer.shared.take(identity.resolvedUrl)
                     if (prewarmed != null) {
                         bridgeHolder.bridge = prewarmed.bridge
-                        prewarmed.activateIn(onContentResize, onDocumentReset, onLoadFailed)
+                        prewarmed.activateIn(identity, onContentResize, onDocumentReset, onLoadFailed)
                     } else {
                         val configured = createPaywallWebView(
                             context = context,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -36,10 +36,10 @@ import kotlin.math.abs
 @Suppress("LongParameterList", "TooManyFunctions")
 internal class WebViewJavaScriptBridge(
     webView: WebView,
-    private val componentId: String,
+    private var componentId: String,
     expectedUrl: String,
-    private val sizeToContentWidth: Boolean = false,
-    private val sizeToContentHeight: Boolean = false,
+    private var sizeToContentWidth: Boolean = false,
+    private var sizeToContentHeight: Boolean = false,
     private val onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
     private val onDocumentReset: () -> Unit = {},
     private val onSecureMessagingUnsupported: () -> Unit = {},
@@ -127,10 +127,23 @@ internal class WebViewJavaScriptBridge(
     }
 
     /**
+     * Repoints this bridge at the component adopting it, before the navigation that re-handshakes.
+     * A prewarmed view is keyed on URL alone, so the component it ends up serving may declare a
+     * different id or different `Fit` axes than the one it was warmed for. Both are only ever sent
+     * during the handshake, which [onMainFrameNavigationStarted] resets, so updating them here is
+     * enough for the next `init` and `fit` to carry the adopting component's values.
+     */
+    fun rebindComponent(componentId: String, sizeToContentWidth: Boolean, sizeToContentHeight: Boolean) {
+        this.componentId = componentId
+        this.sizeToContentWidth = sizeToContentWidth
+        this.sizeToContentHeight = sizeToContentHeight
+    }
+
+    /**
      * Starts a new main-frame document (load, same-origin nav, or reload): resets handshake and
      * resize state so it can `connect` again.
      */
-    @MainThread
+
     fun onMainFrameNavigationStarted() {
         if (released) return
         documentScope.cancel()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -133,6 +133,7 @@ internal class WebViewJavaScriptBridge(
      * during the handshake, which [onMainFrameNavigationStarted] resets, so updating them here is
      * enough for the next `init` and `fit` to carry the adopting component's values.
      */
+    @MainThread
     fun rebindComponent(componentId: String, sizeToContentWidth: Boolean, sizeToContentHeight: Boolean) {
         this.componentId = componentId
         this.sizeToContentWidth = sizeToContentWidth
@@ -143,7 +144,7 @@ internal class WebViewJavaScriptBridge(
      * Starts a new main-frame document (load, same-origin nav, or reload): resets handshake and
      * resize state so it can `connect` again.
      */
-
+    @MainThread
     fun onMainFrameNavigationStarted() {
         if (released) return
         documentScope.cancel()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -33,7 +33,6 @@ internal class PaywallWebViewPrewarmerTest {
     private companion object {
         const val URL = "https://example.com/index.html"
         const val OTHER_URL = "https://example.com/other.html"
-        const val THIRD_URL = "https://example.com/third.html"
         const val COMPONENT_ID = "component-1"
     }
 
@@ -229,7 +228,7 @@ internal class PaywallWebViewPrewarmerTest {
         val prewarmer = prewarmer()
         prewarmer.prewarm(context, URL, COMPONENT_ID)
 
-        assertThat(prewarmer.take("https://example.com/other.html")).isNull()
+        assertThat(prewarmer.take(OTHER_URL)).isNull()
     }
 
     @Test
@@ -241,85 +240,127 @@ internal class PaywallWebViewPrewarmerTest {
         assertThat(prewarmer.take(URL)).isNull()
     }
 
-    // The slot can only serve one url, but the others are still worth loading: running a document fills
-    // the profile's http cache, which survives the WebView that filled it.
+    // A paywall can carry several web_view components, so each distinct url gets its own entry.
     @Test
-    fun `holds the first url and warms the cache for the rest`() {
+    fun `holds one entry per distinct url`() {
         val prewarmer = prewarmer()
-        prewarmer.prewarm(context, URL, COMPONENT_ID)
 
+        prewarmer.prewarm(context, URL, COMPONENT_ID)
         prewarmer.prewarm(context, OTHER_URL, "component-2")
 
-        verify(exactly = 2) { WebViewCompat.prerenderUrlAsync(any(), any(), any(), any(), any()) }
-        assertThat(prewarmer.isWarmingCache).isTrue()
         assertThat(prewarmer.take(URL)).isNotNull()
+        assertThat(prewarmer.take(OTHER_URL)).isNotNull()
     }
 
     @Test
-    fun `warms one queued url at a time`() {
-        val prewarmer = prewarmer()
-
-        prewarmer.prewarm(context, URL, COMPONENT_ID)
-        prewarmer.prewarm(context, OTHER_URL, "component-2")
-        prewarmer.prewarm(context, THIRD_URL, "component-3")
-
-        // The slot, plus the first cache warm. The third url waits its turn.
-        verify(exactly = 2) { WebViewCompat.prerenderUrlAsync(any(), any(), any(), any(), any()) }
-        assertThat(prewarmer.queuedCacheWarmCount).isEqualTo(1)
-    }
-
-    @Test
-    fun `starts the next cache warm once the previous document finishes`() {
-        val prewarmer = prewarmer()
-        prewarmer.prewarm(context, URL, COMPONENT_ID)
-        val warming = capturingWebView { prewarmer.prewarm(context, OTHER_URL, "component-2") }
-        prewarmer.prewarm(context, THIRD_URL, "component-3")
-
-        shadowOf(warming).webViewClient.onPageFinished(warming, OTHER_URL)
-
-        verify(exactly = 3) { WebViewCompat.prerenderUrlAsync(any(), any(), any(), any(), any()) }
-        assertThat(prewarmer.queuedCacheWarmCount).isZero()
-    }
-
-    // Whether a prerendered document reports onPageFinished before activation is undocumented, so a warm
-    // that never signals must not stall the queue behind it.
-    @Test
-    fun `abandons a cache warm that never finishes and moves on`() {
-        val prewarmer = prewarmer()
-        prewarmer.prewarm(context, URL, COMPONENT_ID)
-        prewarmer.prewarm(context, OTHER_URL, "component-2")
-        prewarmer.prewarm(context, THIRD_URL, "component-3")
-
-        shadowOf(Looper.getMainLooper())
-            .idleFor(Duration.ofMillis(PaywallWebViewPrewarmer.CACHE_WARM_BUDGET_MS))
-
-        verify(exactly = 3) { WebViewCompat.prerenderUrlAsync(any(), any(), any(), any(), any()) }
-        assertThat(prewarmer.queuedCacheWarmCount).isZero()
-    }
-
-    @Test
-    fun `does not warm a url it is already holding`() {
+    fun `does not prerender a url that is already held`() {
         val prewarmer = prewarmer()
         prewarmer.prewarm(context, URL, COMPONENT_ID)
 
         prewarmer.prewarm(context, URL, "component-2")
 
         verify(exactly = 1) { WebViewCompat.prerenderUrlAsync(any(), any(), any(), any(), any()) }
-        assertThat(prewarmer.isWarmingCache).isFalse()
-        assertThat(prewarmer.take(URL)).isNotNull()
+    }
+
+    // A held entry is worth more than a queued one, so the pool is never evicted to make room. The
+    // overflow is still loaded, for the http cache alone.
+    @Test
+    fun `warms urls beyond the pool for the cache instead of evicting`() {
+        val prewarmer = prewarmer()
+        fillPool(prewarmer)
+
+        prewarmer.prewarm(context, URL, COMPONENT_ID)
+
+        assertThat(prewarmer.heldCount).isEqualTo(PaywallWebViewPrewarmer.MAX_PREWARMED)
+        assertThat(prewarmer.take("https://example.com/0.html")).isNotNull()
+        assertThat(prewarmer.isWarmingCache).isTrue()
+    }
+
+    @Test
+    fun `warms one overflow url at a time`() {
+        val prewarmer = prewarmer()
+        fillPool(prewarmer)
+
+        prewarmer.prewarm(context, URL, COMPONENT_ID)
+        prewarmer.prewarm(context, OTHER_URL, "overflow-2")
+
+        assertThat(prewarmer.isWarmingCache).isTrue()
+        assertThat(prewarmer.queuedCacheWarmCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `starts the next cache warm once the previous document finishes`() {
+        val prewarmer = prewarmer()
+        fillPool(prewarmer)
+        val warming = capturingWebView { prewarmer.prewarm(context, URL, COMPONENT_ID) }
+        prewarmer.prewarm(context, OTHER_URL, "overflow-2")
+
+        shadowOf(warming).webViewClient.onPageFinished(warming, URL)
+
+        assertThat(prewarmer.queuedCacheWarmCount).isZero()
+        assertThat(prewarmer.isWarmingCache).isTrue()
+    }
+
+    // Whether a prerendered document reports onPageFinished before activation is undocumented, so a warm
+    // that never signals must not stall the ones behind it.
+    @Test
+    fun `abandons a cache warm that never finishes and moves on`() {
+        val prewarmer = prewarmer()
+        fillPool(prewarmer)
+        prewarmer.prewarm(context, URL, COMPONENT_ID)
+        prewarmer.prewarm(context, OTHER_URL, "overflow-2")
+
+        shadowOf(Looper.getMainLooper())
+            .idleFor(Duration.ofMillis(PaywallWebViewPrewarmer.CACHE_WARM_BUDGET_MS))
+
+        assertThat(prewarmer.queuedCacheWarmCount).isZero()
+        assertThat(prewarmer.isWarmingCache).isTrue()
     }
 
     // The display path's own load fills the http cache, so a queued warm for that url is pure waste.
     @Test
     fun `drops a queued warm for a url the display path asks for`() {
         val prewarmer = prewarmer()
+        fillPool(prewarmer)
         prewarmer.prewarm(context, URL, COMPONENT_ID)
-        prewarmer.prewarm(context, OTHER_URL, "component-2")
-        prewarmer.prewarm(context, THIRD_URL, "component-3")
+        prewarmer.prewarm(context, OTHER_URL, "overflow-2")
 
-        prewarmer.take(THIRD_URL)
+        prewarmer.take(OTHER_URL)
 
         assertThat(prewarmer.queuedCacheWarmCount).isZero()
+    }
+
+    private fun fillPool(prewarmer: PaywallWebViewPrewarmer) {
+        repeat(PaywallWebViewPrewarmer.MAX_PREWARMED) { index ->
+            prewarmer.prewarm(context, "https://example.com/$index.html", "component-$index")
+        }
+    }
+
+    @Test
+    fun `an async error only drops the entry it belongs to`() {
+        val callbacks = mutableListOf<PrerenderOperationCallback>()
+        every {
+            WebViewCompat.prerenderUrlAsync(any(), any(), any(), any(), capture(callbacks))
+        } returns Unit
+        val prewarmer = prewarmer()
+        prewarmer.prewarm(context, URL, COMPONENT_ID)
+        prewarmer.prewarm(context, OTHER_URL, "component-2")
+
+        callbacks.first().onError(mockk<PrerenderException>(relaxed = true))
+
+        assertThat(prewarmer.take(URL)).isNull()
+        assertThat(prewarmer.take(OTHER_URL)).isNotNull()
+    }
+
+    // Siblings belong to other components on the same paywall and are very likely about to be taken.
+    @Test
+    fun `a miss leaves the other entries held`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarm(context, URL, COMPONENT_ID)
+
+        assertThat(prewarmer.take(OTHER_URL)).isNull()
+
+        assertThat(prewarmer.take(URL)).isNotNull()
     }
 
     @Test
@@ -345,24 +386,39 @@ internal class PaywallWebViewPrewarmerTest {
     @Test
     fun `abandons every tier when the app is asked to trim memory`() {
         val prewarmer = prewarmer()
+        fillPool(prewarmer)
         prewarmer.prewarm(context, URL, COMPONENT_ID)
-        prewarmer.prewarm(context, OTHER_URL, "component-2")
-        prewarmer.prewarm(context, THIRD_URL, "component-3")
+        prewarmer.prewarm(context, OTHER_URL, "overflow-2")
 
         (context as Application).onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN)
 
-        assertThat(prewarmer.take(URL)).isNull()
+        assertThat(prewarmer.heldCount).isZero()
         assertThat(prewarmer.isWarmingCache).isFalse()
         assertThat(prewarmer.queuedCacheWarmCount).isZero()
     }
 
     @Test
-    fun `releaseAll drops the prewarmed view`() {
+    fun `each entry expires on its own schedule`() {
         val prewarmer = prewarmer()
         prewarmer.prewarm(context, URL, COMPONENT_ID)
+        val half = PaywallWebViewPrewarmer.HOLD_TIMEOUT_MS / 2
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(half))
+        prewarmer.prewarm(context, OTHER_URL, "component-2")
+
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(PaywallWebViewPrewarmer.HOLD_TIMEOUT_MS - half))
+
+        assertThat(prewarmer.take(URL)).isNull()
+        assertThat(prewarmer.take(OTHER_URL)).isNotNull()
+    }
+
+    @Test
+    fun `releaseAll drops every prewarmed view`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarm(context, URL, COMPONENT_ID)
+        prewarmer.prewarm(context, OTHER_URL, "component-2")
 
         prewarmer.releaseAll()
 
-        assertThat(prewarmer.take(URL)).isNull()
+        assertThat(prewarmer.heldCount).isZero()
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -80,7 +80,7 @@ internal class PaywallWebViewPrewarmerTest {
         val prewarmer = prewarmer()
         prewarmer.prewarm(context, URL, COMPONENT_ID)
 
-        assertThat(prewarmer.take(identity())).isNotNull()
+        assertThat(prewarmer.take(URL)).isNotNull()
     }
 
     @Test
@@ -91,7 +91,7 @@ internal class PaywallWebViewPrewarmerTest {
         prewarmer.prewarm(context, URL, COMPONENT_ID)
 
         assertNotPrerendered()
-        assertThat(prewarmer.take(identity())).isNull()
+        assertThat(prewarmer.take(URL)).isNull()
     }
 
     @Test
@@ -133,7 +133,7 @@ internal class PaywallWebViewPrewarmerTest {
         prewarmer.prewarm(context, URL, COMPONENT_ID)
 
         assertNotPrerendered()
-        assertThat(prewarmer.take(identity())).isNull()
+        assertThat(prewarmer.take(URL)).isNull()
     }
 
     @Test
@@ -145,7 +145,7 @@ internal class PaywallWebViewPrewarmerTest {
 
         prewarmer.prewarm(context, URL, COMPONENT_ID)
 
-        assertThat(prewarmer.take(identity())).isNull()
+        assertThat(prewarmer.take(URL)).isNull()
     }
 
     @Test
@@ -159,7 +159,7 @@ internal class PaywallWebViewPrewarmerTest {
 
         callback.captured.onError(mockk<PrerenderException>(relaxed = true))
 
-        assertThat(prewarmer.take(identity())).isNull()
+        assertThat(prewarmer.take(URL)).isNull()
     }
 
     // Replaying a prewarm-time load failure onto the adopting component would make prewarming worse than
@@ -171,7 +171,7 @@ internal class PaywallWebViewPrewarmerTest {
 
         failMainFrameLoad(webView)
 
-        assertThat(prewarmer.take(identity())).isNull()
+        assertThat(prewarmer.take(URL)).isNull()
     }
 
     @Test
@@ -206,20 +206,30 @@ internal class PaywallWebViewPrewarmerTest {
         shadowOf(webView).webViewClient.onReceivedError(webView, request, mockk(relaxed = true))
     }
 
+    // Keyed on URL alone, matching iOS. The component id and Fit axes are rebound at activation, so a
+    // view warmed for one component serves any component pointing at the same bundle.
     @Test
-    fun `does not hand the view to a different component`() {
+    fun `hands the view to a different component with the same url`() {
         val prewarmer = prewarmer()
         prewarmer.prewarm(context, URL, COMPONENT_ID)
 
-        assertThat(prewarmer.take(identity(componentId = "other"))).isNull()
+        assertThat(prewarmer.take(URL)).isNotNull()
     }
 
     @Test
-    fun `does not hand the view to a component with different fit axes`() {
+    fun `hands the view to a component with different fit axes`() {
         val prewarmer = prewarmer()
         prewarmer.prewarm(context, URL, COMPONENT_ID, sizeToContentHeight = true)
 
-        assertThat(prewarmer.take(identity(sizeToContentHeight = false))).isNull()
+        assertThat(prewarmer.take(URL)).isNotNull()
+    }
+
+    @Test
+    fun `does not hand the view to a different url`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarm(context, URL, COMPONENT_ID)
+
+        assertThat(prewarmer.take("https://example.com/other.html")).isNull()
     }
 
     @Test
@@ -227,8 +237,8 @@ internal class PaywallWebViewPrewarmerTest {
         val prewarmer = prewarmer()
         prewarmer.prewarm(context, URL, COMPONENT_ID)
 
-        assertThat(prewarmer.take(identity())).isNotNull()
-        assertThat(prewarmer.take(identity())).isNull()
+        assertThat(prewarmer.take(URL)).isNotNull()
+        assertThat(prewarmer.take(URL)).isNull()
     }
 
     // The slot can only serve one url, but the others are still worth loading: running a document fills
@@ -242,7 +252,7 @@ internal class PaywallWebViewPrewarmerTest {
 
         verify(exactly = 2) { WebViewCompat.prerenderUrlAsync(any(), any(), any(), any(), any()) }
         assertThat(prewarmer.isWarmingCache).isTrue()
-        assertThat(prewarmer.take(identity())).isNotNull()
+        assertThat(prewarmer.take(URL)).isNotNull()
     }
 
     @Test
@@ -296,6 +306,7 @@ internal class PaywallWebViewPrewarmerTest {
 
         verify(exactly = 1) { WebViewCompat.prerenderUrlAsync(any(), any(), any(), any(), any()) }
         assertThat(prewarmer.isWarmingCache).isFalse()
+        assertThat(prewarmer.take(URL)).isNotNull()
     }
 
     // The display path's own load fills the http cache, so a queued warm for that url is pure waste.
@@ -306,7 +317,7 @@ internal class PaywallWebViewPrewarmerTest {
         prewarmer.prewarm(context, OTHER_URL, "component-2")
         prewarmer.prewarm(context, THIRD_URL, "component-3")
 
-        prewarmer.take(identity(url = THIRD_URL, componentId = "component-3"))
+        prewarmer.take(THIRD_URL)
 
         assertThat(prewarmer.queuedCacheWarmCount).isZero()
     }
@@ -318,7 +329,7 @@ internal class PaywallWebViewPrewarmerTest {
 
         shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(PaywallWebViewPrewarmer.HOLD_TIMEOUT_MS))
 
-        assertThat(prewarmer.take(identity())).isNull()
+        assertThat(prewarmer.take(URL)).isNull()
     }
 
     @Test
@@ -328,7 +339,7 @@ internal class PaywallWebViewPrewarmerTest {
 
         shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(PaywallWebViewPrewarmer.HOLD_TIMEOUT_MS - 1))
 
-        assertThat(prewarmer.take(identity())).isNotNull()
+        assertThat(prewarmer.take(URL)).isNotNull()
     }
 
     @Test
@@ -340,7 +351,7 @@ internal class PaywallWebViewPrewarmerTest {
 
         (context as Application).onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN)
 
-        assertThat(prewarmer.take(identity())).isNull()
+        assertThat(prewarmer.take(URL)).isNull()
         assertThat(prewarmer.isWarmingCache).isFalse()
         assertThat(prewarmer.queuedCacheWarmCount).isZero()
     }
@@ -352,6 +363,6 @@ internal class PaywallWebViewPrewarmerTest {
 
         prewarmer.releaseAll()
 
-        assertThat(prewarmer.take(identity())).isNull()
+        assertThat(prewarmer.take(URL)).isNull()
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -33,6 +33,7 @@ internal class PaywallWebViewPrewarmerTest {
     private companion object {
         const val URL = "https://example.com/index.html"
         const val OTHER_URL = "https://example.com/other.html"
+        const val THIRD_URL = "https://example.com/third.html"
         const val COMPONENT_ID = "component-1"
     }
 
@@ -336,22 +337,21 @@ internal class PaywallWebViewPrewarmerTest {
         }
     }
 
-    // The bound caps live renderer processes, not just map size, so the eldest view has to be gone before
-    // the new one is built.
+    // The bound caps live renderer processes, not just map size. An overflow url is loaded too, so at most
+    // one cache warm may be in flight alongside a full pool.
     @Test
-    fun `evicts the oldest entry before building the new view`() {
+    fun `never holds more than the pool bound plus one cache warm`() {
         val prewarmer = prewarmer()
-        repeat(PaywallWebViewPrewarmer.MAX_PREWARMED) { index ->
-            prewarmer.prewarm(context, "https://example.com/$index.html", "component-$index")
-        }
-        var heldWhileBuilding = -1
-        every { WebViewCompat.prerenderUrlAsync(any(), URL, any(), any(), any()) } answers {
-            heldWhileBuilding = prewarmer.heldCount()
-        }
+        fillPool(prewarmer)
 
         prewarmer.prewarm(context, URL, COMPONENT_ID)
+        prewarmer.prewarm(context, OTHER_URL, "overflow-2")
+        prewarmer.prewarm(context, THIRD_URL, "overflow-3")
 
-        assertThat(heldWhileBuilding).isEqualTo(PaywallWebViewPrewarmer.MAX_PREWARMED - 1)
+        assertThat(prewarmer.heldCount).isEqualTo(PaywallWebViewPrewarmer.MAX_PREWARMED)
+        verify(exactly = PaywallWebViewPrewarmer.MAX_PREWARMED + 1) {
+            WebViewCompat.prerenderUrlAsync(any(), any(), any(), any(), any())
+        }
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -336,6 +336,24 @@ internal class PaywallWebViewPrewarmerTest {
         }
     }
 
+    // The bound caps live renderer processes, not just map size, so the eldest view has to be gone before
+    // the new one is built.
+    @Test
+    fun `evicts the oldest entry before building the new view`() {
+        val prewarmer = prewarmer()
+        repeat(PaywallWebViewPrewarmer.MAX_PREWARMED) { index ->
+            prewarmer.prewarm(context, "https://example.com/$index.html", "component-$index")
+        }
+        var heldWhileBuilding = -1
+        every { WebViewCompat.prerenderUrlAsync(any(), URL, any(), any(), any()) } answers {
+            heldWhileBuilding = prewarmer.heldCount()
+        }
+
+        prewarmer.prewarm(context, URL, COMPONENT_ID)
+
+        assertThat(heldWhileBuilding).isEqualTo(PaywallWebViewPrewarmer.MAX_PREWARMED - 1)
+    }
+
     @Test
     fun `an async error only drops the entry it belongs to`() {
         val callbacks = mutableListOf<PrerenderOperationCallback>()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PrewarmedWebViewTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PrewarmedWebViewTest.kt
@@ -45,7 +45,7 @@ internal class PrewarmedWebViewTest {
             webView = webView,
             bridge = bridge,
             callbacks = callbacks,
-            identity = WebViewIdentity(URL, COMPONENT_ID, false, false),
+            resolvedUrl = URL,
             cancellationSignal = CancellationSignal(),
         )
     }
@@ -56,9 +56,17 @@ internal class PrewarmedWebViewTest {
     }
 
     private fun activate(
+        componentId: String = COMPONENT_ID,
+        sizeToContentWidth: Boolean = false,
+        sizeToContentHeight: Boolean = false,
         onContentResize: (Int?, Int?) -> Unit = { _, _ -> },
         onLoadFailed: () -> Unit = {},
-    ) = prewarmed.activateIn(onContentResize, onDocumentReset = {}, onLoadFailed = onLoadFailed)
+    ) = prewarmed.activateIn(
+        identity = WebViewIdentity(URL, componentId, sizeToContentWidth, sizeToContentHeight),
+        onContentResize = onContentResize,
+        onDocumentReset = {},
+        onLoadFailed = onLoadFailed,
+    )
 
     @Test
     fun `activation navigates the prewarmed view to the prerendered url`() {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -143,6 +143,27 @@ internal class WebViewJavaScriptBridgeTest {
         assertThat(script).contains("\"component_id\":\"promo_web_view\"")
     }
 
+    // A prewarmed view is keyed on URL alone, so it can be adopted by a component declaring a different
+    // id or different Fit axes. Both are only ever sent during the handshake, so rebinding before the
+    // activation navigation is what makes the URL key safe.
+    @Test
+    fun `handshake after rebind carries the adopting component's id and fit axes`() {
+        val bridge = bridge(sizeToContentWidth = false, sizeToContentHeight = false)
+        bridge.connect()
+        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"component_id\":\"promo_web_view\"")
+
+        bridge.rebindComponent("adopting_component", sizeToContentWidth = true, sizeToContentHeight = true)
+        // Activation reloads the prerendered URL, which resets the handshake; the content reconnects.
+        bridge.onMainFrameNavigationStarted()
+        bridge.connect()
+
+        val script = shadowWebView.lastEvaluatedJavascript
+        assertThat(script).contains("\"component_id\":\"adopting_component\"")
+        assertThat(script).contains("\"type\":\"fit\"")
+        assertThat(script).contains("\"width\":true")
+        assertThat(script).contains("\"height\":true")
+    }
+
     @Test
     fun `completes connect handshake before the web view URL is available`() {
         val bridge = bridge(navigateTo = null)


### PR DESCRIPTION
- Fixes a real bug in the single-slot design: a paywall with two `web_view` components had whichever composed first destroy the other's prerender. Both Cursor and an internal review flagged it.
- Two changes. The match key narrows from `WebViewIdentity` (url + component id + Fit axes) to the **resolved url alone**, matching iOS; and the single slot becomes a **bounded pool of 3**, keyed on that url.
- Component id and the Fit axes stop being part of identity and become late-bound bridge state, rebound just before activation triggers the handshake that transmits them. So a view warmed for one component now serves any component pointing at the same bundle.
- **The pool is not exercised yet.** `prewarm` is still reached only from the paywall tester; nothing in core calls it, because prerender is not wired to the `PaywallAssetWarmer` seam. This lands the mechanism so the wiring PR does not have to change policy at the same time.
- The bound of 3 comes from on-device memory measurement, not a guess. Details below.
- The pool bound now only governs the *activation* tier. Urls beyond it are not dropped and no longer evict a held entry: they fall through to the sequential http-cache warm added in #3897, so coverage no longer depends on `MAX_PREWARMED`.
- Tripling the ceiling makes the release path matter more than it did, so `onTrimMemory` release comes in with #3897 and drops both tiers at any trim level.
- Stacked on #3897.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

`PaywallWebViewPrewarmer` held one slot keyed on the full `WebViewIdentity`. Two independent problems followed.

The key was too narrow. Two components sharing a bundle url but differing in component id, or in a Fit axis, could not reuse each other's prerender even though the prerendered content is identical. iOS keys on component url, so this was also a gratuitous divergence.

The slot was too small. A paywall can carry 0..N `web_view` components, and real offerings have been observed with 4 to 6 on a single paywall. With more than one, `take()` on the first component destroyed the entry the second would have used, so the second rendered cold *and* paid for a wasted prerender.

### Description

**Rekeying.** `PrewarmedWebView` holds `resolvedUrl` instead of a `WebViewIdentity`. `componentId`, `sizeToContentWidth` and `sizeToContentHeight` become `var` on `WebViewJavaScriptBridge`, with a new `rebindComponent(...)` that `activateIn` calls before `loadUrl`. This is safe because those three values only ever cross to the page during the `rc-web-components` handshake (`init` and `fit`), which activation re-triggers, so rebinding before the reload is equivalent to having constructed the bridge with them.

**Pooling.** The slot becomes a `LinkedHashMap<String, PrewarmedWebView>` bounded at `MAX_PREWARMED`:

- Nothing is evicted at capacity. A held entry is worth more than a new one, and the overflow url still gets its bundle into the http cache via the second tier, so evicting would trade a certain win for a speculative one.
- A repeat `prewarm` for a url already held, in flight, or queued is a no-op.
- Each entry gets its own expiry `Runnable` rather than one shared timeout, so an entry added later is not cut short by an earlier one's clock.
- An async `PrerenderException` discards only its own entry.
- A `take()` miss leaves the pool untouched. Under the old design a miss destroyed the held view; with siblings that is exactly wrong, since they belong to other components on the same paywall and are very likely about to be taken.

### Why the bound is 3

Measured on device, holding prerenders costs almost nothing after the first one or two, because the cost is dominated by renderer processes and WebView caps those itself:

| Held prerenders | Marginal cost |
|---|---|
| 1st | ~104 MB |
| 2nd | ~104 MB |
| 3rd to 5th | ~1-6 MB each |

The cap was 2 renderer processes on a 5.6 GB device and 1 on a 4 GB device, regardless of how many prerenders were requested. Renderer processes run as `com.google.android.webview:sandboxed_processN`, outside the app's own process, which is worth knowing if anyone re-measures this with `dumpsys meminfo`.

So 3 covers the multi-`web_view` paywalls we have actually seen while staying inside the platform's own ceiling. It is no longer a coverage ceiling either: with the cache tier, a paywall with 6 `web_view` urls gets 3 activations and 3 cache hits rather than 3 activations and 3 cold loads.

### Known limitation: a replayed size can come from another component

Under the old identity key, warm and adopter agreed on the Fit axes by construction, so replaying the cached content size was always sound. Keying on url alone drops that guarantee: resize reporting is gated on the *warmed* component's Fit axes, and `ignoreDocumentResetFromActivation` deliberately keeps that size across activation. Reachable damage is limited to an adopter whose `Fill` axis turns out unbounded at measure time, which then consumes a size measured under another component's contract. Masking the replay to the adopter's own Fit axes is the fix; not done here.

### Still undecided

The pool *size* is settled by the measurement above; the pool *policy* is not. What to prerender and when is still an open cross-platform question with iOS, which is building the same url-keyed pool starting at one view. Nothing here commits us: `MAX_PREWARMED` is one constant, and the wiring PR chooses which urls get offered.

Also unsettled: what the cache tier is worth today is capped by CDN config, not by this code. The bundle HTML ships no `Cache-Control` and the SDK script ships `max-age=60, must-revalidate`, so a warm outside the freshness window saves the body but not the round trip. Measured headers and the CDN-side fix are in #3897.

### Tests

`PaywallWebViewPrewarmerTest` gates this change with `holds one entry per distinct url`, `warms urls beyond the pool for the cache instead of evicting`, `never holds more than the pool bound plus one cache warm`, `each entry expires on its own schedule`, `an async error only drops the entry it belongs to`, and `a miss leaves the other entries held`.

Two pre-existing tests asserted the behaviour this deliberately inverts (a view not being handed to a different component, or to different Fit axes). They were rewritten to assert the new behaviour, and `does not hand the view to a different url` was added so the negative case is still covered.

</details>

