### PR TITLE
Customer Center: dates are always formatted as "dd MMM yyyy" regardless of locale conventions

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/DateFormatter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/DateFormatter.kt
@@ -2,8 +2,9 @@ package com.revenuecat.purchases.ui.revenuecatui.utils
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import java.text.SimpleDateFormat
+import java.text.DateFormat
 import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.util.Date
 import java.util.Locale
 
@@ -25,12 +26,12 @@ internal class DefaultDateFormatter : DateFormatter {
     @RequiresApi(Build.VERSION_CODES.O)
     private fun formatUsingDateTimeFormatter(date: Date, locale: Locale): String {
         val localDate = date.toInstant().atZone(java.time.ZoneId.systemDefault()).toLocalDate()
-        val formatter = DateTimeFormatter.ofPattern("dd MMM yyyy", locale)
+        val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)
         return localDate.format(formatter)
     }
 
     private fun formatUsingSimpleDateFormat(date: Date, locale: Locale): String {
-        val formatter = SimpleDateFormat("dd MMM yyyy", locale)
+        val formatter = DateFormat.getDateInstance(DateFormat.MEDIUM, locale)
         return formatter.format(date)
     }
 }


### PR DESCRIPTION
Replace hardcoded "dd MMM yyyy" date pattern with locale-sensitive formatting using `DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)` and `DateFormat.getDateInstance(DateFormat.MEDIUM, locale)`

Found via automated repo scanning, fix written and reviewed before opening.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI localization change to date display only; no auth, data, or business-logic impact.
> 
> **Overview**
> Customer Center dates no longer always render as `"dd MMM yyyy"`. `DefaultDateFormatter` now uses **locale-aware medium date styles** (`DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)` / `DateFormat.getDateInstance(MEDIUM)`), so expiration and renewal dates follow each locale’s conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c7f135d0821c947a6e571c88f3cc0378485074a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->