### PR TITLE
Fix font scaling setting on workflow paywalls

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -129,6 +129,7 @@ public data class WorkflowScreen(
     @SerialName("config") val config: JsonObject = JsonObject(emptyMap()),
     @SerialName("offering_identifier") val offeringIdentifier: String? = null,
     @SerialName("exit_offers") val exitOffers: ExitOffers? = null,
+    @SerialName("automatically_scale_font_size") val automaticallyScaleFontSize: Boolean = true,
     @Serializable(with = StateDeclarationMapSerializer::class)
     @SerialName("state_declarations") val stateDeclarations: Map<String, StateDeclaration>? = null,
 )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -115,6 +115,29 @@ internal class WorkflowModelsDeserializationTest {
         assertThat(declaration?.defaultValue?.content).isEqualTo("monthly")
     }
 
+    @Test
+    fun `WorkflowScreen reads automatically_scale_font_size`() {
+        val json = """
+            {
+              "template_name": "components",
+              "asset_base_url": "https://assets.pawwalls.com",
+              "components_config": {
+                "base": {
+                  "stack": {"type": "stack", "components": []},
+                  "background": {"type": "color", "value": {"light": {"type": "hex", "value": "#ffffff"}}}
+                }
+              },
+              "components_localizations": {"en_US": {}},
+              "default_locale": "en_US",
+              "automatically_scale_font_size": false
+            }
+        """.trimIndent()
+
+        val screen = JsonTools.json.decodeFromString(WorkflowScreen.serializer(), json)
+
+        assertThat(screen.automaticallyScaleFontSize).isFalse()
+    }
+
     /**
      * A workflow screen and an offering's paywall are the same backend document decoded through two
      * independent field lists, which is how `state_declarations` went missing.
@@ -130,8 +153,6 @@ internal class WorkflowModelsDeserializationTest {
             // Absent from the backend's per-screen payload (serialize_paywalls_as_screens).
             "zero_decimal_place_countries",
             "play_store_product_change_mode",
-            // Sent per screen but not wired through yet: workflow-backed paywalls use the default.
-            "automatically_scale_font_size",
         )
 
         val missing = PaywallComponentsData.serializer().descriptor.elementNames.toSet() -

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapper.kt
@@ -20,6 +20,7 @@ internal object WorkflowScreenMapper {
             defaultLocaleIdentifier = screen.defaultLocaleIdentifier,
             revision = screen.revision,
             exitOffers = screen.exitOffers,
+            automaticallyScaleFontSize = screen.automaticallyScaleFontSize,
             stateDeclarations = screen.stateDeclarations,
         )
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
@@ -75,6 +75,16 @@ class WorkflowScreenMapperTest {
     }
 
     @Test
+    fun `toPaywallComponentsData maps automaticallyScaleFontSize`() {
+        val data = WorkflowScreenMapper.toPaywallComponentsData(
+            screen = screen.copy(automaticallyScaleFontSize = false),
+            screenId = "screen_abc",
+        )
+
+        assertThat(data.automaticallyScaleFontSize).isFalse()
+    }
+
+    @Test
     fun `toPaywallComponents uses provided uiConfig`() {
         val screenId = "screen_abc"
         val uiConfig = UiConfig()


### PR DESCRIPTION
Workflow-backed paywalls drop `automatically_scale_font_size`, so the dashboard setting has no effect on Android.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small data-model and mapper change with tests; no auth or payment logic touched.
> 
> **Overview**
> Workflow-backed paywalls were ignoring the dashboard **automatically scale font size** setting because `automatically_scale_font_size` was never decoded on `WorkflowScreen` or passed through `WorkflowScreenMapper` to `PaywallComponentsData`.
> 
> This PR adds the field to `WorkflowScreen` (default `true`, matching offering paywalls), maps it in `WorkflowScreenMapper`, and updates the `PaywallComponentsData` field-parity test so the setting is no longer allow-listed as unwired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68b3ecb2a56d23e9b3f745bad55767e30d706291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->