### PR TITLE
fix(paywalls): Prevent an invisible leftover header from blocking taps on workflow paywalls

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalLayoutDirection
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -37,6 +37,25 @@ internal data class WorkflowHeaderPresentation(
     val headerStepId: String,
     val role: WorkflowHeaderTransitionRole,
 )
+
+/**
+ * Fades a header, reading the animation in the layout phase so frames cost no recomposition.
+ *
+ * Compose does not hit-test unplaced nodes, whereas an alpha 0 node stays interactive while being
+ * excluded from rendering and from the accessibility tree.
+ */
+internal fun Modifier.workflowHeaderFade(
+    role: WorkflowHeaderTransitionRole,
+    transitionState: WorkflowTransitionState,
+): Modifier = layout { measurable, constraints ->
+    val headerAlpha = headerAlpha(role, transitionState.animatable.value)
+    val placeable = measurable.measure(constraints)
+    layout(placeable.width, placeable.height) {
+        if (headerAlpha > 0f) {
+            placeable.placeWithLayer(x = 0, y = 0) { alpha = headerAlpha }
+        }
+    }
+}
 
 internal fun headerAlpha(role: WorkflowHeaderTransitionRole, progress: Float): Float = when (role) {
     WorkflowHeaderTransitionRole.ENTERING -> progress
@@ -97,11 +116,7 @@ internal fun LoadedWorkflowPaywall(
                 onClick = headerOnClick,
                 modifier = Modifier
                     .fillMaxWidth()
-                    // Read animatable.value inside graphicsLayer (draw phase), like workflowTransition,
-                    // so the fade stays in lock-step with the slide without recomposing every frame.
-                    .graphicsLayer {
-                        alpha = headerAlpha(headerPresentation.role, transitionState.animatable.value)
-                    },
+                    .workflowHeaderFade(headerPresentation.role, transitionState),
             )
         }
     }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowHeaderFadeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowHeaderFadeTest.kt
@@ -1,0 +1,101 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * A header that outlives its transition must not receive touches: at alpha 0 a node stays
+ * hit-testable while being invisible to both screenshots and the accessibility tree.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class WorkflowHeaderFadeTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun transitionStateAt(progress: Float) = WorkflowTransitionState.SlideInOut(
+        animatingFromStepId = "from",
+        animatingToStepId = "to",
+        animatingDirection = NavigationDirection.FORWARD,
+        animatable = Animatable(progress),
+    )
+
+    private fun clickThroughHeader(
+        role: WorkflowHeaderTransitionRole,
+        progress: Float,
+    ): Pair<Int, Int> {
+        var headerClicks = 0
+        var stepClicks = 0
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize()) {
+                Box(Modifier.fillMaxSize().clickable { stepClicks++ })
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .workflowHeaderFade(role, transitionStateAt(progress))
+                        .clickable { headerClicks++ },
+                )
+            }
+        }
+        composeTestRule.onRoot().performTouchInput { click() }
+        composeTestRule.waitForIdle()
+        return headerClicks to stepClicks
+    }
+
+    @Test
+    fun `fully faded leaving header does not intercept touches`() {
+        val (headerClicks, stepClicks) = clickThroughHeader(
+            role = WorkflowHeaderTransitionRole.LEAVING,
+            progress = 1f,
+        )
+
+        assertThat(headerClicks).isZero()
+        assertThat(stepClicks).isOne()
+    }
+
+    @Test
+    fun `partially faded leaving header still intercepts touches`() {
+        val (headerClicks, stepClicks) = clickThroughHeader(
+            role = WorkflowHeaderTransitionRole.LEAVING,
+            progress = 0.5f,
+        )
+
+        assertThat(headerClicks).isOne()
+        assertThat(stepClicks).isZero()
+    }
+
+    @Test
+    fun `stable header intercepts touches`() {
+        val (headerClicks, stepClicks) = clickThroughHeader(
+            role = WorkflowHeaderTransitionRole.STABLE,
+            progress = 1f,
+        )
+
+        assertThat(headerClicks).isOne()
+        assertThat(stepClicks).isZero()
+    }
+
+    @Test
+    fun `entering header at the start of its fade does not intercept touches`() {
+        val (headerClicks, stepClicks) = clickThroughHeader(
+            role = WorkflowHeaderTransitionRole.ENTERING,
+            progress = 0f,
+        )
+
+        assertThat(headerClicks).isZero()
+        assertThat(stepClicks).isOne()
+    }
+}


### PR DESCRIPTION
## Motivation
On a workflow paywall, tapping the top-left of a step could silently navigate to the previous step instead of hitting that step's own control. The leftover control is invisible, so the tap looks like it did nothing or went to the wrong place. 

Cause: a header that fades out during a step transition can outlive the transition. At alpha 0 it is invisible and excluded from the accessibility tree, but still receives touches over the incoming step.

Latent on `main`: reproducing it needs a recomposition to not run after the animation settles. **It reproduces deterministically on Kotlin 2.2.10**, which is why the Kotlin bump at #3934 surfaced it. (i.e. this blocks AGP9)

## Changes
- Fix: a fully faded header is left unplaced instead of drawn transparent. An unplaced node is not hit-tested.
- Also changes an entering header at progress 0: it is now unplaced for that first frame rather than placed and clickable while invisible. Same invariant, but it is a second case the diff touches.
- Regression test `WorkflowHeaderFadeTest`.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

A workflow step whose next step has no header of its own takes the `LEAVING` path in
`selectWorkflowHeaderPresentation`. The outgoing header is then rendered as a `Box` overlay above the
step content and faded out with `graphicsLayer { alpha = 1f - progress }`.

Removing that overlay depends on a recomposition that runs after the animation settles. That
recomposition is not guaranteed: instrumenting the composition shows the parent recomposing into the
final `STABLE` state with no matching disposal of the header subtree, and no recomposition of the
scaffold content that would drop it.

While it lingers, `alpha = 0f` hides it from rendering and from the accessibility tree, but does not
disable hit testing. It keeps consuming touches over the incoming step's controls.

Concretely, on a 320x640 @160dpi screen the leftover "Back" control from the previous step covers
roughly `[0,24]` to `[32,42]`, sitting on top of the last step's close control. A tap there navigates
back a step instead of closing. The behavior is deterministic and survives 12s of idle; forcing a
recomposition by rotating clears it, which confirms the stale-subtree diagnosis.

The bug is device dependent only because it depends on where the control lands: on a large screen the
same relative tap position falls outside the leftover control's bounds.

### Description

- `Modifier.workflowHeaderFade` replaces the header's `graphicsLayer { alpha = ... }`. It reads the
  animation in the layout phase, so frames still cost no recomposition, and skips placing the child
  when the computed alpha is 0.
- Correctness no longer depends on the removal recomposition happening. The animatable's own frame
  updates drive the header to unplaced.
- The modifier measures the child and reports its size unchanged, so `OverlayLayout`'s
  `headerHeightPx` and all surrounding layout are untouched. Only placement is skipped, and only when
  nothing was being drawn anyway.
- `placeWithLayer { alpha }` and `graphicsLayer { alpha }` render identically at intermediate values,
  so no snapshot drift is expected.
- `workflowHeaderFade` is `internal` rather than `private` so the test can exercise it directly.

Approaches that were tried and did not work, for reviewers wondering why the fix is not structural:
keying the header `ComponentView` by step id, and keeping `WorkflowStepsContent` in a stable slot so
the leaving-header branch never swaps. Both left the leftover control hit-testable. Only skipping
placement fixed it, so only that change is in the diff.

### Testing

- New `WorkflowHeaderFadeTest`, 4 cases. Two assert a fully faded leaving header and an entering
  header at progress 0 do not intercept touches; two assert a partially faded leaving header and a
  stable header still do, so the fix does not simply disable the header.
- Verified against a CI-equivalent AVD (320x640 @160dpi, API 32), which is the geometry that
  reproduces the bug: the tap that previously navigated back now reaches the close control on 6/6
  runs, and the full `maestro/workflows` suite passes on both Kotlin 2.0.21 and 2.2.10.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes layout and hit-testing for workflow paywall headers during transitions, which can affect navigation taps on a monetization-critical UI surface. Scope is small and covered by new regression tests.
> 
> **Overview**
> Fixes a workflow paywall bug where a leftover header could stay invisible but still steal taps after a step transition, sending users back instead of hitting the current step's controls.
> 
> Replaces the header's `graphicsLayer` alpha fade with `workflowHeaderFade`, which still animates without recomposition but **skips placing** the node when alpha is 0. Unplaced nodes are not hit-tested, so fully faded leaving headers and entering headers at progress 0 no longer intercept touches.
> 
> Adds `WorkflowHeaderFadeTest` to lock in that faded headers pass taps through while partially faded and stable headers remain interactive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28522542abbcd5794510990efeea8fe87aee486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->