### PR TITLE
feat(paywalls): warm the web_views of the current offering and every placement's

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -341,10 +341,6 @@ internal class PurchasesFactory(
             // ones the manager warms on commit. Registered as commit listeners; a null manager means workflows
             // are off, so neither exists.
             val uiConfigProvider = remoteConfigManager?.let { UiConfigProvider(it) }
-            // Warms a workflow's assets (images, web_view bundles, ui_config fonts) once: eagerly at load
-            // time for the workflow behind every offering the customer could be served next (transiently, so
-            // the cache stays byte-only) and on the render path. Shared with WorkflowManager so both dedup
-            // against one set of warmed workflow ids.
             val workflowAssetPrewarmer = uiConfigProvider?.let {
                 WorkflowAssetPrewarmer(it, paywallAssetWarming, offeringFontPreDownloader)
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -508,6 +508,7 @@ internal class PurchasesFactory(
                 diagnosticsTracker,
                 offeringFontPreDownloader = offeringFontPreDownloader,
                 offeringWebViewPrewarmer = OfferingWebViewPrewarmer(assetWarming = paywallAssetWarming),
+                dispatcher = dispatcher,
                 uiPreviewMode = appConfig.uiPreviewMode,
                 workflowManager = workflowManager,
             )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -77,9 +77,11 @@ import com.revenuecat.purchases.utils.DefaultUrlConnectionFactory
 import com.revenuecat.purchases.utils.EventsFileHelper
 import com.revenuecat.purchases.utils.IsDebugBuildProvider
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
+import com.revenuecat.purchases.utils.OfferingWebViewPrewarmer
 import com.revenuecat.purchases.utils.PurchaseParamsValidator
 import com.revenuecat.purchases.utils.UrlConnectionFactory
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
+import com.revenuecat.purchases.utils.prewarmTargetOfferingIds
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencyManager
 import java.net.URL
 import java.util.concurrent.ExecutorService
@@ -339,10 +341,10 @@ internal class PurchasesFactory(
             // ones the manager warms on commit. Registered as commit listeners; a null manager means workflows
             // are off, so neither exists.
             val uiConfigProvider = remoteConfigManager?.let { UiConfigProvider(it) }
-            // Warms a workflow's assets (images + ui_config fonts) once — eagerly at load time for the current
-            // offering's workflow (transiently so the cache stays byte-only, mirroring how offerings pre-download
-            // only the current offering's assets) and on the render path. Shared with WorkflowManager so both
-            // dedup against one set of warmed workflow ids.
+            // Warms a workflow's assets (images, web_view bundles, ui_config fonts) once: eagerly at load
+            // time for the workflow behind every offering the customer could be served next (transiently, so
+            // the cache stays byte-only) and on the render path. Shared with WorkflowManager so both dedup
+            // against one set of warmed workflow ids.
             val workflowAssetPrewarmer = uiConfigProvider?.let {
                 WorkflowAssetPrewarmer(it, paywallAssetWarming, offeringFontPreDownloader)
             }
@@ -350,7 +352,10 @@ internal class PurchasesFactory(
                 WorkflowsConfigProvider(
                     it,
                     currentOfferingIdProvider = { offeringsCache.cachedOfferings?.current?.identifier },
-                    onCurrentWorkflowLoaded = workflowAssetPrewarmer?.let { it::onCurrentWorkflowLoaded },
+                    prewarmOfferingIdsProvider = {
+                        offeringsCache.cachedOfferings?.prewarmTargetOfferingIds().orEmpty()
+                    },
+                    onWorkflowLoaded = workflowAssetPrewarmer?.let { it::onWorkflowLoaded },
                 )
             }
             val checkpointsConfigProvider = remoteConfigManager?.let {
@@ -506,6 +511,7 @@ internal class PurchasesFactory(
                 OfferingImagePreDownloader(assetWarming = paywallAssetWarming),
                 diagnosticsTracker,
                 offeringFontPreDownloader = offeringFontPreDownloader,
+                offeringWebViewPrewarmer = OfferingWebViewPrewarmer(assetWarming = paywallAssetWarming),
                 uiPreviewMode = appConfig.uiPreviewMode,
                 workflowManager = workflowManager,
             )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -20,6 +20,8 @@ import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.strings.OfferingStrings
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
+import com.revenuecat.purchases.utils.OfferingWebViewPrewarmer
+import com.revenuecat.purchases.utils.prewarmTargetOfferings
 import org.json.JSONObject
 import java.util.Date
 import java.util.concurrent.atomic.AtomicInteger
@@ -34,6 +36,7 @@ internal class OfferingsManager(
     private val offeringImagePreDownloader: OfferingImagePreDownloader,
     private val diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
     private val offeringFontPreDownloader: OfferingFontPreDownloader,
+    private val offeringWebViewPrewarmer: OfferingWebViewPrewarmer,
     private val uiPreviewMode: Boolean = false,
     private val dateProvider: DateProvider = DefaultDateProvider(),
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
@@ -283,13 +286,15 @@ internal class OfferingsManager(
                 // the decoded result is cached and delivered to the original caller. This re-runs the store-product
                 // query; it is bounded to once per session because the kill-switch disable is one-shot.
                 if (cacheGeneration.get() == fetchGeneration) {
-                    offeringsResultData.offerings.current?.let {
-                        offeringImagePreDownloader.preDownloadOfferingImages(it)
-                    }
+                    val prewarmTargets = offeringsResultData.offerings.prewarmTargetOfferings()
+                    prewarmTargets.forEach(offeringImagePreDownloader::preDownloadOfferingImages)
                     offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                     offeringsCache.cacheOfferings(offeringsResultData.offerings, responsePayloadToCache)
                     val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
                     workflowManager?.onPaywallConfigReady(onComplete = dispatchSuccess) ?: dispatchSuccess()
+                    // After delivery: this decodes a component tree per placement offering, and warming has
+                    // no reason to sit ahead of the caller's callback.
+                    offeringWebViewPrewarmer.prewarmWebViews(prewarmTargets)
                 } else {
                     log(LogIntent.DEBUG) { OfferingStrings.OFFERINGS_CACHE_INVALIDATED_SKIPPING_STALE_WRITE }
                     createAndCacheOfferings(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -286,14 +286,17 @@ internal class OfferingsManager(
                 // the decoded result is cached and delivered to the original caller. This re-runs the store-product
                 // query; it is bounded to once per session because the kill-switch disable is one-shot.
                 if (cacheGeneration.get() == fetchGeneration) {
-                    val prewarmTargets = offeringsResultData.offerings.prewarmTargetOfferings()
-                    prewarmTargets.forEach(offeringImagePreDownloader::preDownloadOfferingImages)
+                    val current = offeringsResultData.offerings.current
+                    current?.let(offeringImagePreDownloader::preDownloadOfferingImages)
                     offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                     offeringsCache.cacheOfferings(offeringsResultData.offerings, responsePayloadToCache)
                     val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
                     workflowManager?.onPaywallConfigReady(onComplete = dispatchSuccess) ?: dispatchSuccess()
-                    // After delivery: this decodes a component tree per placement offering, and warming has
-                    // no reason to sit ahead of the caller's callback.
+                    // After delivery: each of these decodes its own component tree, and warming has no
+                    // reason to sit ahead of the caller's callback.
+                    val prewarmTargets = offeringsResultData.offerings.prewarmTargetOfferings()
+                    prewarmTargets.filterNot { it.identifier == current?.identifier }
+                        .forEach(offeringImagePreDownloader::preDownloadOfferingImages)
                     offeringWebViewPrewarmer.prewarmWebViews(prewarmTargets)
                 } else {
                     log(LogIntent.DEBUG) { OfferingStrings.OFFERINGS_CACHE_INVALIDATED_SKIPPING_STALE_WRITE }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.GetOfferingsErrorHandlingBehavior
 import com.revenuecat.purchases.common.HTTPResponseOriginalSource
 import com.revenuecat.purchases.common.LogIntent
@@ -37,6 +38,7 @@ internal class OfferingsManager(
     private val diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
     private val offeringFontPreDownloader: OfferingFontPreDownloader,
     private val offeringWebViewPrewarmer: OfferingWebViewPrewarmer,
+    private val dispatcher: Dispatcher,
     private val uiPreviewMode: Boolean = false,
     private val dateProvider: DateProvider = DefaultDateProvider(),
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
@@ -292,11 +294,14 @@ internal class OfferingsManager(
                     offeringsCache.cacheOfferings(offeringsResultData.offerings, responsePayloadToCache)
                     val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
                     workflowManager?.onPaywallConfigReady(onComplete = dispatchSuccess) ?: dispatchSuccess()
-                    // Each of these decodes a component tree, so none may sit ahead of the caller's callback.
-                    val prewarmTargets = offeringsResultData.offerings.prewarmTargetOfferings()
-                    prewarmTargets.filterNot { it.identifier == current?.identifier }
-                        .forEach(offeringImagePreDownloader::preDownloadOfferingImages)
-                    offeringWebViewPrewarmer.prewarmWebViews(prewarmTargets)
+                    // Enqueued, not just written last: dispatch() only posts the callback, so running this
+                    // inline would hold the backend response thread for a component-tree decode per target.
+                    dispatcher.enqueue({
+                        val prewarmTargets = offeringsResultData.offerings.prewarmTargetOfferings()
+                        prewarmTargets.filterNot { it.identifier == current?.identifier }
+                            .forEach(offeringImagePreDownloader::preDownloadOfferingImages)
+                        offeringWebViewPrewarmer.prewarmWebViews(prewarmTargets)
+                    })
                 } else {
                     log(LogIntent.DEBUG) { OfferingStrings.OFFERINGS_CACHE_INVALIDATED_SKIPPING_STALE_WRITE }
                     createAndCacheOfferings(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -292,8 +292,7 @@ internal class OfferingsManager(
                     offeringsCache.cacheOfferings(offeringsResultData.offerings, responsePayloadToCache)
                     val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
                     workflowManager?.onPaywallConfigReady(onComplete = dispatchSuccess) ?: dispatchSuccess()
-                    // After delivery: each of these decodes its own component tree, and warming has no
-                    // reason to sit ahead of the caller's callback.
+                    // Each of these decodes a component tree, so none may sit ahead of the caller's callback.
                     val prewarmTargets = offeringsResultData.offerings.prewarmTargetOfferings()
                     prewarmTargets.filterNot { it.identifier == current?.identifier }
                         .forEach(offeringImagePreDownloader::preDownloadOfferingImages)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmer.kt
@@ -17,9 +17,9 @@ import kotlinx.coroutines.CancellationException
  *
  * - **Render path** — [preDownloadWorkflowAssets]: `WorkflowManager.getWorkflow` already has the decoded
  *   workflow and resolved `ui_config`, so it hands them straight in.
- * - **Load path** — [onCurrentWorkflowLoaded]: wired as [WorkflowsConfigProvider]'s load callback, it runs when
- *   the config layer loads the **current offering's** workflow — mirroring the offerings path, which
- *   pre-downloads only the current offering's assets, not every offering's. It dedups by id **before** decoding,
+ * - **Load path**, [onWorkflowLoaded]: wired as [WorkflowsConfigProvider]'s load callback, it runs for each
+ *   workflow behind an offering the customer could be served next (the current one, plus each placement's).
+ *   It dedups by id **before** decoding,
  *   then decodes **transiently** (via the decoder the provider hands it, which never populates the provider's
  *   retained decode cache — the workflows cache stays raw-bytes-only). Because both paths share
  *   [warmedWorkflowIds], a workflow already warmed on render is skipped here before it is ever decoded.
@@ -45,13 +45,15 @@ internal class WorkflowAssetPrewarmer(
         if (assetWarming.isAvailable) {
             val assets = workflow.screens.values.map { it.componentsConfig.base.collectAssets() }
             assetWarming.warmImages(assets.flatMapTo(mutableSetOf()) { it.imageUris })
-            if (assets.any { it.webViews.isNotEmpty() }) assetWarming.prebootWebView()
+            assetWarming.warmWebViewUrls(
+                assets.flatMapTo(linkedSetOf<String>()) { it.webViewUrls },
+            )
         }
         offeringFontPreDownloader.preDownloadFontsIfNeeded(uiConfig.app.fonts.values)
     }
 
     /** Load-path callback for [WorkflowsConfigProvider]; see the class KDoc. */
-    suspend fun onCurrentWorkflowLoaded(
+    suspend fun onWorkflowLoaded(
         workflowId: String,
         transientDecode: suspend (String) -> PublishedWorkflow?,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmer.kt
@@ -17,9 +17,8 @@ import kotlinx.coroutines.CancellationException
  *
  * - **Render path** — [preDownloadWorkflowAssets]: `WorkflowManager.getWorkflow` already has the decoded
  *   workflow and resolved `ui_config`, so it hands them straight in.
- * - **Load path**, [onWorkflowLoaded]: wired as [WorkflowsConfigProvider]'s load callback, it runs for each
- *   workflow behind an offering the customer could be served next (the current one, plus each placement's).
- *   It dedups by id **before** decoding,
+ * - **Load path**, [onWorkflowLoaded]: runs for every offering the customer could be served next, as the
+ *   config layer loads each one. It dedups by id **before** decoding,
  *   then decodes **transiently** (via the decoder the provider hands it, which never populates the provider's
  *   retained decode cache — the workflows cache stays raw-bytes-only). Because both paths share
  *   [warmedWorkflowIds], a workflow already warmed on render is skipped here before it is ever decoded.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -154,7 +154,7 @@ internal class WorkflowManager(
     fun onPaywallConfigReady(onComplete: () -> Unit) {
         // warm() may already have run with no current offering (config commits before offerings land), and the
         // fast path below would then never re-run it. Deduped by workflow id, so a repeat call is free.
-        workflowsConfigProvider.prewarmCurrentOfferingAssets()
+        workflowsConfigProvider.prewarmOfferingAssets()
         if (uiConfigProvider.isWarm() && workflowsConfigProvider.isWarmForCurrentOffering()) {
             onComplete()
             return

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -46,12 +46,14 @@ import kotlinx.serialization.json.JsonPrimitive
 internal class WorkflowsConfigProvider(
     private val manager: RemoteConfigManager,
     private val currentOfferingIdProvider: () -> String? = { null },
-    // Called after warm() loads the current offering's workflow, so a collaborator can warm that workflow's
-    // assets at load time — mirroring the offerings path, which pre-downloads only the current offering's assets.
-    // The second argument decodes a workflow from the config layer WITHOUT populating this provider's retained
-    // decode cache, so prewarming never forces the memory-first Lazy the render path holds — the in-memory cache
-    // stays raw-bytes-only.
-    private val onCurrentWorkflowLoaded: (
+    // Wider than [currentOfferingIdProvider], which gates the readiness check and byte caching on the one
+    // paywall about to be shown.
+    private val prewarmOfferingIdsProvider: () -> Set<String> = { setOfNotNull(currentOfferingIdProvider()) },
+    // Called after warm() loads a workflow whose offering is worth prewarming, so a collaborator can warm that
+    // workflow's assets at load time. The second argument decodes a workflow from the config layer WITHOUT
+    // populating this provider's retained decode cache, so prewarming never forces the memory-first Lazy the
+    // render path holds; the in-memory cache stays raw-bytes-only.
+    private val onWorkflowLoaded: (
         suspend (workflowId: String, transientDecode: suspend (String) -> PublishedWorkflow?) -> Unit
     )? = null,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
@@ -254,30 +256,25 @@ internal class WorkflowsConfigProvider(
         }
         cache.store(generation, Cached(workflows, offeringToWorkflowId))
 
-        announceCurrentWorkflow(offeringToWorkflowId)
+        announceWorkflowsToPrewarm(offeringToWorkflowId)
     }
 
-    /** Announces against the already-warmed cache, for callers that learn the current offering after [warm]. */
-    fun prewarmCurrentOfferingAssets() {
-        announceCurrentWorkflow(cache.cached?.offeringToWorkflowId)
+    /** Announces against the already-warmed cache, for callers that learn the current offerings after [warm]. */
+    fun prewarmOfferingAssets() {
+        announceWorkflowsToPrewarm(cache.cached?.offeringToWorkflowId)
     }
 
-    // Warm the current offering's workflow assets (images + ui_config fonts) at load time — mirrors the
-    // offerings path, which pre-downloads only the current offering's assets, never other offerings'. So a
-    // prefetch-flagged workflow that isn't the current offering's has its bytes cached but not its assets: it
-    // isn't the paywall about to be shown. Fire-and-forget so it never blocks warm() or the getOfferings
-    // readiness gate. resolveWorkflowBody decodes transiently: it reads bytes + parses without touching the
-    // retained Lazy, so prewarming keeps the cache raw-bytes-only.
-    private fun announceCurrentWorkflow(offeringToWorkflowId: Map<String, String>?) {
-        val notify = onCurrentWorkflowLoaded ?: return
-        // Notify whenever the current offering maps to a workflow — do NOT gate on `workflows` (the byte-warm
-        // map), whose parallel preload can miss a body that hasn't finished its LOW-priority prefetch yet.
-        // resolveWorkflowBody fetches the body on demand, so gating here would drop the current offering's
-        // asset prewarm purely on preload timing.
-        val currentWorkflowId = currentOfferingIdProvider()
-            ?.let { offeringToWorkflowId?.get(it) }
-            ?: return
-        scope.launch { notify(currentWorkflowId, ::resolveWorkflowBody) }
+    // resolveWorkflowBody decodes transiently: it reads bytes + parses without touching the retained Lazy, so
+    // prewarming keeps the cache raw-bytes-only.
+    private fun announceWorkflowsToPrewarm(offeringToWorkflowId: Map<String, String>?) {
+        val notify = onWorkflowLoaded ?: return
+        // Gated on the metadata map alone, never on the byte-warm map: a body may not have finished its
+        // LOW-priority prefetch yet, and resolveWorkflowBody fetches on demand anyway.
+        val workflowIds = offeringToWorkflowId?.let { mapping ->
+            prewarmOfferingIdsProvider().mapNotNullTo(linkedSetOf(), mapping::get)
+        }
+        if (workflowIds.isNullOrEmpty()) return
+        workflowIds.forEach { workflowId -> scope.launch { notify(workflowId, ::resolveWorkflowBody) } }
     }
 
     /** Warms at the current config generation; used by the offerings readiness gate. */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -46,13 +46,8 @@ import kotlinx.serialization.json.JsonPrimitive
 internal class WorkflowsConfigProvider(
     private val manager: RemoteConfigManager,
     private val currentOfferingIdProvider: () -> String? = { null },
-    // Wider than [currentOfferingIdProvider], which gates the readiness check and byte caching on the one
-    // paywall about to be shown.
     private val prewarmOfferingIdsProvider: () -> Set<String> = { setOfNotNull(currentOfferingIdProvider()) },
-    // Called after warm() loads a workflow whose offering is worth prewarming, so a collaborator can warm that
-    // workflow's assets at load time. The second argument decodes a workflow from the config layer WITHOUT
-    // populating this provider's retained decode cache, so prewarming never forces the memory-first Lazy the
-    // render path holds; the in-memory cache stays raw-bytes-only.
+    // transientDecode must not populate the retained decode cache: the workflows cache stays raw-bytes-only.
     private val onWorkflowLoaded: (
         suspend (workflowId: String, transientDecode: suspend (String) -> PublishedWorkflow?) -> Unit
     )? = null,
@@ -259,17 +254,15 @@ internal class WorkflowsConfigProvider(
         announceWorkflowsToPrewarm(offeringToWorkflowId)
     }
 
-    /** Announces against the already-warmed cache, for callers that learn the current offerings after [warm]. */
+    /** For callers that learn the current offerings after [warm]. */
     fun prewarmOfferingAssets() {
         announceWorkflowsToPrewarm(cache.cached?.offeringToWorkflowId)
     }
 
-    // resolveWorkflowBody decodes transiently: it reads bytes + parses without touching the retained Lazy, so
-    // prewarming keeps the cache raw-bytes-only.
     private fun announceWorkflowsToPrewarm(offeringToWorkflowId: Map<String, String>?) {
         val notify = onWorkflowLoaded ?: return
-        // Gated on the metadata map alone, never on the byte-warm map: a body may not have finished its
-        // LOW-priority prefetch yet, and resolveWorkflowBody fetches on demand anyway.
+        // Never gated on the byte-warm map: a body's LOW-priority prefetch may still be in flight, and
+        // resolveWorkflowBody fetches on demand anyway.
         val workflowIds = offeringToWorkflowId?.let { mapping ->
             prewarmOfferingIdsProvider().mapNotNullTo(linkedSetOf(), mapping::get)
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarmer.kt
@@ -18,4 +18,10 @@ public interface PaywallAssetWarmer {
 
     /** Starts the WebView engine, so the first `web_view` render does not pay for it on the UI thread. */
     public fun prebootWebView(context: Context)
+
+    /**
+     * Loads each `web_view` bundle offscreen so displaying it later can be served from the http cache.
+     * Only a bounded number load at once, so this returns long before the last one is done.
+     */
+    public fun warmWebViewUrls(context: Context, urls: List<String>)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarmer.kt
@@ -19,9 +19,6 @@ public interface PaywallAssetWarmer {
     /** Starts the WebView engine, so the first `web_view` render does not pay for it on the UI thread. */
     public fun prebootWebView(context: Context)
 
-    /**
-     * Loads each `web_view` bundle offscreen so displaying it later can be served from the http cache.
-     * Only a bounded number load at once, so this returns long before the last one is done.
-     */
+    /** Loads bundles offscreen into the http cache. Bounded concurrency, so it returns before they finish. */
     public fun warmWebViewUrls(context: Context, urls: List<String>)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarming.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarming.kt
@@ -50,9 +50,7 @@ internal class PaywallAssetWarming(
         if (urls.isEmpty()) return
         val warmer = warmer ?: return
         debugLog { "Warming ${urls.size} Paywalls V2 web_view bundle(s): $urls" }
-        // A warm constructs a WebView and starts the engine anyway; this gets that off the thread the first
-        // load would otherwise pay it on. It returns before startup finishes, so the first warm can still
-        // overlap it.
+        // Moves WebView startup off the thread the first load would otherwise pay it on.
         prebootWebView()
         // Posted so warming never runs inline on the frame that delivered the offerings.
         mainHandler.post {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarming.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarming.kt
@@ -4,6 +4,8 @@ package com.revenuecat.purchases.paywalls
 
 import android.content.Context
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
@@ -19,6 +21,8 @@ internal class PaywallAssetWarming(
 ) {
 
     private val warmer: PaywallAssetWarmer? by lazy { warmerProvider() }
+
+    private val mainHandler by lazy { Handler(Looper.getMainLooper()) }
 
     val isAvailable: Boolean
         get() = warmer != null
@@ -39,6 +43,22 @@ internal class PaywallAssetWarming(
         debugLog { "Prebooting the WebView engine for a paywall web_view component." }
         runCatching { warmer.prebootWebView(context) }.onFailure { error ->
             errorLog(error) { "Paywalls V2 WebView preboot failed." }
+        }
+    }
+
+    fun warmWebViewUrls(urls: Collection<String>) {
+        if (urls.isEmpty()) return
+        val warmer = warmer ?: return
+        debugLog { "Warming ${urls.size} Paywalls V2 web_view bundle(s): $urls" }
+        // A warm constructs a WebView and starts the engine anyway; this gets that off the thread the first
+        // load would otherwise pay it on. It returns before startup finishes, so the first warm can still
+        // overlap it.
+        prebootWebView()
+        // Posted so warming never runs inline on the frame that delivered the offerings.
+        mainHandler.post {
+            runCatching { warmer.warmWebViewUrls(context, urls.toList()) }.onFailure { error ->
+                errorLog(error) { "Paywalls V2 web_view warming failed." }
+            }
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -33,8 +33,7 @@ internal class OfferingImagePreDownloader(
     }
 
     private fun downloadV2Images(offering: Offering) {
-        val assets = offering.baseComponentsConfig()?.collectAssets() ?: return
-        assetWarming.warmImages(assets.imageUris)
-        if (assets.webViews.isNotEmpty()) assetWarming.prebootWebView()
+        val componentsConfig = offering.baseComponentsConfig() ?: return
+        assetWarming.warmImages(componentsConfig.collectAssets().imageUris)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -33,7 +33,10 @@ internal class OfferingImagePreDownloader(
     }
 
     private fun downloadV2Images(offering: Offering) {
-        val componentsConfig = offering.baseComponentsConfig() ?: return
-        assetWarming.warmImages(componentsConfig.collectAssets().imageUris)
+        val assets = offering.baseComponentsConfig()?.collectAssets() ?: return
+        assetWarming.warmImages(assets.imageUris)
+        // Runs before offerings are delivered, so a paywall presented from that callback does not pay WebView
+        // engine startup on the UI thread. Warming the bundles themselves happens later.
+        if (assets.webViewUrls.isNotEmpty()) assetWarming.prebootWebView()
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingWebViewPrewarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingWebViewPrewarmer.kt
@@ -1,0 +1,24 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.utils
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.paywalls.PaywallAssetWarming
+
+/**
+ * A no-op unless the offerings response carries the component tree, which it does only while remote config
+ * is disabled. With it enabled the tree arrives on the workflows topic, warmed by `WorkflowAssetPrewarmer`.
+ */
+internal class OfferingWebViewPrewarmer(
+    private val assetWarming: PaywallAssetWarming,
+) {
+
+    fun prewarmWebViews(offerings: List<Offering>) {
+        if (!assetWarming.isAvailable) return
+        val urls = offerings.flatMapTo(linkedSetOf<String>()) { offering ->
+            offering.baseComponentsConfig()?.collectAssets()?.webViewUrls.orEmpty()
+        }
+        assetWarming.warmWebViewUrls(urls)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingWebViewPrewarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingWebViewPrewarmer.kt
@@ -7,8 +7,8 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.PaywallAssetWarming
 
 /**
- * A no-op unless the offerings response carries the component tree, which it does only while remote config
- * is disabled. With it enabled the tree arrives on the workflows topic, warmed by `WorkflowAssetPrewarmer`.
+ * A no-op unless the offerings response carries the component tree, which it does only while remote config is
+ * disabled; with it enabled the tree arrives on the workflows topic instead.
  */
 internal class OfferingWebViewPrewarmer(
     private val assetWarming: PaywallAssetWarming,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentAssets.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentAssets.kt
@@ -30,19 +30,11 @@ import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
 
 internal data class PaywallComponentAssets(
     val imageUris: Set<Uri>,
-    val webViews: Set<WebViewAsset>,
-)
-
-internal data class WebViewAsset(
-    val url: String,
-    val componentId: String,
-    val sizeToContentWidth: Boolean,
-    val sizeToContentHeight: Boolean,
+    val webViewUrls: Set<String>,
 )
 
 /**
@@ -57,25 +49,17 @@ internal fun Offering.baseComponentsConfig(): PaywallComponentsConfig? =
 
 internal fun PaywallComponentsConfig.collectAssets(): PaywallComponentAssets {
     val imageUris = background.findImageUris().toMutableSet()
-    val webViews = mutableSetOf<WebViewAsset>()
+    val webViewUrls = linkedSetOf<String>()
 
     listOfNotNull(stack, header?.stack, stickyFooter?.stack).forEach { tree ->
         tree.flatten().forEach { component ->
             imageUris += component.findImageUris()
-            if (component is WebViewComponent) webViews += component.toWebViewAsset()
+            if (component is WebViewComponent) webViewUrls += component.url
         }
     }
 
-    return PaywallComponentAssets(imageUris = imageUris, webViews = webViews)
+    return PaywallComponentAssets(imageUris = imageUris, webViewUrls = webViewUrls)
 }
-
-private fun WebViewComponent.toWebViewAsset(): WebViewAsset = WebViewAsset(
-    url = url,
-    componentId = id,
-    // The schema lets an override change only `visible`, so size is always the base component's.
-    sizeToContentWidth = size.width is SizeConstraint.Fit,
-    sizeToContentHeight = size.height is SizeConstraint.Fit,
-)
 
 /** Image URIs this component references directly; descendants are visited separately by [flatten]. */
 @Suppress("CyclomaticComplexMethod")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PrewarmTargetOfferings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PrewarmTargetOfferings.kt
@@ -7,15 +7,11 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 
 /**
- * The offerings a customer could be served next: a project using placements gets one current offering per
- * placement, so all of them plus the fallback count, not just [Offerings.current].
+ * The offerings a customer could be served next: with placements that is one per placement plus the fallback,
+ * not just [Offerings.current]. All of it arrives in the same response, so this costs no network.
  *
- * All of it arrives in the same offerings response, so this costs no network. Resolved against
- * [Offerings.all] rather than [Offerings.getCurrentOfferingForPlacement], which allocates a
- * presented-context copy warming has no use for.
- *
- * Experiments need no handling: the backend sets the winning variant as the current offering before the SDK
- * sees the response.
+ * Resolved against [Offerings.all], not [Offerings.getCurrentOfferingForPlacement], which allocates a
+ * presented-context copy. Experiments need no handling: the backend makes the winning variant current.
  */
 internal fun Offerings.prewarmTargetOfferingIds(): Set<String> {
     val identifiers = linkedSetOf<String>()
@@ -28,6 +24,5 @@ internal fun Offerings.prewarmTargetOfferingIds(): Set<String> {
     return identifiers
 }
 
-/** The offerings [prewarmTargetOfferingIds] names, resolved in the same order. */
 internal fun Offerings.prewarmTargetOfferings(): List<Offering> =
     prewarmTargetOfferingIds().mapNotNull(::getOffering)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PrewarmTargetOfferings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PrewarmTargetOfferings.kt
@@ -1,0 +1,33 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.utils
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Offerings
+
+/**
+ * The offerings a customer could be served next: a project using placements gets one current offering per
+ * placement, so all of them plus the fallback count, not just [Offerings.current].
+ *
+ * All of it arrives in the same offerings response, so this costs no network. Resolved against
+ * [Offerings.all] rather than [Offerings.getCurrentOfferingForPlacement], which allocates a
+ * presented-context copy warming has no use for.
+ *
+ * Experiments need no handling: the backend sets the winning variant as the current offering before the SDK
+ * sees the response.
+ */
+internal fun Offerings.prewarmTargetOfferingIds(): Set<String> {
+    val identifiers = linkedSetOf<String>()
+    current?.identifier?.let(identifiers::add)
+    placements?.let { config ->
+        // A placement mapped to null means "show nothing here", so it contributes no offering.
+        config.offeringIdsByPlacement.values.filterNotNullTo(identifiers)
+        config.fallbackOfferingId?.let(identifiers::add)
+    }
+    return identifiers
+}
+
+/** The offerings [prewarmTargetOfferingIds] names, resolved in the same order. */
+internal fun Offerings.prewarmTargetOfferings(): List<Offering> =
+    prewarmTargetOfferingIds().mapNotNull(::getOffering)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -13,6 +13,8 @@ import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.utils.ONE_OFFERINGS_RESPONSE
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
+import com.revenuecat.purchases.utils.OfferingWebViewPrewarmer
+import com.revenuecat.purchases.utils.prewarmTargetOfferings
 import com.revenuecat.purchases.utils.STUB_OFFERING_IDENTIFIER
 import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
 import com.revenuecat.purchases.utils.stubOfferings
@@ -48,6 +50,7 @@ class OfferingsManagerTest {
     private lateinit var offeringImagePreDownloader: OfferingImagePreDownloader
     private lateinit var mockDiagnosticsTracker: DiagnosticsTracker
     private lateinit var mockOfferingFontPreDownloader: OfferingFontPreDownloader
+    private lateinit var mockOfferingWebViewPrewarmer: OfferingWebViewPrewarmer
     private lateinit var mockWorkflowManager: WorkflowManager
 
     private lateinit var offeringsManager: OfferingsManager
@@ -64,6 +67,9 @@ class OfferingsManagerTest {
         mockOfferingFontPreDownloader = mockk<OfferingFontPreDownloader>().apply {
             every { preDownloadOfferingFontsIfNeeded(any()) } just Runs
         }
+        mockOfferingWebViewPrewarmer = mockk<OfferingWebViewPrewarmer>().apply {
+            every { prewarmWebViews(any()) } just Runs
+        }
         mockWorkflowManager = mockk(relaxed = true)
         every { mockWorkflowManager.onPaywallConfigReady(onComplete = any()) } answers {
             firstArg<() -> Unit>().invoke()
@@ -79,6 +85,7 @@ class OfferingsManagerTest {
             offeringImagePreDownloader = offeringImagePreDownloader,
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
             workflowManager = mockWorkflowManager,
         )
     }
@@ -533,6 +540,7 @@ class OfferingsManagerTest {
             offeringImagePreDownloader = offeringImagePreDownloader,
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
             workflowManager = null,
         )
         every { cache.cachedOfferings } returns null
@@ -649,6 +657,28 @@ class OfferingsManagerTest {
     }
 
     // endregion pre download offering images
+
+    // region prewarm web_view bundles
+
+    @Test
+    fun `getOfferings prewarms web_view bundles`() {
+        every { cache.cachedOfferings } returns null
+        mockOfferingsFactory()
+        mockDeviceCache()
+
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { fail("should be a success") },
+            onSuccess = {},
+        )
+
+        verify(exactly = 1) {
+            mockOfferingWebViewPrewarmer.prewarmWebViews(testOfferings.prewarmTargetOfferings())
+        }
+    }
+
+    // endregion prewarm web_view bundles
 
     // region pre download font files
 
@@ -886,6 +916,7 @@ class OfferingsManagerTest {
             offeringImagePreDownloader = offeringImagePreDownloader,
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
             uiPreviewMode = true,
         )
 
@@ -915,6 +946,7 @@ class OfferingsManagerTest {
             offeringImagePreDownloader = offeringImagePreDownloader,
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
             uiPreviewMode = true,
         )
         mockCacheStale(offeringsStale = true)
@@ -936,6 +968,7 @@ class OfferingsManagerTest {
             offeringImagePreDownloader = offeringImagePreDownloader,
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
             uiPreviewMode = true,
         )
 
@@ -1093,6 +1126,7 @@ class OfferingsManagerTest {
             offeringImagePreDownloader = offeringImagePreDownloader,
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
             workflowManager = null,
         )
 
@@ -1126,6 +1160,7 @@ class OfferingsManagerTest {
             offeringImagePreDownloader = offeringImagePreDownloader,
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
             workflowManager = mockWorkflowManager,
         )
 
@@ -1163,6 +1198,7 @@ class OfferingsManagerTest {
             offeringImagePreDownloader = offeringImagePreDownloader,
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
             workflowManager = mockWorkflowManager,
         )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -6,12 +6,16 @@ import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.Delay
+import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.GetOfferingsErrorHandlingBehavior
 import com.revenuecat.purchases.common.HTTPResponseOriginalSource
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.utils.ONE_OFFERINGS_RESPONSE
+import com.revenuecat.purchases.utils.MockHandlerFactory
+import com.revenuecat.purchases.utils.SyncDispatcher
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
 import com.revenuecat.purchases.utils.OfferingWebViewPrewarmer
 import com.revenuecat.purchases.utils.prewarmTargetOfferings
@@ -86,6 +90,7 @@ class OfferingsManagerTest {
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
             offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
+            dispatcher = SyncDispatcher(),
             workflowManager = mockWorkflowManager,
         )
     }
@@ -541,6 +546,7 @@ class OfferingsManagerTest {
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
             offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
+            dispatcher = SyncDispatcher(),
             workflowManager = null,
         )
         every { cache.cachedOfferings } returns null
@@ -654,6 +660,53 @@ class OfferingsManagerTest {
         verify(exactly = 1) {
             offeringImagePreDownloader.preDownloadOfferingImages(testOfferings.current!!)
         }
+    }
+
+    // A SyncDispatcher runs the block inline, so this holds the command instead: without the enqueue the
+    // fan-out would decode on the backend response thread.
+    @Test
+    fun `getOfferings enqueues placement target warming rather than running it on the response thread`() {
+        val commands = mutableListOf<Runnable>()
+        val holdingDispatcher = object : Dispatcher(mockk(), MockHandlerFactory.createMockHandler()) {
+            override fun enqueue(command: Runnable, delay: Delay) {
+                commands += command
+            }
+        }
+        val other = mockk<Offering>(relaxed = true).apply { every { identifier } returns "onboarding" }
+        val offerings = testOfferings.copy(
+            all = testOfferings.all + ("onboarding" to other),
+            placements = Offerings.Placements(
+                fallbackOfferingId = null,
+                offeringIdsByPlacement = mapOf("onboarding" to "onboarding"),
+            ),
+        )
+        val manager = OfferingsManager(
+            offeringsCache = cache,
+            backend = backend,
+            offeringsFactory = offeringsFactory,
+            offeringImagePreDownloader = offeringImagePreDownloader,
+            diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
+            offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
+            dispatcher = holdingDispatcher,
+            workflowManager = null,
+        )
+        every { cache.cachedOfferings } returns null
+        mockOfferingsFactory(offerings)
+        mockDeviceCache()
+        val warmed = mutableListOf<String>()
+        every { offeringImagePreDownloader.preDownloadOfferingImages(any()) } answers {
+            warmed += firstArg<Offering>().identifier
+        }
+
+        manager.getOfferings(appUserId, appInBackground = false, onError = { fail("should be a success") })
+
+        assertThat(warmed).containsExactly(offerings.current!!.identifier)
+        assertThat(commands).hasSize(1)
+
+        commands.forEach { it.run() }
+
+        assertThat(warmed).containsExactly(offerings.current!!.identifier, "onboarding")
     }
 
     // Each placement target decodes its own component tree, so the fan-out must stay off this path.
@@ -948,6 +1001,7 @@ class OfferingsManagerTest {
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
             offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
+            dispatcher = SyncDispatcher(),
             uiPreviewMode = true,
         )
 
@@ -978,6 +1032,7 @@ class OfferingsManagerTest {
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
             offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
+            dispatcher = SyncDispatcher(),
             uiPreviewMode = true,
         )
         mockCacheStale(offeringsStale = true)
@@ -1000,6 +1055,7 @@ class OfferingsManagerTest {
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
             offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
+            dispatcher = SyncDispatcher(),
             uiPreviewMode = true,
         )
 
@@ -1158,6 +1214,7 @@ class OfferingsManagerTest {
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
             offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
+            dispatcher = SyncDispatcher(),
             workflowManager = null,
         )
 
@@ -1192,6 +1249,7 @@ class OfferingsManagerTest {
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
             offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
+            dispatcher = SyncDispatcher(),
             workflowManager = mockWorkflowManager,
         )
 
@@ -1230,6 +1288,7 @@ class OfferingsManagerTest {
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
             offeringWebViewPrewarmer = mockOfferingWebViewPrewarmer,
+            dispatcher = SyncDispatcher(),
             workflowManager = mockWorkflowManager,
         )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -656,6 +656,38 @@ class OfferingsManagerTest {
         }
     }
 
+    // Each placement target decodes its own component tree, so the fan-out must not sit ahead of the
+    // caller's callback the way the current offering's single decode does.
+    @Test
+    fun `getOfferings pre downloads placement target images only after delivering offerings`() {
+        val other = mockk<Offering>(relaxed = true).apply { every { identifier } returns "onboarding" }
+        val offerings = testOfferings.copy(
+            all = testOfferings.all + ("onboarding" to other),
+            placements = Offerings.Placements(
+                fallbackOfferingId = null,
+                offeringIdsByPlacement = mapOf("onboarding" to "onboarding"),
+            ),
+        )
+        every { cache.cachedOfferings } returns null
+        mockOfferingsFactory(offerings)
+        mockDeviceCache()
+        val warmed = mutableListOf<String>()
+        every { offeringImagePreDownloader.preDownloadOfferingImages(any()) } answers {
+            warmed += firstArg<Offering>().identifier
+        }
+        var warmedAtDelivery: List<String>? = null
+
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { fail("should be a success") },
+            onSuccess = { warmedAtDelivery = warmed.toList() },
+        )
+
+        assertThat(warmedAtDelivery).containsExactly(offerings.current!!.identifier)
+        assertThat(warmed).containsExactly(offerings.current!!.identifier, "onboarding")
+    }
+
     // endregion pre download offering images
 
     // region prewarm web_view bundles

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -656,8 +656,7 @@ class OfferingsManagerTest {
         }
     }
 
-    // Each placement target decodes its own component tree, so the fan-out must not sit ahead of the
-    // caller's callback the way the current offering's single decode does.
+    // Each placement target decodes its own component tree, so the fan-out must stay off this path.
     @Test
     fun `getOfferings pre downloads placement target images only after delivering offerings`() {
         val other = mockk<Offering>(relaxed = true).apply { every { identifier } returns "onboarding" }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.emptyUiConfig
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
@@ -22,6 +23,8 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConf
 import com.revenuecat.purchases.uiConfigWithFonts
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.PaywallAssetWarming
 import com.revenuecat.purchases.utils.collectAssets
 import io.mockk.coEvery
@@ -94,6 +97,37 @@ class WorkflowAssetPrewarmerTest {
     }
 
     @Test
+    fun `preDownloadWorkflowAssets warms the web_view bundles across a workflow's screens`() {
+        val workflow = createWorkflow(
+            "wf_1",
+            screens = mapOf(
+                "screen_1" to createScreen(webViewComponentsConfig("https://a.example.com/i.html")),
+                "screen_2" to createScreen(webViewComponentsConfig("https://b.example.com/i.html")),
+                "screen_3" to createScreen(emptyComponentsConfig()),
+            ),
+        )
+
+        prewarmer.preDownloadWorkflowAssets(workflow, emptyUiConfig())
+
+        verify(exactly = 1) {
+            assetWarming.warmWebViewUrls(
+                setOf("https://a.example.com/i.html", "https://b.example.com/i.html"),
+            )
+        }
+    }
+
+    @Test
+    fun `preDownloadWorkflowAssets finds no web_view bundles when no screen has one`() {
+        val workflow = createWorkflow("wf_1", screens = mapOf("screen_1" to createScreen(emptyComponentsConfig())))
+        val urls = slot<Collection<String>>()
+
+        prewarmer.preDownloadWorkflowAssets(workflow, emptyUiConfig())
+
+        verify { assetWarming.warmWebViewUrls(capture(urls)) }
+        assertThat(urls.captured).isEmpty()
+    }
+
+    @Test
     fun `preDownloadWorkflowAssets only downloads each workflow once`() {
         val screenConfig = emptyComponentsConfig()
         val workflow = createWorkflow("wf_1", screens = mapOf("screen_1" to createScreen(screenConfig)))
@@ -122,14 +156,14 @@ class WorkflowAssetPrewarmerTest {
 
     // endregion render path
 
-    // region load path (onCurrentWorkflowLoaded)
+    // region load path (onWorkflowLoaded)
 
     @Test
-    fun `onCurrentWorkflowLoaded decodes and prewarms the workflow, resolving ui_config once`() = runTest {
+    fun `onWorkflowLoaded decodes and prewarms the workflow, resolving ui_config once`() = runTest {
         val screenConfig = emptyComponentsConfig()
         val workflow = createWorkflow("wf_1", screens = mapOf("screen_1" to createScreen(screenConfig)))
 
-        prewarmer.onCurrentWorkflowLoaded("wf_1") { workflow }
+        prewarmer.onWorkflowLoaded("wf_1") { workflow }
 
         verify(exactly = 1) { assetWarming.warmImages(screenConfig.collectAssets().imageUris) }
         verify(exactly = 1) { fontPreDownloader.preDownloadFontsIfNeeded(any()) }
@@ -137,12 +171,12 @@ class WorkflowAssetPrewarmerTest {
     }
 
     @Test
-    fun `onCurrentWorkflowLoaded dedups by id before decoding on a re-warm`() = runTest {
+    fun `onWorkflowLoaded dedups by id before decoding on a re-warm`() = runTest {
         var decodeCount = 0
         val decode: suspend (String) -> PublishedWorkflow? = { id -> decodeCount++; createWorkflow(id) }
 
-        prewarmer.onCurrentWorkflowLoaded("wf_1", decode)
-        prewarmer.onCurrentWorkflowLoaded("wf_1", decode)
+        prewarmer.onWorkflowLoaded("wf_1", decode)
+        prewarmer.onWorkflowLoaded("wf_1", decode)
 
         // Second warm never decodes wf_1 again (dedup happens before the transient decode).
         assertThat(decodeCount).isEqualTo(1)
@@ -150,26 +184,26 @@ class WorkflowAssetPrewarmerTest {
     }
 
     @Test
-    fun `onCurrentWorkflowLoaded skips when ui_config is unavailable, then retries on the next warm`() = runTest {
+    fun `onWorkflowLoaded skips when ui_config is unavailable, then retries on the next warm`() = runTest {
         coEvery { mockUiConfigProvider.getUiConfig() } returns null
 
-        prewarmer.onCurrentWorkflowLoaded("wf_1") { id -> createWorkflow(id) }
+        prewarmer.onWorkflowLoaded("wf_1") { id -> createWorkflow(id) }
         verify(exactly = 0) { fontPreDownloader.preDownloadFontsIfNeeded(any()) }
 
         // ui_config now available: the workflow was not marked warmed, so it is retried.
         coEvery { mockUiConfigProvider.getUiConfig() } returns uiConfig
-        prewarmer.onCurrentWorkflowLoaded("wf_1") { id -> createWorkflow(id) }
+        prewarmer.onWorkflowLoaded("wf_1") { id -> createWorkflow(id) }
         verify(exactly = 1) { fontPreDownloader.preDownloadFontsIfNeeded(any()) }
     }
 
     @Test
-    fun `onCurrentWorkflowLoaded skips a workflow that fails to decode without marking it warmed`() = runTest {
+    fun `onWorkflowLoaded skips a workflow that fails to decode without marking it warmed`() = runTest {
         // First warm: decode returns null (bytes missing / parse fail) -> skipped, not marked.
-        prewarmer.onCurrentWorkflowLoaded("wf_1") { null }
+        prewarmer.onWorkflowLoaded("wf_1") { null }
         verify(exactly = 0) { fontPreDownloader.preDownloadFontsIfNeeded(any()) }
 
         // Second warm: decode now succeeds -> warmed (proves the failed attempt did not mark it).
-        prewarmer.onCurrentWorkflowLoaded("wf_1") { id -> createWorkflow(id) }
+        prewarmer.onWorkflowLoaded("wf_1") { id -> createWorkflow(id) }
         verify(exactly = 1) { fontPreDownloader.preDownloadFontsIfNeeded(any()) }
     }
 
@@ -182,7 +216,7 @@ class WorkflowAssetPrewarmerTest {
 
         // ...so the load path skips it before decoding — the concrete win of the shared dedup set.
         var decodeCount = 0
-        prewarmer.onCurrentWorkflowLoaded("wf_1") { id -> decodeCount++; createWorkflow(id) }
+        prewarmer.onWorkflowLoaded("wf_1") { id -> decodeCount++; createWorkflow(id) }
 
         assertThat(decodeCount).isEqualTo(0)
     }
@@ -199,6 +233,22 @@ class WorkflowAssetPrewarmerTest {
     private fun emptyComponentsConfig(): PaywallComponentsConfig =
         PaywallComponentsConfig(
             stack = StackComponent(components = emptyList()),
+            background = Background.Color(ColorScheme(light = ColorInfo.Alias(ColorAlias("")))),
+            stickyFooter = null,
+        )
+
+    private fun webViewComponentsConfig(url: String): PaywallComponentsConfig =
+        PaywallComponentsConfig(
+            stack = StackComponent(
+                components = listOf(
+                    WebViewComponent(
+                        url = url,
+                        id = "component-1",
+                        protocolVersion = WebViewComponent.SUPPORTED_PROTOCOL_VERSION,
+                        size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fill),
+                    ),
+                ),
+            ),
             background = Background.Color(ColorScheme(light = ColorInfo.Alias(ColorAlias("")))),
             stickyFooter = null,
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -230,7 +230,7 @@ class WorkflowManagerTest {
     @Test
     fun `onPaywallConfigReady fires onComplete synchronously when both caches are already warm`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
-        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
+        every { mockProvider.prewarmOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns true
         every { mockUiConfigProvider.isWarm() } returns true
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
@@ -248,20 +248,20 @@ class WorkflowManagerTest {
     @Test
     fun `onPaywallConfigReady prewarms the current offering's assets even on the warm fast path`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
-        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
+        every { mockProvider.prewarmOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns true
         every { mockUiConfigProvider.isWarm() } returns true
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
 
         manager.onPaywallConfigReady { }
 
-        verify(exactly = 1) { mockProvider.prewarmCurrentOfferingAssets() }
+        verify(exactly = 1) { mockProvider.prewarmOfferingAssets() }
     }
 
     @Test
     fun `onPaywallConfigReady warms both providers and invokes onComplete when cold`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
-        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
+        every { mockProvider.prewarmOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } just Runs
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
@@ -278,7 +278,7 @@ class WorkflowManagerTest {
     @Test
     fun `onPaywallConfigReady still completes and error-logs when ui_config resolution throws`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
-        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
+        every { mockProvider.prewarmOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } just Runs
         coEvery { mockUiConfigProvider.resolveUiConfig() } throws RuntimeException("boom")
@@ -295,7 +295,7 @@ class WorkflowManagerTest {
     @Test
     fun `onPaywallConfigReady still completes and error-logs when a published ui_config is unavailable`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
-        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
+        every { mockProvider.prewarmOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } just Runs
         coEvery { mockUiConfigProvider.resolveUiConfig() } returns UiConfigResolution.Unavailable
@@ -322,7 +322,7 @@ class WorkflowManagerTest {
 
         validOutcomes.forEach { outcome ->
             val mockProvider = mockk<WorkflowsConfigProvider>()
-        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
+        every { mockProvider.prewarmOfferingAssets() } just Runs
             every { mockProvider.isWarmForCurrentOffering() } returns false
             coEvery { mockProvider.warm() } just Runs
             coEvery { mockUiConfigProvider.resolveUiConfig() } returns outcome
@@ -340,7 +340,7 @@ class WorkflowManagerTest {
     @Test
     fun `onPaywallConfigReady still completes when warming the workflows cache fails`() {
         val mockProvider = mockk<WorkflowsConfigProvider>()
-        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
+        every { mockProvider.prewarmOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } throws RuntimeException("boom")
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
@@ -358,7 +358,7 @@ class WorkflowManagerTest {
     fun `onPaywallConfigReady coalesces overlapping calls so readiness work runs only once and both callbacks fire`() {
         val gate = CompletableDeferred<Unit>()
         val mockProvider = mockk<WorkflowsConfigProvider>()
-        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
+        every { mockProvider.prewarmOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } coAnswers { gate.await() }
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = testScope)
@@ -388,7 +388,7 @@ class WorkflowManagerTest {
         // Use a dedicated scope so closing the manager doesn't cancel the shared testScope.
         val managerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
         val mockProvider = mockk<WorkflowsConfigProvider>()
-        every { mockProvider.prewarmCurrentOfferingAssets() } just Runs
+        every { mockProvider.prewarmOfferingAssets() } just Runs
         every { mockProvider.isWarmForCurrentOffering() } returns false
         coEvery { mockProvider.warm() } coAnswers { gate.await() }
         val manager = WorkflowManager(mockProvider, mockUiConfigProvider, mockAssetPreDownloader, scope = managerScope)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
@@ -376,12 +376,12 @@ internal class WorkflowsConfigProviderTest {
     }
 
     @Test
-    fun `warm notifies onCurrentWorkflowLoaded with only the current offering's workflow`() = runTest {
+    fun `warm does not announce a workflow outside the prewarm set`() = runTest {
         var announcedId: String? = null
         val providerWithListener = WorkflowsConfigProvider(
             manager,
             currentOfferingIdProvider = { currentOfferingId },
-            onCurrentWorkflowLoaded = { workflowId, _ -> announcedId = workflowId },
+            onWorkflowLoaded = { workflowId, _ -> announcedId = workflowId },
             scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
         )
         stubTopic()
@@ -390,19 +390,58 @@ internal class WorkflowsConfigProviderTest {
 
         providerWithListener.warm(generation = 0)
 
-        // Mirrors the offerings path: only the current offering's workflow is announced for asset prewarming.
-        // WF_PREFETCH's bytes are cached too, but a prefetch-only workflow (not the current offering's) is not
-        // the paywall about to be shown, so its assets are not warmed.
+        // WF_PREFETCH's bytes are cached too, but a prefetch-flagged workflow behind no offering this customer
+        // could be served is not a paywall they are about to see, so its assets are not warmed.
         assertThat(announcedId).isEqualTo(WF_CURRENT)
     }
 
+    // A project using placements gets one current offering per placement, and each can have its own workflow.
     @Test
-    fun `warm notifies onCurrentWorkflowLoaded even when the workflow body was not byte-warmed`() = runTest {
+    fun `warm announces the workflow behind every offering in the prewarm set`() = runTest {
+        val announced = mutableListOf<String>()
+        val providerWithListener = WorkflowsConfigProvider(
+            manager,
+            currentOfferingIdProvider = { currentOfferingId },
+            prewarmOfferingIdsProvider = { setOf(CURRENT_OFFERING, OTHER_OFFERING) },
+            onWorkflowLoaded = { workflowId, _ -> announced += workflowId },
+            scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        stubTopic()
+        stubWorkflowBody(WF_PREFETCH)
+        stubWorkflowBody(WF_CURRENT)
+        stubWorkflowBody(WF_OTHER)
+
+        providerWithListener.warm(generation = 0)
+
+        assertThat(announced).containsExactlyInAnyOrder(WF_CURRENT, WF_OTHER)
+    }
+
+    @Test
+    fun `warm announces each workflow once when the current offering is also in the prewarm set`() = runTest {
+        val announced = mutableListOf<String>()
+        val providerWithListener = WorkflowsConfigProvider(
+            manager,
+            currentOfferingIdProvider = { currentOfferingId },
+            prewarmOfferingIdsProvider = { setOf(CURRENT_OFFERING) },
+            onWorkflowLoaded = { workflowId, _ -> announced += workflowId },
+            scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        stubTopic()
+        stubWorkflowBody(WF_PREFETCH)
+        stubWorkflowBody(WF_CURRENT)
+
+        providerWithListener.warm(generation = 0)
+
+        assertThat(announced).containsExactly(WF_CURRENT)
+    }
+
+    @Test
+    fun `warm notifies onWorkflowLoaded even when the workflow body was not byte-warmed`() = runTest {
         var announcedId: String? = null
         val providerWithListener = WorkflowsConfigProvider(
             manager,
             currentOfferingIdProvider = { currentOfferingId },
-            onCurrentWorkflowLoaded = { workflowId, _ -> announcedId = workflowId },
+            onWorkflowLoaded = { workflowId, _ -> announcedId = workflowId },
             scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
         )
         stubTopic()
@@ -422,13 +461,13 @@ internal class WorkflowsConfigProviderTest {
 
     // Cold start: warm() runs before the offerings response, so it has no current offering to announce.
     @Test
-    fun `prewarmCurrentOfferingAssets announces once the offering is known after a warm that had none`() = runTest {
+    fun `prewarmOfferingAssets announces once the offering is known after a warm that had none`() = runTest {
         var announcedId: String? = null
         currentOfferingId = null
         val providerWithListener = WorkflowsConfigProvider(
             manager,
             currentOfferingIdProvider = { currentOfferingId },
-            onCurrentWorkflowLoaded = { workflowId, _ -> announcedId = workflowId },
+            onWorkflowLoaded = { workflowId, _ -> announcedId = workflowId },
             scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
         )
         stubTopic()
@@ -441,34 +480,34 @@ internal class WorkflowsConfigProviderTest {
         assertThat(providerWithListener.isWarmForCurrentOffering()).isTrue
 
         currentOfferingId = CURRENT_OFFERING
-        providerWithListener.prewarmCurrentOfferingAssets()
+        providerWithListener.prewarmOfferingAssets()
 
         assertThat(announcedId).isEqualTo(WF_CURRENT)
     }
 
     @Test
-    fun `prewarmCurrentOfferingAssets does not announce when nothing has been warmed yet`() = runTest {
+    fun `prewarmOfferingAssets does not announce when nothing has been warmed yet`() = runTest {
         var announced = false
         val providerWithListener = WorkflowsConfigProvider(
             manager,
             currentOfferingIdProvider = { currentOfferingId },
-            onCurrentWorkflowLoaded = { _, _ -> announced = true },
+            onWorkflowLoaded = { _, _ -> announced = true },
             scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
         )
 
-        providerWithListener.prewarmCurrentOfferingAssets()
+        providerWithListener.prewarmOfferingAssets()
 
         assertThat(announced).isFalse
     }
 
     @Test
-    fun `warm does not notify onCurrentWorkflowLoaded when the current offering has no workflow`() = runTest {
+    fun `warm does not notify onWorkflowLoaded when the current offering has no workflow`() = runTest {
         var announced = false
         currentOfferingId = "offering_without_workflow"
         val providerWithListener = WorkflowsConfigProvider(
             manager,
             currentOfferingIdProvider = { currentOfferingId },
-            onCurrentWorkflowLoaded = { _, _ -> announced = true },
+            onWorkflowLoaded = { _, _ -> announced = true },
             scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
         )
         stubTopic()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
@@ -390,8 +390,7 @@ internal class WorkflowsConfigProviderTest {
 
         providerWithListener.warm(generation = 0)
 
-        // WF_PREFETCH's bytes are cached too, but a prefetch-flagged workflow behind no offering this customer
-        // could be served is not a paywall they are about to see, so its assets are not warmed.
+        // WF_PREFETCH's bytes are cached, but it sits behind no offering this customer could be served.
         assertThat(announcedId).isEqualTo(WF_CURRENT)
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallAssetWarmingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallAssetWarmingTest.kt
@@ -2,30 +2,40 @@ package com.revenuecat.purchases.paywalls
 
 import android.content.Context
 import android.net.Uri
+import android.os.Looper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(AndroidJUnit4::class)
 class PaywallAssetWarmingTest {
 
     private val context = mockk<Context>(relaxed = true)
     private val uri = Uri.parse("https://example.com/image.webp")
+    private val webViewUrl = "https://example.com/index.html"
 
     private fun warming(warmer: PaywallAssetWarmer?) =
         PaywallAssetWarming(context, warmerProvider = { warmer })
 
+    private fun idle() = shadowOf(Looper.getMainLooper()).idle()
+
     private class RecordingWarmer : PaywallAssetWarmer {
         val warmed = mutableListOf<Uri>()
         var prebootCount = 0
+        val warmedWebViewUrls = mutableListOf<String>()
         override fun warmImages(context: Context, imageUris: List<Uri>) {
             warmed.addAll(imageUris)
         }
 
         override fun prebootWebView(context: Context) {
             prebootCount++
+        }
+
+        override fun warmWebViewUrls(context: Context, urls: List<String>) {
+            warmedWebViewUrls.addAll(urls)
         }
     }
 
@@ -63,6 +73,65 @@ class PaywallAssetWarmingTest {
     }
 
     @Test
+    fun `hands the web_view urls to the registered warmer`() {
+        val warmer = RecordingWarmer()
+
+        warming(warmer).warmWebViewUrls(listOf(webViewUrl))
+        idle()
+
+        assertThat(warmer.warmedWebViewUrls).containsExactly(webViewUrl)
+    }
+
+    // The warm is posted, so preboot is requested first and nothing warms on the caller's frame.
+    @Test
+    fun `warms web_view urls after preboot, not inline with it`() {
+        val warmer = RecordingWarmer()
+
+        warming(warmer).warmWebViewUrls(listOf(webViewUrl))
+
+        assertThat(warmer.prebootCount).isEqualTo(1)
+        assertThat(warmer.warmedWebViewUrls).isEmpty()
+
+        idle()
+
+        assertThat(warmer.warmedWebViewUrls).containsExactly(webViewUrl)
+    }
+
+    @Test
+    fun `does not warm web_view urls when nothing is registered`() {
+        warming(warmer = null).warmWebViewUrls(listOf(webViewUrl))
+    }
+
+    @Test
+    fun `does not call the warmer with an empty url list`() {
+        val warmer = RecordingWarmer()
+
+        warming(warmer).warmWebViewUrls(emptyList())
+
+        assertThat(warmer.warmedWebViewUrls).isEmpty()
+    }
+
+    // Warming a bundle constructs a WebView, so the engine starts either way; callers should not have to know
+    // to ask for it first.
+    @Test
+    fun `preboots the engine before warming web_view urls`() {
+        val warmer = RecordingWarmer()
+
+        warming(warmer).warmWebViewUrls(listOf(webViewUrl))
+
+        assertThat(warmer.prebootCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `does not preboot when there are no web_view urls to warm`() {
+        val warmer = RecordingWarmer()
+
+        warming(warmer).warmWebViewUrls(emptyList())
+
+        assertThat(warmer.prebootCount).isZero()
+    }
+
+    @Test
     fun `preboots the web view through the registered warmer`() {
         val warmer = RecordingWarmer()
 
@@ -81,10 +150,13 @@ class PaywallAssetWarmingTest {
         val throwingWarmer = object : PaywallAssetWarmer {
             override fun warmImages(context: Context, imageUris: List<Uri>) = throw RuntimeException("boom")
             override fun prebootWebView(context: Context) = throw RuntimeException("boom")
+            override fun warmWebViewUrls(context: Context, urls: List<String>) = throw RuntimeException("boom")
         }
 
         warming(throwingWarmer).warmImages(listOf(uri))
         warming(throwingWarmer).prebootWebView()
+        warming(throwingWarmer).warmWebViewUrls(listOf("https://example.com/index.html"))
+        idle()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallAssetWarmingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallAssetWarmingTest.kt
@@ -72,17 +72,7 @@ class PaywallAssetWarmingTest {
         assertThat(warmer.warmed).isEmpty()
     }
 
-    @Test
-    fun `hands the web_view urls to the registered warmer`() {
-        val warmer = RecordingWarmer()
-
-        warming(warmer).warmWebViewUrls(listOf(webViewUrl))
-        idle()
-
-        assertThat(warmer.warmedWebViewUrls).containsExactly(webViewUrl)
-    }
-
-    // The warm is posted, so preboot is requested first and nothing warms on the caller's frame.
+    // Posted, so nothing warms on the caller's frame.
     @Test
     fun `warms web_view urls after preboot, not inline with it`() {
         val warmer = RecordingWarmer()
@@ -103,31 +93,13 @@ class PaywallAssetWarmingTest {
     }
 
     @Test
-    fun `does not call the warmer with an empty url list`() {
+    fun `neither warms nor preboots for an empty url list`() {
         val warmer = RecordingWarmer()
 
         warming(warmer).warmWebViewUrls(emptyList())
+        idle()
 
         assertThat(warmer.warmedWebViewUrls).isEmpty()
-    }
-
-    // Warming a bundle constructs a WebView, so the engine starts either way; callers should not have to know
-    // to ask for it first.
-    @Test
-    fun `preboots the engine before warming web_view urls`() {
-        val warmer = RecordingWarmer()
-
-        warming(warmer).warmWebViewUrls(listOf(webViewUrl))
-
-        assertThat(warmer.prebootCount).isEqualTo(1)
-    }
-
-    @Test
-    fun `does not preboot when there are no web_view urls to warm`() {
-        val warmer = RecordingWarmer()
-
-        warming(warmer).warmWebViewUrls(emptyList())
-
         assertThat(warmer.prebootCount).isZero()
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
@@ -130,11 +130,20 @@ class OfferingImagePreDownloaderTest {
     // region Paywalls V2
 
     @Test
-    fun `paywalls V2 - a web_view in the tree is not this path's concern`() {
+    fun `paywalls V2 - does not preboot the engine when the tree has no web_view`() {
+        preDownloader.preDownloadOfferingImages(createOfferingWithV2Paywall())
+
+        assertThat(warmer.prebootCount).isZero()
+    }
+
+    // Preboot has to happen on this path because it runs before offerings are delivered; the bundle loads
+    // themselves are the offerings-prewarm path's job.
+    @Test
+    fun `paywalls V2 - preboots the engine for a web_view without warming it`() {
         preDownloader.preDownloadOfferingImages(offeringWithWebView())
 
         assertThat(warmer.warmed).isEmpty()
-        assertThat(warmer.prebootCount).isZero()
+        assertThat(warmer.prebootCount).isEqualTo(1)
         assertThat(warmer.warmedWebViewUrls).isEmpty()
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
@@ -69,12 +69,17 @@ class OfferingImagePreDownloaderTest {
     private class RecordingWarmer : PaywallAssetWarmer {
         val warmed = mutableListOf<Uri>()
         var prebootCount = 0
+        val warmedWebViewUrls = mutableListOf<String>()
         override fun warmImages(context: Context, imageUris: List<Uri>) {
             warmed.addAll(imageUris)
         }
 
         override fun prebootWebView(context: Context) {
             prebootCount++
+        }
+
+        override fun warmWebViewUrls(context: Context, urls: List<String>) {
+            warmedWebViewUrls.addAll(urls)
         }
     }
 
@@ -124,19 +129,13 @@ class OfferingImagePreDownloaderTest {
 
     // region Paywalls V2
 
-    // WebView startup is not free, so it is triggered only for paywalls that actually carry a web_view.
     @Test
-    fun `paywalls V2 - preboots the web view when the tree has one`() {
+    fun `paywalls V2 - a web_view in the tree is not this path's concern`() {
         preDownloader.preDownloadOfferingImages(offeringWithWebView())
 
-        assertThat(warmer.prebootCount).isEqualTo(1)
-    }
-
-    @Test
-    fun `paywalls V2 - does not preboot the web view when the tree has none`() {
-        preDownloader.preDownloadOfferingImages(createOfferingWithV2Paywall())
-
-        assertThat(warmer.prebootCount).isEqualTo(0)
+        assertThat(warmer.warmed).isEmpty()
+        assertThat(warmer.prebootCount).isZero()
+        assertThat(warmer.warmedWebViewUrls).isEmpty()
     }
 
     private fun offeringWithWebView(): Offering = createOfferingWithV2Paywall(
@@ -165,8 +164,8 @@ class OfferingImagePreDownloaderTest {
     @Test
     fun `paywalls V2 - if the component tree fails to decode, it does not throw and downloads nothing`() {
         val offering = mockk<Offering>().apply {
-            every { paywall } returns null
             every { identifier } returns "broken"
+            every { paywall } returns null
             every { paywallComponents } returns Offering.PaywallComponents(
                 uiConfig = mockk(),
                 componentsHash = "hash",

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingWebViewPrewarmerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingWebViewPrewarmerTest.kt
@@ -49,7 +49,7 @@ internal class OfferingWebViewPrewarmerTest {
         PaywallAssetWarming(context = mockk(relaxed = true), warmerProvider = { warmer }),
     )
 
-    // The actual warm is posted to the main thread, so tests need a pump to see it.
+    // The warm is posted to the main thread, so tests need a pump to see it.
     private fun OfferingWebViewPrewarmer.prewarmAndIdle(offerings: Offerings) {
         prewarmWebViews(offerings.prewarmTargetOfferings())
         shadowOf(Looper.getMainLooper()).idle()
@@ -71,94 +71,14 @@ internal class OfferingWebViewPrewarmerTest {
     }
 
     @Test
-    fun `warms the current offering's web_view`() {
-        prewarmer.prewarmAndIdle(offeringsWith(current = offeringWithWebViews("a", "https://a.example.com/i.html")))
-
-        assertThat(warmer.warmedWebViewUrls).containsExactly("https://a.example.com/i.html")
-    }
-
-    @Test
-    fun `warms every web_view in one offering`() {
+    fun `warms every web_view in the current offering, prebooting the engine once`() {
         val offering = offeringWithWebViews("a", "https://a.example.com/1.html", "https://a.example.com/2.html")
 
         prewarmer.prewarmAndIdle(offeringsWith(current = offering))
 
         assertThat(warmer.warmedWebViewUrls)
             .containsExactly("https://a.example.com/1.html", "https://a.example.com/2.html")
-    }
-
-    @Test
-    fun `warms the offering each placement resolves to`() {
-        val current = offeringWithWebViews("current", "https://current.example.com/i.html")
-        val onboarding = offeringWithWebViews("onboarding", "https://onboarding.example.com/i.html")
-        val settings = offeringWithWebViews("settings", "https://settings.example.com/i.html")
-
-        prewarmer.prewarmAndIdle(
-            offeringsWith(
-                current = current,
-                others = listOf(onboarding, settings),
-                placements = Offerings.Placements(
-                    fallbackOfferingId = null,
-                    offeringIdsByPlacement = mapOf("onboarding" to "onboarding", "settings" to "settings"),
-                ),
-            ),
-        )
-
-        assertThat(warmer.warmedWebViewUrls).containsExactlyInAnyOrder(
-            "https://current.example.com/i.html",
-            "https://onboarding.example.com/i.html",
-            "https://settings.example.com/i.html",
-        )
-    }
-
-    @Test
-    fun `warms the placement fallback offering`() {
-        val fallback = offeringWithWebViews("fallback", "https://fallback.example.com/i.html")
-
-        prewarmer.prewarmAndIdle(
-            offeringsWith(
-                current = null,
-                others = listOf(fallback),
-                placements = Offerings.Placements(
-                    fallbackOfferingId = "fallback",
-                    offeringIdsByPlacement = emptyMap(),
-                ),
-            ),
-        )
-
-        assertThat(warmer.warmedWebViewUrls).containsExactly("https://fallback.example.com/i.html")
-    }
-
-    // A placement mapped to null is a deliberate "show nothing here".
-    @Test
-    fun `ignores a placement mapped to no offering`() {
-        prewarmer.prewarmAndIdle(
-            offeringsWith(
-                current = null,
-                placements = Offerings.Placements(
-                    fallbackOfferingId = null,
-                    offeringIdsByPlacement = mapOf("onboarding" to null),
-                ),
-            ),
-        )
-
-        assertThat(warmer.warmedWebViewUrls).isEmpty()
-        assertThat(warmer.prebootCount).isZero()
-    }
-
-    @Test
-    fun `ignores a placement naming an offering that is not in the response`() {
-        prewarmer.prewarmAndIdle(
-            offeringsWith(
-                current = null,
-                placements = Offerings.Placements(
-                    fallbackOfferingId = null,
-                    offeringIdsByPlacement = mapOf("onboarding" to "missing"),
-                ),
-            ),
-        )
-
-        assertThat(warmer.warmedWebViewUrls).isEmpty()
+        assertThat(warmer.prebootCount).isEqualTo(1)
     }
 
     @Test
@@ -187,13 +107,6 @@ internal class OfferingWebViewPrewarmerTest {
 
         assertThat(warmer.warmedWebViewUrls).isEmpty()
         assertThat(warmer.prebootCount).isZero()
-    }
-
-    @Test
-    fun `preboots the engine when there is something to warm`() {
-        prewarmer.prewarmAndIdle(offeringsWith(current = offeringWithWebViews("a", "https://a.example.com/i.html")))
-
-        assertThat(warmer.prebootCount).isEqualTo(1)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingWebViewPrewarmerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingWebViewPrewarmerTest.kt
@@ -1,0 +1,293 @@
+package com.revenuecat.purchases.utils
+
+import android.content.Context
+import android.net.Uri
+import android.os.Looper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ColorAlias
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.paywalls.PaywallAssetWarmer
+import com.revenuecat.purchases.paywalls.PaywallAssetWarming
+import com.revenuecat.purchases.paywalls.components.PaywallComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.TextComponent
+import com.revenuecat.purchases.paywalls.components.WebViewComponent
+import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.SerializationException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import java.net.URL
+
+@RunWith(AndroidJUnit4::class)
+internal class OfferingWebViewPrewarmerTest {
+
+    private lateinit var warmer: RecordingWarmer
+    private lateinit var prewarmer: OfferingWebViewPrewarmer
+
+    @Before
+    fun setUp() {
+        warmer = RecordingWarmer()
+        prewarmer = prewarmerWith(warmer)
+    }
+
+    private fun prewarmerWith(warmer: PaywallAssetWarmer?) = OfferingWebViewPrewarmer(
+        PaywallAssetWarming(context = mockk(relaxed = true), warmerProvider = { warmer }),
+    )
+
+    // The actual warm is posted to the main thread, so tests need a pump to see it.
+    private fun OfferingWebViewPrewarmer.prewarmAndIdle(offerings: Offerings) {
+        prewarmWebViews(offerings.prewarmTargetOfferings())
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private class RecordingWarmer : PaywallAssetWarmer {
+        val warmedWebViewUrls = mutableListOf<String>()
+        var prebootCount = 0
+
+        override fun warmImages(context: Context, imageUris: List<Uri>) = Unit
+
+        override fun prebootWebView(context: Context) {
+            prebootCount++
+        }
+
+        override fun warmWebViewUrls(context: Context, urls: List<String>) {
+            warmedWebViewUrls.addAll(urls)
+        }
+    }
+
+    @Test
+    fun `warms the current offering's web_view`() {
+        prewarmer.prewarmAndIdle(offeringsWith(current = offeringWithWebViews("a", "https://a.example.com/i.html")))
+
+        assertThat(warmer.warmedWebViewUrls).containsExactly("https://a.example.com/i.html")
+    }
+
+    @Test
+    fun `warms every web_view in one offering`() {
+        val offering = offeringWithWebViews("a", "https://a.example.com/1.html", "https://a.example.com/2.html")
+
+        prewarmer.prewarmAndIdle(offeringsWith(current = offering))
+
+        assertThat(warmer.warmedWebViewUrls)
+            .containsExactly("https://a.example.com/1.html", "https://a.example.com/2.html")
+    }
+
+    @Test
+    fun `warms the offering each placement resolves to`() {
+        val current = offeringWithWebViews("current", "https://current.example.com/i.html")
+        val onboarding = offeringWithWebViews("onboarding", "https://onboarding.example.com/i.html")
+        val settings = offeringWithWebViews("settings", "https://settings.example.com/i.html")
+
+        prewarmer.prewarmAndIdle(
+            offeringsWith(
+                current = current,
+                others = listOf(onboarding, settings),
+                placements = Offerings.Placements(
+                    fallbackOfferingId = null,
+                    offeringIdsByPlacement = mapOf("onboarding" to "onboarding", "settings" to "settings"),
+                ),
+            ),
+        )
+
+        assertThat(warmer.warmedWebViewUrls).containsExactlyInAnyOrder(
+            "https://current.example.com/i.html",
+            "https://onboarding.example.com/i.html",
+            "https://settings.example.com/i.html",
+        )
+    }
+
+    @Test
+    fun `warms the placement fallback offering`() {
+        val fallback = offeringWithWebViews("fallback", "https://fallback.example.com/i.html")
+
+        prewarmer.prewarmAndIdle(
+            offeringsWith(
+                current = null,
+                others = listOf(fallback),
+                placements = Offerings.Placements(
+                    fallbackOfferingId = "fallback",
+                    offeringIdsByPlacement = emptyMap(),
+                ),
+            ),
+        )
+
+        assertThat(warmer.warmedWebViewUrls).containsExactly("https://fallback.example.com/i.html")
+    }
+
+    // A placement mapped to null is a deliberate "show nothing here".
+    @Test
+    fun `ignores a placement mapped to no offering`() {
+        prewarmer.prewarmAndIdle(
+            offeringsWith(
+                current = null,
+                placements = Offerings.Placements(
+                    fallbackOfferingId = null,
+                    offeringIdsByPlacement = mapOf("onboarding" to null),
+                ),
+            ),
+        )
+
+        assertThat(warmer.warmedWebViewUrls).isEmpty()
+        assertThat(warmer.prebootCount).isZero()
+    }
+
+    @Test
+    fun `ignores a placement naming an offering that is not in the response`() {
+        prewarmer.prewarmAndIdle(
+            offeringsWith(
+                current = null,
+                placements = Offerings.Placements(
+                    fallbackOfferingId = null,
+                    offeringIdsByPlacement = mapOf("onboarding" to "missing"),
+                ),
+            ),
+        )
+
+        assertThat(warmer.warmedWebViewUrls).isEmpty()
+    }
+
+    @Test
+    fun `warms a url shared by several offerings only once`() {
+        val shared = "https://shared.example.com/i.html"
+        val current = offeringWithWebViews("current", shared)
+        val other = offeringWithWebViews("other", shared)
+
+        prewarmer.prewarmAndIdle(
+            offeringsWith(
+                current = current,
+                others = listOf(other),
+                placements = Offerings.Placements(
+                    fallbackOfferingId = null,
+                    offeringIdsByPlacement = mapOf("onboarding" to "other"),
+                ),
+            ),
+        )
+
+        assertThat(warmer.warmedWebViewUrls).containsExactly(shared)
+    }
+
+    @Test
+    fun `does nothing when no offering has a web_view`() {
+        prewarmer.prewarmAndIdle(offeringsWith(current = offeringWithoutWebViews("current")))
+
+        assertThat(warmer.warmedWebViewUrls).isEmpty()
+        assertThat(warmer.prebootCount).isZero()
+    }
+
+    @Test
+    fun `preboots the engine when there is something to warm`() {
+        prewarmer.prewarmAndIdle(offeringsWith(current = offeringWithWebViews("a", "https://a.example.com/i.html")))
+
+        assertThat(warmer.prebootCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `collects nothing when no warmer is registered`() {
+        val unavailable = prewarmerWith(warmer = null)
+
+        unavailable.prewarmAndIdle(offeringsWith(current = offeringWithWebViews("a", "https://a.example.com/i.html")))
+
+        assertThat(warmer.warmedWebViewUrls).isEmpty()
+    }
+
+    @Test
+    fun `skips an offering whose component tree fails to decode, and warms the rest`() {
+        val broken = mockk<Offering>().apply {
+            every { identifier } returns "broken"
+            every { paywallComponents } returns Offering.PaywallComponents(
+                uiConfig = mockk(),
+                componentsHash = "hash",
+            ) {
+                throw SerializationException("Malformed component tree")
+            }
+        }
+        val healthy = offeringWithWebViews("healthy", "https://healthy.example.com/i.html")
+
+        prewarmer.prewarmAndIdle(
+            offeringsWith(
+                current = broken,
+                others = listOf(healthy),
+                placements = Offerings.Placements(
+                    fallbackOfferingId = "healthy",
+                    offeringIdsByPlacement = emptyMap(),
+                ),
+            ),
+        )
+
+        assertThat(warmer.warmedWebViewUrls).containsExactly("https://healthy.example.com/i.html")
+    }
+
+    @Test
+    fun `ignores an offering with no paywall components`() {
+        val v1Only = mockk<Offering>().apply {
+            every { identifier } returns "v1"
+            every { paywallComponents } returns null
+        }
+
+        prewarmer.prewarmAndIdle(offeringsWith(current = v1Only))
+
+        assertThat(warmer.warmedWebViewUrls).isEmpty()
+    }
+
+    private fun offeringWithWebViews(identifier: String, vararg urls: String): Offering =
+        offeringWith(
+            identifier = identifier,
+            components = urls.mapIndexed { index, url ->
+                WebViewComponent(
+                    url = url,
+                    id = "$identifier-component-$index",
+                    protocolVersion = WebViewComponent.SUPPORTED_PROTOCOL_VERSION,
+                    size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fill),
+                )
+            },
+        )
+
+    private fun offeringWithoutWebViews(identifier: String): Offering = offeringWith(
+        identifier = identifier,
+        components = listOf(
+            TextComponent(
+                text = LocalizationKey("key"),
+                color = ColorScheme(light = ColorInfo.Alias(ColorAlias(""))),
+            ),
+        ),
+    )
+
+    private fun offeringWith(
+        identifier: String,
+        components: List<PaywallComponent>,
+    ): Offering = mockk<Offering>().apply {
+        every { this@apply.identifier } returns identifier
+        every { paywallComponents } returns Offering.PaywallComponents(
+            uiConfig = mockk(),
+            data = PaywallComponentsData(
+                id = "paywall_id",
+                templateName = "template",
+                assetBaseURL = URL("https://assets.example.com"),
+                componentsConfig = ComponentsConfig(
+                    base = PaywallComponentsConfig(
+                        stack = StackComponent(components = components),
+                        background = Background.Color(ColorScheme(light = ColorInfo.Alias(ColorAlias("")))),
+                        stickyFooter = null,
+                    ),
+                ),
+                componentsLocalizations = mapOf(),
+                defaultLocaleIdentifier = LocaleId("en_US"),
+            ),
+        )
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/PaywallComponentAssetsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/PaywallComponentAssetsTest.kt
@@ -27,82 +27,51 @@ import java.net.URL
 class PaywallComponentAssetsTest {
 
     @Test
-    fun `collects a web_view's url and component id`() {
-        val config = configWith(webView(url = "https://example.com/index.html", id = "component-1"))
+    fun `collects a web_view's url`() {
+        val config = configWith(webView(url = "https://example.com/index.html"))
 
         val assets = config.collectAssets()
 
-        assertThat(assets.webViews).containsExactly(
-            WebViewAsset(
-                url = "https://example.com/index.html",
-                componentId = "component-1",
-                sizeToContentWidth = false,
-                sizeToContentHeight = false,
-            ),
-        )
-    }
-
-    @Test
-    fun `derives each fit axis independently`() {
-        val config = configWith(
-            webView(
-                id = "fit-height-only",
-                size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()),
-            ),
-        )
-
-        val webView = config.collectAssets().webViews.single()
-
-        assertThat(webView.sizeToContentWidth).isFalse()
-        assertThat(webView.sizeToContentHeight).isTrue()
-    }
-
-    @Test
-    fun `treats a fixed axis as not sizing to content`() {
-        val config = configWith(
-            webView(size = Size(width = SizeConstraint.Fixed(320u), height = SizeConstraint.Fixed(240u))),
-        )
-
-        val webView = config.collectAssets().webViews.single()
-
-        assertThat(webView.sizeToContentWidth).isFalse()
-        assertThat(webView.sizeToContentHeight).isFalse()
+        assertThat(assets.webViewUrls).containsExactly("https://example.com/index.html")
     }
 
     @Test
     fun `finds web_views nested anywhere in the tree`() {
         val config = PaywallComponentsConfig(
             stack = StackComponent(
-                components = listOf(StackComponent(components = listOf(webView(id = "nested")))),
+                components = listOf(StackComponent(components = listOf(webView(url = "https://a.example.com/x.html")))),
             ),
             background = transparentBackground,
-            header = HeaderComponent(StackComponent(components = listOf(webView(id = "in-header")))),
+            header = HeaderComponent(StackComponent(components = listOf(webView(url = "https://b.example.com/x.html")))),
             stickyFooter = StickyFooterComponent(
-                StackComponent(components = listOf(webView(id = "in-footer"))),
+                StackComponent(components = listOf(webView(url = "https://c.example.com/x.html"))),
             ),
         )
 
         val assets = config.collectAssets()
 
-        assertThat(assets.webViews.map { it.componentId })
-            .containsExactlyInAnyOrder("nested", "in-header", "in-footer")
+        assertThat(assets.webViewUrls).containsExactlyInAnyOrder(
+            "https://a.example.com/x.html",
+            "https://b.example.com/x.html",
+            "https://c.example.com/x.html",
+        )
     }
 
     @Test
-    fun `keeps two components sharing a url apart by component id`() {
+    fun `collapses two components sharing a url into one`() {
         val config = configWith(
             webView(url = "https://example.com/index.html", id = "first"),
             webView(url = "https://example.com/index.html", id = "second"),
         )
 
-        assertThat(config.collectAssets().webViews).hasSize(2)
+        assertThat(config.collectAssets().webViewUrls).containsExactly("https://example.com/index.html")
     }
 
     @Test
     fun `reports no web_views when the tree has none`() {
         val config = configWith()
 
-        assertThat(config.collectAssets().webViews).isEmpty()
+        assertThat(config.collectAssets().webViewUrls).isEmpty()
     }
 
     @Test
@@ -119,7 +88,7 @@ class PaywallComponentAssetsTest {
 
         val assets = config.collectAssets()
 
-        assertThat(assets.webViews.map { it.componentId }).containsExactly("component-1")
+        assertThat(assets.webViewUrls).containsExactly("https://example.com/index.html")
         assertThat(assets.imageUris.map { it.toString() }).containsExactly("https://example.com/stack.webp")
     }
 
@@ -134,12 +103,11 @@ class PaywallComponentAssetsTest {
     private fun webView(
         url: String = "https://example.com/index.html",
         id: String = "component-1",
-        size: Size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fill),
     ) = WebViewComponent(
         url = url,
         id = id,
         protocolVersion = WebViewComponent.SUPPORTED_PROTOCOL_VERSION,
-        size = size,
+        size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fill),
     )
 
     private fun imageUrls(webpLowRes: String) = ImageUrls(

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/PrewarmTargetOfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/PrewarmTargetOfferingsTest.kt
@@ -78,7 +78,6 @@ internal class PrewarmTargetOfferingsTest {
         assertThat(offerings.prewarmTargetOfferingIds()).containsExactlyInAnyOrder("current", "shared")
     }
 
-    // Ids, not offerings: resolving them against the response is prewarmTargetOfferings' job.
     @Test
     fun `reports an id a placement names even when the response has no such offering`() {
         val offerings = offeringsWith(
@@ -90,6 +89,23 @@ internal class PrewarmTargetOfferingsTest {
         )
 
         assertThat(offerings.prewarmTargetOfferingIds()).containsExactly("missing")
+        assertThat(offerings.prewarmTargetOfferings()).isEmpty()
+    }
+
+    @Test
+    fun `resolves ids to offerings in the same order`() {
+        val current = offering("current")
+        val onboarding = offering("onboarding")
+        val offerings = offeringsWith(
+            current = current,
+            others = listOf(onboarding),
+            placements = Offerings.Placements(
+                fallbackOfferingId = null,
+                offeringIdsByPlacement = mapOf("onboarding" to "onboarding"),
+            ),
+        )
+
+        assertThat(offerings.prewarmTargetOfferings()).containsExactly(current, onboarding)
     }
 
     private fun offering(identifier: String): Offering = mockk<Offering>().apply {

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/PrewarmTargetOfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/PrewarmTargetOfferingsTest.kt
@@ -1,0 +1,99 @@
+package com.revenuecat.purchases.utils
+
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Offerings
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class PrewarmTargetOfferingsTest {
+
+    @Test
+    fun `is just the current offering when there are no placements`() {
+        val offerings = offeringsWith(current = offering("current"))
+
+        assertThat(offerings.prewarmTargetOfferingIds()).containsExactly("current")
+    }
+
+    @Test
+    fun `is empty when there is no current offering and no placements`() {
+        assertThat(offeringsWith(current = null).prewarmTargetOfferingIds()).isEmpty()
+    }
+
+    @Test
+    fun `includes the offering each placement resolves to`() {
+        val offerings = offeringsWith(
+            current = offering("current"),
+            others = listOf(offering("onboarding"), offering("settings")),
+            placements = Offerings.Placements(
+                fallbackOfferingId = null,
+                offeringIdsByPlacement = mapOf("onboarding" to "onboarding", "settings" to "settings"),
+            ),
+        )
+
+        assertThat(offerings.prewarmTargetOfferingIds())
+            .containsExactlyInAnyOrder("current", "onboarding", "settings")
+    }
+
+    @Test
+    fun `includes the placement fallback offering`() {
+        val offerings = offeringsWith(
+            current = null,
+            others = listOf(offering("fallback")),
+            placements = Offerings.Placements(
+                fallbackOfferingId = "fallback",
+                offeringIdsByPlacement = emptyMap(),
+            ),
+        )
+
+        assertThat(offerings.prewarmTargetOfferingIds()).containsExactly("fallback")
+    }
+
+    // A placement mapped to null means "show nothing here".
+    @Test
+    fun `skips a placement mapped to no offering`() {
+        val offerings = offeringsWith(
+            current = null,
+            placements = Offerings.Placements(
+                fallbackOfferingId = null,
+                offeringIdsByPlacement = mapOf("onboarding" to null),
+            ),
+        )
+
+        assertThat(offerings.prewarmTargetOfferingIds()).isEmpty()
+    }
+
+    @Test
+    fun `reports an id once when several placements resolve to the same offering`() {
+        val offerings = offeringsWith(
+            current = offering("current"),
+            others = listOf(offering("shared")),
+            placements = Offerings.Placements(
+                fallbackOfferingId = "shared",
+                offeringIdsByPlacement = mapOf("a" to "shared", "b" to "shared"),
+            ),
+        )
+
+        assertThat(offerings.prewarmTargetOfferingIds()).containsExactlyInAnyOrder("current", "shared")
+    }
+
+    // Ids, not offerings: resolving them against the response is prewarmTargetOfferings' job.
+    @Test
+    fun `reports an id a placement names even when the response has no such offering`() {
+        val offerings = offeringsWith(
+            current = null,
+            placements = Offerings.Placements(
+                fallbackOfferingId = null,
+                offeringIdsByPlacement = mapOf("onboarding" to "missing"),
+            ),
+        )
+
+        assertThat(offerings.prewarmTargetOfferingIds()).containsExactly("missing")
+    }
+
+    private fun offering(identifier: String): Offering = mockk<Offering>().apply {
+        every { this@apply.identifier } returns identifier
+    }
+
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/offeringStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/offeringStubs.kt
@@ -1,0 +1,16 @@
+package com.revenuecat.purchases.utils
+
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Offerings
+
+/** An [Offerings] whose `all` map is derived from [current] + [others], the way a real response's is. */
+internal fun offeringsWith(
+    current: Offering?,
+    others: List<Offering> = emptyList(),
+    placements: Offerings.Placements? = null,
+): Offerings = Offerings(
+    current = current,
+    all = (listOfNotNull(current) + others).associateBy { it.identifier },
+    placements = placements,
+    targeting = null,
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/paywalls/PaywallAssetWarmerImpl.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/paywalls/PaywallAssetWarmerImpl.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import coil.request.ImageRequest
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.PaywallAssetWarmer
+import com.revenuecat.purchases.ui.revenuecatui.components.webview.PaywallWebViewPrewarmer
 import com.revenuecat.purchases.ui.revenuecatui.components.webview.PaywallWebViewStartUp
 
 @OptIn(InternalRevenueCatAPI::class)
@@ -19,5 +20,9 @@ internal class PaywallAssetWarmerImpl : PaywallAssetWarmer {
 
     override fun prebootWebView(context: Context) {
         PaywallWebViewStartUp.startUp(context)
+    }
+
+    override fun warmWebViewUrls(context: Context, urls: List<String>) {
+        urls.forEach { url -> PaywallWebViewPrewarmer.shared.prewarm(context, url) }
     }
 }


### PR DESCRIPTION
- Warms the assets of every offering a customer could be served next: the current one, each placement's, and the placement fallback.
- Only `offerings.current` was warmed before, so a paywall reached through a placement was always cold.
- One target set now drives image prewarming, `web_view` warming and the WebView preboot trigger, so the three cannot disagree.
- The workflows topic gets the same treatment: the workflow behind every target offering is loaded and its images, `web_view` bundles and fonts warmed, one job each so a failure cannot cancel its siblings.
- A decode failure for one offering never aborts the others, and nothing is attempted when no `PaywallAssetWarmer` is registered.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details>
<summary>Agent description</summary>

### Motivation

A project using placements gets one current offering per placement, so the paywall a customer actually sees is often not `offerings.current`. Warming only the current offering left every placement-reached paywall to load cold.

### Description

- `prewarmTargetOfferings()`: current, every non-null placement value, and the placement fallback, deduped and resolved against `Offerings.all`. All of it arrives in the same offerings response, so it costs no extra network. Resolved once per fetch and shared by every consumer.
- Resolved against `all` rather than `getCurrentOfferingForPlacement`, which allocates a presented-context copy warming has no use for. A placement mapped to null contributes nothing, matching its "show nothing here" meaning.
- `PaywallAssetWarmer` gains `warmWebViewUrls`. Core hands over urls and the UI module owns the WebView rules.
- `collectAssets` now collects `web_view` urls rather than a per-component asset. Nothing read that type's componentId or sizing axes: warming keys on url, and the display path builds its identity from the component style. Two components sharing a url therefore collapse to one warm, which is what the http cache does anyway.
- Warming is announced off the workflow metadata map, never the byte-warm map, so a body still finishing a low-priority prefetch is not skipped.
- Drive-by: the video predownloader moves onto the same `baseComponentsConfig()` helper, which also gets the offering identifier into its error log.

### Which path carries the component tree

`paywall_components` is present in the offerings response only while remote config is disabled. With it enabled the tree arrives on the workflows topic instead. Both paths warm, and `OfferingWebViewPrewarmer` is a no-op in the second.

### Regression gates

`getOfferings prewarms web_view bundles` catches the wiring being narrowed back to the current offering. `warms the offering each placement resolves to` and `warms the placement fallback offering` cover the target set; `ignores a placement mapped to no offering` and `ignores a placement naming an offering that is not in the response` cover its edges. `skips an offering whose component tree fails to decode, and warms the rest` covers the decode failure path, and `warms a url shared by several offerings only once` covers the dedup.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands background warming (images, WebView engine, HTTP cache) across more offerings and workflows, with extra main-thread posting and component-tree decode. Failures are best-effort and should not change offerings delivery, but WebView/cache behavior is more aggressive.
> 
> **Overview**
> Paywall asset warming now covers every offering a customer could see next—`current`, each placement, and the placement fallback—instead of only `offerings.current`. Placement-reached paywalls no longer start cold.
> 
> The same target set drives image pre-download, `web_view` bundle warming, and WebView engine preboot. `PaywallAssetWarmer` gains `warmWebViewUrls`; core collects URLs only (deduped), and the UI module loads them offscreen. Current-offering images still warm before `getOfferings` delivers; extra targets and bundle loads are enqueued so they do not block the backend response thread.
> 
> Workflows get the same expansion: `WorkflowsConfigProvider` announces every target offering’s workflow (not just current) so images, fonts, and web_view URLs warm independently. Decode failures skip that offering and leave siblings unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8f9fba81cb3853c4b77d78049fd05fbb55c9756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->