### PR TITLE
feat(checkpoints): Add SubscriberDimensionProvider with the customer's purchases

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -33,6 +33,7 @@ import com.revenuecat.purchases.common.localrules.DeviceDimensionProvider
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesEngineLoggerBridge
 import com.revenuecat.purchases.common.localrules.StoreDimensionProvider
+import com.revenuecat.purchases.common.localrules.SubscriberDimensionProvider
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.networking.APISourceFailover
 import com.revenuecat.purchases.common.networking.DeviceConnectivityChecker
@@ -51,6 +52,8 @@ import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopicStore
+import com.revenuecat.purchases.common.safeResume
+import com.revenuecat.purchases.common.safeResumeWithException
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
@@ -79,6 +82,7 @@ import com.revenuecat.purchases.utils.PurchaseParamsValidator
 import com.revenuecat.purchases.utils.UrlConnectionFactory
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencyManager
+import kotlinx.coroutines.suspendCancellableCoroutine
 import java.net.URL
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -361,6 +365,10 @@ internal class PurchasesFactory(
                     // Only read during a checkpoint evaluation, so the instance is configured by then. Same
                     // reasoning as CheckpointWorkflowResolverImpl's getOfferings.
                     StoreDimensionProvider { Purchases.sharedInstance.awaitStorefrontCountryCode() },
+                    SubscriberDimensionProvider(
+                        appUserId = { Purchases.sharedInstance.purchasesOrchestrator.appUserID },
+                        customerInfo = { Purchases.sharedInstance.purchasesOrchestrator.awaitCustomerInfo() },
+                    ),
                 ),
             )
             if (remoteConfigManager != null && uiConfigProvider != null && workflowsConfigProvider != null) {
@@ -677,3 +685,22 @@ internal class PurchasesFactory(
         ): Boolean = diagnosticsEnabled && !uiPreviewMode
     }
 }
+
+/**
+ * The cache when it is warm, the initial fetch otherwise, so the first checkpoint of a session can still read
+ * subscriber dimensions.
+ *
+ * Goes through the orchestrator rather than `Purchases.awaitCustomerInfo`, which only exists in the `defaults`
+ * source set: local rule evaluation is wired for both flavors.
+ */
+private suspend fun PurchasesOrchestrator.awaitCustomerInfo(): CustomerInfo =
+    suspendCancellableCoroutine { continuation ->
+        getCustomerInfo(
+            fetchPolicy = CacheFetchPolicy.default(),
+            trackDiagnostics = false,
+            callback = receiveCustomerInfoCallback(
+                onSuccess = { continuation.safeResume(it) },
+                onError = { continuation.safeResumeWithException(PurchasesException(it)) },
+            ),
+        )
+    }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -18,6 +18,9 @@ internal enum class RulesDimensionNamespace(val key: String) {
     Custom("custom"),
     Device("device"),
     Store("store"),
+
+    /** What the customer has bought. Named for the dashboard's own word for it, not for `CustomerInfo`. */
+    Subscriber("subscriber"),
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberDimensionProvider.kt
@@ -1,0 +1,240 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.EntitlementInfo
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.OwnershipType
+import com.revenuecat.purchases.PeriodType
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.SubscriptionInfo
+import com.revenuecat.purchases.common.warnLog
+import com.revenuecat.purchases.models.Transaction
+import kotlinx.coroutines.CancellationException
+import java.util.Date
+
+/**
+ * Subscriber dimensions: what the customer has bought, and when.
+ *
+ * Everything but the app user ID is derived from [CustomerInfo], read on every evaluation because a purchase, a
+ * renewal or a cancellation lands mid-session and an audience keyed on subscription state has to agree with what
+ * the customer's access actually is.
+ *
+ * Unlike the dashboard, which evaluates the same audience over production purchases only, sandbox purchases count
+ * here: a rule has to be testable in a debug build or against a license tester, where every purchase is a sandbox
+ * one. [hasMadeSandboxPurchase][KEY_HAS_MADE_SANDBOX_PURCHASE] is the one dimension that reads the flag itself.
+ *
+ * A dimension the customer has no value for is omitted rather than guessed — an absent key resolves to null in the
+ * engine, which is an ordinary non-match. Booleans are the exception: "has never purchased" answers
+ * `hasMadeNonSubscriptionPurchase` with a definite `false`, it does not leave it unknown.
+ */
+internal class SubscriberDimensionProvider(
+    private val appUserId: () -> String?,
+    private val customerInfo: suspend () -> CustomerInfo,
+) : RulesDimensionProvider {
+
+    override val identifier: String = "subscriber"
+
+    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.Subscriber
+
+    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+        appUserIdDimension() + customerInfoDimensions(date)
+
+    /**
+     * Read separately from the rest so a rule targeting the app user ID does not depend on the network: the ID is
+     * known as soon as the SDK is configured, while [CustomerInfo] may still be in flight.
+     */
+    private fun appUserIdDimension(): Map<String, RulesDimensionValue> {
+        val appUserId = try {
+            appUserId()
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            warnLog { "The app user ID is unavailable, so the customerId dimension can't be evaluated: $e" }
+            null
+        }
+        return appUserId
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { mapOf(KEY_CUSTOMER_ID to RulesDimensionValue.StringValue(it)) }
+            .orEmpty()
+    }
+
+    /**
+     * A customer info that cannot be read contributes no dimensions instead of failing the snapshot: the read
+     * reaches out through the configured instance, which an app can tear down mid-evaluation, and it can fall back
+     * to the network, which can fail. Neither should abort the snapshot and take an otherwise resolvable
+     * checkpoint down with it. Cancellation is not a failure and propagates.
+     */
+    private suspend fun customerInfoDimensions(date: Date): Map<String, RulesDimensionValue> {
+        val customerInfo = try {
+            customerInfo()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            warnLog { "The customer info is unavailable, so subscriber dimensions can't be evaluated: $e" }
+            return emptyMap()
+        }
+        return customerInfo.dimensions(date)
+    }
+
+    private fun CustomerInfo.dimensions(date: Date): Map<String, RulesDimensionValue> {
+        val subscriptions = subscriptionsByProductIdentifier.values
+        val transactions = nonSubscriptionTransactions
+        val latestSubscription = subscriptions.maxByOrNull { it.purchaseDate }
+        val latestPurchase = latestPurchase(latestSubscription, transactions)
+        val trialSubscription = subscriptions
+            .filter { it.periodType == PeriodType.TRIAL }
+            .maxByOrNull { it.purchaseDate }
+        val optOutAt = latestSubscription?.unsubscribeDetectedAt
+        val optedOutOfTrial = latestSubscription?.periodType == PeriodType.TRIAL
+
+        return buildMap {
+            putString(KEY_ORIGINAL_APP_USER_ID, originalAppUserId)
+            putBool(KEY_IS_CURRENTLY_TRIALING, subscriptions.any { it.isActive && it.periodType == PeriodType.TRIAL })
+            putBool(KEY_IS_RC_PROMO, latestPurchase?.store == Store.PROMOTIONAL)
+            putBool(KEY_HAS_MADE_NON_SUBSCRIPTION_PURCHASE, transactions.isNotEmpty())
+            putBool(
+                KEY_HAS_MADE_SANDBOX_PURCHASE,
+                subscriptions.any { it.isSandbox } || transactions.any { it.isSandbox },
+            )
+            // Only a subscription has a renewal intent; with none there is nothing to report rather than a `false`.
+            latestSubscription?.let { putBool(KEY_LATEST_AUTO_RENEW_INTENT, it.willRenew) }
+
+            putStringList(KEY_ALL_PURCHASED_PRODUCT_IDS, allPurchasedProductIds.sorted())
+            putStringList(
+                KEY_ANY_ACTIVE_STORE,
+                subscriptions.filter { it.isActiveOrInGracePeriod(date) }
+                    .map { it.store.stringValue }
+                    .distinct()
+                    .sorted(),
+            )
+            putStringList(KEY_LATEST_ENTITLEMENTS, latestEntitlementIdentifiers(latestPurchase))
+
+            putString(KEY_LATEST_STORE, latestPurchase?.store?.stringValue)
+            putString(KEY_LATEST_OWNERSHIP_TYPE, latestPurchase?.subscription?.ownershipType?.dimensionValue)
+
+            putDate(KEY_FIRST_SEEN_AT, earliestKnownDate(subscriptions, transactions))
+            // The date the backend last answered us, which is when it last saw this customer through this device.
+            putDate(KEY_LAST_SEEN_AT, requestDate)
+            putDate(KEY_LATEST_EXPIRATION_AT, latestExpirationDate)
+            putDate(KEY_MOST_RECENT_PURCHASE_AT, latestPurchase?.purchaseDate)
+            // A renewal starts a new subscription period, so it is that period's purchase date.
+            putDate(KEY_MOST_RECENT_RENEWAL_AT, latestSubscription?.purchaseDate)
+            // Reading only the latest subscription is what makes these go back to absent on a resubscribe.
+            putDate(KEY_SUBSCRIPTION_OPT_OUT_AT, optOutAt?.takeUnless { optedOutOfTrial })
+            putDate(KEY_TRIAL_OPT_OUT_AT, optOutAt?.takeIf { optedOutOfTrial })
+            // Known only while the trial is the current period: once it converts, the SDK no longer carries the
+            // trial window.
+            putDate(KEY_TRIAL_START_AT, trialSubscription?.purchaseDate)
+            putDate(KEY_TRIAL_END_AT, trialSubscription?.expiresDate)
+        }
+    }
+
+    private fun latestPurchase(
+        latestSubscription: SubscriptionInfo?,
+        transactions: List<Transaction>,
+    ): LatestPurchase? = listOfNotNull(
+        latestSubscription?.let {
+            LatestPurchase(it.purchaseDate, it.productIdentifier, it.productPlanIdentifier, it.store, subscription = it)
+        },
+        transactions.maxByOrNull { it.purchaseDate }?.let {
+            LatestPurchase(it.purchaseDate, it.productIdentifier, productPlanIdentifier = null, it.store, null)
+        },
+    ).maxByOrNull { it.purchaseDate }
+
+    private fun CustomerInfo.latestEntitlementIdentifiers(latestPurchase: LatestPurchase?): List<String> =
+        latestPurchase?.let { purchase ->
+            entitlements.all.values
+                .filter { it.unlockedBy(purchase) }
+                .map { it.identifier }
+                .sorted()
+        }.orEmpty()
+
+    /**
+     * The dashboard builds this out of the customer's creation date too, which is the backend's alone. The rest of
+     * it is here: when this install first saw the customer, and when they first bought anything.
+     */
+    private fun CustomerInfo.earliestKnownDate(
+        subscriptions: Collection<SubscriptionInfo>,
+        transactions: List<Transaction>,
+    ): Date = (
+        listOf(firstSeen) +
+            listOfNotNull(originalPurchaseDate) +
+            subscriptions.flatMap { listOfNotNull(it.originalPurchaseDate, it.purchaseDate) } +
+            transactions.flatMap { listOfNotNull(it.originalPurchaseDate, it.purchaseDate) }
+        ).min()
+
+    /**
+     * The customer's most recent purchase of any kind. A subscription carries facts a one-time purchase does not,
+     * so it rides along for the dimensions only it can answer.
+     */
+    private class LatestPurchase(
+        val purchaseDate: Date,
+        val productIdentifier: String,
+        val productPlanIdentifier: String?,
+        val store: Store,
+        val subscription: SubscriptionInfo?,
+    )
+
+    internal companion object {
+        const val KEY_ALL_PURCHASED_PRODUCT_IDS = "allPurchasedProductIds"
+        const val KEY_ANY_ACTIVE_STORE = "anyActiveStore"
+        const val KEY_CUSTOMER_ID = "customerId"
+        const val KEY_FIRST_SEEN_AT = "firstSeenAt"
+        const val KEY_HAS_MADE_NON_SUBSCRIPTION_PURCHASE = "hasMadeNonSubscriptionPurchase"
+        const val KEY_HAS_MADE_SANDBOX_PURCHASE = "hasMadeSandboxPurchase"
+        const val KEY_IS_CURRENTLY_TRIALING = "isCurrentlyTrialing"
+        const val KEY_IS_RC_PROMO = "isRcPromo"
+        const val KEY_LAST_SEEN_AT = "lastSeenAt"
+        const val KEY_LATEST_AUTO_RENEW_INTENT = "latestAutoRenewIntent"
+        const val KEY_LATEST_ENTITLEMENTS = "latestEntitlements"
+        const val KEY_LATEST_EXPIRATION_AT = "latestExpirationAt"
+        const val KEY_LATEST_OWNERSHIP_TYPE = "latestOwnershipType"
+        const val KEY_LATEST_STORE = "latestStore"
+        const val KEY_MOST_RECENT_PURCHASE_AT = "mostRecentPurchaseAt"
+        const val KEY_MOST_RECENT_RENEWAL_AT = "mostRecentRenewalAt"
+        const val KEY_ORIGINAL_APP_USER_ID = "originalAppUserId"
+        const val KEY_SUBSCRIPTION_OPT_OUT_AT = "subscriptionOptOutAt"
+        const val KEY_TRIAL_END_AT = "trialEndAt"
+        const val KEY_TRIAL_OPT_OUT_AT = "trialOptOutAt"
+        const val KEY_TRIAL_START_AT = "trialStartAt"
+
+        /**
+         * The store keeps serving a subscription while a billing issue is being retried, so a customer in a grace
+         * period is one the dashboard counts as buying from that store.
+         */
+        private fun SubscriptionInfo.isActiveOrInGracePeriod(date: Date): Boolean =
+            isActive || gracePeriodExpiresDate?.after(date) == true
+
+        /**
+         * The base plan is part of what was bought on Google, so it is part of the comparison: two base plans of
+         * one subscription are two different products.
+         */
+        private fun EntitlementInfo.unlockedBy(purchase: LatestPurchase): Boolean =
+            productIdentifier == purchase.productIdentifier &&
+                productPlanIdentifier == purchase.productPlanIdentifier
+
+        private val OwnershipType.dimensionValue: String?
+            get() = when (this) {
+                OwnershipType.PURCHASED -> "PURCHASED"
+                OwnershipType.FAMILY_SHARED -> "FAMILY_SHARED"
+                // Not a value to compare against: an unknown ownership type is the absence of one.
+                OwnershipType.UNKNOWN -> null
+            }
+
+        private fun MutableMap<String, RulesDimensionValue>.putBool(key: String, value: Boolean) {
+            put(key, RulesDimensionValue.BoolValue(value))
+        }
+
+        private fun MutableMap<String, RulesDimensionValue>.putString(key: String, value: String?) {
+            if (!value.isNullOrEmpty()) put(key, RulesDimensionValue.StringValue(value))
+        }
+
+        private fun MutableMap<String, RulesDimensionValue>.putDate(key: String, value: Date?) {
+            if (value != null) put(key, RulesDimensionValue.DateValue(value))
+        }
+
+        private fun MutableMap<String, RulesDimensionValue>.putStringList(key: String, values: List<String>) {
+            if (values.isNotEmpty()) put(key, RulesDimensionValue.StringListValue(values))
+        }
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberDimensionProviderTest.kt
@@ -1,0 +1,414 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.CustomerInfoFactory
+import com.revenuecat.purchases.rules.RulesEngine
+import com.revenuecat.purchases.rules.Value
+import com.revenuecat.purchases.utils.Iso8601Utils
+import com.revenuecat.purchases.utils.Responses
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class SubscriberDimensionProviderTest {
+
+    private val date = Date(1_700_000_000_000)
+
+    @Test
+    fun `provides the subscriber dimensions`() = runTest {
+        val dimensions = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date)
+
+        assertThat(dimensions).isEqualTo(
+            mapOf(
+                "customerId" to string("current_user"),
+                "originalAppUserId" to string("original_user"),
+                "allPurchasedProductIds" to list("coins", "legacy:annual", "premium:monthly"),
+                "anyActiveStore" to list("amazon", "play_store"),
+                "latestEntitlements" to list("extra", "premium"),
+                "latestStore" to string("play_store"),
+                "latestOwnershipType" to string("PURCHASED"),
+                "isCurrentlyTrialing" to bool(false),
+                "isRcPromo" to bool(false),
+                "hasMadeNonSubscriptionPurchase" to bool(true),
+                "hasMadeSandboxPurchase" to bool(true),
+                "latestAutoRenewIntent" to bool(true),
+                "firstSeenAt" to date("2021-01-01T00:00:00Z"),
+                "lastSeenAt" to date("2024-06-01T00:00:00Z"),
+                "latestExpirationAt" to date("2100-01-01T00:00:00Z"),
+                "mostRecentPurchaseAt" to date("2024-01-15T10:00:00Z"),
+                "mostRecentRenewalAt" to date("2024-01-15T10:00:00Z"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a customer who has never purchased answers the questions that have an answer`() = runTest {
+        val dimensions = provider(customerInfo(Responses.validEmptyPurchaserResponse)).dimensions(date)
+
+        assertThat(dimensions).isEqualTo(
+            mapOf(
+                "customerId" to string("current_user"),
+                "isCurrentlyTrialing" to bool(false),
+                "isRcPromo" to bool(false),
+                "hasMadeNonSubscriptionPurchase" to bool(false),
+                "hasMadeSandboxPurchase" to bool(false),
+                "firstSeenAt" to date("2019-07-17T00:05:54Z"),
+                "lastSeenAt" to date("2019-08-16T10:30:42Z"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a trial reports its window and keeps its opt-out apart from a subscription's`() = runTest {
+        val dimensions = provider(customerInfo(TRIALING_RESPONSE)).dimensions(date)
+
+        assertThat(dimensions["isCurrentlyTrialing"]).isEqualTo(bool(true))
+        assertThat(dimensions["trialStartAt"]).isEqualTo(date("2024-05-01T00:00:00Z"))
+        assertThat(dimensions["trialEndAt"]).isEqualTo(date("2100-01-01T00:00:00Z"))
+        assertThat(dimensions["trialOptOutAt"]).isEqualTo(date("2024-05-03T00:00:00Z"))
+        assertThat(dimensions).doesNotContainKey("subscriptionOptOutAt")
+        // An unsubscribe is exactly what says the renewal is not coming.
+        assertThat(dimensions["latestAutoRenewIntent"]).isEqualTo(bool(false))
+    }
+
+    @Test
+    fun `a paid subscription's opt-out is kept apart from a trial's`() = runTest {
+        val dimensions = provider(customerInfo(UNSUBSCRIBED_RESPONSE)).dimensions(date)
+
+        assertThat(dimensions["subscriptionOptOutAt"]).isEqualTo(date("2024-05-03T00:00:00Z"))
+        assertThat(dimensions).doesNotContainKey("trialOptOutAt")
+        assertThat(dimensions["isCurrentlyTrialing"]).isEqualTo(bool(false))
+    }
+
+    @Test
+    fun `an entitlement granted through RevenueCat is reported as a promo`() = runTest {
+        val dimensions = provider(customerInfo(PROMO_RESPONSE)).dimensions(date)
+
+        assertThat(dimensions["isRcPromo"]).isEqualTo(bool(true))
+        assertThat(dimensions["latestStore"]).isEqualTo(string("promotional"))
+        // A promo never renews.
+        assertThat(dimensions["latestAutoRenewIntent"]).isEqualTo(bool(false))
+    }
+
+    @Test
+    fun `an unknown ownership type is reported as no ownership type at all`() = runTest {
+        val dimensions = provider(customerInfo(PROMO_RESPONSE)).dimensions(date)
+
+        assertThat(dimensions).doesNotContainKey("latestOwnershipType")
+    }
+
+    @Test
+    fun `family sharing is reported when the latest purchase is shared`() = runTest {
+        val dimensions = provider(customerInfo(FAMILY_SHARED_RESPONSE)).dimensions(date)
+
+        assertThat(dimensions["latestOwnershipType"]).isEqualTo(string("FAMILY_SHARED"))
+    }
+
+    @Test
+    fun `a customer info that cannot be read leaves the other dimensions usable`() = runTest {
+        // Not just PurchasesException: the read goes through the configured instance, which an app can tear down
+        // mid-evaluation, and it can fall back to the network.
+        val failures = listOf(
+            PurchasesException(PurchasesError(PurchasesErrorCode.NetworkError, "Nope.")),
+            UninitializedPropertyAccessException("There is no singleton instance."),
+            IllegalStateException("Something else entirely."),
+        )
+
+        for (failure in failures) {
+            val snapshot = RulesDimensionResolver(
+                providers = listOf(
+                    deviceProvider(),
+                    SubscriberDimensionProvider(appUserId = { "current_user" }, customerInfo = { throw failure }),
+                ),
+            ).snapshot()
+
+            assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
+            // The app user ID is known without asking the backend, so a rule on it survives the failure.
+            assertThat(snapshot.getOrThrow().values["subscriber"]).describedAs("%s", failure).isEqualTo(
+                Value.ObjectValue(mapOf("customerId" to Value.StringValue("current_user"))),
+            )
+        }
+    }
+
+    @Test
+    fun `an unknown app user ID leaves the subscriber dimensions usable`() = runTest {
+        val provider = SubscriberDimensionProvider(
+            appUserId = { throw UninitializedPropertyAccessException("There is no singleton instance.") },
+            customerInfo = { customerInfo(SUBSCRIBED_RESPONSE) },
+        )
+
+        val dimensions = provider.dimensions(date)
+
+        assertThat(dimensions).doesNotContainKey("customerId")
+        assertThat(dimensions["originalAppUserId"]).isEqualTo(string("original_user"))
+    }
+
+    @Test
+    fun `cancellation while reading the customer info propagates`() = runTest {
+        val cancelling = SubscriberDimensionProvider(
+            appUserId = { "current_user" },
+            customerInfo = { throw CancellationException("cancelled") },
+        )
+
+        val thrown = try {
+            cancelling.dimensions(date)
+            null
+        } catch (e: CancellationException) {
+            e
+        }
+
+        assertThat(thrown).hasMessage("cancelled")
+    }
+
+    @Test
+    fun `the customer info is read on every evaluation`() = runTest {
+        var response = Responses.validEmptyPurchaserResponse
+        val provider = SubscriberDimensionProvider(
+            appUserId = { "current_user" },
+            customerInfo = { customerInfo(response) },
+        )
+
+        assertThat(provider.dimensions(date)["hasMadeNonSubscriptionPurchase"]).isEqualTo(bool(false))
+
+        response = SUBSCRIBED_RESPONSE
+
+        assertThat(provider.dimensions(date)["hasMadeNonSubscriptionPurchase"]).isEqualTo(bool(true))
+    }
+
+    @Test
+    fun `a subscription in a grace period still counts as bought from its store`() = runTest {
+        // "legacy:annual" expired in 2023 but its grace period runs to 2100.
+        val dimensions = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date)
+
+        assertThat(dimensions["anyActiveStore"]).isEqualTo(list("amazon", "play_store"))
+    }
+
+    @Test
+    fun `subscriber dimensions are reachable by dot-path from a predicate`() = runTest {
+        val values = RulesDimensionResolver(providers = listOf(provider(customerInfo(SUBSCRIBED_RESPONSE))))
+            .snapshot()
+            .getOrThrow()
+            .values
+
+        val predicates = listOf(
+            """{"==": [{"var": "subscriber.customerId"}, "current_user"]}""",
+            """{">": [{"var": "subscriber.latestExpirationAt"}, 1700000000000]}""",
+            """{"in": ["premium", {"var": "subscriber.latestEntitlements"}]}""",
+            """{"!": [{"var": "subscriber.isCurrentlyTrialing"}]}""",
+        )
+
+        for (predicate in predicates) {
+            assertThat(RulesEngine.evaluate(predicate, values).getOrThrow()).describedAs(predicate).isTrue()
+        }
+    }
+
+    private fun provider(customerInfo: CustomerInfo) = SubscriberDimensionProvider(
+        appUserId = { "current_user" },
+        customerInfo = { customerInfo },
+    )
+
+    private fun deviceProvider() = object : RulesDimensionProvider {
+        override val identifier = "device"
+        override val namespace = RulesDimensionNamespace.Device
+        override suspend fun dimensions(date: Date) = mapOf("platform" to string("android"))
+    }
+
+    private fun customerInfo(response: String): CustomerInfo =
+        CustomerInfoFactory.buildCustomerInfo(JSONObject(response), null, VerificationResult.NOT_REQUESTED)
+
+    private fun string(value: String) = RulesDimensionValue.StringValue(value)
+    private fun bool(value: Boolean) = RulesDimensionValue.BoolValue(value)
+    private fun list(vararg values: String) = RulesDimensionValue.StringListValue(values.toList())
+    private fun date(iso8601: String) = RulesDimensionValue.DateValue(Iso8601Utils.parse(iso8601))
+
+    private companion object {
+
+        /**
+         * A Google subscription bought most recently, an Amazon one that expired but is in a grace period, and a
+         * one-time purchase. Two entitlements are unlocked by the latest subscription and one by the older one.
+         */
+        val SUBSCRIBED_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "premium": {
+                  ${subscription(
+                store = "play_store",
+                purchaseDate = "2024-01-15T10:00:00Z",
+                originalPurchaseDate = "2021-01-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = "PURCHASED",
+            )}
+                },
+                "legacy": {
+                  ${subscription(
+                store = "amazon",
+                purchaseDate = "2022-06-01T00:00:00Z",
+                originalPurchaseDate = "2022-06-01T00:00:00Z",
+                expiresDate = "2023-06-01T00:00:00Z",
+                ownershipType = "FAMILY_SHARED",
+                productPlanIdentifier = "annual",
+                gracePeriodExpiresDate = "2100-01-01T00:00:00Z",
+            )}
+                }
+            """,
+            nonSubscriptions = """
+                "coins": [
+                  {
+                    "id": "abc123",
+                    "is_sandbox": true,
+                    "original_purchase_date": "2023-03-03T00:00:00Z",
+                    "purchase_date": "2023-03-03T00:00:00Z",
+                    "store": "play_store"
+                  }
+                ]
+            """,
+            entitlements = """
+                "premium": {
+                  "expires_date": "2100-01-01T00:00:00Z",
+                  "product_identifier": "premium",
+                  "product_plan_identifier": "monthly",
+                  "purchase_date": "2024-01-15T10:00:00Z"
+                },
+                "extra": {
+                  "expires_date": "2100-01-01T00:00:00Z",
+                  "product_identifier": "premium",
+                  "product_plan_identifier": "monthly",
+                  "purchase_date": "2024-01-15T10:00:00Z"
+                },
+                "old": {
+                  "expires_date": "2023-06-01T00:00:00Z",
+                  "product_identifier": "legacy",
+                  "product_plan_identifier": "annual",
+                  "purchase_date": "2022-06-01T00:00:00Z"
+                }
+            """,
+        )
+
+        val TRIALING_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "premium": {
+                  ${subscription(
+                store = "play_store",
+                purchaseDate = "2024-05-01T00:00:00Z",
+                originalPurchaseDate = "2024-05-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = "PURCHASED",
+                periodType = "trial",
+                unsubscribeDetectedAt = "2024-05-03T00:00:00Z",
+            )}
+                }
+            """,
+        )
+
+        val UNSUBSCRIBED_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "premium": {
+                  ${subscription(
+                store = "play_store",
+                purchaseDate = "2024-05-01T00:00:00Z",
+                originalPurchaseDate = "2024-05-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = "PURCHASED",
+                unsubscribeDetectedAt = "2024-05-03T00:00:00Z",
+            )}
+                }
+            """,
+        )
+
+        val PROMO_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "rc_promo_pro_monthly": {
+                  ${subscription(
+                store = "promotional",
+                purchaseDate = "2024-05-01T00:00:00Z",
+                originalPurchaseDate = "2024-05-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = null,
+            )}
+                }
+            """,
+        )
+
+        val FAMILY_SHARED_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "premium": {
+                  ${subscription(
+                store = "app_store",
+                purchaseDate = "2024-05-01T00:00:00Z",
+                originalPurchaseDate = "2024-05-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = "FAMILY_SHARED",
+            )}
+                }
+            """,
+        )
+
+        @Suppress("LongParameterList")
+        private fun subscription(
+            store: String,
+            purchaseDate: String,
+            originalPurchaseDate: String,
+            expiresDate: String,
+            ownershipType: String?,
+            productPlanIdentifier: String? = "monthly",
+            periodType: String = "normal",
+            unsubscribeDetectedAt: String? = null,
+            gracePeriodExpiresDate: String? = null,
+        ) = """
+            "store": "$store",
+            "product_plan_identifier": ${productPlanIdentifier.asJsonString()},
+            "purchase_date": "$purchaseDate",
+            "original_purchase_date": "$originalPurchaseDate",
+            "expires_date": "$expiresDate",
+            "period_type": "$periodType",
+            "is_sandbox": true,
+            "unsubscribe_detected_at": ${unsubscribeDetectedAt.asJsonString()},
+            "billing_issues_detected_at": null,
+            "grace_period_expires_date": ${gracePeriodExpiresDate.asJsonString()},
+            "auto_resume_date": null,
+            "refunded_at": null,
+            "store_transaction_id": "GPA.0000-0000-0000-00000"${ownershipType.asOwnershipTypeEntry()}
+        """
+
+        private fun subscriberResponse(
+            subscriptions: String = "",
+            nonSubscriptions: String = "",
+            entitlements: String = "",
+        ) = """
+            {
+              "request_date": "2024-06-01T00:00:00Z",
+              "subscriber": {
+                "original_app_user_id": "original_user",
+                "original_application_version": "1.0",
+                "first_seen": "2022-01-01T00:00:00Z",
+                "original_purchase_date": "2021-01-01T00:00:00Z",
+                "management_url": null,
+                "subscriptions": { $subscriptions },
+                "non_subscriptions": { $nonSubscriptions },
+                "entitlements": { $entitlements }
+              }
+            }
+        """
+
+        private fun String?.asJsonString() = this?.let { "\"$it\"" } ?: "null"
+
+        // The backend omits the key rather than sending null, and so must the fixture: the response model
+        // defaults it instead of accepting null.
+        private fun String?.asOwnershipTypeEntry() = this?.let { ",\n\"ownership_type\": \"$it\"" }.orEmpty()
+    }
+}


### PR DESCRIPTION
### Description

Adds the customer's subscription state as a third dimension source, under a `subscriber` namespace: 21 of the 23 fields `dimensions.csv` lists for that group, all derived on-device from `CustomerInfo`.

| Key | Derived from |
|---|---|
| `customerId` / `originalAppUserId` | the app user ID / `CustomerInfo.originalAppUserId` |
| `allPurchasedProductIds` | `CustomerInfo.allPurchasedProductIds` |
| `anyActiveStore` | the stores of the subscriptions that are active or in a grace period |
| `latestStore`, `latestOwnershipType`, `isRcPromo`, `latestEntitlements` | the most recent purchase of any kind (its subscription, where only a subscription can answer) |
| `latestAutoRenewIntent`, `mostRecentRenewalAt`, `subscriptionOptOutAt`, `trialOptOutAt` | the most recent subscription |
| `isCurrentlyTrialing`, `trialStartAt`, `trialEndAt` | the subscription whose current period is a trial |
| `hasMadeNonSubscriptionPurchase`, `hasMadeSandboxPurchase`, `mostRecentPurchaseAt` | every purchase |
| `firstSeenAt`, `lastSeenAt`, `latestExpirationAt` | `firstSeen` + the earliest purchase, `requestDate`, `latestExpirationDate` |

Read on every evaluation rather than snapshotted: a purchase, a renewal or a cancellation lands mid-session, and an audience keyed on subscription state has to agree with what the customer's access actually is. It goes through the orchestrator rather than `Purchases.awaitCustomerInfo`, which only exists in the `defaults` source set, and asks for the cache with a fetch fallback so the first checkpoint of a session is not left without subscriber dimensions on a fresh install.

The app user ID is read separately from the rest, so a rule on `subscriber.customerId` still gets an answer when the customer info read fails. A failed read contributes no other dimensions instead of failing the snapshot, like `StoreDimensionProvider`.

#### Deliberate differences from the dashboard

- **Sandbox purchases count.** The dashboard evaluates these fields over production purchases only. Mirroring that would leave every subscriber rule unmatchable in a debug build or against a license tester, where every purchase is a sandbox one. `hasMadeSandboxPurchase` is the one dimension that reads the flag itself.
- **`status` and `latestProduct` are left out.** `status`'s value set isn't settled, and `latestProduct`'s exact operators compare the RevenueCat product ID, which the SDK never sees — it only has the store identifier. A predicate reading either resolves to null in the engine, which is an ordinary non-match rather than an error.

#### Known local limitations

- `trialStartAt` / `trialEndAt` are knowable only while the trial is the current period. Once it converts, the SDK no longer carries the trial window while the backend still does.
- `firstSeenAt` cannot include the backend's customer creation date; `firstSeen` and the earliest purchase are the closest local facts.
- `lastSeenAt` is `CustomerInfo.requestDate` — when the backend last answered us, which is when it last saw this customer through this device.
