### PR TITLE
ci: install mise Ruby 3.3.0 so CI honors Gemfile.lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,12 +59,6 @@ parameters:
     default: alpha
 
 commands:
-  install-mise-tools:
-    description: Install mise tools from mise.toml (Java, etc.)
-    steps:
-      - revenuecat/install-mise-tools:
-          tools: java
-
   android-dependencies:
     steps:
       - android/restore_gradle_cache
@@ -170,7 +164,8 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/accept_licenses
@@ -186,7 +181,8 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/accept_licenses
@@ -202,7 +198,8 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/accept_licenses
@@ -222,7 +219,8 @@ jobs:
       - revenuecat/trust-github-key
       - checkout-submodule:
           path: upstream/paywall-preview-resources
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/accept_licenses
       - android/restore_gradle_cache
       - run:
@@ -256,7 +254,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore_gradle_cache
       - run:
           name: Run << parameters.flavor >> << parameters.build_type >> Tests
@@ -293,7 +292,8 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore_gradle_cache
       - run:
           name: Run dokka-hide-internal Tests
@@ -309,7 +309,8 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore_gradle_cache
       - run:
           name: Run detekt-rules Tests
@@ -324,7 +325,8 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore_gradle_cache
       - run:
           name: Detekt
@@ -336,7 +338,8 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore_gradle_cache
       - run:
           name: Validate binary compatibility
@@ -347,7 +350,8 @@ jobs:
     <<: *android-executor
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore_gradle_cache
       - android/restore_build_cache
       - run:
@@ -375,7 +379,8 @@ jobs:
     <<: *android-executor
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/setup-git-credentials
       - revenuecat/trust-github-key
       - revenuecat/install-gem-unix-dependencies:
@@ -394,7 +399,8 @@ jobs:
     <<: *android-executor
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - revenuecat/setup-git-credentials
@@ -407,7 +413,8 @@ jobs:
     <<: *android-executor
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/restore_gradle_cache:
@@ -454,7 +461,8 @@ jobs:
     <<: *android-executor
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/accept_licenses
@@ -481,7 +489,8 @@ jobs:
     <<: *android-executor
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - build-paywall-tester
@@ -493,7 +502,8 @@ jobs:
         type: string
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - build-paywall-tester
@@ -506,7 +516,8 @@ jobs:
     <<: *android-executor
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - build-rct-tester
@@ -518,7 +529,8 @@ jobs:
         type: string
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - build-rct-tester
@@ -541,7 +553,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/create_avd:
@@ -567,7 +580,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/create_avd:
@@ -595,13 +609,15 @@ jobs:
       - revenuecat/trust-github-key
       - checkout-submodule:
           path: upstream/paywall-preview-resources
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/restore_build_cache
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/restore_gradle_cache
@@ -618,7 +634,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - prepare-signing-key
@@ -636,7 +653,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - run:
           name: Prepare Keystore
           working_directory: integration-tests
@@ -673,7 +691,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/restore_gradle_cache
@@ -696,7 +715,8 @@ jobs:
           path: upstream/paywall-preview-resources
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       # Required by Emerge CLI
       - install-ruby:
           version: 3.2.0
@@ -755,7 +775,8 @@ jobs:
       - run:
           name: Clone paywall-rendering-validation repository
           command: git clone git@github.com:RevenueCat/paywall-rendering-validation.git ../paywall-rendering-validation
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/restore_build_cache
@@ -776,7 +797,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/create_avd:
           avd_name: test-revenuecat-ui
           system_image: system-images;android-32;google_apis;x86_64
@@ -808,7 +830,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - run:
           name: Replace API_KEY (Using Test store API key from Production Integration Tests Android project)
           working_directory: test-apps/e2etests/src/main/java/com/revenuecat/e2etests/
@@ -843,7 +866,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/create_avd:
           avd_name: test-e2e-workflow-tester
           system_image: system-images;android-32;google_apis;x86_64
@@ -875,7 +899,8 @@ jobs:
     <<: *android-machine-emulator
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/setup-git-credentials
       - revenuecat/trust-github-key
       - revenuecat/install-gem-unix-dependencies:
@@ -914,7 +939,8 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore_gradle_cache
       - run:
           name: Run Android Lint
@@ -928,7 +954,8 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore_gradle_cache
       - run:
           name: Verify purchases-android target SDK (33)
@@ -943,7 +970,8 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore_gradle_cache
       - run:
           name: Assemble checkpoint tester
@@ -1235,7 +1263,8 @@ workflows:
                 command: |
                   echo 'export JVM_OPTS=-Xmx6g' >> "$BASH_ENV"
                   echo 'export GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2' >> "$BASH_ENV"
-            - install-mise-tools
+            - revenuecat/install-mise-tools:
+                tools: java,ruby
             - revenuecat/install-gem-unix-dependencies:
                 cache-version: v1
             - android/restore_gradle_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,28 +122,6 @@ commands:
       - android/save_gradle_cache
       - android/save_build_cache
 
-  install-ruby:
-    description: "Installs the provided version of Ruby using RVM."
-    parameters:
-      version:
-        type: string
-    steps:
-      - run:
-          name: Install RVM and Ruby << parameters.version >>
-          command: |
-            # Import GPG keys first
-            command curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-            command curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
-            # Install RVM and Ruby
-            \curl -sSL https://get.rvm.io | bash -s stable
-            source ~/.rvm/scripts/rvm
-            rvm install << parameters.version >>
-            rvm use << parameters.version >>
-            echo 'source ~/.rvm/scripts/rvm' >> $BASH_ENV
-            echo 'rvm use << parameters.version >>' >> $BASH_ENV
-            source $BASH_ENV
-            ruby -v
-
   checkout-submodule:
     description: "Checks out a git submodule."
     parameters:
@@ -717,12 +695,13 @@ jobs:
           at: .
       - revenuecat/install-mise-tools:
           tools: java,ruby
-      # Required by Emerge CLI
-      - install-ruby:
-          version: 3.2.0
       - run:
           name: Install Emerge CLI
-          command: gem install emerge
+          # mise only shims binaries present at install time, so a gem executable
+          # needs a reshim to land on PATH.
+          command: |
+            gem install emerge
+            mise reshim
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/restore_gradle_cache


### PR DESCRIPTION
The android docker image (`cimg/android:2025.04.1`) ships Ruby 3.0.x, so bundler cannot self-install the 2.6.6 pinned in `Gemfile.lock` (needs Ruby >= 3.1) and the lockfile is unusable: every android job discarded it and re-resolved against live rubygems.org.

- That made gem versions drift per run and left CI exposed to any upstream release. fastlane 2.238.0, published 2026-08-12 12:16 UTC, is the one that broke it.
- Fix: the 21 jobs that run bundler install the Ruby 3.3.0 already pinned in `mise.toml`/`mise.lock`, so they install `Gemfile.lock` verbatim. The 14 that never touch bundler keep installing Java only.
- Also drops the RVM Ruby 3.2.0 install from the paparazzi job, along with the now-unused `install-ruby` command: it existed only because the image Ruby was too old for the Emerge CLI gem, and RVM prepending to `PATH` meant that job bundled on a different Ruby than every other job.


<details><summary>Agent description</summary>

### Motivation

`mise.toml` pins Ruby 3.3.0 and `Gemfile.lock` records `BUNDLED WITH 2.6.6`, but jobs on the android docker executor were using the image's Ruby 3.0.x and its bundler 2.5.23. Bundler 2.6.x requires Ruby >= 3.1, so the self-install failed with `Your lockfile is locked to a version of bundler (2.6.6) that doesn't exist at https://rubygems.org/` and the job continued on 2.5.23.

The lockfile itself was then unusable on Ruby 3.0, so bundler silently threw it away and resolved from scratch against live rubygems.org on every run. The last green run before the break downgraded 16 gems relative to the lockfile (`nokogiri 1.17.2` from `1.19.4`, `public_suffix 6.0.2` from `7.0.5`, `excon 1.2.5` from `1.5.0`, and so on) and installed 120 gems instead of the lockfile's 132.

Because `gem "fastlane"` is unpinned, that re-resolve always took the newest fastlane. fastlane 2.238.0 swaps `faraday ~> 1.0` plus `faraday_middleware ~> 1.0` for `faraday ~> 2.7` and friends, and `terminal-table ~> 3` for `~> 4`. Bundler 2.5.23 fails on that graph and reports it as `Because fastlane < 0.1.0 depends on deliver >= 0 [...] requires nokogiri >= 1.6.3.1, < 1.6.4.A`, which names none of the gems actually involved.

Two data points fixed the diagnosis. Cross-referencing the downgraded gems' `required_ruby_version` on rubygems brackets the image Ruby at `>= 3.0, < 3.1`. And `record-and-upload-paparazzi-revenuecatui-snapshots`, the one android-docker job that installs a newer Ruby (RVM 3.2.0, for the Emerge CLI), passed in the same pipeline with `Bundle complete! 132 gems` and no re-resolution, as did the machine-executor and `cimg/ruby` jobs.

### Description

- Replaces the local `install-mise-tools` wrapper with direct `revenuecat/install-mise-tools` calls: `tools: java,ruby` at the 21 sites in jobs that also run `revenuecat/install-gem-unix-dependencies`, `tools: java` at the other 14.
- `update-paywall-preview-resources-submodule` bundles gems but is untouched: it runs on `cimg/ruby:3.2.0` and never called the wrapper.
- `emerge_purchases_ui_snapshot_tests` installs tools and gems twice, once before and once after `attach_workspace`. Left as is rather than deduplicated, since the workspace attaches over the project directory.
- `mise.lock` already carries Ruby 3.3.0 prebuilt tarballs for `linux-x64` and `linux-arm64` (`[settings.ruby] compile = false`), so this is a download and extract, not a compile.
- No extra `PATH` wiring: `revenuecat/install-mise` already prepends the mise shims via `BASH_ENV`.
- Precedent for mise Ruby on Linux docker images: `purchases-unity` (`install-bundle-dependencies`, `tools: ruby`) and `purchases-kmp` (`tools: java,ruby`).
- `record-and-upload-paparazzi-revenuecatui-snapshots` loses the RVM step and the `install-ruby` command it was the only caller of. The Emerge CLI gem requires Ruby >= 3.2, which mise 3.3.0 satisfies. `gem install emerge` is followed by `mise reshim`, since mise only shims binaries that exist at tool-install time; that job is in `build-test-deploy`, so this PR exercises it.
- Considered and skipped: adding `emerge` to the `Gemfile` instead of `gem install`. It would pin the version, but it drags `ruby_tree_sitter` (native build) and `xcodeproj ~> 1.27.0` into every job's bundle.
- Considered and skipped: pinning fastlane in the `Gemfile` (band-aid, leaves CI ignoring the lockfile), and `BUNDLE_FROZEN` plus `bundle lock --add-platform x86_64-linux` as a guard against silent re-resolution (matching Ruby versions is what makes the lockfile authoritative; frozen mode needs its own validation).
- Verify on a previously failing job (`assemble-admob-integration-sample-app`, `emerge_size_analysis_tests`, `run-backend-integration-tests`): the mise step installs `ruby@3.3.0`, and `Bundle install` prints `Bundle complete! 5 Gemfile dependencies, 132 gems` with no `Resolving dependencies...` and no `Using X (was Y)` lines.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many release, deploy, and test jobs’ toolchain setup; misconfigured tool lists could break bundler or fastlane across the pipeline, but changes are limited to CI config with a clear java vs java,ruby split.
> 
> **Overview**
> Android CircleCI jobs no longer rely on the docker image’s Ruby 3.0.x for bundler. The local **`install-mise-tools`** wrapper and the RVM-based **`install-ruby`** command are removed; jobs call **`revenuecat/install-mise-tools`** instead.
> 
> Jobs that run **`bundle exec`** / **`install-gem-unix-dependencies`** install **`tools: java,ruby`** (mise Ruby **3.3.0** from **`mise.toml`**), so **`Gemfile.lock`** and Bundler **2.6.6** apply instead of re-resolving gems on each run. Gradle-only jobs keep **`tools: java`**.
> 
> The Paparazzi snapshot job drops RVM **3.2.0** in favor of mise Ruby and runs **`mise reshim`** after **`gem install emerge`** so the Emerge CLI is on PATH. The **`update-error-codes`** workflow’s custom API steps get the same **`java,ruby`** mise install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc2117301db8e92b19818f383b4d8a296c81a5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->