### PR TITLE
perf(paywalls): warm a paywall's first page before its later ones

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmer.kt
@@ -42,7 +42,7 @@ internal class WorkflowAssetPrewarmer(
             if (!warmedWorkflowIds.add(workflow.id)) return
         }
         if (assetWarming.isAvailable) {
-            val assets = workflow.screensInWarmOrder().map { it.componentsConfig.base.collectAssets() }
+            val assets = workflow.screensInVisitOrder().map { it.componentsConfig.base.collectAssets() }
             assetWarming.warmImages(assets.flatMapTo(mutableSetOf()) { it.imageUris })
             assetWarming.warmWebViewUrls(
                 assets.flatMapTo(linkedSetOf<String>()) { it.webViewUrls },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmer.kt
@@ -42,7 +42,7 @@ internal class WorkflowAssetPrewarmer(
             if (!warmedWorkflowIds.add(workflow.id)) return
         }
         if (assetWarming.isAvailable) {
-            val assets = workflow.screens.values.map { it.componentsConfig.base.collectAssets() }
+            val assets = workflow.screensInWarmOrder().map { it.componentsConfig.base.collectAssets() }
             assetWarming.warmImages(assets.flatMapTo(mutableSetOf()) { it.imageUris })
             assetWarming.warmWebViewUrls(
                 assets.flatMapTo(linkedSetOf<String>()) { it.webViewUrls },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowScreenOrder.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowScreenOrder.kt
@@ -5,15 +5,15 @@ package com.revenuecat.purchases.common.workflows
 import com.revenuecat.purchases.InternalRevenueCatAPI
 
 /**
- * The screens a customer reaches, breadth first from this workflow's entry steps. Asset warming is bounded and
- * gets cut short by a paywall opening or a memory trim, so this order decides which pages are warm by then.
+ * The screens a customer reaches, breadth first from this workflow's entry steps. Warming gets cut short by a
+ * paywall opening or a memory trim, so this order decides which pages are warm by then.
  *
- * Screens no step reaches come last rather than being dropped: [WorkflowTriggerAction] has an `Unknown`
- * variant and [WorkflowStep.type] is an open string, so a navigation this SDK version cannot read would
- * otherwise silently stop warming a page that really does get shown.
+ * Unreachable screens come last rather than being dropped: [WorkflowTriggerAction] has an `Unknown` variant
+ * and [WorkflowStep.type] is an open string, so a navigation this SDK version cannot read must not silently
+ * stop a page that really is shown from warming.
  *
- * [PublishedWorkflow.singleStepFallbackId] is an entry step alongside [PublishedWorkflow.initialStepId]: it is
- * the step [PublishedWorkflow.dismissExitOffer] reads, and nothing guarantees triggers reach it.
+ * [PublishedWorkflow.singleStepFallbackId] counts as an entry step: [PublishedWorkflow.dismissExitOffer]
+ * reads it, and nothing guarantees triggers reach it.
  */
 internal fun PublishedWorkflow.screensInVisitOrder(): List<WorkflowScreen> {
     val roots = setOfNotNull(initialStepId, singleStepFallbackId)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowScreenOrder.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowScreenOrder.kt
@@ -5,43 +5,33 @@ package com.revenuecat.purchases.common.workflows
 import com.revenuecat.purchases.InternalRevenueCatAPI
 
 /**
- * This workflow's screens in the order a customer is likely to reach them: the initial step's screen, then
- * the screens of the steps it can navigate to, breadth first. Warming is bounded and gets cut short by a
- * paywall opening or a memory trim, so the order decides which pages are warm when that happens.
+ * The screens a customer reaches, breadth first from this workflow's entry steps. Asset warming is bounded and
+ * gets cut short by a paywall opening or a memory trim, so this order decides which pages are warm by then.
  *
  * Screens no step reaches come last rather than being dropped: [WorkflowTriggerAction] has an `Unknown`
  * variant and [WorkflowStep.type] is an open string, so a navigation this SDK version cannot read would
  * otherwise silently stop warming a page that really does get shown.
  *
- * Rooted at [PublishedWorkflow.singleStepFallbackId] as well as [PublishedWorkflow.initialStepId], since
- * nothing guarantees the fallback step is reachable through triggers.
+ * [PublishedWorkflow.singleStepFallbackId] is an entry step alongside [PublishedWorkflow.initialStepId]: it is
+ * the step [PublishedWorkflow.dismissExitOffer] reads, and nothing guarantees triggers reach it.
  */
-internal fun PublishedWorkflow.screensInWarmOrder(): List<WorkflowScreen> {
+internal fun PublishedWorkflow.screensInVisitOrder(): List<WorkflowScreen> {
+    val roots = setOfNotNull(initialStepId, singleStepFallbackId)
+    val seenSteps = roots.toMutableSet()
+    val frontier = ArrayDeque(roots)
     val screenIds = linkedSetOf<String>()
-    val seenSteps = mutableSetOf<String>()
-    val frontier = ArrayDeque<String>()
-    listOfNotNull(initialStepId, singleStepFallbackId).forEach { stepId ->
-        if (seenSteps.add(stepId)) frontier.addLast(stepId)
-    }
     while (frontier.isNotEmpty()) {
         val step = steps[frontier.removeFirst()] ?: continue
         step.screenId?.let(screenIds::add)
         step.nextStepIds().forEach { stepId -> if (seenSteps.add(stepId)) frontier.addLast(stepId) }
     }
-    // Already-added ids keep their position, so this appends only the screens the walk never reached.
-    screenIds.addAll(screens.keys)
-    return screenIds.mapNotNull { screenId -> screens[screenId] }
+    return (screenIds + screens.keys).mapNotNull { screenId -> screens[screenId] }
 }
 
 /**
- * The steps this one can navigate to, in the order its triggers are declared, which is the order the
- * components firing them appear. An action no trigger references still counts, so an entry point this
- * SDK version does not model cannot hide a step.
+ * Triggers first, in the order the components firing them appear. An action no trigger references still
+ * counts, so an entry point this SDK version does not model cannot hide a step.
  */
-private fun WorkflowStep.nextStepIds(): List<String> {
-    val triggeredActionIds = triggers.map { trigger -> trigger.actionId }
-    val actionIds = triggeredActionIds + triggerActions.keys.filterNot { it in triggeredActionIds }
-    return actionIds.mapNotNull { actionId ->
-        (triggerActions[actionId] as? WorkflowTriggerAction.Step)?.stepId
-    }
-}
+private fun WorkflowStep.nextStepIds(): List<String> =
+    (triggers.map { trigger -> trigger.actionId } + triggerActions.keys)
+        .mapNotNull { actionId -> (triggerActions[actionId] as? WorkflowTriggerAction.Step)?.stepId }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowScreenOrder.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowScreenOrder.kt
@@ -5,15 +5,13 @@ package com.revenuecat.purchases.common.workflows
 import com.revenuecat.purchases.InternalRevenueCatAPI
 
 /**
- * The screens a customer reaches, breadth first from this workflow's entry steps. Warming gets cut short by a
- * paywall opening or a memory trim, so this order decides which pages are warm by then.
+ * Screens in the order a customer reaches them. Warming stops when a paywall opens or memory is trimmed, so
+ * this order decides which are warm by then.
  *
- * Unreachable screens come last rather than being dropped: [WorkflowTriggerAction] has an `Unknown` variant
- * and [WorkflowStep.type] is an open string, so a navigation this SDK version cannot read must not silently
- * stop a page that really is shown from warming.
- *
- * [PublishedWorkflow.singleStepFallbackId] counts as an entry step: [PublishedWorkflow.dismissExitOffer]
- * reads it, and nothing guarantees triggers reach it.
+ * Unreachable screens come last, not dropped: [WorkflowTriggerAction] has an `Unknown` variant and
+ * [WorkflowStep.type] is an open string, so a navigation this version cannot read must not stop a real page
+ * from warming. [PublishedWorkflow.singleStepFallbackId] is an entry step because
+ * [PublishedWorkflow.dismissExitOffer] reads it.
  */
 internal fun PublishedWorkflow.screensInVisitOrder(): List<WorkflowScreen> {
     val roots = setOfNotNull(initialStepId, singleStepFallbackId)
@@ -28,10 +26,6 @@ internal fun PublishedWorkflow.screensInVisitOrder(): List<WorkflowScreen> {
     return (screenIds + screens.keys).mapNotNull { screenId -> screens[screenId] }
 }
 
-/**
- * Triggers first, in the order the components firing them appear. An action no trigger references still
- * counts, so an entry point this SDK version does not model cannot hide a step.
- */
 private fun WorkflowStep.nextStepIds(): List<String> =
     (triggers.map { trigger -> trigger.actionId } + triggerActions.keys)
         .mapNotNull { actionId -> (triggerActions[actionId] as? WorkflowTriggerAction.Step)?.stepId }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowScreenOrder.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowScreenOrder.kt
@@ -5,13 +5,10 @@ package com.revenuecat.purchases.common.workflows
 import com.revenuecat.purchases.InternalRevenueCatAPI
 
 /**
- * Screens in the order a customer reaches them. Warming stops when a paywall opens or memory is trimmed, so
- * this order decides which are warm by then.
- *
+ * Screens in the order a user reaches them.
  * Unreachable screens come last, not dropped: [WorkflowTriggerAction] has an `Unknown` variant and
  * [WorkflowStep.type] is an open string, so a navigation this version cannot read must not stop a real page
- * from warming. [PublishedWorkflow.singleStepFallbackId] is an entry step because
- * [PublishedWorkflow.dismissExitOffer] reads it.
+ * from warming.
  */
 internal fun PublishedWorkflow.screensInVisitOrder(): List<WorkflowScreen> {
     val roots = setOfNotNull(initialStepId, singleStepFallbackId)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowScreenOrder.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowScreenOrder.kt
@@ -1,0 +1,47 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.workflows
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+
+/**
+ * This workflow's screens in the order a customer is likely to reach them: the initial step's screen, then
+ * the screens of the steps it can navigate to, breadth first. Warming is bounded and gets cut short by a
+ * paywall opening or a memory trim, so the order decides which pages are warm when that happens.
+ *
+ * Screens no step reaches come last rather than being dropped: [WorkflowTriggerAction] has an `Unknown`
+ * variant and [WorkflowStep.type] is an open string, so a navigation this SDK version cannot read would
+ * otherwise silently stop warming a page that really does get shown.
+ *
+ * Rooted at [PublishedWorkflow.singleStepFallbackId] as well as [PublishedWorkflow.initialStepId], since
+ * nothing guarantees the fallback step is reachable through triggers.
+ */
+internal fun PublishedWorkflow.screensInWarmOrder(): List<WorkflowScreen> {
+    val screenIds = linkedSetOf<String>()
+    val seenSteps = mutableSetOf<String>()
+    val frontier = ArrayDeque<String>()
+    listOfNotNull(initialStepId, singleStepFallbackId).forEach { stepId ->
+        if (seenSteps.add(stepId)) frontier.addLast(stepId)
+    }
+    while (frontier.isNotEmpty()) {
+        val step = steps[frontier.removeFirst()] ?: continue
+        step.screenId?.let(screenIds::add)
+        step.nextStepIds().forEach { stepId -> if (seenSteps.add(stepId)) frontier.addLast(stepId) }
+    }
+    // Already-added ids keep their position, so this appends only the screens the walk never reached.
+    screenIds.addAll(screens.keys)
+    return screenIds.mapNotNull { screenId -> screens[screenId] }
+}
+
+/**
+ * The steps this one can navigate to, in the order its triggers are declared, which is the order the
+ * components firing them appear. An action no trigger references still counts, so an entry point this
+ * SDK version does not model cannot hide a step.
+ */
+private fun WorkflowStep.nextStepIds(): List<String> {
+    val triggeredActionIds = triggers.map { trigger -> trigger.actionId }
+    val actionIds = triggeredActionIds + triggerActions.keys.filterNot { it in triggeredActionIds }
+    return actionIds.mapNotNull { actionId ->
+        (triggerActions[actionId] as? WorkflowTriggerAction.Step)?.stepId
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
@@ -116,6 +116,43 @@ class WorkflowAssetPrewarmerTest {
         }
     }
 
+    // Warming is bounded and gets cut short by a paywall opening, so the page that opens must be queued first.
+    @Test
+    fun `preDownloadWorkflowAssets warms the first page's bundle ahead of later pages`() {
+        val workflow = createWorkflow(
+            "wf_1",
+            // Response order puts the second page first, so map order alone cannot produce the expected result.
+            screens = linkedMapOf(
+                "screen_second" to createScreen(webViewComponentsConfig("https://second.example.com/i.html")),
+                "screen_first" to createScreen(webViewComponentsConfig("https://first.example.com/i.html")),
+            ),
+            steps = mapOf(
+                "step_1" to WorkflowStep(
+                    id = "step_1",
+                    type = "screen",
+                    screenId = "screen_first",
+                    triggers = listOf(
+                        WorkflowTrigger(
+                            name = "next",
+                            type = WorkflowTriggerType.ON_PRESS,
+                            actionId = "action_1",
+                            componentId = "component-1",
+                        ),
+                    ),
+                    triggerActions = mapOf("action_1" to WorkflowTriggerAction.Step("step_2")),
+                ),
+                "step_2" to WorkflowStep(id = "step_2", type = "screen", screenId = "screen_second"),
+            ),
+        )
+        val urls = slot<Collection<String>>()
+
+        prewarmer.preDownloadWorkflowAssets(workflow, emptyUiConfig())
+
+        verify { assetWarming.warmWebViewUrls(capture(urls)) }
+        assertThat(urls.captured)
+            .containsExactly("https://first.example.com/i.html", "https://second.example.com/i.html")
+    }
+
     @Test
     fun `preDownloadWorkflowAssets finds no web_view bundles when no screen has one`() {
         val workflow = createWorkflow("wf_1", screens = mapOf("screen_1" to createScreen(emptyComponentsConfig())))
@@ -221,12 +258,16 @@ class WorkflowAssetPrewarmerTest {
         assertThat(decodeCount).isEqualTo(0)
     }
 
-    private fun createWorkflow(id: String, screens: Map<String, WorkflowScreen> = emptyMap()): PublishedWorkflow =
+    private fun createWorkflow(
+        id: String,
+        screens: Map<String, WorkflowScreen> = emptyMap(),
+        steps: Map<String, WorkflowStep> = emptyMap(),
+    ): PublishedWorkflow =
         PublishedWorkflow(
             id = id,
             displayName = "Workflow $id",
             initialStepId = "step_1",
-            steps = emptyMap(),
+            steps = steps,
             screens = screens,
         )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
@@ -116,7 +116,6 @@ class WorkflowAssetPrewarmerTest {
         }
     }
 
-    // Warming is bounded and gets cut short by a paywall opening, so the page that opens must be queued first.
     @Test
     fun `preDownloadWorkflowAssets warms the first page's bundle ahead of later pages`() {
         val workflow = createWorkflow(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
@@ -120,7 +120,6 @@ class WorkflowAssetPrewarmerTest {
     fun `preDownloadWorkflowAssets warms the first page's bundle ahead of later pages`() {
         val workflow = createWorkflow(
             "wf_1",
-            // Response order is reversed, so map order alone cannot produce the expected result.
             screens = linkedMapOf(
                 "screen_second" to createScreen(webViewComponentsConfig("https://second.example.com/i.html")),
                 "screen_first" to createScreen(webViewComponentsConfig("https://first.example.com/i.html")),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowAssetPrewarmerTest.kt
@@ -120,7 +120,7 @@ class WorkflowAssetPrewarmerTest {
     fun `preDownloadWorkflowAssets warms the first page's bundle ahead of later pages`() {
         val workflow = createWorkflow(
             "wf_1",
-            // Response order puts the second page first, so map order alone cannot produce the expected result.
+            // Response order is reversed, so map order alone cannot produce the expected result.
             screens = linkedMapOf(
                 "screen_second" to createScreen(webViewComponentsConfig("https://second.example.com/i.html")),
                 "screen_first" to createScreen(webViewComponentsConfig("https://first.example.com/i.html")),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowScreenOrderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowScreenOrderTest.kt
@@ -1,0 +1,207 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.workflows
+
+import com.revenuecat.purchases.ColorAlias
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.net.URL
+
+class WorkflowScreenOrderTest {
+
+    @Test
+    fun `orders screens breadth first from the initial step`() {
+        val workflow = workflow(
+            initialStepId = "step_1",
+            steps = listOf(
+                step("step_1", screenId = "screen_1", next = listOf("step_2")),
+                step("step_2", screenId = "screen_2", next = listOf("step_3")),
+                step("step_3", screenId = "screen_3"),
+            ),
+            screens = screens("screen_3", "screen_1", "screen_2"),
+        )
+
+        assertThat(workflow.screensInWarmOrder().map { it.name })
+            .containsExactly("screen_1", "screen_2", "screen_3")
+    }
+
+    // A step's triggers are declared in the order the components firing them appear, which is a better guess
+    // at what the customer reaches next than the trigger_actions map order.
+    @Test
+    fun `follows trigger declaration order for sibling steps`() {
+        val firstStep = WorkflowStep(
+            id = "step_1",
+            type = "screen",
+            screenId = "screen_1",
+            triggers = listOf(
+                trigger(actionId = "action_b"),
+                trigger(actionId = "action_a"),
+            ),
+            triggerActions = mapOf(
+                "action_a" to WorkflowTriggerAction.Step("step_a"),
+                "action_b" to WorkflowTriggerAction.Step("step_b"),
+            ),
+        )
+        val workflow = workflow(
+            initialStepId = "step_1",
+            steps = listOf(firstStep, step("step_a", screenId = "screen_a"), step("step_b", screenId = "screen_b")),
+            screens = screens("screen_1", "screen_a", "screen_b"),
+        )
+
+        assertThat(workflow.screensInWarmOrder().map { it.name })
+            .containsExactly("screen_1", "screen_b", "screen_a")
+    }
+
+    // WorkflowTriggerAction has an Unknown variant, so a navigation this SDK version cannot read must not be
+    // able to drop a page from warming entirely.
+    @Test
+    fun `appends screens no step reaches`() {
+        val workflow = workflow(
+            initialStepId = "step_1",
+            steps = listOf(step("step_1", screenId = "screen_1")),
+            screens = screens("screen_orphan", "screen_1"),
+        )
+
+        assertThat(workflow.screensInWarmOrder().map { it.name })
+            .containsExactly("screen_1", "screen_orphan")
+    }
+
+    @Test
+    fun `walks a step whose action no trigger references`() {
+        val firstStep = WorkflowStep(
+            id = "step_1",
+            type = "screen",
+            screenId = "screen_1",
+            triggers = emptyList(),
+            triggerActions = mapOf("action_a" to WorkflowTriggerAction.Step("step_2")),
+        )
+        val workflow = workflow(
+            initialStepId = "step_1",
+            steps = listOf(firstStep, step("step_2", screenId = "screen_2")),
+            screens = screens("screen_2", "screen_1"),
+        )
+
+        assertThat(workflow.screensInWarmOrder().map { it.name })
+            .containsExactly("screen_1", "screen_2")
+    }
+
+    @Test
+    fun `terminates on a cycle`() {
+        val workflow = workflow(
+            initialStepId = "step_1",
+            steps = listOf(
+                step("step_1", screenId = "screen_1", next = listOf("step_2")),
+                step("step_2", screenId = "screen_2", next = listOf("step_1")),
+            ),
+            screens = screens("screen_1", "screen_2"),
+        )
+
+        assertThat(workflow.screensInWarmOrder().map { it.name })
+            .containsExactly("screen_1", "screen_2")
+    }
+
+    // Nothing guarantees the fallback step is reachable through triggers, and it is the step dismissExitOffer
+    // reads.
+    @Test
+    fun `roots at the single step fallback as well as the initial step`() {
+        val workflow = workflow(
+            initialStepId = "step_1",
+            steps = listOf(
+                step("step_1", screenId = "screen_1"),
+                step("step_fallback", screenId = "screen_fallback", next = listOf("step_deep")),
+                step("step_deep", screenId = "screen_deep"),
+            ),
+            screens = screens("screen_deep", "screen_fallback", "screen_1"),
+            singleStepFallbackId = "step_fallback",
+        )
+
+        assertThat(workflow.screensInWarmOrder().map { it.name })
+            .containsExactly("screen_1", "screen_fallback", "screen_deep")
+    }
+
+    @Test
+    fun `ignores a missing step and a screen id with no screen`() {
+        val workflow = workflow(
+            initialStepId = "step_1",
+            steps = listOf(
+                step("step_1", screenId = "screen_missing", next = listOf("step_absent", "step_2")),
+                step("step_2", screenId = "screen_2"),
+            ),
+            screens = screens("screen_2"),
+        )
+
+        assertThat(workflow.screensInWarmOrder().map { it.name }).containsExactly("screen_2")
+    }
+
+    @Test
+    fun `is empty when the workflow has no screens`() {
+        val workflow = workflow(
+            initialStepId = "step_1",
+            steps = listOf(step("step_1", screenId = null)),
+            screens = emptyMap(),
+        )
+
+        assertThat(workflow.screensInWarmOrder()).isEmpty()
+    }
+
+    private fun workflow(
+        initialStepId: String,
+        steps: List<WorkflowStep>,
+        screens: Map<String, WorkflowScreen>,
+        singleStepFallbackId: String? = null,
+    ): PublishedWorkflow = PublishedWorkflow(
+        id = "wf_1",
+        displayName = "Workflow",
+        initialStepId = initialStepId,
+        steps = steps.associateBy { it.id },
+        screens = screens,
+        singleStepFallbackId = singleStepFallbackId,
+    )
+
+    private fun step(id: String, screenId: String?, next: List<String> = emptyList()): WorkflowStep {
+        val actions = next.withIndex().associate { (index, stepId) ->
+            "action_${id}_$index" to WorkflowTriggerAction.Step(stepId)
+        }
+        return WorkflowStep(
+            id = id,
+            type = "screen",
+            screenId = screenId,
+            triggers = actions.keys.map { actionId -> trigger(actionId) },
+            triggerActions = actions,
+        )
+    }
+
+    private fun trigger(actionId: String) = WorkflowTrigger(
+        name = "trigger_$actionId",
+        type = WorkflowTriggerType.ON_PRESS,
+        actionId = actionId,
+        componentId = "component_$actionId",
+    )
+
+    /** Screens keyed by id, in the given order, so a test can put response order at odds with visit order. */
+    private fun screens(vararg ids: String): Map<String, WorkflowScreen> =
+        ids.associateWith { id -> screen(id) }
+
+    private fun screen(name: String) = WorkflowScreen(
+        name = name,
+        templateName = "template",
+        assetBaseURL = URL("https://assets.revenuecat.com"),
+        componentsConfig = ComponentsConfig(
+            PaywallComponentsConfig(
+                stack = StackComponent(components = emptyList()),
+                background = Background.Color(ColorScheme(light = ColorInfo.Alias(ColorAlias("")))),
+                stickyFooter = null,
+            ),
+        ),
+        componentsLocalizations = emptyMap(),
+        defaultLocaleIdentifier = LocaleId("en_US"),
+    )
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowScreenOrderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowScreenOrderTest.kt
@@ -29,12 +29,10 @@ class WorkflowScreenOrderTest {
             screens = screens("screen_3", "screen_1", "screen_2"),
         )
 
-        assertThat(workflow.screensInWarmOrder().map { it.name })
+        assertThat(workflow.screensInVisitOrder().map { it.name })
             .containsExactly("screen_1", "screen_2", "screen_3")
     }
 
-    // A step's triggers are declared in the order the components firing them appear, which is a better guess
-    // at what the customer reaches next than the trigger_actions map order.
     @Test
     fun `follows trigger declaration order for sibling steps`() {
         val firstStep = WorkflowStep(
@@ -56,12 +54,10 @@ class WorkflowScreenOrderTest {
             screens = screens("screen_1", "screen_a", "screen_b"),
         )
 
-        assertThat(workflow.screensInWarmOrder().map { it.name })
+        assertThat(workflow.screensInVisitOrder().map { it.name })
             .containsExactly("screen_1", "screen_b", "screen_a")
     }
 
-    // WorkflowTriggerAction has an Unknown variant, so a navigation this SDK version cannot read must not be
-    // able to drop a page from warming entirely.
     @Test
     fun `appends screens no step reaches`() {
         val workflow = workflow(
@@ -70,7 +66,7 @@ class WorkflowScreenOrderTest {
             screens = screens("screen_orphan", "screen_1"),
         )
 
-        assertThat(workflow.screensInWarmOrder().map { it.name })
+        assertThat(workflow.screensInVisitOrder().map { it.name })
             .containsExactly("screen_1", "screen_orphan")
     }
 
@@ -89,7 +85,7 @@ class WorkflowScreenOrderTest {
             screens = screens("screen_2", "screen_1"),
         )
 
-        assertThat(workflow.screensInWarmOrder().map { it.name })
+        assertThat(workflow.screensInVisitOrder().map { it.name })
             .containsExactly("screen_1", "screen_2")
     }
 
@@ -104,12 +100,10 @@ class WorkflowScreenOrderTest {
             screens = screens("screen_1", "screen_2"),
         )
 
-        assertThat(workflow.screensInWarmOrder().map { it.name })
+        assertThat(workflow.screensInVisitOrder().map { it.name })
             .containsExactly("screen_1", "screen_2")
     }
 
-    // Nothing guarantees the fallback step is reachable through triggers, and it is the step dismissExitOffer
-    // reads.
     @Test
     fun `roots at the single step fallback as well as the initial step`() {
         val workflow = workflow(
@@ -123,7 +117,7 @@ class WorkflowScreenOrderTest {
             singleStepFallbackId = "step_fallback",
         )
 
-        assertThat(workflow.screensInWarmOrder().map { it.name })
+        assertThat(workflow.screensInVisitOrder().map { it.name })
             .containsExactly("screen_1", "screen_fallback", "screen_deep")
     }
 
@@ -138,7 +132,7 @@ class WorkflowScreenOrderTest {
             screens = screens("screen_2"),
         )
 
-        assertThat(workflow.screensInWarmOrder().map { it.name }).containsExactly("screen_2")
+        assertThat(workflow.screensInVisitOrder().map { it.name }).containsExactly("screen_2")
     }
 
     @Test
@@ -149,7 +143,7 @@ class WorkflowScreenOrderTest {
             screens = emptyMap(),
         )
 
-        assertThat(workflow.screensInWarmOrder()).isEmpty()
+        assertThat(workflow.screensInVisitOrder()).isEmpty()
     }
 
     private fun workflow(
@@ -167,9 +161,7 @@ class WorkflowScreenOrderTest {
     )
 
     private fun step(id: String, screenId: String?, next: List<String> = emptyList()): WorkflowStep {
-        val actions = next.withIndex().associate { (index, stepId) ->
-            "action_${id}_$index" to WorkflowTriggerAction.Step(stepId)
-        }
+        val actions = next.associate { stepId -> "action_to_$stepId" to WorkflowTriggerAction.Step(stepId) }
         return WorkflowStep(
             id = id,
             type = "screen",
@@ -186,7 +178,6 @@ class WorkflowScreenOrderTest {
         componentId = "component_$actionId",
     )
 
-    /** Screens keyed by id, in the given order, so a test can put response order at odds with visit order. */
     private fun screens(vararg ids: String): Map<String, WorkflowScreen> =
         ids.associateWith { id -> screen(id) }
 


### PR DESCRIPTION
- Warms a workflow's pages in the order a customer reaches them, breadth first from its entry steps, so a warm cut short covers what is seen first.
- Warming is bounded and gets cut short by a paywall opening or a memory trim, and map order is not visit order.
- Screens no step reaches are appended rather than dropped: `WorkflowTriggerAction` has an `Unknown` variant and `WorkflowStep.type` is an open string, so a navigation this SDK version cannot read must not silently stop a page that really is shown from warming.
- `singleStepFallbackId` counts as an entry step alongside `initialStepId`, since `dismissExitOffer` reads it and nothing guarantees triggers reach it.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details>
<summary>Agent description</summary>

### Motivation

Which pages are warm when warming stops depends entirely on the order they are visited, and the order screens appear in the response has nothing to do with the order a customer reaches them.

### Description

- `PublishedWorkflow.screensInVisitOrder()`: breadth-first from `initialStepId` and `singleStepFallbackId`, following each step's trigger actions in the order the components firing them appear, then appending any screen the walk never reached.
- An action no trigger references still counts as an edge, so an entry point this SDK version does not model cannot hide a step.
- Cycle-safe through a visited set, and a missing step or a screen id with no screen is skipped rather than throwing.

### Regression gates

`orders screens breadth first from the initial step` and `follows trigger declaration order for sibling steps` are the ordering gates, and their fixture deliberately puts the second page first in response order so map order alone cannot produce the expected result. `appends screens no step reaches` and `walks a step whose action no trigger references` cover the forward-compatibility cases, and `terminates on a cycle` covers a self-referential workflow.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal prefetch ordering only; no purchase, auth, or rendering path changes. Worst case is still warming the same assets in a different sequence.
> 
> **Overview**
> Paywall asset prewarm now follows the order a customer actually reaches screens, not the order they appear in the workflow payload. Warming is often cut short, so the first page’s images and web-view bundles get queued first.
> 
> `screensInVisitOrder()` walks steps breadth-first from `initialStepId` and `singleStepFallbackId`, following trigger actions (including actions no trigger references). Unreachable screens are appended rather than dropped so unknown navigation types cannot skip a real page. Cycles and missing steps/screens are skipped safely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 958593a40039f74fb04ee91bc88fb5574ef217cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->