### PR TITLE
Report public API changes on PRs and in the SDK API feed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -967,6 +967,12 @@ workflows:
     jobs:
       - revenuecat/danger:
           ruby_version: "3.2.0"
+          context:
+            - slack-secrets
+          post-steps:
+            - run:
+                name: Run api diff report unit tests
+                command: ruby danger/api_diff_report_test.rb
 
   snapshot-deploy-manual:
     when:

--- a/Dangerfile
+++ b/Dangerfile
@@ -61,3 +61,23 @@ if total_changed > PROD_LINES_LIMIT
 end
 
 fail_on_generated_edits(["purchases/src/main/kotlin/generated/"])
+
+# Report the public API this PR changes, and mirror it into the SDK API feed channel.
+# Best effort: a raise here would take every other rule in this file down with it.
+begin
+  require_relative "danger/api_diff_report"
+
+  api_diff = ApiDiffReport.run(
+    changed_files: git.modified_files + git.added_files + git.deleted_files,
+    patch_for: ->(file) { git.diff_for_file(file)&.patch },
+    pull_request_link: "<#{github.pr_json['html_url']}|##{github.pr_json['number']}>",
+  )
+
+  if api_diff
+    markdown(api_diff[:comment])
+    warn("The public API changed, but it was not announced in the SDK API feed: #{api_diff[:slack_error]}.") if api_diff[:slack_error]
+  end
+rescue StandardError => e
+  # `warn` is Danger's DSL: surfaces on the PR without failing the run.
+  warn("Could not report the public API changes: #{e.message}")
+end

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -1,0 +1,203 @@
+# Reports the public API a PR changes, from the metalava signature diffs. Loaded by the Dangerfile.
+
+require 'json'
+require 'net/http'
+require 'uri'
+
+module ApiDiffReport
+  PLATFORM_LABEL = "Android :android:".freeze
+
+  # The same two patterns scripts/api-check.sh gates on.
+  SIGNATURE_GLOBS = ["api.txt", "api-*.txt"].freeze
+
+  # A metalava 4.0 file holds nothing but the banner, `package … {`, `}`, types and members.
+  NOISE = %r{\A(\}|package\s|//)}.freeze
+
+  SLACK_LIMIT = 10
+
+  # Slack stops wrapping code blocks past this; the full list is in the PR comment.
+  SLACK_WIDTH = 160
+
+  # GitHub answers 422 over 65536 characters, and Danger shares one comment across every rule.
+  MARKDOWN_LIMIT = 200
+  MARKDOWN_WIDTH = 200
+
+  module_function
+
+  def signature_file?(path)
+    basename = File.basename(path.to_s)
+
+    SIGNATURE_GLOBS.any? { |glob| File.fnmatch?(glob, basename) }
+  end
+
+  def module_name(path)
+    File.dirname(path.to_s).tr("/", ":")
+  end
+
+  def declarations(patch)
+    added = []
+    removed = []
+
+    patch.to_s.each_line do |raw_line|
+      sign = raw_line[0]
+      next unless sign == "+" || sign == "-"
+      next if raw_line.start_with?("+++", "---")
+
+      line = raw_line[1..].to_s.strip
+      next if line.empty? || NOISE.match?(line)
+
+      # Members end in `;`; only a type header carries the opening brace of its body.
+      (sign == "+" ? added : removed) << line.sub(/\s*\{\z/, "")
+    end
+
+    [added, removed]
+  end
+
+  # A member line omits its owning type, so two types in one file can add the same text. Identity is
+  # therefore the text plus how many times it has already appeared in that file.
+  def occurrences(declarations)
+    seen = Hash.new(0)
+
+    declarations.map do |declaration|
+      seen[declaration] += 1
+      [declaration, seen[declaration]]
+    end
+  end
+
+  def build(patches_by_path)
+    by_module = {}
+
+    patches_by_path.each do |path, patch|
+      path_added, path_removed = declarations(patch)
+      next if path_added.empty? && path_removed.empty?
+
+      # :purchases keeps two flavour files of largely the same surface, so a shared declaration
+      # lands in both. Union per module, which keeps repeats inside one file.
+      bucket = (by_module[module_name(path)] ||= { added: [], removed: [] })
+      bucket[:added] |= occurrences(path_added)
+      bucket[:removed] |= occurrences(path_removed)
+    end
+
+    modules = by_module.keys.sort
+
+    {
+      added: modules.flat_map { |name| by_module[name][:added].map(&:first) },
+      removed: modules.flat_map { |name| by_module[name][:removed].map(&:first) },
+      modules: modules
+    }
+  end
+
+  def empty?(report)
+    report[:added].empty? && report[:removed].empty?
+  end
+
+  def counts(report)
+    parts = []
+    parts << "#{report[:added].count} new declaration#{'s' if report[:added].count != 1}" if report[:added].any?
+    parts << "#{report[:removed].count} removed" if report[:removed].any?
+    parts.join(", ")
+  end
+
+  def diff_lines(report)
+    report[:removed].map { |declaration| "- #{declaration}" } +
+      report[:added].map { |declaration| "+ #{declaration}" }
+  end
+
+  def capped_lines(lines, limit:, width:)
+    shown = lines.first(limit).map do |line|
+      line.length > width ? "#{line[0, width - 1]}…" : line
+    end
+    remaining = lines.count - shown.count
+    shown << "…and #{remaining} more" if remaining.positive?
+
+    shown
+  end
+
+  def markdown_section(report)
+    summary = "Public API changes in #{report[:modules].join(', ')} (#{counts(report)})"
+    body = capped_lines(diff_lines(report), limit: MARKDOWN_LIMIT, width: MARKDOWN_WIDTH)
+
+    [
+      "<details><summary>#{summary}</summary>",
+      "",
+      "```diff",
+      body.join("\n"),
+      "```",
+      "",
+      "</details>"
+    ].join("\n")
+  end
+
+  def slack_message(report, pull_request_link)
+    # Metalava renders a changed signature as a removal plus an addition.
+    headline = report[:removed].any? ? ":warning: *Public API removed or changed*" : ":sparkles: *New public API*"
+    body = capped_lines(diff_lines(report), limit: SLACK_LIMIT, width: SLACK_WIDTH)
+
+    lines = [[headline, PLATFORM_LABEL, *report[:modules].map { |name| "`#{name}`" }].join(" · ")]
+    lines << pull_request_link unless pull_request_link.to_s.empty?
+    lines << counts(report)
+    lines << "```\n#{body.join("\n")}\n```"
+
+    lines.join("\n")
+  end
+
+  # The shared slack-secrets context still carries this token under its original iOS-only name.
+  TOKEN_VARIABLES = ["SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB", "SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS"].freeze
+
+  def slack_credentials
+    token = TOKEN_VARIABLES.map { |name| ENV[name].to_s }.find { |value| !value.empty? }
+    channel = ENV["SLACK_CHANNEL_SDK_NEW_API"].to_s
+    return nil if token.nil? || channel.empty?
+
+    [token, channel]
+  end
+
+  def slack_request(message, bot_token:, channel:)
+    {
+      url: "https://slack.com/api/chat.postMessage",
+      headers: { "Content-Type" => "application/json", "Authorization" => "Bearer #{bot_token}" },
+      body: { channel: channel, text: message }
+    }
+  end
+
+  def post(request, poster: nil)
+    poster ||= ->(url, body, headers) { Net::HTTP.post(URI.parse(url), body, headers) }
+
+    response = poster.call(request[:url], request[:body].to_json, request[:headers])
+    raise "Slack returned #{response.code}: #{response.body}" unless (200..299).cover?(response.code.to_i)
+
+    # chat.postMessage answers 200 with ok:false.
+    parsed = begin
+      JSON.parse(response.body.to_s)
+    rescue JSON::ParserError
+      nil
+    end
+    raise "Slack rejected the message: #{parsed['error']}" if parsed.is_a?(Hash) && parsed["ok"] == false
+
+    nil
+  end
+
+  # The PR comment is the report and Slack only mirrors it, so a failed announcement must not cost
+  # us the comment. Returns the reason it was not announced, or nil.
+  def announce(report, pull_request_link, credentials, poster)
+    return "no Slack credentials were reachable" if credentials.nil?
+
+    bot_token, channel = credentials
+    post(slack_request(slack_message(report, pull_request_link), bot_token: bot_token, channel: channel), poster: poster)
+    nil
+  rescue StandardError => e
+    e.message
+  end
+
+  # Returns { comment:, slack_error: }, or nil when the public API did not change.
+  def run(changed_files:, patch_for:, pull_request_link:, credentials: slack_credentials, poster: nil)
+    signature_files = changed_files.uniq.select { |file| signature_file?(file) }
+    report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
+    return nil if empty?(report)
+
+    {
+      comment: markdown_section(report),
+      slack_error: announce(report, pull_request_link, credentials, poster)
+    }
+  end
+end

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -1,0 +1,295 @@
+require 'minitest/autorun'
+require_relative 'api_diff_report'
+
+class ApiDiffReportTest < Minitest::Test
+  # Synthetic declarations: a plausible unreleased API name in a public repo reads as a roadmap hint.
+  ADDED_METHOD_PATCH = <<~PATCH.freeze
+    --- a/purchases/api-defauts.txt
+    +++ b/purchases/api-defauts.txt
+    @@ -10,6 +10,7 @@ package com.revenuecat.purchases {
+
+       public final class ApiDiffDemo {
+         method public void apiDiffDemoPing();
+    +    method public void apiDiffDemoPong();
+       }
+
+     }
+  PATCH
+
+  SIGNATURE_CHANGE_PATCH = <<~PATCH.freeze
+    --- a/ui/revenuecatui/api.txt
+    +++ b/ui/revenuecatui/api.txt
+    @@ -3,5 +3,5 @@ package com.revenuecat.purchases.ui.revenuecatui {
+
+       public final class ApiDiffDemoKt {
+    -    method public static void apiDiffDemoPing(String value);
+    +    method public static void apiDiffDemoPing(String value, optional int count);
+       }
+  PATCH
+
+  NEW_TYPE_PATCH = <<~PATCH.freeze
+    --- a/feature/amazon/api.txt
+    +++ b/feature/amazon/api.txt
+    @@ -1,3 +1,9 @@
+     // Signature format: 4.0
+    +package com.revenuecat.purchases.apidiffdemo {
+    +
+    +  public final class ApiDiffDemo {
+    +    method public void apiDiffDemoPing();
+    +  }
+    +
+    +}
+     package com.revenuecat.purchases.amazon {
+  PATCH
+
+  # Must accept everything the `api.txt` / `api-*.txt` pathspecs in scripts/api-check.sh gate on.
+  def test_signature_file_matches_the_api_check_globs
+    assert ApiDiffReport.signature_file?("ui/revenuecatui/api.txt")
+    assert ApiDiffReport.signature_file?("purchases/api-defauts.txt")
+    assert ApiDiffReport.signature_file?("purchases/api-entitlement.txt")
+    assert ApiDiffReport.signature_file?("purchases/api-release.debug.txt")
+    refute ApiDiffReport.signature_file?("purchases/src/main/kotlin/Api.kt")
+    refute ApiDiffReport.signature_file?("docs/api.txt.md")
+    refute ApiDiffReport.signature_file?("docs/notapi.txt")
+  end
+
+  def test_module_name_uses_gradle_path_notation
+    assert_equal "purchases", ApiDiffReport.module_name("purchases/api-defauts.txt")
+    assert_equal "ui:revenuecatui", ApiDiffReport.module_name("ui/revenuecatui/api.txt")
+  end
+
+  def test_build_collects_added_declarations_in_file_order
+    report = ApiDiffReport.build("feature/amazon/api.txt" => NEW_TYPE_PATCH)
+
+    assert_equal ["public final class ApiDiffDemo", "method public void apiDiffDemoPing();"], report[:added]
+    assert_empty report[:removed]
+    assert_equal ["feature:amazon"], report[:modules]
+  end
+
+  def test_build_reports_a_signature_change_as_a_removal_and_an_addition
+    report = ApiDiffReport.build("ui/revenuecatui/api.txt" => SIGNATURE_CHANGE_PATCH)
+
+    assert_equal 1, report[:added].count
+    assert_equal 1, report[:removed].count
+    assert_includes report[:added].first, "optional int count"
+  end
+
+  def test_build_ignores_braces_package_lines_and_the_banner
+    report = ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH)
+
+    assert_equal ["method public void apiDiffDemoPong();"], report[:added]
+  end
+
+  def test_build_deduplicates_across_flavour_files
+    report = ApiDiffReport.build(
+      "purchases/api-defauts.txt" => ADDED_METHOD_PATCH,
+      "purchases/api-entitlement.txt" => ADDED_METHOD_PATCH.gsub("api-defauts", "api-entitlement")
+    )
+
+    assert_equal 1, report[:added].count
+    assert_equal ["purchases"], report[:modules]
+  end
+
+  # Member lines omit the owning type, so two types can add the same text in one file.
+  def test_build_keeps_identical_declarations_on_different_types
+    patch = <<~PATCH
+      --- a/purchases/api-defauts.txt
+      +++ b/purchases/api-defauts.txt
+      @@ -10,6 +10,8 @@ package com.revenuecat.purchases {
+      +  public final class Foo {
+      +    method public String getName();
+      +  }
+      +  public final class Bar {
+      +    method public String getName();
+      +  }
+    PATCH
+
+    report = ApiDiffReport.build("purchases/api-defauts.txt" => patch)
+
+    assert_equal 2, report[:added].count { |d| d == "method public String getName();" }
+  end
+
+  def test_build_is_empty_when_no_declaration_changed
+    report = ApiDiffReport.build("purchases/api-defauts.txt" => "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-}\n+}\n")
+
+    assert ApiDiffReport.empty?(report)
+  end
+
+  def test_capped_lines_truncates_by_count_and_width
+    lines = (1..15).map { |index| "line#{index} #{'a' * 400}" }
+
+    shown = ApiDiffReport.capped_lines(lines, limit: 10, width: 50)
+
+    assert_equal 11, shown.count
+    assert_equal "…and 5 more", shown.last
+    assert shown.first(10).all? { |line| line.length <= 50 }
+  end
+
+  def test_capped_lines_leaves_short_lists_alone
+    shown = ApiDiffReport.capped_lines(["a", "b"], limit: 10, width: 50)
+
+    assert_equal ["a", "b"], shown
+  end
+
+  def test_slack_message_labels_the_platform_and_modules
+    report = ApiDiffReport.build("ui/revenuecatui/api.txt" => ADDED_METHOD_PATCH)
+
+    message = ApiDiffReport.slack_message(report, "<https://github.com/RevenueCat/purchases-android/pull/42|#42>")
+
+    assert message.start_with?(":sparkles: *New public API* · Android :android: · `ui:revenuecatui`")
+    assert_includes message, "|#42>"
+    assert_includes message, "1 new declaration"
+    assert_includes message, "+ method public void apiDiffDemoPong"
+  end
+
+  def test_slack_message_warns_when_something_was_removed
+    report = ApiDiffReport.build("ui/revenuecatui/api.txt" => SIGNATURE_CHANGE_PATCH)
+
+    message = ApiDiffReport.slack_message(report, "")
+
+    assert message.start_with?(":warning: *Public API removed or changed* · Android :android: · `ui:revenuecatui`")
+    assert_includes message, "1 new declaration, 1 removed"
+    refute_includes message, "|#"
+  end
+
+  def test_markdown_section_is_a_collapsible_diff_block
+    report = ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH)
+
+    section = ApiDiffReport.markdown_section(report)
+
+    assert_includes section, "<details><summary>Public API changes in purchases (1 new declaration)</summary>"
+    assert_includes section, "```diff"
+    assert_includes section, "+ method public void apiDiffDemoPong"
+    refute_match(/…and \d+ more/, section)
+  end
+
+  # A metalava format bump rewrites whole signature files.
+  def test_markdown_section_stays_under_the_github_comment_limit
+    wholesale_rewrite = { added: (1..4000).map { |index| "method public void f#{index}(#{'a' * 800});" }, removed: [], modules: ["purchases"] }
+
+    section = ApiDiffReport.markdown_section(wholesale_rewrite)
+
+    assert section.length < 65_536, "section was #{section.length} characters"
+    assert_match(/…and \d+ more/, section)
+  end
+
+  def test_slack_request_targets_chat_post_message
+    request = ApiDiffReport.slack_request("hi", bot_token: "xoxb-1", channel: "#some-channel")
+
+    assert_equal "https://slack.com/api/chat.postMessage", request[:url]
+    assert_equal "Bearer xoxb-1", request[:headers]["Authorization"]
+    assert_equal({ channel: "#some-channel", text: "hi" }, request[:body])
+  end
+
+  def test_post_raises_when_slack_answers_ok_false
+    response = Struct.new(:code, :body).new("200", '{"ok":false,"error":"channel_not_found"}')
+    request = ApiDiffReport.slack_request("hi", bot_token: "xoxb-1", channel: "#some-channel")
+
+    error = assert_raises(RuntimeError) { ApiDiffReport.post(request, poster: ->(*) { response }) }
+    assert_includes error.message, "channel_not_found"
+  end
+
+  def test_post_raises_on_a_non_success_status
+    response = Struct.new(:code, :body).new("500", "boom")
+    request = ApiDiffReport.slack_request("hi", bot_token: "xoxb-1", channel: "#some-channel")
+
+    assert_raises(RuntimeError) { ApiDiffReport.post(request, poster: ->(*) { response }) }
+  end
+
+  def test_post_accepts_a_successful_response
+    response = Struct.new(:code, :body).new("200", '{"ok":true}')
+    request = ApiDiffReport.slack_request("hi", bot_token: "xoxb-1", channel: "#some-channel")
+
+    assert_nil ApiDiffReport.post(request, poster: ->(*) { response })
+  end
+
+  PATCHES = {
+    "purchases/api-defauts.txt" => ADDED_METHOD_PATCH,
+    "purchases/src/main/kotlin/Purchases.kt" => "irrelevant"
+  }.freeze
+
+  def test_run_returns_the_comment_body_and_posts_to_slack
+    posted = []
+
+    body = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      pull_request_link: "<url|#42>",
+      credentials: ["xoxb-1", "#some-channel"],
+      poster: lambda do |_url, request_body, _headers|
+        posted << JSON.parse(request_body)
+        Struct.new(:code, :body).new("200", '{"ok":true}')
+      end
+    )
+
+    assert_includes body[:comment], "+ method public void apiDiffDemoPong"
+    assert_nil body[:slack_error]
+    assert_equal 1, posted.count
+    assert_includes posted.first["text"], "<url|#42>"
+  end
+
+  def test_run_reports_a_skipped_announcement_without_credentials
+    body = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      pull_request_link: "<url|#42>",
+      credentials: nil,
+      poster: ->(*) { raise "must not post" }
+    )
+
+    assert_includes body[:comment], "+ method public void apiDiffDemoPong"
+    assert_equal "no Slack credentials were reachable", body[:slack_error]
+  end
+
+  # The comment is the report; Slack only mirrors it.
+  def test_run_still_returns_the_comment_when_slack_fails
+    body = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      pull_request_link: "<url|#42>",
+      credentials: ["xoxb-1", "#some-channel"],
+      poster: ->(*) { raise "slack is down" }
+    )
+
+    assert_includes body[:comment], "+ method public void apiDiffDemoPong"
+    assert_equal "slack is down", body[:slack_error]
+  end
+
+  def test_slack_credentials_accepts_the_legacy_ios_token_name
+    ENV["SLACK_CHANNEL_SDK_NEW_API"] = "#some-channel"
+    ENV["SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS"] = "xoxb-legacy"
+
+    assert_equal ["xoxb-legacy", "#some-channel"], ApiDiffReport.slack_credentials
+  ensure
+    ENV.delete("SLACK_CHANNEL_SDK_NEW_API")
+    ENV.delete("SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS")
+  end
+
+  def test_slack_credentials_is_nil_without_a_channel
+    ENV["SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB"] = "xoxb-1"
+    ENV.delete("SLACK_CHANNEL_SDK_NEW_API")
+
+    assert_nil ApiDiffReport.slack_credentials
+  ensure
+    ENV.delete("SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB")
+  end
+
+  def test_run_is_nil_when_no_signature_file_changed
+    assert_nil ApiDiffReport.run(
+      changed_files: ["purchases/src/main/kotlin/Purchases.kt"],
+      patch_for: ->(_file) { "irrelevant" },
+      pull_request_link: "<url|#42>",
+      credentials: ["xoxb-1", "#some-channel"],
+      poster: ->(*) { raise "must not post" }
+    )
+  end
+
+  def test_run_tolerates_a_missing_patch
+    assert_nil ApiDiffReport.run(
+      changed_files: ["purchases/api-defauts.txt"],
+      patch_for: ->(_file) { nil },
+      pull_request_link: "",
+      credentials: nil
+    )
+  end
+end


### PR DESCRIPTION
Brings the public API detector to Android: a Danger rule diffs the metalava signature files against the PR base, posts a collapsible diff on the PR, and mirrors a summary into the SDK API feed channel.

Companion change on `purchases-ios`: https://github.com/RevenueCat/purchases-ios/pull/7425

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

`purchases-ios` announces public API changes on every PR that touches its API surface. Android already has the hard half: metalava signature files committed to the repo, and the `metalava` job that fails when they drift.

What was missing is the "what changed in this PR" view. The drift gate cannot provide it: once the author regenerates the dump, the working-tree diff is empty and the evidence is gone. `purchases-ios` solves this by extracting its baselines at the merge base. Danger supplies it for free here, since its diff is already taken against the PR base.

### Description

- `danger/api_diff_report.rb` parses metalava signature diffs. It drops `}`, `package … {` and the format banner rather than allowlisting `method`/`ctor`/`field`, so a keyword metalava adds in a future release cannot silently go unreported.
- Declarations are deduplicated across `purchases/api-defauts.txt` and `purchases/api-entitlement.txt`, which hold two flavours of largely the same surface, so a shared addition is counted once. File order is preserved so a new type reads before its own members.
- `ApiDiffReport.run` is the single entry point: the Dangerfile passes in Danger's changed-file list, a patch lookup and the PR link, and gets back the comment body. Any failure in the block warns instead of failing the run, so a Slack outage or a parser bug cannot take the rest of the Dangerfile down with it.
- The channel name comes from the context rather than the CI config: the orb's `danger` job accepts no `environment:` block, and keeping an internal channel name out of a public repo is preferable regardless.
- The unit tests run as `post-steps` on the existing `revenuecat/danger` job, which already has Ruby and the checkout, so no job gains a toolchain it did not need.
- Test fixtures use deliberately synthetic declarations (`apiDiffDemoPing`), since a plausible-looking unreleased API name in a public repo reads as a roadmap hint.

Verification not visible in the diff: `danger dry_run` always feeds an empty file list, so it only proves the Dangerfile parses, `require_relative` resolves under Danger's `instance_eval`, and the rule is a no-op when nothing changed. The populated path was exercised by feeding a real `git diff` of `ui/debugview/api.txt` straight into `ApiDiffReport`. Two seams neither covers, both needing a PR that actually changes a signature file: `git.diff_for_file(...).patch` returning that unified diff, and `github.pr_json` supplying the PR link.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/Danger-only automation with isolated error handling; no runtime SDK or customer-facing behavior changes.
> 
> **Overview**
> Adds Android parity with **purchases-ios** for surfacing **public API** changes on PRs that touch metalava signature files (`api.txt`, `api-*.txt`).
> 
> **Danger** loads `ApiDiffReport`, diffs those files against the PR base, posts a **collapsible diff** on the PR, and **best-effort** posts a summary to the SDK API feed Slack channel via `slack-secrets`. Slack failures only **warn**; they do not fail Danger or block the PR comment.
> 
> **`danger/api_diff_report.rb`** parses unified patches (filters metalava noise, dedupes across `purchases` flavour files, caps size for GitHub/Slack). **`danger/api_diff_report_test.rb`** covers parsing, formatting, and Slack posting. CircleCI runs those tests as a **post-step** on the existing Danger job and wires the **`slack-secrets`** context for tokens/channel env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b0f82c064521ff11d7942bf163376408e79149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->