### PR TITLE
Fix flaky cached offerings integration test and cover the fully-offline case

### DIFF
--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -88,6 +88,9 @@ abstract class BasePurchasesIntegrationTest {
         override fun modifyRequestURL(url: URL, endpoint: Endpoint): URL {
             return forceServerErrorsStrategy?.modifyRequestURL(url, endpoint) ?: url
         }
+        override fun shouldForceConnectionFailure(url: String): Boolean {
+            return forceServerErrorsStrategy?.shouldForceConnectionFailure(url) ?: false
+        }
         override fun fakeResponseWithoutPerformingRequest(baseURL: URL, endpoint: Endpoint): HTTPResult? {
             return forceServerErrorsStrategy?.fakeResponseWithoutPerformingRequest(baseURL, endpoint)
         }

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/cachedofferings/BaseCachedOfferingsUsageIntegrationTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/cachedofferings/BaseCachedOfferingsUsageIntegrationTest.kt
@@ -21,6 +21,25 @@ import java.net.URL
 
 abstract class BaseCachedOfferingsUsageIntegrationTest : BasePurchasesIntegrationTest() {
 
+    private companion object {
+        const val UNREACHABLE_URL = "http://localhost:100/unreachable-address"
+
+        /**
+         * These tests restart the SDK twice against the real backend, and `getOfferings` only returns once the
+         * `/v1/config` paywall data is ready, which can include downloading config blobs from the config CDN.
+         * `runTest`'s 10s default is a deadlock guard, not a latency budget, and it is too tight for that.
+         */
+        const val BACKEND_TEST_TIMEOUT_MS = 60_000L
+    }
+
+    /** The RevenueCat API is unreachable. The config CDN, a different host, still is. */
+    private val apiUnreachable = object : ForceServerErrorStrategy {
+        override val serverErrorURL: String
+            get() = UNREACHABLE_URL
+
+        override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean = true
+    }
+
     @get:Rule
     var instantExecutorRule = InstantTaskExecutorRule()
 
@@ -36,7 +55,9 @@ abstract class BaseCachedOfferingsUsageIntegrationTest : BasePurchasesIntegratio
     }
 
     @Test
-    fun cachedOfferingsAreUsedWhenCachedOfferingsAndServerErrorWith5xx() = runTest {
+    fun cachedOfferingsAreUsedWhenCachedOfferingsAndServerErrorWith5xx() = runTest(
+        dispatchTimeoutMs = BACKEND_TEST_TIMEOUT_MS,
+    ) {
         val networkOfferings = Purchases.sharedInstance.awaitOfferings()
 
         simulateSdkRestart(activity, forceServerErrorsStrategy = ForceServerErrorStrategy.failAll)
@@ -47,20 +68,12 @@ abstract class BaseCachedOfferingsUsageIntegrationTest : BasePurchasesIntegratio
     }
 
     @Test
-    fun cachedOfferingsAreUsedWhenCachedOfferingsAndServerCannotBeReached() = runTest {
+    fun cachedOfferingsAreUsedWhenCachedOfferingsAndServerCannotBeReached() = runTest(
+        dispatchTimeoutMs = BACKEND_TEST_TIMEOUT_MS,
+    ) {
         val networkOfferings = Purchases.sharedInstance.awaitOfferings()
 
-        simulateSdkRestart(
-            activity,
-            forceServerErrorsStrategy = object : ForceServerErrorStrategy {
-                override val serverErrorURL: String
-                    get() = "http://localhost:100/unreachable-address"
-
-                override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean {
-                    return true
-                }
-            },
-        )
+        simulateSdkRestart(activity, forceServerErrorsStrategy = apiUnreachable)
 
         val cachedOfferings = Purchases.sharedInstance.awaitOfferings()
 
@@ -68,7 +81,9 @@ abstract class BaseCachedOfferingsUsageIntegrationTest : BasePurchasesIntegratio
     }
 
     @Test
-    fun cachedOfferingsAreNotUsedWhenCachedOfferingsAndErrorWith4xx() = runTest {
+    fun cachedOfferingsAreNotUsedWhenCachedOfferingsAndErrorWith4xx() = runTest(
+        dispatchTimeoutMs = BACKEND_TEST_TIMEOUT_MS,
+    ) {
         Purchases.sharedInstance.awaitOfferings()
 
         simulateSdkRestart(

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/cachedofferings/BaseCachedOfferingsUsageIntegrationTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/integration/cachedofferings/BaseCachedOfferingsUsageIntegrationTest.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
 import com.revenuecat.purchases.helpers.mockQueryProductDetails
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -38,6 +39,16 @@ abstract class BaseCachedOfferingsUsageIntegrationTest : BasePurchasesIntegratio
             get() = UNREACHABLE_URL
 
         override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean = true
+    }
+
+    /** Nothing is reachable: neither the API nor any direct download (config blobs). */
+    private val fullyOffline = object : ForceServerErrorStrategy {
+        override val serverErrorURL: String
+            get() = UNREACHABLE_URL
+
+        override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean = true
+
+        override fun shouldForceConnectionFailure(url: String): Boolean = true
     }
 
     @get:Rule
@@ -74,6 +85,25 @@ abstract class BaseCachedOfferingsUsageIntegrationTest : BasePurchasesIntegratio
         val networkOfferings = Purchases.sharedInstance.awaitOfferings()
 
         simulateSdkRestart(activity, forceServerErrorsStrategy = apiUnreachable)
+
+        val cachedOfferings = Purchases.sharedInstance.awaitOfferings()
+
+        assertThat(cachedOfferings).isEqualTo(networkOfferings)
+    }
+
+    /**
+     * Unlike the test above, this one keeps `runTest`'s tight default budget on purpose: with no host reachable
+     * there is nothing legitimate left to wait for, so it also guards against the paywall-config readiness gate
+     * stranding or slowing down a `getOfferings` that the disk cache can already answer.
+     */
+    @Test
+    fun cachedOfferingsAreUsedWhenFullyOffline() = runTest {
+        val networkOfferings = Purchases.sharedInstance.awaitOfferings()
+
+        // Config blobs cached by the first fetch would let the readiness gate resolve without the network,
+        // hiding the very wait this test exists to catch.
+        RemoteConfigBlobStore(activity).clear()
+        simulateSdkRestart(activity, forceServerErrorsStrategy = fullyOffline)
 
         val cachedOfferings = Purchases.sharedInstance.awaitOfferings()
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ForceServerErrorStrategy.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ForceServerErrorStrategy.kt
@@ -20,6 +20,15 @@ internal fun interface ForceServerErrorStrategy {
 
     fun modifyRequestURL(url: URL, endpoint: Endpoint): URL = url
 
+    /**
+     * Whether a direct [java.net.HttpURLConnection] download of [url] should fail as if the host were
+     * unreachable. Unlike the rest of this interface, this covers requests that never reach `HTTPClient`: remote
+     * config blobs are fetched straight from the config CDN, a different host from the API, so forcing API
+     * errors alone leaves them downloading normally. Default `false` keeps that (an API outage does not imply
+     * the CDN is down); return `true` to simulate having no network at all.
+     */
+    fun shouldForceConnectionFailure(url: String): Boolean = false
+
     @OptIn(InternalRevenueCatAPI::class)
     fun fakeResponseWithoutPerformingRequest(baseURL: URL, endpoint: Endpoint): HTTPResult? {
         return null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ForcedFailureUrlConnectionFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ForcedFailureUrlConnectionFactory.kt
@@ -1,0 +1,27 @@
+package com.revenuecat.purchases
+
+import com.revenuecat.purchases.utils.UrlConnection
+import com.revenuecat.purchases.utils.UrlConnectionFactory
+import java.io.IOException
+
+/**
+ * Wraps [delegate] so downloads [strategy] declares unreachable throw instead of connecting, letting an
+ * integration test simulate no network on paths that bypass `HTTPClient`.
+ */
+internal class ForcedFailureUrlConnectionFactory(
+    private val delegate: UrlConnectionFactory,
+    private val strategy: ForceServerErrorStrategy,
+) : UrlConnectionFactory {
+
+    override fun createConnection(
+        url: String,
+        connectTimeoutMillis: Int,
+        readTimeoutMillis: Int,
+        requestMethod: String,
+    ): UrlConnection {
+        if (strategy.shouldForceConnectionFailure(url)) {
+            throw IOException("Forced connection failure for $url")
+        }
+        return delegate.createConnection(url, connectTimeoutMillis, readTimeoutMillis, requestMethod)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -65,11 +65,13 @@ import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
 import com.revenuecat.purchases.utils.CoilImageDownloader
+import com.revenuecat.purchases.utils.DefaultUrlConnectionFactory
 import com.revenuecat.purchases.utils.EventsFileHelper
 import com.revenuecat.purchases.utils.IsDebugBuildProvider
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
 import com.revenuecat.purchases.utils.PaywallComponentsImagePreDownloader
 import com.revenuecat.purchases.utils.PurchaseParamsValidator
+import com.revenuecat.purchases.utils.UrlConnectionFactory
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencyManager
 import java.net.URL
@@ -307,7 +309,12 @@ internal class PurchasesFactory(
                     blobStore = remoteConfigBlobStore,
                     topicStore = remoteConfigTopicStore,
                     sourceProvider = apiSourceProvider,
-                    blobFetcher = RemoteConfigBlobFetcher(remoteConfigBlobStore, apiSourceProvider, timeoutManager),
+                    blobFetcher = RemoteConfigBlobFetcher(
+                        remoteConfigBlobStore,
+                        apiSourceProvider,
+                        timeoutManager,
+                        urlConnectionFactory = blobUrlConnectionFactory(forceServerErrorStrategy),
+                    ),
                     // Bootstrap source for a cold on-demand read's self-triggered sync (see blobData()); after
                     // the first identity change the manager syncs for the user clearCache() binds instead.
                     appUserIDProvider = { cache.getCachedAppUserID() },
@@ -613,6 +620,11 @@ internal class PurchasesFactory(
             return apiKeyValidationResult
         }
     }
+
+    private fun blobUrlConnectionFactory(strategy: ForceServerErrorStrategy?): UrlConnectionFactory =
+        DefaultUrlConnectionFactory().let { default ->
+            strategy?.let { ForcedFailureUrlConnectionFactory(default, it) } ?: default
+        }
 
     private fun Context.getApplication() = applicationContext as Application
 

--- a/purchases/src/test/java/com/revenuecat/purchases/ForcedFailureUrlConnectionFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/ForcedFailureUrlConnectionFactoryTest.kt
@@ -1,0 +1,65 @@
+package com.revenuecat.purchases
+
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.utils.UrlConnection
+import com.revenuecat.purchases.utils.UrlConnectionFactory
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.IOException
+import java.net.URL
+
+@RunWith(RobolectricTestRunner::class)
+class ForcedFailureUrlConnectionFactoryTest {
+
+    private companion object {
+        const val BLOB_URL = "https://config.revenuecat-static.com/project/blob-ref"
+    }
+
+    private lateinit var delegate: UrlConnectionFactory
+    private lateinit var delegateConnection: UrlConnection
+
+    @Before
+    fun setUp() {
+        delegateConnection = mockk(relaxed = true)
+        delegate = mockk<UrlConnectionFactory>().apply {
+            every { createConnection(any(), any(), any(), any()) } returns delegateConnection
+        }
+    }
+
+    @Test
+    fun `delegates when the strategy does not force a connection failure`() {
+        val factory = ForcedFailureUrlConnectionFactory(delegate, strategy(forceConnectionFailure = false))
+
+        assertThat(factory.createConnection(BLOB_URL, 1, 2, "GET")).isSameAs(delegateConnection)
+        verify(exactly = 1) { delegate.createConnection(BLOB_URL, 1, 2, "GET") }
+    }
+
+    @Test
+    fun `throws without connecting when the strategy forces a connection failure`() {
+        val factory = ForcedFailureUrlConnectionFactory(delegate, strategy(forceConnectionFailure = true))
+
+        assertThatThrownBy { factory.createConnection(BLOB_URL, 1, 2, "GET") }
+            .isInstanceOf(IOException::class.java)
+            .hasMessageContaining(BLOB_URL)
+        verify(exactly = 0) { delegate.createConnection(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `forcing server errors does not force connection failures by default`() {
+        val factory = ForcedFailureUrlConnectionFactory(delegate, ForceServerErrorStrategy.failAll)
+
+        assertThat(factory.createConnection(BLOB_URL, 1, 2, "GET")).isSameAs(delegateConnection)
+    }
+
+    private fun strategy(forceConnectionFailure: Boolean) = object : ForceServerErrorStrategy {
+        override fun shouldForceServerError(baseURL: URL, endpoint: Endpoint): Boolean = true
+        override fun shouldForceConnectionFailure(url: String): Boolean = forceConnectionFailure
+    }
+}


### PR DESCRIPTION
tldr: Increased timeout of tests that _do_ call CDN, and added a true "full offline" one

- `cachedOfferingsAreUsedWhenCachedOfferingsAndServerCannotBeReached` has been failing intermittently with `UncompletedCoroutinesError: After waiting for 10s`, on roughly two thirds of production integration runs.
- It is not a code regression: an unchanged sha fails and then passes on a rerun, and only the production project is affected because the load-shedder ones publish no `ui_config`/`workflows` topics.
- The forced-server-error harness only rewrites requests that go through `HTTPClient`. Config blobs are fetched straight from the config CDN, a different host, so "the server is unreachable" left a real download inside a 10s budget.
- Fix: a 60s budget on the three tests that restart the SDK against the real backend. This does not make the test unfailable, it stops it failing for a legitimate wait.
- New: an opt-in hook for forcing direct connections to fail, and a `cachedOfferingsAreUsedWhenFullyOffline` test that uses it with the blob cache cleared.


### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

The failure is a timeout, not a bad assertion: `runTest` on coroutines-test 1.6.4 gives the body a hard 10s of wall clock, and the second `awaitOfferings()` does not come back in time. Reruns of an identical sha pass, so nothing in the diff of any PR caused it. The earliest occurrence found was 2026-08-06T16:17Z, on four unrelated branches at once.

What the test believes it sets up is "nothing is reachable". What it actually sets up is "the RevenueCat API is unreachable, the config CDN is fine". `ForceServerErrorStrategy` is consulted by `HTTPClient` only, and `RemoteConfigBlobFetcher.tryDownloadVerifyStore` opens its connection through `UrlConnectionFactory` directly, so blob traffic to `config.revenuecat-static.com` was never redirected.

That distinction is not a bug in the SDK. Paywall data moved to a separately hosted config layer precisely so it survives an API outage, so continuing to read it from the CDN while the API is down is the design working. The stale assumption was the test's: since `OfferingsManager` gates its `onSuccess` on `WorkflowManager.onPaywallConfigReady`, which can wait on `awaitTopicAndPrefetchBlobsReady`, the test body has always included a real CDN download whose worst case is the 30s blob timeout.

The production integration project publishes `ui_config` and `workflows` (one workflow, a 23KB blob, plus a 54KB localizations blob), which is why only that job is exposed.

### Description

- Raise the budget to 60s on the three tests that restart the SDK against the real backend. 10s is a deadlock guard, not a latency budget.
- Hoist the duplicated unreachable-URL strategy into one `apiUnreachable` field.
- Add `ForceServerErrorStrategy.shouldForceConnectionFailure(url)`, defaulting to `false` so existing tests keep today's semantics: an API outage does not imply the CDN is down.
- Add `ForcedFailureUrlConnectionFactory`, wired into `RemoteConfigBlobFetcher` from `PurchasesFactory` only when a strategy is present. No public API change.
- Add `cachedOfferingsAreUsedWhenFullyOffline`, which clears the blob store before the restart so the readiness gate has to face a dead network, and keeps the tight 10s default on purpose: with no host reachable there is nothing legitimate to wait for, so the budget doubles as the guard.

`cachedOfferingsAreUsedWhenFullyOffline` is the regression gate. It is not passing vacuously: on device it logs 24 forced connection failures, blob downloads failing across both `revenuecat-static.com` and `.net`, and `Error fetching offerings. Using disk cache.`, all inside 10s. Reverting the `ForcedFailureUrlConnectionFactory` wiring makes it exercise nothing, since the blobs simply re-download.

Measured on a Pixel emulator against the production project, the second `awaitOfferings()` takes 103, 103, 180, 105 and 125ms across five cold runs. The margin over 10s is large locally and thin on a CI emulator, which is what the 60s budget absorbs.

Known limitation: the hook covers remote config blobs only. Fonts, the file repository and source health checks take the same direct path and are unaffected by it, so a test asking for "no network" still leaves those three connecting.

</details>
