### PR TITLE
test(checkpoints): Hardcode audience rules to exercise rule selection [DO NOT MERGE]

### DIFF
--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/onboarding/OnboardingScreen.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/onboarding/OnboardingScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -40,6 +41,17 @@ fun OnboardingScreen(
         )
         Text(text = state.step.title, style = MaterialTheme.typography.headlineSmall)
         Text(text = state.step.body, style = MaterialTheme.typography.bodyMedium)
+
+        if (state.step == Step.Personalize) {
+            OutlinedTextField(
+                value = state.name,
+                onValueChange = viewModel::onNameChange,
+                label = { Text(text = "custom.name (optional)") },
+                singleLine = true,
+                enabled = !state.running,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
 
         StepControls(
             step = state.step,

--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/onboarding/OnboardingViewModel.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/onboarding/OnboardingViewModel.kt
@@ -39,6 +39,7 @@ class OnboardingViewModel : ViewModel() {
 
     data class UiState(
         val step: Step = Step.Welcome,
+        val name: String = "",
         val running: Boolean = false,
         val message: String? = null,
     ) {
@@ -48,6 +49,11 @@ class OnboardingViewModel : ViewModel() {
 
     private val _state = MutableStateFlow(UiState())
     val state: StateFlow<UiState> = _state.asStateFlow()
+
+    fun onNameChange(value: String) {
+        if (_state.value.running) return
+        _state.update { it.copy(name = value) }
+    }
 
     fun next() {
         if (_state.value.running) return
@@ -73,10 +79,17 @@ class OnboardingViewModel : ViewModel() {
     private fun runCheckpointThenFinish() {
         _state.update { it.copy(running = true, message = null) }
         viewModelScope.launch {
+            // An empty name sends no `custom.name` at all, so a rule reading it sees an absent dimension rather
+            // than an empty string.
+            val customVariables = buildMap {
+                put("step", CustomVariableValue.String(Step.Personalize.name))
+                _state.value.name.trim().takeIf { it.isNotEmpty() }
+                    ?.let { name -> put("name", CustomVariableValue.String(name)) }
+            }
             val message = try {
                 val result = Purchases.sharedInstance.awaitCheckpoint(
                     "onboarding_complete",
-                    CheckpointParams("step" to CustomVariableValue.String(Step.Personalize.name)),
+                    CheckpointParams(customVariables),
                 )
                 when (result) {
                     is CheckpointResult.ReceivedOffering ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -37,6 +37,8 @@ import kotlinx.serialization.json.JsonPrimitive
  * [SIMULATED_ERROR_CHECKPOINT_ID] is the one piece of PoC scaffolding left: it is the only way for the tester
  * apps to exercise the throw path, since nothing in the config-driven path throws.
  */
+// TooManyFunctions/LongParameterList: both are the hardcoded test-rule scaffolding, not the real shape.
+@Suppress("LongParameterList", "TooManyFunctions")
 internal class CheckpointWorkflowResolverImpl(
     private val workflowManager: WorkflowManager?,
     private val uiConfigProvider: UiConfigProvider?,
@@ -45,6 +47,9 @@ internal class CheckpointWorkflowResolverImpl(
     private val getOfferings: suspend () -> Offerings,
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     private val audiencePredicate: String = PLACEHOLDER_AUDIENCE_PREDICATE,
+    // TEMPORARY, not for main: see [TEST_RULES]. Tests opt out to exercise the published-rule walk.
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    private val useHardcodedTestRules: Boolean = true,
 ) : CheckpointWorkflowResolver {
 
     override suspend fun resolve(
@@ -78,8 +83,13 @@ internal class CheckpointWorkflowResolverImpl(
             CheckpointRulesResolution.Unavailable ->
                 return configurationUnavailable("The rules for checkpoint '$identifier' could not be read.")
         }
+        val rules = if (useHardcodedTestRules) {
+            hardcodedTestRules(workflowManager)
+        } else {
+            checkpoint.rules.map { rule -> AudienceRule(rule, audiencePredicate) }
+        }
         val matchResult = localRulesEvaluator.match(
-            rules = checkpoint.rules.map { rule -> AudienceRule(rule, audiencePredicate) },
+            rules = rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
         )
         // An audience the SDK failed to evaluate is not the same answer as an audience the customer is outside of,
@@ -209,6 +219,40 @@ internal class CheckpointWorkflowResolverImpl(
     }
 
     /**
+     * TEMPORARY, not for main: builds [TEST_RULES] into rules the evaluator can walk.
+     *
+     * The targets are named by offering rather than by workflow because workflow ids are generated per project,
+     * while the offering ids are the ones a tester recognises, so the workflow that renders each target offering is
+     * looked up by inverting [WorkflowManager.offeringIdByWorkflowId].
+     *
+     * A rule whose offering no workflow renders is skipped rather than kept, unlike the real walk where it would
+     * win and then fail: skipping keeps the remaining rules testable on a project that lacks one of the offerings.
+     */
+    private suspend fun hardcodedTestRules(workflowManager: WorkflowManager): List<AudienceRule> {
+        val workflowIdByOfferingId = workflowManager.offeringIdByWorkflowId()
+            .entries
+            .associate { (workflowId, offeringId) -> offeringId to workflowId }
+        return TEST_RULES.mapNotNull { (predicate, offeringId) ->
+            val workflowId = workflowIdByOfferingId[offeringId]
+            if (workflowId == null) {
+                warnLog { "Skipping hardcoded test rule for offering '$offeringId': no workflow renders it." }
+                null
+            } else {
+                AudienceRule(
+                    checkpointRule = CheckpointRule(
+                        id = "hardcoded_$offeringId",
+                        audienceId = "hardcoded_$offeringId",
+                        workflowId = workflowId,
+                    ),
+                    predicate = predicate,
+                )
+            }
+        }.also { rules ->
+            debugLog { "Evaluating ${rules.size} hardcoded test rules instead of the published ones." }
+        }
+    }
+
+    /**
      * Pairs a checkpoint rule with the predicate its audience stands for. Audience predicates will arrive in their
      * own remote-config topic, whose shape is not settled, so until then every audience matches and the rules are
      * effectively still walked in published order.
@@ -223,5 +267,16 @@ internal class CheckpointWorkflowResolverImpl(
         const val OFFERING_STEP_TYPE = "offering"
         const val OFFERING_IDENTIFIER_PARAM = "offering_identifier"
         const val PLACEHOLDER_AUDIENCE_PREDICATE = "true"
+
+        /**
+         * TEMPORARY, not for main: predicate to target offering, in priority order. Stands in for the audiences
+         * topic so rule selection can be exercised by hand before that topic exists.
+         */
+        val TEST_RULES = listOf(
+            """{"and": [{"==": [{"var": "custom.name"}, "Antonio"]}, """ +
+                """{"==": [{"var": "device.locale"}, "en_us"]}]}""" to "default",
+            """{"==": [{"var": "custom.name"}, "Antonio"]}""" to "rick",
+            "true" to "no_name",
+        )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -89,6 +89,7 @@ class CheckpointWorkflowResolverImplTest {
                 offeringsFetchError?.let { throw PurchasesException(it) }
                 mockOfferings
             },
+            useHardcodedTestRules = false,
         )
     }
 
@@ -112,6 +113,7 @@ class CheckpointWorkflowResolverImplTest {
             checkpointsConfigProvider = null,
             localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
             getOfferings = { mockOfferings },
+            useHardcodedTestRules = false,
         )
 
         assertThat(noActionReason(resolve()))
@@ -241,6 +243,7 @@ class CheckpointWorkflowResolverImplTest {
                 checkpointsConfigProvider = mockCheckpointsConfigProvider,
                 localRulesEvaluator = LocalRulesEvaluator(providers = listOf(FailingDimensionProvider)),
                 getOfferings = { mockOfferings },
+                useHardcodedTestRules = false,
             )
 
             assertThat(noActionReason(resolve()))
@@ -308,6 +311,7 @@ class CheckpointWorkflowResolverImplTest {
                 offeringsFetched++
                 mockOfferings
             },
+            useHardcodedTestRules = false,
         )
 
         assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.DISABLED)
@@ -448,6 +452,7 @@ class CheckpointWorkflowResolverImplTest {
             checkpointsConfigProvider = mockCheckpointsConfigProvider,
             localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
             getOfferings = { throw CancellationException("cancelled") },
+            useHardcodedTestRules = false,
         )
 
         val thrown = runCatching { resolve() }.exceptionOrNull()
@@ -462,6 +467,39 @@ class CheckpointWorkflowResolverImplTest {
             throw IllegalStateException("no dimensions")
     }
 
+    @Test
+    fun `the hardcoded test rules select a workflow by custom name`() = runTest {
+        // No device provider, so device.locale is absent and the first rule can never match: the name alone
+        // decides between the 'rick' and 'no_name' rules.
+        coEvery { mockWorkflowManager.offeringIdByWorkflowId() } returns mapOf(
+            "wf_default" to "default",
+            "wf_rick" to "rick",
+            "wf_no_name" to "no_name",
+        )
+        every { mockOfferings.all } returns mapOf("rick" to mockOffering, "no_name" to mockOffering)
+        val resolver = CheckpointWorkflowResolverImpl(
+            workflowManager = mockWorkflowManager,
+            uiConfigProvider = mockUiConfigProvider,
+            checkpointsConfigProvider = mockCheckpointsConfigProvider,
+            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+            getOfferings = { mockOfferings },
+        )
+
+        val named = resolver.resolve(
+            checkpointId,
+            mapOf("name" to RulesDimensionValue.StringValue("Antonio")),
+        ) as CheckpointResolution.MatchedWorkflow
+        val other = resolver.resolve(
+            checkpointId,
+            mapOf("name" to RulesDimensionValue.StringValue("Someone else")),
+        ) as CheckpointResolution.MatchedWorkflow
+        val nameless = resolver.resolve(checkpointId, emptyMap()) as CheckpointResolution.MatchedWorkflow
+
+        assertThat(named.workflow.id).isEqualTo("wf_rick")
+        assertThat(other.workflow.id).isEqualTo("wf_no_name")
+        assertThat(nameless.workflow.id).isEqualTo("wf_no_name")
+    }
+
     private fun resolverWithPredicate(predicate: String) = CheckpointWorkflowResolverImpl(
         workflowManager = mockWorkflowManager,
         uiConfigProvider = mockUiConfigProvider,
@@ -469,6 +507,7 @@ class CheckpointWorkflowResolverImplTest {
         localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
         getOfferings = { mockOfferings },
         audiencePredicate = predicate,
+        useHardcodedTestRules = false,
     )
 
     private fun rule(workflowId: String) = CheckpointRule(


### PR DESCRIPTION
### ⚠️ Not for main

Testing scaffolding only. It replaces config-driven rule data with constants so the audience walk can be exercised on a device before the topic that serves real predicates exists.

### Description

Substitutes three hardcoded rules for the published ones, in priority order:

| # | Predicate | Presents the workflow whose offering is |
| --- | --- | --- |
| 1 | `custom.name == "Antonio"` and `device.locale == "en_us"` | `default` |
| 2 | `custom.name == "Antonio"` | `rick` |
| 3 | `true` | `no_name` |

Targets are named by offering rather than by workflow, because workflow ids are generated per project while the offering ids are the ones a tester recognises — the workflow that renders each is found by inverting `offeringIdByWorkflowId`. A rule whose offering no workflow renders is skipped, so the rest stay testable on a project that lacks one of the three.

The `checkpoint_rules` read is untouched, so `DISABLED` / `UNKNOWN_CHECKPOINT` / `Unavailable` still behave as they do today; only the rule data is replaced. The switch is a defaulted constructor param, and the existing resolver tests opt out so they keep covering the real published-rule walk.

`custom.name` comes from a new field on the checkpoint tester's onboarding Personalize step. An empty field sends no `custom.name` at all, so a rule reading it sees an absent dimension rather than an empty string.

### How to test

In `examples/checkpointtester` → Onboarding, with `onboarding_complete` configured and offerings `default`, `rick` and `no_name` each backed by a workflow:

| Input | Expected |
| --- | --- |
| `Antonio`, en-US device | rule 1 → `default` |
| `Antonio`, any other locale | rule 2 → `rick` |
| any other name | rule 3 → `no_name` |
| empty | rule 3 → `no_name` |

Which rule won shows in logcat: `Checkpoint resolved to workflow '<id>' (offering: <id>)`.

Stacked on #3969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
