### PR TITLE
Scope paywall ViewModels to each presentation

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -18,10 +18,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.currentCompositeKeyHash
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,7 +35,11 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.unit.Density
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -49,6 +55,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelFactory
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelStoreHolder
 import com.revenuecat.purchases.ui.revenuecatui.data.currentColors
 import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
@@ -363,8 +370,9 @@ internal fun getPaywallViewModel(
     shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null,
 ): PaywallViewModel {
     val applicationContext = LocalContext.current.applicationContext
+    val viewModelStoreOwner = rememberPaywallViewModelStoreOwner(currentCompositeKeyHash)
     val viewModel = viewModel<PaywallViewModelImpl>(
-        key = options.hashCode().toString(),
+        viewModelStoreOwner = viewModelStoreOwner,
         factory = PaywallViewModelFactory(
             applicationContext.toResourceProvider(),
             options,
@@ -376,6 +384,32 @@ internal fun getPaywallViewModel(
     )
     viewModel.updateOptions(options)
     return viewModel
+}
+
+/**
+ * Scopes a Paywall ViewModel to one presentation while retaining it through configuration changes.
+ *
+ * This deliberately does not provide SavedStateHandle support. Replace it with Lifecycle's scoped ViewModel APIs
+ * instead of extending it if PaywallViewModelImpl starts depending on saved state.
+ */
+@Composable
+internal fun rememberPaywallViewModelStoreOwner(
+    key: Any,
+    parentOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "CompositionLocal LocalViewModelStoreOwner not present"
+    },
+    holder: PaywallViewModelStoreHolder = viewModel(viewModelStoreOwner = parentOwner),
+): ViewModelStoreOwner {
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val lease = remember(holder, key, lifecycle) { holder.acquire(key) }
+
+    DisposableEffect(lease, lifecycle) {
+        onDispose {
+            lease.release(clear = lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED))
+        }
+    }
+
+    return lease.owner
 }
 
 @ReadOnlyComposable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -30,8 +30,8 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.OfferingSelection
-import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
@@ -237,7 +237,7 @@ internal class PaywallActivity : ComponentActivity() {
                             viewModel.preloadExitOffering()
                         }
 
-                        Paywall(paywallOptions)
+                        InternalPaywall(paywallOptions, viewModel)
                     }
                 }
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelStoreHolder.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelStoreHolder.kt
@@ -1,0 +1,61 @@
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+
+internal class PaywallViewModelStoreHolder : ViewModel() {
+    private val entries = mutableMapOf<Any, Entry>()
+
+    fun acquire(key: Any): Lease {
+        val entry = entries.getOrPut(key) { Entry() }
+        entry.referenceCount++
+        return Lease(
+            owner = entry.owner,
+            release = { clear -> release(key, entry, clear) },
+        )
+    }
+
+    private fun release(key: Any, entry: Entry, clear: Boolean) {
+        if (clear) entry.pendingClear = true
+        entry.referenceCount--
+        clearIfUnused(key, entry)
+    }
+
+    private fun clearIfUnused(key: Any, entry: Entry) {
+        if (!entry.pendingClear || entry.referenceCount > 0) return
+        if (!entries.remove(key, entry)) return
+
+        entry.store.clear()
+    }
+
+    override fun onCleared() {
+        entries.toMap().forEach { (key, entry) ->
+            entry.pendingClear = true
+            clearIfUnused(key, entry)
+        }
+    }
+
+    private class Entry(
+        val store: ViewModelStore = ViewModelStore(),
+        var referenceCount: Int = 0,
+        var pendingClear: Boolean = false,
+    ) {
+        val owner = object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore = store
+        }
+    }
+
+    class Lease internal constructor(
+        val owner: ViewModelStoreOwner,
+        private val release: (Boolean) -> Unit,
+    ) {
+        private var isReleased = false
+
+        fun release(clear: Boolean) {
+            if (isReleased) return
+            isReleased = true
+            release.invoke(clear)
+        }
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewModelStoreOwnerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewModelStoreOwnerTest.kt
@@ -1,0 +1,214 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesAreCompletedBy
+import com.revenuecat.purchases.common.workflows.WorkflowResolution
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PaywallViewModelStoreOwnerTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        val purchases = mockk<Purchases>()
+        mockkObject(Purchases)
+        every { Purchases.sharedInstance } returns purchases
+        every { purchases.purchasesAreCompletedBy } returns PurchasesAreCompletedBy.REVENUECAT
+        every { purchases.storefrontCountryCode } returns "US"
+        every { purchases.preferredUILocaleOverride } returns null
+        every { purchases.track(any()) } just Runs
+        every { purchases.currentConfiguration } returns mockk {
+            every { dangerousSettings } returns DangerousSettings()
+        }
+        coEvery { purchases.resolveWorkflow(any()) } returns WorkflowResolution.NoWorkflow
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `removing presentation from live parent clears its ViewModel`() {
+        val parentOwner = TestViewModelStoreOwner()
+        val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
+        var showPresentation by mutableStateOf(true)
+        var capturedViewModel: TrackingViewModel? = null
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalViewModelStoreOwner provides parentOwner,
+                LocalLifecycleOwner provides lifecycleOwner,
+            ) {
+                if (showPresentation) {
+                    val owner = rememberPaywallViewModelStoreOwner("paywall")
+                    capturedViewModel = ViewModelProvider(owner)[TrackingViewModel::class.java]
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        val firstViewModel = checkNotNull(capturedViewModel)
+
+        composeTestRule.runOnIdle { showPresentation = false }
+        composeTestRule.waitForIdle()
+
+        assertThat(firstViewModel.clearCount).isEqualTo(1)
+
+        composeTestRule.runOnIdle { showPresentation = true }
+        composeTestRule.waitForIdle()
+
+        assertThat(capturedViewModel).isNotSameAs(firstViewModel)
+    }
+
+    @Test
+    fun `configuration recreation retains presentation ViewModel`() {
+        val parentOwner = TestViewModelStoreOwner()
+        val firstLifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
+        var lifecycleOwner by mutableStateOf(firstLifecycleOwner)
+        var showPresentation by mutableStateOf(true)
+        var capturedViewModel: TrackingViewModel? = null
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalViewModelStoreOwner provides parentOwner,
+                LocalLifecycleOwner provides lifecycleOwner,
+            ) {
+                if (showPresentation) {
+                    val owner = rememberPaywallViewModelStoreOwner("paywall")
+                    capturedViewModel = ViewModelProvider(owner)[TrackingViewModel::class.java]
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        val firstViewModel = checkNotNull(capturedViewModel)
+
+        composeTestRule.runOnIdle {
+            firstLifecycleOwner.moveTo(Lifecycle.State.DESTROYED)
+            showPresentation = false
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(firstViewModel.clearCount).isZero()
+
+        composeTestRule.runOnIdle {
+            lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
+            showPresentation = true
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(capturedViewModel).isSameAs(firstViewModel)
+    }
+
+    @Test
+    fun `getPaywallViewModel creates a new instance for a new presentation`() {
+        val parentOwner = TestViewModelStoreOwner()
+        val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
+        val options = PaywallOptions.Builder(dismissRequest = {})
+            .setOffering(TestData.template1Offering)
+            .build()
+        var showPresentation by mutableStateOf(true)
+        var capturedViewModel: PaywallViewModel? = null
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalViewModelStoreOwner provides parentOwner,
+                LocalLifecycleOwner provides lifecycleOwner,
+            ) {
+                if (showPresentation) {
+                    capturedViewModel = getPaywallViewModel(options)
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        val firstViewModel = checkNotNull(capturedViewModel)
+
+        composeTestRule.runOnIdle { showPresentation = false }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle { showPresentation = true }
+        composeTestRule.waitForIdle()
+
+        assertThat(capturedViewModel).isNotSameAs(firstViewModel)
+    }
+
+    @Test
+    fun `identical options at separate call sites use separate ViewModels`() {
+        val parentOwner = TestViewModelStoreOwner()
+        val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
+        val options = PaywallOptions.Builder(dismissRequest = {})
+            .setOffering(TestData.template1Offering)
+            .build()
+        var firstViewModel: PaywallViewModel? = null
+        var secondViewModel: PaywallViewModel? = null
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalViewModelStoreOwner provides parentOwner,
+                LocalLifecycleOwner provides lifecycleOwner,
+            ) {
+                firstViewModel = getPaywallViewModel(options)
+                secondViewModel = getPaywallViewModel(options)
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        assertThat(secondViewModel).isNotSameAs(firstViewModel)
+    }
+
+    private class TestViewModelStoreOwner : ViewModelStoreOwner {
+        override val viewModelStore = ViewModelStore()
+    }
+
+    private class TestLifecycleOwner(initialState: Lifecycle.State) : LifecycleOwner {
+        private val registry = LifecycleRegistry(this).apply {
+            currentState = initialState
+        }
+
+        override val lifecycle: Lifecycle = registry
+
+        fun moveTo(state: Lifecycle.State) {
+            registry.currentState = state
+        }
+    }
+
+    class TrackingViewModel : ViewModel() {
+        var clearCount = 0
+            private set
+
+        override fun onCleared() {
+            clearCount++
+        }
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelStoreHolderTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelStoreHolderTest.kt
@@ -1,0 +1,128 @@
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class PaywallViewModelStoreHolderTest {
+
+    @Test
+    fun `overlapping leases share store and clear after final release`() {
+        val holder = PaywallViewModelStoreHolder()
+        val first = holder.acquire("paywall")
+        val second = holder.acquire("paywall")
+        val tracked = ViewModelProvider(first.owner)[TrackingViewModel::class.java]
+
+        first.release(clear = true)
+
+        assertThat(tracked.clearCount).isZero()
+        assertThat(second.owner.viewModelStore).isSameAs(first.owner.viewModelStore)
+
+        second.release(clear = true)
+
+        assertThat(tracked.clearCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `configuration release retains store for next lease`() {
+        val holder = PaywallViewModelStoreHolder()
+        val first = holder.acquire("paywall")
+        val tracked = ViewModelProvider(first.owner)[TrackingViewModel::class.java]
+
+        first.release(clear = false)
+        val second = holder.acquire("paywall")
+
+        assertThat(ViewModelProvider(second.owner)[TrackingViewModel::class.java]).isSameAs(tracked)
+    }
+
+    @Test
+    fun `normal release makes next presentation use new store`() {
+        val holder = PaywallViewModelStoreHolder()
+        val first = holder.acquire("paywall")
+        val firstViewModel = ViewModelProvider(first.owner)[TrackingViewModel::class.java]
+
+        first.release(clear = true)
+        val second = holder.acquire("paywall")
+        val secondViewModel = ViewModelProvider(second.owner)[TrackingViewModel::class.java]
+
+        assertThat(firstViewModel.clearCount).isEqualTo(1)
+        assertThat(secondViewModel).isNotSameAs(firstViewModel)
+    }
+
+    @Test
+    fun `distinct keys with the same hash use separate stores`() {
+        val holder = PaywallViewModelStoreHolder()
+        val first = holder.acquire(CollidingKey())
+        val second = holder.acquire(CollidingKey())
+
+        assertThat(second.owner.viewModelStore).isNotSameAs(first.owner.viewModelStore)
+    }
+
+    @Test
+    fun `releasing a lease twice does not clear an active sibling`() {
+        val holder = PaywallViewModelStoreHolder()
+        val first = holder.acquire("paywall")
+        val second = holder.acquire("paywall")
+        val tracked = ViewModelProvider(first.owner)[TrackingViewModel::class.java]
+
+        first.release(clear = true)
+        first.release(clear = true)
+
+        assertThat(tracked.clearCount).isZero()
+
+        second.release(clear = true)
+
+        assertThat(tracked.clearCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `clearing parent defers active child cleanup until final release`() {
+        val parentStore = ViewModelStore()
+        val parentOwner = object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore = parentStore
+        }
+        val holder = ViewModelProvider(parentOwner)[PaywallViewModelStoreHolder::class.java]
+        val lease = holder.acquire("paywall")
+        val tracked = ViewModelProvider(lease.owner)[TrackingViewModel::class.java]
+
+        parentStore.clear()
+
+        assertThat(tracked.clearCount).isZero()
+
+        lease.release(clear = false)
+
+        assertThat(tracked.clearCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `clearing parent clears child retained after configuration release`() {
+        val parentStore = ViewModelStore()
+        val parentOwner = object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore = parentStore
+        }
+        val holder = ViewModelProvider(parentOwner)[PaywallViewModelStoreHolder::class.java]
+        val lease = holder.acquire("paywall")
+        val tracked = ViewModelProvider(lease.owner)[TrackingViewModel::class.java]
+        lease.release(clear = false)
+
+        parentStore.clear()
+
+        assertThat(tracked.clearCount).isEqualTo(1)
+    }
+
+    private class CollidingKey {
+        override fun hashCode(): Int = 0
+    }
+
+    class TrackingViewModel : ViewModel() {
+        var clearCount = 0
+            private set
+
+        override fun onCleared() {
+            clearCount++
+        }
+    }
+}


### PR DESCRIPTION
Reopening a multi-page paywall can reuse the host-scoped `PaywallViewModel`, so it resumes at the previous workflow step. #3921 resets this state in the retained ViewModel. I think scoping the ViewModel to one presentation is safer, but we can't use Lifecycle 2.11's `rememberViewModelStoreProvider` until the AGP and compile SDK update is unblocked.

### Description
Backport the ownership behavior we need locally:

- retain the paywall ViewModel across configuration changes
- clear it when the presentation leaves composition
- reference count overlapping compositions using the same call-site key
- reuse the Activity's ViewModel instead of acquiring a second store lease

This is internal to RevenueCatUI. It doesn't change Lifecycle, AGP, compile SDK, or consumer requirements.

Tested with the new ownership and holder tests, the existing dialog, Activity, and workflow tests, `detektAll`, and `scripts/api-check.sh`.
