### PR TITLE
fix: re-arm billing reconnection ladder when the service disconnects with pending requests

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -752,6 +752,15 @@ internal class BillingWrapper(
             BillingStrings.BILLING_SERVICE_DISCONNECTED_INSTANCE.format(billingClient?.toString())
         }
         diagnosticsTrackerIfEnabled?.trackGoogleBillingServiceDisconnected()
+        // If the service died while a connection attempt was in flight (e.g. the Play Store was
+        // updating or was killed mid-connection), that attempt will never deliver
+        // onBillingSetupFinished, and a later startConnection() call while BillingClient is still
+        // CONNECTING only produces a DEVELOPER_ERROR ("client is already in the process of
+        // connecting") which does not retry either. Without re-arming the reconnection ladder
+        // here, queued service requests would wait forever.
+        if (serviceRequests.isNotEmpty()) {
+            retryBillingServiceConnectionWithExponentialBackoff()
+        }
     }
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1576,6 +1576,106 @@ class BillingWrapperTest {
     }
 
     @Test
+    fun `onBillingServiceDisconnected with pending service requests re-arms the reconnection ladder`() {
+        every { mockClient.isReady } returns false
+        every { mockClient.queryProductDetailsAsync(any(), any()) } just runs
+
+        val capturedDelays = mutableListOf<Long>()
+        val runnableSlot = slot<Runnable>()
+        every {
+            handler.postDelayed(capture(runnableSlot), capture(capturedDelays))
+        } returns true
+
+        // Queue a request while the client is not ready, mirroring work queued during a
+        // connection attempt.
+        wrapper.queryProductDetailsAsync(
+            productType = ProductType.SUBS,
+            productIds = setOf("product_a"),
+            onReceive = { },
+            onError = { fail("shouldn't be an error") }
+        )
+        val scheduledCallsBeforeDisconnect = capturedDelays.size
+
+        wrapper.onBillingServiceDisconnected()
+
+        // The disconnect must schedule a reconnection using the existing backoff ladder.
+        assertThat(capturedDelays.size).isEqualTo(scheduledCallsBeforeDisconnect + 1)
+        assertThat(capturedDelays.last()).isEqualTo(1000L) // RECONNECT_TIMER_START_MILLISECONDS
+
+        // Running the scheduled reconnection starts a new connection attempt.
+        runnableSlot.captured.run()
+        verify(exactly = 2) { mockClient.startConnection(any()) }
+
+        // Once the new connection succeeds, the queued request executes instead of hanging.
+        every { mockClient.isReady } returns true
+        every {
+            handler.postDelayed(capture(runnableSlot), any())
+        } answers {
+            runnableSlot.captured.run()
+            true
+        }
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
+        verify(exactly = 1) { mockClient.queryProductDetailsAsync(any(), any()) }
+    }
+
+    @Test
+    fun `onBillingServiceDisconnected without pending service requests does not schedule a reconnection`() {
+        val capturedDelays = mutableListOf<Long>()
+        every {
+            handler.postDelayed(any(), capture(capturedDelays))
+        } returns true
+
+        wrapper.onBillingServiceDisconnected()
+
+        assertThat(capturedDelays).isEmpty()
+    }
+
+    @Test
+    fun `disconnect during an in-flight connection attempt eventually executes queued requests`() {
+        // Reproduces the wedge where the billing service dies while a connection attempt is in
+        // flight: the in-flight attempt never delivers onBillingSetupFinished, and a concurrent
+        // startConnection() only produces DEVELOPER_ERROR ("client is already in the process of
+        // connecting"), which must not be the end of the line for queued requests.
+        every { mockClient.isReady } returns false
+        every { mockClient.queryProductDetailsAsync(any(), any()) } just runs
+
+        val scheduledRunnables = mutableListOf<Runnable>()
+        every {
+            handler.postDelayed(capture(scheduledRunnables), any())
+        } returns true
+
+        wrapper.queryProductDetailsAsync(
+            productType = ProductType.SUBS,
+            productIds = setOf("product_a"),
+            onReceive = { },
+            onError = { fail("shouldn't be an error") }
+        )
+
+        // A second connection attempt while the first is in flight finishes with DEVELOPER_ERROR,
+        // which intentionally schedules nothing.
+        wrapper.onBillingSetupFinished(BillingClient.BillingResponseCode.DEVELOPER_ERROR.buildResult())
+        val scheduledBeforeDisconnect = scheduledRunnables.size
+
+        // The service then dies mid-connection: the in-flight attempt will never call back, so
+        // the disconnect is the only signal left and it must schedule a reconnection.
+        wrapper.onBillingServiceDisconnected()
+        assertThat(scheduledRunnables.size).isEqualTo(scheduledBeforeDisconnect + 1)
+
+        // The scheduled reconnection runs and the connection succeeds.
+        scheduledRunnables.last().run()
+        every { mockClient.isReady } returns true
+        every {
+            handler.postDelayed(capture(scheduledRunnables), any())
+        } answers {
+            scheduledRunnables.last().run()
+            true
+        }
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
+
+        verify(exactly = 1) { mockClient.queryProductDetailsAsync(any(), any()) }
+    }
+
+    @Test
     fun `normalizing Google purchase returns correct product ID and null store user ID`() {
         val expectedProductID = "expectedProductID"
 


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids (not applicable: Play Billing reconnection is Android specific)

### Motivation

Fixes #3922 (full repro and log evidence in the issue).

When the Play billing service dies while a `startConnection` attempt is in flight, that attempt never delivers `onBillingSetupFinished`. A concurrent `startConnection` call in that state yields `DEVELOPER_ERROR` ("Client is already in the process of connecting to billing service."), which `onBillingSetupFinished` deliberately ignores:

```kotlin
BillingClient.BillingResponseCode.DEVELOPER_ERROR -> {
    // Billing service is already trying to connect. Don't do anything.
}
```

and `onBillingServiceDisconnected` only logged and tracked diagnostics:

```kotlin
override fun onBillingServiceDisconnected() {
    log(LogIntent.WARNING) {
        BillingStrings.BILLING_SERVICE_DISCONNECTED_INSTANCE.format(billingClient?.toString())
    }
    diagnosticsTrackerIfEnabled?.trackGoogleBillingServiceDisconnected()
}
```

With no callback left to fire, nothing in the system ever calls `startConnection` again. Requests queued in `serviceRequests` wait forever, and `getOfferings` pends silently until an app lifecycle event happens to arm a new connection.

### Description

`onBillingServiceDisconnected` now calls the existing `retryBillingServiceConnectionWithExponentialBackoff()` when `serviceRequests` is non-empty. That is the whole change: one call into the retry ladder the wrapper already has (1s start, 15min cap, `reconnectionAlreadyScheduled` dedupe guard). Empty-queue behavior is unchanged, since the next API request still arms its own connection through `executeRequestOnUIThread`. A retry that fires while a live connect attempt is in flight is absorbed by the existing `DEVELOPER_ERROR` no-op or the `isReady` early return in `performStartConnection`, so there is no double-connect risk.

New tests in `BillingWrapperTest` (mocked handlers, no wall-clock waits):

- `onBillingServiceDisconnected with pending service requests re-arms the reconnection ladder`
- `onBillingServiceDisconnected without pending service requests does not schedule a reconnection`
- `disconnect during an in-flight connection attempt eventually executes queued requests` (full wedge choreography: request queued, DEVELOPER_ERROR ignored, disconnect schedules the retry, queued request completes)

A/B: with the fix, `BillingWrapperTest` passes 71/71. With `BillingWrapper.kt` reverted to main, exactly the two wedge tests fail. All four CI unit test lanes (`testDefaultsDebugUnitTest`, `testDefaultsReleaseUnitTest`, and both `CustomEntitlementComputation` variants) and `detektAll` pass locally.

Real-device validation, measured from a production Flutter app's test rig (repeated `force-stop` of the Play Store while a connection attempt is in flight and a `getOfferings` composite is queued):

| Scenario | Stock 10.16.1 | With this fix |
|---|---|---|
| Service death mid-connect with queued requests | Zero `Starting connection` attempts after the death; queued requests pended 13m03s on a physical Pixel (192-203s on an emulator) and released only on an app foreground event | Ladder re-armed after every mid-connect death: `Starting connection` at +1.0s, +2.1s, +4.2s, +8.4s, +16.2s, +32.1s, +64.3s; queued request completed about 18s after the service recovered, with zero user interaction and zero lifecycle events |

No behavior change for apps that never hit this state; the added call is gated on a non-empty request queue and reuses the existing scheduling guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Google Play Billing connection and retry timing; change is gated on a non-empty queue and reuses existing backoff/dedupe, with strong unit tests.
> 
> **Overview**
> Fixes a wedge where Play Billing dies mid-`startConnection`: the in-flight attempt never calls `onBillingSetupFinished`, and further `startConnection` calls only get `DEVELOPER_ERROR` with no retry, so **queued `serviceRequests` (e.g. offerings) could hang until a lifecycle event**.
> 
> **`onBillingServiceDisconnected`** now calls the existing **`retryBillingServiceConnectionWithExponentialBackoff()`** when the request queue is non-empty; empty-queue disconnects behave as before.
> 
> Adds **`BillingWrapperTest`** coverage for disconnect with/without pending requests and the full mid-connect death scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 833c1e028e130bf6d0e891f8d5694f7c3bdb111b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->