### PR TITLE
Deserialize audience rules for rules engine evaluation

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/Audience.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/Audience.kt
@@ -1,0 +1,40 @@
+package com.revenuecat.purchases.common.audiences
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+internal data class Audience(
+    val id: String,
+    @Serializable(with = JsonObjectStringSerializer::class)
+    val rules: String,
+)
+
+internal object JsonObjectStringSerializer : KSerializer<String> {
+    override val descriptor: SerialDescriptor = JsonObject.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): String {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("Audience rules can only be deserialized from JSON.")
+        val element = jsonDecoder.decodeJsonElement()
+        val rules = element as? JsonObject
+            ?: throw SerializationException("Audience rules must be a JSON object.")
+        return rules.toString()
+    }
+
+    override fun serialize(encoder: Encoder, value: String) {
+        val jsonEncoder = encoder as? JsonEncoder
+            ?: throw SerializationException("Audience rules can only be serialized to JSON.")
+        val element = jsonEncoder.json.parseToJsonElement(value)
+        val rules = element as? JsonObject
+            ?: throw SerializationException("Audience rules must be a JSON object.")
+        jsonEncoder.encodeJsonElement(rules)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
@@ -2,11 +2,10 @@ package com.revenuecat.purchases.common.audiences
 
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
-import kotlinx.serialization.json.JsonObject
 
 internal class AudiencesConfigProvider(
     private val manager: RemoteConfigManager,
 ) {
-    suspend fun getAudience(identifier: String): JsonObject? =
+    suspend fun getAudience(identifier: String): Audience? =
         manager.blobData(RemoteConfigTopic.Audiences, identifier)
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudienceTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudienceTest.kt
@@ -1,0 +1,83 @@
+package com.revenuecat.purchases.common.audiences
+
+import com.revenuecat.purchases.JsonTools
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.jsonObject
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+
+internal class AudienceTest {
+
+    @Test
+    fun `decodes nested rules as a compact JSON string and ignores unknown fields`() {
+        val audience = JsonTools.json.decodeFromString<Audience>(
+            """
+            {
+              "id": "aud_1",
+              "created_via": "dashboard",
+              "rules": {
+                "in": [
+                  { "var": "last_seen.country" },
+                  ["US", "CA"]
+                ]
+              }
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(audience).isEqualTo(
+            Audience(
+                id = "aud_1",
+                rules = """{"in":[{"var":"last_seen.country"},["US","CA"]]}""",
+            ),
+        )
+    }
+
+    @Test
+    fun `accepts an empty rules object`() {
+        val audience = JsonTools.json.decodeFromString<Audience>(
+            """{"id":"aud_1","rules":{}}""",
+        )
+
+        assertThat(audience.rules).isEqualTo("{}")
+    }
+
+    @Test
+    fun `rejects a missing or incorrectly typed id`() {
+        assertMalformed("""{"rules":{}}""")
+        assertMalformed("""{"id":1,"rules":{}}""")
+    }
+
+    @Test
+    fun `rejects missing null array and primitive rules`() {
+        assertMalformed("""{"id":"aud_1"}""")
+        assertMalformed("""{"id":"aud_1","rules":null}""")
+        assertMalformed("""{"id":"aud_1","rules":[]}""")
+        assertMalformed("""{"id":"aud_1","rules":"rule"}""")
+        assertMalformed("""{"id":"aud_1","rules":1}""")
+        assertMalformed("""{"id":"aud_1","rules":true}""")
+    }
+
+    @Test
+    fun `serializes the rules string as a JSON object and round trips`() {
+        val audience = Audience(
+            id = "aud_1",
+            rules = """{"and":[true,{"var":"last_seen.country"}]}""",
+        )
+
+        val encoded = JsonTools.json.encodeToString(audience)
+        val encodedObject = JsonTools.json.parseToJsonElement(encoded).jsonObject
+
+        assertThat(encodedObject["rules"]).isEqualTo(
+            JsonTools.json.parseToJsonElement(audience.rules),
+        )
+        assertThat(JsonTools.json.decodeFromString<Audience>(encoded)).isEqualTo(audience)
+    }
+
+    private fun assertMalformed(payload: String) {
+        assertThatThrownBy { JsonTools.json.decodeFromString<Audience>(payload) }
+            .isInstanceOf(SerializationException::class.java)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.common.audiences
 
-import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
@@ -9,8 +8,6 @@ import io.mockk.MockKMatcherScope
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -44,7 +41,7 @@ internal class AudiencesConfigProviderTest {
     }
 
     @Test
-    fun `getAudience decodes and preserves the complete opaque payload`() = runTest {
+    fun `getAudience decodes a typed audience and ignores unknown fields`() = runTest {
         returnBlob(
             "aud_123",
             """
@@ -56,12 +53,11 @@ internal class AudiencesConfigProviderTest {
             """.trimIndent(),
         )
 
-        val audience = provider.getAudience("aud_123")
-
-        assertThat(audience).isEqualTo(
-            JsonTools.json.parseToJsonElement(
-                """{"id":"aud_123","created_via":"dashboard","rules":{"and":[{"var":"country"},true]}}""",
-            ).jsonObject,
+        assertThat(provider.getAudience("aud_123")).isEqualTo(
+            Audience(
+                id = "aud_123",
+                rules = """{"and":[{"var":"country"},true]}""",
+            ),
         )
     }
 
@@ -74,16 +70,27 @@ internal class AudiencesConfigProviderTest {
         assertThat(provider.getAudience("array")).isNull()
     }
 
-    private suspend fun MockKMatcherScope.blobRead(identifier: String): JsonObject? =
+    @Test
+    fun `a malformed audience does not prevent reading another audience`() = runTest {
+        returnBlob("invalid", """{"id":"invalid","rules":[]}""")
+        returnBlob("valid", """{"id":"valid","rules":{"==":[1,1]}}""")
+
+        assertThat(provider.getAudience("invalid")).isNull()
+        assertThat(provider.getAudience("valid")).isEqualTo(
+            Audience(id = "valid", rules = """{"==":[1,1]}"""),
+        )
+    }
+
+    private suspend fun MockKMatcherScope.blobRead(identifier: String): Audience? =
         manager.blobData(
             RemoteConfigTopic.Audiences,
             identifier,
-            any<(ByteArray) -> JsonObject?>(),
+            any<(ByteArray) -> Audience?>(),
         )
 
     private fun returnBlob(identifier: String, json: String) {
         coEvery { blobRead(identifier) } answers {
-            thirdArg<(ByteArray) -> JsonObject?>().invoke(json.toByteArray())
+            thirdArg<(ByteArray) -> Audience?>().invoke(json.toByteArray())
         }
     }
 }


### PR DESCRIPTION
The rules engine accepts rules as a string, so decoding the whole audience as an opaque blob would make us deserialize it again later.

Implements [WFL-464](https://linear.app/revenuecat/issue/WFL-464/android-deserialize-audience-rules-for-rules-engine-evaluation).