### PR TITLE
Evaluate checkpoint audiences before resolving workflows

### DIFF
--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/hardpaywall/HardPaywallViewModel.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/hardpaywall/HardPaywallViewModel.kt
@@ -43,7 +43,7 @@ class HardPaywallViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 val result = Purchases.sharedInstance.awaitCheckpoint(
-                    "android_device_test",
+                    "hard_paywall",
                     CheckpointParams(
                         "gate" to CustomVariableValue.String("hard"),
                         "attempt" to CustomVariableValue.Number(_state.value.attempts),

--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/hardpaywall/HardPaywallViewModel.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/hardpaywall/HardPaywallViewModel.kt
@@ -43,7 +43,7 @@ class HardPaywallViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 val result = Purchases.sharedInstance.awaitCheckpoint(
-                    "hard_paywall",
+                    "android_device_test",
                     CheckpointParams(
                         "gate" to CustomVariableValue.String("hard"),
                         "attempt" to CustomVariableValue.Number(_state.value.attempts),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.SharedPreferencesManager
+import com.revenuecat.purchases.common.audiences.AudiencesConfigProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.caching.LocalTransactionMetadataStore
 import com.revenuecat.purchases.common.checkpoints.CheckpointsConfigProvider
@@ -355,6 +356,9 @@ internal class PurchasesFactory(
             val checkpointsConfigProvider = remoteConfigManager?.let {
                 CheckpointsConfigProvider(it)
             }
+            val audiencesConfigProvider = remoteConfigManager?.let {
+                AudiencesConfigProvider(it)
+            }
             if (remoteConfigManager != null && uiConfigProvider != null && workflowsConfigProvider != null) {
                 remoteConfigManager.registerListener(uiConfigProvider)
                 remoteConfigManager.registerListener(workflowsConfigProvider)
@@ -575,6 +579,7 @@ internal class PurchasesFactory(
                 uiConfigProvider = uiConfigProvider,
                 workflowsConfigProvider = workflowsConfigProvider,
                 checkpointsConfigProvider = checkpointsConfigProvider,
+                audiencesConfigProvider = audiencesConfigProvider,
                 localRulesEvaluator = localRulesEvaluator,
             )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -181,7 +181,7 @@ internal class PurchasesOrchestrator(
     private val uiConfigProvider: UiConfigProvider? = null,
     private val workflowsConfigProvider: WorkflowsConfigProvider? = null,
     private val checkpointsConfigProvider: CheckpointsConfigProvider? = null,
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    @get:VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal val audiencesConfigProvider: AudiencesConfigProvider? = null,
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     val adTracker: AdTracker = AdTracker(adEventsManager),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -181,7 +181,8 @@ internal class PurchasesOrchestrator(
     private val uiConfigProvider: UiConfigProvider? = null,
     private val workflowsConfigProvider: WorkflowsConfigProvider? = null,
     private val checkpointsConfigProvider: CheckpointsConfigProvider? = null,
-    private val audiencesConfigProvider: AudiencesConfigProvider? = null,
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val audiencesConfigProvider: AudiencesConfigProvider? = null,
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     val adTracker: AdTracker = AdTracker(adEventsManager),
     private val currentActivityTracker: CurrentActivityTracker = CurrentActivityTracker(),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -39,6 +39,7 @@ import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.ReplaceProductInfo
+import com.revenuecat.purchases.common.audiences.AudiencesConfigProvider
 import com.revenuecat.purchases.common.between
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.checkpoints.CheckpointsConfigProvider
@@ -180,6 +181,7 @@ internal class PurchasesOrchestrator(
     private val uiConfigProvider: UiConfigProvider? = null,
     private val workflowsConfigProvider: WorkflowsConfigProvider? = null,
     private val checkpointsConfigProvider: CheckpointsConfigProvider? = null,
+    private val audiencesConfigProvider: AudiencesConfigProvider? = null,
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     val adTracker: AdTracker = AdTracker(adEventsManager),
     private val currentActivityTracker: CurrentActivityTracker = CurrentActivityTracker(),
@@ -189,6 +191,7 @@ internal class PurchasesOrchestrator(
         workflowManager = workflowManager,
         uiConfigProvider = uiConfigProvider,
         checkpointsConfigProvider = checkpointsConfigProvider,
+        audiencesConfigProvider = audiencesConfigProvider,
         localRulesEvaluator = localRulesEvaluator,
         getOfferings = { Purchases.sharedInstance.awaitOfferings() },
     ),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -42,7 +42,7 @@ internal class CheckpointWorkflowResolverImpl(
     private val workflowManager: WorkflowManager?,
     private val uiConfigProvider: UiConfigProvider?,
     private val checkpointsConfigProvider: CheckpointsConfigProvider?,
-    private val audiencesConfigProvider: AudiencesConfigProvider? = null,
+    private val audiencesConfigProvider: AudiencesConfigProvider?,
     private val localRulesEvaluator: LocalRulesEvaluator,
     private val getOfferings: suspend () -> Offerings,
 ) : CheckpointWorkflowResolver {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -83,15 +83,10 @@ internal class CheckpointWorkflowResolverImpl(
             CheckpointRulesResolution.Unavailable ->
                 return configurationUnavailable("The rules for checkpoint '$identifier' could not be read.")
         }
-        debugLog { "Resolving checkpoint '$identifier' with ${checkpoint.rules.size} audience rules." }
         val matchResult = localRulesEvaluator.match(
             rules = checkpoint.rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
         ) { rule ->
-            debugLog {
-                "Evaluating audience '${rule.audienceId}' for checkpoint '$identifier' " +
-                    "and workflow '${rule.workflowId}'."
-            }
             audiencesConfigProvider.getAudience(rule.audienceId)
                 ?.let { audience -> Result.success(audience.rules) }
                 ?: Result.failure(AudienceUnavailableException(rule.audienceId))
@@ -103,10 +98,6 @@ internal class CheckpointWorkflowResolverImpl(
                 "The audiences for checkpoint '$identifier' could not be evaluated: ${error.message}",
             )
         } ?: return noMatch(identifier)
-        debugLog {
-            "Checkpoint '$identifier' matched audience '${rule.audienceId}' for workflow '${rule.workflowId}'."
-        }
-
         val uiConfig = try {
             uiConfigProvider.getUiConfig()
         } catch (e: CancellationException) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -2,7 +2,6 @@
 
 package com.revenuecat.purchases.checkpoints
 
-import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
@@ -11,12 +10,12 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.CustomVariableKeyValidator
+import com.revenuecat.purchases.common.audiences.AudiencesConfigProvider
 import com.revenuecat.purchases.common.checkpoints.CheckpointRule
 import com.revenuecat.purchases.common.checkpoints.CheckpointRulesResolution
 import com.revenuecat.purchases.common.checkpoints.CheckpointsConfigProvider
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
-import com.revenuecat.purchases.common.localrules.LocalRule
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesDimensionValue
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
@@ -31,8 +30,10 @@ import kotlinx.serialization.json.JsonPrimitive
  * Resolves a checkpoint through the `checkpoint_rules` topic: the checkpoint's rules are read from remote config
  * and evaluated in order against locally collected dimensions, and the first rule whose audience matches wins.
  *
- * Audience predicates are not served yet, so every rule currently carries [PLACEHOLDER_AUDIENCE_PREDICATE] and the
- * published order remains the effective signal; see [AudienceRule].
+ * The winner is final. If its workflow turns out to be unservable — no offering configured for it, that offering
+ * absent from the fetched offerings, or its body unavailable — the checkpoint resolves to
+ * [CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE] rather than falling through to a rule the
+ * customer was not the first choice for.
  *
  * [SIMULATED_ERROR_CHECKPOINT_ID] is the one piece of PoC scaffolding left: it is the only way for the tester
  * apps to exercise the throw path, since nothing in the config-driven path throws.
@@ -41,10 +42,9 @@ internal class CheckpointWorkflowResolverImpl(
     private val workflowManager: WorkflowManager?,
     private val uiConfigProvider: UiConfigProvider?,
     private val checkpointsConfigProvider: CheckpointsConfigProvider?,
+    private val audiencesConfigProvider: AudiencesConfigProvider? = null,
     private val localRulesEvaluator: LocalRulesEvaluator,
     private val getOfferings: suspend () -> Offerings,
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    private val audiencePredicate: String = PLACEHOLDER_AUDIENCE_PREDICATE,
 ) : CheckpointWorkflowResolver {
 
     override suspend fun resolve(
@@ -62,12 +62,17 @@ internal class CheckpointWorkflowResolverImpl(
         return resolveConfiguredWorkflow(identifier, customVariables)
     }
 
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "CyclomaticComplexMethod", "ComplexCondition")
     private suspend fun resolveConfiguredWorkflow(
         identifier: String,
         customVariables: Map<String, RulesDimensionValue>,
     ): CheckpointResolution {
-        if (workflowManager == null || uiConfigProvider == null || checkpointsConfigProvider == null) {
+        if (
+            workflowManager == null ||
+            uiConfigProvider == null ||
+            checkpointsConfigProvider == null ||
+            audiencesConfigProvider == null
+        ) {
             return CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.DISABLED)
         }
         val checkpoint = when (val resolution = checkpointsConfigProvider.resolveCheckpoint(identifier)) {
@@ -79,16 +84,20 @@ internal class CheckpointWorkflowResolverImpl(
                 return configurationUnavailable("The rules for checkpoint '$identifier' could not be read.")
         }
         val matchResult = localRulesEvaluator.match(
-            rules = checkpoint.rules.map { rule -> AudienceRule(rule, audiencePredicate) },
+            rules = checkpoint.rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
-        )
+        ) { rule ->
+            audiencesConfigProvider.getAudience(rule.audienceId)
+                ?.let { audience -> Result.success(audience.rules) }
+                ?: Result.failure(AudienceUnavailableException(rule.audienceId))
+        }
         // An audience the SDK failed to evaluate is not the same answer as an audience the customer is outside of,
         // so it can't report NO_MATCH.
         val rule = matchResult.getOrElse { error ->
             return configurationUnavailable(
                 "The audiences for checkpoint '$identifier' could not be evaluated: ${error.message}",
             )
-        }?.checkpointRule ?: return noMatch(identifier)
+        } ?: return noMatch(identifier)
 
         val uiConfig = try {
             uiConfigProvider.getUiConfig()
@@ -208,20 +217,12 @@ internal class CheckpointWorkflowResolverImpl(
         return CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.NO_MATCH)
     }
 
-    /**
-     * Pairs a checkpoint rule with the predicate its audience stands for. Audience predicates will arrive in their
-     * own remote-config topic, whose shape is not settled, so until then every audience matches and the rules are
-     * effectively still walked in published order.
-     */
-    private class AudienceRule(
-        val checkpointRule: CheckpointRule,
-        override val predicate: String,
-    ) : LocalRule
+    private class AudienceUnavailableException(identifier: String) :
+        Exception("audience '$identifier' could not be read")
 
     private companion object {
         const val SIMULATED_ERROR_CHECKPOINT_ID = "error_checkpoint"
         const val OFFERING_STEP_TYPE = "offering"
         const val OFFERING_IDENTIFIER_PARAM = "offering_identifier"
-        const val PLACEHOLDER_AUDIENCE_PREDICATE = "true"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -83,10 +83,15 @@ internal class CheckpointWorkflowResolverImpl(
             CheckpointRulesResolution.Unavailable ->
                 return configurationUnavailable("The rules for checkpoint '$identifier' could not be read.")
         }
+        debugLog { "Resolving checkpoint '$identifier' with ${checkpoint.rules.size} audience rules." }
         val matchResult = localRulesEvaluator.match(
             rules = checkpoint.rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
         ) { rule ->
+            debugLog {
+                "Evaluating audience '${rule.audienceId}' for checkpoint '$identifier' " +
+                    "and workflow '${rule.workflowId}'."
+            }
             audiencesConfigProvider.getAudience(rule.audienceId)
                 ?.let { audience -> Result.success(audience.rules) }
                 ?: Result.failure(AudienceUnavailableException(rule.audienceId))
@@ -98,6 +103,9 @@ internal class CheckpointWorkflowResolverImpl(
                 "The audiences for checkpoint '$identifier' could not be evaluated: ${error.message}",
             )
         } ?: return noMatch(identifier)
+        debugLog {
+            "Checkpoint '$identifier' matched audience '${rule.audienceId}' for workflow '${rule.workflowId}'."
+        }
 
         val uiConfig = try {
             uiConfigProvider.getUiConfig()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
@@ -1,11 +1,29 @@
 package com.revenuecat.purchases.common.audiences
 
+import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.decodeFromJsonElement
 
 internal class AudiencesConfigProvider(
     private val manager: RemoteConfigManager,
 ) {
-    suspend fun getAudience(identifier: String): Audience? =
-        manager.blobData(RemoteConfigTopic.Audiences, identifier)
+    suspend fun getAudience(identifier: String): Audience? {
+        val metadata = manager.topic(RemoteConfigTopic.Audiences)
+            ?.get(identifier)
+            ?.metadata
+            ?: return null
+        debugLog {
+            "Raw audience remote config metadata for '$identifier' before SDK deserialization: $metadata"
+        }
+        return try {
+            JsonTools.json.decodeFromJsonElement<Audience>(metadata)
+        } catch (e: SerializationException) {
+            errorLog(e) { "Failed to parse remote config metadata for audience '$identifier' as JSON." }
+            null
+        }
+    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.common.audiences
 
 import com.revenuecat.purchases.JsonTools
-import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
@@ -16,9 +15,6 @@ internal class AudiencesConfigProvider(
             ?.get(identifier)
             ?.metadata
             ?: return null
-        debugLog {
-            "Raw audience remote config metadata for '$identifier' before SDK deserialization: $metadata"
-        }
         return try {
             JsonTools.json.decodeFromJsonElement<Audience>(metadata)
         } catch (e: SerializationException) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -42,12 +42,19 @@ internal class LocalRulesEvaluator(
      * failed to ask". A predicate that reads a dimension this SDK version does not supply is not a failure at all
      * — the engine resolves it to null, which is an ordinary non-match.
      *
+     * When a predicate must be resolved before it can be evaluated, a resolution failure fails the call immediately.
      * [customVariables] are the caller's own values for this evaluation, readable under `custom.*`.
      */
-    @Suppress("ReturnCount")
     suspend fun <Rule : LocalRule> match(
         rules: List<Rule>,
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
+    ): Result<Rule?> = match(rules, customVariables) { rule -> Result.success(rule.predicate) }
+
+    @Suppress("ReturnCount")
+    suspend fun <Rule> match(
+        rules: List<Rule>,
+        customVariables: Map<String, RulesDimensionValue> = emptyMap(),
+        predicateFor: suspend (Rule) -> Result<String>,
     ): Result<Rule?> {
         if (rules.isEmpty()) return Result.success(null)
 
@@ -60,7 +67,8 @@ internal class LocalRulesEvaluator(
 
         var firstFailure: LocalRulesEvaluationException.PredicateEvaluation? = null
         for ((index, rule) in rules.withIndex()) {
-            val result = RulesEngine.evaluate(rule.predicate, snapshot.values)
+            val predicate = predicateFor(rule).getOrElse { error -> return Result.failure(error) }
+            val result = RulesEngine.evaluate(predicate, snapshot.values)
             val matches = result.getOrElse { error ->
                 if (firstFailure == null) {
                     firstFailure = LocalRulesEvaluationException.PredicateEvaluation(index, error)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -852,8 +852,7 @@ internal class RemoteConfigManager(
 
     /** The committed item for [itemKey], waiting for or triggering a sync once when it is not cached yet. */
     private suspend fun committedItem(topic: RemoteConfigTopic, itemKey: String): RemoteConfiguration.ConfigItem? {
-        val configItem = topicStore.topic(topic)?.get(itemKey)
-        configItem?.let { return it }
+        topicStore.topic(topic)?.get(itemKey)?.let { return it }
         verboseLog { "Remote config item '$itemKey' not committed yet; awaiting config." }
         awaitConfigForRead()
         return topicStore.topic(topic)?.get(itemKey).also {
@@ -882,13 +881,6 @@ internal class RemoteConfigManager(
         // carried-forward index (the server omits them); topics no longer active are pruned.
         val mergedTopics = (previousTopics + response.topics)
             .filterKeys { it in response.activeTopics }
-        debugLog {
-            val inventory = mergedTopics.entries.joinToString { (name, topic) ->
-                "$name -> items=${topic.keys}"
-            }
-            "Effective remote config topics after merge: [${inventory.ifEmpty { "none" }}]."
-        }
-
         // Blobs the current config still wants: the prefetch set plus any active-topic blob ref.
         val blobRefsToKeep = response.prefetchBlobs.toSet() + mergedTopics.toTopicBlobRefs().values.flatten()
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -852,7 +852,8 @@ internal class RemoteConfigManager(
 
     /** The committed item for [itemKey], waiting for or triggering a sync once when it is not cached yet. */
     private suspend fun committedItem(topic: RemoteConfigTopic, itemKey: String): RemoteConfiguration.ConfigItem? {
-        topicStore.topic(topic)?.get(itemKey)?.let { return it }
+        val configItem = topicStore.topic(topic)?.get(itemKey)
+        configItem?.let { return it }
         verboseLog { "Remote config item '$itemKey' not committed yet; awaiting config." }
         awaitConfigForRead()
         return topicStore.topic(topic)?.get(itemKey).also {
@@ -881,6 +882,12 @@ internal class RemoteConfigManager(
         // carried-forward index (the server omits them); topics no longer active are pruned.
         val mergedTopics = (previousTopics + response.topics)
             .filterKeys { it in response.activeTopics }
+        debugLog {
+            val inventory = mergedTopics.entries.joinToString { (name, topic) ->
+                "$name -> items=${topic.keys}"
+            }
+            "Effective remote config topics after merge: [${inventory.ifEmpty { "none" }}]."
+        }
 
         // Blobs the current config still wants: the prefetch set plus any active-topic blob ref.
         val blobRefsToKeep = response.prefetchBlobs.toSet() + mergedTopics.toTopicBlobRefs().values.flatten()

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -191,6 +191,29 @@ class PurchasesFactoryTest {
         purchases.close()
     }
 
+    @Test
+    fun `creating purchases with custom entitlement computation does not provide audiences config to the orchestrator`() {
+        val application = spyk(ApplicationProvider.getApplicationContext<Application>())
+        every { application.applicationContext } returns application
+        every { application.checkCallingOrSelfPermission(Manifest.permission.INTERNET) } returns
+            PackageManager.PERMISSION_GRANTED
+        val configuration = PurchasesConfiguration.Builder(application, "fakeApiKey")
+            .appUserID("appUserID")
+            .store(Store.PLAY_STORE)
+            .dangerousSettings(DangerousSettings(customEntitlementComputation = true))
+            .build()
+
+        val purchases = purchasesFactory.createPurchases(
+            configuration = configuration,
+            platformInfo = PlatformInfo(flavor = "test", version = null),
+            proxyURL = null,
+            overrideBillingAbstract = mockk<BillingAbstract>(relaxed = true),
+        )
+
+        assertThat(purchases.purchasesOrchestrator.audiencesConfigProvider).isNull()
+        purchases.close()
+    }
+
     // region shouldInitializeDiagnostics
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -5,11 +5,15 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.BillingAbstract
+import com.revenuecat.purchases.common.PlatformInfo
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -163,6 +167,28 @@ class PurchasesFactoryTest {
 
         // Assert
         verify(exactly = 0) { applicationMock.startActivity(any()) }
+    }
+
+    @Test
+    fun `creating purchases with remote config enabled provides audiences config to the orchestrator`() {
+        val application = spyk(ApplicationProvider.getApplicationContext<Application>())
+        every { application.applicationContext } returns application
+        every { application.checkCallingOrSelfPermission(Manifest.permission.INTERNET) } returns
+            PackageManager.PERMISSION_GRANTED
+        val configuration = PurchasesConfiguration.Builder(application, "fakeApiKey")
+            .appUserID("appUserID")
+            .store(Store.PLAY_STORE)
+            .build()
+
+        val purchases = purchasesFactory.createPurchases(
+            configuration = configuration,
+            platformInfo = PlatformInfo(flavor = "test", version = null),
+            proxyURL = null,
+            overrideBillingAbstract = mockk<BillingAbstract>(relaxed = true),
+        )
+
+        assertThat(purchases.purchasesOrchestrator.audiencesConfigProvider).isNotNull()
+        purchases.close()
     }
 
     // region shouldInitializeDiagnostics

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -216,7 +216,7 @@ class CheckpointWorkflowResolverImplTest {
     fun `audiences after the first match are not loaded`() = runTest {
         configureRules(rule("wf1234"), rule("wf5678"))
 
-        val resolution = resolve() as CheckpointResolution.Workflow
+        val resolution = resolve() as CheckpointResolution.MatchedWorkflow
 
         assertThat(resolution.workflow).isEqualTo(mockWorkflow)
         coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience("aud_wf5678") }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -4,15 +4,12 @@ package com.revenuecat.purchases.checkpoints
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.LogLevel
-import com.revenuecat.purchases.LogMessage
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.UiConfig
-import com.revenuecat.purchases.assertLogs
 import com.revenuecat.purchases.common.audiences.Audience
 import com.revenuecat.purchases.common.audiences.AudiencesConfigProvider
 import com.revenuecat.purchases.common.checkpoints.CheckpointResponse
@@ -216,39 +213,10 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
-    fun `checkpoint audience resolution emits debug diagnostics`() {
-        configureRules(rule("wf5678"), rule("wf1234"))
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf5678") } returns
-            Audience("aud_wf5678", "false")
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
-            Audience("aud_wf1234", "true")
-
-        assertLogs(
-            listOf(
-                LogMessage(LogLevel.DEBUG, "Resolving checkpoint 'test_checkpoint' with 2 audience rules."),
-                LogMessage(
-                    LogLevel.DEBUG,
-                    "Evaluating audience 'aud_wf5678' for checkpoint 'test_checkpoint' and workflow 'wf5678'.",
-                ),
-                LogMessage(
-                    LogLevel.DEBUG,
-                    "Evaluating audience 'aud_wf1234' for checkpoint 'test_checkpoint' and workflow 'wf1234'.",
-                ),
-                LogMessage(
-                    LogLevel.DEBUG,
-                    "Checkpoint 'test_checkpoint' matched audience 'aud_wf1234' for workflow 'wf1234'.",
-                ),
-            ),
-        ) {
-            runTest { resolve() }
-        }
-    }
-
-    @Test
     fun `audiences after the first match are not loaded`() = runTest {
         configureRules(rule("wf1234"), rule("wf5678"))
 
-        val resolution = resolve() as CheckpointResolution.MatchedWorkflow
+        val resolution = resolve() as CheckpointResolution.Workflow
 
         assertThat(resolution.workflow).isEqualTo(mockWorkflow)
         coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience("aud_wf5678") }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -4,12 +4,15 @@ package com.revenuecat.purchases.checkpoints
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.LogLevel
+import com.revenuecat.purchases.LogMessage
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.assertLogs
 import com.revenuecat.purchases.common.audiences.Audience
 import com.revenuecat.purchases.common.audiences.AudiencesConfigProvider
 import com.revenuecat.purchases.common.checkpoints.CheckpointResponse
@@ -213,10 +216,39 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
+    fun `checkpoint audience resolution emits debug diagnostics`() {
+        configureRules(rule("wf5678"), rule("wf1234"))
+        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf5678") } returns
+            Audience("aud_wf5678", "false")
+        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
+            Audience("aud_wf1234", "true")
+
+        assertLogs(
+            listOf(
+                LogMessage(LogLevel.DEBUG, "Resolving checkpoint 'test_checkpoint' with 2 audience rules."),
+                LogMessage(
+                    LogLevel.DEBUG,
+                    "Evaluating audience 'aud_wf5678' for checkpoint 'test_checkpoint' and workflow 'wf5678'.",
+                ),
+                LogMessage(
+                    LogLevel.DEBUG,
+                    "Evaluating audience 'aud_wf1234' for checkpoint 'test_checkpoint' and workflow 'wf1234'.",
+                ),
+                LogMessage(
+                    LogLevel.DEBUG,
+                    "Checkpoint 'test_checkpoint' matched audience 'aud_wf1234' for workflow 'wf1234'.",
+                ),
+            ),
+        ) {
+            runTest { resolve() }
+        }
+    }
+
+    @Test
     fun `audiences after the first match are not loaded`() = runTest {
         configureRules(rule("wf1234"), rule("wf5678"))
 
-        val resolution = resolve() as CheckpointResolution.Workflow
+        val resolution = resolve() as CheckpointResolution.MatchedWorkflow
 
         assertThat(resolution.workflow).isEqualTo(mockWorkflow)
         coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience("aud_wf5678") }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -10,6 +10,8 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.common.audiences.Audience
+import com.revenuecat.purchases.common.audiences.AudiencesConfigProvider
 import com.revenuecat.purchases.common.checkpoints.CheckpointResponse
 import com.revenuecat.purchases.common.checkpoints.CheckpointRule
 import com.revenuecat.purchases.common.checkpoints.CheckpointRulesResolution
@@ -53,6 +55,7 @@ class CheckpointWorkflowResolverImplTest {
     private lateinit var mockWorkflowManager: WorkflowManager
     private lateinit var mockUiConfigProvider: UiConfigProvider
     private lateinit var mockCheckpointsConfigProvider: CheckpointsConfigProvider
+    private lateinit var mockAudiencesConfigProvider: AudiencesConfigProvider
     private lateinit var mockWorkflow: PublishedWorkflow
     private lateinit var mockUiConfig: UiConfig
     private lateinit var mockOffering: Offering
@@ -67,6 +70,7 @@ class CheckpointWorkflowResolverImplTest {
         mockWorkflowManager = mockk()
         mockUiConfigProvider = mockk()
         mockCheckpointsConfigProvider = mockk()
+        mockAudiencesConfigProvider = mockk()
         mockWorkflow = uiWorkflow("wf1234")
         mockUiConfig = mockk()
         mockOffering = mockk {
@@ -78,11 +82,16 @@ class CheckpointWorkflowResolverImplTest {
         every { mockWorkflowManager.prewarmWorkflowAssets(any(), any()) } just Runs
         coEvery { mockUiConfigProvider.getUiConfig() } returns mockUiConfig
         every { mockOfferings.all } returns mapOf("default" to mockOffering)
+        coEvery { mockAudiencesConfigProvider.getAudience(any()) } answers {
+            val audienceId = firstArg<String>()
+            Audience(id = audienceId, rules = "true")
+        }
         configureRules(rule("wf1234"))
         resolver = CheckpointWorkflowResolverImpl(
             workflowManager = mockWorkflowManager,
             uiConfigProvider = mockUiConfigProvider,
             checkpointsConfigProvider = mockCheckpointsConfigProvider,
+            audiencesConfigProvider = mockAudiencesConfigProvider,
             localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
             getOfferings = {
                 offeringsFetched++
@@ -110,6 +119,7 @@ class CheckpointWorkflowResolverImplTest {
             workflowManager = null,
             uiConfigProvider = null,
             checkpointsConfigProvider = null,
+            audiencesConfigProvider = null,
             localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
             getOfferings = { mockOfferings },
         )
@@ -188,8 +198,53 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
-    fun `checkpoint resolves the workflow of the first rule`() = runTest {
+    fun `the first matching audience determines the workflow`() = runTest {
+        configureRules(rule("wf5678"), rule("wf1234"))
+        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf5678") } returns
+            Audience("aud_wf5678", "false")
+        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
+            Audience("aud_wf1234", "true")
+
+        val resolution = resolve() as CheckpointResolution.MatchedWorkflow
+
+        assertThat(resolution.workflow).isEqualTo(mockWorkflow)
+    }
+
+    @Test
+    fun `audiences after the first match are not loaded`() = runTest {
         configureRules(rule("wf1234"), rule("wf5678"))
+
+        resolve()
+
+        coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience("aud_wf5678") }
+    }
+
+    @Test
+    fun `a missing audience before a match is configuration unavailable`() = runTest {
+        configureRules(rule("missing"), rule("wf1234"))
+        coEvery { mockAudiencesConfigProvider.getAudience("aud_missing") } returns null
+
+        assertThat(noActionReason(resolve()))
+            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience("aud_wf1234") }
+    }
+
+    @Test
+    fun `false audiences resolve to no match`() = runTest {
+        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
+            Audience("aud_wf1234", "false")
+
+        assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
+        assertThat(offeringsFetched).isZero()
+    }
+
+    @Test
+    fun `a malformed audience before a match does not prevent a later matching workflow`() = runTest {
+        configureRules(rule("wf5678"), rule("wf1234"))
+        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf5678") } returns
+            Audience("aud_wf5678", "{not json")
+        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
+            Audience("aud_wf1234", "true")
 
         val resolution = resolve() as CheckpointResolution.MatchedWorkflow
 
@@ -239,6 +294,7 @@ class CheckpointWorkflowResolverImplTest {
                 workflowManager = mockWorkflowManager,
                 uiConfigProvider = mockUiConfigProvider,
                 checkpointsConfigProvider = mockCheckpointsConfigProvider,
+                audiencesConfigProvider = mockAudiencesConfigProvider,
                 localRulesEvaluator = LocalRulesEvaluator(providers = listOf(FailingDimensionProvider)),
                 getOfferings = { mockOfferings },
             )
@@ -267,7 +323,8 @@ class CheckpointWorkflowResolverImplTest {
 
     @Test
     fun `a custom variable the audience requires resolves the workflow`() = runTest {
-        resolver = resolverWithPredicate("""{"==": [{"var": "custom.source"}, "settings"]}""")
+        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
+            Audience("aud_wf1234", """{"==": [{"var": "custom.source"}, "settings"]}""")
 
         val resolution = resolver.resolve(checkpointId, mapOf("source" to RulesDimensionValue.StringValue("settings")))
 
@@ -276,7 +333,8 @@ class CheckpointWorkflowResolverImplTest {
 
     @Test
     fun `a custom variable the audience does not accept resolves NoAction with NO_MATCH`() = runTest {
-        resolver = resolverWithPredicate("""{"==": [{"var": "custom.source"}, "settings"]}""")
+        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
+            Audience("aud_wf1234", """{"==": [{"var": "custom.source"}, "settings"]}""")
 
         assertThat(noActionReason(resolver.resolve(checkpointId, mapOf("source" to RulesDimensionValue.StringValue("onboarding")))))
             .isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
@@ -303,6 +361,7 @@ class CheckpointWorkflowResolverImplTest {
             workflowManager = mockWorkflowManager,
             uiConfigProvider = null,
             checkpointsConfigProvider = mockCheckpointsConfigProvider,
+            audiencesConfigProvider = mockAudiencesConfigProvider,
             localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
             getOfferings = {
                 offeringsFetched++
@@ -446,6 +505,7 @@ class CheckpointWorkflowResolverImplTest {
             workflowManager = mockWorkflowManager,
             uiConfigProvider = mockUiConfigProvider,
             checkpointsConfigProvider = mockCheckpointsConfigProvider,
+            audiencesConfigProvider = mockAudiencesConfigProvider,
             localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
             getOfferings = { throw CancellationException("cancelled") },
         )
@@ -460,15 +520,6 @@ class CheckpointWorkflowResolverImplTest {
         override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
             throw IllegalStateException("no dimensions")
     }
-
-    private fun resolverWithPredicate(predicate: String) = CheckpointWorkflowResolverImpl(
-        workflowManager = mockWorkflowManager,
-        uiConfigProvider = mockUiConfigProvider,
-        checkpointsConfigProvider = mockCheckpointsConfigProvider,
-        localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
-        getOfferings = { mockOfferings },
-        audiencePredicate = predicate,
-    )
 
     private fun rule(workflowId: String) = CheckpointRule(
         id = "rule_$workflowId",

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -134,6 +134,7 @@ class CheckpointWorkflowResolverImplTest {
 
         assertThat(noActionReason(resolve()))
             .isEqualTo(CheckpointResolution.NoAction.Reason.DISABLED)
+        coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience(any()) }
     }
 
     @Test
@@ -150,6 +151,7 @@ class CheckpointWorkflowResolverImplTest {
 
         assertThat(noActionReason(resolve()))
             .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience(any()) }
     }
 
     @Test
@@ -214,8 +216,9 @@ class CheckpointWorkflowResolverImplTest {
     fun `audiences after the first match are not loaded`() = runTest {
         configureRules(rule("wf1234"), rule("wf5678"))
 
-        resolve()
+        val resolution = resolve() as CheckpointResolution.Workflow
 
+        assertThat(resolution.workflow).isEqualTo(mockWorkflow)
         coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience("aud_wf5678") }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
@@ -1,13 +1,16 @@
 package com.revenuecat.purchases.common.audiences
 
+import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.common.currentLogHandler
+import com.revenuecat.purchases.common.remoteconfig.ConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
-import io.mockk.MockKMatcherScope
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.jsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -42,9 +45,8 @@ internal class AudiencesConfigProviderTest {
 
     @Test
     fun `getAudience decodes a typed audience and ignores unknown fields`() = runTest {
-        returnBlob(
-            "aud_123",
-            """
+        returnMetadata(
+            "aud_123" to """
             {
               "id": "aud_123",
               "created_via": "dashboard",
@@ -62,18 +64,23 @@ internal class AudiencesConfigProviderTest {
     }
 
     @Test
-    fun `getAudience returns null for malformed or non-object payloads`() = runTest {
-        returnBlob("malformed", "not-json")
-        returnBlob("array", "[1, 2, 3]")
+    fun `getAudience returns null for missing or invalid metadata`() = runTest {
+        returnMetadata(
+            "missing-id" to """{"rules":{"==":[1,1]}}""",
+            "array-rules" to """{"id":"array-rules","rules":[1,2,3]}""",
+        )
 
-        assertThat(provider.getAudience("malformed")).isNull()
-        assertThat(provider.getAudience("array")).isNull()
+        assertThat(provider.getAudience("missing-id")).isNull()
+        assertThat(provider.getAudience("array-rules")).isNull()
+        assertThat(provider.getAudience("unknown")).isNull()
     }
 
     @Test
     fun `a malformed audience does not prevent reading another audience`() = runTest {
-        returnBlob("invalid", """{"id":"invalid","rules":[]}""")
-        returnBlob("valid", """{"id":"valid","rules":{"==":[1,1]}}""")
+        returnMetadata(
+            "invalid" to """{"id":"invalid","rules":[]}""",
+            "valid" to """{"id":"valid","rules":{"==":[1,1]}}""",
+        )
 
         assertThat(provider.getAudience("invalid")).isNull()
         assertThat(provider.getAudience("valid")).isEqualTo(
@@ -81,16 +88,12 @@ internal class AudiencesConfigProviderTest {
         )
     }
 
-    private suspend fun MockKMatcherScope.blobRead(identifier: String): Audience? =
-        manager.blobData(
-            RemoteConfigTopic.Audiences,
-            identifier,
-            any<(ByteArray) -> Audience?>(),
-        )
-
-    private fun returnBlob(identifier: String, json: String) {
-        coEvery { blobRead(identifier) } answers {
-            thirdArg<(ByteArray) -> Audience?>().invoke(json.toByteArray())
+    private fun returnMetadata(vararg audiences: Pair<String, String>) {
+        val items = audiences.associate { (identifier, json) ->
+            identifier to RemoteConfiguration.ConfigItem(
+                metadata = JsonTools.json.parseToJsonElement(json).jsonObject,
+            )
         }
+        coEvery { manager.topic(RemoteConfigTopic.Audiences) } returns ConfigTopic(items)
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -106,6 +106,34 @@ class LocalRulesEvaluatorTest {
     }
 
     @Test
+    fun `lazy predicates are resolved in order only until a rule matches`() = runTest {
+        val resolved = mutableListOf<String>()
+        val rules = listOf("first", "second", "unused")
+
+        val result = evaluator().match(rules) { rule ->
+            resolved += rule
+            Result.success(if (rule == "second") matchingPredicate else nonMatchingPredicate)
+        }
+
+        assertThat(result.getOrThrow()).isEqualTo("second")
+        assertThat(resolved).containsExactly("first", "second")
+    }
+
+    @Test
+    fun `predicate resolution failure stops evaluation`() = runTest {
+        val resolved = mutableListOf<String>()
+        val failure = IllegalStateException("audience unavailable")
+
+        val result = evaluator().match(listOf("missing", "unused")) { rule ->
+            resolved += rule
+            if (rule == "missing") Result.failure(failure) else Result.success(matchingPredicate)
+        }
+
+        assertThat(result.exceptionOrNull()).isSameAs(failure)
+        assertThat(resolved).containsExactly("missing")
+    }
+
+    @Test
     fun `a predicate reading a custom variable matches`() = runTest {
         val rules = listOf(TestRule("only", """{"==": [{"var": "custom.source"}, "settings"]}"""))
 
@@ -140,13 +168,9 @@ class LocalRulesEvaluatorTest {
 
     @Test
     fun `dimensions are collected once per call regardless of rule count`() = runTest {
-        evaluator().match(
-            listOf(
-                TestRule("first", nonMatchingPredicate),
-                TestRule("second", nonMatchingPredicate),
-                TestRule("third", matchingPredicate),
-            ),
-        )
+        evaluator().match(listOf("first", "second", "third")) { rule ->
+            Result.success(if (rule == "third") matchingPredicate else nonMatchingPredicate)
+        }
 
         assertThat(snapshotsTaken).isEqualTo(1)
     }


### PR DESCRIPTION
Evaluates the audience explicitly before the checkpoint answers with a workflow.

Audience definitions are stored inline in `ConfigItem.metadata`, without a `blob_ref`, so `AudiencesConfigProvider` now reads and decodes the topic metadata directly.

[WFL-464](https://linear.app/revenuecat/issue/WFL-464/android-deserialize-audience-rules-for-rules-engine-evaluation).

Validation: `:purchases:compileDefaultsDebugKotlin` and the pre-commit Detekt check. The existing blob-backed `AudiencesConfigProviderTest` cases were not updated as part of this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint targeting logic and remote-config read path for audiences; misconfiguration or parse failures alter which workflow (or no action) customers see, though behavior is fail-closed toward configuration unavailable rather than silent wrong matches.
> 
> **Overview**
> Checkpoint resolution no longer treats every checkpoint rule as matching via a placeholder predicate. Each rule’s `audience_id` is resolved through **`AudiencesConfigProvider`**, and **`LocalRulesEvaluator`** evaluates the audience’s rules JSON against device/store/custom dimensions until the first match picks a workflow.
> 
> **`AudiencesConfigProvider`** now loads audiences from inline remote-config topic **`metadata`** (not blob storage) and decodes them to **`Audience`** for the rules engine.
> 
> **`PurchasesFactory`** wires **`AudiencesConfigProvider`** into the orchestrator when remote config is enabled (absent for custom entitlement computation). Missing or unreadable audiences surface **`CONFIGURATION_UNAVAILABLE`** instead of **`NO_MATCH`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdbcf963e24eb0531497078acd04185ab399fae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->