### PR TITLE
fix: only log unfetched products once

### DIFF
--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
@@ -156,6 +156,7 @@ internal class GalaxyBillingWrapper(
     override fun queryProductDetailsAsync(
         productType: ProductType,
         productIds: Set<String>,
+        logUnfetchedProducts: Boolean,
         onReceive: StoreProductsCallback,
         onError: PurchasesErrorCallback,
     ) {
@@ -167,6 +168,7 @@ internal class GalaxyBillingWrapper(
             productDataHandler.getProductDetails(
                 productIds = productIds,
                 productType = productType,
+                logUnfetchedProducts = logUnfetchedProducts,
                 onReceive = {
                     onReceive(it)
                     finish()

--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/handler/ProductDataHandler.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/handler/ProductDataHandler.kt
@@ -36,6 +36,7 @@ internal class ProductDataHandler(
     private data class Request(
         val productIds: Set<String>,
         val productType: ProductType,
+        val logUnfetchedProducts: Boolean,
         val onReceive: StoreProductsCallback,
         val onError: PurchasesErrorCallback,
     )
@@ -44,6 +45,7 @@ internal class ProductDataHandler(
     override fun getProductDetails(
         productIds: Set<String>,
         productType: ProductType,
+        logUnfetchedProducts: Boolean,
         onReceive: (List<StoreProduct>) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -70,6 +72,7 @@ internal class ProductDataHandler(
         this.inFlightRequest = Request(
             productIds = productIds,
             productType = productType,
+            logUnfetchedProducts = logUnfetchedProducts,
             onReceive = onReceive,
             onError = onError,
         )
@@ -102,10 +105,12 @@ internal class ProductDataHandler(
         products: List<ProductVo?>,
     ) {
         val nonNullProducts = products.mapNotNull { it }
-        logMissingProductIdsIfAny(
-            requestedProductIds = inFlightRequest?.productIds,
-            products = nonNullProducts,
-        )
+        inFlightRequest?.takeIf { it.logUnfetchedProducts }?.let { request ->
+            logMissingProductIdsIfAny(
+                requestedProductIds = request.productIds,
+                products = nonNullProducts,
+            )
+        }
 
         val subscriptionProducts = nonNullProducts.filter {
             it.type.createRevenueCatProductTypeFromSamsungIAPTypeString() == ProductType.SUBS

--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/listener/ProductDataResponseListener.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/listener/ProductDataResponseListener.kt
@@ -18,6 +18,7 @@ internal interface ProductDataResponseListener : OnGetProductsDetailsListener {
     fun getProductDetails(
         productIds: Set<String>,
         productType: ProductType,
+        logUnfetchedProducts: Boolean,
         onReceive: (List<StoreProduct>) -> Unit,
         onError: (PurchasesError) -> Unit,
     )

--- a/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/GalaxyBillingWrapperTest.kt
+++ b/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/GalaxyBillingWrapperTest.kt
@@ -171,9 +171,10 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
         )
 
         verify(exactly = 1) {
-            productDataHandler.getProductDetails(
+                productDataHandler.getProductDetails(
                 productIds = capture(idsSlot),
                 productType = capture(typeSlot),
+                logUnfetchedProducts = any(),
                 onReceive = capture(onReceiveSlot),
                 onError = capture(onErrorSlot),
             )
@@ -202,7 +203,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
             onError = { fail("should be ignored") },
         )
 
-        verify(exactly = 0) { productDataHandler.getProductDetails(any(), any(), any(), any()) }
+        verify(exactly = 0) { productDataHandler.getProductDetails(any(), any(), any(), any(), any()) }
     }
 
     @OptIn(GalaxySerialOperation::class)

--- a/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/handler/ProductDataHandlerTest.kt
+++ b/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/handler/ProductDataHandlerTest.kt
@@ -10,10 +10,8 @@ import com.revenuecat.purchases.galaxy.GalaxyStoreTest
 import com.revenuecat.purchases.galaxy.IAPHelperProvider
 import com.revenuecat.purchases.galaxy.constants.GalaxyErrorCode
 import com.revenuecat.purchases.galaxy.listener.PromotionEligibilityResponseListener
-import com.revenuecat.purchases.galaxy.logging.LogIntent
 import com.revenuecat.purchases.galaxy.logging.currentLogHandler
 import com.revenuecat.purchases.galaxy.utils.GalaxySerialOperation
-import com.revenuecat.purchases.galaxy.GalaxyStrings
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.models.StoreProduct
@@ -54,6 +52,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = emptySet(),
             productType = ProductType.INAPP,
+            logUnfetchedProducts = true,
             onReceive = { receivedProducts = it },
             onError = unexpectedOnError,
         )
@@ -71,6 +70,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = productIds,
             productType = ProductType.INAPP,
+            logUnfetchedProducts = true,
             onReceive = unexpectedOnReceive,
             onError = unexpectedOnError,
         )
@@ -78,6 +78,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = setOf("second"),
             productType = ProductType.SUBS,
+            logUnfetchedProducts = true,
             onReceive = unexpectedOnReceive,
             onError = { receivedError = it },
         )
@@ -106,6 +107,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = productIds,
             productType = ProductType.SUBS,
+            logUnfetchedProducts = true,
             onReceive = { receivedProducts = it },
             onError = unexpectedOnError,
         )
@@ -135,6 +137,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = productIds,
             productType = ProductType.SUBS,
+            logUnfetchedProducts = true,
             onReceive = unexpectedOnReceive,
             onError = unexpectedOnError,
         )
@@ -170,6 +173,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = setOf("iap", "sub"),
             productType = ProductType.INAPP,
+            logUnfetchedProducts = true,
             onReceive = { receivedProducts = it },
             onError = unexpectedOnError,
         )
@@ -206,6 +210,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = setOf("iap"),
             productType = ProductType.INAPP,
+            logUnfetchedProducts = true,
             onReceive = { receivedProducts = it },
             onError = unexpectedOnError,
         )
@@ -234,6 +239,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = setOf("iap"),
             productType = ProductType.INAPP,
+            logUnfetchedProducts = true,
             onReceive = { receivedProducts = it },
             onError = unexpectedOnError,
         )
@@ -263,6 +269,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = productIds,
             productType = ProductType.INAPP,
+            logUnfetchedProducts = true,
             onReceive = { receivedProducts = it },
             onError = unexpectedOnError,
         )
@@ -287,6 +294,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = setOf("iap"),
             productType = ProductType.INAPP,
+            logUnfetchedProducts = true,
             onReceive = unexpectedOnReceive,
             onError = { receivedError = it },
         )
@@ -304,6 +312,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = setOf("next"),
             productType = ProductType.INAPP,
+            logUnfetchedProducts = true,
             onReceive = unexpectedOnReceive,
             onError = unexpectedOnError,
         )
@@ -324,6 +333,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = setOf("iap"),
             productType = ProductType.INAPP,
+            logUnfetchedProducts = true,
             onReceive = unexpectedOnReceive,
             onError = { receivedError = it },
         )
@@ -360,6 +370,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = setOf("subscription"),
             productType = ProductType.SUBS,
+            logUnfetchedProducts = true,
             onReceive = unexpectedOnReceive,
             onError = { receivedError = it },
         )
@@ -384,6 +395,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         productDataHandler.getProductDetails(
             productIds = setOf("next"),
             productType = ProductType.INAPP,
+            logUnfetchedProducts = true,
             onReceive = unexpectedOnReceive,
             onError = unexpectedOnError,
         )
@@ -414,6 +426,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
             productDataHandler.getProductDetails(
                 productIds = setOf("iap", "missing"),
                 productType = ProductType.INAPP,
+                logUnfetchedProducts = true,
                 onReceive = { },
                 onError = unexpectedOnError,
             )
@@ -430,11 +443,9 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
             Config.logLevel = previousLogLevel
         }
 
-        val expectedMessage = "${LogIntent.GALAXY_WARNING.emojiList.joinToString("")} " +
-            GalaxyStrings.GET_PRODUCT_DETAILS_RESPONSE_MISSING_PRODUCTS.format(
-                "iap, missing",
-                "missing",
-            )
+        val expectedMessage =
+            "✨‼️ The Galaxy Store returned product details for only some of the requested product IDs. " +
+                "Requested: iap, missing. Missing: missing"
         assertThat(loggedMessages).contains(expectedMessage)
     }
 
@@ -462,6 +473,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
             productDataHandler.getProductDetails(
                 productIds = setOf("iap", "sub"),
                 productType = ProductType.INAPP,
+                logUnfetchedProducts = true,
                 onReceive = { },
                 onError = unexpectedOnError,
             )
@@ -481,6 +493,52 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
             Config.logLevel = previousLogLevel
         }
 
-        assertThat(loggedMessages).noneMatch { it.contains("returned product details for only") }
+        val expectedMessage =
+            "✨‼️ The Galaxy Store returned product details for only some of the requested product IDs. " +
+                "Requested: iap, sub. Missing: sub"
+        assertThat(loggedMessages).doesNotContain(expectedMessage)
+    }
+
+    @OptIn(GalaxySerialOperation::class, InternalRevenueCatAPI::class)
+    @Test
+    fun `missing products are not logged when logging is disabled`() {
+        val capturedListener = slot<OnGetProductsDetailsListener>()
+        every { iapHelperProvider.getProductsDetails(any(), capture(capturedListener)) } returns Unit
+        val previousLogHandler = currentLogHandler
+        val previousLogLevel = Config.logLevel
+        val loggedMessages = mutableListOf<String>()
+        currentLogHandler = object : LogHandler {
+            override fun v(tag: String, msg: String) = Unit
+            override fun d(tag: String, msg: String) = Unit
+            override fun i(tag: String, msg: String) = Unit
+            override fun w(tag: String, msg: String) { loggedMessages.add(msg) }
+            override fun e(tag: String, msg: String, throwable: Throwable?) = Unit
+        }
+        Config.logLevel = LogLevel.VERBOSE
+
+        try {
+            productDataHandler.getProductDetails(
+                productIds = setOf("iap", "missing"),
+                productType = ProductType.INAPP,
+                logUnfetchedProducts = false,
+                onReceive = {},
+                onError = unexpectedOnError,
+            )
+            val successErrorVo = mockk<ErrorVo> {
+                every { errorCode } returns GalaxyErrorCode.IAP_ERROR_NONE.code
+            }
+            capturedListener.captured.onGetProducts(
+                successErrorVo,
+                arrayListOf(createProductVo(itemId = "iap", type = "item")),
+            )
+        } finally {
+            currentLogHandler = previousLogHandler
+            Config.logLevel = previousLogLevel
+        }
+
+        val expectedMessage =
+            "✨‼️ The Galaxy Store returned product details for only some of the requested product IDs. " +
+                "Requested: iap, missing. Missing: missing"
+        assertThat(loggedMessages).doesNotContain(expectedMessage)
     }
 }

--- a/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/handler/ProductDataHandlerTest.kt
+++ b/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/handler/ProductDataHandlerTest.kt
@@ -493,10 +493,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
             Config.logLevel = previousLogLevel
         }
 
-        val expectedMessage =
-            "✨‼️ The Galaxy Store returned product details for only some of the requested product IDs. " +
-                "Requested: iap, sub. Missing: sub"
-        assertThat(loggedMessages).doesNotContain(expectedMessage)
+        assertThat(loggedMessages).isEmpty()
     }
 
     @OptIn(GalaxySerialOperation::class, InternalRevenueCatAPI::class)

--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/helpers/BillingAbstractMockHelper.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/helpers/BillingAbstractMockHelper.kt
@@ -18,6 +18,7 @@ internal fun BillingAbstract.mockQueryProductDetails(
             queryProductDetailsAsync(
                 productType = ProductType.SUBS,
                 productIds = any(),
+                logUnfetchedProducts = any(),
                 onReceive = capture(subsReceiveCallbackSlot),
                 onError = any(),
             )
@@ -30,8 +31,9 @@ internal fun BillingAbstract.mockQueryProductDetails(
             queryProductDetailsAsync(
                 productType = ProductType.INAPP,
                 productIds = any(),
-                capture(inappReceiveCallbackSlot),
-                any(),
+                logUnfetchedProducts = any(),
+                onReceive = capture(inappReceiveCallbackSlot),
+                onError = any(),
             )
         } answers {
             inappReceiveCallbackSlot.captured.invoke(queryProductDetailsInAppReturn)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -1437,9 +1437,11 @@ internal class PurchasesOrchestrator(
         val type = typesRemaining.firstOrNull()?.also { typesRemaining.remove(it) }
 
         type?.let {
+            val isFinalQuery = typesRemaining.isEmpty()
             billing.queryProductDetailsAsync(
                 productType = it,
                 productIds = productIds,
+                logUnfetchedProducts = isFinalQuery,
                 onReceive = { storeProducts ->
                     dispatch {
                         getProductsOfTypes(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -1438,7 +1438,7 @@ internal class PurchasesOrchestrator(
         val typesRemaining = types.toMutableSet()
         val type = typesRemaining.firstOrNull()?.also { typesRemaining.remove(it) }
 
-        type?.let { productType ->
+        type?.takeIf { productIds.isNotEmpty() }?.let { productType ->
             val isFinalQuery = typesRemaining.isEmpty()
             billing.queryProductDetailsAsync(
                 productType = productType,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -1428,24 +1428,26 @@ internal class PurchasesOrchestrator(
         startTime: Date? = null,
         callback: GetStoreProductsCallback,
     ) {
+        val collectedProductIds = collectedStoreProducts.map { it.purchasingData.productId }
+        val requestedProductIds = productIds + collectedProductIds
         val nonNullStartTime = startTime ?: run {
-            trackGetProductsStarted(productIds)
+            trackGetProductsStarted(requestedProductIds)
             dateProvider.now
         }
 
         val typesRemaining = types.toMutableSet()
         val type = typesRemaining.firstOrNull()?.also { typesRemaining.remove(it) }
 
-        type?.let {
+        type?.let { productType ->
             val isFinalQuery = typesRemaining.isEmpty()
             billing.queryProductDetailsAsync(
-                productType = it,
+                productType = productType,
                 productIds = productIds,
                 logUnfetchedProducts = isFinalQuery,
                 onReceive = { storeProducts ->
                     dispatch {
                         getProductsOfTypes(
-                            productIds,
+                            productIds - storeProducts.map { it.purchasingData.productId }.toSet(),
                             typesRemaining,
                             collectedStoreProducts + storeProducts,
                             nonNullStartTime,
@@ -1455,14 +1457,13 @@ internal class PurchasesOrchestrator(
                 },
                 onError = {
                     dispatch {
-                        trackGetProductsResult(nonNullStartTime, productIds, productIds, it)
+                        trackGetProductsResult(nonNullStartTime, requestedProductIds, productIds, it)
                         callback.onError(it)
                     }
                 },
             )
         } ?: run {
-            val notFoundProductIds = productIds - collectedStoreProducts.map { it.id }.toSet()
-            trackGetProductsResult(nonNullStartTime, productIds, notFoundProductIds, null)
+            trackGetProductsResult(nonNullStartTime, requestedProductIds, productIds, null)
             callback.onReceived(collectedStoreProducts)
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -180,6 +180,7 @@ internal class AmazonBilling(
     override fun queryProductDetailsAsync(
         productType: RevenueCatProductType,
         productIds: Set<String>,
+        logUnfetchedProducts: Boolean,
         onReceive: StoreProductsCallback,
         onError: PurchasesErrorCallback,
     ) {
@@ -192,6 +193,7 @@ internal class AmazonBilling(
                         productDataHandler.getProductData(
                             productIds,
                             userData.marketplace,
+                            logUnfetchedProducts,
                             {
                                 trackAmazonQueryProductDetailsRequestIfNeeded(
                                     wasSuccessful = true,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
@@ -31,6 +31,7 @@ internal class ProductDataHandler(
     private data class Request(
         val skuList: List<String>,
         val marketplace: String,
+        val logUnfetchedProducts: Boolean,
         val onReceive: StoreProductsCallback,
         val onError: PurchasesErrorCallback,
     )
@@ -44,6 +45,7 @@ internal class ProductDataHandler(
     override fun getProductData(
         skus: Set<String>,
         marketplace: String,
+        logUnfetchedProducts: Boolean,
         onReceive: (List<StoreProduct>) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -55,7 +57,7 @@ internal class ProductDataHandler(
                 handleSuccessfulProductDataResponse(cachedProducts, marketplace, onReceive)
             } else {
                 val productDataRequestId = purchasingServiceProvider.getProductData(skus)
-                val request = Request(skus.toList(), marketplace, onReceive, onError)
+                val request = Request(skus.toList(), marketplace, logUnfetchedProducts, onReceive, onError)
                 synchronized(this) {
                     productDataRequests[productDataRequestId] = request
                     addTimeoutToProductDataRequest(productDataRequestId)
@@ -69,12 +71,12 @@ internal class ProductDataHandler(
         try {
             log(LogIntent.DEBUG) { AmazonStrings.PRODUCTS_REQUEST_FINISHED.format(response.requestStatus.name) }
 
-            if (response.unavailableSkus.isNotEmpty()) {
-                log(LogIntent.DEBUG) { AmazonStrings.PRODUCTS_REQUEST_UNAVAILABLE.format(response.unavailableSkus) }
-            }
-
             val requestId = response.requestId
             val request = getRequest(requestId) ?: return
+
+            if (request.logUnfetchedProducts && response.unavailableSkus.isNotEmpty()) {
+                log(LogIntent.DEBUG) { AmazonStrings.PRODUCTS_REQUEST_UNAVAILABLE.format(response.unavailableSkus) }
+            }
 
             val responseIsSuccessful = response.requestStatus == ProductDataResponse.RequestStatus.SUCCESSFUL
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/listener/ProductDataResponseListener.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/listener/ProductDataResponseListener.kt
@@ -23,6 +23,7 @@ internal interface ProductDataResponseListener : PurchasingListener {
     fun getProductData(
         skus: Set<String>,
         marketplace: String,
+        logUnfetchedProducts: Boolean,
         onReceive: (List<StoreProduct>) -> Unit,
         onError: (PurchasesError) -> Unit,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -61,6 +61,7 @@ public abstract class BillingAbstract(
     public abstract fun queryProductDetailsAsync(
         productType: ProductType,
         productIds: Set<String>,
+        logUnfetchedProducts: Boolean = true,
         onReceive: StoreProductsCallback,
         onError: PurchasesErrorCallback,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
@@ -150,6 +150,9 @@ internal class OfferingsFactory(
         billing.queryProductDetailsAsync(
             productType = ProductType.SUBS,
             productIds = productIds,
+            // A product missing from the SUBS query may be an INAPP product, so defer logging
+            // unfetched products until we've checked for INAPP products as well
+            logUnfetchedProducts = false,
             onReceive = { subscriptionProducts ->
                 dispatcher.enqueue(command = {
                     val productsById = subscriptionProducts
@@ -162,6 +165,7 @@ internal class OfferingsFactory(
                         billing.queryProductDetailsAsync(
                             productType = ProductType.INAPP,
                             productIds = inAppProductIds,
+                            logUnfetchedProducts = true,
                             onReceive = { inAppProducts ->
                                 dispatcher.enqueue(command = {
                                     productsById.putAll(inAppProducts.map { it.purchasingData.productId to listOf(it) })

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -246,6 +246,7 @@ internal class BillingWrapper(
     override fun queryProductDetailsAsync(
         productType: ProductType,
         productIds: Set<String>,
+        logUnfetchedProducts: Boolean,
         onReceive: StoreProductsCallback,
         onError: PurchasesErrorCallback,
     ) {
@@ -257,6 +258,7 @@ internal class BillingWrapper(
                 productIds,
                 productType,
                 appInBackground,
+                logUnfetchedProducts,
             ),
             onReceive,
             onError,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCase.kt
@@ -34,6 +34,7 @@ constructor(
     val productIds: Set<String>,
     val productType: ProductType,
     override val appInBackground: Boolean,
+    val logUnfetchedProducts: Boolean = true,
 ) : UseCaseParams
 
 @OptIn(InternalRevenueCatAPI::class)
@@ -84,7 +85,7 @@ internal class QueryProductDetailsUseCase(
         log(LogIntent.PURCHASE) {
             OfferingStrings.RETRIEVED_PRODUCTS.format(received.productDetailsList.joinToString { it.toString() })
         }
-        received.unfetchedProductList.takeIf { it.isNotEmpty() }?.let {
+        received.unfetchedProductList.takeIf { useCaseParams.logUnfetchedProducts && it.isNotEmpty() }?.let {
             log(LogIntent.INFO) {
                 OfferingStrings.MISSING_PRODUCT_DETAILS.format(
                     received.unfetchedProductList.joinToString { it.toString() },
@@ -95,7 +96,7 @@ internal class QueryProductDetailsUseCase(
         received.productDetailsList.takeUnless { it.isEmpty() }?.forEach {
             log(LogIntent.PURCHASE) { OfferingStrings.LIST_PRODUCTS.format(it.productId, it) }
         }
-        received.unfetchedProductList.takeUnless { it.isEmpty() }?.forEach {
+        received.unfetchedProductList.takeIf { useCaseParams.logUnfetchedProducts && it.isNotEmpty() }?.forEach {
             log(LogIntent.INFO) {
                 OfferingStrings.LIST_UNFETCHED_PRODUCTS.format(
                     it.productId,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/simulatedstore/SimulatedStoreBillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/simulatedstore/SimulatedStoreBillingWrapper.kt
@@ -74,6 +74,7 @@ internal class SimulatedStoreBillingWrapper(
     override fun queryProductDetailsAsync(
         productType: ProductType,
         productIds: Set<String>,
+        logUnfetchedProducts: Boolean,
         onReceive: StoreProductsCallback,
         onError: PurchasesErrorCallback,
     ) {

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -423,6 +423,7 @@ internal open class BasePurchasesTest {
             mockBillingAbstract.queryProductDetailsAsync(
                 type,
                 productIds.toSet(),
+                any(),
                 captureLambda(),
                 any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -151,7 +151,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         val productIds = subProductIds + inappProductIds
 
         val subStoreProducts = mockStoreProduct(productIds, subProductIds, ProductType.SUBS)
-        val inappStoreProducts = mockStoreProduct(productIds, inappProductIds, ProductType.INAPP)
+        val inappStoreProducts = mockStoreProduct(inappProductIds, inappProductIds, ProductType.INAPP)
         val storeProducts = subStoreProducts + inappStoreProducts
 
         purchases.getProducts(productIds,
@@ -170,10 +170,12 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
-    fun `getProducts logs unfetched products only for the final product type query`() {
-        val productIds = listOf("product")
-        mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
-        mockStoreProduct(productIds, emptyList(), ProductType.INAPP)
+    fun `getProducts queries only remaining IDs and logs unfetched products for the final product type query`() {
+        val subscriptionProductId = "subscription"
+        val unfetchedProductId = "unfetched"
+        val productIds = listOf(subscriptionProductId, unfetchedProductId)
+        mockStoreProduct(productIds, listOf(subscriptionProductId), ProductType.SUBS)
+        mockStoreProduct(listOf(unfetchedProductId), emptyList(), ProductType.INAPP)
 
         purchases.getProducts(
             productIds,
@@ -193,10 +195,19 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             )
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.INAPP,
-                productIds.toSet(),
+                setOf(unfetchedProductId),
                 true,
                 any(),
                 any(),
+            )
+        }
+        verify(exactly = 1) {
+            mockDiagnosticsTracker.trackGetProductsResult(
+                requestedProductIds = productIds.toSet(),
+                notFoundProductIds = setOf(unfetchedProductId),
+                errorMessage = null,
+                errorCode = null,
+                responseTime = any(),
             )
         }
     }
@@ -483,7 +494,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         every {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.INAPP,
-                setOf(normalizedProductId, productIdWithoutBasePlan),
+                setOf(productIdWithoutBasePlan),
                 any(),
                 captureLambda(),
                 any(),
@@ -2399,6 +2410,54 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 errorMessage = null,
                 errorCode = null,
                 responseTime = 123.milliseconds
+            )
+        }
+    }
+
+    @Test
+    fun `getProducts tracks diagnostics with INAPP and SUBS queries`() {
+        val subscriptionProductId = "subscription"
+        val inAppProductId = "inapp"
+        val productIds = listOf(subscriptionProductId, inAppProductId)
+
+        every { mockDateProvider.now } returnsMany listOf(
+            Date(0),
+            Date(123),
+        )
+        mockStoreProduct(productIds, listOf(subscriptionProductId), ProductType.SUBS)
+        mockStoreProduct(listOf(inAppProductId), listOf(inAppProductId), ProductType.INAPP)
+
+        purchases.getProducts(
+            productIds,
+            object : GetStoreProductsCallback {
+                override fun onReceived(storeProducts: List<StoreProduct>) = Unit
+                override fun onError(error: PurchasesError) = fail("shouldn't be error")
+            },
+        )
+
+        verifyOrder {
+            mockBillingAbstract.queryProductDetailsAsync(
+                ProductType.SUBS,
+                productIds.toSet(),
+                false,
+                any(),
+                any(),
+            )
+            mockBillingAbstract.queryProductDetailsAsync(
+                ProductType.INAPP,
+                setOf(inAppProductId),
+                true,
+                any(),
+                any(),
+            )
+        }
+        verify(exactly = 1) {
+            mockDiagnosticsTracker.trackGetProductsResult(
+                requestedProductIds = productIds.toSet(),
+                notFoundProductIds = emptySet(),
+                errorMessage = null,
+                errorCode = null,
+                responseTime = 123.milliseconds,
             )
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -170,6 +170,63 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
+    fun `getProducts logs unfetched products only for the final product type query`() {
+        val productIds = listOf("product")
+        mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
+        mockStoreProduct(productIds, emptyList(), ProductType.INAPP)
+
+        purchases.getProducts(
+            productIds,
+            object : GetStoreProductsCallback {
+                override fun onReceived(storeProducts: List<StoreProduct>) = Unit
+                override fun onError(error: PurchasesError) = fail("shouldn't be error")
+            },
+        )
+
+        verifyOrder {
+            mockBillingAbstract.queryProductDetailsAsync(
+                ProductType.SUBS,
+                productIds.toSet(),
+                false,
+                any(),
+                any(),
+            )
+            mockBillingAbstract.queryProductDetailsAsync(
+                ProductType.INAPP,
+                productIds.toSet(),
+                true,
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `getProducts logs unfetched products for a single product type query`() {
+        val productIds = listOf("product")
+        mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
+
+        purchases.getProducts(
+            productIds,
+            ProductType.SUBS,
+            object : GetStoreProductsCallback {
+                override fun onReceived(storeProducts: List<StoreProduct>) = Unit
+                override fun onError(error: PurchasesError) = fail("shouldn't be error")
+            },
+        )
+
+        verify(exactly = 1) {
+            mockBillingAbstract.queryProductDetailsAsync(
+                ProductType.SUBS,
+                productIds.toSet(),
+                true,
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun getsSubscriptionProducts() {
         val subProductIds = listOf("onemonth_freetrial")
         val inappProductIds = listOf("normal_purchase")
@@ -263,6 +320,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.SUBS,
                 setOf(normalizedProductId),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -274,6 +332,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.INAPP,
                 setOf(normalizedProductId),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -341,6 +400,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.SUBS,
                 setOf(normalizedProductId),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -412,6 +472,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.SUBS,
                 setOf(normalizedProductId, productIdWithoutBasePlan),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -423,6 +484,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.INAPP,
                 setOf(normalizedProductId, productIdWithoutBasePlan),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -519,6 +581,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.SUBS,
                 setOf(normalizedProductId),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -530,6 +593,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.INAPP,
                 setOf(normalizedProductId),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -627,6 +691,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.SUBS,
                 setOf(normalizedProductId),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -638,6 +703,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.INAPP,
                 setOf(normalizedProductId),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -734,6 +800,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.SUBS,
                 setOf(normalizedProductId),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -745,6 +812,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 ProductType.INAPP,
                 setOf(normalizedProductId),
+                any(),
                 captureLambda(),
                 any(),
             )
@@ -2349,6 +2417,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = ProductType.SUBS,
                 productIds = productIds,
+                logUnfetchedProducts = any(),
                 onReceive = any(),
                 onError = captureLambda()
             )
@@ -3087,6 +3156,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = storeProduct.type,
                 productIds = setOf(productId),
+                logUnfetchedProducts = any(),
                 onReceive = captureLambda(),
                 onError = any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -213,6 +213,39 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
+    fun `getProducts does not query the next product type when all IDs were found`() {
+        val productIds = listOf("subscription")
+        mockStoreProduct(productIds, productIds, ProductType.SUBS)
+
+        purchases.getProducts(
+            productIds,
+            object : GetStoreProductsCallback {
+                override fun onReceived(storeProducts: List<StoreProduct>) = Unit
+                override fun onError(error: PurchasesError) = fail("shouldn't be error")
+            },
+        )
+
+        verify(exactly = 1) {
+            mockBillingAbstract.queryProductDetailsAsync(
+                ProductType.SUBS,
+                productIds.toSet(),
+                false,
+                any(),
+                any(),
+            )
+        }
+        verify(exactly = 0) {
+            mockBillingAbstract.queryProductDetailsAsync(
+                ProductType.INAPP,
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun `getProducts logs unfetched products for a single product type query`() {
         val productIds = listOf("product")
         mockStoreProduct(productIds, emptyList(), ProductType.SUBS)

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
@@ -174,7 +174,7 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = ProductType.SUBS,
                 productIds = productIds.toSet(),
-                logUnfetchedProducts = false,
+                logUnfetchedProducts = any(),
                 onReceive = captureLambda(),
                 onError = any(),
             )
@@ -184,8 +184,8 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
         every {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = ProductType.INAPP,
-                productIds = inAppIds.toSet(),
-                logUnfetchedProducts = true,
+                productIds = any(),
+                logUnfetchedProducts = any(),
                 onReceive = captureLambda(),
                 onError = any(),
             )
@@ -211,7 +211,7 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = ProductType.SUBS,
                 productIds = productIds.toSet(),
-                logUnfetchedProducts = false,
+                logUnfetchedProducts = any(),
                 onReceive = any(),
                 onError = captureLambda(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
@@ -174,6 +174,7 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = ProductType.SUBS,
                 productIds = productIds.toSet(),
+                logUnfetchedProducts = false,
                 onReceive = captureLambda(),
                 onError = any(),
             )
@@ -183,7 +184,8 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
         every {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = ProductType.INAPP,
-                productIds = productIds.toSet(),
+                productIds = inAppIds.toSet(),
+                logUnfetchedProducts = true,
                 onReceive = captureLambda(),
                 onError = any(),
             )
@@ -209,6 +211,7 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = ProductType.SUBS,
                 productIds = productIds.toSet(),
+                logUnfetchedProducts = false,
                 onReceive = any(),
                 onError = captureLambda(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -524,7 +524,7 @@ class AmazonBillingTest {
         val storeProducts = listOfNotNull(dummyAmazonProduct().toStoreProduct(countryCode))
 
         every {
-            mockProductDataHandler.getProductData(productIds, capture(marketplaceSlot), captureLambda(), any())
+            mockProductDataHandler.getProductData(productIds, capture(marketplaceSlot), any(), captureLambda(), any())
         } answers {
             lambda<(List<StoreProduct>) -> Unit>().captured.invoke(storeProducts)
         }
@@ -1200,7 +1200,7 @@ class AmazonBillingTest {
         val storeProducts = listOfNotNull(dummyAmazonProduct().toStoreProduct(countryCode))
 
         every {
-            mockProductDataHandler.getProductData(productIds, capture(marketplaceSlot), captureLambda(), any())
+            mockProductDataHandler.getProductData(productIds, capture(marketplaceSlot), any(), captureLambda(), any())
         } answers {
             lambda<(List<StoreProduct>) -> Unit>().captured.invoke(storeProducts)
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
@@ -7,12 +7,15 @@ import com.amazon.device.iap.model.Product
 import com.amazon.device.iap.model.ProductDataResponse
 import com.amazon.device.iap.model.RequestId
 import com.revenuecat.purchases.LogHandler
+import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.amazon.helpers.MockDeviceCache
 import com.revenuecat.purchases.amazon.helpers.PurchasingServiceProviderForTest
 import com.revenuecat.purchases.amazon.helpers.dummyAmazonProduct
+import com.revenuecat.purchases.common.Config
+import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.models.StoreProduct
 import io.mockk.every
 import io.mockk.mockk
@@ -66,6 +69,7 @@ class ProductDataHandlerTest {
         underTest.getProductData(
             expectedSkus,
             "US",
+            true,
             onReceive = {
                 receivedStoreProducts = it
             },
@@ -98,6 +102,7 @@ class ProductDataHandlerTest {
         underTest.getProductData(
             expectedProductData.keys,
             "US",
+            true,
             onReceive = {
                 receivedStoreProducts = it
             },
@@ -137,6 +142,7 @@ class ProductDataHandlerTest {
         underTest.getProductData(
             expectedProductData.keys,
             "US",
+            true,
             onReceive = {
                 receivedStoreProducts = it
             },
@@ -176,6 +182,7 @@ class ProductDataHandlerTest {
 //        underTest.getProductData(
 //            expectedProductData.keys,
 //            "US",
+//            true,
 //            onReceive = {
 //                receivedStoreProducts = it
 //            },
@@ -231,6 +238,7 @@ class ProductDataHandlerTest {
 //        underTest.getProductData(
 //            expectedProductData.keys,
 //            marketPlace,
+//            true,
 //            onReceive = {
 //                receivedStoreProducts = it
 //            },
@@ -265,6 +273,7 @@ class ProductDataHandlerTest {
         underTest.getProductData(
             expectedProductData.keys,
             "US",
+            true,
             unexpectedOnSuccess,
             onError = {
                 receivedError = it
@@ -301,6 +310,7 @@ class ProductDataHandlerTest {
         underTest.getProductData(
             expectedProductData.keys,
             marketPlace,
+            true,
             onReceive = {
                 receivedCount++
             },
@@ -353,6 +363,7 @@ class ProductDataHandlerTest {
         underTest.getProductData(
             expectedProductData.keys,
             marketPlace,
+            true,
             onReceive = { throw expectedException },
             unexpectedOnError
         )
@@ -382,6 +393,7 @@ class ProductDataHandlerTest {
         underTest.getProductData(
             setOf("sku_a", "sku_b"),
             "US",
+            true,
             unexpectedOnSuccess,
             unexpectedOnError
         )
@@ -403,6 +415,7 @@ class ProductDataHandlerTest {
         underTest.getProductData(
             expectedProductData.keys,
             "US",
+            true,
             unexpectedOnSuccess
         ) { resultError = it }
 
@@ -431,6 +444,7 @@ class ProductDataHandlerTest {
         underTest.getProductData(
             expectedProductData.keys,
             "US",
+            true,
             unexpectedOnSuccess
         ) { resultError = it }
 
@@ -460,6 +474,7 @@ class ProductDataHandlerTest {
         underTest.getProductData(
             expectedProductData.keys,
             "US",
+            true,
             { resultProducts = it },
             unexpectedOnError
         )
@@ -477,6 +492,56 @@ class ProductDataHandlerTest {
 
         assertThat(resultProducts).isNotNull
         assertThat(resultProducts?.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `logUnfetchedProducts works`() {
+        val previousLogHandler = currentLogHandler
+        val previousLogLevel = Config.logLevel
+        val loggedMessages = mutableListOf<String>()
+        currentLogHandler = object : LogHandler {
+            override fun v(tag: String, msg: String) = Unit
+            override fun d(tag: String, msg: String) { loggedMessages.add(msg) }
+            override fun i(tag: String, msg: String) = Unit
+            override fun w(tag: String, msg: String) = Unit
+            override fun e(tag: String, msg: String, throwable: Throwable?) = Unit
+        }
+        Config.logLevel = LogLevel.VERBOSE
+
+        try {
+            listOf(false, true).forEach { logUnfetchedProducts ->
+                val unavailableSku = "missing_sku"
+                val requestId = "request_$logUnfetchedProducts"
+                purchasingServiceProvider.getProductDataRequestId = requestId
+                val loggedMessagesBeforeRequest = loggedMessages.size
+
+                underTest.getProductData(
+                    skus = setOf(unavailableSku),
+                    marketplace = "US",
+                    logUnfetchedProducts = logUnfetchedProducts,
+                    onReceive = {},
+                    onError = unexpectedOnError,
+                )
+                underTest.onProductDataResponse(
+                    getDummyProductDataResponse(
+                        requestId = requestId,
+                        unavailableSkus = setOf(unavailableSku),
+                        productData = emptyMap(),
+                    ),
+                )
+
+                val requestLogs = loggedMessages.drop(loggedMessagesBeforeRequest)
+                val expectedLog = "ℹ️ Unavailable products: [missing_sku]"
+                if (logUnfetchedProducts) {
+                    assertThat(requestLogs).contains(expectedLog)
+                } else {
+                    assertThat(requestLogs).doesNotContain(expectedLog)
+                }
+            }
+        } finally {
+            currentLogHandler = previousLogHandler
+            Config.logLevel = previousLogLevel
+        }
     }
 
     private fun setupMainHandler() {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
@@ -768,6 +768,7 @@ class OfferingsFactoryTest {
             billing.queryProductDetailsAsync(
                 type,
                 productIds.toSet(),
+                any(),
                 captureLambda(),
                 any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1339,6 +1339,7 @@ class BillingWrapperTest {
         wrapper.queryProductDetailsAsync(
             ProductType.SUBS,
             setOf("product_a"),
+            true,
             {},
             {
                 fail("shouldn't be an error")

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCaseTest.kt
@@ -6,6 +6,9 @@ import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetailsResponseListener
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryProductDetailsResult
+import com.android.billingclient.api.UnfetchedProduct
+import com.revenuecat.purchases.LogHandler
+import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -14,6 +17,8 @@ import com.revenuecat.purchases.google.productId
 import com.revenuecat.purchases.google.productList
 import com.revenuecat.purchases.google.productType
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.common.Config as PurchasesConfig
+import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.utils.mockProductDetails
 import io.mockk.Runs
 import io.mockk.every
@@ -73,6 +78,64 @@ internal class QueryProductDetailsUseCaseTest : BaseBillingUseCaseTest() {
 
         assertThat(receivedList).isNotNull
         assertThat(receivedList!!.size).isZero
+    }
+
+    @Test
+    fun `logUnfetchedProducts works`() {
+        val unfetchedProduct = UnfetchedProduct.fromJson(
+            """{"productId":"missing_product","type":"subs","statusCode":3,"serializedDocid":""}""",
+        )
+        val result = QueryProductDetailsResult.create(emptyList(), listOf(unfetchedProduct))
+        val listener = slot<ProductDetailsResponseListener>()
+        every { mockClient.queryProductDetailsAsync(any(), capture(listener)) } answers {
+            listener.captured.onProductDetailsResponse(billingClientOKResult, result)
+        }
+
+        val previousLogHandler = currentLogHandler
+        val previousLogLevel = PurchasesConfig.logLevel
+        val loggedMessages = mutableListOf<String>()
+        currentLogHandler = object : LogHandler {
+            override fun v(tag: String, msg: String) = Unit
+            override fun d(tag: String, msg: String) = Unit
+            override fun i(tag: String, msg: String) { loggedMessages.add(msg) }
+            override fun w(tag: String, msg: String) = Unit
+            override fun e(tag: String, msg: String, throwable: Throwable?) = Unit
+        }
+        PurchasesConfig.logLevel = LogLevel.VERBOSE
+
+        try {
+            val expectedMissingProductDetailsLog =
+                "ℹ️ Missing productDetails: UnfetchedProduct{productId='missing_product', productType='subs', statusCode=3}"
+            val expectedUnfetchedProductLog =
+                "ℹ️ Product not found: missing_product - Product Type: subs, Reason: PRODUCT_NOT_FOUND, Serialized doc ID: "
+
+            listOf(false, true).forEach { logUnfetchedProducts ->
+                val loggedMessagesBeforeQuery = loggedMessages.size
+                wrapper.queryProductDetailsAsync(
+                    productType = ProductType.SUBS,
+                    productIds = setOf("missing_product"),
+                    logUnfetchedProducts = logUnfetchedProducts,
+                    onReceive = {},
+                    onError = { fail("shouldn't be an error") },
+                )
+
+                val queryLogs = loggedMessages.drop(loggedMessagesBeforeQuery)
+                if (logUnfetchedProducts) {
+                    assertThat(queryLogs).contains(
+                        expectedMissingProductDetailsLog,
+                        expectedUnfetchedProductLog,
+                    )
+                } else {
+                    assertThat(queryLogs).doesNotContain(
+                        expectedMissingProductDetailsLog,
+                        expectedUnfetchedProductLog,
+                    )
+                }
+            }
+        } finally {
+            currentLogHandler = previousLogHandler
+            PurchasesConfig.logLevel = previousLogLevel
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation
When fetching products, the SDK queries the stores twice: once for subscription products, and again for one-time purchases. The SDK logs warning messages when stores don't return all expected products. This is a good log to keep, but when querying for a one-time product, the SDK will log the "unfetched product" log when the subscription product query returns nothing, even when the one-time purchase query will be successful.

This creates confusion for humans/agents reading through the SDK logs, as the product isn't truly unfetched yet, it just hasn't been fetched yet.

### Description
This PR updates how the SDK generates "product not fetched" logs so that it only logs it once per product request. Since the logs contain store-specific information, they must be generated in each stores' `BillingWrapper` implementation. So, to accomodate this, we've added a `logUnfetchedProducts` param to `BillingAbstract.queryProductDetailsAsync()`, and `queryProductDetailsAsync()` consumers specify whether or not they'd like the unfetched logs to be generated.

### Testing
Added unit tests to confirm whether the `logUnfetchedProducts` param works as intended, and to check that the `queryProductDetailsAsync()` consumers are passing in the proper values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to logging timing and slightly more efficient product-type chaining; product fetch semantics and billing APIs stay the same aside from an optional parameter defaulting to true.
> 
> **Overview**
> Adds a **`logUnfetchedProducts`** flag through **`BillingAbstract.queryProductDetailsAsync()`** and each store billing wrapper (Google, Amazon, Galaxy, simulated). Store handlers only emit “missing/unfetched product” warnings when that flag is **true**, so multi-step fetches do not warn prematurely.
> 
> **`PurchasesOrchestrator.getProductsOfTypes`** now passes **`logUnfetchedProducts = false`** on intermediate product-type queries and **`true`** only on the last query in the chain. It also stops querying the next product type when there are no remaining IDs, and only queries INAPP for IDs not already returned from SUBS. Diagnostics **`notFound`** tracking uses the remaining requested ID set at completion instead of recomputing from collected products.
> 
> **`OfferingsFactory`** uses the same pattern: SUBS query with logging disabled, INAPP follow-up with logging enabled when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01df168afe204cd86a69ba9273d8f7e6360cb700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->