### PR TITLE
feat(checkpoints): expose CheckpointParams customProperties as paywall custom variables

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointParams.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointParams.kt
@@ -1,12 +1,14 @@
 package com.revenuecat.purchases.ui.revenuecatui.checkpoints
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 /**
  * Per-call parameters for [com.revenuecat.purchases.ui.revenuecatui.checkpoints.awaitCheckpoint].
  *
- * [customProperties] values must be [String], [Number] or [Boolean]. Invalid values are dropped with a warning.
+ * [customProperties] values must be [String], [Int], [Long], [Double], [Float] or [Boolean]. Invalid values are
+ * dropped with a warning.
  */
 @InternalRevenueCatAPI
 public class CheckpointParams(
@@ -17,7 +19,7 @@ public class CheckpointParams(
 
     public val customProperties: Map<String, Any> = customProperties.mapNotNull { (key, value) ->
         when (value) {
-            is String, is Number, is Boolean -> key to value
+            is String, is Int, is Long, is Double, is Float, is Boolean -> key to value
             else -> {
                 Logger.w("Dropping invalid checkpoint custom property '$key': ${value?.javaClass?.name ?: "null"}")
                 null
@@ -32,3 +34,10 @@ public class CheckpointParams(
 
     override fun toString(): String = "CheckpointParams(customProperties=$customProperties)"
 }
+
+// Safe because the constructor drops every value type CustomVariableValue.from does not accept. Keys are left
+// alone here: PaywallOptions.Builder.setCustomVariables validates them for the paywall, while the rules engine
+// takes them unfiltered.
+@OptIn(InternalRevenueCatAPI::class)
+internal val CheckpointParams.customVariables: Map<String, CustomVariableValue>
+    get() = customProperties.mapValues { (_, value) -> CustomVariableValue.from(value) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivity.kt
@@ -41,15 +41,17 @@ internal class CheckpointWorkflowActivity : ComponentActivity() {
         // when the pending call no longer exists.
         val manager = if (Purchases.isConfigured) Purchases.sharedInstance.checkpointsManager else null
         this.manager = manager
-        val resolution = id?.let { manager?.resolution(it) }
-        if (id == null || manager == null || resolution == null) {
+        val presentation = id?.let { manager?.presentation(it) }
+        if (id == null || manager == null || presentation == null) {
             Logger.w("Checkpoint call '$id' no longer exists. Closing the checkpoint workflow.")
             finish()
             return
         }
         manager.onPresentationStarted(id, this)
+        val resolution = presentation.resolution
         val options = PaywallOptions.Builder(dismissRequest = ::finish)
             .injectedWorkflow(resolution.workflow, resolution.offering, resolution.uiConfig)
+            .setCustomVariables(presentation.customVariables)
             .setListener(outcomeListener)
             .build()
         setContent {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.checkpoints.CheckpointResolution
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -14,6 +15,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.lang.ref.WeakReference
 import java.util.UUID
+
+/**
+ * Everything [CheckpointWorkflowActivity] needs to build its paywall, read in a single pass so it can't observe
+ * a call that was taken between two accessors.
+ */
+internal class CheckpointPresentation(
+    val resolution: CheckpointResolution.Workflow,
+    val customVariables: Map<String, CustomVariableValue>,
+)
 
 /**
  * Runs a checkpoint hit end to end: fires listener events, asks the core module what the checkpoint resolves
@@ -30,6 +40,7 @@ internal class CheckpointsManager {
     private class PendingCall(
         val callId: String,
         val resolution: CheckpointResolution.Workflow,
+        val customVariables: Map<String, CustomVariableValue>,
         val paywallFinished: CompletableDeferred<CheckpointPaywallOutcome>,
     ) {
         // Kept here rather than on the activity so a configuration change doesn't reset it.
@@ -64,7 +75,10 @@ internal class CheckpointsManager {
         val resolution = purchases.resolveCheckpoint(identifier, checkpoint.params.customProperties)
         val result = when (resolution) {
             is CheckpointResolution.Workflow ->
-                CheckpointResult.PaywallPresented(checkpoint, present(purchases, resolution))
+                CheckpointResult.PaywallPresented(
+                    checkpoint,
+                    present(purchases, resolution, checkpoint.params.customVariables),
+                )
             is CheckpointResolution.NoAction ->
                 CheckpointResult.NoAction(checkpoint, resolution.reason.toResultReason())
         }
@@ -72,8 +86,8 @@ internal class CheckpointsManager {
         result
     }
 
-    fun resolution(callId: String): CheckpointResolution.Workflow? =
-        withPendingCall(callId) { it.resolution }
+    fun presentation(callId: String): CheckpointPresentation? =
+        withPendingCall(callId) { CheckpointPresentation(it.resolution, it.customVariables) }
 
     fun onPresentationStarted(callId: String, activity: Activity) {
         withPendingCall(callId) { it.activity = WeakReference(activity) }
@@ -97,12 +111,13 @@ internal class CheckpointsManager {
     private suspend fun present(
         purchases: Purchases,
         resolution: CheckpointResolution.Workflow,
+        customVariables: Map<String, CustomVariableValue>,
     ): CheckpointPaywallOutcome {
         val activity = purchases.currentActivity ?: presentationError(
             PurchasesErrorCode.ConfigurationError,
             "Cannot present checkpoint workflow: no started Activity found.",
         )
-        val call = PendingCall(UUID.randomUUID().toString(), resolution, CompletableDeferred())
+        val call = PendingCall(UUID.randomUUID().toString(), resolution, customVariables, CompletableDeferred())
         val claimed = synchronized(this) { (pendingCall == null).also { if (it) pendingCall = call } }
         if (!claimed) {
             presentationError(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowActivityTest.kt
@@ -97,7 +97,7 @@ class CheckpointWorkflowActivityTest {
 
         launchActivity<CheckpointWorkflowActivity>(intentFor("call-id-from-a-previous-process"))
 
-        assertThat(mockPurchases.checkpointsManager.resolution(liveCallId)).isNotNull
+        assertThat(mockPurchases.checkpointsManager.presentation(liveCallId)).isNotNull
     }
 
     private fun intentFor(callId: String) = Intent(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.checkpoints.CheckpointResolution
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -135,11 +136,39 @@ class CheckpointsManagerTest {
     fun `only valid custom properties are forwarded to the resolver`() = runTest(dispatcher) {
         resolvesTo(CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.NO_MATCH))
 
-        checkpoint(CheckpointParams("goal" to "test", "invalid" to Any()))
+        checkpoint(CheckpointParams("goal" to "test", "invalid" to Any(), "unsupportedNumber" to 1.toShort()))
 
         val customProperties = slot<Map<String, Any>>()
         coVerify { mockPurchases.resolveCheckpoint(checkpointId, capture(customProperties)) }
         assertThat(customProperties.captured).isEqualTo(mapOf("goal" to "test"))
+    }
+
+    @Test
+    fun `custom properties are exposed to the presented paywall as custom variables`() = runTest(dispatcher) {
+        resolvesToWorkflow()
+        val call = launch {
+            checkpoint(
+                CheckpointParams(
+                    "gate" to "hard",
+                    "attempt" to 2,
+                    "ratio" to 0.5,
+                    "flag" to true,
+                    "invalid" to Any(),
+                ),
+            )
+        }
+
+        assertThat(manager.presentation(currentCallId())!!.customVariables).isEqualTo(
+            mapOf(
+                "gate" to CustomVariableValue.String("hard"),
+                "attempt" to CustomVariableValue.Number(2),
+                "ratio" to CustomVariableValue.Number(0.5),
+                "flag" to CustomVariableValue.Boolean(true),
+            ),
+        )
+
+        finishPaywall(CheckpointPaywallOutcome.Dismissed)
+        call.join()
     }
 
     @Test
@@ -253,7 +282,7 @@ class CheckpointsManagerTest {
         manager.onActivityDestroyed("unknown-call-id", isChangingConfigurations = false)
         manager.recordOutcome("unknown-call-id", CheckpointPaywallOutcome.Dismissed)
 
-        assertThat(manager.resolution("unknown-call-id")).isNull()
+        assertThat(manager.presentation("unknown-call-id")).isNull()
     }
 
     @Test
@@ -266,7 +295,7 @@ class CheckpointsManagerTest {
         manager.onActivityDestroyed(callId, isChangingConfigurations = true)
 
         assertThat(result).isNull()
-        assertThat(manager.resolution(callId)).isNotNull
+        assertThat(manager.presentation(callId)).isNotNull
 
         finishPaywall(CheckpointPaywallOutcome.Dismissed)
         call.join()
@@ -288,7 +317,7 @@ class CheckpointsManagerTest {
 
         assertThat((result as CheckpointResult.PaywallPresented).paywallOutcome)
             .isEqualTo(CheckpointPaywallOutcome.Purchased(customerInfo))
-        assertThat(manager.resolution(callId)).isNull()
+        assertThat(manager.presentation(callId)).isNull()
     }
 
     @Test
@@ -318,7 +347,7 @@ class CheckpointsManagerTest {
     // record the outcome, then report the paywall as finished.
     private fun finishPaywall(outcome: CheckpointPaywallOutcome) {
         val callId = currentCallId()
-        assertThat(manager.resolution(callId)).isNotNull
+        assertThat(manager.presentation(callId)).isNotNull
         manager.recordOutcome(callId, outcome)
         manager.onActivityDestroyed(callId, isChangingConfigurations = false)
     }


### PR DESCRIPTION
Checkpoint calls can carry per-call data:

```kotlin
Purchases.sharedInstance.awaitCheckpoint("hard_paywall", CheckpointParams("gate" to "hard", "attempt" to 2))
```

Until now those properties only reached the rules resolver (currently unused), but not the paywall itself. This PR forwards them to the presented paywall as custom variables.

`CheckpointParams` also now accepts exactly the value types custom variables support (`String`, `Int`, `Long`, `Double`, `Float`, `Boolean`). Other `Number` subtypes were previously forwarded to the rules resolver and are now dropped with a warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint paywall presentation plumbing and narrows accepted custom property types, which can drop previously accepted Number subtypes. Changes are internal API and covered by tests.
> 
> **Overview**
> **Forwards checkpoint `customProperties` into the presented paywall as custom variables**, so per-call data like `CheckpointParams("gate" to "hard", "attempt" to 2)` can personalize paywall text—not just reach the rules resolver.
> 
> `CheckpointParams` now accepts only the types `CustomVariableValue` supports (`String`, `Int`, `Long`, `Double`, `Float`, `Boolean`); other `Number` subtypes are dropped with a warning. Presentation plumbing is tightened via a new `CheckpointPresentation` snapshot (replacing `resolution()` with `presentation()`) so the activity reads resolution and variables atomically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578d0240862ddd08807c3e69f069927b4a2fdc52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->