### PR TITLE
refactor(checkpoints): Add DeviceDimensionProvider

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -29,6 +29,7 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.EventsManager
 import com.revenuecat.purchases.common.isDeviceProtectedStorageCompat
+import com.revenuecat.purchases.common.localrules.DeviceDimensionProvider
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesEngineLoggerBridge
 import com.revenuecat.purchases.common.log
@@ -352,10 +353,10 @@ internal class PurchasesFactory(
             val checkpointsConfigProvider = remoteConfigManager?.let {
                 CheckpointsConfigProvider(it)
             }
-            // Dimension providers are added here as they land; with none registered, only predicates that read no
-            // dimensions can match.
             RulesEngine.setLogger(RulesEngineLoggerBridge)
-            val localRulesEvaluator = LocalRulesEvaluator(providers = emptyList())
+            val localRulesEvaluator = LocalRulesEvaluator(
+                providers = listOf(DeviceDimensionProvider(appConfig, localeProvider)),
+            )
             if (remoteConfigManager != null && uiConfigProvider != null && workflowsConfigProvider != null) {
                 remoteConfigManager.registerListener(uiConfigProvider)
                 remoteConfigManager.registerListener(workflowsConfigProvider)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -9,7 +9,6 @@ import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.ForceServerErrorStrategy
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
@@ -664,7 +663,7 @@ internal class HTTPClient(
             // compression and never the HTTP transport encoding.
             RC_FORMAT_ACCEPT_ENCODING_HEADER to
                 if (endpoint.expectsRCFormatResponse) RC_FORMAT_ACCEPT_ENCODING else null,
-            "X-Platform" to getXPlatformHeader(),
+            "X-Platform" to appConfig.store.platformName,
             "X-Platform-Flavor" to appConfig.platformInfo.flavor,
             "X-Platform-Flavor-Version" to appConfig.platformInfo.version,
             "X-Platform-Version" to Build.VERSION.SDK_INT.toString(),
@@ -712,11 +711,6 @@ internal class HTTPClient(
                 writeFully(buffer(os), body.toString())
             }
         }
-    }
-
-    private fun getXPlatformHeader() = when (appConfig.store) {
-        Store.AMAZON -> "amazon"
-        else -> "android"
     }
 
     private fun verifyResponse(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/StorePlatform.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/StorePlatform.kt
@@ -1,0 +1,14 @@
+package com.revenuecat.purchases.common
+
+import com.revenuecat.purchases.Store
+
+/**
+ * The platform name the backend knows this SDK by, sent as the `X-Platform` header.
+ *
+ * Deliberately not exhaustive over [Store]: every store other than Amazon is served by the Android SDK build.
+ */
+internal val Store.platformName: String
+    get() = when (this) {
+        Store.AMAZON -> "amazon"
+        else -> "android"
+    }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
@@ -1,0 +1,74 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import android.os.Build
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.AppConfig
+import com.revenuecat.purchases.common.Config
+import com.revenuecat.purchases.common.LocaleProvider
+import com.revenuecat.purchases.common.platformName
+import java.util.Date
+
+/**
+ * Device and environment dimensions.
+ *
+ * Everything but the locale is fixed for the life of the process and is read once. The locale is read per
+ * evaluation because the system locale can change mid-session and `preferredUILocaleOverride` can be set at any
+ * time, and an audience keyed on locale has to agree with what the customer will actually be shown.
+ *
+ * A dimension the device has no value for is omitted; see [hasValue].
+ */
+internal class DeviceDimensionProvider(
+    appConfig: AppConfig,
+    private val localeProvider: LocaleProvider,
+) : RulesDimensionProvider {
+
+    override val identifier: String = "device"
+
+    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.Device
+
+    private val fixedDimensions: Map<String, RulesDimensionValue> = mapOf(
+        KEY_APP_VERSION to RulesDimensionValue.StringValue(appConfig.versionName),
+        KEY_PLATFORM to RulesDimensionValue.StringValue(appConfig.store.platformName),
+        KEY_PLATFORM_VERSION to RulesDimensionValue.IntValue(Build.VERSION.SDK_INT.toLong()),
+        KEY_SDK_VERSION to RulesDimensionValue.StringValue(Config.frameworkVersion),
+    )
+
+    // Snapshotted at configure time, so it is the fallback for the rare case where the live preference list is
+    // empty.
+    private val fallbackLanguageTag: String = appConfig.languageTag
+
+    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+        (fixedDimensions + (KEY_LOCALE to RulesDimensionValue.StringValue(currentLocale())))
+            .filterValues { value -> value.hasValue }
+
+    /**
+     * [LocaleProvider.currentLocalesLanguageTags] is the comma-joined preference list sent as a header. A
+     * dimension has to be a scalar to be usable with `==` or `in`, so only the preferred locale is exposed.
+     *
+     * Normalized to lowercase snake case (`en_us`) so one predicate can target a locale on every platform,
+     * whatever casing and separator that platform's locale API happens to use.
+     */
+    private fun currentLocale(): String =
+        localeProvider.currentLocalesLanguageTags
+            .substringBefore(',')
+            .ifEmpty { fallbackLanguageTag }
+            .lowercase()
+            .replace(oldChar = '-', newChar = '_')
+
+    internal companion object {
+        const val KEY_APP_VERSION = "appVersion"
+        const val KEY_LOCALE = "locale"
+        const val KEY_PLATFORM = "platform"
+        const val KEY_PLATFORM_VERSION = "platformVersion"
+        const val KEY_SDK_VERSION = "sdkVersion"
+
+        /**
+         * A dimension the device could not tell us about is omitted rather than reported as an empty string: an
+         * absent key resolves to null in the engine, while `""` would compare equal to another absent value.
+         */
+        private val RulesDimensionValue.hasValue: Boolean
+            get() = this !is RulesDimensionValue.StringValue || value.isNotEmpty()
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -7,7 +7,7 @@ import java.util.Date
  * the contract predicates are authored against, so a provider must not be able to invent one.
  *
  * Each entry becomes a real nested object in the evaluated scope, because the engine's `var` operator walks
- * nested objects by strict dot-path and has no flat-key fallback — `device.app_version` resolves *through*
+ * nested objects by strict dot-path and has no flat-key fallback — `device.appVersion` resolves *through*
  * `device`, it is never a literal key.
  */
 internal enum class RulesDimensionNamespace(val key: String) {
@@ -42,7 +42,7 @@ internal interface RulesDimensionProvider {
     val namespace: RulesDimensionNamespace
 
     /**
-     * The complete current set of values relative to [namespace], keyed in lowercase snake_case (`app_version`);
+     * The complete current set of values relative to [namespace], keyed in camelCase (`appVersion`);
      * [RulesDimensionResolver] adds the namespace.
      *
      * A value that is unavailable is omitted rather than guessed: an absent key resolves to null in the engine,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/StorePlatformTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/StorePlatformTest.kt
@@ -1,0 +1,20 @@
+package com.revenuecat.purchases.common
+
+import com.revenuecat.purchases.Store
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class StorePlatformTest {
+
+    @Test
+    fun `amazon is its own platform`() {
+        assertThat(Store.AMAZON.platformName).isEqualTo("amazon")
+    }
+
+    @Test
+    fun `every other store is served by the android platform`() {
+        val platformNames = Store.values().filterNot { it == Store.AMAZON }.map { it.platformName }
+
+        assertThat(platformNames).isNotEmpty.containsOnly("android")
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
@@ -1,0 +1,103 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.common.AppConfig
+import com.revenuecat.purchases.common.Config
+import com.revenuecat.purchases.common.LocaleProvider
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config as RobolectricConfig
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@RobolectricConfig(manifest = RobolectricConfig.NONE, sdk = [34])
+class DeviceDimensionProviderTest {
+
+    private val date = Date(1_700_000_000_000)
+    private var languageTags = "en-US"
+
+    private val localeProvider = object : LocaleProvider {
+        override val currentLocalesLanguageTags: String
+            get() = languageTags
+    }
+
+    @Test
+    fun `provides the device dimensions`() = runTest {
+        val dimensions = provider().dimensions(date)
+
+        assertThat(dimensions).isEqualTo(
+            mapOf(
+                "appVersion" to RulesDimensionValue.StringValue("1.2.3"),
+                "locale" to RulesDimensionValue.StringValue("en_us"),
+                "platform" to RulesDimensionValue.StringValue("android"),
+                "platformVersion" to RulesDimensionValue.IntValue(34),
+                "sdkVersion" to RulesDimensionValue.StringValue(Config.frameworkVersion),
+            ),
+        )
+    }
+
+    @Test
+    fun `platform reflects the store`() = runTest {
+        val dimensions = provider(store = Store.AMAZON).dimensions(date)
+
+        assertThat(dimensions["platform"]).isEqualTo(RulesDimensionValue.StringValue("amazon"))
+    }
+
+    @Test
+    fun `only the preferred locale of the preference list is exposed`() = runTest {
+        languageTags = "es-ES,en-US"
+
+        val dimensions = provider().dimensions(date)
+
+        assertThat(dimensions["locale"]).isEqualTo(RulesDimensionValue.StringValue("es_es"))
+    }
+
+    @Test
+    fun `locale is re-read on every evaluation`() = runTest {
+        val provider = provider()
+        assertThat(provider.dimensions(date)["locale"]).isEqualTo(RulesDimensionValue.StringValue("en_us"))
+
+        languageTags = "fr-FR"
+
+        assertThat(provider.dimensions(date)["locale"]).isEqualTo(RulesDimensionValue.StringValue("fr_fr"))
+    }
+
+    @Test
+    fun `locale falls back to the configured language tag when no locale is preferred`() = runTest {
+        languageTags = ""
+
+        val dimensions = provider(languageTag = "de-DE").dimensions(date)
+
+        assertThat(dimensions["locale"]).isEqualTo(RulesDimensionValue.StringValue("de_de"))
+    }
+
+    @Test
+    fun `dimensions the device has no value for are omitted`() = runTest {
+        languageTags = ""
+
+        val dimensions = provider(languageTag = "", versionName = "").dimensions(date)
+
+        assertThat(dimensions).containsOnlyKeys("platform", "platformVersion", "sdkVersion")
+    }
+
+    private fun provider(
+        store: Store = Store.PLAY_STORE,
+        languageTag: String = "en-US",
+        versionName: String = "1.2.3",
+    ): DeviceDimensionProvider {
+        val appConfig = mockk<AppConfig>().also {
+            every { it.store } returns store
+            every { it.languageTag } returns languageTag
+            every { it.versionName } returns versionName
+        }
+        return DeviceDimensionProvider(appConfig, localeProvider)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -20,13 +20,13 @@ class RulesDimensionResolverTest {
     @Test
     fun `dimensions are nested under their provider's namespace`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "app_version" to string("1.2.3")),
+            provider(RulesDimensionNamespace.Device, "appVersion" to string("1.2.3")),
         )
 
         val values = resolver.snapshot().getOrThrow().values
 
         assertThat(values).isEqualTo(
-            mapOf("device" to Value.ObjectValue(mapOf("app_version" to Value.StringValue("1.2.3")))),
+            mapOf("device" to Value.ObjectValue(mapOf("appVersion" to Value.StringValue("1.2.3")))),
         )
     }
 


### PR DESCRIPTION
### Description

Adds the first dimension provider, so rule predicates have something to read: `device.appVersion`, `device.locale`, `device.platform`, `device.platformVersion` and `device.sdkVersion`.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables real checkpoint audience matching on device/locale/platform fields; camelCase dimension keys are a new predicate contract, though behavior is additive with tests covering provider and platform mapping.
> 
> **Overview**
> **Local rules can now read device context.** `PurchasesFactory` wires `DeviceDimensionProvider` into `LocalRulesEvaluator` (replacing an empty provider list), so checkpoint predicates can target `device.appVersion`, `device.locale`, `device.platform`, `device.platformVersion`, and `device.sdkVersion`.
> 
> `DeviceDimensionProvider` snapshots most values at configure time but **re-reads locale** on each evaluation (normalized to lowercase `en_us`), omits empty string dimensions, and maps Amazon vs other stores via shared `Store.platformName`. That same extension replaces `HTTPClient`'s private `X-Platform` mapping so headers and rules stay aligned.
> 
> Dimension key documentation and resolver tests move from **snake_case to camelCase** (`appVersion` vs `app_version`) to match the nested `device.*` paths the engine resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d52917764ec5bf1b8d1fc0eb864fb189777fff62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->