### PR TITLE
fix(paywalls): Expose compose-foundation-layout so PaywallFooter is callable without extra setup

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -126,6 +126,7 @@ commonmark-strikethrough = { module = "org.commonmark:commonmark-ext-gfm-striket
 
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayout" }
+compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" }
 compose-material = { module = "androidx.compose.material:material" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-material3Adaptive = { module = "androidx.compose.material3.adaptive:adaptive" }

--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -88,8 +88,6 @@ tasks.withType<KotlinCompile>().configureEach {
 
 dependencies {
     api(project(":purchases"))
-    // PaddingValues and BoxScope appear in this module's public API, so the BOM that versions
-    // them has to be exported too: without it the published api variant has no version for them.
     api(platform(libs.compose.bom))
     api(libs.compose.foundation.layout)
 

--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -88,8 +88,11 @@ tasks.withType<KotlinCompile>().configureEach {
 
 dependencies {
     api(project(":purchases"))
+    // PaddingValues and BoxScope appear in this module's public API, so the BOM that versions
+    // them has to be exported too: without it the published api variant has no version for them.
+    api(platform(libs.compose.bom))
+    api(libs.compose.foundation.layout)
 
-    implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.util)
     implementation(libs.compose.ui.graphics)


### PR DESCRIPTION
- `PaywallFooter`, `OriginalTemplatePaywallFooter` and `CloseButton` expose `PaddingValues` and `BoxScope` in their signatures, but every Compose dependency was declared `implementation`, so consumers never received `foundation-layout` on their compile classpath.
- Kotlin 2.0.x tolerated the unresolvable type. Kotlin 2.2 rejects it, so consumers building with a recent Kotlin already cannot call those APIs against released versions unless they happen to pull `foundation-layout` in themselves. Most Compose apps do, via `foundation` or `material`, which is why this went unnoticed.
- The Compose BOM is promoted to `api` as well. Without it the published Gradle metadata lists `foundation-layout` with no version in the api variant, so a consumer without their own Compose BOM could not resolve it.
- Headline caveat: that promotion means our BOM now participates in Gradle consumers' Compose version resolution, as a constraint they can still override. Maven consumers already got exactly this through `dependencyManagement`, so this aligns Gradle with existing Maven behavior rather than adding a new constraint.
- Additive for consumers and no public API change: `scripts/api-check.sh` reports no signature diff.
- Measured effect: `foundation-layout` on `api-tester`'s compile classpath goes from absent to resolving at 1.7.2, with `api-tester` declaring nothing.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

`:ui:revenuecatui` declared every Compose dependency as `implementation`, with `api(project(":purchases"))`
as the only exported dependency. Three public declarations nevertheless reference
`androidx.compose.foundation.layout` types:

```
OriginalTemplatePaywallFooter(..., mainContent: Function1<PaddingValues,Unit>?)
PaywallFooter(...)  // deprecated, same signature
CloseButton(BoxScope, ...)  // extension receiver
```

A consumer therefore needs `foundation-layout` on its own compile classpath to call them, even though
nothing in the published metadata says so.

Removing the workaround from `api-tester` and compiling reproduces it:

```
PaywallAPI.kt:23:9 Cannot access class 'PaddingValues'.
  PaywallFooter(options = options)
  OriginalTemplatePaywallFooter(options = options)
```

Note it fails on the overloads that pass no lambda at all, because the compiler still resolves the
default parameter's type.

The consumer compiles with their own Kotlin, not ours, so this is not caused by the SDK's toolchain:
anyone on Kotlin 2.2 or newer is already affected by shipped versions. It surfaced here only because
`api-tester` is an unusually minimal consumer, pulling `compose-ui`, `activity-compose` and
`compose-ui-google-fonts` but neither `foundation` nor `material`, both of which would have dragged
`foundation-layout` in transitively.

### Description

- `api(libs.compose.foundation.layout)` in `:ui:revenuecatui`, plus a catalog entry for it.
- `api(platform(libs.compose.bom))`, replacing the `implementation` declaration of the same platform.
  This is required, not incidental. With the BOM left at `implementation`, the generated POM is fine,
  because the BOM is already published as a `dependencyManagement` import and Maven resolves the
  version from it, but the Gradle module metadata api variant comes out as:

  ```
  androidx.compose.foundation:foundation-layout:NO-VERSION
  ```

  with no accompanying platform dependency or constraint. Gradle consumers are the majority here, so
  the POM alone being correct is not enough.

- No source changes and no signature changes.

### Testing

- `foundation-layout` in `:api-tester`'s `defaultsDebugCompileClasspath`: absent before, resolves to
  1.7.2 after, without `api-tester` declaring it.
- Inspected the generated POM and `module.json` before and after. The POM gains
  `foundation-layout` at `compile` scope; the api variant gains both `compose-bom:2024.09.00` and
  `foundation-layout`.
- `assembleDefaultsRelease`, `:api-tester:compileDefaultsDebugKotlin`, `detektAll`, and
  `scripts/api-check.sh` all pass locally.
- End to end: with #3934 stacked on top of this branch, so Kotlin is 2.2.10 and `api-tester` declares
  no Compose layout dependency of its own, `:api-tester:compileDefaultsDebugKotlin` succeeds. That is
  the exact compilation that fails without this change.
- `api-tester` is the lasting regression gate: it exercises these call sites, and under Kotlin 2.2 it
  cannot compile unless this dependency is exported.

### Related

- #3934 (Kotlin 2.2.10) is stacked on this branch. It originally carried an `api-tester` workaround for
  the same problem; that commit is dropped now that the dependency is exported properly, which is also
  the end to end check described above.

</details>
