### PR TITLE
refactor(checkpoints): Local rule evaluation foundation

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -29,6 +29,8 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.EventsManager
 import com.revenuecat.purchases.common.isDeviceProtectedStorageCompat
+import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
+import com.revenuecat.purchases.common.localrules.RulesEngineLoggerBridge
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.networking.APISourceFailover
 import com.revenuecat.purchases.common.networking.DeviceConnectivityChecker
@@ -60,6 +62,7 @@ import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.paywalls.PaywallAssetWarming
 import com.revenuecat.purchases.paywalls.PaywallPresentedCache
 import com.revenuecat.purchases.paywalls.events.PaywallStoredEvent
+import com.revenuecat.purchases.rules.RulesEngine
 import com.revenuecat.purchases.storage.DefaultFileRepository
 import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.strings.Emojis
@@ -349,6 +352,10 @@ internal class PurchasesFactory(
             val checkpointsConfigProvider = remoteConfigManager?.let {
                 CheckpointsConfigProvider(it)
             }
+            // Dimension providers are added here as they land; with none registered, only predicates that read no
+            // dimensions can match.
+            RulesEngine.setLogger(RulesEngineLoggerBridge)
+            val localRulesEvaluator = LocalRulesEvaluator(providers = emptyList())
             if (remoteConfigManager != null && uiConfigProvider != null && workflowsConfigProvider != null) {
                 remoteConfigManager.registerListener(uiConfigProvider)
                 remoteConfigManager.registerListener(workflowsConfigProvider)
@@ -551,6 +558,7 @@ internal class PurchasesFactory(
                 uiConfigProvider = uiConfigProvider,
                 workflowsConfigProvider = workflowsConfigProvider,
                 checkpointsConfigProvider = checkpointsConfigProvider,
+                localRulesEvaluator = localRulesEvaluator,
             )
 
             return Purchases(purchasesOrchestrator)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -46,6 +46,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.events.EventsManager
 import com.revenuecat.purchases.common.events.FeatureEvent
+import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
@@ -176,11 +177,13 @@ internal class PurchasesOrchestrator(
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     val adTracker: AdTracker = AdTracker(adEventsManager),
     private val currentActivityTracker: CurrentActivityTracker = CurrentActivityTracker(),
+    private val localRulesEvaluator: LocalRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
     @OptIn(InternalRevenueCatAPI::class)
     private val checkpointWorkflowResolver: CheckpointWorkflowResolver = CheckpointWorkflowResolverImpl(
         workflowManager = workflowManager,
         uiConfigProvider = uiConfigProvider,
         checkpointsConfigProvider = checkpointsConfigProvider,
+        localRulesEvaluator = localRulesEvaluator,
         getOfferings = { Purchases.sharedInstance.awaitOfferings() },
     ),
 ) : LifecycleDelegate, CustomActivityLifecycleHandler {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -14,20 +14,23 @@ import com.revenuecat.purchases.common.checkpoints.CheckpointRulesResolution
 import com.revenuecat.purchases.common.checkpoints.CheckpointsConfigProvider
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.localrules.LocalRule
+import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.common.workflows.WorkflowManager
 
 /**
- * Resolves a checkpoint through the `checkpoint_rules` topic: the checkpoint's rules are read from remote
- * config, and the first one that resolves to a presentable workflow wins. Rules arrive ordered, and walking them
- * in order is the placeholder for the audience evaluation that will eventually pick the first rule whose
- * `audience_id` matches this customer — until then the order the dashboard published is the only signal.
+ * Resolves a checkpoint through the `checkpoint_rules` topic: the checkpoint's rules are read from remote config
+ * and evaluated in order against locally collected dimensions, and the first rule whose audience matches wins.
  *
- * A rule is skipped when its workflow can't be served (no offering configured for it, that offering absent from
- * the fetched offerings, or its body unavailable), mirroring the "unservable outcome → next rule" rule the
- * evaluator will keep. The shared reads a presentation needs — `ui_config` and offerings — happen once, outside
- * the walk, since a failure there is not specific to any rule.
+ * The winner is final. If its workflow turns out to be unservable — no offering configured for it, that offering
+ * absent from the fetched offerings, or its body unavailable — the checkpoint resolves to
+ * [CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE] rather than falling through to a rule the
+ * customer was not the first choice for.
+ *
+ * Audience predicates are not served yet, so every rule currently carries [PLACEHOLDER_AUDIENCE_PREDICATE] and the
+ * published order remains the effective signal; see [AudienceRule].
  *
  * [SIMULATED_ERROR_CHECKPOINT_ID] is the one piece of PoC scaffolding left: it is the only way for the tester
  * apps to exercise the throw path, since nothing in the config-driven path throws.
@@ -36,6 +39,7 @@ internal class CheckpointWorkflowResolverImpl(
     private val workflowManager: WorkflowManager?,
     private val uiConfigProvider: UiConfigProvider?,
     private val checkpointsConfigProvider: CheckpointsConfigProvider?,
+    private val localRulesEvaluator: LocalRulesEvaluator,
     private val getOfferings: suspend () -> Offerings,
 ) : CheckpointWorkflowResolver {
 
@@ -64,23 +68,18 @@ internal class CheckpointWorkflowResolverImpl(
             CheckpointRulesResolution.Unavailable ->
                 return configurationUnavailable("The rules for checkpoint '$identifier' could not be read.")
         }
-        if (checkpoint.rules.isEmpty()) return noMatch(identifier)
+        val matchResult = localRulesEvaluator.match(checkpoint.rules.map { rule -> AudienceRule(rule) })
+        // An audience the SDK failed to evaluate is not the same answer as an audience the customer is outside of,
+        // so it can't report NO_MATCH.
+        val rule = matchResult.getOrElse { error ->
+            return configurationUnavailable(
+                "The audiences for checkpoint '$identifier' could not be evaluated: ${error.message}",
+            )
+        }?.checkpointRule ?: return noMatch(identifier)
 
-        // A rule whose workflow has no offering can never be served, so filtering on the workflow index first
-        // keeps an entirely unservable checkpoint from also triggering an offerings fetch.
-        val offeringIdByWorkflowId = workflowManager.offeringIdByWorkflowId()
-        val candidates = checkpoint.rules.mapNotNull { rule ->
-            val offeringId = offeringIdByWorkflowId[rule.workflowId]
-            if (offeringId == null) {
-                logSkippedRule(rule, "no offering is mapped to it in the workflows topic")
-                null
-            } else {
-                rule to offeringId
-            }
-        }
-        if (candidates.isEmpty()) {
-            return configurationUnavailable("No rule for checkpoint '$identifier' points at a servable workflow.")
-        }
+        // Resolved before ui_config and offerings so an unservable winner doesn't also trigger an offerings fetch.
+        val offeringId = workflowManager.offeringIdByWorkflowId()[rule.workflowId]
+            ?: return unservableRule(rule, "no offering is mapped to it in the workflows topic")
         val uiConfig = uiConfigProvider.getUiConfig()
             ?: return configurationUnavailable("UI config is unavailable for checkpoint '$identifier'.")
         val offerings = try {
@@ -90,9 +89,7 @@ internal class CheckpointWorkflowResolverImpl(
                 "Offerings could not be fetched for checkpoint '$identifier': ${e.error}",
             )
         }
-        return candidates.firstNotNullOfOrNull { (rule, offeringId) ->
-            resolveRule(workflowManager, rule, offeringId, offerings, uiConfig)
-        } ?: configurationUnavailable("No rule for checkpoint '$identifier' resolved to a presentable workflow.")
+        return resolveRule(workflowManager, rule, offeringId, offerings, uiConfig)
     }
 
     @Suppress("ReturnCount")
@@ -102,17 +99,13 @@ internal class CheckpointWorkflowResolverImpl(
         offeringId: String,
         offerings: Offerings,
         uiConfig: UiConfig,
-    ): CheckpointResolution.Workflow? {
+    ): CheckpointResolution {
         val offering: Offering = offerings.all[offeringId]
-            ?: run {
-                logSkippedRule(rule, "offering '$offeringId' was not found in offerings")
-                return null
-            }
+            ?: return unservableRule(rule, "offering '$offeringId' was not found in offerings")
         val workflow = try {
             workflowManager.getWorkflow(rule.workflowId)
         } catch (e: PurchasesException) {
-            logSkippedRule(rule, "it could not be loaded: ${e.error}")
-            return null
+            return unservableRule(rule, "it could not be loaded: ${e.error}")
         }
         debugLog {
             "Checkpoint resolved to workflow '${rule.workflowId}' (offering: ${offering.identifier})"
@@ -120,8 +113,9 @@ internal class CheckpointWorkflowResolverImpl(
         return CheckpointResolution.Workflow(workflow, uiConfig, offering)
     }
 
-    private fun logSkippedRule(rule: CheckpointRule, reason: String) {
-        warnLog { "Skipping checkpoint rule for workflow '${rule.workflowId}': $reason." }
+    private fun unservableRule(rule: CheckpointRule, reason: String): CheckpointResolution.NoAction {
+        warnLog { "The matched checkpoint rule for workflow '${rule.workflowId}' can't be served: $reason." }
+        return CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
     }
 
     private fun configurationUnavailable(message: String): CheckpointResolution.NoAction {
@@ -135,11 +129,21 @@ internal class CheckpointWorkflowResolverImpl(
     }
 
     private fun noMatch(identifier: String): CheckpointResolution.NoAction {
-        debugLog { "Checkpoint '$identifier' is configured, but has no rules." }
+        debugLog { "No rule for checkpoint '$identifier' matched." }
         return CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.NO_MATCH)
+    }
+
+    /**
+     * Pairs a checkpoint rule with the predicate its audience stands for. Audience predicates will arrive in their
+     * own remote-config topic, whose shape is not settled, so until then every audience matches and the rules are
+     * effectively still walked in published order.
+     */
+    private class AudienceRule(val checkpointRule: CheckpointRule) : LocalRule {
+        override val predicate: String = PLACEHOLDER_AUDIENCE_PREDICATE
     }
 
     private companion object {
         const val SIMULATED_ERROR_CHECKPOINT_ID = "error_checkpoint"
+        const val PLACEHOLDER_AUDIENCE_PREDICATE = "true"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRule.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRule.kt
@@ -1,0 +1,13 @@
+package com.revenuecat.purchases.common.localrules
+
+/**
+ * A rule that can be evaluated against locally collected dimensions.
+ *
+ * Consumers implement this on their own type, and [LocalRulesEvaluator.match] hands that same instance back when
+ * the rule wins, so whatever the rule needs to carry rides along without this package knowing about it.
+ */
+internal interface LocalRule {
+
+    /** The rule's JSON Logic predicate, evaluated against a [RulesDimensionSnapshot]. */
+    val predicate: String
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -1,0 +1,70 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.rules.RulesEngine
+
+internal sealed class LocalRulesEvaluationException(message: String) : Exception(message) {
+
+    /** The predicate at [ruleIndex] could not be evaluated; [error] is a `RulesEngine.EvaluationException`. */
+    internal data class PredicateEvaluation(
+        val ruleIndex: Int,
+        val error: Throwable,
+    ) : LocalRulesEvaluationException("rule at index $ruleIndex could not be evaluated: ${error.message}")
+
+    /** [reason] is a [RulesDimensionResolutionException]. */
+    internal data class DimensionResolution(
+        val reason: Throwable,
+    ) : LocalRulesEvaluationException("dimensions could not be collected: ${reason.message}")
+}
+
+/**
+ * Evaluates rules against freshly collected dimensions.
+ *
+ * One snapshot serves a whole call, so every rule in it is judged against the same view of the customer.
+ */
+internal class LocalRulesEvaluator(
+    providers: List<RulesDimensionProvider>,
+    dateProvider: DateProvider = DefaultDateProvider(),
+) {
+
+    private val dimensionResolver = RulesDimensionResolver(providers, dateProvider)
+
+    /**
+     * The first rule that matches, or `null` when none does.
+     *
+     * A predicate the engine cannot evaluate (malformed JSON, an operator this SDK version does not implement) is
+     * not enough to fail the call on its own: a later rule may still match definitively, and it wins. Only when
+     * nothing matched does the first such failure surface, because then "no match" cannot be told apart from "we
+     * failed to ask". A predicate that reads a dimension this SDK version does not supply is not a failure at all
+     * — the engine resolves it to null, which is an ordinary non-match.
+     */
+    @Suppress("ReturnCount")
+    suspend fun <Rule : LocalRule> match(rules: List<Rule>): Result<Rule?> {
+        if (rules.isEmpty()) return Result.success(null)
+
+        val snapshot = dimensionResolver.snapshot().fold(
+            onSuccess = { snapshot -> snapshot },
+            onFailure = { error ->
+                return Result.failure(LocalRulesEvaluationException.DimensionResolution(error))
+            },
+        )
+
+        var firstFailure: LocalRulesEvaluationException.PredicateEvaluation? = null
+        for ((index, rule) in rules.withIndex()) {
+            val result = RulesEngine.evaluate(rule.predicate, snapshot.values)
+            val matches = result.getOrElse { error ->
+                if (firstFailure == null) {
+                    firstFailure = LocalRulesEvaluationException.PredicateEvaluation(index, error)
+                }
+                false
+            }
+            if (matches) return Result.success(rule)
+        }
+
+        return firstFailure?.let { failure -> Result.failure(failure) } ?: Result.success(null)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -1,0 +1,56 @@
+package com.revenuecat.purchases.common.localrules
+
+import java.util.Date
+
+/**
+ * The SDK-owned roots a predicate can read. Closed on purpose, like `RemoteConfigTopic`: these names are part of
+ * the contract predicates are authored against, so a provider must not be able to invent one.
+ *
+ * Each entry becomes a real nested object in the evaluated scope, because the engine's `var` operator walks
+ * nested objects by strict dot-path and has no flat-key fallback — `device.app_version` resolves *through*
+ * `device`, it is never a literal key.
+ */
+internal enum class RulesDimensionNamespace(val key: String) {
+    Device("device"),
+}
+
+/**
+ * A scalar exposed to the rules engine.
+ *
+ * Keeps providers independent from the engine's own value representation, and encodes that a dimension is a
+ * scalar: arrays and objects are deliberately not expressible yet.
+ */
+internal sealed class RulesDimensionValue {
+    internal data class StringValue(val value: String) : RulesDimensionValue()
+    internal data class BoolValue(val value: Boolean) : RulesDimensionValue()
+    internal data class IntValue(val value: Long) : RulesDimensionValue()
+    internal data class DoubleValue(val value: Double) : RulesDimensionValue()
+}
+
+/**
+ * Supplies one subtree of on-device dimensions.
+ *
+ * Implementations may observe or persist state internally, but values are pulled only when an evaluation asks for
+ * a new snapshot, since eligibility reflects the customer's state at the moment the rule is evaluated.
+ */
+internal interface RulesDimensionProvider {
+
+    /** Stable identifier, used only for diagnostics. */
+    val identifier: String
+
+    /** The root this provider's values are nested under. */
+    val namespace: RulesDimensionNamespace
+
+    /**
+     * The complete current set of values relative to [namespace], keyed in lowercase snake_case (`app_version`);
+     * [RulesDimensionResolver] adds the namespace.
+     *
+     * A value that is unavailable is omitted rather than guessed: an absent key resolves to null in the engine,
+     * which is a non-match rather than an error. Throwing is reserved for a systemic failure to produce this
+     * provider's values.
+     *
+     * [date] is the common reference instant for the evaluation. It does not indicate when the underlying values
+     * were observed.
+     */
+    suspend fun dimensions(date: Date): Map<String, RulesDimensionValue>
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -1,0 +1,94 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.rules.Value
+import kotlinx.coroutines.CancellationException
+import java.util.Date
+
+/**
+ * An immutable, point-in-time scope ready to be handed to the rules engine.
+ */
+internal data class RulesDimensionSnapshot(
+    val values: Map<String, Value>,
+    val evaluationDate: Date,
+)
+
+internal sealed class RulesDimensionResolutionException(message: String) : Exception(message) {
+
+    internal data class ProviderFailed(
+        val identifier: String,
+        val reason: String,
+    ) : RulesDimensionResolutionException("dimension provider '$identifier' failed: $reason")
+
+    internal data class ConflictingDimension(
+        val path: String,
+    ) : RulesDimensionResolutionException("two dimension providers supplied '$path'")
+}
+
+/**
+ * Builds the scope local rule evaluation runs against by collecting every provider once and nesting its values
+ * under the provider's namespace.
+ *
+ * All providers see the same reference instant, so every dimension in one snapshot is consistent with the others.
+ *
+ * Both failure modes are configuration bugs rather than runtime conditions — a provider that cannot produce its
+ * values, and two providers claiming the same path — so they fail the whole snapshot instead of silently
+ * degrading a rule to a non-match, which would be indistinguishable from a customer who genuinely does not match.
+ * Cancellation is neither, and propagates.
+ */
+internal class RulesDimensionResolver(
+    private val providers: List<RulesDimensionProvider>,
+    private val dateProvider: DateProvider = DefaultDateProvider(),
+) {
+
+    @Suppress("ReturnCount")
+    suspend fun snapshot(): Result<RulesDimensionSnapshot> {
+        val date = dateProvider.now
+        val values = mutableMapOf<String, MutableMap<String, Value>>()
+
+        for (provider in providers) {
+            val dimensions = try {
+                provider.dimensions(date)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+                return Result.failure(
+                    RulesDimensionResolutionException.ProviderFailed(
+                        identifier = provider.identifier,
+                        reason = error.message ?: error.toString(),
+                    ),
+                )
+            }
+            val namespace = values.getOrPut(provider.namespace.key) { mutableMapOf() }
+            for ((name, value) in dimensions) {
+                if (namespace.containsKey(name)) {
+                    return Result.failure(
+                        RulesDimensionResolutionException.ConflictingDimension(
+                            "${provider.namespace.key}.$name",
+                        ),
+                    )
+                }
+                namespace[name] = value.asRulesEngineValue
+            }
+        }
+
+        return Result.success(
+            RulesDimensionSnapshot(
+                values = values.mapValues { (_, dimensions) -> Value.ObjectValue(dimensions) },
+                evaluationDate = date,
+            ),
+        )
+    }
+}
+
+private val RulesDimensionValue.asRulesEngineValue: Value
+    get() = when (this) {
+        is RulesDimensionValue.StringValue -> Value.StringValue(value)
+        is RulesDimensionValue.BoolValue -> Value.BoolValue(value)
+        is RulesDimensionValue.IntValue -> Value.IntValue(value)
+        is RulesDimensionValue.DoubleValue -> Value.FloatValue(value)
+    }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesEngineLoggerBridge.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesEngineLoggerBridge.kt
@@ -1,0 +1,25 @@
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.verboseLog
+import com.revenuecat.purchases.rules.RulesEngineLogger
+
+/**
+ * Routes rules engine diagnostics through the SDK logger, which the engine does not depend on directly so that it
+ * stays extractable.
+ *
+ * Nothing reaches warning level: a predicate reading a dimension this SDK version does not supply is the expected
+ * forward-compatibility path, not something an app developer should see warnings about on every evaluation.
+ */
+internal object RulesEngineLoggerBridge : RulesEngineLogger {
+
+    override fun warn(message: String) {
+        debugLog { "$LOG_PREFIX$message" }
+    }
+
+    override fun log(message: String) {
+        verboseLog { "$LOG_PREFIX$message" }
+    }
+
+    private const val LOG_PREFIX = "Rules engine: "
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -14,6 +14,10 @@ import com.revenuecat.purchases.common.checkpoints.CheckpointResponse
 import com.revenuecat.purchases.common.checkpoints.CheckpointRule
 import com.revenuecat.purchases.common.checkpoints.CheckpointRulesResolution
 import com.revenuecat.purchases.common.checkpoints.CheckpointsConfigProvider
+import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
+import com.revenuecat.purchases.common.localrules.RulesDimensionNamespace
+import com.revenuecat.purchases.common.localrules.RulesDimensionProvider
+import com.revenuecat.purchases.common.localrules.RulesDimensionValue
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowManager
@@ -28,6 +32,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -67,6 +72,7 @@ class CheckpointWorkflowResolverImplTest {
             workflowManager = mockWorkflowManager,
             uiConfigProvider = mockUiConfigProvider,
             checkpointsConfigProvider = mockCheckpointsConfigProvider,
+            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
             getOfferings = {
                 offeringsFetched++
                 offeringsFetchError?.let { throw PurchasesException(it) }
@@ -93,6 +99,7 @@ class CheckpointWorkflowResolverImplTest {
             workflowManager = null,
             uiConfigProvider = null,
             checkpointsConfigProvider = null,
+            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
             getOfferings = { mockOfferings },
         )
 
@@ -179,29 +186,28 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
-    fun `rules whose workflow is not mapped to an offering are skipped`() = runTest {
+    fun `a matched rule whose workflow is not mapped to an offering does not fall through`() = runTest {
         configureRules(rule("wf5678"), rule("wf1234"))
         coEvery { mockWorkflowManager.offeringIdByWorkflowId() } returns mapOf("wf1234" to "default")
 
-        val resolution = resolve() as CheckpointResolution.Workflow
-
-        assertThat(resolution.workflow).isEqualTo(mockWorkflow)
+        assertThat(noActionReason(resolve()))
+            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        coVerify(exactly = 0) { mockWorkflowManager.getWorkflow("wf1234") }
     }
 
     @Test
-    fun `rules whose offering is missing from offerings are skipped`() = runTest {
+    fun `a matched rule whose offering is missing from offerings does not fall through`() = runTest {
         configureRules(rule("wf5678"), rule("wf1234"))
         coEvery { mockWorkflowManager.offeringIdByWorkflowId() } returns
             mapOf("wf5678" to "missing", "wf1234" to "default")
 
-        val resolution = resolve() as CheckpointResolution.Workflow
-
-        assertThat(resolution.workflow).isEqualTo(mockWorkflow)
-        coVerify(exactly = 0) { mockWorkflowManager.getWorkflow("wf5678") }
+        assertThat(noActionReason(resolve()))
+            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        coVerify(exactly = 0) { mockWorkflowManager.getWorkflow("wf1234") }
     }
 
     @Test
-    fun `rules whose workflow fails to load are skipped`() = runTest {
+    fun `a matched rule whose workflow fails to load does not fall through`() = runTest {
         configureRules(rule("wf5678"), rule("wf1234"))
         coEvery { mockWorkflowManager.offeringIdByWorkflowId() } returns
             mapOf("wf5678" to "default", "wf1234" to "default")
@@ -209,23 +215,26 @@ class CheckpointWorkflowResolverImplTest {
             PurchasesError(PurchasesErrorCode.UnknownError, "Workflow unavailable."),
         )
 
-        val resolution = resolve() as CheckpointResolution.Workflow
-
-        assertThat(resolution.workflow).isEqualTo(mockWorkflow)
+        assertThat(noActionReason(resolve()))
+            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        coVerify(exactly = 0) { mockWorkflowManager.getWorkflow("wf1234") }
     }
 
     @Test
-    fun `checkpoint resolves NoAction with CONFIGURATION_UNAVAILABLE when no rule is servable`() = runTest {
-        configureRules(rule("wf1234"), rule("wf5678"))
-        coEvery { mockWorkflowManager.offeringIdByWorkflowId() } returns
-            mapOf("wf1234" to "default", "wf5678" to "default")
-        coEvery { mockWorkflowManager.getWorkflow(any()) } throws PurchasesException(
-            PurchasesError(PurchasesErrorCode.UnknownError, "Workflow unavailable."),
-        )
+    fun `checkpoint resolves NoAction with CONFIGURATION_UNAVAILABLE when audiences cannot be evaluated`() =
+        runTest {
+            resolver = CheckpointWorkflowResolverImpl(
+                workflowManager = mockWorkflowManager,
+                uiConfigProvider = mockUiConfigProvider,
+                checkpointsConfigProvider = mockCheckpointsConfigProvider,
+                localRulesEvaluator = LocalRulesEvaluator(providers = listOf(FailingDimensionProvider)),
+                getOfferings = { mockOfferings },
+            )
 
-        assertThat(noActionReason(resolve()))
-            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
-    }
+            assertThat(noActionReason(resolve()))
+                .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+            coVerify(exactly = 0) { mockWorkflowManager.getWorkflow(any()) }
+        }
 
     @Test
     fun `checkpoint resolves NoAction with CONFIGURATION_UNAVAILABLE when the offerings fetch fails`() = runTest {
@@ -245,17 +254,21 @@ class CheckpointWorkflowResolverImplTest {
         }
 
     @Test
-    fun `offerings and ui config are resolved once regardless of how many rules are walked`() = runTest {
-        configureRules(rule("wf5678"), rule("wf9012"), rule("wf1234"))
+    fun `offerings and ui config are resolved once`() = runTest {
+        configureRules(rule("wf1234"), rule("wf5678"))
         coEvery { mockWorkflowManager.offeringIdByWorkflowId() } returns
-            mapOf("wf5678" to "default", "wf9012" to "default", "wf1234" to "default")
-        coEvery { mockWorkflowManager.getWorkflow(match { it != "wf1234" }) } throws PurchasesException(
-            PurchasesError(PurchasesErrorCode.UnknownError, "Workflow unavailable."),
-        )
+            mapOf("wf1234" to "default", "wf5678" to "default")
 
         assertThat(resolve()).isInstanceOf(CheckpointResolution.Workflow::class.java)
         assertThat(offeringsFetched).isEqualTo(1)
         coVerify(exactly = 1) { mockUiConfigProvider.getUiConfig() }
+    }
+
+    private object FailingDimensionProvider : RulesDimensionProvider {
+        override val identifier = "failing"
+        override val namespace = RulesDimensionNamespace.Device
+        override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+            throw IllegalStateException("no dimensions")
     }
 
     private fun rule(workflowId: String) = CheckpointRule(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -1,0 +1,129 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.rules.RulesEngine
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.Date
+
+class LocalRulesEvaluatorTest {
+
+    private val matchingPredicate = """{"==": [{"var": "device.platform"}, "android"]}"""
+    private val nonMatchingPredicate = """{"==": [{"var": "device.platform"}, "amazon"]}"""
+    private val malformedPredicate = "{not json"
+
+    private var snapshotsTaken = 0
+    private val deviceProvider = object : RulesDimensionProvider {
+        override val identifier = "device"
+        override val namespace = RulesDimensionNamespace.Device
+        override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+            snapshotsTaken++
+            return mapOf("platform" to RulesDimensionValue.StringValue("android"))
+        }
+    }
+
+    @Test
+    fun `no rules matches nothing without collecting dimensions`() = runTest {
+        val result = evaluator().match(emptyList<TestRule>())
+
+        assertThat(result.getOrThrow()).isNull()
+        assertThat(snapshotsTaken).isZero()
+    }
+
+    @Test
+    fun `the first matching rule wins`() = runTest {
+        val result = evaluator().match(
+            listOf(
+                TestRule("first", nonMatchingPredicate),
+                TestRule("second", matchingPredicate),
+                TestRule("third", matchingPredicate),
+            ),
+        )
+
+        assertThat(result.getOrThrow()?.name).isEqualTo("second")
+    }
+
+    @Test
+    fun `nothing matches when no predicate is satisfied`() = runTest {
+        val result = evaluator().match(listOf(TestRule("only", nonMatchingPredicate)))
+
+        assertThat(result.getOrThrow()).isNull()
+    }
+
+    @Test
+    fun `a predicate reading an unsupplied dimension is an ordinary non-match`() = runTest {
+        val result = evaluator().match(
+            listOf(TestRule("only", """{"==": [{"var": "device.unknown_dimension"}, true]}""")),
+        )
+
+        assertThat(result.getOrThrow()).isNull()
+    }
+
+    @Test
+    fun `a later match wins over an earlier unevaluable predicate`() = runTest {
+        val result = evaluator().match(
+            listOf(
+                TestRule("broken", malformedPredicate),
+                TestRule("match", matchingPredicate),
+            ),
+        )
+
+        assertThat(result.getOrThrow()?.name).isEqualTo("match")
+    }
+
+    @Test
+    fun `an unevaluable predicate surfaces when nothing matched`() = runTest {
+        val result = evaluator().match(
+            listOf(
+                TestRule("first", nonMatchingPredicate),
+                TestRule("broken", malformedPredicate),
+                TestRule("also broken", """{"nonexistent": []}"""),
+            ),
+        )
+
+        val error = result.exceptionOrNull() as LocalRulesEvaluationException.PredicateEvaluation
+        assertThat(error.ruleIndex).isEqualTo(1)
+        assertThat(error.error).isInstanceOf(RulesEngine.EvaluationException.Parse::class.java)
+    }
+
+    @Test
+    fun `a failed dimension snapshot fails the evaluation`() = runTest {
+        val failing = object : RulesDimensionProvider {
+            override val identifier = "failing"
+            override val namespace = RulesDimensionNamespace.Device
+            override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+                throw IllegalStateException("nope")
+        }
+
+        val result = LocalRulesEvaluator(providers = listOf(failing))
+            .match(listOf(TestRule("only", matchingPredicate)))
+
+        val error = result.exceptionOrNull() as LocalRulesEvaluationException.DimensionResolution
+        assertThat(error.reason)
+            .isEqualTo(RulesDimensionResolutionException.ProviderFailed("failing", "nope"))
+    }
+
+    @Test
+    fun `dimensions are collected once per call regardless of rule count`() = runTest {
+        evaluator().match(
+            listOf(
+                TestRule("first", nonMatchingPredicate),
+                TestRule("second", nonMatchingPredicate),
+                TestRule("third", matchingPredicate),
+            ),
+        )
+
+        assertThat(snapshotsTaken).isEqualTo(1)
+    }
+
+    private fun evaluator() = LocalRulesEvaluator(providers = listOf(deviceProvider))
+
+    private data class TestRule(
+        val name: String,
+        override val predicate: String,
+    ) : LocalRule
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -1,0 +1,185 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.rules.RulesEngine
+import com.revenuecat.purchases.rules.Value
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.Date
+
+class RulesDimensionResolverTest {
+
+    private val evaluationDate = Date(1_700_000_000_000)
+
+    @Test
+    fun `dimensions are nested under their provider's namespace`() = runTest {
+        val resolver = resolver(
+            provider(RulesDimensionNamespace.Device, "app_version" to string("1.2.3")),
+        )
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values).isEqualTo(
+            mapOf("device" to Value.ObjectValue(mapOf("app_version" to Value.StringValue("1.2.3")))),
+        )
+    }
+
+    @Test
+    fun `nested dimensions are reachable by dot-path from a predicate`() = runTest {
+        val resolver = resolver(
+            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
+        )
+        val values = resolver.snapshot().getOrThrow().values
+
+        val matches = RulesEngine.evaluate("""{"==": [{"var": "device.platform"}, "android"]}""", values)
+
+        assertThat(matches.getOrThrow()).isTrue()
+    }
+
+    @Test
+    fun `providers sharing a namespace are merged`() = runTest {
+        val resolver = resolver(
+            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
+            provider(RulesDimensionNamespace.Device, "locale" to string("en-US")),
+        )
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values).isEqualTo(
+            mapOf(
+                "device" to Value.ObjectValue(
+                    mapOf(
+                        "platform" to Value.StringValue("android"),
+                        "locale" to Value.StringValue("en-US"),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `two providers supplying the same dimension fail the snapshot`() = runTest {
+        val resolver = resolver(
+            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
+            provider(RulesDimensionNamespace.Device, "platform" to string("amazon")),
+        )
+
+        val error = resolver.snapshot().exceptionOrNull()
+
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("device.platform"))
+    }
+
+    @Test
+    fun `a provider that throws fails the snapshot with its identifier`() = runTest {
+        val resolver = resolver(
+            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
+            object : RulesDimensionProvider {
+                override val identifier = "failing"
+                override val namespace = RulesDimensionNamespace.Device
+                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+                    throw IllegalStateException("nope")
+            },
+        )
+
+        val error = resolver.snapshot().exceptionOrNull()
+
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ProviderFailed("failing", "nope"))
+    }
+
+    @Test
+    fun `cancellation propagates instead of failing the snapshot`() = runTest {
+        val resolver = resolver(
+            object : RulesDimensionProvider {
+                override val identifier = "cancelling"
+                override val namespace = RulesDimensionNamespace.Device
+                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+                    throw CancellationException("cancelled")
+            },
+        )
+
+        val thrown = try {
+            resolver.snapshot()
+            null
+        } catch (e: CancellationException) {
+            e
+        }
+
+        assertThat(thrown).hasMessage("cancelled")
+    }
+
+    @Test
+    fun `every provider sees the same evaluation date`() = runTest {
+        val dates = mutableListOf<Date>()
+        val recordingProvider = { name: String ->
+            object : RulesDimensionProvider {
+                override val identifier = name
+                override val namespace = RulesDimensionNamespace.Device
+                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+                    dates += date
+                    return emptyMap()
+                }
+            }
+        }
+        val resolver = resolver(recordingProvider("first"), recordingProvider("second"))
+
+        val snapshot = resolver.snapshot().getOrThrow()
+
+        assertThat(dates).containsExactly(evaluationDate, evaluationDate)
+        assertThat(snapshot.evaluationDate).isEqualTo(evaluationDate)
+    }
+
+    @Test
+    fun `each dimension value maps to its engine counterpart`() = runTest {
+        val resolver = resolver(
+            provider(
+                RulesDimensionNamespace.Device,
+                "text" to RulesDimensionValue.StringValue("value"),
+                "flag" to RulesDimensionValue.BoolValue(true),
+                "count" to RulesDimensionValue.IntValue(3),
+                "ratio" to RulesDimensionValue.DoubleValue(1.5),
+            ),
+        )
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values["device"]).isEqualTo(
+            Value.ObjectValue(
+                mapOf(
+                    "text" to Value.StringValue("value"),
+                    "flag" to Value.BoolValue(true),
+                    "count" to Value.IntValue(3),
+                    "ratio" to Value.FloatValue(1.5),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `no providers yields an empty scope`() = runTest {
+        assertThat(resolver().snapshot().getOrThrow().values).isEmpty()
+    }
+
+    private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
+        providers = providers.toList(),
+        dateProvider = object : DateProvider {
+            override val now: Date = evaluationDate
+        },
+    )
+
+    private fun string(value: String) = RulesDimensionValue.StringValue(value)
+
+    private fun provider(
+        dimensionNamespace: RulesDimensionNamespace,
+        vararg values: Pair<String, RulesDimensionValue>,
+    ) = object : RulesDimensionProvider {
+        override val identifier = dimensionNamespace.key
+        override val namespace = dimensionNamespace
+        override suspend fun dimensions(date: Date) = values.toMap()
+    }
+}


### PR DESCRIPTION
### Description

Starts introducing the infrastructure for rule evaluation in the SDK and providing dimensions for the evaluation of rules.

One behavior change to mention is that we will now pick the first rule with an audience that matches, instead of the first rule with a servable workflow, which I think is desired and matches iOS.

No audience providers are added yet. This will be done in follow-up PRs.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint workflow selection semantics (no fallthrough when the matched rule is unservable), which can alter which paywall/workflow is shown. Dimension providers are not live yet, so runtime impact is limited until follow-ups.
> 
> **Overview**
> Adds a **local rules evaluation** layer and wires checkpoints through it, so rule selection is based on audience match rather than “first servable workflow.”
> 
> Introduces `common/localrules` with `LocalRulesEvaluator`, dimension providers/resolver, and a `RulesEngine` logger bridge. Checkpoints now pick the **first audience-matching rule**; if that winner’s workflow is unservable, resolution returns `CONFIGURATION_UNAVAILABLE` instead of falling through. No dimension providers are registered yet, and predicates are still the placeholder `"true"`, so published order remains the effective signal until follow-ups land.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4336fae5ccc5d8c26176d6c1f50319dec908440b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->