### PR TITLE
build: migrate to AGP 9 built-in Kotlin

### DIFF
--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -2,7 +2,6 @@
 
 plugins {
     alias(libs.plugins.android.test)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.baselineprofile)
 }
 

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigureAndroidApplication.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigureAndroidApplication.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.android.buildlogic.convention
 
-import com.android.build.gradle.BaseExtension
+import com.android.build.api.dsl.ApplicationExtension
 import com.revenuecat.purchases.android.buildlogic.ktx.getVersion
 import com.revenuecat.purchases.android.buildlogic.ktx.versionCatalog
 import org.gradle.api.JavaVersion
@@ -14,8 +14,8 @@ internal fun Project.configureAndroidApplication() {
     val minSdkVersion = libs.getVersion("android-minSdk").toInt()
     val targetSdkVersion = libs.getVersion("android-targetSdk").toInt()
 
-    extensions.configure<BaseExtension> {
-        compileSdkVersion(compileSdkVersion)
+    extensions.configure<ApplicationExtension> {
+        compileSdk = compileSdkVersion
 
         defaultConfig {
             minSdk = minSdkVersion

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigureAndroidLibrary.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigureAndroidLibrary.kt
@@ -1,8 +1,8 @@
 package com.revenuecat.purchases.android.buildlogic.convention
 
+import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.HasUnitTestBuilder
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
-import com.android.build.gradle.LibraryExtension
 import com.revenuecat.purchases.android.buildlogic.ktx.getVersion
 import com.revenuecat.purchases.android.buildlogic.ktx.versionCatalog
 import org.gradle.api.JavaVersion

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/AndroidApplicationConventionPlugin.kt
@@ -15,7 +15,6 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
             apply(libs.plugins.android.application.get().pluginId)
-            apply(libs.plugins.kotlin.android.get().pluginId)
         }
         configureAndroidApplication()
     }

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/ApiTesterApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/ApiTesterApplicationConventionPlugin.kt
@@ -16,7 +16,6 @@ class ApiTesterApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
             apply(libs.plugins.android.application.get().pluginId)
-            apply(libs.plugins.kotlin.android.get().pluginId)
         }
 
         configureAndroidApplication()

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/PublicLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/PublicLibraryConventionPlugin.kt
@@ -19,7 +19,6 @@ class PublicLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
             apply(libs.plugins.android.library.get().pluginId)
-            apply(libs.plugins.kotlin.android.get().pluginId)
             apply(libs.plugins.kover.get().pluginId)
             apply(libs.plugins.baselineprofile.get().pluginId)
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.compose.compiler) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kover) apply false
     alias(libs.plugins.emerge) apply false

--- a/examples/checkpointtester/build.gradle.kts
+++ b/examples/checkpointtester/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
 
 plugins {
@@ -85,6 +86,6 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }

--- a/examples/rcttester/build.gradle.kts
+++ b/examples/rcttester/build.gradle.kts
@@ -1,6 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
 }
@@ -81,6 +81,6 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }

--- a/examples/web-purchase-redemption-sample/build.gradle.kts
+++ b/examples/web-purchase-redemption-sample/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
 }
 

--- a/feature/galaxy/build.gradle.kts
+++ b/feature/galaxy/build.gradle.kts
@@ -21,5 +21,5 @@ dependencies {
 
     implementation(libs.samsung.iap)
     testImplementation(libs.bundles.test)
-    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlin.test.junit)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,8 +58,3 @@ org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 
 # Enable the Gradle build cache (local task-output cache) for the main build.
 org.gradle.caching=true
-
-# AGP 9 enables built-in Kotlin and rejects the kotlin-android plugin, which also needs the
-# new DSL. Both flags go away in AGP 10.
-android.builtInKotlin=false
-android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ amazon = "3.0.5"
 androidxCardView = "1.0.0"
 androidxConstraintLayout = "2.1.3"
 androidxCore = "1.8.0"
-androidxNavigation = "2.5.3"
+androidxNavigation = "2.9.8"
 annotation = "1.3.0"
 annotationExperimental = "1.5.1"
 appcompat = "1.4.1"
@@ -44,7 +44,6 @@ recyclerview = "1.2.1"
 roboelectric = "4.16"
 kotlin = "2.3.21"
 kotlinLanguage = "2.0"
-# Can't update until we use more recent kotlin. 1.6.0 uses Kotlin 1.9.0
 kotlinxSerializationJSON = "1.5.1"
 samsungIap = "6.5.2"
 kover = "0.9.9"
@@ -195,7 +194,6 @@ dependencyGraph = { id = "com.savvasdalkitsis.module-dependency-graph", version.
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id ="org.jetbrains.dokka", version.ref = "dokka"}
 emerge = { id = "com.emergetools.android", version.ref = "emergeGradlePlugin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -161,6 +161,7 @@ google-mobile-ads = { module = "com.google.android.gms:play-services-ads", versi
 hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }
 
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJSON" }
 
 material = { module = "com.google.android.material:material", version.ref = "material" }

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -251,14 +251,13 @@ fun DokkaSourceSetSpec.configureDocumentedSourceSet() {
 
 dokka {
     dokkaSourceSets {
-        named("customEntitlementComputation") {
+        // Dokka only documents release variants, which still leaves the release variant of the
+        // customEntitlementComputation flavor. Variant source sets are registered after this
+        // block runs, so they can only be reached lazily.
+        matching { it.name.startsWith("customEntitlementComputation") }.configureEach {
             suppress.set(true)
         }
-        named("defaults") {
-            dependentSourceSets.addLater(dokkaSourceSets.named("main").flatMap { it.sourceSetId })
-            configureDocumentedSourceSet()
-        }
-        named("main") {
+        matching { it.name == "defaultsRelease" }.configureEach {
             configureDocumentedSourceSet()
             sourceLink {
                 localDirectory.set(file("src/main/kotlin"))

--- a/test-apps/e2etests/build.gradle.kts
+++ b/test-apps/e2etests/build.gradle.kts
@@ -1,8 +1,8 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
 }
 
@@ -73,6 +73,6 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }

--- a/test-apps/testpurchasesandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesandroidcompatibility/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.emerge)
     alias(libs.plugins.compose.compiler)
 }

--- a/ui/debugview/api.txt
+++ b/ui/debugview/api.txt
@@ -11,11 +11,3 @@ package com.revenuecat.purchases.ui.debugview {
 
 }
 
-package com.revenuecat.purchases.ui.debugview.models {
-
-  public final class InternalDebugRevenueCatScreenViewModelFactory extends androidx.lifecycle.ViewModelProvider.NewInstanceFactory {
-    ctor public InternalDebugRevenueCatScreenViewModelFactory(kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.models.StoreTransaction,kotlin.Unit> onPurchaseCompleted, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesTransactionException,kotlin.Unit> onPurchaseErrored);
-  }
-
-}
-

--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -142,10 +142,8 @@ dependencies {
 
 dokka {
     dokkaSourceSets {
-        named("defaults") {
-            dependentSourceSets.addLater(dokkaSourceSets.named("main").flatMap { it.sourceSetId })
-        }
-        named("main") {
+        // Variant source sets are registered after this block runs, so they can only be reached lazily.
+        matching { it.name == "defaultsRelease" }.configureEach {
             reportUndocumented.set(true)
             skipDeprecated.set(true)
 


### PR DESCRIPTION
- Removes the `android.builtInKotlin=false` and `android.newDsl=false` opt-out that #3964 added, and takes the `kotlin-android` plugin out of 13 build scripts and the 3 convention plugins. AGP 10 removes the ability to opt out at all, so this is the migration rather than a deferral.
- Headline caveat: `ui/debugview/api.txt` loses `InternalDebugRevenueCatScreenViewModelFactory`. Metalava now analyses the release variant, and that class lives in `src/debug`. The release AAR contains zero occurrences of it, so it never shipped and the entry was wrong, but it reads as an API removal and deserves a second opinion.
- Bumps `androidx.navigation` 2.5.3 to 2.9.8. safeargs 2.5.3 detects AGP through the old DSL and hard fails, so the navigation bump is a prerequisite for the new DSL rather than the independent change the upgrade inventory described.
- Reworks the Dokka config in `:purchases` and `:ui:revenuecatui`. Built-in Kotlin registers one source set per Android variant instead of the main and flavor source sets, and registers them lazily, so both modules now select the documented variant through `configureEach`.
- Stacked on #3964, which is the AGP 9 bump itself.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

AGP 9 enables built-in Kotlin and rejects the `org.jetbrains.kotlin.android` plugin outright:

```
The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0.
```

Opting out needs two flags together, `android.builtInKotlin=false` and `android.newDsl=false`, because
the kotlin-android plugin is not compatible with the new DSL. #3964 takes that opt-out so the version
bump stays reviewable. AGP 10 removes the opt-out, so the migration has to happen regardless; doing it
separately keeps the two diffs legible.

### Description

Three things blocked the migration, each hidden behind the previous one.

**The old DSL extension types are gone.** `com.android.build.gradle.BaseExtension` and
`com.android.build.gradle.LibraryExtension` do not exist once the new DSL is active. The convention
plugins now configure `com.android.build.api.dsl.ApplicationExtension` and
`com.android.build.api.dsl.LibraryExtension`, and set `compileSdk` directly rather than calling
`compileSdkVersion()`.

**safeargs 2.5.3 cannot see AGP 9.** It fails with `safeargs plugin must be used with android plugin`,
because its detection goes through the old DSL. `androidx.navigation` moves to 2.9.8, the current
stable. Worth flagging that the upgrade inventory lists the navigation bump as independent and
optional; it is neither.

**Dokka source sets changed shape.** With the kotlin-android plugin, Dokka saw the Kotlin source sets
and the config addressed `main`, `defaults` and `customEntitlementComputation`. Built-in Kotlin instead
registers one source set per Android variant:

```
defaultsDebug   customEntitlementComputationDebug
defaultsRelease customEntitlementComputationRelease
plus the AndroidTest and UnitTest variants
```

They are also registered after the `dokka { }` block runs, so `named("defaultsRelease")` throws even
though the name is valid later. Both modules now use `configureEach` with a name check, suppressing
everything except the documented variant.

`:purchases` keeps `reportUndocumented`, `skipDeprecated`, the Android external documentation link, the
two source links, and the `paywalls.components` suppression, all moved onto the selected variant.

### Testing

- `assembleDebug` across all modules, `:purchases` unit tests, `detektAll`, and `scripts/api-check.sh`.
- Dokka generates 956 pages, the public entry points are present, and the internal
  `com.revenuecat.purchases.paywalls.components` package is still suppressed. Checked explicitly,
  because a bad rewrite of that block would silently produce empty or over-broad docs rather than fail.
- For the signature change: unpacked `debugview-defaults-release.aar` and confirmed it contains no
  `InternalDebugRevenueCatScreenViewModelFactory`, so the class was only ever in debug builds.

</details>
