### PR TITLE
feat(checkpoints): Add StoreDimensionProvider with store.country

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -32,6 +32,7 @@ import com.revenuecat.purchases.common.isDeviceProtectedStorageCompat
 import com.revenuecat.purchases.common.localrules.DeviceDimensionProvider
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesEngineLoggerBridge
+import com.revenuecat.purchases.common.localrules.StoreDimensionProvider
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.networking.APISourceFailover
 import com.revenuecat.purchases.common.networking.DeviceConnectivityChecker
@@ -355,7 +356,12 @@ internal class PurchasesFactory(
             }
             RulesEngine.setLogger(RulesEngineLoggerBridge)
             val localRulesEvaluator = LocalRulesEvaluator(
-                providers = listOf(DeviceDimensionProvider(appConfig, localeProvider)),
+                providers = listOf(
+                    DeviceDimensionProvider(appConfig, localeProvider),
+                    // Only read during a checkpoint evaluation, so the instance is configured by then. Same
+                    // reasoning as CheckpointWorkflowResolverImpl's getOfferings.
+                    StoreDimensionProvider { Purchases.sharedInstance.awaitStorefrontCountryCode() },
+                ),
             )
             if (remoteConfigManager != null && uiConfigProvider != null && workflowsConfigProvider != null) {
                 remoteConfigManager.registerListener(uiConfigProvider)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -17,6 +17,7 @@ internal enum class RulesDimensionNamespace(val key: String) {
     /** Values supplied by the caller for one evaluation; see [LocalRulesEvaluator.match]. */
     Custom("custom"),
     Device("device"),
+    Store("store"),
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -47,8 +47,7 @@ internal class RulesDimensionResolver(
 
     /**
      * [customVariables] are the caller's own values for this one evaluation, exposed under
-     * [RulesDimensionNamespace.Custom]. An empty map contributes no namespace at all rather than an empty object,
-     * which is truthy in JSON Logic: a call with no values should read as absent, not as present-but-empty.
+     * [RulesDimensionNamespace.Custom].
      */
     @Suppress("ReturnCount")
     suspend fun snapshot(
@@ -75,10 +74,8 @@ internal class RulesDimensionResolver(
             }
         }
 
-        if (customVariables.isNotEmpty()) {
-            values.addDimensions(RulesDimensionNamespace.Custom, customVariables)?.let { conflict ->
-                return Result.failure(conflict)
-            }
+        values.addDimensions(RulesDimensionNamespace.Custom, customVariables)?.let { conflict ->
+            return Result.failure(conflict)
         }
 
         return Result.success(
@@ -91,10 +88,14 @@ internal class RulesDimensionResolver(
 }
 
 /** Nests [dimensions] under [namespace], or returns the conflict that stops the whole snapshot. */
+@Suppress("ReturnCount")
 private fun MutableMap<String, MutableMap<String, Value>>.addDimensions(
     namespace: RulesDimensionNamespace,
     dimensions: Map<String, RulesDimensionValue>,
 ): RulesDimensionResolutionException.ConflictingDimension? {
+    // A source with nothing to say contributes no namespace at all: an empty object is truthy in JSON Logic, so
+    // `{"var": "store"}` would read as present for a customer whose store never answered.
+    if (dimensions.isEmpty()) return null
     val target = getOrPut(namespace.key) { mutableMapOf() }
     for ((name, value) in dimensions) {
         if (target.containsKey(name)) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/StoreDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/StoreDimensionProvider.kt
@@ -1,0 +1,70 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.warnLog
+import kotlinx.coroutines.CancellationException
+import java.util.Date
+import java.util.IllformedLocaleException
+import java.util.Locale
+import java.util.MissingResourceException
+
+/**
+ * Store dimensions: what the customer's storefront says about where they buy.
+ *
+ * `country` is an ISO 3166-1 **alpha-3** code such as `USA`, which is the format StoreKit hands the iOS SDK, so one
+ * predicate can target a country on either platform. Android's stores report alpha-2 (`US`), so it is converted
+ * here, and a code with no alpha-3 equivalent is omitted rather than guessed — the Amazon Appstore reports a
+ * marketplace rather than a country, and values like `UK` are not ISO regions.
+ */
+internal class StoreDimensionProvider(
+    private val storefrontCountryCode: suspend () -> String?,
+) : RulesDimensionProvider {
+
+    override val identifier: String = "store"
+
+    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.Store
+
+    /**
+     * Fetched rather than snapshotted: the storefront is not known until the store has been asked, and it can
+     * change while the app is running.
+     *
+     * A store that cannot answer contributes no dimensions instead of failing the snapshot, whatever the reason:
+     * the Galaxy Store never answers, any store can fail transiently, and the fetch reaches out through the
+     * configured instance, which an app can tear down mid-evaluation. None of that should abort the snapshot and
+     * take the other dimensions — and an otherwise resolvable checkpoint — down with it. Cancellation is not a
+     * failure and propagates.
+     */
+    @Suppress("ReturnCount")
+    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+        val countryCode = try {
+            storefrontCountryCode()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            warnLog { "The store country is unavailable, so store dimensions can't be evaluated: $e" }
+            return emptyMap()
+        }
+        if (countryCode.isNullOrEmpty()) return emptyMap()
+
+        val alpha3CountryCode = countryCode.asAlpha3CountryCodeOrNull() ?: run {
+            warnLog { "Ignoring store country '$countryCode': it has no ISO 3166-1 alpha-3 equivalent." }
+            return emptyMap()
+        }
+        return mapOf(KEY_COUNTRY to RulesDimensionValue.StringValue(alpha3CountryCode))
+    }
+
+    private fun String.asAlpha3CountryCodeOrNull(): String? =
+        try {
+            Locale.Builder().setRegion(this).build().isO3Country.ifEmpty { null }
+        } catch (_: IllformedLocaleException) {
+            null
+        } catch (_: MissingResourceException) {
+            null
+        }
+
+    internal companion object {
+        const val KEY_COUNTRY = "country"
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -191,6 +191,20 @@ class RulesDimensionResolverTest {
     }
 
     @Test
+    fun `a provider with nothing to contribute leaves its namespace absent`() = runTest {
+        val resolver = resolver(
+            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
+            provider(RulesDimensionNamespace.Store),
+        )
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values).containsOnlyKeys("device")
+        // An empty object would be truthy, which is what makes the absence matter.
+        assertThat(RulesEngine.evaluate("""{"!!": [{"var": "store"}]}""", values).getOrThrow()).isFalse()
+    }
+
+    @Test
     fun `no providers yields an empty scope`() = runTest {
         assertThat(resolver().snapshot().getOrThrow().values).isEmpty()
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
@@ -1,0 +1,116 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.rules.RulesEngine
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class StoreDimensionProviderTest {
+
+    private val date = Date(1_700_000_000_000)
+
+    @Test
+    fun `the store country is exposed as a three-letter code`() = runTest {
+        assertThat(provider("US").dimensions(date))
+            .isEqualTo(mapOf("country" to RulesDimensionValue.StringValue("USA")))
+        assertThat(provider("ES").dimensions(date))
+            .isEqualTo(mapOf("country" to RulesDimensionValue.StringValue("ESP")))
+    }
+
+    @Test
+    fun `an unknown store country contributes nothing`() = runTest {
+        // "UK" is what the Amazon Appstore reports for the United Kingdom, and it is not an ISO region. Region
+        // subtags are two letters, so a store already reporting an alpha-3 code would be dropped too.
+        for (countryCode in listOf(null, "", "UK", "ZZ", "abc", "1", "USA")) {
+            assertThat(provider(countryCode).dimensions(date))
+                .describedAs("country code '%s'", countryCode)
+                .isEmpty()
+        }
+    }
+
+    @Test
+    fun `a store that cannot answer leaves the other dimensions usable`() = runTest {
+        // Not just PurchasesException: the fetch goes through the configured instance, which an app can tear down
+        // mid-evaluation, and the store is a third party.
+        val failures = listOf(
+            PurchasesException(PurchasesError(PurchasesErrorCode.StoreProblemError, "Nope.")),
+            UninitializedPropertyAccessException("There is no singleton instance."),
+            IllegalStateException("Something else entirely."),
+        )
+
+        for (failure in failures) {
+            val snapshot = RulesDimensionResolver(
+                providers = listOf(
+                    provider(RulesDimensionNamespace.Device, "platform" to "android"),
+                    StoreDimensionProvider { throw failure },
+                ),
+            ).snapshot()
+
+            assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
+            assertThat(snapshot.getOrThrow().values)
+                .describedAs("%s", failure)
+                .containsOnlyKeys("device")
+        }
+    }
+
+    @Test
+    fun `cancellation while fetching the store country propagates`() = runTest {
+        val cancelling = StoreDimensionProvider { throw CancellationException("cancelled") }
+
+        val thrown = try {
+            cancelling.dimensions(date)
+            null
+        } catch (e: CancellationException) {
+            e
+        }
+
+        assertThat(thrown).hasMessage("cancelled")
+    }
+
+    @Test
+    fun `the store country is fetched on every evaluation`() = runTest {
+        var countryCode: String? = "US"
+        val provider = StoreDimensionProvider { countryCode }
+
+        assertThat(provider.dimensions(date)["country"]).isEqualTo(RulesDimensionValue.StringValue("USA"))
+
+        countryCode = "ES"
+
+        assertThat(provider.dimensions(date)["country"]).isEqualTo(RulesDimensionValue.StringValue("ESP"))
+    }
+
+    @Test
+    fun `the store country is reachable by dot-path from a predicate`() = runTest {
+        val values = RulesDimensionResolver(providers = listOf(provider("US"))).snapshot().getOrThrow().values
+
+        val matches = RulesEngine.evaluate("""{"==": [{"var": "store.country"}, "USA"]}""", values)
+
+        assertThat(matches.getOrThrow()).isTrue()
+    }
+
+    private fun provider(countryCode: String?) = StoreDimensionProvider { countryCode }
+
+    private fun provider(
+        dimensionNamespace: RulesDimensionNamespace,
+        vararg values: Pair<String, String>,
+    ) = object : RulesDimensionProvider {
+        override val identifier = dimensionNamespace.key
+        override val namespace = dimensionNamespace
+        override suspend fun dimensions(date: Date) =
+            values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }
+    }
+}


### PR DESCRIPTION
### Description

Adds the store as a third dimension source, with one dimension for now: `store.country`.

Note that what we get in Android is a different code than in iOS. For example, we get the 2-letter `US` instead of the 3-letter `USA` as in iOS. In this PR, I try to mimick the format in iOS, so we can consolidate the rules.

It fetches through `awaitStorefrontCountryCode` rather than reading the cached property, so the dimension is available on the first checkpoint of a session instead of missing until the billing client happens to connect. A store that can't answer contributes nothing instead of failing the snapshot — that is a routine outcome (the Galaxy Store never answers), while a failure would abort the evaluation and take an otherwise resolvable checkpoint down with it.

Similar to RevenueCat/purchases-ios#7399.

Also fixes `RulesDimensionResolver` nesting an empty object for a source with nothing to contribute. An empty object is truthy in JSON Logic, so `{"var": "store"}` would have read as present for a customer whose store never answered — reachable for the first time now that a provider routinely returns nothing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint rule evaluation semantics (new dimension and absent-vs-empty namespace behavior) and adds an async storefront fetch on the evaluation path, though store failures are isolated and do not abort snapshots.
> 
> **Overview**
> Checkpoint **local rules** can now read **`store.country`** (ISO 3166-1 alpha-3, e.g. `USA`) so predicates can align with iOS. Android alpha-2 storefront codes are converted at evaluation time; unmapped or invalid codes are omitted.
> 
> **`StoreDimensionProvider`** is registered on **`LocalRulesEvaluator`** and resolves the country via **`awaitStorefrontCountryCode()`** on each evaluation (not a cached snapshot), so the first checkpoint in a session can still get a value once the store responds. Store errors, missing answers, or teardown mid-evaluation yield **no store namespace** instead of failing the whole dimension snapshot.
> 
> **`RulesDimensionResolver`** no longer nests an empty object when a source has nothing to contribute (including empty **custom** variables). Empty objects are truthy in JSON Logic, so absent namespaces correctly mean “store/custom not present” for predicates like `{"var": "store"}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee6973ec9a534cf6caa670171c703c2fe35f0cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->