### PR TITLE
build: fix api-tester customEntitlementComputation variant resolution after Kover bump

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigureApisFlavorsForApplication.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigureApisFlavorsForApplication.kt
@@ -18,6 +18,8 @@ internal fun Project.configureApisFlavorsForApplication() {
             }
             create("customEntitlementComputation") {
                 dimension = "apis"
+                // Library modules other than :purchases only publish the "defaults" flavor
+                matchingFallbacks += "defaults"
             }
         }
     }


### PR DESCRIPTION
- `:api-tester`'s `customEntitlementComputation` flavor now falls back to `defaults` when resolving library modules, which only publish that flavor.
- Fixes `androidDependencies` failing with "No matching variant of project :feature:amazon" (also `:feature:galaxy`, `:ui:debugview`, `:ui:revenuecatui`) since #3932.
- The bug predates the Kover bump: Kover 0.7.0's `koverArtifact` configuration declared no usage/category attributes, so Gradle silently bound those modules to an empty coverage artifact instead of the real library. 0.9.9 gives it a `kover` usage attribute, so the accidental match is gone and resolution fails.

<details>
<summary>Agent description</summary>

### Motivation

`assemble-admob-integration-sample-app` started failing on every branch at the "Download Dependencies"
step (`./gradlew androidDependencies`). First red run on main is the Kover 0.9.9 merge (#3932); the run
immediately before it is green.

`:api-tester` declares the `apis` dimension with both `defaults` and `customEntitlementComputation`.
Every library module except `:purchases` declares the dimension with only `defaults`, and the app's CEC
flavor never declared `matchingFallbacks`, so there has never been a matching variant for
`:feature:amazon`, `:feature:galaxy`, `:ui:debugview` or `:ui:revenuecatui` on the
`customEntitlementComputationDebugCompileClasspath`.

It resolved anyway because Kover 0.7.0's `koverArtifact` consumable configuration declared no
`org.gradle.usage` or `org.gradle.category`, so Gradle scored it compatible on every requested attribute
and picked it. `dependencyInsight` on 0.7.0 confirms it: `project :feature:amazon` resolved to
`Variant koverArtifact`. Kover 0.9.x tags that configuration with a `kover` usage, it becomes
incompatible, no candidate is left and the resolution fails.

### Description

- `ConfigureApisFlavorsForApplication`: `matchingFallbacks += "defaults"` on the
  `customEntitlementComputation` flavor. That plugin is applied only by `:api-tester`.
- Verified by bisecting the version in isolation: repo-wide `androidDependencies` fails on 0.9.9 and
  passes on 0.7.0 with no other change, and passes on 0.9.9 with this fallback.
- `dependencyInsight --configuration customEntitlementComputationDebugCompileClasspath --dependency
  :feature:amazon` now reports `defaultsDebugApiElements` instead of `koverArtifact`.
- `:api-tester:compileCustomEntitlementComputationDebugSources` builds, which is new: `src/main`
  references `com.revenuecat.purchases.amazon` classes that the empty kover artifact did not carry.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Gradle flavor matching fix limited to build configuration for `:api-tester`; no runtime or security impact.
> 
> **Overview**
> Fixes Gradle variant resolution for `:api-tester`'s `customEntitlementComputation` flavor by falling back to `defaults` when consuming library modules that only publish that flavor.
> 
> This restores `androidDependencies` / compile resolution after the Kover bump stopped accidentally matching an empty `koverArtifact` configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1787ce2cefe704a8ce3703aaf2c2b3369f3dce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->