### PR TITLE
feat(admob): add next-gen suspend interstitial loading

### DIFF
--- a/feature/admob-next-gen/README.md
+++ b/feature/admob-next-gen/README.md
@@ -172,6 +172,22 @@ Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
 interstitialAd?.show(this, placement = "level_complete_interstitial")
 ```
 
+The coroutine overload returns Google's original load result:
+
+```kotlin
+lifecycleScope.launch {
+    when (
+        val result = Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
+            adRequest = adRequest,
+            placement = "game_interstitial",
+        )
+    ) {
+        is AdLoadResult.Success -> interstitialAd = result.ad
+        is AdLoadResult.Failure -> interstitialAd = null
+    }
+}
+```
+
 > [!IMPORTANT]
 > Do not assign `interstitialAd.adEventCallback` directly after a tracked load. Direct assignment replaces
 > RevenueCat's tracking wrapper and prevents `show(activity, placement)` from applying its placement override. Pass

--- a/feature/admob-next-gen/api.txt
+++ b/feature/admob-next-gen/api.txt
@@ -2,7 +2,8 @@
 package com.revenuecat.purchases.admob.nextgen {
 
   public final class AdTrackerAdMobNextGen {
-    method @KotlinOnly @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void loadAndTrackInterstitialAd(com.revenuecat.purchases.ads.events.AdTracker, com.google.android.libraries.ads.mobile.sdk.common.AdRequest adRequest, optional String? placement, optional com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback<com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd>? loadCallback, optional com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback? adEventCallback);
+    method @KotlinOnly @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static void loadAndTrackInterstitialAd(com.revenuecat.purchases.ads.events.AdTracker, com.google.android.libraries.ads.mobile.sdk.common.AdRequest adRequest, optional String? placement, com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback<com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd> loadCallback, optional com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback? adEventCallback);
+    method @KotlinOnly @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static suspend Object? loadAndTrackInterstitialAd(com.revenuecat.purchases.ads.events.AdTracker, com.google.android.libraries.ads.mobile.sdk.common.AdRequest adRequest, optional String? placement, optional com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback? adEventCallback, kotlin.coroutines.Continuation<? super com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult<com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd>>);
   }
 
   public final class RCAdMobNextGenInterstitialAd {

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/AdTrackerAdMobExtensions.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/AdTrackerAdMobExtensions.kt
@@ -6,12 +6,15 @@ package com.revenuecat.purchases.admob.nextgen
 
 import android.annotation.SuppressLint
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingAdLoadCallback
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingInterstitialAdEventCallback
+import com.revenuecat.purchases.admob.nextgen.tracking.trackAdFailedToLoad
+import com.revenuecat.purchases.admob.nextgen.tracking.trackAdLoaded
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import kotlin.jvm.JvmSynthetic
@@ -24,7 +27,7 @@ import kotlin.jvm.JvmSynthetic
  *
  * @param adRequest The [AdRequest] to load. Its ad unit ID is used for tracking.
  * @param placement Optional placement identifier used in RevenueCat tracking.
- * @param loadCallback Optional callback to receive load success and failure events.
+ * @param loadCallback Callback to receive load success and failure events.
  * @param adEventCallback Optional callback for interstitial lifecycle and paid events.
  */
 @ExperimentalPreviewRevenueCatPurchasesAPI
@@ -32,7 +35,7 @@ import kotlin.jvm.JvmSynthetic
 public fun AdTracker.loadAndTrackInterstitialAd(
     adRequest: AdRequest,
     placement: String? = null,
-    loadCallback: AdLoadCallback<InterstitialAd>? = null,
+    loadCallback: AdLoadCallback<InterstitialAd>,
     adEventCallback: InterstitialAdEventCallback? = null,
 ) {
     val adUnitId = adRequest.adUnitId
@@ -44,13 +47,54 @@ public fun AdTracker.loadAndTrackInterstitialAd(
             placement = placement,
             adUnitId = adUnitId,
             configureAd = { ad ->
-                ad.adEventCallback = TrackingInterstitialAdEventCallback(
-                    initialDelegate = adEventCallback,
-                    initialPlacement = placement,
-                    adUnitId = adUnitId,
-                    responseInfoProvider = ad::getResponseInfo,
-                )
+                ad.installTrackingEventCallback(adEventCallback, placement, adUnitId)
             },
         ),
+    )
+}
+
+/**
+ * Loads an [InterstitialAd] using Google Mobile Ads' suspending API and automatically tracks RevenueCat ad events.
+ *
+ * The original [AdLoadResult] is returned unchanged. A successfully loaded ad has event tracking installed before
+ * this function returns. Call via `Purchases.sharedInstance.adTracker`.
+ *
+ * @param adRequest The [AdRequest] to load. Its ad unit ID is used for tracking.
+ * @param placement Optional placement identifier used in RevenueCat tracking.
+ * @param adEventCallback Optional callback for interstitial lifecycle and paid events.
+ */
+@ExperimentalPreviewRevenueCatPurchasesAPI
+@JvmSynthetic
+public suspend fun AdTracker.loadAndTrackInterstitialAd(
+    adRequest: AdRequest,
+    placement: String? = null,
+    adEventCallback: InterstitialAdEventCallback? = null,
+): AdLoadResult<InterstitialAd> {
+    val adUnitId = adRequest.adUnitId
+    val result = InterstitialAd.load(adRequest)
+
+    when (result) {
+        is AdLoadResult.Success -> {
+            trackAdLoaded(result.ad.getResponseInfo(), AdFormat.INTERSTITIAL, placement, adUnitId)
+            result.ad.installTrackingEventCallback(adEventCallback, placement, adUnitId)
+        }
+        is AdLoadResult.Failure -> {
+            trackAdFailedToLoad(result.error, AdFormat.INTERSTITIAL, placement, adUnitId)
+        }
+    }
+
+    return result
+}
+
+private fun InterstitialAd.installTrackingEventCallback(
+    delegate: InterstitialAdEventCallback?,
+    placement: String?,
+    adUnitId: String,
+) {
+    adEventCallback = TrackingInterstitialAdEventCallback(
+        initialDelegate = delegate,
+        initialPlacement = placement,
+        adUnitId = adUnitId,
+        responseInfoProvider = ::getResponseInfo,
     )
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdFlowTest.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases.admob.nextgen
 
 import android.app.Activity
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
@@ -22,6 +23,7 @@ import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdLoadedData
 import com.revenuecat.purchases.ads.events.types.AdMediatorName
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -30,6 +32,7 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
@@ -152,6 +155,89 @@ class InterstitialAdFlowTest {
         assertEquals(AdFormat.INTERSTITIAL, failedData.captured.adFormat)
         assertEquals("interstitial-unit", failedData.captured.adUnitId)
         assertEquals("load-placement", failedData.captured.placement)
+    }
+
+    @Test
+    fun `suspending interstitial success tracks and installs callback before returning original result`() =
+        runBlocking {
+            val adRequest = mockk<AdRequest> {
+                every { adUnitId } returns "suspend-interstitial-unit"
+            }
+            val responseInfo = mockk<ResponseInfo>(relaxed = true) {
+                every { adapterClassName } returns "suspend-test-network"
+                every { responseId } returns "suspend-response-id"
+            }
+            var installedCallback: InterstitialAdEventCallback? = null
+            val interstitialAd = mockk<InterstitialAd>(relaxed = true) {
+                every { getResponseInfo() } returns responseInfo
+                every { adEventCallback } answers { installedCallback }
+                every { adEventCallback = any() } answers { installedCallback = firstArg() }
+            }
+            val eventCallback = RecordingInterstitialAdEventCallback()
+            val sdkResult = AdLoadResult.Success(interstitialAd)
+
+            coEvery { InterstitialAd.load(adRequest) } returns sdkResult
+
+            val result = adTracker.loadAndTrackInterstitialAd(
+                adRequest = adRequest,
+                placement = "suspend-load-placement",
+                adEventCallback = eventCallback,
+            )
+
+            assertSame(sdkResult, result)
+            val trackingCallback = installedCallback as TrackingInterstitialAdEventCallback
+            trackingCallback.onAppEvent("name", "data")
+            assertTrue(eventCallback.appEventCalled)
+
+            val loadedData = slot<AdLoadedData>()
+            verify(exactly = 1) {
+                adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER)
+            }
+            assertEquals(
+                AdLoadedData(
+                    networkName = "suspend-test-network",
+                    mediatorName = AdMediatorName.AD_MOB,
+                    adFormat = AdFormat.INTERSTITIAL,
+                    placement = "suspend-load-placement",
+                    adUnitId = "suspend-interstitial-unit",
+                    impressionId = "suspend-response-id",
+                ),
+                loadedData.captured,
+            )
+        }
+
+    @Test
+    fun `suspending interstitial failure tracks error and returns original result`() = runBlocking {
+        val adRequest = mockk<AdRequest> {
+            every { adUnitId } returns "suspend-interstitial-unit"
+        }
+        val error = mockk<LoadAdError> {
+            every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR
+        }
+        val sdkResult = AdLoadResult.Failure<InterstitialAd>(error)
+
+        coEvery { InterstitialAd.load(adRequest) } returns sdkResult
+
+        val result = adTracker.loadAndTrackInterstitialAd(
+            adRequest = adRequest,
+            placement = "suspend-load-placement",
+        )
+
+        assertSame(sdkResult, result)
+        val failedData = slot<AdFailedToLoadData>()
+        verify(exactly = 1) {
+            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
+        }
+        assertEquals(
+            AdFailedToLoadData(
+                mediatorName = AdMediatorName.AD_MOB,
+                adFormat = AdFormat.INTERSTITIAL,
+                placement = "suspend-load-placement",
+                adUnitId = "suspend-interstitial-unit",
+                mediatorErrorCode = LoadAdError.ErrorCode.NETWORK_ERROR.value,
+            ),
+            failedData.captured,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add the coroutine counterpart to callback-based Next-Gen interstitial loading.
- Track successful and failed loads while returning Google's original result and preserving lifecycle callbacks.
- Require a callback for the callback-based overload so loaded ads cannot be silently discarded.

## Testing

- `./gradlew :feature:admob-next-gen:testDefaultsDebugUnitTest detektAll :feature:admob-next-gen:metalavaCheckCompatibilityDefaultsRelease`
- `./scripts/api-check.sh`
