### PR TITLE
Android KMP Paywall Events are sent to the Production Amplitude project instead of Sandbox and use incorrect platform value (android instead of Android)

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -262,7 +262,7 @@ internal sealed class BackendEvent : Event {
             val locale: String? = null,
         ) {
             private companion object {
-                const val WORKFLOW_CONTEXT_PLATFORM = "android"
+                const val WORKFLOW_CONTEXT_PLATFORM = "Android"
             }
         }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/WorkflowEventsRequestSerializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/WorkflowEventsRequestSerializationTest.kt
@@ -23,7 +23,7 @@ class WorkflowEventsRequestSerializationTest {
                 timestampMs = 123456789L,
                 appUserID = "appUserID",
                 context = BackendEvent.Workflows.Context(
-                    platform = "android",
+                    platform = "Android",
                     sdkVersion = RevenueCatConfig.frameworkVersion,
                     locale = "en_US",
                 ),
@@ -53,7 +53,7 @@ class WorkflowEventsRequestSerializationTest {
                         "\"timestamp_ms\":123456789," +
                         "\"app_user_id\":\"appUserID\"," +
                         "\"context\":{" +
-                            "\"platform\":\"android\"," +
+                            "\"platform\":\"Android\"," +
                             "\"sdk_version\":\"${RevenueCatConfig.frameworkVersion}\"," +
                             "\"locale\":\"en_US\"" +
                         "}," +
@@ -113,7 +113,7 @@ class WorkflowEventsRequestSerializationTest {
                     timestampMs = 123456789L,
                     appUserID = "appUserID",
                     context = BackendEvent.Workflows.Context(
-                        platform = "android",
+                        platform = "Android",
                         sdkVersion = RevenueCatConfig.frameworkVersion,
                     ),
                     properties = BackendEvent.Workflows.Properties(


### PR DESCRIPTION
Change `WORKFLOW_CONTEXT_PLATFORM` from `"android"` to `"Android"` in `BackendEvent.Workflows.Context` to fix the incorrect platform value sent with KMP paywall workflow events.

Scoped to just the platform-casing bug. The original report also mentions KMP paywall events being sent to the Production Amplitude project instead of Sandbox — that's a separate, unrelated issue and will be tracked/fixed in its own PR rather than bundled in here.

Found via automated repo scanning, fix written and reviewed before opening.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single string constant and test expectation change for analytics payload casing only; no auth, billing, or runtime behavior changes.
> 
> **Overview**
> Fixes the **`context.platform`** value on serialized **workflow** backend events (KMP paywall workflow lifecycle) so it is **`"Android"`** instead of **`"android"`**, matching the expected khepri / WorkflowsEvent wire shape.
> 
> The default comes from **`WORKFLOW_CONTEXT_PLATFORM`** in **`BackendEvent.Workflows.Context`**; workflow serialization tests were updated to assert **`"Android"`** in encoded JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f09ffbd078e0be0d2d5e2420963174985157ff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->