### PR TITLE
feat(checkpoints): Add date and record collection rules dimension values

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -112,4 +112,8 @@ private val RulesDimensionValue.asRulesEngineValue: Value
         is RulesDimensionValue.BoolValue -> Value.BoolValue(value)
         is RulesDimensionValue.IntValue -> Value.IntValue(value)
         is RulesDimensionValue.DoubleValue -> Value.FloatValue(value)
+        is RulesDimensionValue.DateValue -> Value.IntValue(value.time)
+        is RulesDimensionValue.ObjectListValue -> Value.ArrayValue(
+            value.map { record -> Value.ObjectValue(record.mapValues { (_, item) -> item.asRulesEngineValue }) },
+        )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValue.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValue.kt
@@ -1,12 +1,15 @@
 package com.revenuecat.purchases.common.localrules
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import java.util.Date
 
 /**
- * A scalar exposed to the rules engine.
+ * A value exposed to the rules engine.
  *
- * Keeps the sources of dimensions independent from the engine's own value representation, and encodes that a
- * dimension is a scalar: arrays and objects are deliberately not expressible yet.
+ * Keeps the sources of dimensions independent from the engine's own value representation, so a source says what a
+ * dimension *is* and this package decides how JSON Logic sees it. A dimension has to be something an operator can
+ * compare or search, so an object is expressible only as an element of a collection — which is what the iteration
+ * operators search — and never on its own.
  *
  * Integers and doubles are separate so a source can say which it means — an API level is a whole number, a ratio is
  * not — even though the engine collapses both into the single number JSON Logic models, comparing and rendering
@@ -20,4 +23,24 @@ public sealed class RulesDimensionValue {
     public data class BoolValue(val value: Boolean) : RulesDimensionValue()
     public data class IntValue(val value: Long) : RulesDimensionValue()
     public data class DoubleValue(val value: Double) : RulesDimensionValue()
+
+    /**
+     * Reaches the engine as epoch milliseconds, so a predicate orders dates with the ordinary numeric operators
+     * and there is no date type for one platform to spell differently than another.
+     */
+    public data class DateValue(val value: Date) : RulesDimensionValue()
+
+    /**
+     * A collection of records, for a dimension the customer has any number of rather than one of — their
+     * purchases, their entitlements.
+     *
+     * Reaches the engine as an array of objects, which `some`, `all`, `none` and `filter` walk one record at a
+     * time. A record's own values are dimensions in their own right, so the same rules apply to them: a value the
+     * record has none of is left out, and an absent key resolves to null in the engine.
+     *
+     * A predicate inside an iteration operator sees only the record it is looking at, with no access to the scope
+     * around it, so a record has to carry every value a predicate about it might need — including the evaluation
+     * instant it is compared against.
+     */
+    public data class ObjectListValue(val value: List<Map<String, RulesDimensionValue>>) : RulesDimensionValue()
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -143,6 +143,10 @@ class RulesDimensionResolverTest {
                 "flag" to RulesDimensionValue.BoolValue(true),
                 "count" to RulesDimensionValue.IntValue(3),
                 "ratio" to RulesDimensionValue.DoubleValue(1.5),
+                "date" to RulesDimensionValue.DateValue(evaluationDate),
+                "records" to RulesDimensionValue.ObjectListValue(
+                    listOf(mapOf("id" to RulesDimensionValue.StringValue("one"))),
+                ),
             ),
         )
 
@@ -155,9 +159,84 @@ class RulesDimensionResolverTest {
                     "flag" to Value.BoolValue(true),
                     "count" to Value.IntValue(3),
                     "ratio" to Value.FloatValue(1.5),
+                    "date" to Value.IntValue(1_700_000_000_000),
+                    "records" to Value.ArrayValue(
+                        listOf(Value.ObjectValue(mapOf("id" to Value.StringValue("one")))),
+                    ),
                 ),
             ),
         )
+    }
+
+    @Test
+    fun `a date dimension is ordered by a predicate`() = runTest {
+        val resolver = resolver(
+            provider(
+                RulesDimensionNamespace.Device,
+                "expiresAt" to RulesDimensionValue.DateValue(Date(1_700_000_000_000)),
+            ),
+        )
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(
+            RulesEngine.evaluate("""{">": [{"var": "device.expiresAt"}, 1699999999999]}""", values).getOrThrow(),
+        ).isTrue()
+        assertThat(
+            RulesEngine.evaluate("""{">": [{"var": "device.expiresAt"}, 1700000000001]}""", values).getOrThrow(),
+        ).isFalse()
+    }
+
+    @Test
+    fun `an object list dimension is walked one record at a time by a predicate`() = runTest {
+        val resolver = resolver(
+            provider(
+                RulesDimensionNamespace.Device,
+                "purchases" to RulesDimensionValue.ObjectListValue(
+                    listOf(
+                        mapOf(
+                            "productId" to RulesDimensionValue.StringValue("plus"),
+                            "isActive" to RulesDimensionValue.BoolValue(false),
+                        ),
+                        mapOf(
+                            "productId" to RulesDimensionValue.StringValue("pro"),
+                            "isActive" to RulesDimensionValue.BoolValue(true),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val values = resolver.snapshot().getOrThrow().values
+
+        val active = """{"some": [{"var": "device.purchases"},
+            {"and": [{"==": [{"var": "productId"}, "pro"]}, {"var": "isActive"}]}]}"""
+        assertThat(RulesEngine.evaluate(active, values).getOrThrow()).isTrue()
+
+        // A record is searched on its own values, so the same product with the other record's state does not match.
+        val inactive = """{"some": [{"var": "device.purchases"},
+            {"and": [{"==": [{"var": "productId"}, "plus"]}, {"var": "isActive"}]}]}"""
+        assertThat(RulesEngine.evaluate(inactive, values).getOrThrow()).isFalse()
+
+        // A record is reachable by index too.
+        val byIndex = """{"==": [{"var": "device.purchases.1.productId"}, "pro"]}"""
+        assertThat(RulesEngine.evaluate(byIndex, values).getOrThrow()).isTrue()
+    }
+
+    @Test
+    fun `an empty object list is an empty array rather than an absent dimension`() = runTest {
+        val resolver = resolver(
+            provider(
+                RulesDimensionNamespace.Device,
+                "purchases" to RulesDimensionValue.ObjectListValue(emptyList()),
+            ),
+        )
+        val values = resolver.snapshot().getOrThrow().values
+
+        // "Has bought nothing" has to be a definite answer, which only a present, empty array gives.
+        assertThat(values["device"]).isEqualTo(Value.ObjectValue(mapOf("purchases" to Value.ArrayValue(emptyList()))))
+        assertThat(
+            RulesEngine.evaluate("""{"none": [{"var": "device.purchases"}, {"var": "isActive"}]}""", values)
+                .getOrThrow(),
+        ).isTrue()
     }
 
     @Test


### PR DESCRIPTION
### Description

`RulesDimensionValue` was limited to basic primitives. This PR adds support for 2 more types: Dates and Records. These will be used in the follow-up PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive sealed-class variants and resolver mapping in local rules with no changes to purchase or auth flows; risk is limited to how new dimension types are serialized for rules evaluation.
> 
> **Overview**
> Extends **`RulesDimensionValue`** beyond string/bool/int/double so checkpoint rules can express **dates** and **collections of records** (e.g. purchases, entitlements).
> 
> **`DateValue`** is converted to epoch milliseconds in the rules engine, so predicates use normal numeric comparison without a separate date type.
> 
> **`ObjectListValue`** becomes an array of objects for JSON Logic iteration (`some`, `all`, `none`, `filter`); nested record fields map recursively, and an empty list stays a present empty array so “no records” is explicit.
> 
> **`RulesDimensionResolver`** mapping and **`RulesDimensionResolverTest`** cover conversion, date ordering, per-record predicates, and empty lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b171d10a0edb1370d172c97814402ec213f552f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->