### PR TITLE
fix: avoid OutOfMemoryError parsing large offerings responses

### DIFF
--- a/purchases/src/main/baseline-prof.txt
+++ b/purchases/src/main/baseline-prof.txt
@@ -650,7 +650,7 @@ HSPLcom/revenuecat/purchases/common/Backend;->addCallback(Ljava/util/Map;Lcom/re
 HSPLcom/revenuecat/purchases/common/Backend;->getCallbacks()Ljava/util/Map;
 HSPLcom/revenuecat/purchases/common/Backend;->getCustomerInfo(Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 PLcom/revenuecat/purchases/common/Backend;->getDiagnosticsCallbacks()Ljava/util/Map;
-HSPLcom/revenuecat/purchases/common/Backend;->getOfferings(Ljava/lang/String;ZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;)V
+HSPLcom/revenuecat/purchases/common/Backend;->getOfferings(Ljava/lang/String;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 HSPLcom/revenuecat/purchases/common/Backend;->getOfferingsCallbacks()Ljava/util/Map;
 HSPLcom/revenuecat/purchases/common/Backend;->getPaywallEventsCallbacks()Ljava/util/Map;
 PLcom/revenuecat/purchases/common/Backend;->getProductEntitlementCallbacks()Ljava/util/Map;

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -65,7 +65,7 @@ internal typealias CallbackCacheKey = List<String>
 
 /** @suppress */
 @OptIn(InternalRevenueCatAPI::class)
-internal typealias OfferingsSuccessCallback = (JSONObject, HTTPResponseOriginalSource, responsePayload: String) -> Unit
+internal typealias OfferingsSuccessCallback = (responsePayload: String, HTTPResponseOriginalSource) -> Unit
 
 /** @suppress */
 @OptIn(InternalRevenueCatAPI::class)
@@ -457,12 +457,7 @@ internal class Backend(
                     offeringsCallbacks.remove(cacheKey)
                 }?.forEach { (onSuccess, onError) ->
                     if (result.isSuccessful()) {
-                        try {
-                            onSuccess(result.body, result.originalDataSource, result.payloadText)
-                        } catch (e: JSONException) {
-                            val errorBehavior = GetOfferingsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_OFFERINGS
-                            onError(e.toPurchasesError().also { errorLog(it) }, errorBehavior)
-                        }
+                        onSuccess(result.payloadText, result.originalDataSource)
                     } else {
                         val errorBehavior = if (RCHTTPStatusCodes.isServerError(result.responseCode)) {
                             GetOfferingsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_OFFERINGS

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.common.offerings.RawPaywallComponents
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
@@ -42,12 +43,15 @@ internal abstract class OfferingParser(
      */
     @OptIn(InternalRevenueCatAPI::class)
     @JvmOverloads
+    @Suppress("LongParameterList")
     fun createOfferings(
         offeringsJson: JSONObject,
         productsById: Map<String, List<StoreProduct>>,
         originalSource: HTTPResponseOriginalSource? = null,
         loadedFromDiskCache: Boolean = false,
         configuredStore: Store = Store.PLAY_STORE,
+        // Index-parallel to the `offerings` array; empty when [offeringsJson] still carries un-elided components.
+        paywallComponents: List<RawPaywallComponents?> = emptyList(),
     ): Offerings {
         log(LogIntent.DEBUG) { OfferingStrings.BUILDING_OFFERINGS.format(productsById.size) }
 
@@ -69,7 +73,7 @@ internal abstract class OfferingParser(
         val offerings = mutableMapOf<String, Offering>()
         for (i in 0 until jsonOfferings.length()) {
             val offeringJson = jsonOfferings.getJSONObject(i)
-            createOffering(offeringJson, productsById, uiConfig)?.let {
+            createOffering(offeringJson, productsById, uiConfig, paywallComponents.getOrNull(i))?.let {
                 offerings[it.identifier] = it
 
                 if (it.availablePackages.isEmpty()) {
@@ -128,6 +132,7 @@ internal abstract class OfferingParser(
         offeringJson: JSONObject,
         productsById: Map<String, List<StoreProduct>>,
         uiConfig: UiConfig?,
+        rawPaywallComponents: RawPaywallComponents? = null,
     ): Offering? {
         val offeringIdentifier = offeringJson.getString("identifier")
         val metadata = offeringJson.optJSONObject("metadata")?.toMap<Any>(deep = true) ?: emptyMap()
@@ -158,8 +163,18 @@ internal abstract class OfferingParser(
         // Presence is tracked independently of whether we decode: [Offering.hasPaywall] must keep reporting a
         // components paywall even when we skip capturing it (workflows serve it), so external integrators still
         // see the offering as paywall-capable.
-        val hasPaywallComponents = hasWellShapedPaywallComponents(paywallComponentsJson, uiConfig)
-        val paywallComponents = createPaywallComponents(paywallComponentsJson, uiConfig, hasPaywallComponents)
+        val hasPaywallComponents = uiConfig != null && when {
+            rawPaywallComponents != null ->
+                rawPaywallComponents.topLevelKeys.containsAll(REQUIRED_PAYWALL_COMPONENTS_KEYS)
+            paywallComponentsJson != null -> REQUIRED_PAYWALL_COMPONENTS_KEYS.all(paywallComponentsJson::has)
+            else -> false
+        }
+        val paywallComponents = createPaywallComponents(
+            rawPaywallComponents,
+            paywallComponentsJson,
+            uiConfig,
+            hasPaywallComponents,
+        )
 
         val webCheckoutURL = offeringJson.getWebCheckoutURL()
 
@@ -178,11 +193,6 @@ internal abstract class OfferingParser(
         }
     }
 
-    /** Whether the backend sent a `paywall_components` object with the required shape for the given [uiConfig]. */
-    @OptIn(InternalRevenueCatAPI::class)
-    private fun hasWellShapedPaywallComponents(paywallComponentsJson: JSONObject?, uiConfig: UiConfig?): Boolean =
-        paywallComponentsJson != null && uiConfig != null && paywallComponentsJson.hasPaywallComponentsShape()
-
     /**
      * Builds the (lazily-decoded) [Offering.PaywallComponents] from the raw JSON, or `null` when there is nothing
      * to build ([hasWellShaped] is false) or when [shouldParsePaywallComponents] says to skip capturing it.
@@ -190,11 +200,13 @@ internal abstract class OfferingParser(
     @OptIn(InternalRevenueCatAPI::class)
     @Suppress("ReturnCount")
     private fun createPaywallComponents(
+        rawPaywallComponents: RawPaywallComponents?,
         paywallComponentsJson: JSONObject?,
         uiConfig: UiConfig?,
         hasWellShaped: Boolean,
     ): Offering.PaywallComponents? {
-        if (paywallComponentsJson == null || uiConfig == null) return null
+        if (uiConfig == null) return null
+        if (rawPaywallComponents == null && paywallComponentsJson == null) return null
         if (!hasWellShaped) {
             warnLog { "Skipping paywall components data with unexpected shape for offering" }
             return null
@@ -202,13 +214,12 @@ internal abstract class OfferingParser(
         if (!shouldParsePaywallComponents()) return null
 
         // Defer the (potentially expensive) component-tree deserialization until the paywall is actually
-        // accessed/displayed. Capturing the raw JSON string here is cheap; without this we would eagerly
-        // deserialize every cached offering's component tree at load, even those that are never shown.
-        val rawPaywallComponents = paywallComponentsJson.toString()
+        // accessed/displayed.
+        val rawText = rawPaywallComponents?.text() ?: paywallComponentsJson!!.toString()
         // A content hash of the raw JSON serves as the equality key, so comparing offerings (e.g. cached vs
         // network) never forces the lazy decode.
-        return Offering.PaywallComponents(uiConfig, componentsHash = rawPaywallComponents.sha256()) {
-            json.decodeFromString<PaywallComponentsData>(rawPaywallComponents)
+        return Offering.PaywallComponents(uiConfig, componentsHash = rawText.sha256()) {
+            json.decodeFromString<PaywallComponentsData>(rawText)
         }
     }
 
@@ -251,15 +262,11 @@ private fun String.toPackageType(): PackageType =
     PackageType.values().firstOrNull { it.identifier == this }
         ?: if (this.startsWith("\$rc_")) PackageType.UNKNOWN else PackageType.CUSTOM
 
-/**
- * Cheap structural check that a `paywall_components` object has the required top-level keys, without
- * deserializing the (potentially large) component tree. Mirrors the required fields of `PaywallComponentsData`,
- * so an obviously-malformed object is treated as "no paywall" at parse time (as before). Deeper structural
- * problems surface when the tree is lazily decoded and are handled by the paywall presentation layer.
- */
-private fun JSONObject.hasPaywallComponentsShape(): Boolean =
-    has("template_name") &&
-        has("asset_base_url") &&
-        has("components_config") &&
-        has("components_localizations") &&
-        has("default_locale")
+/** Mirrors the required fields of `PaywallComponentsData`, checked without decoding the component tree. */
+private val REQUIRED_PAYWALL_COMPONENTS_KEYS = setOf(
+    "template_name",
+    "asset_base_url",
+    "components_config",
+    "components_localizations",
+    "default_locale",
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -589,8 +589,8 @@ public open class DeviceCache(
     // region offerings response
 
     @Synchronized
-    internal fun getOfferingsResponseCache(): JSONObject? {
-        return getJSONObjectOrNull(offeringsResponseCacheKey)
+    internal fun getOfferingsResponseCacheText(): String? {
+        return preferences.getString(offeringsResponseCacheKey, null)
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
@@ -8,7 +8,6 @@ import com.revenuecat.purchases.common.LocaleProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.caching.InMemoryCachedObject
 import com.revenuecat.purchases.common.caching.isCacheStale
-import org.json.JSONObject
 
 @OptIn(InternalRevenueCatAPI::class)
 internal class OfferingsCache(
@@ -69,9 +68,9 @@ internal class OfferingsCache(
 
     // region Offerings response cache
 
-    val cachedOfferingsResponse: JSONObject?
+    val cachedOfferingsResponse: String?
         @Synchronized
-        get() = deviceCache.getOfferingsResponseCache()
+        get() = deviceCache.getOfferingsResponseCacheText()
 
     // endregion Offerings response cache
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
@@ -29,12 +29,13 @@ internal class OfferingsFactory(
 
     @SuppressWarnings("TooGenericExceptionCaught", "LongMethod")
     fun createOfferings(
-        offeringsJSON: JSONObject,
+        parsedResponse: ParsedOfferingsResponse,
         originalDataSource: HTTPResponseOriginalSource?,
         loadedFromDiskCache: Boolean,
         onError: (PurchasesError) -> Unit,
         onSuccess: (OfferingsResultData) -> Unit,
     ) {
+        val offeringsJSON = parsedResponse.json
         try {
             val allRequestedProductIdentifiers = extractProductIdentifiers(offeringsJSON)
             if (allRequestedProductIdentifiers.isEmpty()) {
@@ -74,6 +75,7 @@ internal class OfferingsFactory(
                                 originalDataSource,
                                 loadedFromDiskCache,
                                 appConfig.store,
+                                parsedResponse.paywallComponents,
                             )
                             if (offerings.all.isEmpty()) {
                                 onError(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -255,6 +255,15 @@ internal class OfferingsManager(
         onError: ((PurchasesError) -> Unit)?,
         onSuccess: ((OfferingsResultData) -> Unit)?,
     ) {
+        val inMemoryOfferings = offeringsCache.cachedOfferings
+        // A generation bump means this copy was parsed with components skipped, so use the disk copy instead.
+        if (inMemoryOfferings != null && cacheGeneration.get() == fetchGeneration) {
+            warnLog { OfferingStrings.FETCHING_OFFERINGS_ERROR.format(backendError) }
+            log(LogIntent.DEBUG) { OfferingStrings.VENDING_OFFERINGS_CACHE }
+            offeringsCache.cacheOfferings(inMemoryOfferings, responsePayload = null)
+            deliverSuccess(OfferingsResultData(inMemoryOfferings, emptySet(), emptySet()), onSuccess)
+            return
+        }
         val parsedDiskResponse = offeringsCache.cachedOfferingsResponse?.let { responseText ->
             warnLog { OfferingStrings.ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE }
             try {
@@ -278,6 +287,12 @@ internal class OfferingsManager(
             onError = onError,
             onSuccess = onSuccess,
         )
+    }
+
+    /** Delivers [result] only once the workflows paywall config the render path reads is primed. */
+    private fun deliverSuccess(result: OfferingsResultData, onSuccess: ((OfferingsResultData) -> Unit)?) {
+        val dispatchSuccess = { dispatch { onSuccess?.invoke(result) } }
+        workflowManager?.onPaywallConfigReady(onComplete = dispatchSuccess) ?: dispatchSuccess()
     }
 
     private fun createAndCacheOfferings(
@@ -312,8 +327,7 @@ internal class OfferingsManager(
                     }
                     offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                     offeringsCache.cacheOfferings(offeringsResultData.offerings, responsePayloadToCache)
-                    val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
-                    workflowManager?.onPaywallConfigReady(onComplete = dispatchSuccess) ?: dispatchSuccess()
+                    deliverSuccess(offeringsResultData, onSuccess)
                 } else {
                     log(LogIntent.DEBUG) { OfferingStrings.OFFERINGS_CACHE_INVALIDATED_SKIPPING_STALE_WRITE }
                     createAndCacheOfferings(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -15,12 +15,13 @@ import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.between
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.toPurchasesError
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.strings.OfferingStrings
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
-import org.json.JSONObject
+import org.json.JSONException
 import java.util.Date
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
@@ -217,36 +218,28 @@ internal class OfferingsManager(
         backend.getOfferings(
             appUserID,
             appInBackground,
-            { body, originalDataSource, responsePayload ->
-                createAndCacheOfferings(
-                    offeringsJSON = body,
-                    originalDataSource = originalDataSource,
-                    responsePayloadToCache = responsePayload,
-                    fetchGeneration = fetchGeneration,
-                    onError,
-                    onSuccess,
-                )
+            { responsePayload, originalDataSource ->
+                val parsedResponse = try {
+                    OfferingsResponseParser.parse(responsePayload)
+                } catch (e: JSONException) {
+                    fallBackToCachedOfferingsOrError(e.toPurchasesError(), fetchGeneration, onError, onSuccess)
+                    null
+                }
+                parsedResponse?.let {
+                    createAndCacheOfferings(
+                        parsedResponse = it,
+                        originalDataSource = originalDataSource,
+                        responsePayloadToCache = responsePayload,
+                        fetchGeneration = fetchGeneration,
+                        onError = onError,
+                        onSuccess = onSuccess,
+                    )
+                }
             },
             { backendError, errorBehavior ->
                 when (errorBehavior) {
                     GetOfferingsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_OFFERINGS -> {
-                        val cachedOfferingsResponse = offeringsCache.cachedOfferingsResponse
-                        if (cachedOfferingsResponse == null) {
-                            handleErrorFetchingOfferings(backendError, onError)
-                        } else {
-                            warnLog { OfferingStrings.ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE }
-                            createAndCacheOfferings(
-                                offeringsJSON = cachedOfferingsResponse,
-                                // Unknown: the source of the response that originally populated the
-                                // disk cache is not persisted, because persisting it is what forced the
-                                // response body to be re-serialized on every write.
-                                originalDataSource = null,
-                                responsePayloadToCache = null,
-                                fetchGeneration = fetchGeneration,
-                                onError,
-                                onSuccess,
-                            )
-                        }
+                        fallBackToCachedOfferingsOrError(backendError, fetchGeneration, onError, onSuccess)
                     }
                     GetOfferingsErrorHandlingBehavior.SHOULD_NOT_FALLBACK -> {
                         handleErrorFetchingOfferings(backendError, onError)
@@ -256,8 +249,39 @@ internal class OfferingsManager(
         )
     }
 
+    private fun fallBackToCachedOfferingsOrError(
+        backendError: PurchasesError,
+        fetchGeneration: Int,
+        onError: ((PurchasesError) -> Unit)?,
+        onSuccess: ((OfferingsResultData) -> Unit)?,
+    ) {
+        val parsedDiskResponse = offeringsCache.cachedOfferingsResponse?.let { responseText ->
+            warnLog { OfferingStrings.ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE }
+            try {
+                OfferingsResponseParser.parse(responseText)
+            } catch (@Suppress("SwallowedException") e: JSONException) {
+                null
+            }
+        }
+        if (parsedDiskResponse == null) {
+            handleErrorFetchingOfferings(backendError, onError)
+            return
+        }
+        createAndCacheOfferings(
+            parsedResponse = parsedDiskResponse,
+            // Unknown: the source of the response that originally populated the
+            // disk cache is not persisted, because persisting it is what forced the
+            // response body to be re-serialized on every write.
+            originalDataSource = null,
+            responsePayloadToCache = null,
+            fetchGeneration = fetchGeneration,
+            onError = onError,
+            onSuccess = onSuccess,
+        )
+    }
+
     private fun createAndCacheOfferings(
-        offeringsJSON: JSONObject,
+        parsedResponse: ParsedOfferingsResponse,
         originalDataSource: HTTPResponseOriginalSource?,
         /** Null when this parse came from the disk cache; see [OfferingsCache.cacheOfferings]. */
         responsePayloadToCache: String?,
@@ -267,7 +291,7 @@ internal class OfferingsManager(
     ) {
         val loadedFromDiskCache = responsePayloadToCache == null
         offeringsFactory.createOfferings(
-            offeringsJSON,
+            parsedResponse,
             originalDataSource,
             loadedFromDiskCache,
             onError = { error ->
@@ -293,7 +317,7 @@ internal class OfferingsManager(
                 } else {
                     log(LogIntent.DEBUG) { OfferingStrings.OFFERINGS_CACHE_INVALIDATED_SKIPPING_STALE_WRITE }
                     createAndCacheOfferings(
-                        offeringsJSON = offeringsJSON,
+                        parsedResponse = parsedResponse,
                         originalDataSource = originalDataSource,
                         responsePayloadToCache = responsePayloadToCache,
                         fetchGeneration = cacheGeneration.get(),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsResponseParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsResponseParser.kt
@@ -1,0 +1,285 @@
+package com.revenuecat.purchases.common.offerings
+
+import com.revenuecat.purchases.common.warnLog
+import org.json.JSONObject
+
+internal class RawPaywallComponents(
+    private val payloadText: String,
+    private val start: Int,
+    private val end: Int,
+    val topLevelKeys: Set<String>,
+) {
+    fun text(): String = payloadText.substring(start, end)
+}
+
+/**
+ * [json] has every `paywall_components` object elided to `null`; [paywallComponents] holds them as raw text,
+ * index-parallel to the `offerings` array (`null` for an offering without one).
+ */
+internal class ParsedOfferingsResponse(
+    val json: JSONObject,
+    val paywallComponents: List<RawPaywallComponents?>,
+)
+
+/**
+ * Parses an offerings response keeping `paywall_components` as raw text instead of [JSONObject] nodes. Those
+ * subtrees measured 96-99% of compact response size on components-heavy accounts.
+ */
+internal object OfferingsResponseParser {
+
+    private const val NULL_LITERAL = "null"
+
+    fun parse(payloadText: String): ParsedOfferingsResponse {
+        return try {
+            val scanner = Scanner(payloadText)
+            scanner.parseRoot()
+            ParsedOfferingsResponse(
+                json = JSONObject(elide(payloadText, scanner.componentSpans)),
+                paywallComponents = scanner.componentsByOfferingIndex,
+            )
+        } catch (@Suppress("SwallowedException") e: UnrecognizedShape) {
+            warnLog { "Unrecognized offerings response shape; falling back to a full-tree parse." }
+            ParsedOfferingsResponse(json = JSONObject(payloadText), paywallComponents = emptyList())
+        }
+    }
+
+    private fun elide(payloadText: String, spans: List<IntRange>): String {
+        if (spans.isEmpty()) return payloadText
+        val elidedLength = spans.sumOf { it.last - it.first + 1 }
+        val builder = StringBuilder(payloadText.length - elidedLength + spans.size * NULL_LITERAL.length)
+        var cursor = 0
+        for (span in spans) {
+            builder.append(payloadText, cursor, span.first)
+            builder.append(NULL_LITERAL)
+            cursor = span.last + 1
+        }
+        builder.append(payloadText, cursor, payloadText.length)
+        return builder.toString()
+    }
+
+    private class UnrecognizedShape : Exception()
+
+    @Suppress("TooManyFunctions")
+    private class Scanner(private val text: String) {
+        private var pos = 0
+        val componentSpans = mutableListOf<IntRange>()
+        val componentsByOfferingIndex = mutableListOf<RawPaywallComponents?>()
+
+        fun parseRoot() {
+            skipWhitespace()
+            expect('{')
+            var seenOfferings = false
+            parseMembers { key ->
+                if (key == "offerings") {
+                    // org.json keeps only the last of duplicate keys, desyncing the index-parallel list.
+                    if (seenOfferings) throw UnrecognizedShape()
+                    seenOfferings = true
+                    parseOfferingsArray()
+                } else {
+                    skipValue()
+                }
+            }
+        }
+
+        private fun parseOfferingsArray() {
+            skipWhitespace()
+            expect('[')
+            skipWhitespace()
+            if (peekIs(']')) {
+                pos++
+                return
+            }
+            while (true) {
+                parseOfferingObject()
+                skipWhitespace()
+                when {
+                    peekIs(',') -> {
+                        pos++
+                        skipWhitespace()
+                    }
+                    peekIs(']') -> {
+                        pos++
+                        return
+                    }
+                    else -> throw UnrecognizedShape()
+                }
+            }
+        }
+
+        private fun parseOfferingObject() {
+            skipWhitespace()
+            expect('{')
+            var components: RawPaywallComponents? = null
+            parseMembers { key ->
+                if (key == "paywall_components") {
+                    if (components != null) throw UnrecognizedShape()
+                    skipWhitespace()
+                    val start = pos
+                    if (peekIs('{')) {
+                        val topLevelKeys = parseObjectCollectingTopLevelKeys()
+                        components = RawPaywallComponents(text, start, pos, topLevelKeys)
+                        componentSpans.add(start until pos)
+                    } else {
+                        skipValue()
+                    }
+                } else {
+                    skipValue()
+                }
+            }
+            componentsByOfferingIndex.add(components)
+        }
+
+        private fun parseObjectCollectingTopLevelKeys(): Set<String> {
+            val keys = mutableSetOf<String>()
+            expect('{')
+            parseMembers { key ->
+                keys.add(key)
+                skipValue()
+            }
+            return keys
+        }
+
+        /** Opening brace already consumed. [onMember] must consume exactly its key's value. */
+        private inline fun parseMembers(onMember: (String) -> Unit) {
+            skipWhitespace()
+            if (peekIs('}')) {
+                pos++
+                return
+            }
+            while (true) {
+                skipWhitespace()
+                val key = parseStringRaw()
+                skipWhitespace()
+                expect(':')
+                skipWhitespace()
+                onMember(key)
+                skipWhitespace()
+                when {
+                    peekIs(',') -> pos++
+                    peekIs('}') -> {
+                        pos++
+                        return
+                    }
+                    else -> throw UnrecognizedShape()
+                }
+            }
+        }
+
+        private fun skipValue() {
+            skipWhitespace()
+            when (peek()) {
+                '"' -> skipString()
+                '{' -> skipObject()
+                '[' -> skipArray()
+                else -> skipLiteral()
+            }
+        }
+
+        private fun skipObject() {
+            expect('{')
+            skipWhitespace()
+            if (peekIs('}')) {
+                pos++
+                return
+            }
+            while (true) {
+                skipWhitespace()
+                skipString()
+                skipWhitespace()
+                expect(':')
+                skipWhitespace()
+                skipValue()
+                skipWhitespace()
+                when {
+                    peekIs(',') -> pos++
+                    peekIs('}') -> {
+                        pos++
+                        return
+                    }
+                    else -> throw UnrecognizedShape()
+                }
+            }
+        }
+
+        private fun skipArray() {
+            expect('[')
+            skipWhitespace()
+            if (peekIs(']')) {
+                pos++
+                return
+            }
+            while (true) {
+                skipValue()
+                skipWhitespace()
+                when {
+                    peekIs(',') -> {
+                        pos++
+                        skipWhitespace()
+                    }
+                    peekIs(']') -> {
+                        pos++
+                        return
+                    }
+                    else -> throw UnrecognizedShape()
+                }
+            }
+        }
+
+        private fun skipLiteral() {
+            val start = pos
+            while (pos < text.length && !text[pos].terminatesLiteral()) pos++
+            if (pos == start) throw UnrecognizedShape()
+        }
+
+        private fun Char.terminatesLiteral(): Boolean = when (this) {
+            ',', '}', ']', ' ', '\t', '\n', '\r' -> true
+            else -> false
+        }
+
+        /** Every key compared against this is plain ASCII, so an escaped key is an unrecognized shape. */
+        private fun parseStringRaw(): String {
+            expect('"')
+            val start = pos
+            skipStringBody()
+            val raw = text.substring(start, pos - 1)
+            if (raw.indexOf('\\') >= 0) throw UnrecognizedShape()
+            return raw
+        }
+
+        private fun skipString() {
+            expect('"')
+            skipStringBody()
+        }
+
+        /** Advances from just after the opening quote to just after the closing quote. */
+        private fun skipStringBody() {
+            while (true) {
+                if (pos >= text.length) throw UnrecognizedShape()
+                when (text[pos]) {
+                    '\\' -> pos += 2
+                    '"' -> {
+                        pos++
+                        return
+                    }
+                    else -> pos++
+                }
+            }
+        }
+
+        private fun skipWhitespace() {
+            while (pos < text.length && text[pos].isWhitespace()) pos++
+        }
+
+        private fun peek(): Char {
+            if (pos >= text.length) throw UnrecognizedShape()
+            return text[pos]
+        }
+
+        private fun peekIs(char: Char): Boolean = pos < text.length && text[pos] == char
+
+        private fun expect(char: Char) {
+            if (!peekIs(char)) throw UnrecognizedShape()
+            pos++
+        }
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsSourceTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsSourceTest.kt
@@ -35,7 +35,7 @@ class OfferingsSourceTest {
         offeringParser = GoogleOfferingParser()
         deviceCache = mockk()
         every { deviceCache.cacheOfferingsResponse(any()) } returns Unit
-        every { deviceCache.getOfferingsResponseCache() } returns null
+        every { deviceCache.getOfferingsResponseCacheText() } returns null
         offeringsCache = OfferingsCache(deviceCache, localeProvider = com.revenuecat.purchases.common.DefaultLocaleProvider())
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.UiConfig.AppConfig.FontsConfig.FontInfo
 import com.revenuecat.purchases.common.HTTPResponseOriginalSource
+import com.revenuecat.purchases.common.offerings.OfferingsResponseParser
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
@@ -649,6 +650,60 @@ class OfferingsTest {
             .isEqualTo("monthly")
         assertThat(uiConfig.variableConfig.variableCompatibilityMap["new var"]).isEqualTo("guaranteed var")
         assertThat(uiConfig.variableConfig.functionCompatibilityMap["new fun"]).isEqualTo("guaranteed fun")
+    }
+
+    @Test
+    fun `createOfferings from an elided response yields the same paywallComponents as the un-elided one`() {
+        val storeProductMonthly = getStoreProduct(productIdentifier, monthlyPeriod, monthlyBasePlanId)
+        val storeProductAnnual = getStoreProduct(productIdentifier, annualPeriod, annualBasePlanId)
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly, storeProductAnnual))
+        val uiConfigJson = getUiConfigJson(
+            colors = mapOf("primary" to "#ff00ff"),
+            fonts = emptyMap(),
+            localizations = emptyMap(),
+        )
+        val offeringJson = getOfferingJSON(paywallComponents = getPaywallComponentsDataJson())
+        val offeringsJson = getOfferingsJSON(offerings = JSONArray(listOf(offeringJson)), uiConfig = uiConfigJson)
+        val parsedResponse = OfferingsResponseParser.parse(offeringsJson.toString())
+        assertThat(parsedResponse.paywallComponents.filterNotNull()).hasSize(1)
+
+        val fromElided = offeringsParser.createOfferings(
+            offeringsJson = parsedResponse.json,
+            productsById = products,
+            paywallComponents = parsedResponse.paywallComponents,
+        ).all.values.first()
+        val fromUnElided = offeringsParser.createOfferings(offeringsJson, products).all.values.first()
+
+        assertThat(fromElided.hasPaywallComponents).isTrue
+        val elidedComponents = fromElided.paywallComponents ?: fail("paywallComponents is null")
+        assertThat(elidedComponents.data.getOrNull())
+            .isEqualTo((fromUnElided.paywallComponents ?: fail("paywallComponents is null")).data.getOrNull())
+        assertThat(elidedComponents).isEqualTo(fromUnElided.paywallComponents)
+    }
+
+    @Test
+    fun `createOfferings from an elided response yields null paywallComponents for a malformed components object`() {
+        val storeProductMonthly = getStoreProduct(productIdentifier, monthlyPeriod, monthlyBasePlanId)
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly))
+        val uiConfigJson = getUiConfigJson(
+            colors = mapOf("primary" to "#ff00ff"),
+            fonts = emptyMap(),
+            localizations = emptyMap(),
+        )
+        val malformedComponents = JSONObject(getPaywallComponentsDataJson().toString())
+            .apply { remove("default_locale") }
+        val offeringJson = getOfferingJSON(paywallComponents = malformedComponents)
+        val offeringsJson = getOfferingsJSON(offerings = JSONArray(listOf(offeringJson)), uiConfig = uiConfigJson)
+        val parsedResponse = OfferingsResponseParser.parse(offeringsJson.toString())
+
+        val offering = offeringsParser.createOfferings(
+            offeringsJson = parsedResponse.json,
+            productsById = products,
+            paywallComponents = parsedResponse.paywallComponents,
+        ).all.values.first()
+
+        assertThat(offering.paywallComponents).isNull()
+        assertThat(offering.hasPaywallComponents).isFalse
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/FallbackURLBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/FallbackURLBackendIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
+import org.json.JSONObject
 import org.junit.Test
 
 internal class FallbackURLBackendIntegrationTest: BaseBackendIntegrationTest() {
@@ -82,8 +83,8 @@ internal class FallbackURLBackendIntegrationTest: BaseBackendIntegrationTest() {
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource, _ ->
-                    assertThat(offeringsResponse.getJSONArray("offerings").length()).isGreaterThan(0)
+                onSuccess = { offeringsResponse, originalDataSource ->
+                    assertThat(JSONObject(offeringsResponse).getJSONArray("offerings").length()).isGreaterThan(0)
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.FALLBACK)
                     latch.countDown()
                 },
@@ -110,8 +111,8 @@ internal class FallbackURLBackendIntegrationTest: BaseBackendIntegrationTest() {
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource, _ ->
-                    assertThat(offeringsResponse.getJSONArray("offerings").length()).isGreaterThan(0)
+                onSuccess = { offeringsResponse, originalDataSource ->
+                    assertThat(JSONObject(offeringsResponse).getJSONArray("offerings").length()).isGreaterThan(0)
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.FALLBACK)
                     latch.countDown()
                 },

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderUSEast1BackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderUSEast1BackendIntegrationTest.kt
@@ -9,6 +9,7 @@ import io.mockk.every
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
 import java.net.URL
@@ -132,8 +133,8 @@ internal open class LoadShedderUSEast1BackendIntegrationTest: BaseBackendIntegra
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource, _ ->
-                    assertThat(offeringsResponse.getString("current_offering_id")).isEqualTo("default")
+                onSuccess = { offeringsResponse, originalDataSource ->
+                    assertThat(JSONObject(offeringsResponse).getString("current_offering_id")).isEqualTo("default")
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.LOAD_SHEDDER)
                     latch.countDown()
                 },
@@ -158,8 +159,8 @@ internal open class LoadShedderUSEast1BackendIntegrationTest: BaseBackendIntegra
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource, _ ->
-                    assertThat(offeringsResponse.getString("current_offering_id")).isEqualTo("default")
+                onSuccess = { offeringsResponse, originalDataSource ->
+                    assertThat(JSONObject(offeringsResponse).getString("current_offering_id")).isEqualTo("default")
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.LOAD_SHEDDER)
                     latch.countDown()
                 },

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -94,8 +94,8 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource, _ ->
-                    assertThat(offeringsResponse.length()).isPositive
+                onSuccess = { offeringsResponse, originalDataSource ->
+                    assertThat(offeringsResponse.length).isPositive
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
                     latch.countDown()
                 },
@@ -120,8 +120,8 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
             backend.getOfferings(
                 appUserID = "test-user-id",
                 appInBackground = false,
-                onSuccess = { offeringsResponse, originalDataSource, _ ->
-                    assertThat(offeringsResponse.length()).isPositive
+                onSuccess = { offeringsResponse, originalDataSource ->
+                    assertThat(offeringsResponse.length).isPositive
                     assertThat(originalDataSource).isEqualTo(HTTPResponseOriginalSource.MAIN)
                     latch.countDown()
                 },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -707,9 +707,9 @@ class DeviceCacheTest {
     @Test
     fun `gets offerings from shared preferences`() {
         every { mockPrefs.getString(offeringsResponseCacheKey, null) } returns "{\"test-key\": \"test-value\"}"
-        val offeringsResponse = cache.getOfferingsResponseCache()
+        val offeringsResponse = cache.getOfferingsResponseCacheText()
         assertThat(offeringsResponse).isNotNull
-        assertThat(offeringsResponse?.getString("test-key")).isEqualTo("test-value")
+        assertThat(JSONObject(offeringsResponse!!).getString("test-key")).isEqualTo("test-value")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -93,7 +93,6 @@ class BackendTest {
         mockkObject(CustomerInfoFactory)
         mockkObject(VirtualCurrenciesFactory)
         receivedError = null
-        receivedOfferingsJSON = null
         receivedCustomerInfo = null
         receivedPostReceiptErrorHandlingBehavior = null
         receivedCustomerInfoCreated = null
@@ -174,7 +173,6 @@ class BackendTest {
     private var receivedVirtualCurrencies: VirtualCurrencies? = null
     private var receivedWebBillingProductsResponse: WebBillingProductsResponse? = null
     private var receivedAliasUsersCallCount: Int = 0
-    private var receivedOfferingsJSON: JSONObject? = null
     private var receivedOriginalDataSource: HTTPResponseOriginalSource? = null
     private var receivedOfferingsPayload: String? = null
     private var receivedError: PurchasesError? = null
@@ -206,9 +204,8 @@ class BackendTest {
         this@BackendTest.receivedIsServerError = isServerError
     }
 
-    private val onReceiveOfferingsResponseSuccessHandler: (JSONObject, HTTPResponseOriginalSource, String) -> Unit =
-        { offeringsJSON, originalDataSource, responsePayload ->
-            this@BackendTest.receivedOfferingsJSON = offeringsJSON
+    private val onReceiveOfferingsResponseSuccessHandler: (String, HTTPResponseOriginalSource) -> Unit =
+        { responsePayload, originalDataSource ->
             this@BackendTest.receivedOriginalDataSource = originalDataSource
             this@BackendTest.receivedOfferingsPayload = responsePayload
         }
@@ -331,7 +328,7 @@ class BackendTest {
         backend.getOfferings(
             appUserID = "id",
             appInBackground = false,
-            onSuccess = { _, _, _ -> },
+            onSuccess = { _, _ -> },
             onError = { _, _ -> }
         )
 
@@ -340,7 +337,7 @@ class BackendTest {
         backend.getOfferings(
             appUserID = "id",
             appInBackground = false,
-            onSuccess = { _, _, _ -> },
+            onSuccess = { _, _ -> },
             onError = { _, _ -> }
         )
     }
@@ -1619,9 +1616,10 @@ class BackendTest {
             onError = { _, _ -> fail("Should be success") }
         )
 
-        assertThat(receivedOfferingsJSON).`as`("Received offerings response is not null").isNotNull
-        assertThat(receivedOfferingsJSON!!.getJSONArray("offerings").length()).isZero
-        assertThat(receivedOfferingsJSON!!.getNullableString("current_offering_id")).isNull()
+        assertThat(receivedOfferingsPayload).`as`("Received offerings response is not null").isNotNull
+        val receivedOfferingsJSON = JSONObject(receivedOfferingsPayload!!)
+        assertThat(receivedOfferingsJSON.getJSONArray("offerings").length()).isZero
+        assertThat(receivedOfferingsJSON.getNullableString("current_offering_id")).isNull()
     }
 
     @Test
@@ -1647,7 +1645,7 @@ class BackendTest {
         backend.getOfferings(
             appUserID,
             appInBackground = false,
-            onSuccess = { _, _, _ -> fail("Should be error") },
+            onSuccess = { _, _ -> fail("Should be error") },
             onError = onReceiveOfferingsErrorHandler
         )
 
@@ -1662,7 +1660,7 @@ class BackendTest {
         backend.getOfferings(
             appUserID,
             appInBackground = false,
-            onSuccess = { _, _, _ -> fail("Should be error") },
+            onSuccess = { _, _ -> fail("Should be error") },
             onError = onReceiveOfferingsErrorHandler
         )
 
@@ -1681,10 +1679,10 @@ class BackendTest {
             true
         )
         val lock = CountDownLatch(2)
-        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
-        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
@@ -1711,10 +1709,10 @@ class BackendTest {
             true
         )
         val lock = CountDownLatch(2)
-        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
-        asyncBackend.getOfferings("anotherUser", appInBackground = false, onSuccess = { _, _, _ ->
+        asyncBackend.getOfferings("anotherUser", appInBackground = false, onSuccess = { _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
@@ -1750,10 +1748,10 @@ class BackendTest {
             true
         )
         val lock = CountDownLatch(2)
-        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
-        asyncBackend.getOfferings(appUserID, appInBackground = true, onSuccess = { _, _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = true, onSuccess = { _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
@@ -1774,10 +1772,10 @@ class BackendTest {
             true
         )
         val lock = CountDownLatch(2)
-        asyncBackend.getOfferings(appUserID, appInBackground = true, onSuccess = { _, _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = true, onSuccess = { _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
-        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _, _ ->
+        asyncBackend.getOfferings(appUserID, appInBackground = false, onSuccess = { _, _ ->
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
@@ -17,7 +17,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -170,7 +169,7 @@ class OfferingsCacheTest {
     @Test
     fun `clearInMemoryOfferingsCache preserves disk cache for fallback`() {
         mockDeviceCacheOfferingResponse()
-        every { deviceCache.getOfferingsResponseCache() } returns JSONObject(ONE_OFFERINGS_RESPONSE)
+        every { deviceCache.getOfferingsResponseCacheText() } returns ONE_OFFERINGS_RESPONSE
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
         }, ONE_OFFERINGS_RESPONSE)
@@ -282,8 +281,8 @@ class OfferingsCacheTest {
 
     @Test
     fun `offerings cache returns device cache offerings response`() {
-        val offeringsResponse = mockk<JSONObject>()
-        every { deviceCache.getOfferingsResponseCache() } returns offeringsResponse
+        val offeringsResponse = ONE_OFFERINGS_RESPONSE
+        every { deviceCache.getOfferingsResponseCacheText() } returns offeringsResponse
         assertThat(offeringsCache.cachedOfferingsResponse).isEqualTo(offeringsResponse)
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
@@ -266,7 +266,7 @@ class OfferingsFactoryTest {
         every { appConfig.store } returns Store.PLAY_STORE
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithNoProductsResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithNoProductsResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { purchasesError = it },
@@ -293,7 +293,7 @@ class OfferingsFactoryTest {
 
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithNoProductsResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithNoProductsResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { purchasesError = it },
@@ -320,7 +320,7 @@ class OfferingsFactoryTest {
 
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithNoProductsResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithNoProductsResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { purchasesError = it },
@@ -347,7 +347,7 @@ class OfferingsFactoryTest {
 
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithNoProductsResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithNoProductsResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { purchasesError = it },
@@ -374,7 +374,7 @@ class OfferingsFactoryTest {
 
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithNoProductsResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithNoProductsResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { purchasesError = it },
@@ -418,7 +418,7 @@ class OfferingsFactoryTest {
     fun `createOfferings returns error if json with wrong format`() {
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = JSONObject("{}"),
+            parsedResponse = ParsedOfferingsResponse(json = JSONObject("{}"), paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { purchasesError = it },
@@ -436,7 +436,7 @@ class OfferingsFactoryTest {
 
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { purchasesError = it },
@@ -460,7 +460,7 @@ class OfferingsFactoryTest {
 
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { purchasesError = it },
@@ -481,7 +481,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Expected success. Got error: $it") },
@@ -501,7 +501,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingInAppProductResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingInAppProductResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Expected success. Got error: $it") },
@@ -521,7 +521,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithPaywall,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithPaywall, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Error: $it") },
@@ -541,7 +541,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithInvalidPaywallResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithInvalidPaywallResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Error: $it") },
@@ -561,7 +561,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithPlacement,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithPlacement, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Error: $it") },
@@ -586,7 +586,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithPlacementWithNullFallback,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithPlacementWithNullFallback, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Error: $it") },
@@ -611,7 +611,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithTargeting,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithTargeting, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Error: $it") },
@@ -645,7 +645,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Expected success. Got error: $it") },
@@ -668,7 +668,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingWithWPL,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingWithWPL, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Error: $it") },
@@ -698,7 +698,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = invalidUrlWPL,
+            parsedResponse = ParsedOfferingsResponse(json = invalidUrlWPL, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Error: $it") },
@@ -720,7 +720,7 @@ class OfferingsFactoryTest {
 
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
-            offeringsJSON = oneOfferingResponse,
+            parsedResponse = ParsedOfferingsResponse(json = oneOfferingResponse, paywallComponents = emptyList()),
             originalDataSource = HTTPResponseOriginalSource.MAIN,
             loadedFromDiskCache = false,
             onError = { fail("Expected success. Got error: $it") },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -464,7 +464,7 @@ class OfferingsManagerTest {
         } just Runs
 
         mockBackendResponseError()
-        val backendResponse = JSONObject(ONE_OFFERINGS_RESPONSE)
+        val backendResponse = ONE_OFFERINGS_RESPONSE
         every { cache.cachedOfferingsResponse } returns backendResponse
         mockDeviceCache(wasSuccessful = false)
         mockOfferingsFactory()
@@ -484,7 +484,7 @@ class OfferingsManagerTest {
         verify(exactly = 1) { cache.cacheOfferings(testOfferings, null) }
         verify(exactly = 1) {
             offeringsFactory.createOfferings(
-                offeringsJSON = backendResponse,
+                parsedResponse = match { it.json.toString() == JSONObject(backendResponse).toString() },
                 originalDataSource = null,
                 loadedFromDiskCache = true,
                 onError = any(),
@@ -507,7 +507,7 @@ class OfferingsManagerTest {
             error = expectedError,
             errorBehavior = GetOfferingsErrorHandlingBehavior.SHOULD_NOT_FALLBACK,
         )
-        val backendResponse = JSONObject(ONE_OFFERINGS_RESPONSE)
+        val backendResponse = ONE_OFFERINGS_RESPONSE
         every { cache.cachedOfferingsResponse } returns backendResponse
         mockDeviceCache(wasSuccessful = false)
         mockOfferingsFactory()
@@ -562,7 +562,7 @@ class OfferingsManagerTest {
         } just Runs
 
         mockBackendResponseError()
-        val backendResponse = JSONObject(ONE_OFFERINGS_RESPONSE)
+        val backendResponse = ONE_OFFERINGS_RESPONSE
         every { cache.cachedOfferingsResponse } returns backendResponse
         mockDeviceCache(wasSuccessful = false)
         val expectedError = PurchasesError(PurchasesErrorCode.StoreProblemError)
@@ -631,7 +631,7 @@ class OfferingsManagerTest {
         } just Runs
 
         mockBackendResponseError()
-        val backendResponse = JSONObject(ONE_OFFERINGS_RESPONSE)
+        val backendResponse = ONE_OFFERINGS_RESPONSE
         every { cache.cachedOfferingsResponse } returns backendResponse
         mockDeviceCache(wasSuccessful = false)
         mockOfferingsFactory()
@@ -971,7 +971,7 @@ class OfferingsManagerTest {
         if (error == null) {
             every {
                 offeringsFactory.createOfferings(
-                    offeringsJSON = any(),
+                    parsedResponse = any(),
                     originalDataSource = any(),
                     loadedFromDiskCache = any(),
                     onError = any(),
@@ -989,7 +989,7 @@ class OfferingsManagerTest {
         } else {
             every {
                 offeringsFactory.createOfferings(
-                    offeringsJSON = any(),
+                    parsedResponse = any(),
                     originalDataSource = any(),
                     loadedFromDiskCache = any(),
                     onError = captureLambda(),
@@ -1009,7 +1009,7 @@ class OfferingsManagerTest {
         val onSuccessSlot = slot<(OfferingsResultData) -> Unit>()
         every {
             offeringsFactory.createOfferings(
-                offeringsJSON = any(),
+                parsedResponse = any(),
                 originalDataSource = any(),
                 loadedFromDiskCache = any(),
                 onError = any(),
@@ -1023,10 +1023,9 @@ class OfferingsManagerTest {
         every {
             backend.getOfferings(any(), any(), captureLambda(), any())
         } answers {
-            lambda<(JSONObject, HTTPResponseOriginalSource, String) -> Unit>().captured.invoke(
-                JSONObject(response),
-                HTTPResponseOriginalSource.MAIN,
+            lambda<(String, HTTPResponseOriginalSource) -> Unit>().captured.invoke(
                 response,
+                HTTPResponseOriginalSource.MAIN,
             )
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -1183,5 +1183,100 @@ class OfferingsManagerTest {
         assertThat(receivedOfferings).isEqualTo(testOfferings)
     }
 
+    @Test
+    fun `in-memory fallback does not call onSuccess until onPaywallConfigReady completes`() {
+        val mockWorkflowManager = mockk<WorkflowManager>()
+        val onCompleteSlot = slot<() -> Unit>()
+        every {
+            mockWorkflowManager.onPaywallConfigReady(onComplete = capture(onCompleteSlot))
+        } just Runs
+
+        val managerWithWorkflow = OfferingsManager(
+            offeringsCache = cache,
+            backend = backend,
+            offeringsFactory = offeringsFactory,
+            offeringImagePreDownloader = offeringImagePreDownloader,
+            diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
+            offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            workflowManager = mockWorkflowManager,
+        )
+
+        mockBackendResponseError()
+        every { cache.cachedOfferings } returns testOfferings
+        every { cache.cacheOfferings(any(), any()) } just Runs
+        mockCacheStale(offeringsStale = true)
+
+        var receivedOfferings: OfferingsResultData? = null
+        managerWithWorkflow.fetchAndCacheOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { fail("should be success") },
+            onSuccess = { receivedOfferings = it },
+        )
+
+        assertThat(receivedOfferings).isNull()
+
+        onCompleteSlot.captured.invoke()
+
+        assertThat(receivedOfferings?.offerings).isEqualTo(testOfferings)
+    }
+
+    @Test
+    fun `in-memory fallback neither reads the disk copy nor re-parses it`() {
+        mockBackendResponseError()
+        every { cache.cachedOfferings } returns testOfferings
+        every { cache.cacheOfferings(any(), any()) } just Runs
+        mockCacheStale(offeringsStale = true)
+
+        var received: OfferingsResultData? = null
+        offeringsManager.fetchAndCacheOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { fail("should be success") },
+            onSuccess = { received = it },
+        )
+
+        assertThat(received?.offerings).isEqualTo(testOfferings)
+        verify(exactly = 0) { cache.cachedOfferingsResponse }
+        verify(exactly = 0) {
+            offeringsFactory.createOfferings(any(), any(), any(), onError = any(), onSuccess = any())
+        }
+    }
+
+    @Test
+    fun `in-memory fallback is skipped after an invalidating clear so the disk copy is re-parsed`() {
+        mockBackendResponseError()
+        every { cache.cachedOfferings } returns testOfferings
+        every { cache.cachedOfferingsResponse } returns ONE_OFFERINGS_RESPONSE
+        every { cache.cacheOfferings(any(), any()) } just Runs
+        every { cache.clearInMemoryOfferingsCache() } just Runs
+        mockDeviceCache(wasSuccessful = false)
+        mockOfferingsFactory()
+
+        val onSuccessSlot = slot<(String, HTTPResponseOriginalSource) -> Unit>()
+        val onErrorSlot = slot<(PurchasesError, GetOfferingsErrorHandlingBehavior) -> Unit>()
+        every {
+            backend.getOfferings(any(), any(), capture(onSuccessSlot), capture(onErrorSlot))
+        } just Runs
+
+        offeringsManager.fetchAndCacheOfferings(appUserId, appInBackground = false)
+        offeringsManager.clearInMemoryOfferingsCache(invalidateInFlightFetches = true)
+        onErrorSlot.captured.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetOfferingsErrorHandlingBehavior.SHOULD_FALLBACK_TO_CACHED_OFFERINGS,
+        )
+
+        verify(atLeast = 1) { cache.cachedOfferingsResponse }
+        verify(atLeast = 1) {
+            offeringsFactory.createOfferings(
+                parsedResponse = any(),
+                originalDataSource = null,
+                loadedFromDiskCache = true,
+                onError = any(),
+                onSuccess = any(),
+            )
+        }
+    }
+
     // endregion workflowManager onComplete integration
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsResponseParserMemoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsResponseParserMemoryTest.kt
@@ -1,0 +1,119 @@
+package com.revenuecat.purchases.common.offerings
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.lang.reflect.Method
+
+/**
+ * Allocation is tracked through `com.sun.management.ThreadMXBean#getThreadAllocatedBytes`, which counts
+ * cumulative bytes per thread and is unaffected by GC timing. Reflection is needed because this module's Kotlin
+ * JVM target (1.8) limits the compile-time JDK surface to `java.base`, which excludes `java.management`.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class OfferingsResponseParserMemoryTest {
+
+    private companion object {
+        const val OFFERING_COUNT = 100
+        // components_config dominates a real components-heavy response.
+        const val COMPONENTS_CONFIG_TARGET_CHARS = 20_000
+
+        val managementFactoryGetThreadMXBean: Method =
+            Class.forName("java.lang.management.ManagementFactory").getMethod("getThreadMXBean")
+        val getThreadAllocatedBytesMethod: Method =
+            Class.forName("com.sun.management.ThreadMXBean")
+                .getMethod("getThreadAllocatedBytes", Long::class.javaPrimitiveType)
+    }
+
+    @Test
+    fun `parsing a components-heavy response allocates a small multiple of the elided tree, not the payload`() {
+        val payload = buildComponentsHeavyPayload()
+        warmUp()
+
+        var elidedSize = 0
+        val elidedBytes = measureAllocatedBytes {
+            val result = OfferingsResponseParser.parse(payload)
+            elidedSize = result.json.toString().length
+        }
+
+        var fullSize = 0
+        val fullTreeBytes = measureAllocatedBytes {
+            fullSize = JSONObject(payload).toString().length
+        }
+
+        println(
+            "OfferingsResponseParser memory profile (payload ${payload.length} chars, " +
+                "$OFFERING_COUNT offerings with components)",
+        )
+        println("  elided parse:    ${elidedBytes / 1024} KB allocated, elided tree $elidedSize chars")
+        println("  full tree parse: ${fullTreeBytes / 1024} KB allocated, full tree $fullSize chars")
+
+        assertThat(elidedSize).isLessThan(fullSize)
+        // The scan walks the payload once, so its cost is bounded by payload size; a full tree build scales
+        // with it instead (~8.5x measured). Without the allocation-free skip path this measured ~3x, not ~0.2x.
+        assertThat(elidedBytes).isLessThan(payload.length.toLong())
+        assertThat(elidedBytes).isLessThan(fullTreeBytes / 10)
+    }
+
+    private fun warmUp() {
+        val warmUpPayload = buildComponentsHeavyPayload(offeringCount = 1, componentsConfigTargetChars = 100)
+        OfferingsResponseParser.parse(warmUpPayload)
+        JSONObject(warmUpPayload).toString()
+    }
+
+    private fun measureAllocatedBytes(block: () -> Unit): Long {
+        val threadId = Thread.currentThread().id
+        val before = getThreadAllocatedBytes(threadId)
+        check(before >= 0) { "ThreadMXBean allocation tracking is unavailable; the memory gates cannot run." }
+        block()
+        return getThreadAllocatedBytes(threadId) - before
+    }
+
+    private fun getThreadAllocatedBytes(threadId: Long): Long {
+        val threadMXBean = managementFactoryGetThreadMXBean.invoke(null)
+        return getThreadAllocatedBytesMethod.invoke(threadMXBean, threadId) as Long
+    }
+
+    private fun buildComponentsHeavyPayload(
+        offeringCount: Int = OFFERING_COUNT,
+        componentsConfigTargetChars: Int = COMPONENTS_CONFIG_TARGET_CHARS,
+    ): String {
+        val componentsConfig = buildComponentsConfig(componentsConfigTargetChars)
+        val builder = StringBuilder()
+        builder.append("{\"offerings\":[")
+        for (index in 0 until offeringCount) {
+            if (index > 0) builder.append(',')
+            builder.append(
+                "{\"identifier\":\"offering_$index\"," +
+                    "\"description\":\"paywall \\\"v2\\\" config\"," +
+                    "\"packages\":[{\"identifier\":\"monthly\",\"platform_product_identifier\":\"prod_$index\"}]," +
+                    "\"paywall_components\":{" +
+                    "\"template_name\":\"template_1\"," +
+                    "\"asset_base_url\":\"https://example.com\"," +
+                    "\"components_config\":$componentsConfig," +
+                    "\"components_localizations\":{\"en_US\":{}}," +
+                    "\"default_locale\":\"en_US\"}}",
+            )
+        }
+        builder.append("],\"current_offering_id\":null}")
+        return builder.toString()
+    }
+
+    private fun buildComponentsConfig(targetChars: Int): String {
+        val builder = StringBuilder("{\"type\":\"stack\",\"children\":[")
+        var index = 0
+        while (builder.length < targetChars) {
+            if (index > 0) builder.append(',')
+            builder.append(
+                "{\"type\":\"text\",\"value\":\"Billed at {{ product.price_per_month }}/mo, item $index\"}",
+            )
+            index++
+        }
+        builder.append("]}")
+        return builder.toString()
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsResponseParserTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsResponseParserTest.kt
@@ -1,0 +1,319 @@
+package com.revenuecat.purchases.common.offerings
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.json.JSONException
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class OfferingsResponseParserTest {
+
+    @Test
+    fun `elides paywall_components out of the returned json`() {
+        val payload = offeringsPayload(offeringWithComponents("offering_1"))
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        val offeringJson = result.json.getJSONArray("offerings").getJSONObject(0)
+        assertThat(offeringJson.isNull("paywall_components")).isTrue
+        assertThat(result.paywallComponents).hasSize(1)
+        assertThat(result.paywallComponents[0]).isNotNull
+    }
+
+    @Test
+    fun `extracted component text reparses to exactly the original subtree`() {
+        val payload = offeringsPayload(offeringWithComponents("offering_1"))
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        val originalComponents = JSONObject(payload)
+            .getJSONArray("offerings")
+            .getJSONObject(0)
+            .getJSONObject("paywall_components")
+        val extracted = JSONObject(result.paywallComponents[0]!!.text())
+        assertThat(extracted.toString()).isEqualTo(originalComponents.toString())
+    }
+
+    @Test
+    fun `captures the top-level keys of the components object`() {
+        val payload = offeringsPayload(offeringWithComponents("offering_1"))
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.paywallComponents[0]!!.topLevelKeys).containsExactlyInAnyOrder(
+            "template_name",
+            "asset_base_url",
+            "components_config",
+            "components_localizations",
+            "default_locale",
+        )
+    }
+
+    @Test
+    fun `braces inside string values do not confuse span detection`() {
+        val componentsConfig = """{"text":"Billed at {{ product.price_per_month }}/mo. {{ product.relative_discount }} OFF"}"""
+        val payload = offeringsPayload(offeringWithComponents("offering_1", componentsConfig = componentsConfig))
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.json.getJSONArray("offerings").getJSONObject(0).isNull("paywall_components")).isTrue
+        val extracted = JSONObject(result.paywallComponents[0]!!.text())
+        assertThat(extracted.getJSONObject("components_config").getString("text"))
+            .isEqualTo("Billed at {{ product.price_per_month }}/mo. {{ product.relative_discount }} OFF")
+    }
+
+    @Test
+    fun `escaped quotes inside string values do not confuse span detection`() {
+        val componentsConfig = """{"text":"Save \"big\" today"}"""
+        val payload = offeringsPayload(offeringWithComponents("offering_1", componentsConfig = componentsConfig))
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.json.getJSONArray("offerings").getJSONObject(0).isNull("paywall_components")).isTrue
+        val extracted = JSONObject(result.paywallComponents[0]!!.text())
+        assertThat(extracted.getJSONObject("components_config").getString("text")).isEqualTo("Save \"big\" today")
+    }
+
+    @Test
+    fun `nested objects and arrays inside paywall_components are spanned correctly`() {
+        val componentsConfig = """
+            {
+                "type": "stack",
+                "children": [
+                    {"type": "text", "value": "Hello"},
+                    {"type": "stack", "children": [{"type": "text", "value": "Nested"}]}
+                ]
+            }
+        """.trimIndent()
+        val payload = offeringsPayload(offeringWithComponents("offering_1", componentsConfig = componentsConfig))
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        val originalComponents = JSONObject(payload)
+            .getJSONArray("offerings")
+            .getJSONObject(0)
+            .getJSONObject("paywall_components")
+        val extracted = JSONObject(result.paywallComponents[0]!!.text())
+        assertThat(extracted.toString()).isEqualTo(originalComponents.toString())
+        assertThat(
+            extracted.getJSONObject("components_config").getJSONArray("children").length(),
+        ).isEqualTo(2)
+    }
+
+    @Test
+    fun `offerings without paywall_components keep the list index-aligned`() {
+        val payload = offeringsPayload(
+            offeringWithComponents("offering_1"),
+            offeringWithoutComponents("offering_2"),
+            offeringWithComponents("offering_3"),
+        )
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.paywallComponents).hasSize(3)
+        assertThat(result.paywallComponents[0]).isNotNull
+        assertThat(result.paywallComponents[1]).isNull()
+        assertThat(result.paywallComponents[2]).isNotNull
+    }
+
+    @Test
+    fun `paywall_components as the last key of the last offering is elided correctly`() {
+        // language=JSON
+        val payload = """
+            {
+                "offerings": [
+                    {
+                        "identifier": "offering_1",
+                        "description": "d",
+                        "packages": [],
+                        "paywall_components": ${sampleComponentsJson()}
+                    }
+                ],
+                "current_offering_id": "offering_1"
+            }
+        """.trimIndent()
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        val offeringJson = result.json.getJSONArray("offerings").getJSONObject(0)
+        assertThat(offeringJson.isNull("paywall_components")).isTrue
+        assertThat(result.paywallComponents).hasSize(1)
+        assertThat(result.paywallComponents[0]).isNotNull
+    }
+
+    @Test
+    fun `the elided tree preserves every non-components key`() {
+        // language=JSON
+        val payload = """
+            {
+                "offerings": [
+                    {
+                        "identifier": "offering_1",
+                        "description": "The base offering",
+                        "metadata": {"title": "Premium"},
+                        "packages": [{"identifier": "monthly", "platform_product_identifier": "prod_1"}],
+                        "web_checkout_url": "https://example.com/checkout",
+                        "paywall_components": ${sampleComponentsJson()}
+                    }
+                ],
+                "current_offering_id": "offering_1",
+                "ui_config": {"app_icon": "icon.png"},
+                "targeting": {"revision": 1, "rule_id": "abc123"},
+                "placements": {"fallback_offering_id": "offering_1", "offering_ids_by_placement": {"a": "offering_1"}}
+            }
+        """.trimIndent()
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.json.getString("current_offering_id")).isEqualTo("offering_1")
+        assertThat(result.json.getJSONObject("ui_config").getString("app_icon")).isEqualTo("icon.png")
+        assertThat(result.json.getJSONObject("targeting").getInt("revision")).isEqualTo(1)
+        assertThat(result.json.getJSONObject("targeting").getString("rule_id")).isEqualTo("abc123")
+        assertThat(result.json.getJSONObject("placements").getString("fallback_offering_id"))
+            .isEqualTo("offering_1")
+        val offeringJson = result.json.getJSONArray("offerings").getJSONObject(0)
+        assertThat(offeringJson.getString("identifier")).isEqualTo("offering_1")
+        assertThat(offeringJson.getString("description")).isEqualTo("The base offering")
+        assertThat(offeringJson.getJSONObject("metadata").getString("title")).isEqualTo("Premium")
+        assertThat(offeringJson.getJSONArray("packages").length()).isEqualTo(1)
+        assertThat(
+            offeringJson.getJSONArray("packages").getJSONObject(0).getString("platform_product_identifier"),
+        ).isEqualTo("prod_1")
+        assertThat(offeringJson.getString("web_checkout_url")).isEqualTo("https://example.com/checkout")
+        assertThat(offeringJson.isNull("paywall_components")).isTrue
+    }
+
+    @Test
+    fun `a response shape without an offerings array falls back to a plain full parse`() {
+        val payload = """{"foo": "bar"}"""
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.json.getString("foo")).isEqualTo("bar")
+        assertThat(result.paywallComponents).isEmpty()
+    }
+
+    @Test
+    fun `lenient single-quoted JSON defeats the strict scanner but still parses via the fallback`() {
+        val payload = "{'offerings': [{'identifier':'id','description':'d','packages':[]}]," +
+            "'current_offering_id': 'id'}"
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.json.getJSONArray("offerings").length()).isEqualTo(1)
+        assertThat(result.paywallComponents).isEmpty()
+    }
+
+    @Test
+    fun `a genuinely invalid payload throws JSONException like a plain parse would`() {
+        val payload = "this is not json"
+
+        assertThatThrownBy { OfferingsResponseParser.parse(payload) }.isInstanceOf(JSONException::class.java)
+    }
+
+    @Test
+    fun `a duplicate offerings key falls back rather than desynchronizing the component list`() {
+        val payload = "{\"offerings\": [${offeringWithComponents("offering_1")}], " +
+            "\"offerings\": [${offeringWithoutComponents("offering_2")}], \"current_offering_id\": null}"
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.paywallComponents).isEmpty()
+        assertThat(result.json.getJSONArray("offerings").getJSONObject(0).getString("identifier"))
+            .isEqualTo("offering_2")
+    }
+
+    @Test
+    fun `a duplicate paywall_components key falls back rather than eliding two spans for one entry`() {
+        val payload = offeringsPayload(
+            """
+            {
+                "identifier": "offering_1",
+                "description": "d",
+                "packages": [],
+                "paywall_components": ${sampleComponentsJson()},
+                "paywall_components": ${sampleComponentsJson()}
+            }
+            """.trimIndent(),
+        )
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.paywallComponents).isEmpty()
+        assertThat(
+            result.json.getJSONArray("offerings").getJSONObject(0).getJSONObject("paywall_components")
+                .getString("default_locale"),
+        ).isEqualTo("en_US")
+    }
+
+    @Test
+    fun `an escaped key falls back so it is not misjudged against the raw comparison`() {
+        // Unescapes to `paywall_components`, which only the full parse resolves.
+        val escapedKey = "paywall_com\\u0070onents"
+        val payload = "{\"offerings\": [{\"identifier\": \"offering_1\", \"description\": \"d\", " +
+            "\"packages\": [], \"$escapedKey\": ${sampleComponentsJson()}}], \"current_offering_id\": null}"
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.paywallComponents).isEmpty()
+        assertThat(
+            result.json.getJSONArray("offerings").getJSONObject(0).getJSONObject("paywall_components")
+                .getString("template_name"),
+        ).isEqualTo("template_1")
+    }
+
+    @Test
+    fun `a malformed escape inside components is carried through rather than failing the whole response`() {
+        // org.json rejects a truncated \u, so eliding the span moves that failure from the response parse to
+        // the components decode, leaving the other offerings usable.
+        val payload = offeringsPayload(
+            offeringWithComponents("offering_1", componentsConfig = """{"text":"\u12"}"""),
+            offeringWithComponents("offering_2"),
+        )
+        assertThatThrownBy { JSONObject(payload) }.isInstanceOf(JSONException::class.java)
+
+        val result = OfferingsResponseParser.parse(payload)
+
+        assertThat(result.json.getJSONArray("offerings").length()).isEqualTo(2)
+        assertThat(result.paywallComponents.filterNotNull()).hasSize(2)
+        assertThat(result.paywallComponents[0]!!.text()).contains("""\u12""")
+        assertThat(result.paywallComponents[1]!!.text()).contains("template_1")
+    }
+
+    private fun sampleComponentsJson(): String = """
+        {
+            "template_name": "template_1",
+            "asset_base_url": "https://example.com",
+            "components_config": {"type": "stack"},
+            "components_localizations": {"en_US": {}},
+            "default_locale": "en_US"
+        }
+    """.trimIndent()
+
+    private fun offeringWithComponents(identifier: String, componentsConfig: String = """{"type": "stack"}"""): String =
+        """
+        {
+            "identifier": "$identifier",
+            "description": "d",
+            "packages": [],
+            "paywall_components": {
+                "template_name": "template_1",
+                "asset_base_url": "https://example.com",
+                "components_config": $componentsConfig,
+                "components_localizations": {"en_US": {}},
+                "default_locale": "en_US"
+            }
+        }
+        """.trimIndent()
+
+    private fun offeringWithoutComponents(identifier: String): String =
+        """{"identifier": "$identifier", "description": "d", "packages": []}"""
+
+    private fun offeringsPayload(vararg offerings: String): String =
+        """{"offerings": [${offerings.joinToString(",")}], "current_offering_id": null}"""
+}


### PR DESCRIPTION
Fetching offerings parsed the entire response into an `org.json` tree. Paywall components are the bulk of that response, and `OfferingParser` only ever needed them as text to hand to kotlinx.serialization, so most of that tree was built just to be serialized straight back to a string and thrown away. Building it is what ran out of memory.

- **Keep components out of the tree.** The response text is scanned once, each `paywall_components` object is replaced by `null`, and only the much smaller remainder is parsed. Components are kept as offsets into the payload and sliced out as text on demand, so the round-trip through `JSONObject.toString()` is gone.
- **Stop re-parsing the disk copy.** When a fetch fails and parsed offerings are already in memory, the fallback reuses them instead of rebuilding them from the cached response. Its most common trigger is a background refresh whose callbacks are both null, so that work was being discarded anyway.
- **This lowers the ceiling, it does not remove it.** The payload text and the extracted component text are still held, and SharedPreferences still retains a copy of the response. Stripping components server-side (khepri#21713) is still the real fix.
- **Behavior change**, offline-with-warm-memory path only: store products are no longer re-queried, so prices are not refreshed and offerings whose products all disappeared are no longer dropped. If the cache went stale because the device locale changed, offerings stay on the old locale until the cache window expires.
- **Behavior change:** malformed JSON inside a components object no longer fails the whole response; it surfaces when those components are decoded, leaving the other offerings usable.
- Part of #3867, which should stay open until the server-side strip lands.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### How the scan works

It walks the response text tracking strings and escapes, so braces inside paywall copy (mustache variables like `{{ product.price_per_month }}`) are not mistaken for object delimiters. For each offering it records the start and end offset of that offering's `paywall_components` object, then builds the text to parse by copying everything except those spans, writing `null` in their place. `RawPaywallComponents` holds the offsets and produces the text lazily, so `OfferingParser` decodes from the original payload rather than from a re-serialized tree.

Anything the scanner does not recognize throws internally and falls back to a plain full parse, so unrecognized payloads behave exactly as before. Duplicate `offerings` or `paywall_components` keys take that same path deliberately: `org.json` keeps only the last value, so continuing would desynchronize the index-parallel component list and could attach one offering's paywall to another.

### Notes for reviewers

- `Backend` now hands the offerings success callback the payload text rather than `result.body`, so nothing reads `HTTPResult.body` on this path. Coalesced `getOfferings` callbacks therefore each run the scan where the `by lazy` previously parsed once; that is still far cheaper than the old full tree, and each caller now gets its own tree instead of sharing a mutable one.
- `componentsHash` is now derived from the raw payload text rather than `org.json`'s reserialization, so its values change. It is `private`, used only for in-process `equals`/`hashCode`, and never persisted or transmitted; the disk cache stores the payload verbatim, so cached-vs-network comparisons still hash identically.
- The in-memory fallback only takes effect while the cache generation still matches. A mismatch means that copy was parsed with components skipped, so it falls through to the disk copy rather than re-caching a stale parse.
- `TemplatePreviews.kt` binds `createOfferings(JSONObject, Map)` reflectively, so the `@JvmOverloads` two-argument bridge has to keep working; breaking it fails Paparazzi at runtime with no compile error.
- `baseline-prof.txt` needed its `getOfferings` descriptor updated for the narrowed callback arity.

### Regression gates

- `OfferingsResponseParserMemoryTest` gates allocations of the parse, so losing the allocation-free skip path fails the build.
- `OfferingsResponseParserTest` covers braces and escapes inside strings, nested structures, index alignment, duplicate and escaped keys, and the malformed-escape deferral.
- `OfferingsManagerTest` covers the generation guard, the workflow gate, and that the in-memory fallback neither reads the disk copy nor re-enters the factory.
- `OfferingsTest` covers elided-vs-un-elided equivalence; every pre-existing `OfferingParser` test used the un-elided overload, so the production path had no coverage.

### Known, not addressed here

The generation check and the cache write in the fallback are not atomic, so an invalidating clear landing between them can re-cache offerings the kill switch meant to drop. The same check-then-write exists on `main` in `createAndCacheOfferings` with a wider window, so this is pre-existing in kind; fixing it properly means making validation and write indivisible across both sites.

`ui_config` and v1 `PaywallData` still round-trip through `toString()`. Both are eagerly decoded, so slicing them would save only the intermediate string and not the decode. Recorded on SDK-4433.

</details>
