### PR TITLE
`OutOfMemoryError` caching large offerings responses (`DeviceCache.cacheOfferingsResponse`, `ETagPayloadStore.read`)

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -65,6 +65,7 @@ import com.revenuecat.purchases.strings.Emojis
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
+import java.io.File
 import com.revenuecat.purchases.utils.CoilImageDownloader
 import com.revenuecat.purchases.utils.DefaultUrlConnectionFactory
 import com.revenuecat.purchases.utils.EventsFileHelper
@@ -206,7 +207,11 @@ internal class PurchasesFactory(
             }
             val signingManager = SigningManager(signatureVerificationMode, appConfig, apiKey)
 
-            val cache = DeviceCache(prefs, apiKey)
+            val offeringsResponseFile = File(
+                File(contextForStorage.cacheDir, "RevenueCat"),
+                "offerings_response",
+            )
+            val cache = DeviceCache(prefs, apiKey, offeringsResponseFile = offeringsResponseFile)
 
             val localeProvider = DefaultLocaleProvider()
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -37,6 +37,9 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import org.json.JSONException
 import org.json.JSONObject
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 import java.util.Date
 import kotlin.time.Duration.Companion.hours
 
@@ -60,6 +63,7 @@ public open class DeviceCache(
     private val preferences: SharedPreferences,
     private val apiKey: String,
     private val dateProvider: DateProvider = DefaultDateProvider(),
+    private val offeringsResponseFile: File? = null,
 ) : StorefrontProvider {
     private companion object {
         private const val CUSTOMER_INFO_SCHEMA_VERSION_KEY = "schema_version"
@@ -590,15 +594,38 @@ public open class DeviceCache(
 
     @Synchronized
     internal fun getOfferingsResponseCache(): JSONObject? {
+        val file = offeringsResponseFile
+        if (file != null && file.exists()) {
+            return try {
+                JSONObject(file.readText(Charsets.UTF_8))
+            } catch (e: Exception) {
+                null
+            }
+        }
+        // Fallback: read from SharedPreferences for users upgrading from a previous version.
         return getJSONObjectOrNull(offeringsResponseCacheKey)
     }
 
     /**
-     * Serializing a [JSONObject] here instead of storing [offeringsResponse] as received would cost a
-     * contiguous allocation of several times the response size, which OOMs on low-heap devices.
+     * Persists [offeringsResponse] to a file rather than SharedPreferences so the payload is not
+     * loaded into the in-memory preferences map on every app start, which OOMs on low-heap devices
+     * when the response is several megabytes.
      */
     @Synchronized
     internal fun cacheOfferingsResponse(offeringsResponse: String) {
+        val file = offeringsResponseFile
+        if (file != null) {
+            try {
+                file.parentFile?.mkdirs()
+                // Stream through OutputStreamWriter so no full-payload ByteArray is allocated.
+                FileOutputStream(file).writer(Charsets.UTF_8).use { it.write(offeringsResponse) }
+                // Clean up any legacy SharedPreferences entry left by a previous version.
+                preferences.edit().remove(offeringsResponseCacheKey).apply()
+            } catch (e: IOException) {
+                errorLog(e) { "Failed to write offerings response to disk." }
+            }
+            return
+        }
         preferences.edit()
             .putString(offeringsResponseCacheKey, offeringsResponse)
             .apply()
@@ -606,6 +633,7 @@ public open class DeviceCache(
 
     @Synchronized
     internal fun clearOfferingsResponseCache() {
+        offeringsResponseFile?.delete()
         preferences.edit().remove(offeringsResponseCacheKey).apply()
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagPayloadStore.kt
@@ -74,8 +74,10 @@ internal class ETagPayloadStore(
         return try {
             FileInputStream(fileFor(urlString)).use { input ->
                 val sizeBytes = input.channel.size()
-                // Not an integrity check: ByteArray would throw past the IOException catch below.
-                if (sizeBytes > Int.MAX_VALUE) return null
+                // Guards against OOM on low-heap devices: a ByteArray this large, plus the String
+                // built from it, would exhaust the heap. Oversized files fall back to a fresh
+                // network request. MAX_PAYLOAD_BYTES < Int.MAX_VALUE so the cast below is safe.
+                if (sizeBytes > MAX_PAYLOAD_BYTES) return null
                 val bytes = ByteArray(sizeBytes.toInt())
                 DataInputStream(input).readFully(bytes)
                 if (crc32Of(bytes) != expectedChecksum) return null
@@ -169,5 +171,8 @@ internal class ETagPayloadStore(
         const val TRASH_SUFFIX = ".trash"
         const val CHUNK_CHARS = 64 * 1024
         const val WRITE_BUFFER_BYTES = 256 * 1024
+        // A read allocates ~2x this in heap (ByteArray + String). Cap at 10 MB so the spike is at
+        // most ~20 MB; larger payloads fall back to a fresh network request instead of OOMing.
+        const val MAX_PAYLOAD_BYTES = 10L * 1024 * 1024
     }
 }


### PR DESCRIPTION
Switch offerings response cache from SharedPreferences to file-based storage (avoiding permanent in-memory map pressure on low-heap devices), and add a 10 MB size guard in ETagPayloadStore.read to prevent OOM when allocating ByteArray + String for oversized cached payloads.

Found via automated repo scanning, fix written and reviewed before opening.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence of offerings responses and ETag cache read behavior, which can affect cold-start/offline offerings availability if file I/O fails. Mitigated by SharedPreferences fallback and treating oversized ETag payloads as cache misses.
> 
> **Overview**
> Fixes **OutOfMemoryError** on low-heap devices when caching multi-MB offerings/ETag responses.
> 
> **Offerings cache** now writes to a file under `cacheDir/RevenueCat/offerings_response` instead of SharedPreferences, so the large payload is no longer kept in the in-memory prefs map. Reads fall back to the legacy prefs entry on upgrade, and successful file writes remove that entry.
> 
> **ETag payload reads** reject files larger than **10 MB** (instead of `Int.MAX_VALUE`), treating them as cache misses so oversized payloads trigger a fresh network request rather than allocating a huge `ByteArray` + `String`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ff183ac79b6bee3ac2628bd0a7620d602ff3213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->