### PR TITLE
Fix misleading ui_config warnings for projects without paywalls

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -612,6 +612,17 @@ internal class RemoteConfigManager(
     }
 
     /**
+     * Waits for the refresh that is currently in flight, if any, then returns the latest committed [topic].
+     * Unlike [topic], this never starts a refresh. This lets a consumer avoid treating a stale-but-committed
+     * empty topic as authoritative while AppStart is already fetching a newer configuration.
+     */
+    suspend fun committedTopicAfterInFlightRefresh(topic: RemoteConfigTopic): ConfigTopic? =
+        withContext(ioDispatcher) {
+            awaitInFlightRefresh()
+            if (disabled) null else topicStore.topic(topic)
+        }
+
+    /**
      * Like [topic], but additionally waits for the topic's `prefetch`-marked blobs to finish caching before
      * returning: the config request must be committed **and** every item in [topic] flagged `prefetch` must have
      * its referenced blob resolved (already inlined-and-cached, or downloaded now). Inlined blobs are cached

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
@@ -117,8 +117,15 @@ internal class UiConfigProvider(
         scope.cancel()
     }
 
-    private suspend fun resolve(): UiConfig? =
-        manager.mergeItemsBlobData<UiConfig>(RemoteConfigTopic.UiConfig, ITEM_KEYS)
+    private suspend fun resolve(): UiConfig? {
+        if (manager.isDisabled) return null
+        // topic() waits for or primes the initial config sync on a cold cache. Once that authoritative topic is
+        // available, an absent topic or one with none of the ui_config parts means the project has no ui_config;
+        // avoid asking the generic all-or-nothing merger to resolve four known-missing blobs and warning about it.
+        val topic = manager.topic(RemoteConfigTopic.UiConfig)
+        if (topic == null || ITEM_KEYS.none(topic::containsKey)) return null
+        return manager.mergeItemsBlobData<UiConfig>(RemoteConfigTopic.UiConfig, ITEM_KEYS)
+    }
 
     /**
      * Tells "there is nothing to resolve" apart from "resolving what is published failed". Only ever called

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
@@ -122,7 +122,10 @@ internal class UiConfigProvider(
         // topic() waits for or primes the initial config sync on a cold cache. Once that authoritative topic is
         // available, an absent topic or one with none of the ui_config parts means the project has no ui_config;
         // avoid asking the generic all-or-nothing merger to resolve four known-missing blobs and warning about it.
-        val topic = manager.topic(RemoteConfigTopic.UiConfig)
+        var topic = manager.topic(RemoteConfigTopic.UiConfig)
+        if (topic != null && ITEM_KEYS.none(topic::containsKey)) {
+            topic = manager.committedTopicAfterInFlightRefresh(RemoteConfigTopic.UiConfig)
+        }
         return if (topic == null || ITEM_KEYS.none(topic::containsKey)) {
             null
         } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
@@ -123,8 +123,11 @@ internal class UiConfigProvider(
         // available, an absent topic or one with none of the ui_config parts means the project has no ui_config;
         // avoid asking the generic all-or-nothing merger to resolve four known-missing blobs and warning about it.
         val topic = manager.topic(RemoteConfigTopic.UiConfig)
-        if (topic == null || ITEM_KEYS.none(topic::containsKey)) return null
-        return manager.mergeItemsBlobData<UiConfig>(RemoteConfigTopic.UiConfig, ITEM_KEYS)
+        return if (topic == null || ITEM_KEYS.none(topic::containsKey)) {
+            null
+        } else {
+            manager.mergeItemsBlobData<UiConfig>(RemoteConfigTopic.UiConfig, ITEM_KEYS)
+        }
     }
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
@@ -46,6 +46,7 @@ internal class UiConfigProviderTest {
         every { manager.configGeneration } returns 0
         // Defaults for the outcome classification a failed resolve now runs; per-test stubs override them.
         every { manager.isDisabled } returns false
+        coEvery { manager.topic(RemoteConfigTopic.UiConfig) } returns uiConfigTopic()
         coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns null
         currentLogHandler = object : LogHandler {
             override fun v(tag: String, msg: String) {}
@@ -206,23 +207,30 @@ internal class UiConfigProviderTest {
     fun `resolveUiConfig returns NotConfigured when the ui_config topic is absent`() = runTest {
         // A project with no paywalls configured publishes no ui_config topic at all. That is a valid state, not
         // a failure the caller should report as an error.
-        stubUnresolvableMergedRead()
+        coEvery { manager.topic(RemoteConfigTopic.UiConfig) } returns null
         coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns null
 
         assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.NotConfigured)
+        coVerify(exactly = 0) {
+            manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
+        }
     }
 
     @Test
     fun `resolveUiConfig returns NotConfigured when the committed topic carries no ui_config part`() = runTest {
-        stubUnresolvableMergedRead()
+        coEvery { manager.topic(RemoteConfigTopic.UiConfig) } returns ConfigTopic(emptyMap())
         coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns ConfigTopic(emptyMap())
 
         assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.NotConfigured)
 
         // Same for a topic that only carries items the ui_config merge doesn't read.
+        coEvery { manager.topic(RemoteConfigTopic.UiConfig) } returns uiConfigTopic("something_else")
         coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns uiConfigTopic("something_else")
 
         assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.NotConfigured)
+        coVerify(exactly = 0) {
+            manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
+        }
     }
 
     @Test
@@ -230,6 +238,7 @@ internal class UiConfigProviderTest {
         // The topic does carry ui_config parts, so failing to assemble them into a UiConfig is a real failure —
         // including a partially published topic, since the merge is all-or-nothing.
         stubUnresolvableMergedRead()
+        coEvery { manager.topic(RemoteConfigTopic.UiConfig) } returns uiConfigTopic("app")
         coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns uiConfigTopic("app")
 
         assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.Unavailable)
@@ -243,18 +252,20 @@ internal class UiConfigProviderTest {
         every { manager.isDisabled } returns true
 
         assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.Disabled)
+        coVerify(exactly = 0) { manager.topic(any()) }
         coVerify(exactly = 0) { manager.committedTopicOrNull(any()) }
     }
 
     @Test
-    fun `resolveUiConfig classifies only after attempting the resolve`() = runTest {
-        // A resolve on a cold cache waits for (or triggers) a /v1/config sync, so the committed topic must only
-        // be inspected afterwards; checking first would report NotConfigured for a project that has a ui_config.
+    fun `resolveUiConfig primes the topic before attempting the resolve and classifies afterwards`() = runTest {
+        // topic() waits for (or triggers) a /v1/config sync on a cold cache. Only after it confirms that ui_config
+        // parts are published should the provider attempt the all-or-nothing merge and classify a failure.
         stubUnresolvableMergedRead()
 
         provider.resolveUiConfig()
 
         coVerifyOrder {
+            manager.topic(RemoteConfigTopic.UiConfig)
             manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
             manager.committedTopicOrNull(RemoteConfigTopic.UiConfig)
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
@@ -48,6 +48,7 @@ internal class UiConfigProviderTest {
         every { manager.isDisabled } returns false
         coEvery { manager.topic(RemoteConfigTopic.UiConfig) } returns uiConfigTopic()
         coEvery { manager.committedTopicOrNull(RemoteConfigTopic.UiConfig) } returns null
+        coEvery { manager.committedTopicAfterInFlightRefresh(RemoteConfigTopic.UiConfig) } returns null
         currentLogHandler = object : LogHandler {
             override fun v(tag: String, msg: String) {}
             override fun d(tag: String, msg: String) {}
@@ -229,6 +230,22 @@ internal class UiConfigProviderTest {
 
         assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.NotConfigured)
         coVerify(exactly = 0) {
+            manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
+        }
+    }
+
+    @Test
+    fun `resolveUiConfig uses ui_config parts committed by an in-flight refresh`() = runTest {
+        coEvery { manager.topic(RemoteConfigTopic.UiConfig) } returns ConfigTopic(emptyMap())
+        coEvery {
+            manager.committedTopicAfterInFlightRefresh(RemoteConfigTopic.UiConfig)
+        } returns uiConfigTopic()
+        stubMergedRead(minimalUiConfigJson())
+
+        assertThat(provider.resolveUiConfig()).isInstanceOf(UiConfigResolution.Found::class.java)
+        coVerifyOrder {
+            manager.topic(RemoteConfigTopic.UiConfig)
+            manager.committedTopicAfterInFlightRefresh(RemoteConfigTopic.UiConfig)
             manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -380,13 +380,11 @@ class WorkflowsConfigIntegrationTest {
         }
 
     @Test
-    fun `repeated onPaywallConfigReady for a project with no paywalls issues a single config request`() =
+    fun `cold onPaywallConfigReady completes an empty config fetch without blob warnings or downloads`() =
         runTest(testDispatcher) {
             // A project with no paywalls configured still gets both paywall topics, committed with no items, so
-            // every ui_config part misses. Each of those misses used to self-prime its own sync, since a
-            // successful sync clears the attempt cooldown — one (or more) config request per getOfferings.
-            sync(NO_PAYWALLS_CONFIG)
-
+            // readiness should self-prime one config request, then treat the empty ui_config as not configured.
+            assertThat(persistedState).isNull()
             val workflowManager = workflowManagerWithRealUiConfig()
             val warningLogs = mutableListOf<String>()
             val previousLogHandler = currentLogHandler
@@ -400,10 +398,22 @@ class WorkflowsConfigIntegrationTest {
                     }
                     override fun e(tag: String, msg: String, throwable: Throwable?) = Unit
                 }
-                repeat(3) {
-                    var completed = false
-                    workflowManager.onPaywallConfigReady { completed = true }
-                    assertThat(completed).isTrue()
+
+                var completed = false
+                workflowManager.onPaywallConfigReady { completed = true }
+
+                assertThat(completed).isFalse()
+                verify(exactly = 1) {
+                    backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any())
+                }
+
+                onSuccess.invoke(containerWith(NO_PAYWALLS_CONFIG), Date(), VerificationResult.VERIFIED)
+
+                assertThat(completed).isTrue()
+                repeat(2) {
+                    var warmCompleted = false
+                    workflowManager.onPaywallConfigReady { warmCompleted = true }
+                    assertThat(warmCompleted).isTrue()
                 }
             } finally {
                 currentLogHandler = previousLogHandler

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -425,6 +425,72 @@ class WorkflowsConfigIntegrationTest {
         }
 
     @Test
+    fun `onPaywallConfigReady awaits an in-flight refresh when the cached ui_config topic is empty`() =
+        runTest(testDispatcher) {
+            sync(NO_PAYWALLS_CONFIG)
+            val uiConfigProvider = UiConfigProvider(manager, scope = testScope)
+            val workflowManager = WorkflowManager(
+                workflowsConfigProvider = provider,
+                uiConfigProvider = uiConfigProvider,
+                workflowAssetPrewarmer = mockk(relaxed = true),
+                scope = testScope,
+            )
+
+            manager.refreshRemoteConfig(
+                appInBackground = false,
+                appUserID = "user-1",
+                fetchContext = RemoteConfigFetchContext.Foreground,
+            )
+            var completed = false
+            workflowManager.onPaywallConfigReady { completed = true }
+
+            assertThat(completed).isFalse()
+
+            val app = """{"colors":{},"fonts":{}}"""
+            val localizations = "{}"
+            val variableConfig = """{"variable_compatibility_map":{},"function_compatibility_map":{}}"""
+            val customVariables = "{}"
+            val appRef = refOf(app.toByteArray())
+            val localizationsRef = refOf(localizations.toByteArray())
+            val variableConfigRef = refOf(variableConfig.toByteArray())
+            val customVariablesRef = refOf(customVariables.toByteArray())
+            val config = """
+                {
+                  "domain": "app",
+                  "manifest": "v1.ui_config:etag2",
+                  "active_topics": ["workflows", "ui_config"],
+                  "topics": {
+                    "workflows": {},
+                    "ui_config": {
+                      "app": { "blob_ref": "$appRef" },
+                      "localizations": { "blob_ref": "$localizationsRef" },
+                      "variable_config": { "blob_ref": "$variableConfigRef" },
+                      "custom_variables": { "blob_ref": "$customVariablesRef" }
+                    }
+                  }
+                }
+            """.trimIndent()
+            onSuccess.invoke(
+                containerWith(
+                    config,
+                    appRef to app,
+                    localizationsRef to localizations,
+                    variableConfigRef to variableConfig,
+                    customVariablesRef to customVariables,
+                ),
+                Date(),
+                VerificationResult.VERIFIED,
+            )
+
+            assertThat(completed).isTrue()
+            assertThat(uiConfigProvider.isWarm()).isTrue()
+            verify(exactly = 2) {
+                backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any())
+            }
+            assertThat(downloadCount).isZero()
+        }
+
+    @Test
     fun `a paywall published later is picked up on the next commit`() = runTest(testDispatcher) {
         // The flip side of gating read priming: a project that had no paywalls must still converge on one
         // published later. That happens on the next ordinary (stale-driven) sync, not on every getOfferings.

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -5,12 +5,14 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.emptyUiConfig
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCElement
 import com.revenuecat.purchases.common.remoteconfig.PersistedRemoteConfigurationState
@@ -386,14 +388,30 @@ class WorkflowsConfigIntegrationTest {
             sync(NO_PAYWALLS_CONFIG)
 
             val workflowManager = workflowManagerWithRealUiConfig()
-            repeat(3) {
-                var completed = false
-                workflowManager.onPaywallConfigReady { completed = true }
-                assertThat(completed).isTrue()
+            val warningLogs = mutableListOf<String>()
+            val previousLogHandler = currentLogHandler
+            try {
+                currentLogHandler = object : LogHandler {
+                    override fun v(tag: String, msg: String) = Unit
+                    override fun d(tag: String, msg: String) = Unit
+                    override fun i(tag: String, msg: String) = Unit
+                    override fun w(tag: String, msg: String) {
+                        warningLogs += msg
+                    }
+                    override fun e(tag: String, msg: String, throwable: Throwable?) = Unit
+                }
+                repeat(3) {
+                    var completed = false
+                    workflowManager.onPaywallConfigReady { completed = true }
+                    assertThat(completed).isTrue()
+                }
+            } finally {
+                currentLogHandler = previousLogHandler
             }
 
             verify(exactly = 1) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
             assertThat(downloadCount).isZero()
+            assertThat(warningLogs).noneMatch { it.contains("Could not resolve remote config blob(s)") }
         }
 
     @Test


### PR DESCRIPTION
## Description
As reported on [a community post](https://community.revenuecat.com/sdks-51/kmp-sdk-warning-could-not-resolve-remote-config-blob-s-for-4-of-4-requested-item-s-in-topic-ui-config-7785), for apps without a published `ui_config` blobs (any app without any paywalls). The `UiConfigProvider` attempts to merge the (4) independently fetched blobs in order to construct a `UIConfig` object.

Merging these fails if any of the 4 blobs are absent (which makes sense). However when a `UIConfig` genuinely isn't available for an app, we should not be logging this as a failure of individual blobs failing to load when merging. But rather just treat this as the `UIConfig` not being available. 

In this case the following was logged every time
```
WARN: Could not resolve remote config blob(s) for 4 of 4 requested item(s) in topic 'ui_config': [app, localizations, variable_config, custom_variables]. Returning null
```

## Changes
We'll now check whether we have any of the (currently 4) available parts (blobs) for the `UIConfig`. If not, we'll consider the `UIConfig` as unavailable, rather than attempting to merge and construct a `UIConfig` object, which would fail and trigger the log. This should be in line with the reasoning of https://github.com/RevenueCat/purchases-android/pull/3894

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to ui_config resolution and logging for projects without paywalls; remote config merge and auth paths are untouched.
> 
> **Overview**
> Fixes noisy **WARN** logs for apps with **no paywalls**, where `UiConfigProvider` used to call the all-or-nothing `mergeItemsBlobData` path even when none of the four `ui_config` parts were published—surfacing *Could not resolve remote config blob(s) for 4 of 4…* on every read.
> 
> **`UiConfigProvider.resolve()`** now primes config via `topic()`, checks whether any of `app`, `localizations`, `variable_config`, or `custom_variables` exist, and returns `null` (treated as **not configured**) without merging when none are present. If the committed topic is empty but a refresh is already in flight, it re-reads via **`committedTopicAfterInFlightRefresh`** so paywall readiness does not treat stale empty cache as final while AppStart is still fetching.
> 
> **`RemoteConfigManager`** adds that helper: await the in-flight refresh without starting a new one, then return the latest committed topic.
> 
> Tests cover no-merge on absent/empty topics, in-flight refresh picking up newly committed parts, and cold `onPaywallConfigReady` completing without blob warnings or extra downloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ae109830867438c13af9307670267a3c909e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->