### PR TITLE
build: update Kover to 0.9.9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ kotlinLanguage = "1.8"
 # Can't update until we use more recent kotlin. 1.6.0 uses Kotlin 1.9.0
 kotlinxSerializationJSON = "1.5.1"
 samsungIap = "6.5.2"
-kover = "0.7.0"
+kover = "0.9.9"
 legacyCoreUi = "1.0.0"
 lifecycle = "2.5.0"
 material = "1.6.0"

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -235,6 +235,8 @@ dependencies {
 
     baselineProfile(project(":baselineprofile"))
     testImplementation(kotlin("test"))
+
+    kover(project(":feature:amazon"))
 }
 
 fun DokkaSourceSetSpec.configureDocumentedSourceSet() {
@@ -273,14 +275,6 @@ dokka {
                 suppress.set(true)
             }
         }
-    }
-}
-
-// Remove afterEvaluate
-// after https://github.com/Kotlin/kotlinx-kover/issues/362 is fixed
-afterEvaluate {
-    dependencies {
-        add("kover", project(":feature:amazon"))
     }
 }
 


### PR DESCRIPTION
Part of the AGP 9 upgrade pre-work: Kover 0.7.0 fails AGP 9 configuration outright, so it has to move before the AGP bump.
- No `kover { }`/`koverReport { }` DSL exists in the repo, only the plugin applied via the public-library convention plugin, so the 0.8.0 breaking DSL revision doesn't touch us.
- Also drops the `afterEvaluate` wrapper around the `:feature:amazon` coverage merge in `purchases/build.gradle.kts`, since kotlinx-kover#362 is fixed

<details>
<summary>Agent description</summary>

### Motivation

Kover 0.7.0 fails AGP 9's configuration phase (`gradleWrapper.getProperty must not be null`), so
it needs to move ahead of the AGP bump. Pulled out of a broader AGP 9 upgrade reconnaissance pass
as a standalone, AGP-8-safe PR.

Kover 0.8.0 was a breaking DSL revision (report/verify task and configuration renames), but this
repo has no `kover { }`, `koverReport { }` or `koverVerify` blocks anywhere, only the plugin
application in `PublicLibraryConventionPlugin` and one dependency-wiring line, so there was
nothing to migrate.

`purchases/build.gradle.kts` also carried an `afterEvaluate { dependencies { add("kover",
project(":feature:amazon")) } } }` with a comment saying to remove it once
kotlinx-kover/issues/362 was fixed. That issue is closed (kotlinx-kover PR #406, merged
2023-06-16), well inside 0.9.9, so this PR does the removal the comment asks for.

### Description

- `gradle/libs.versions.toml`: `kover` `0.7.0` → `0.9.9`.
- `purchases/build.gradle.kts`: removed the `afterEvaluate` wrapper and the stale comment; moved
  the `:feature:amazon` coverage merge into the module's existing `dependencies { }` block, now as
  the type-safe `kover(project(":feature:amazon"))` accessor.

Tested by running the same two tasks CI runs (`koverHtmlReportDefaultsRelease`,
`koverXmlReportDefaultsRelease`) before and after the bump: the XML report lands at the identical
path and byte size, and the amazon-module class count inside it is unchanged, confirming both the
task wiring and the coverage merge survive the version bump and the `afterEvaluate` removal.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tool and Gradle wiring only; no runtime SDK or coverage DSL changes, with behavior validated by existing Kover report tasks.
> 
> **Overview**
> Bumps **Kover** from `0.7.0` to `0.9.9` so Gradle configuration can succeed with **AGP 9** (0.7.0 fails during configuration). The repo only applies the plugin via `PublicLibraryConventionPlugin` and has no `kover { }` / report DSL, so the 0.8+ DSL renames do not require migration here.
> 
> In `purchases/build.gradle.kts`, the `:feature:amazon` coverage merge is wired directly in the `dependencies` block as `kover(project(":feature:amazon"))`, replacing the `afterEvaluate { add("kover", …) }` workaround for kotlinx-kover#362.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb3477e41cf15b108a07af35fc7a9f162ea26018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->