### PR TITLE
fix: don't share a MessageDigest across coroutines in FontLoader and DefaultFileCache

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/utils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/utils.kt
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Base64
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.models.toHexString
 import java.security.MessageDigest
 import java.util.Locale
 
@@ -34,6 +35,18 @@ public fun String.sha256(): String =
         .digest(this.toByteArray()).let {
             String(Base64.encode(it, Base64.NO_WRAP))
         }
+
+/**
+ * The MD5 of these bytes, as a lowercase hex string.
+ *
+ * This creates a new [MessageDigest] on every call, on purpose. [MessageDigest] is not thread-safe. A shared
+ * instance corrupts its internal state when two threads digest at the same time. It then either throws or
+ * returns a wrong digest, depending on the security provider.
+ */
+internal fun ByteArray.md5Hex(): String =
+    MessageDigest.getInstance("MD5")
+        .digest(this)
+        .toHexString()
 
 internal val Context.versionName: String?
     get() = this.packageManager.getPackageInfo(this.packageName, 0).versionName

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/FontLoader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/FontLoader.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.UiConfig.AppConfig.FontsConfig.FontInfo
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.md5Hex
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.paywalls.fonts.DownloadableFontInfo
@@ -18,7 +19,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.io.File
 import java.io.IOException
-import java.security.MessageDigest
 import java.util.concurrent.atomic.AtomicBoolean
 import com.revenuecat.purchases.utils.Result as RCResult
 
@@ -33,10 +33,6 @@ internal class FontLoader(
 
     private val cacheDirectory: File? by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
         providedCacheDir ?: context.cacheDir?.let { File(it, "rc_paywall_fonts") }
-    }
-
-    private val md: MessageDigest by lazy {
-        MessageDigest.getInstance("MD5")
     }
 
     private val fontInfosForHash = mutableMapOf<String, MutableSet<DownloadableFontInfo>>()
@@ -92,7 +88,7 @@ internal class FontLoader(
                 return@launch
             }
 
-            val urlHash = md5Hex(url.toByteArray(Charsets.UTF_8))
+            val urlHash = url.toByteArray(Charsets.UTF_8).md5Hex()
             val extension = url.substringAfterLast('.', missingDelimiterValue = "")
             val cachedFile = File(cacheDir, "$urlHash.$extension")
 
@@ -208,7 +204,7 @@ internal class FontLoader(
         try {
             urlConnectionFactory.downloadToFile(url, tempFile, description = "paywall font")
 
-            val actualMd5 = md5Hex(tempFile.readBytes())
+            val actualMd5 = tempFile.readBytes().md5Hex()
             if (!actualMd5.equals(expectedMd5, ignoreCase = true)) {
                 tempFile.delete()
                 errorLog { "Downloaded font file is corrupt for $url. expected=$expectedMd5, actual=$actualMd5" }
@@ -226,10 +222,5 @@ internal class FontLoader(
             errorLog { "Error downloading font from $url: ${e.message}" }
             return Result.failure(e)
         }
-    }
-
-    private fun md5Hex(bytes: ByteArray): String {
-        val digest = md.digest(bytes)
-        return digest.joinToString("") { "%02x".format(it) }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/storage/DefaultFileRepository.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/storage/DefaultFileRepository.kt
@@ -5,6 +5,7 @@ import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.common.currentLogHandler
+import com.revenuecat.purchases.common.md5Hex
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.models.Checksum
 import com.revenuecat.purchases.models.toHexString
@@ -204,10 +205,6 @@ internal class DefaultFileCache(
         private const val BUFFER_SIZE = 256 * 1024 // 256KB
     }
 
-    private val md: MessageDigest by lazy {
-        MessageDigest.getInstance("MD5")
-    }
-
     private val cacheDir: File by lazy {
         val dir = File(context.cacheDir, subDir)
         if (!dir.exists()) {
@@ -217,7 +214,7 @@ internal class DefaultFileCache(
     }
 
     override fun generateLocalFilesystemURI(remoteURL: URL, checksum: Checksum?): URI? {
-        val urlHash = md5Hex(remoteURL.toString().toByteArray())
+        val urlHash = remoteURL.toString().toByteArray().md5Hex()
         // Use checksum value as part of the file name (like iOS)
         val fileName = File(urlHash).name + (checksum?.value ?: "")
         if (fileName.isEmpty()) return null
@@ -268,9 +265,6 @@ internal class DefaultFileCache(
             tempFile.delete()
         }
     }
-
-    private fun md5Hex(bytes: ByteArray): String =
-        md.digest(bytes).joinToString("") { "%02x".format(it) }
 
     @Throws(IOException::class)
     private fun streamToFile(inputStream: InputStream, file: File) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HashUtilsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HashUtilsTest.kt
@@ -1,0 +1,71 @@
+package com.revenuecat.purchases.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class HashUtilsTest {
+
+    @Test
+    fun `md5Hex returns the expected lowercase hex digest`() {
+        assertThat("abc".toByteArray().md5Hex()).isEqualTo("900150983cd24fb0d6963f7d28e17f72")
+        assertThat(ByteArray(0).md5Hex()).isEqualTo("d41d8cd98f00b204e9800998ecf8427e")
+    }
+
+    @Test
+    fun `md5Hex pads bytes that need a leading zero`() {
+        // The first digest byte here is 0x0c, so this catches a format that drops the leading zero.
+        assertThat("a".toByteArray().md5Hex()).isEqualTo("0cc175b9c0f1b6a831c399e269772661")
+    }
+
+    /**
+     * Regression test for the concurrency crash in FontLoader and DefaultFileRepository. Both used to hold one
+     * shared MessageDigest and call digest() from several coroutines at the same time. MessageDigest is not
+     * thread-safe, so the internal buffer got corrupted and threw, most often ArrayIndexOutOfBoundsException
+     * from the digest's own state.
+     *
+     * Against a shared instance this fails well within these iteration counts. Against a per-call instance it
+     * cannot fail, because there is no shared state left.
+     */
+    @Test
+    fun `md5Hex is thread safe when called concurrently`() {
+        val input = "https://assets.pawwalls.com/fonts/Regular.ttf".toByteArray()
+        val expected = input.md5Hex()
+
+        val pool = Executors.newFixedThreadPool(THREADS)
+        val startSignal = CountDownLatch(1)
+        val finished = CountDownLatch(THREADS)
+        val failures = Collections.synchronizedList(mutableListOf<Throwable>())
+
+        repeat(THREADS) {
+            pool.execute {
+                try {
+                    startSignal.await()
+                    repeat(ITERATIONS_PER_THREAD) {
+                        assertThat(input.md5Hex()).isEqualTo(expected)
+                    }
+                } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+                    failures.add(t)
+                } finally {
+                    finished.countDown()
+                }
+            }
+        }
+
+        startSignal.countDown()
+        val completed = finished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        pool.shutdownNow()
+
+        assertThat(completed).isTrue()
+        assertThat(failures).isEmpty()
+    }
+
+    private companion object {
+        const val THREADS = 8
+        const val ITERATIONS_PER_THREAD = 2000
+        const val TIMEOUT_SECONDS = 30L
+    }
+}


### PR DESCRIPTION
### Issue

Crash affecting [this customer](https://revenuecat.zendesk.com/agent/tickets/82655).

`FontLoader` and `DefaultFileCache` each held a single shared `MessageDigest`.

MessageDigest is not thread-safe, and both classes call it from concurrent coroutines, so the digest's internal state gets corrupted and throws ultimately killing the app.

### The fix

Replaced both private helpers with one internal fun `ByteArray.md5Hex()` in `common/utils.kt`, next to the existing sha1()/sha256(), which already build the digest per call. It reuses the existing `ByteArray.toHexString()`.

Added tests as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent download/cache paths for paywall fonts and file prefetching; the fix is localized and digest output should match, but these are customer-visible failure paths that previously crashed the app.
> 
> **Overview**
> Fixes a **production crash** when paywall fonts or cached remote files are hashed from **multiple coroutines at once**. `FontLoader` and `DefaultFileCache` each kept one lazy `MessageDigest` and called `digest()` concurrently; `MessageDigest` is not thread-safe, which corrupted state and could throw (e.g. `ArrayIndexOutOfBoundsException`).
> 
> The PR **centralizes MD5-as-hex** in a new internal `ByteArray.md5Hex()` in `common/utils.kt`, matching the existing per-call pattern used by `sha1()` / `sha256()`, and reuses `toHexString()`. Both classes drop their shared digest and private helpers and call the extension for URL hashing and font integrity checks.
> 
> **Tests** in `HashUtilsTest` cover expected digests (including leading-zero padding) and a multi-threaded regression that would fail with a shared instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03bb3c5d2b4e7b35429018468247845060ffa46e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->