### PR TITLE
feat(checkpoints): Add the customer's purchases as a rules dimension

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfo.kt
@@ -83,6 +83,12 @@ public class CustomerInfo internal constructor(
     private val jsonObject: JSONObject,
     internal val originalSource: CustomerInfoOriginalSource = CustomerInfoOriginalSource.DEFAULT,
     internal val loadedFromCache: Boolean = false,
+    /**
+     * When the backend last saw this customer, on any device. Absent from a payload cached by a version that did
+     * not read it. Deliberately not part of equality, like [requestDate]: it moves with every response, and
+     * `CustomerInfoUpdateHandler` would then notify its listeners on every refresh.
+     */
+    internal val lastSeen: Date? = null,
 ) : Parcelable, RawDataContainer<JSONObject> {
 
     public constructor(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -30,6 +30,7 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.EventsManager
 import com.revenuecat.purchases.common.isDeviceProtectedStorageCompat
+import com.revenuecat.purchases.common.localrules.CustomerInfoDimensionProvider
 import com.revenuecat.purchases.common.localrules.DeviceDimensionProvider
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesEngineLoggerBridge
@@ -53,6 +54,8 @@ import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopicStore
+import com.revenuecat.purchases.common.safeResume
+import com.revenuecat.purchases.common.safeResumeWithException
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
@@ -81,6 +84,7 @@ import com.revenuecat.purchases.utils.PurchaseParamsValidator
 import com.revenuecat.purchases.utils.UrlConnectionFactory
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencyManager
+import kotlinx.coroutines.suspendCancellableCoroutine
 import java.net.URL
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -398,6 +402,10 @@ internal class PurchasesFactory(
                             identityManager.currentAppUserID,
                         )
                     },
+                    CustomerInfoDimensionProvider(
+                        appUserId = { identityManager.currentAppUserID },
+                        customerInfo = { Purchases.sharedInstance.purchasesOrchestrator.awaitCustomerInfo() },
+                    ),
                 ),
             )
 
@@ -693,3 +701,22 @@ internal class PurchasesFactory(
         ): Boolean = diagnosticsEnabled && !uiPreviewMode
     }
 }
+
+/**
+ * The cache when it is warm, the initial fetch otherwise, so the first checkpoint of a session can still read
+ * customer dimensions.
+ *
+ * Goes through the orchestrator rather than `Purchases.awaitCustomerInfo`, which only exists in the `defaults`
+ * source set: local rule evaluation is wired for both flavors.
+ */
+private suspend fun PurchasesOrchestrator.awaitCustomerInfo(): CustomerInfo =
+    suspendCancellableCoroutine { continuation ->
+        getCustomerInfo(
+            fetchPolicy = CacheFetchPolicy.default(),
+            trackDiagnostics = false,
+            callback = receiveCustomerInfoCallback(
+                onSuccess = { continuation.safeResume(it) },
+                onError = { continuation.safeResumeWithException(PurchasesException(it)) },
+            ),
+        )
+    }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -404,7 +404,9 @@ internal class PurchasesFactory(
                     },
                     CustomerInfoDimensionProvider(
                         appUserId = { identityManager.currentAppUserID },
-                        customerInfo = { Purchases.sharedInstance.purchasesOrchestrator.awaitCustomerInfo() },
+                        customerInfo = { appUserID ->
+                            Purchases.sharedInstance.purchasesOrchestrator.awaitCustomerInfo(appUserID)
+                        },
                     ),
                 ),
             )
@@ -706,9 +708,10 @@ internal class PurchasesFactory(
  * The cache when it is warm, the initial fetch otherwise. Goes through the orchestrator because
  * `Purchases.awaitCustomerInfo` only exists in the `defaults` source set, while this is compiled for both flavors.
  */
-private suspend fun PurchasesOrchestrator.awaitCustomerInfo(): CustomerInfo =
+private suspend fun PurchasesOrchestrator.awaitCustomerInfo(appUserID: String): CustomerInfo =
     suspendCancellableCoroutine { continuation ->
         getCustomerInfo(
+            appUserID = appUserID,
             fetchPolicy = CacheFetchPolicy.default(),
             trackDiagnostics = false,
             callback = receiveCustomerInfoCallback(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -403,7 +403,7 @@ internal class PurchasesFactory(
                         )
                     },
                     CustomerInfoDimensionProvider(
-                        appUserId = { identityManager.currentAppUserID },
+                        currentAppUserId = { identityManager.currentAppUserID },
                         customerInfo = { appUserID ->
                             Purchases.sharedInstance.purchasesOrchestrator.awaitCustomerInfo(appUserID)
                         },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -703,11 +703,8 @@ internal class PurchasesFactory(
 }
 
 /**
- * The cache when it is warm, the initial fetch otherwise, so the first checkpoint of a session can still read
- * customer dimensions.
- *
- * Goes through the orchestrator rather than `Purchases.awaitCustomerInfo`, which only exists in the `defaults`
- * source set: local rule evaluation is wired for both flavors.
+ * The cache when it is warm, the initial fetch otherwise. Goes through the orchestrator because
+ * `Purchases.awaitCustomerInfo` only exists in the `defaults` source set, while this is compiled for both flavors.
  */
 private suspend fun PurchasesOrchestrator.awaitCustomerInfo(): CustomerInfo =
     suspendCancellableCoroutine { continuation ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -409,6 +409,7 @@ internal class PurchasesFactory(
                         },
                     ),
                 ),
+                currentAppUserId = { identityManager.currentAppUserID },
             )
 
             val customerInfoUpdateHandler = CustomerInfoUpdateHandler(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -397,17 +397,12 @@ internal class PurchasesFactory(
                     // Only read during a checkpoint evaluation, so the instance is configured by then. Same
                     // reasoning as CheckpointWorkflowResolverImpl's getOfferings.
                     StoreDimensionProvider { Purchases.sharedInstance.awaitStorefrontCountryCode() },
-                    SubscriberAttributesDimensionProvider {
-                        subscriberAttributesCache.getAllStoredSubscriberAttributes(
-                            identityManager.currentAppUserID,
-                        )
+                    SubscriberAttributesDimensionProvider { appUserID ->
+                        subscriberAttributesCache.getAllStoredSubscriberAttributes(appUserID)
                     },
-                    CustomerInfoDimensionProvider(
-                        currentAppUserId = { identityManager.currentAppUserID },
-                        customerInfo = { appUserID ->
-                            Purchases.sharedInstance.purchasesOrchestrator.awaitCustomerInfo(appUserID)
-                        },
-                    ),
+                    CustomerInfoDimensionProvider { appUserID ->
+                        Purchases.sharedInstance.purchasesOrchestrator.awaitCustomerInfo(appUserID)
+                    },
                 ),
                 currentAppUserId = { identityManager.currentAppUserID },
             )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -970,8 +970,21 @@ internal class PurchasesOrchestrator(
         trackDiagnostics: Boolean,
         callback: ReceiveCustomerInfoCallback,
     ) {
+        getCustomerInfo(identityManager.currentAppUserID, fetchPolicy, trackDiagnostics, callback)
+    }
+
+    /**
+     * For a caller that has already read the app user ID and needs the answer to describe that same customer even
+     * if the app logs in or out while the request is in flight.
+     */
+    fun getCustomerInfo(
+        appUserID: String,
+        fetchPolicy: CacheFetchPolicy,
+        trackDiagnostics: Boolean,
+        callback: ReceiveCustomerInfoCallback,
+    ) {
         customerInfoHelper.retrieveCustomerInfo(
-            identityManager.currentAppUserID,
+            appUserID,
             fetchPolicy,
             state.appInBackground,
             allowSharingPlayStoreAccount,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -974,8 +974,12 @@ internal class PurchasesOrchestrator(
     }
 
     /**
-     * For a caller that has already read the app user ID and needs the answer to describe that same customer even
-     * if the app logs in or out while the request is in flight.
+     * For a caller that has already read the app user ID: the cache lookup and the backend request both use the
+     * given ID instead of re-reading the current one.
+     *
+     * Not a guarantee that the answer describes that customer. On a cold cache the pending-purchase sync runs
+     * first and reads the current app user for itself, so a caller that needs the guarantee checks the ID again
+     * once the answer is in.
      */
     fun getCustomerInfo(
         appUserID: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/CustomerInfoFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/CustomerInfoFactory.kt
@@ -79,6 +79,11 @@ internal object CustomerInfoFactory {
 
         val firstSeen = Iso8601Utils.parse(subscriber.getString(CustomerInfoResponseJsonKeys.FIRST_SEEN))
 
+        // Optional: a payload cached by a version that did not read it has none.
+        val lastSeen = subscriber.optNullableString(CustomerInfoResponseJsonKeys.LAST_SEEN)?.let {
+            Iso8601Utils.parse(it)
+        }
+
         val entitlementInfos = entitlements?.buildEntitlementInfos(
             subscriptions,
             nonSubscriptionsLatestPurchases,
@@ -108,6 +113,7 @@ internal object CustomerInfoFactory {
             originalPurchaseDate = originalPurchaseDate,
             originalSource = originalSource,
             loadedFromCache = loadedFromCache,
+            lastSeen = lastSeen,
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -16,45 +16,30 @@ import kotlinx.coroutines.CancellationException
 import java.util.Date
 
 internal class CustomerInfoDimensionProvider(
-    private val currentAppUserId: () -> String,
     private val customerInfo: suspend (appUserId: String) -> CustomerInfo,
 ) : RulesDimensionProvider {
 
     override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.CustomerInfo
 
     /**
-     * The app user ID is read once and used both to request the customer info and as the reported ID. Reading it
-     * again after the request came back would describe a different customer than the purchases alongside it
-     * whenever the app logs in, logs out, or switches user while that request is in flight.
-     *
-     * It is also reported on its own, without waiting for the request, so a rule targeting only the ID does not
-     * depend on the network: the ID is known as soon as the SDK is configured.
+     * The app user ID is reported without waiting for the customer info, so a rule targeting only the ID does not
+     * depend on the network: it is known as soon as the SDK is configured.
      */
-    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
-        val appUserId = currentAppUserId()
-        return customerInfoDimensions(appUserId, date) + buildMap { putString(KEY_APP_USER_ID, appUserId) }
-    }
+    override suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> =
+        customerInfoDimensions(context) + buildMap { putString(KEY_APP_USER_ID, context.appUserId) }
 
     /**
-     * A customer info that cannot be read contributes no dimensions instead of failing the snapshot: the read
-     * reaches out through the configured instance, which an app can tear down mid-evaluation, and it can fall back
-     * to the network, which can fail. Neither should abort the snapshot and take an otherwise resolvable
-     * checkpoint down with it. Cancellation is not a failure and propagates.
+     * A customer info that cannot be read contributes no dimensions rather than failing the snapshot, which would
+     * take an otherwise resolvable checkpoint down with it. Cancellation is not a failure and propagates.
      *
-     * The records are built inside the same guard as the read, because a [CustomerInfo]'s purchases are parsed out
-     * of its raw payload on first access rather than when it is constructed, so that is where a malformed payload
-     * surfaces.
-     *
-     * Asking for one app user is not enough to be answered about them: on a cold cache the SDK syncs pending
-     * purchases first, and that sync reads the current app user for itself. Catching that is
-     * [RulesDimensionResolver]'s job, since it watches the whole collection rather than this read alone, and it
-     * can take the snapshot again instead of leaving a customer half-described.
+     * The records are built inside the same guard, because a [CustomerInfo] parses its purchases out of its raw
+     * payload on first access rather than at construction, so a malformed payload surfaces here.
      */
-    private suspend fun customerInfoDimensions(appUserId: String, date: Date): Map<String, RulesDimensionValue> {
+    private suspend fun customerInfoDimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> {
         // Nobody to ask about: the SDK has no cached user, so there is no request to make on their behalf.
-        if (appUserId.isEmpty()) return emptyMap()
+        if (context.appUserId.isEmpty()) return emptyMap()
         return try {
-            customerInfo(appUserId).dimensions(date)
+            customerInfo(context.appUserId).dimensions(context.date)
         } catch (e: CancellationException) {
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -16,27 +16,23 @@ import kotlinx.coroutines.CancellationException
 import java.util.Date
 
 internal class CustomerInfoDimensionProvider(
-    private val appUserId: () -> String?,
-    private val customerInfo: suspend () -> CustomerInfo,
+    private val appUserId: () -> String,
+    private val customerInfo: suspend (appUserId: String) -> CustomerInfo,
 ) : RulesDimensionProvider {
 
     override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.CustomerInfo
 
-    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
-        appUserIdDimension() + customerInfoDimensions(date)
-
     /**
-     * Read separately from the rest so a rule targeting the app user ID does not depend on the network: the ID is
-     * known as soon as the SDK is configured, while [CustomerInfo] may still be in flight.
+     * The app user ID is read once and used both to request the customer info and as the reported ID. Reading it
+     * again after the request came back would describe a different customer than the purchases alongside it
+     * whenever the app logs in, logs out, or switches user while that request is in flight.
+     *
+     * It is also reported on its own, without waiting for the request, so a rule targeting only the ID does not
+     * depend on the network: the ID is known as soon as the SDK is configured.
      */
-    private fun appUserIdDimension(): Map<String, RulesDimensionValue> {
-        val appUserId = try {
-            appUserId()
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            warnLog { "The app user ID is unavailable, so it can't be evaluated: $e" }
-            null
-        }
-        return buildMap { putString(KEY_APP_USER_ID, appUserId) }
+    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+        val appUserId = appUserId()
+        return customerInfoDimensions(appUserId, date) + buildMap { putString(KEY_APP_USER_ID, appUserId) }
     }
 
     /**
@@ -49,15 +45,18 @@ internal class CustomerInfoDimensionProvider(
      * of its raw payload on first access rather than when it is constructed, so that is where a malformed payload
      * surfaces.
      */
-    private suspend fun customerInfoDimensions(date: Date): Map<String, RulesDimensionValue> =
-        try {
-            customerInfo().dimensions(date)
+    private suspend fun customerInfoDimensions(appUserId: String, date: Date): Map<String, RulesDimensionValue> {
+        // Nobody to ask about: the SDK has no cached user, so there is no request to make on their behalf.
+        if (appUserId.isEmpty()) return emptyMap()
+        return try {
+            customerInfo(appUserId).dimensions(date)
         } catch (e: CancellationException) {
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             warnLog { "The customer info is unavailable, so customer dimensions can't be evaluated: $e" }
             emptyMap()
         }
+    }
 
     private fun CustomerInfo.dimensions(date: Date): Map<String, RulesDimensionValue> = buildMap {
         putString(KEY_ORIGINAL_APP_USER_ID, originalAppUserId)
@@ -65,9 +64,8 @@ internal class CustomerInfoDimensionProvider(
         // The date the backend last answered us, which is when it last saw this customer through this device.
         putDate(KEY_LAST_SEEN_AT, requestDate)
         putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
-        putDate(KEY_EVALUATED_AT, date)
         putObjectList(KEY_PURCHASES, purchaseRecords(date))
-        putObjectList(KEY_ENTITLEMENTS, entitlementRecords(date))
+        putObjectList(KEY_ENTITLEMENTS, entitlementRecords())
     }
 
     /**
@@ -80,14 +78,14 @@ internal class CustomerInfoDimensionProvider(
             .sortedBy { subscription -> subscription.productIdentifier }
             .map { subscription -> subscription.record(date) }
         // Already sorted by purchase date by `CustomerInfo`.
-        val transactions = nonSubscriptionTransactions.map { transaction -> transaction.record(date) }
+        val transactions = nonSubscriptionTransactions.map { transaction -> transaction.record() }
         return (subscriptions + transactions).sortedByDescending { record -> record.dateOrNull(KEY_PURCHASED_AT) }
     }
 
-    private fun CustomerInfo.entitlementRecords(date: Date): List<Map<String, RulesDimensionValue>> =
+    private fun CustomerInfo.entitlementRecords(): List<Map<String, RulesDimensionValue>> =
         entitlements.all.values
             .sortedBy { entitlement -> entitlement.identifier }
-            .map { entitlement -> entitlement.record(date) }
+            .map { entitlement -> entitlement.record() }
 
     private fun SubscriptionInfo.record(date: Date): Map<String, RulesDimensionValue> = buildMap {
         putString(KEY_KIND, KIND_SUBSCRIPTION)
@@ -121,10 +119,9 @@ internal class CustomerInfoDimensionProvider(
         putBool(KEY_IS_REFUNDED, refundedAt != null)
         // A resume date is only ever set while a Google subscription is paused, so having one *is* being paused.
         putBool(KEY_IS_PAUSED, autoResumeDate != null)
-        putDate(KEY_EVALUATED_AT, date)
     }
 
-    private fun Transaction.record(date: Date): Map<String, RulesDimensionValue> = buildMap {
+    private fun Transaction.record(): Map<String, RulesDimensionValue> = buildMap {
         putString(KEY_KIND, KIND_NON_SUBSCRIPTION)
         putString(KEY_PRODUCT_IDENTIFIER, productIdentifier)
         // A one-time purchase has no base plan, so the two forms of the identifier are the same one.
@@ -137,10 +134,9 @@ internal class CustomerInfoDimensionProvider(
         putDate(KEY_PURCHASED_AT, purchaseDate)
         putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
         putBool(KEY_IS_SANDBOX, isSandbox)
-        putDate(KEY_EVALUATED_AT, date)
     }
 
-    private fun EntitlementInfo.record(date: Date): Map<String, RulesDimensionValue> = buildMap {
+    private fun EntitlementInfo.record(): Map<String, RulesDimensionValue> = buildMap {
         putString(KEY_IDENTIFIER, identifier)
         putString(KEY_PRODUCT_IDENTIFIER, productIdentifier)
         putString(KEY_PRODUCT_PLAN_IDENTIFIER, productPlanIdentifier)
@@ -159,13 +155,11 @@ internal class CustomerInfoDimensionProvider(
         putBool(KEY_IS_SANDBOX, isSandbox)
         putBool(KEY_IS_ACTIVE, isActive)
         putBool(KEY_WILL_RENEW, willRenew)
-        putDate(KEY_EVALUATED_AT, date)
     }
 
     internal companion object {
         const val KEY_APP_USER_ID = "appUserId"
         const val KEY_ENTITLEMENTS = "entitlements"
-        const val KEY_EVALUATED_AT = "evaluatedAt"
         const val KEY_FIRST_SEEN_AT = "firstSeenAt"
         const val KEY_LAST_SEEN_AT = "lastSeenAt"
         const val KEY_ORIGINAL_APP_USER_ID = "originalAppUserId"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.CancellationException
 import java.util.Date
 
 internal class CustomerInfoDimensionProvider(
-    private val appUserId: () -> String,
+    private val currentAppUserId: () -> String,
     private val customerInfo: suspend (appUserId: String) -> CustomerInfo,
 ) : RulesDimensionProvider {
 
@@ -31,7 +31,7 @@ internal class CustomerInfoDimensionProvider(
      * depend on the network: the ID is known as soon as the SDK is configured.
      */
     override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
-        val appUserId = appUserId()
+        val appUserId = currentAppUserId()
         return customerInfoDimensions(appUserId, date) + buildMap { putString(KEY_APP_USER_ID, appUserId) }
     }
 
@@ -44,18 +44,32 @@ internal class CustomerInfoDimensionProvider(
      * The records are built inside the same guard as the read, because a [CustomerInfo]'s purchases are parsed out
      * of its raw payload on first access rather than when it is constructed, so that is where a malformed payload
      * surfaces.
+     *
+     * Asking for one app user is not enough to be answered about them: on a cold cache the SDK syncs pending
+     * purchases first, and that sync reads the current app user for itself. So the ID is checked again once the
+     * answer is in, and an answer that arrived across a user change is dropped rather than reported under the ID
+     * this evaluation started with.
      */
+    @Suppress("ReturnCount")
     private suspend fun customerInfoDimensions(appUserId: String, date: Date): Map<String, RulesDimensionValue> {
         // Nobody to ask about: the SDK has no cached user, so there is no request to make on their behalf.
         if (appUserId.isEmpty()) return emptyMap()
-        return try {
+        val dimensions = try {
             customerInfo(appUserId).dimensions(date)
         } catch (e: CancellationException) {
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             warnLog { "The customer info is unavailable, so customer dimensions can't be evaluated: $e" }
-            emptyMap()
+            return emptyMap()
         }
+        if (currentAppUserId() != appUserId) {
+            warnLog {
+                "The app user changed while the customer info was being read, so it can't be evaluated: it may " +
+                    "describe a different customer than the one this evaluation is about."
+            }
+            return emptyMap()
+        }
+        return dimensions
     }
 
     private fun CustomerInfo.dimensions(date: Date): Map<String, RulesDimensionValue> = buildMap {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -51,8 +51,10 @@ internal class CustomerInfoDimensionProvider(
     private fun CustomerInfo.dimensions(date: Date): Map<String, RulesDimensionValue> = buildMap {
         putString(KEY_ORIGINAL_APP_USER_ID, originalAppUserId)
         putDate(KEY_FIRST_SEEN_AT, firstSeen)
-        // The date the backend last answered us, which is when it last saw this customer through this device.
-        putDate(KEY_LAST_SEEN_AT, requestDate)
+        // When the backend last saw this customer on any device, which is what "how long since they last opened
+        // the app" needs. Deliberately not `requestDate`: that is when the backend last answered *us*, and the
+        // SDK refreshes on every foreground, so it would read as "just now" for the whole session.
+        putDate(KEY_LAST_SEEN_AT, lastSeen)
         putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
         putObjectList(KEY_PURCHASES, purchaseRecords(date))
         putObjectList(KEY_ENTITLEMENTS, entitlementRecords())

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -46,30 +46,21 @@ internal class CustomerInfoDimensionProvider(
      * surfaces.
      *
      * Asking for one app user is not enough to be answered about them: on a cold cache the SDK syncs pending
-     * purchases first, and that sync reads the current app user for itself. So the ID is checked again once the
-     * answer is in, and an answer that arrived across a user change is dropped rather than reported under the ID
-     * this evaluation started with.
+     * purchases first, and that sync reads the current app user for itself. Catching that is
+     * [RulesDimensionResolver]'s job, since it watches the whole collection rather than this read alone, and it
+     * can take the snapshot again instead of leaving a customer half-described.
      */
-    @Suppress("ReturnCount")
     private suspend fun customerInfoDimensions(appUserId: String, date: Date): Map<String, RulesDimensionValue> {
         // Nobody to ask about: the SDK has no cached user, so there is no request to make on their behalf.
         if (appUserId.isEmpty()) return emptyMap()
-        val dimensions = try {
+        return try {
             customerInfo(appUserId).dimensions(date)
         } catch (e: CancellationException) {
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             warnLog { "The customer info is unavailable, so customer dimensions can't be evaluated: $e" }
-            return emptyMap()
+            emptyMap()
         }
-        if (currentAppUserId() != appUserId) {
-            warnLog {
-                "The app user changed while the customer info was being read, so it can't be evaluated: it may " +
-                    "describe a different customer than the one this evaluation is about."
-            }
-            return emptyMap()
-        }
-        return dimensions
     }
 
     private fun CustomerInfo.dimensions(date: Date): Map<String, RulesDimensionValue> = buildMap {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -15,31 +15,6 @@ import com.revenuecat.purchases.models.Transaction
 import kotlinx.coroutines.CancellationException
 import java.util.Date
 
-/**
- * Customer dimensions: everything the SDK knows the customer has bought.
- *
- * Where a flat dimension per audience question would have to pick one purchase to describe — the latest
- * subscription, say, which cannot answer anything about the one before it — this hands the engine the whole graph:
- * [KEY_PURCHASES] and [KEY_ENTITLEMENTS] are collections the iteration operators walk. "Is in a trial that ends
- * this week" and "has ever bought this base plan" are then predicates over the same values rather than dimensions
- * the SDK has to ship one at a time.
- *
- * A record carries the facts a predicate cannot work out for itself, and no more: [KEY_PERIOD_TYPE] already answers
- * "is in a trial", so there is no boolean for it, while [KEY_IS_ACTIVE] and [KEY_WILL_RENEW] are derivations no
- * predicate could reproduce.
- *
- * Read on every evaluation because a purchase, a renewal or a cancellation lands mid-session and an audience keyed
- * on subscription state has to agree with what the customer's access actually is.
- *
- * Unlike the dashboard, which evaluates the same audience over production purchases only, sandbox purchases are
- * included here: a rule has to be testable in a debug build or against a license tester, where every purchase is a
- * sandbox one. Each record carries [KEY_IS_SANDBOX] so a predicate that wants only real money can say so.
- *
- * A value the customer has none of is omitted rather than guessed — an absent key resolves to null in the engine,
- * which is an ordinary non-match. Booleans and the two collections are the exception: a customer who has never
- * bought anything answers [KEY_PURCHASES] with an empty array, which `none` reads as a definite yes, rather than
- * leaving it unknown.
- */
 internal class CustomerInfoDimensionProvider(
     private val appUserId: () -> String?,
     private val customerInfo: suspend () -> CustomerInfo,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -102,6 +102,7 @@ internal class CustomerInfoDimensionProvider(
         putString(KEY_STORE, store.stringValue)
         putString(KEY_OWNERSHIP_TYPE, ownershipType.dimensionValue)
         putString(KEY_PERIOD_TYPE, periodType.dimensionValue)
+        putString(KEY_STATUS, status(date))
         putPrice(price)
         putDate(KEY_PURCHASED_AT, purchaseDate)
         putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
@@ -116,7 +117,7 @@ internal class CustomerInfoDimensionProvider(
         putBool(KEY_WILL_RENEW, willRenew)
         // The store keeps serving a subscription while a billing issue is being retried, and `isActive` does not
         // cover that, so `{"or": [isActive, isInGracePeriod]}` is the still-being-served test.
-        putBool(KEY_IS_IN_GRACE_PERIOD, gracePeriodExpiresDate?.after(date) == true)
+        putBool(KEY_IS_IN_GRACE_PERIOD, isInGracePeriod(date))
         putBool(KEY_IS_REFUNDED, refundedAt != null)
         // A resume date is only ever set while a Google subscription is paused, so having one *is* being paused.
         putBool(KEY_IS_PAUSED, autoResumeDate != null)
@@ -193,6 +194,7 @@ internal class CustomerInfoDimensionProvider(
         const val KEY_PURCHASED_AT = "purchasedAt"
         const val KEY_PURCHASED_PRODUCT_IDENTIFIER = "purchasedProductIdentifier"
         const val KEY_REFUNDED_AT = "refundedAt"
+        const val KEY_STATUS = "status"
         const val KEY_STORE = "store"
         const val KEY_STORE_TRANSACTION_ID = "storeTransactionId"
         const val KEY_TRANSACTION_IDENTIFIER = "transactionIdentifier"
@@ -201,6 +203,12 @@ internal class CustomerInfoDimensionProvider(
 
         const val KIND_NON_SUBSCRIPTION = "nonSubscription"
         const val KIND_SUBSCRIPTION = "subscription"
+
+        const val STATUS_ACTIVE = "active"
+        const val STATUS_EXPIRED = "expired"
+        const val STATUS_IN_GRACE_PERIOD = "in_grace_period"
+        const val STATUS_PAUSED = "paused"
+        const val STATUS_TRIALING = "trialing"
 
         /**
          * The base plan is part of what was bought on Google, and it is the form the dashboard lists a
@@ -222,6 +230,34 @@ internal class CustomerInfoDimensionProvider(
                 OwnershipType.FAMILY_SHARED -> "FAMILY_SHARED"
                 OwnershipType.UNKNOWN -> null
             }
+
+        /**
+         * Where the customer is in this subscription's lifecycle, as one value instead of a combination every
+         * predicate has to assemble for itself.
+         *
+         * Read most specific first: a paused subscription is paused whatever its dates say, a billing issue the
+         * store is still serving through outranks the trial or the renewal it interrupted, and anything not
+         * currently granting access has expired.
+         *
+         * `in_billing_retry` and `incomplete` belong to the same vocabulary but are never reported here. Once a
+         * grace period is over, whether the store is still retrying is something it tells the backend and not this
+         * device, which only sees that access lapsed; a predicate that needs the distinction reads
+         * [KEY_BILLING_ISSUE_DETECTED_AT] itself.
+         */
+        private fun SubscriptionInfo.status(date: Date): String = when {
+            autoResumeDate != null -> STATUS_PAUSED
+            isInGracePeriod(date) -> STATUS_IN_GRACE_PERIOD
+            isActive && periodType == PeriodType.TRIAL -> STATUS_TRIALING
+            isActive -> STATUS_ACTIVE
+            else -> STATUS_EXPIRED
+        }
+
+        /**
+         * The store keeps serving a subscription while a billing issue is being retried. Shared by
+         * [KEY_IS_IN_GRACE_PERIOD] and [KEY_STATUS] so the two always agree.
+         */
+        private fun SubscriptionInfo.isInGracePeriod(date: Date): Boolean =
+            gracePeriodExpiresDate?.after(date) == true
 
         private val PeriodType.dimensionValue: String
             get() = when (this) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -1,0 +1,291 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.EntitlementInfo
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.OwnershipType
+import com.revenuecat.purchases.PeriodType
+import com.revenuecat.purchases.SubscriptionInfo
+import com.revenuecat.purchases.common.Constants
+import com.revenuecat.purchases.common.warnLog
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.Transaction
+import kotlinx.coroutines.CancellationException
+import java.util.Date
+
+/**
+ * Customer dimensions: everything the SDK knows the customer has bought.
+ *
+ * Where a flat dimension per audience question would have to pick one purchase to describe — the latest
+ * subscription, say, which cannot answer anything about the one before it — this hands the engine the whole graph:
+ * [KEY_PURCHASES] and [KEY_ENTITLEMENTS] are collections the iteration operators walk. "Is in a trial that ends
+ * this week" and "has ever bought this base plan" are then predicates over the same values rather than dimensions
+ * the SDK has to ship one at a time.
+ *
+ * A record carries the facts a predicate cannot work out for itself, and no more: [KEY_PERIOD_TYPE] already answers
+ * "is in a trial", so there is no boolean for it, while [KEY_IS_ACTIVE] and [KEY_WILL_RENEW] are derivations no
+ * predicate could reproduce.
+ *
+ * Read on every evaluation because a purchase, a renewal or a cancellation lands mid-session and an audience keyed
+ * on subscription state has to agree with what the customer's access actually is.
+ *
+ * Unlike the dashboard, which evaluates the same audience over production purchases only, sandbox purchases are
+ * included here: a rule has to be testable in a debug build or against a license tester, where every purchase is a
+ * sandbox one. Each record carries [KEY_IS_SANDBOX] so a predicate that wants only real money can say so.
+ *
+ * A value the customer has none of is omitted rather than guessed — an absent key resolves to null in the engine,
+ * which is an ordinary non-match. Booleans and the two collections are the exception: a customer who has never
+ * bought anything answers [KEY_PURCHASES] with an empty array, which `none` reads as a definite yes, rather than
+ * leaving it unknown.
+ */
+internal class CustomerInfoDimensionProvider(
+    private val appUserId: () -> String?,
+    private val customerInfo: suspend () -> CustomerInfo,
+) : RulesDimensionProvider {
+
+    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.CustomerInfo
+
+    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+        appUserIdDimension() + customerInfoDimensions(date)
+
+    /**
+     * Read separately from the rest so a rule targeting the app user ID does not depend on the network: the ID is
+     * known as soon as the SDK is configured, while [CustomerInfo] may still be in flight.
+     */
+    private fun appUserIdDimension(): Map<String, RulesDimensionValue> {
+        val appUserId = try {
+            appUserId()
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            warnLog { "The app user ID is unavailable, so it can't be evaluated: $e" }
+            null
+        }
+        return buildMap { putString(KEY_APP_USER_ID, appUserId) }
+    }
+
+    /**
+     * A customer info that cannot be read contributes no dimensions instead of failing the snapshot: the read
+     * reaches out through the configured instance, which an app can tear down mid-evaluation, and it can fall back
+     * to the network, which can fail. Neither should abort the snapshot and take an otherwise resolvable
+     * checkpoint down with it. Cancellation is not a failure and propagates.
+     *
+     * The records are built inside the same guard as the read, because a [CustomerInfo]'s purchases are parsed out
+     * of its raw payload on first access rather than when it is constructed, so that is where a malformed payload
+     * surfaces.
+     */
+    private suspend fun customerInfoDimensions(date: Date): Map<String, RulesDimensionValue> =
+        try {
+            customerInfo().dimensions(date)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            warnLog { "The customer info is unavailable, so customer dimensions can't be evaluated: $e" }
+            emptyMap()
+        }
+
+    private fun CustomerInfo.dimensions(date: Date): Map<String, RulesDimensionValue> = buildMap {
+        putString(KEY_ORIGINAL_APP_USER_ID, originalAppUserId)
+        putDate(KEY_FIRST_SEEN_AT, firstSeen)
+        // The date the backend last answered us, which is when it last saw this customer through this device.
+        putDate(KEY_LAST_SEEN_AT, requestDate)
+        putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
+        putDate(KEY_EVALUATED_AT, date)
+        putObjectList(KEY_PURCHASES, purchaseRecords(date))
+        putObjectList(KEY_ENTITLEMENTS, entitlementRecords(date))
+    }
+
+    /**
+     * Newest first, so `purchases.0` is the customer's most recent purchase of any kind and a rule about it needs
+     * no iteration at all. Subscriptions are ordered by product before the merge, so purchases that share a date
+     * still come out in a defined order.
+     */
+    private fun CustomerInfo.purchaseRecords(date: Date): List<Map<String, RulesDimensionValue>> {
+        val subscriptions = subscriptionsByProductIdentifier.values
+            .sortedBy { subscription -> subscription.productIdentifier }
+            .map { subscription -> subscription.record(date) }
+        // Already sorted by purchase date by `CustomerInfo`.
+        val transactions = nonSubscriptionTransactions.map { transaction -> transaction.record(date) }
+        return (subscriptions + transactions).sortedByDescending { record -> record.dateOrNull(KEY_PURCHASED_AT) }
+    }
+
+    private fun CustomerInfo.entitlementRecords(date: Date): List<Map<String, RulesDimensionValue>> =
+        entitlements.all.values
+            .sortedBy { entitlement -> entitlement.identifier }
+            .map { entitlement -> entitlement.record(date) }
+
+    private fun SubscriptionInfo.record(date: Date): Map<String, RulesDimensionValue> = buildMap {
+        putString(KEY_KIND, KIND_SUBSCRIPTION)
+        putString(KEY_PRODUCT_IDENTIFIER, productIdentifier)
+        putString(KEY_PRODUCT_PLAN_IDENTIFIER, productPlanIdentifier)
+        putString(
+            KEY_PURCHASED_PRODUCT_IDENTIFIER,
+            purchasedProductIdentifier(productIdentifier, productPlanIdentifier),
+        )
+        putString(KEY_STORE_TRANSACTION_ID, storeTransactionId)
+        putString(KEY_DISPLAY_NAME, displayName)
+        putString(KEY_STORE, store.stringValue)
+        putString(KEY_OWNERSHIP_TYPE, ownershipType.dimensionValue)
+        putString(KEY_PERIOD_TYPE, periodType.dimensionValue)
+        putPrice(price)
+        putDate(KEY_PURCHASED_AT, purchaseDate)
+        putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
+        putDate(KEY_EXPIRES_AT, expiresDate)
+        putDate(KEY_UNSUBSCRIBE_DETECTED_AT, unsubscribeDetectedAt)
+        putDate(KEY_BILLING_ISSUE_DETECTED_AT, billingIssuesDetectedAt)
+        putDate(KEY_GRACE_PERIOD_EXPIRES_AT, gracePeriodExpiresDate)
+        putDate(KEY_REFUNDED_AT, refundedAt)
+        putDate(KEY_AUTO_RESUME_AT, autoResumeDate)
+        putBool(KEY_IS_SANDBOX, isSandbox)
+        putBool(KEY_IS_ACTIVE, isActive)
+        putBool(KEY_WILL_RENEW, willRenew)
+        // The store keeps serving a subscription while a billing issue is being retried, and `isActive` does not
+        // cover that, so `{"or": [isActive, isInGracePeriod]}` is the still-being-served test.
+        putBool(KEY_IS_IN_GRACE_PERIOD, gracePeriodExpiresDate?.after(date) == true)
+        putBool(KEY_IS_REFUNDED, refundedAt != null)
+        // A resume date is only ever set while a Google subscription is paused, so having one *is* being paused.
+        putBool(KEY_IS_PAUSED, autoResumeDate != null)
+        putDate(KEY_EVALUATED_AT, date)
+    }
+
+    private fun Transaction.record(date: Date): Map<String, RulesDimensionValue> = buildMap {
+        putString(KEY_KIND, KIND_NON_SUBSCRIPTION)
+        putString(KEY_PRODUCT_IDENTIFIER, productIdentifier)
+        // A one-time purchase has no base plan, so the two forms of the identifier are the same one.
+        putString(KEY_PURCHASED_PRODUCT_IDENTIFIER, productIdentifier)
+        putString(KEY_TRANSACTION_IDENTIFIER, transactionIdentifier)
+        putString(KEY_STORE_TRANSACTION_ID, storeTransactionId)
+        putString(KEY_DISPLAY_NAME, displayName)
+        putString(KEY_STORE, store.stringValue)
+        putPrice(price)
+        putDate(KEY_PURCHASED_AT, purchaseDate)
+        putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
+        putBool(KEY_IS_SANDBOX, isSandbox)
+        putDate(KEY_EVALUATED_AT, date)
+    }
+
+    private fun EntitlementInfo.record(date: Date): Map<String, RulesDimensionValue> = buildMap {
+        putString(KEY_IDENTIFIER, identifier)
+        putString(KEY_PRODUCT_IDENTIFIER, productIdentifier)
+        putString(KEY_PRODUCT_PLAN_IDENTIFIER, productPlanIdentifier)
+        putString(
+            KEY_PURCHASED_PRODUCT_IDENTIFIER,
+            purchasedProductIdentifier(productIdentifier, productPlanIdentifier),
+        )
+        putString(KEY_STORE, store.stringValue)
+        putString(KEY_OWNERSHIP_TYPE, ownershipType.dimensionValue)
+        putString(KEY_PERIOD_TYPE, periodType.dimensionValue)
+        putDate(KEY_LATEST_PURCHASED_AT, latestPurchaseDate)
+        putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
+        putDate(KEY_EXPIRES_AT, expirationDate)
+        putDate(KEY_UNSUBSCRIBE_DETECTED_AT, unsubscribeDetectedAt)
+        putDate(KEY_BILLING_ISSUE_DETECTED_AT, billingIssueDetectedAt)
+        putBool(KEY_IS_SANDBOX, isSandbox)
+        putBool(KEY_IS_ACTIVE, isActive)
+        putBool(KEY_WILL_RENEW, willRenew)
+        putDate(KEY_EVALUATED_AT, date)
+    }
+
+    internal companion object {
+        const val KEY_APP_USER_ID = "appUserId"
+        const val KEY_ENTITLEMENTS = "entitlements"
+        const val KEY_EVALUATED_AT = "evaluatedAt"
+        const val KEY_FIRST_SEEN_AT = "firstSeenAt"
+        const val KEY_LAST_SEEN_AT = "lastSeenAt"
+        const val KEY_ORIGINAL_APP_USER_ID = "originalAppUserId"
+        const val KEY_PURCHASES = "purchases"
+
+        const val KEY_AUTO_RESUME_AT = "autoResumeAt"
+        const val KEY_BILLING_ISSUE_DETECTED_AT = "billingIssueDetectedAt"
+        const val KEY_DISPLAY_NAME = "displayName"
+        const val KEY_EXPIRES_AT = "expiresAt"
+        const val KEY_GRACE_PERIOD_EXPIRES_AT = "gracePeriodExpiresAt"
+        const val KEY_IDENTIFIER = "identifier"
+        const val KEY_IS_ACTIVE = "isActive"
+        const val KEY_IS_IN_GRACE_PERIOD = "isInGracePeriod"
+        const val KEY_IS_PAUSED = "isPaused"
+        const val KEY_IS_REFUNDED = "isRefunded"
+        const val KEY_IS_SANDBOX = "isSandbox"
+        const val KEY_KIND = "kind"
+        const val KEY_LATEST_PURCHASED_AT = "latestPurchasedAt"
+        const val KEY_ORIGINAL_PURCHASED_AT = "originalPurchasedAt"
+        const val KEY_OWNERSHIP_TYPE = "ownershipType"
+        const val KEY_PERIOD_TYPE = "periodType"
+        const val KEY_PRICE_AMOUNT_MICROS = "priceAmountMicros"
+        const val KEY_PRICE_CURRENCY = "priceCurrency"
+        const val KEY_PRODUCT_IDENTIFIER = "productIdentifier"
+        const val KEY_PRODUCT_PLAN_IDENTIFIER = "productPlanIdentifier"
+        const val KEY_PURCHASED_AT = "purchasedAt"
+        const val KEY_PURCHASED_PRODUCT_IDENTIFIER = "purchasedProductIdentifier"
+        const val KEY_REFUNDED_AT = "refundedAt"
+        const val KEY_STORE = "store"
+        const val KEY_STORE_TRANSACTION_ID = "storeTransactionId"
+        const val KEY_TRANSACTION_IDENTIFIER = "transactionIdentifier"
+        const val KEY_UNSUBSCRIBE_DETECTED_AT = "unsubscribeDetectedAt"
+        const val KEY_WILL_RENEW = "willRenew"
+
+        const val KIND_NON_SUBSCRIPTION = "nonSubscription"
+        const val KIND_SUBSCRIPTION = "subscription"
+
+        /**
+         * The base plan is part of what was bought on Google, and it is the form the dashboard lists a
+         * subscription under, so it is spelled out as its own value rather than left for a predicate to
+         * concatenate. Built the same way [CustomerInfo.allPurchasedProductIds] builds its keys.
+         */
+        private fun purchasedProductIdentifier(productIdentifier: String, productPlanIdentifier: String?): String =
+            productPlanIdentifier
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { plan -> "$productIdentifier${Constants.SUBS_ID_BASE_PLAN_ID_SEPARATOR}$plan" }
+                ?: productIdentifier
+
+        /**
+         * Not a value to compare against: an unknown ownership type is the absence of one.
+         */
+        private val OwnershipType.dimensionValue: String?
+            get() = when (this) {
+                OwnershipType.PURCHASED -> "PURCHASED"
+                OwnershipType.FAMILY_SHARED -> "FAMILY_SHARED"
+                OwnershipType.UNKNOWN -> null
+            }
+
+        private val PeriodType.dimensionValue: String
+            get() = when (this) {
+                PeriodType.NORMAL -> "normal"
+                PeriodType.INTRO -> "intro"
+                PeriodType.TRIAL -> "trial"
+                PeriodType.PREPAID -> "prepaid"
+            }
+
+        private fun Map<String, RulesDimensionValue>.dateOrNull(key: String): Date? =
+            (this[key] as? RulesDimensionValue.DateValue)?.value
+
+        private fun MutableMap<String, RulesDimensionValue>.putBool(key: String, value: Boolean) {
+            put(key, RulesDimensionValue.BoolValue(value))
+        }
+
+        private fun MutableMap<String, RulesDimensionValue>.putString(key: String, value: String?) {
+            if (!value.isNullOrEmpty()) put(key, RulesDimensionValue.StringValue(value))
+        }
+
+        private fun MutableMap<String, RulesDimensionValue>.putDate(key: String, value: Date?) {
+            if (value != null) put(key, RulesDimensionValue.DateValue(value))
+        }
+
+        private fun MutableMap<String, RulesDimensionValue>.putObjectList(
+            key: String,
+            value: List<Map<String, RulesDimensionValue>>,
+        ) {
+            put(key, RulesDimensionValue.ObjectListValue(value))
+        }
+
+        /**
+         * The formatted price is deliberately left out: it is rendered in the device's locale, so it is not
+         * something a predicate authored once can compare against.
+         */
+        private fun MutableMap<String, RulesDimensionValue>.putPrice(price: Price?) {
+            if (price == null) return
+            put(KEY_PRICE_AMOUNT_MICROS, RulesDimensionValue.IntValue(price.amountMicros))
+            putString(KEY_PRICE_CURRENCY, price.currencyCode)
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
@@ -8,7 +8,6 @@ import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Config
 import com.revenuecat.purchases.common.LocaleProvider
 import com.revenuecat.purchases.common.platformName
-import java.util.Date
 
 /**
  * Device and environment dimensions.
@@ -37,7 +36,7 @@ internal class DeviceDimensionProvider(
     // empty.
     private val fallbackLanguageTag: String = appConfig.languageTag
 
-    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+    override suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> =
         (fixedDimensions + (KEY_LOCALE to RulesDimensionValue.StringValue(currentLocale())))
             .filterValues { value -> value.hasValue }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -29,9 +29,10 @@ internal sealed class LocalRulesEvaluationException(message: String) : Exception
 internal class LocalRulesEvaluator(
     providers: List<RulesDimensionProvider>,
     dateProvider: DateProvider = DefaultDateProvider(),
+    currentAppUserId: () -> String = { "" },
 ) {
 
-    private val dimensionResolver = RulesDimensionResolver(providers, dateProvider)
+    private val dimensionResolver = RulesDimensionResolver(providers, dateProvider, currentAppUserId)
 
     /**
      * The first rule that matches, or `null` when none does.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -22,6 +22,19 @@ internal enum class RulesDimensionNamespace(val key: String) {
 }
 
 /**
+ * What every provider in one snapshot is answering about.
+ *
+ * @property date the common reference instant for the evaluation. It does not indicate when a provider's
+ * underlying values were observed.
+ * @property appUserId the customer the whole snapshot describes, read once by [RulesDimensionResolver] so that
+ * providers reading it for themselves cannot end up describing two different customers.
+ */
+internal data class RulesDimensionContext(
+    val date: Date,
+    val appUserId: String,
+)
+
+/**
  * Supplies one subtree of on-device dimensions.
  *
  * Implementations may observe or persist state internally, but values are pulled only when an evaluation asks for
@@ -40,9 +53,6 @@ internal interface RulesDimensionProvider {
      * which is a non-match rather than an error. A name no predicate could read is dropped by
      * [RulesDimensionResolver], which applies that rule to every provider. Throwing is reserved for a systemic
      * failure to produce this provider's values.
-     *
-     * [date] is the common reference instant for the evaluation. It does not indicate when the underlying values
-     * were observed.
      */
-    suspend fun dimensions(date: Date): Map<String, RulesDimensionValue>
+    suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue>
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -16,6 +16,9 @@ import java.util.Date
 internal enum class RulesDimensionNamespace(val key: String) {
     /** Values supplied by the caller for one evaluation; see [LocalRulesEvaluator.match]. */
     Custom("custom"),
+
+    /** What the customer has bought, shaped after the SDK's own `CustomerInfo`. */
+    CustomerInfo("customerInfo"),
     Device("device"),
     Store("store"),
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -6,7 +6,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import java.util.Date
 
 /**
- * The SDK-owned roots a predicate can read. Closed on purpose, like `RemoteConfigTopic`: these names are part of
+ * The SDK-owned roots a predicate can read. Closed on purpose: these names are part of
  * the contract predicates are authored against, so a provider must not be able to invent one.
  *
  * Each entry becomes a real nested object in the evaluated scope, because the engine's `var` operator walks
@@ -14,15 +14,10 @@ import java.util.Date
  * `device`, it is never a literal key.
  */
 internal enum class RulesDimensionNamespace(val key: String) {
-    /** Values supplied by the caller for one evaluation; see [LocalRulesEvaluator.match]. */
     Custom("custom"),
-
-    /** What the customer has bought, shaped after the SDK's own `CustomerInfo`. */
     CustomerInfo("customerInfo"),
     Device("device"),
     Store("store"),
-
-    /** What the app has told the SDK about the customer; see `Purchases.setAttributes`. */
     SubscriberAttributes("subscriberAttributes"),
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -34,7 +34,8 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
  * Builds the scope local rule evaluation runs against by collecting every provider once and nesting its values
  * under the provider's namespace.
  *
- * All providers see the same reference instant, so every dimension in one snapshot is consistent with the others.
+ * All providers see the same reference instant, so every dimension in one snapshot is consistent with the
+ * others. That instant is in the scope itself, as [RulesDimensionResolver.KEY_EVALUATED_AT].
  *
  * Both failure modes are configuration bugs rather than runtime conditions — a provider that cannot produce its
  * values, and two providers claiming the same path — so they fail the whole snapshot instead of silently
@@ -81,10 +82,23 @@ internal class RulesDimensionResolver(
 
         return Result.success(
             RulesDimensionSnapshot(
-                values = values.mapValues { (_, dimensions) -> Value.ObjectValue(dimensions) },
+                values = values.mapValuesTo(
+                    mutableMapOf<String, Value>(KEY_EVALUATED_AT to Value.IntValue(date.time)),
+                ) { (_, dimensions) -> Value.ObjectValue(dimensions) },
                 evaluationDate = date,
             ),
         )
+    }
+
+    internal companion object {
+        /**
+         * The instant the snapshot was taken, at the root of the scope rather than repeated on every record.
+         *
+         * Not readable from inside an iteration operator: `some` and its siblings rebind `var` to the current item
+         * with no parent scope, so a predicate comparing a purchase against it reads that purchase by index, as
+         * `customerInfo.purchases.0.expiresAt`.
+         */
+        const val KEY_EVALUATED_AT = "evaluatedAt"
     }
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -58,21 +58,20 @@ internal class RulesDimensionResolver(
      * [customVariables] are the caller's own values for this one evaluation, exposed under
      * [RulesDimensionNamespace.Custom].
      *
-     * A login, logout or user switch part-way through leaves the providers describing two different customers,
-     * since each reads the app user for itself. Reporting the part that survives would let an absence rule match
-     * a customer whose purchases simply were not read, so nothing is reported.
+     * A login, logout or user switch part-way through leaves the collected values describing two different
+     * customers. Reporting the part that survives would let an absence rule match a customer whose purchases
+     * simply were not read, so nothing is reported.
      */
     @Suppress("ReturnCount")
     suspend fun snapshot(
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
     ): Result<RulesDimensionSnapshot> {
-        val appUserId = currentAppUserId()
-        val date = dateProvider.now
+        val context = RulesDimensionContext(date = dateProvider.now, appUserId = currentAppUserId())
         val values = mutableMapOf<String, MutableMap<String, Value>>()
 
         for (provider in providers) {
             val dimensions = try {
-                provider.dimensions(date)
+                provider.dimensions(context)
             } catch (error: CancellationException) {
                 throw error
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
@@ -92,7 +91,10 @@ internal class RulesDimensionResolver(
             return Result.failure(conflict)
         }
 
-        if (currentAppUserId() != appUserId) {
+        // Still worth checking with the id pinned in the context: a customer info read for one app user can
+        // still be answered about another, since on a cold cache the SDK syncs pending purchases first and that
+        // sync reads the current app user for itself.
+        if (currentAppUserId() != context.appUserId) {
             warnLog { "The app user changed while the dimensions were being collected, so they were discarded." }
             return Result.failure(RulesDimensionResolutionException.AppUserChanged)
         }
@@ -100,9 +102,9 @@ internal class RulesDimensionResolver(
         return Result.success(
             RulesDimensionSnapshot(
                 values = values.mapValuesTo(
-                    mutableMapOf<String, Value>(KEY_EVALUATED_AT to Value.IntValue(date.time)),
+                    mutableMapOf<String, Value>(KEY_EVALUATED_AT to Value.IntValue(context.date.time)),
                 ) { (_, dimensions) -> Value.ObjectValue(dimensions) },
-                evaluationDate = date,
+                evaluationDate = context.date,
             ),
         )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -28,32 +28,60 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
     internal data class ConflictingDimension(
         val path: String,
     ) : RulesDimensionResolutionException("two dimension providers supplied '$path'")
+
+    internal object AppUserChanged : RulesDimensionResolutionException(
+        "the app user kept changing while the dimensions were being collected",
+    )
 }
 
 /**
  * Builds the scope local rule evaluation runs against by collecting every provider once and nesting its values
  * under the provider's namespace.
  *
- * All providers see the same reference instant, so every dimension in one snapshot is consistent with the
- * others. That instant is in the scope itself, as [RulesDimensionResolver.KEY_EVALUATED_AT].
+ * Every dimension in one snapshot describes the same customer at the same instant: all providers see the same
+ * reference instant, which is in the scope itself as [RulesDimensionResolver.KEY_EVALUATED_AT], and a collection
+ * the app user changed underneath is thrown away and taken again.
  *
- * Both failure modes are configuration bugs rather than runtime conditions — a provider that cannot produce its
- * values, and two providers claiming the same path — so they fail the whole snapshot instead of silently
- * degrading a rule to a non-match, which would be indistinguishable from a customer who genuinely does not match.
- * Cancellation is neither, and propagates.
+ * The three failure modes fail the whole snapshot instead of silently degrading a rule to a non-match, which
+ * would be indistinguishable from a customer who genuinely does not match: a provider that cannot produce its
+ * values, two providers claiming the same path, and an app user that would not stay still. Cancellation is none
+ * of them, and propagates.
  */
 internal class RulesDimensionResolver(
     private val providers: List<RulesDimensionProvider>,
     private val dateProvider: DateProvider = DefaultDateProvider(),
+    /** No identity source means nothing can change: the same value the SDK reports for an uncached user. */
+    private val currentAppUserId: () -> String = { "" },
 ) {
 
     /**
      * [customVariables] are the caller's own values for this one evaluation, exposed under
      * [RulesDimensionNamespace.Custom].
+     *
+     * A login, logout or user switch part-way through leaves the collected values describing two different
+     * customers, so the whole collection is thrown away and taken again rather than reported: reporting the part
+     * that survives would let an absence rule match a customer whose purchases simply were not read.
      */
     @Suppress("ReturnCount")
     suspend fun snapshot(
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
+    ): Result<RulesDimensionSnapshot> {
+        repeat(ATTEMPTS) {
+            val appUserId = currentAppUserId()
+            val result = collect(customVariables)
+            // A provider that cannot produce its values and two providers claiming the same path are both
+            // configuration bugs. Asking again does not fix either.
+            if (result.isFailure) return result
+            if (currentAppUserId() == appUserId) return result
+            warnLog { "The app user changed while the dimensions were being collected, so they were discarded." }
+        }
+        return Result.failure(RulesDimensionResolutionException.AppUserChanged)
+    }
+
+    /** One pass over every provider, against one reference instant of its own. */
+    @Suppress("ReturnCount")
+    private suspend fun collect(
+        customVariables: Map<String, RulesDimensionValue>,
     ): Result<RulesDimensionSnapshot> {
         val date = dateProvider.now
         val values = mutableMapOf<String, MutableMap<String, Value>>()
@@ -91,6 +119,11 @@ internal class RulesDimensionResolver(
     }
 
     internal companion object {
+        /**
+         * One collection and one retry.
+         */
+        private const val ATTEMPTS = 2
+
         /**
          * The instant the snapshot was taken, at the root of the scope rather than repeated on every record.
          *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -30,7 +30,7 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
     ) : RulesDimensionResolutionException("two dimension providers supplied '$path'")
 
     internal object AppUserChanged : RulesDimensionResolutionException(
-        "the app user kept changing while the dimensions were being collected",
+        "the app user changed while the dimensions were being collected",
     )
 }
 
@@ -40,12 +40,12 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
  *
  * Every dimension in one snapshot describes the same customer at the same instant: all providers see the same
  * reference instant, which is in the scope itself as [RulesDimensionResolver.KEY_EVALUATED_AT], and a collection
- * the app user changed underneath is thrown away and taken again.
+ * the app user changed underneath is not reported at all.
  *
  * The three failure modes fail the whole snapshot instead of silently degrading a rule to a non-match, which
  * would be indistinguishable from a customer who genuinely does not match: a provider that cannot produce its
- * values, two providers claiming the same path, and an app user that would not stay still. Cancellation is none
- * of them, and propagates.
+ * values, two providers claiming the same path, and an app user that changed part-way through. Cancellation is
+ * none of them, and propagates.
  */
 internal class RulesDimensionResolver(
     private val providers: List<RulesDimensionProvider>,
@@ -58,31 +58,15 @@ internal class RulesDimensionResolver(
      * [customVariables] are the caller's own values for this one evaluation, exposed under
      * [RulesDimensionNamespace.Custom].
      *
-     * A login, logout or user switch part-way through leaves the collected values describing two different
-     * customers, so the whole collection is thrown away and taken again rather than reported: reporting the part
-     * that survives would let an absence rule match a customer whose purchases simply were not read.
+     * A login, logout or user switch part-way through leaves the providers describing two different customers,
+     * since each reads the app user for itself. Reporting the part that survives would let an absence rule match
+     * a customer whose purchases simply were not read, so nothing is reported.
      */
     @Suppress("ReturnCount")
     suspend fun snapshot(
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
     ): Result<RulesDimensionSnapshot> {
-        repeat(ATTEMPTS) {
-            val appUserId = currentAppUserId()
-            val result = collect(customVariables)
-            // A provider that cannot produce its values and two providers claiming the same path are both
-            // configuration bugs. Asking again does not fix either.
-            if (result.isFailure) return result
-            if (currentAppUserId() == appUserId) return result
-            warnLog { "The app user changed while the dimensions were being collected, so they were discarded." }
-        }
-        return Result.failure(RulesDimensionResolutionException.AppUserChanged)
-    }
-
-    /** One pass over every provider, against one reference instant of its own. */
-    @Suppress("ReturnCount")
-    private suspend fun collect(
-        customVariables: Map<String, RulesDimensionValue>,
-    ): Result<RulesDimensionSnapshot> {
+        val appUserId = currentAppUserId()
         val date = dateProvider.now
         val values = mutableMapOf<String, MutableMap<String, Value>>()
 
@@ -108,6 +92,11 @@ internal class RulesDimensionResolver(
             return Result.failure(conflict)
         }
 
+        if (currentAppUserId() != appUserId) {
+            warnLog { "The app user changed while the dimensions were being collected, so they were discarded." }
+            return Result.failure(RulesDimensionResolutionException.AppUserChanged)
+        }
+
         return Result.success(
             RulesDimensionSnapshot(
                 values = values.mapValuesTo(
@@ -119,11 +108,6 @@ internal class RulesDimensionResolver(
     }
 
     internal companion object {
-        /**
-         * One collection and one retry.
-         */
-        private const val ATTEMPTS = 2
-
         /**
          * The instant the snapshot was taken, at the root of the scope rather than repeated on every record.
          *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/StoreDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/StoreDimensionProvider.kt
@@ -5,7 +5,6 @@ package com.revenuecat.purchases.common.localrules
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.warnLog
 import kotlinx.coroutines.CancellationException
-import java.util.Date
 import java.util.IllformedLocaleException
 import java.util.Locale
 import java.util.MissingResourceException
@@ -35,7 +34,7 @@ internal class StoreDimensionProvider(
      * failure and propagates.
      */
     @Suppress("ReturnCount")
-    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+    override suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> {
         val countryCode = try {
             storefrontCountryCode()
         } catch (e: CancellationException) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
@@ -5,25 +5,25 @@ package com.revenuecat.purchases.common.localrules
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
-import java.util.Date
 
 internal class SubscriberAttributesDimensionProvider(
-    private val storedAttributes: () -> Map<String, SubscriberAttribute>,
+    private val storedAttributes: (appUserId: String) -> Map<String, SubscriberAttribute>,
 ) : RulesDimensionProvider {
 
     override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.SubscriberAttributes
 
     /**
      * Read per evaluation rather than snapshotted: an app can set an attribute at any time, and an audience keyed
-     * on one has to agree with what the app has said by the time the checkpoint is resolved.
+     * on one has to agree with what the app has said by the time the checkpoint is resolved. Read for the
+     * snapshot's app user, so they describe the same customer as everything alongside them.
      *
      * Attributes that cannot be read contribute no dimensions instead of failing the snapshot: they are parsed out
      * of whatever is on disk, so a payload an older version wrote differently surfaces here, and that should not
      * take an otherwise resolvable checkpoint down with it.
      */
-    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+    override suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> {
         val attributes = try {
-            storedAttributes()
+            storedAttributes(context.appUserId)
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             warnLog { "The subscriber attributes are unavailable, so they can't be evaluated: $e" }
             return emptyMap()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
@@ -28,10 +28,10 @@ internal class SubscriberAttributesDimensionProvider(
             warnLog { "The subscriber attributes are unavailable, so they can't be evaluated: $e" }
             return emptyMap()
         }
-        return attributes.values.mapNotNull { attribute -> attribute.dimension(date) }.toMap()
+        return attributes.values.mapNotNull { attribute -> attribute.dimension() }.toMap()
     }
 
-    private fun SubscriberAttribute.dimension(date: Date): Pair<String, RulesDimensionValue>? {
+    private fun SubscriberAttribute.dimension(): Pair<String, RulesDimensionValue>? {
         // A deleted attribute is kept as a tombstone with no value until it has been posted, and an empty value is
         // the SDK's other spelling of a deletion, so both mean the customer no longer has the attribute.
         val value = value?.takeIf { it.isNotEmpty() } ?: return null
@@ -41,13 +41,11 @@ internal class SubscriberAttributesDimensionProvider(
             mapOf(
                 KEY_VALUE to RulesDimensionValue.StringValue(value),
                 KEY_UPDATED_AT to RulesDimensionValue.DateValue(setTime),
-                KEY_EVALUATED_AT to RulesDimensionValue.DateValue(date),
             ),
         )
     }
 
     internal companion object {
-        const val KEY_EVALUATED_AT = "evaluatedAt"
         const val KEY_UPDATED_AT = "updatedAt"
         const val KEY_VALUE = "value"
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/CustomerInfoResponseJsonKeys.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/CustomerInfoResponseJsonKeys.kt
@@ -8,6 +8,7 @@ internal object CustomerInfoResponseJsonKeys {
     const val ORIGINAL_APPLICATION_VERSION = "original_application_version"
     const val ENTITLEMENTS = "entitlements"
     const val FIRST_SEEN = "first_seen"
+    const val LAST_SEEN = "last_seen"
     const val ORIGINAL_PURCHASE_DATE = "original_purchase_date"
     const val NON_SUBSCRIPTIONS = "non_subscriptions"
     const val SUBSCRIPTIONS = "subscriptions"

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.common.checkpoints.CheckpointRule
 import com.revenuecat.purchases.common.checkpoints.CheckpointRulesResolution
 import com.revenuecat.purchases.common.checkpoints.CheckpointsConfigProvider
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
+import com.revenuecat.purchases.common.localrules.RulesDimensionContext
 import com.revenuecat.purchases.common.localrules.RulesDimensionNamespace
 import com.revenuecat.purchases.common.localrules.RulesDimensionProvider
 import com.revenuecat.purchases.common.localrules.RulesDimensionValue
@@ -520,7 +521,7 @@ class CheckpointWorkflowResolverImplTest {
 
     private object FailingDimensionProvider : RulesDimensionProvider {
         override val namespace = RulesDimensionNamespace.Device
-        override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+        override suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> =
             throw IllegalStateException("no dimensions")
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/CustomerInfoFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/CustomerInfoFactoryTest.kt
@@ -49,6 +49,42 @@ class CustomerInfoFactoryTest {
     }
 
     @Test
+    fun `parses the last seen date`() {
+        val response = JSONObject(Responses.validFullPurchaserResponse).apply {
+            getJSONObject("subscriber").put("last_seen", "2024-05-20T00:00:00Z")
+        }
+
+        val customerInfo = CustomerInfoFactory.buildCustomerInfo(
+            response,
+            overrideRequestDate = null,
+            verificationResult = VerificationResult.NOT_REQUESTED,
+        )
+
+        assertThat(customerInfo.lastSeen).isEqualTo(Iso8601Utils.parse("2024-05-20T00:00:00Z"))
+    }
+
+    @Test
+    fun `a payload with no last seen date parses to none`() {
+        // What a customer info cached by a version that did not read the key looks like.
+        assertThat(defaultCustomerInfo.lastSeen).isNull()
+    }
+
+    @Test
+    fun `two customer infos differing only in the last seen date are equal`() {
+        val laterSeen = CustomerInfoFactory.buildCustomerInfo(
+            JSONObject(Responses.validFullPurchaserResponse).apply {
+                getJSONObject("subscriber").put("last_seen", "2024-05-20T00:00:00Z")
+            },
+            overrideRequestDate = null,
+            verificationResult = VerificationResult.NOT_REQUESTED,
+        )
+
+        // The backend moves this on every response, so counting it would make CustomerInfoUpdateHandler notify
+        // its listeners on every refresh. Same reason requestDate is excluded.
+        assertThat(laterSeen).isEqualTo(defaultCustomerInfo)
+    }
+
+    @Test
     fun `assigns default schema version correctly`() {
         assertThat(defaultCustomerInfo.schemaVersion).isEqualTo(3)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -40,10 +40,30 @@ class CustomerInfoDimensionProviderTest {
                 "appUserId" to string(APP_USER_ID),
                 "originalAppUserId" to string("original_user"),
                 "firstSeenAt" to date("2022-01-01T00:00:00Z"),
-                "lastSeenAt" to date("2024-06-01T00:00:00Z"),
+                "lastSeenAt" to date("2024-05-20T00:00:00Z"),
                 "originalPurchasedAt" to date("2021-01-01T00:00:00Z"),
             ),
         )
+    }
+
+    @Test
+    fun `the last seen date is the backend's, not the date it last answered this device`() = runTest {
+        val dimensions = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(context)
+
+        // `requestDate` is 2024-06-01 and the SDK refreshes on every foreground, so mapping it would read as
+        // "seen just now" for the whole session and "hasn't opened the app in a while" could never match.
+        assertThat(dimensions["lastSeenAt"]).isEqualTo(date("2024-05-20T00:00:00Z"))
+        assertThat(dimensions["lastSeenAt"]).isNotEqualTo(date("2024-06-01T00:00:00Z"))
+    }
+
+    @Test
+    fun `a payload with no last seen date reports none`() = runTest {
+        // A customer info cached by a version that did not read the key.
+        val response = subscriberResponse(lastSeen = null)
+
+        val dimensions = provider(customerInfo(response)).dimensions(context)
+
+        assertThat(dimensions).doesNotContainKey("lastSeenAt")
     }
 
     @Test
@@ -554,6 +574,7 @@ class CustomerInfoDimensionProviderTest {
             subscriptions: String = "",
             nonSubscriptions: String = "",
             entitlements: String = "",
+            lastSeen: String? = "2024-05-20T00:00:00Z",
         ) = """
             {
               "request_date": "2024-06-01T00:00:00Z",
@@ -561,6 +582,7 @@ class CustomerInfoDimensionProviderTest {
                 "original_app_user_id": "original_user",
                 "original_application_version": "1.0",
                 "first_seen": "2022-01-01T00:00:00Z",
+                "last_seen": ${lastSeen.asJsonString()},
                 "original_purchase_date": "2021-01-01T00:00:00Z",
                 "management_url": null,
                 "subscriptions": { $subscriptions },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -1,0 +1,487 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.CustomerInfoFactory
+import com.revenuecat.purchases.rules.RulesEngine
+import com.revenuecat.purchases.rules.Value
+import com.revenuecat.purchases.utils.Iso8601Utils
+import com.revenuecat.purchases.utils.Responses
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class CustomerInfoDimensionProviderTest {
+
+    private val date = Date(1_700_000_000_000)
+
+    @Test
+    fun `provides the customer's identity and lifecycle dimensions`() = runTest {
+        val dimensions = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date)
+
+        assertThat(dimensions.filterValues { it !is RulesDimensionValue.ObjectListValue }).isEqualTo(
+            mapOf(
+                "appUserId" to string("current_user"),
+                "originalAppUserId" to string("original_user"),
+                "firstSeenAt" to date("2022-01-01T00:00:00Z"),
+                "lastSeenAt" to date("2024-06-01T00:00:00Z"),
+                "originalPurchasedAt" to date("2021-01-01T00:00:00Z"),
+                "evaluatedAt" to RulesDimensionValue.DateValue(date),
+            ),
+        )
+    }
+
+    @Test
+    fun `describes every purchase of either kind, newest first`() = runTest {
+        val purchases = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+
+        assertThat(purchases.map { it["kind"] to it["purchasedProductIdentifier"] }).containsExactly(
+            string("subscription") to string("premium:monthly"),
+            string("nonSubscription") to string("coins"),
+            string("subscription") to string("legacy:annual"),
+        )
+    }
+
+    @Test
+    fun `describes a subscription with everything the SDK knows about it`() = runTest {
+        val purchases = provider(customerInfo(FULLY_POPULATED_RESPONSE)).dimensions(date).purchases()
+
+        assertThat(purchases.single()).isEqualTo(
+            mapOf(
+                "kind" to string("subscription"),
+                "productIdentifier" to string("premium"),
+                "productPlanIdentifier" to string("monthly"),
+                "purchasedProductIdentifier" to string("premium:monthly"),
+                "storeTransactionId" to string("GPA.0000-0000-0000-00000"),
+                "displayName" to string("Premium Monthly"),
+                "store" to string("play_store"),
+                "ownershipType" to string("PURCHASED"),
+                "periodType" to string("trial"),
+                "priceAmountMicros" to RulesDimensionValue.IntValue(4_990_000),
+                "priceCurrency" to string("USD"),
+                "purchasedAt" to date("2024-05-01T00:00:00Z"),
+                "originalPurchasedAt" to date("2021-01-01T00:00:00Z"),
+                "expiresAt" to date("2100-01-01T00:00:00Z"),
+                "unsubscribeDetectedAt" to date("2024-05-03T00:00:00Z"),
+                "billingIssueDetectedAt" to date("2024-05-04T00:00:00Z"),
+                "gracePeriodExpiresAt" to date("2024-05-10T00:00:00Z"),
+                "refundedAt" to date("2024-05-05T00:00:00Z"),
+                "autoResumeAt" to date("2024-06-01T00:00:00Z"),
+                "isSandbox" to bool(true),
+                "isActive" to bool(true),
+                "willRenew" to bool(false),
+                "isInGracePeriod" to bool(true),
+                "isRefunded" to bool(true),
+                "isPaused" to bool(true),
+                "evaluatedAt" to RulesDimensionValue.DateValue(date),
+            ),
+        )
+    }
+
+    @Test
+    fun `describes a one-time purchase without the fields only a subscription has`() = runTest {
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+            .single { it["kind"] == string("nonSubscription") }
+
+        assertThat(purchase).isEqualTo(
+            mapOf(
+                "kind" to string("nonSubscription"),
+                "productIdentifier" to string("coins"),
+                "purchasedProductIdentifier" to string("coins"),
+                "transactionIdentifier" to string("abc123"),
+                "store" to string("play_store"),
+                "purchasedAt" to date("2023-03-03T00:00:00Z"),
+                "originalPurchasedAt" to date("2023-03-03T00:00:00Z"),
+                "isSandbox" to bool(true),
+                "evaluatedAt" to RulesDimensionValue.DateValue(date),
+            ),
+        )
+    }
+
+    @Test
+    fun `describes every entitlement, ordered by identifier`() = runTest {
+        val entitlements = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).entitlements()
+
+        assertThat(entitlements.map { it["identifier"] })
+            .containsExactly(string("extra"), string("old"), string("premium"))
+        assertThat(entitlements.single { it["identifier"] == string("old") }).isEqualTo(
+            mapOf(
+                "identifier" to string("old"),
+                "productIdentifier" to string("legacy"),
+                "productPlanIdentifier" to string("annual"),
+                "purchasedProductIdentifier" to string("legacy:annual"),
+                "store" to string("amazon"),
+                "ownershipType" to string("FAMILY_SHARED"),
+                "periodType" to string("normal"),
+                "latestPurchasedAt" to date("2022-06-01T00:00:00Z"),
+                "originalPurchasedAt" to date("2022-06-01T00:00:00Z"),
+                "expiresAt" to date("2023-06-01T00:00:00Z"),
+                "isSandbox" to bool(true),
+                "isActive" to bool(false),
+                "willRenew" to bool(true),
+                "evaluatedAt" to RulesDimensionValue.DateValue(date),
+            ),
+        )
+    }
+
+    @Test
+    fun `a customer who has never bought anything reports empty collections rather than none`() = runTest {
+        val dimensions = provider(customerInfo(Responses.validEmptyPurchaserResponse)).dimensions(date)
+
+        // An empty array is what makes `none` a definite yes and `some` a definite no; an absent key would leave
+        // both unknown.
+        assertThat(dimensions["purchases"]).isEqualTo(RulesDimensionValue.ObjectListValue(emptyList()))
+        assertThat(dimensions["entitlements"]).isEqualTo(RulesDimensionValue.ObjectListValue(emptyList()))
+    }
+
+    @Test
+    fun `a lifetime purchase reports no expiry and stays active`() = runTest {
+        val purchase = provider(customerInfo(LIFETIME_RESPONSE)).dimensions(date).purchases().single()
+
+        assertThat(purchase).doesNotContainKey("expiresAt")
+        assertThat(purchase["isActive"]).isEqualTo(bool(true))
+        // Nothing to renew.
+        assertThat(purchase["willRenew"]).isEqualTo(bool(false))
+    }
+
+    @Test
+    fun `an unknown ownership type is reported as no ownership type at all`() = runTest {
+        val purchase = provider(customerInfo(PROMO_RESPONSE)).dimensions(date).purchases().single()
+
+        assertThat(purchase).doesNotContainKey("ownershipType")
+        assertThat(purchase["store"]).isEqualTo(string("promotional"))
+    }
+
+    @Test
+    fun `a subscription being served through a grace period says so`() = runTest {
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+            .single { it["purchasedProductIdentifier"] == string("legacy:annual") }
+
+        // Expired in 2023, but the store keeps serving it until 2100.
+        assertThat(purchase["isActive"]).isEqualTo(bool(false))
+        assertThat(purchase["isInGracePeriod"]).isEqualTo(bool(true))
+    }
+
+    @Test
+    fun `a customer info that cannot be read leaves the identity dimensions usable`() = runTest {
+        // Not just PurchasesException: the read goes through the configured instance, which an app can tear down
+        // mid-evaluation, and it can fall back to the network.
+        val failures = listOf(
+            PurchasesException(PurchasesError(PurchasesErrorCode.NetworkError, "Nope.")),
+            UninitializedPropertyAccessException("There is no singleton instance."),
+            IllegalStateException("Something else entirely."),
+        )
+
+        for (failure in failures) {
+            val snapshot = RulesDimensionResolver(
+                providers = listOf(
+                    deviceProvider(),
+                    CustomerInfoDimensionProvider(
+                        appUserId = { "current_user" },
+                                    customerInfo = { throw failure },
+                    ),
+                ),
+            ).snapshot()
+
+            assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
+            // The app user ID is known without asking the backend, so a rule on it survives the failure.
+            assertThat(snapshot.getOrThrow().values["customerInfo"]).describedAs("%s", failure).isEqualTo(
+                Value.ObjectValue(mapOf("appUserId" to Value.StringValue("current_user"))),
+            )
+        }
+    }
+
+    @Test
+    fun `an unknown app user ID leaves the rest of the dimensions usable`() = runTest {
+        val provider = CustomerInfoDimensionProvider(
+            appUserId = { throw UninitializedPropertyAccessException("There is no singleton instance.") },
+            customerInfo = { customerInfo(SUBSCRIBED_RESPONSE) },
+        )
+
+        val dimensions = provider.dimensions(date)
+
+        assertThat(dimensions).doesNotContainKey("appUserId")
+        assertThat(dimensions["originalAppUserId"]).isEqualTo(string("original_user"))
+    }
+
+    @Test
+    fun `cancellation while reading the customer info propagates`() = runTest {
+        val cancelling = CustomerInfoDimensionProvider(
+            appUserId = { "current_user" },
+            customerInfo = { throw CancellationException("cancelled") },
+        )
+
+        val thrown = try {
+            cancelling.dimensions(date)
+            null
+        } catch (e: CancellationException) {
+            e
+        }
+
+        assertThat(thrown).hasMessage("cancelled")
+    }
+
+    @Test
+    fun `the customer info is read on every evaluation`() = runTest {
+        var response = Responses.validEmptyPurchaserResponse
+        val provider = CustomerInfoDimensionProvider(
+            appUserId = { "current_user" },
+            customerInfo = { customerInfo(response) },
+        )
+
+        assertThat(provider.dimensions(date).purchases()).isEmpty()
+
+        response = SUBSCRIBED_RESPONSE
+
+        assertThat(provider.dimensions(date).purchases()).hasSize(3)
+    }
+
+    @Test
+    fun `the records are searchable by a predicate`() = runTest {
+        val values = RulesDimensionResolver(providers = listOf(provider(customerInfo(SUBSCRIBED_RESPONSE))))
+            .snapshot()
+            .getOrThrow()
+            .values
+
+        val matching = listOf(
+            """{"==": [{"var": "customerInfo.appUserId"}, "current_user"]}""",
+            """{"some": [{"var": "customerInfo.entitlements"},
+                 {"and": [{"==": [{"var": "identifier"}, "premium"]}, {"var": "isActive"}]}]}""",
+            """{"some": [{"var": "customerInfo.purchases"},
+                 {"==": [{"var": "purchasedProductIdentifier"}, "legacy:annual"]}]}""",
+            // The latest purchase of any kind, with no iteration at all.
+            """{"==": [{"var": "customerInfo.purchases.0.productIdentifier"}, "premium"]}""",
+            // Ends more than a day from the evaluation instant, which only the per-record instant can answer.
+            """{"some": [{"var": "customerInfo.purchases"},
+                 {">": [{"-": [{"var": "expiresAt"}, {"var": "evaluatedAt"}]}, 86400000]}]}""",
+            """{"none": [{"var": "customerInfo.purchases"}, {"var": "isRefunded"}]}""",
+        )
+        val notMatching = listOf(
+            """{"some": [{"var": "customerInfo.entitlements"},
+                 {"and": [{"==": [{"var": "identifier"}, "old"]}, {"var": "isActive"}]}]}""",
+            """{"some": [{"var": "customerInfo.purchases"}, {"==": [{"var": "periodType"}, "trial"]}]}""",
+            """{"some": [{"var": "customerInfo.purchases"},
+                 {"==": [{"var": "purchasedProductIdentifier"}, "legacy"]}]}""",
+        )
+
+        for (predicate in matching) {
+            assertThat(RulesEngine.evaluate(predicate, values).getOrThrow()).describedAs(predicate).isTrue()
+        }
+        for (predicate in notMatching) {
+            assertThat(RulesEngine.evaluate(predicate, values).getOrThrow()).describedAs(predicate).isFalse()
+        }
+    }
+
+    private fun provider(customerInfo: CustomerInfo) = CustomerInfoDimensionProvider(
+        appUserId = { "current_user" },
+        customerInfo = { customerInfo },
+    )
+
+    private fun deviceProvider() = object : RulesDimensionProvider {
+        override val namespace = RulesDimensionNamespace.Device
+        override suspend fun dimensions(date: Date) = mapOf("platform" to string("android"))
+    }
+
+    private fun customerInfo(response: String): CustomerInfo =
+        CustomerInfoFactory.buildCustomerInfo(JSONObject(response), null, VerificationResult.NOT_REQUESTED)
+
+    private fun Map<String, RulesDimensionValue>.purchases() = objectList("purchases")
+    private fun Map<String, RulesDimensionValue>.entitlements() = objectList("entitlements")
+
+    private fun Map<String, RulesDimensionValue>.objectList(key: String) =
+        (this[key] as RulesDimensionValue.ObjectListValue).value
+
+    private fun string(value: String) = RulesDimensionValue.StringValue(value)
+    private fun bool(value: Boolean) = RulesDimensionValue.BoolValue(value)
+    private fun date(iso8601: String) = RulesDimensionValue.DateValue(Iso8601Utils.parse(iso8601))
+
+    private companion object {
+
+        /**
+         * A Google subscription bought most recently, an Amazon one that expired but is in a grace period, and a
+         * one-time purchase in between. Two entitlements are unlocked by the latest subscription and one by the
+         * older one.
+         */
+        val SUBSCRIBED_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "premium": {
+                  ${subscription(
+                store = "play_store",
+                purchaseDate = "2024-01-15T10:00:00Z",
+                originalPurchaseDate = "2021-01-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = "PURCHASED",
+            )}
+                },
+                "legacy": {
+                  ${subscription(
+                store = "amazon",
+                purchaseDate = "2022-06-01T00:00:00Z",
+                originalPurchaseDate = "2022-06-01T00:00:00Z",
+                expiresDate = "2023-06-01T00:00:00Z",
+                ownershipType = "FAMILY_SHARED",
+                productPlanIdentifier = "annual",
+                gracePeriodExpiresDate = "2100-01-01T00:00:00Z",
+            )}
+                }
+            """,
+            nonSubscriptions = """
+                "coins": [
+                  {
+                    "id": "abc123",
+                    "is_sandbox": true,
+                    "original_purchase_date": "2023-03-03T00:00:00Z",
+                    "purchase_date": "2023-03-03T00:00:00Z",
+                    "store": "play_store"
+                  }
+                ]
+            """,
+            entitlements = """
+                "premium": {
+                  "expires_date": "2100-01-01T00:00:00Z",
+                  "product_identifier": "premium",
+                  "product_plan_identifier": "monthly",
+                  "purchase_date": "2024-01-15T10:00:00Z"
+                },
+                "extra": {
+                  "expires_date": "2100-01-01T00:00:00Z",
+                  "product_identifier": "premium",
+                  "product_plan_identifier": "monthly",
+                  "purchase_date": "2024-01-15T10:00:00Z"
+                },
+                "old": {
+                  "expires_date": "2023-06-01T00:00:00Z",
+                  "product_identifier": "legacy",
+                  "product_plan_identifier": "annual",
+                  "purchase_date": "2022-06-01T00:00:00Z"
+                }
+            """,
+        )
+
+        /** Every field the backend can send on a subscription, so a record can be asserted whole. */
+        val FULLY_POPULATED_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "premium": {
+                  ${subscription(
+                store = "play_store",
+                purchaseDate = "2024-05-01T00:00:00Z",
+                originalPurchaseDate = "2021-01-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = "PURCHASED",
+                periodType = "trial",
+                unsubscribeDetectedAt = "2024-05-03T00:00:00Z",
+                billingIssuesDetectedAt = "2024-05-04T00:00:00Z",
+                gracePeriodExpiresDate = "2024-05-10T00:00:00Z",
+                refundedAt = "2024-05-05T00:00:00Z",
+                autoResumeDate = "2024-06-01T00:00:00Z",
+                displayName = "Premium Monthly",
+                price = """{"amount": 4.99, "currency": "USD"}""",
+            )}
+                }
+            """,
+        )
+
+        val LIFETIME_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "lifetime": {
+                  ${subscription(
+                store = "play_store",
+                purchaseDate = "2024-05-01T00:00:00Z",
+                originalPurchaseDate = "2024-05-01T00:00:00Z",
+                expiresDate = null,
+                ownershipType = "PURCHASED",
+            )}
+                }
+            """,
+        )
+
+        val PROMO_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "rc_promo_pro_monthly": {
+                  ${subscription(
+                store = "promotional",
+                purchaseDate = "2024-05-01T00:00:00Z",
+                originalPurchaseDate = "2024-05-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = null,
+            )}
+                }
+            """,
+        )
+
+        @Suppress("LongParameterList")
+        private fun subscription(
+            store: String,
+            purchaseDate: String,
+            originalPurchaseDate: String,
+            expiresDate: String?,
+            ownershipType: String?,
+            productPlanIdentifier: String? = "monthly",
+            periodType: String = "normal",
+            unsubscribeDetectedAt: String? = null,
+            billingIssuesDetectedAt: String? = null,
+            gracePeriodExpiresDate: String? = null,
+            refundedAt: String? = null,
+            autoResumeDate: String? = null,
+            displayName: String? = null,
+            price: String = "null",
+        ) = """
+            "store": "$store",
+            "product_plan_identifier": ${productPlanIdentifier.asJsonString()},
+            "purchase_date": "$purchaseDate",
+            "original_purchase_date": "$originalPurchaseDate",
+            "expires_date": ${expiresDate.asJsonString()},
+            "period_type": "$periodType",
+            "is_sandbox": true,
+            "unsubscribe_detected_at": ${unsubscribeDetectedAt.asJsonString()},
+            "billing_issues_detected_at": ${billingIssuesDetectedAt.asJsonString()},
+            "grace_period_expires_date": ${gracePeriodExpiresDate.asJsonString()},
+            "auto_resume_date": ${autoResumeDate.asJsonString()},
+            "refunded_at": ${refundedAt.asJsonString()},
+            "display_name": ${displayName.asJsonString()},
+            "price": $price,
+            "store_transaction_id": "GPA.0000-0000-0000-00000"${ownershipType.asOwnershipTypeEntry()}
+        """
+
+        private fun subscriberResponse(
+            subscriptions: String = "",
+            nonSubscriptions: String = "",
+            entitlements: String = "",
+        ) = """
+            {
+              "request_date": "2024-06-01T00:00:00Z",
+              "subscriber": {
+                "original_app_user_id": "original_user",
+                "original_application_version": "1.0",
+                "first_seen": "2022-01-01T00:00:00Z",
+                "original_purchase_date": "2021-01-01T00:00:00Z",
+                "management_url": null,
+                "subscriptions": { $subscriptions },
+                "non_subscriptions": { $nonSubscriptions },
+                "entitlements": { $entitlements }
+              }
+            }
+        """
+
+        private fun String?.asJsonString() = this?.let { "\"$it\"" } ?: "null"
+
+        // The backend omits the key rather than sending null, and so must the fixture: the response model
+        // defaults it instead of accepting null.
+        private fun String?.asOwnershipTypeEntry() = this?.let { ",\n\"ownership_type\": \"$it\"" }.orEmpty()
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -41,7 +41,6 @@ class CustomerInfoDimensionProviderTest {
                 "firstSeenAt" to date("2022-01-01T00:00:00Z"),
                 "lastSeenAt" to date("2024-06-01T00:00:00Z"),
                 "originalPurchasedAt" to date("2021-01-01T00:00:00Z"),
-                "evaluatedAt" to RulesDimensionValue.DateValue(date),
             ),
         )
     }
@@ -89,7 +88,6 @@ class CustomerInfoDimensionProviderTest {
                 "isInGracePeriod" to bool(true),
                 "isRefunded" to bool(true),
                 "isPaused" to bool(true),
-                "evaluatedAt" to RulesDimensionValue.DateValue(date),
             ),
         )
     }
@@ -109,7 +107,6 @@ class CustomerInfoDimensionProviderTest {
                 "purchasedAt" to date("2023-03-03T00:00:00Z"),
                 "originalPurchasedAt" to date("2023-03-03T00:00:00Z"),
                 "isSandbox" to bool(true),
-                "evaluatedAt" to RulesDimensionValue.DateValue(date),
             ),
         )
     }
@@ -135,7 +132,6 @@ class CustomerInfoDimensionProviderTest {
                 "isSandbox" to bool(true),
                 "isActive" to bool(false),
                 "willRenew" to bool(true),
-                "evaluatedAt" to RulesDimensionValue.DateValue(date),
             ),
         )
     }
@@ -253,7 +249,7 @@ class CustomerInfoDimensionProviderTest {
                     deviceProvider(),
                     CustomerInfoDimensionProvider(
                         appUserId = { "current_user" },
-                                    customerInfo = { throw failure },
+                        customerInfo = { throw failure },
                     ),
                 ),
             ).snapshot()
@@ -267,16 +263,41 @@ class CustomerInfoDimensionProviderTest {
     }
 
     @Test
-    fun `an unknown app user ID leaves the rest of the dimensions usable`() = runTest {
+    fun `the customer info is requested for the app user the snapshot reports`() = runTest {
+        var currentAppUserId = "before_login"
+        var requestedAppUserId: String? = null
         val provider = CustomerInfoDimensionProvider(
-            appUserId = { throw UninitializedPropertyAccessException("There is no singleton instance.") },
-            customerInfo = { customerInfo(SUBSCRIBED_RESPONSE) },
+            appUserId = { currentAppUserId },
+            customerInfo = { appUserId ->
+                requestedAppUserId = appUserId
+                // The app logs in while the request is in flight.
+                currentAppUserId = "after_login"
+                customerInfo(SUBSCRIBED_RESPONSE)
+            },
         )
 
         val dimensions = provider.dimensions(date)
 
-        assertThat(dimensions).doesNotContainKey("appUserId")
-        assertThat(dimensions["originalAppUserId"]).isEqualTo(string("original_user"))
+        // Reading the ID again after the request came back would file one customer's purchases under another's.
+        assertThat(requestedAppUserId).isEqualTo("before_login")
+        assertThat(dimensions["appUserId"]).isEqualTo(string("before_login"))
+    }
+
+    @Test
+    fun `a customer the SDK has no ID for is not asked about`() = runTest {
+        var asked = false
+        val provider = CustomerInfoDimensionProvider(
+            appUserId = { "" },
+            customerInfo = {
+                asked = true
+                customerInfo(SUBSCRIBED_RESPONSE)
+            },
+        )
+
+        val dimensions = provider.dimensions(date)
+
+        assertThat(asked).isFalse()
+        assertThat(dimensions).isEmpty()
     }
 
     @Test
@@ -326,9 +347,9 @@ class CustomerInfoDimensionProviderTest {
                  {"==": [{"var": "purchasedProductIdentifier"}, "legacy:annual"]}]}""",
             // The latest purchase of any kind, with no iteration at all.
             """{"==": [{"var": "customerInfo.purchases.0.productIdentifier"}, "premium"]}""",
-            // Ends more than a day from the evaluation instant, which only the per-record instant can answer.
-            """{"some": [{"var": "customerInfo.purchases"},
-                 {">": [{"-": [{"var": "expiresAt"}, {"var": "evaluatedAt"}]}, 86400000]}]}""",
+            // Ends more than a day from the evaluation instant. Read by index, since the root instant is not
+            // in scope inside an iteration operator.
+            """{">": [{"-": [{"var": "customerInfo.purchases.0.expiresAt"}, {"var": "evaluatedAt"}]}, 86400000]}""",
             """{"none": [{"var": "customerInfo.purchases"}, {"var": "isRefunded"}]}""",
         )
         val notMatching = listOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -29,14 +29,15 @@ import java.util.Date
 class CustomerInfoDimensionProviderTest {
 
     private val date = Date(1_700_000_000_000)
+    private val context = RulesDimensionContext(date, APP_USER_ID)
 
     @Test
     fun `provides the customer's identity and lifecycle dimensions`() = runTest {
-        val dimensions = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date)
+        val dimensions = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(context)
 
         assertThat(dimensions.filterValues { it !is RulesDimensionValue.ObjectListValue }).isEqualTo(
             mapOf(
-                "appUserId" to string("current_user"),
+                "appUserId" to string(APP_USER_ID),
                 "originalAppUserId" to string("original_user"),
                 "firstSeenAt" to date("2022-01-01T00:00:00Z"),
                 "lastSeenAt" to date("2024-06-01T00:00:00Z"),
@@ -47,7 +48,7 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `describes every purchase of either kind, newest first`() = runTest {
-        val purchases = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+        val purchases = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(context).purchases()
 
         assertThat(purchases.map { it["kind"] to it["purchasedProductIdentifier"] }).containsExactly(
             string("subscription") to string("premium:monthly"),
@@ -58,7 +59,7 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `describes a subscription with everything the SDK knows about it`() = runTest {
-        val purchases = provider(customerInfo(FULLY_POPULATED_RESPONSE)).dimensions(date).purchases()
+        val purchases = provider(customerInfo(FULLY_POPULATED_RESPONSE)).dimensions(context).purchases()
 
         assertThat(purchases.single()).isEqualTo(
             mapOf(
@@ -94,7 +95,7 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `describes a one-time purchase without the fields only a subscription has`() = runTest {
-        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(context).purchases()
             .single { it["kind"] == string("nonSubscription") }
 
         assertThat(purchase).isEqualTo(
@@ -113,7 +114,7 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `describes every entitlement, ordered by identifier`() = runTest {
-        val entitlements = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).entitlements()
+        val entitlements = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(context).entitlements()
 
         assertThat(entitlements.map { it["identifier"] })
             .containsExactly(string("extra"), string("old"), string("premium"))
@@ -165,7 +166,7 @@ class CustomerInfoDimensionProviderTest {
         )
 
         for ((label, expected, response) in cases) {
-            val purchase = provider(customerInfo(response)).dimensions(date).purchases().single()
+            val purchase = provider(customerInfo(response)).dimensions(context).purchases().single()
 
             assertThat(purchase["status"]).describedAs(label).isEqualTo(string(expected))
         }
@@ -173,14 +174,14 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `a lifetime subscription is active`() = runTest {
-        val purchase = provider(customerInfo(LIFETIME_RESPONSE)).dimensions(date).purchases().single()
+        val purchase = provider(customerInfo(LIFETIME_RESPONSE)).dimensions(context).purchases().single()
 
         assertThat(purchase["status"]).isEqualTo(string("active"))
     }
 
     @Test
     fun `the grace period status and the grace period flag always agree`() = runTest {
-        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(context).purchases()
             .single { it["purchasedProductIdentifier"] == string("legacy:annual") }
 
         assertThat(purchase["isInGracePeriod"]).isEqualTo(bool(true))
@@ -189,7 +190,7 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `a one-time purchase has no status, since only a subscription has a lifecycle`() = runTest {
-        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(context).purchases()
             .single { it["kind"] == string("nonSubscription") }
 
         assertThat(purchase).doesNotContainKey("status")
@@ -197,7 +198,7 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `a customer who has never bought anything reports empty collections rather than none`() = runTest {
-        val dimensions = provider(customerInfo(Responses.validEmptyPurchaserResponse)).dimensions(date)
+        val dimensions = provider(customerInfo(Responses.validEmptyPurchaserResponse)).dimensions(context)
 
         // An empty array is what makes `none` a definite yes and `some` a definite no; an absent key would leave
         // both unknown.
@@ -207,7 +208,7 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `a lifetime purchase reports no expiry and stays active`() = runTest {
-        val purchase = provider(customerInfo(LIFETIME_RESPONSE)).dimensions(date).purchases().single()
+        val purchase = provider(customerInfo(LIFETIME_RESPONSE)).dimensions(context).purchases().single()
 
         assertThat(purchase).doesNotContainKey("expiresAt")
         assertThat(purchase["isActive"]).isEqualTo(bool(true))
@@ -217,7 +218,7 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `an unknown ownership type is reported as no ownership type at all`() = runTest {
-        val purchase = provider(customerInfo(PROMO_RESPONSE)).dimensions(date).purchases().single()
+        val purchase = provider(customerInfo(PROMO_RESPONSE)).dimensions(context).purchases().single()
 
         assertThat(purchase).doesNotContainKey("ownershipType")
         assertThat(purchase["store"]).isEqualTo(string("promotional"))
@@ -225,7 +226,7 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `a subscription being served through a grace period says so`() = runTest {
-        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(context).purchases()
             .single { it["purchasedProductIdentifier"] == string("legacy:annual") }
 
         // Expired in 2023, but the store keeps serving it until 2100.
@@ -244,20 +245,12 @@ class CustomerInfoDimensionProviderTest {
         )
 
         for (failure in failures) {
-            val snapshot = RulesDimensionResolver(
-                providers = listOf(
-                    deviceProvider(),
-                    CustomerInfoDimensionProvider(
-                        currentAppUserId = { "current_user" },
-                        customerInfo = { throw failure },
-                    ),
-                ),
-            ).snapshot()
+            val snapshot = resolver(CustomerInfoDimensionProvider { throw failure }).snapshot()
 
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
             // The app user ID is known without asking the backend, so a rule on it survives the failure.
             assertThat(snapshot.getOrThrow().values["customerInfo"]).describedAs("%s", failure).isEqualTo(
-                Value.ObjectValue(mapOf("appUserId" to Value.StringValue("current_user"))),
+                Value.ObjectValue(mapOf("appUserId" to Value.StringValue(APP_USER_ID))),
             )
         }
     }
@@ -265,18 +258,16 @@ class CustomerInfoDimensionProviderTest {
     @Test
     fun `the customer info is requested for the app user the snapshot reports`() = runTest {
         var requestedAppUserId: String? = null
-        val provider = CustomerInfoDimensionProvider(
-            currentAppUserId = { "current_user" },
-            customerInfo = { appUserId ->
-                requestedAppUserId = appUserId
-                customerInfo(SUBSCRIBED_RESPONSE)
-            },
-        )
+        val provider = CustomerInfoDimensionProvider { appUserId ->
+            requestedAppUserId = appUserId
+            customerInfo(SUBSCRIBED_RESPONSE)
+        }
 
-        val dimensions = provider.dimensions(date)
+        val dimensions = provider.dimensions(context)
 
-        assertThat(requestedAppUserId).isEqualTo("current_user")
-        assertThat(dimensions["appUserId"]).isEqualTo(string("current_user"))
+        // Both come from the same pinned id, so they cannot describe two different customers.
+        assertThat(requestedAppUserId).isEqualTo(APP_USER_ID)
+        assertThat(dimensions["appUserId"]).isEqualTo(string(APP_USER_ID))
         assertThat(dimensions.purchases()).isNotEmpty()
     }
 
@@ -284,15 +275,12 @@ class CustomerInfoDimensionProviderTest {
     @Test
     fun `a customer the SDK has no ID for is not asked about`() = runTest {
         var asked = false
-        val provider = CustomerInfoDimensionProvider(
-            currentAppUserId = { "" },
-            customerInfo = {
-                asked = true
-                customerInfo(SUBSCRIBED_RESPONSE)
-            },
-        )
+        val provider = CustomerInfoDimensionProvider {
+            asked = true
+            customerInfo(SUBSCRIBED_RESPONSE)
+        }
 
-        val dimensions = provider.dimensions(date)
+        val dimensions = provider.dimensions(RulesDimensionContext(date, appUserId = ""))
 
         assertThat(asked).isFalse()
         assertThat(dimensions).isEmpty()
@@ -300,13 +288,10 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `cancellation while reading the customer info propagates`() = runTest {
-        val cancelling = CustomerInfoDimensionProvider(
-            currentAppUserId = { "current_user" },
-            customerInfo = { throw CancellationException("cancelled") },
-        )
+        val cancelling = CustomerInfoDimensionProvider { throw CancellationException("cancelled") }
 
         val thrown = try {
-            cancelling.dimensions(date)
+            cancelling.dimensions(context)
             null
         } catch (e: CancellationException) {
             e
@@ -318,27 +303,21 @@ class CustomerInfoDimensionProviderTest {
     @Test
     fun `the customer info is read on every evaluation`() = runTest {
         var response = Responses.validEmptyPurchaserResponse
-        val provider = CustomerInfoDimensionProvider(
-            currentAppUserId = { "current_user" },
-            customerInfo = { customerInfo(response) },
-        )
+        val provider = CustomerInfoDimensionProvider { customerInfo(response) }
 
-        assertThat(provider.dimensions(date).purchases()).isEmpty()
+        assertThat(provider.dimensions(context).purchases()).isEmpty()
 
         response = SUBSCRIBED_RESPONSE
 
-        assertThat(provider.dimensions(date).purchases()).hasSize(3)
+        assertThat(provider.dimensions(context).purchases()).hasSize(3)
     }
 
     @Test
     fun `the records are searchable by a predicate`() = runTest {
-        val values = RulesDimensionResolver(providers = listOf(provider(customerInfo(SUBSCRIBED_RESPONSE))))
-            .snapshot()
-            .getOrThrow()
-            .values
+        val values = resolver(provider(customerInfo(SUBSCRIBED_RESPONSE))).snapshot().getOrThrow().values
 
         val matching = listOf(
-            """{"==": [{"var": "customerInfo.appUserId"}, "current_user"]}""",
+            """{"==": [{"var": "customerInfo.appUserId"}, "$APP_USER_ID"]}""",
             """{"some": [{"var": "customerInfo.entitlements"},
                  {"and": [{"==": [{"var": "identifier"}, "premium"]}, {"var": "isActive"}]}]}""",
             """{"some": [{"var": "customerInfo.purchases"},
@@ -366,14 +345,16 @@ class CustomerInfoDimensionProviderTest {
         }
     }
 
-    private fun provider(customerInfo: CustomerInfo) = CustomerInfoDimensionProvider(
-        currentAppUserId = { "current_user" },
-        customerInfo = { customerInfo },
+    private fun provider(customerInfo: CustomerInfo) = CustomerInfoDimensionProvider { customerInfo }
+
+    private fun resolver(customerInfoProvider: RulesDimensionProvider) = RulesDimensionResolver(
+        providers = listOf(deviceProvider(), customerInfoProvider),
+        currentAppUserId = { APP_USER_ID },
     )
 
     private fun deviceProvider() = object : RulesDimensionProvider {
         override val namespace = RulesDimensionNamespace.Device
-        override suspend fun dimensions(date: Date) = mapOf("platform" to string("android"))
+        override suspend fun dimensions(context: RulesDimensionContext) = mapOf("platform" to string("android"))
     }
 
     private fun customerInfo(response: String): CustomerInfo =
@@ -390,6 +371,8 @@ class CustomerInfoDimensionProviderTest {
     private fun date(iso8601: String) = RulesDimensionValue.DateValue(Iso8601Utils.parse(iso8601))
 
     private companion object {
+
+        const val APP_USER_ID = "current_user"
 
         /**
          * A Google subscription bought most recently, an Amazon one that expired but is in a grace period, and a

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -72,6 +72,7 @@ class CustomerInfoDimensionProviderTest {
                 "store" to string("play_store"),
                 "ownershipType" to string("PURCHASED"),
                 "periodType" to string("trial"),
+                "status" to string("paused"),
                 "priceAmountMicros" to RulesDimensionValue.IntValue(4_990_000),
                 "priceCurrency" to string("USD"),
                 "purchasedAt" to date("2024-05-01T00:00:00Z"),
@@ -137,6 +138,65 @@ class CustomerInfoDimensionProviderTest {
                 "evaluatedAt" to RulesDimensionValue.DateValue(date),
             ),
         )
+    }
+
+    @Test
+    fun `reports where the customer is in each subscription's lifecycle`() = runTest {
+        val cases = listOf(
+            Triple("a paid subscription", "active", statusResponse(expiresDate = FUTURE)),
+            Triple("a free trial", "trialing", statusResponse(expiresDate = FUTURE, periodType = "trial")),
+            // Still being served while the billing issue is retried, which outranks the trial it interrupted.
+            Triple(
+                "a trial in a grace period",
+                "in_grace_period",
+                statusResponse(
+                    expiresDate = FUTURE,
+                    periodType = "trial",
+                    billingIssuesDetectedAt = PAST,
+                    gracePeriodExpiresDate = FUTURE,
+                ),
+            ),
+            // Paused whatever the dates say.
+            Triple("a paused subscription", "paused", statusResponse(expiresDate = FUTURE, autoResumeDate = FUTURE)),
+            Triple("a lapsed subscription", "expired", statusResponse(expiresDate = PAST)),
+            // The device cannot tell a store still retrying from one that gave up long ago, so this does not claim
+            // `in_billing_retry`; `billingIssueDetectedAt` is on the record for a predicate that needs it.
+            Triple(
+                "a subscription that lapsed after a billing issue",
+                "expired",
+                statusResponse(expiresDate = PAST, billingIssuesDetectedAt = PAST),
+            ),
+        )
+
+        for ((label, expected, response) in cases) {
+            val purchase = provider(customerInfo(response)).dimensions(date).purchases().single()
+
+            assertThat(purchase["status"]).describedAs(label).isEqualTo(string(expected))
+        }
+    }
+
+    @Test
+    fun `a lifetime subscription is active`() = runTest {
+        val purchase = provider(customerInfo(LIFETIME_RESPONSE)).dimensions(date).purchases().single()
+
+        assertThat(purchase["status"]).isEqualTo(string("active"))
+    }
+
+    @Test
+    fun `the grace period status and the grace period flag always agree`() = runTest {
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+            .single { it["purchasedProductIdentifier"] == string("legacy:annual") }
+
+        assertThat(purchase["isInGracePeriod"]).isEqualTo(bool(true))
+        assertThat(purchase["status"]).isEqualTo(string("in_grace_period"))
+    }
+
+    @Test
+    fun `a one-time purchase has no status, since only a subscription has a lifecycle`() = runTest {
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+            .single { it["kind"] == string("nonSubscription") }
+
+        assertThat(purchase).doesNotContainKey("status")
     }
 
     @Test
@@ -420,6 +480,36 @@ class CustomerInfoDimensionProviderTest {
                 expiresDate = "2100-01-01T00:00:00Z",
                 ownershipType = null,
             )}
+                }
+            """,
+        )
+
+        const val FUTURE = "2100-01-01T00:00:00Z"
+
+        // Before the evaluation date, so a grace period ending here has already ended.
+        const val PAST = "2023-01-01T00:00:00Z"
+
+        /** One subscription, naming only the fields a status is derived from. */
+        private fun statusResponse(
+            expiresDate: String?,
+            periodType: String = "normal",
+            billingIssuesDetectedAt: String? = null,
+            gracePeriodExpiresDate: String? = null,
+            autoResumeDate: String? = null,
+        ) = subscriberResponse(
+            subscriptions = """
+                "premium": {
+                  ${subscription(
+            store = "play_store",
+            purchaseDate = "2024-05-01T00:00:00Z",
+            originalPurchaseDate = "2024-05-01T00:00:00Z",
+            expiresDate = expiresDate,
+            ownershipType = "PURCHASED",
+            periodType = periodType,
+            billingIssuesDetectedAt = billingIssuesDetectedAt,
+            gracePeriodExpiresDate = gracePeriodExpiresDate,
+            autoResumeDate = autoResumeDate,
+        )}
                 }
             """,
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -280,25 +280,6 @@ class CustomerInfoDimensionProviderTest {
         assertThat(dimensions.purchases()).isNotEmpty()
     }
 
-    @Test
-    fun `a customer info that arrived across a user change is not reported`() = runTest {
-        // Asking for one app user is not enough to be answered about them: on a cold cache the SDK syncs pending
-        // purchases first, and that sync reads the current app user for itself.
-        var currentAppUserId = "before_login"
-        val provider = CustomerInfoDimensionProvider(
-            currentAppUserId = { currentAppUserId },
-            customerInfo = {
-                currentAppUserId = "after_login"
-                customerInfo(SUBSCRIBED_RESPONSE)
-            },
-        )
-
-        val dimensions = provider.dimensions(date)
-
-        // Filing these purchases under either ID would describe a customer who does not exist, so the evaluation
-        // sees a customer it knows nothing about but the ID it started with.
-        assertThat(dimensions).isEqualTo(mapOf("appUserId" to string("before_login")))
-    }
 
     @Test
     fun `a customer the SDK has no ID for is not asked about`() = runTest {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -248,7 +248,7 @@ class CustomerInfoDimensionProviderTest {
                 providers = listOf(
                     deviceProvider(),
                     CustomerInfoDimensionProvider(
-                        appUserId = { "current_user" },
+                        currentAppUserId = { "current_user" },
                         customerInfo = { throw failure },
                     ),
                 ),
@@ -264,13 +264,30 @@ class CustomerInfoDimensionProviderTest {
 
     @Test
     fun `the customer info is requested for the app user the snapshot reports`() = runTest {
-        var currentAppUserId = "before_login"
         var requestedAppUserId: String? = null
         val provider = CustomerInfoDimensionProvider(
-            appUserId = { currentAppUserId },
+            currentAppUserId = { "current_user" },
             customerInfo = { appUserId ->
                 requestedAppUserId = appUserId
-                // The app logs in while the request is in flight.
+                customerInfo(SUBSCRIBED_RESPONSE)
+            },
+        )
+
+        val dimensions = provider.dimensions(date)
+
+        assertThat(requestedAppUserId).isEqualTo("current_user")
+        assertThat(dimensions["appUserId"]).isEqualTo(string("current_user"))
+        assertThat(dimensions.purchases()).isNotEmpty()
+    }
+
+    @Test
+    fun `a customer info that arrived across a user change is not reported`() = runTest {
+        // Asking for one app user is not enough to be answered about them: on a cold cache the SDK syncs pending
+        // purchases first, and that sync reads the current app user for itself.
+        var currentAppUserId = "before_login"
+        val provider = CustomerInfoDimensionProvider(
+            currentAppUserId = { currentAppUserId },
+            customerInfo = {
                 currentAppUserId = "after_login"
                 customerInfo(SUBSCRIBED_RESPONSE)
             },
@@ -278,16 +295,16 @@ class CustomerInfoDimensionProviderTest {
 
         val dimensions = provider.dimensions(date)
 
-        // Reading the ID again after the request came back would file one customer's purchases under another's.
-        assertThat(requestedAppUserId).isEqualTo("before_login")
-        assertThat(dimensions["appUserId"]).isEqualTo(string("before_login"))
+        // Filing these purchases under either ID would describe a customer who does not exist, so the evaluation
+        // sees a customer it knows nothing about but the ID it started with.
+        assertThat(dimensions).isEqualTo(mapOf("appUserId" to string("before_login")))
     }
 
     @Test
     fun `a customer the SDK has no ID for is not asked about`() = runTest {
         var asked = false
         val provider = CustomerInfoDimensionProvider(
-            appUserId = { "" },
+            currentAppUserId = { "" },
             customerInfo = {
                 asked = true
                 customerInfo(SUBSCRIBED_RESPONSE)
@@ -303,7 +320,7 @@ class CustomerInfoDimensionProviderTest {
     @Test
     fun `cancellation while reading the customer info propagates`() = runTest {
         val cancelling = CustomerInfoDimensionProvider(
-            appUserId = { "current_user" },
+            currentAppUserId = { "current_user" },
             customerInfo = { throw CancellationException("cancelled") },
         )
 
@@ -321,7 +338,7 @@ class CustomerInfoDimensionProviderTest {
     fun `the customer info is read on every evaluation`() = runTest {
         var response = Responses.validEmptyPurchaserResponse
         val provider = CustomerInfoDimensionProvider(
-            appUserId = { "current_user" },
+            currentAppUserId = { "current_user" },
             customerInfo = { customerInfo(response) },
         )
 
@@ -369,7 +386,7 @@ class CustomerInfoDimensionProviderTest {
     }
 
     private fun provider(customerInfo: CustomerInfo) = CustomerInfoDimensionProvider(
-        appUserId = { "current_user" },
+        currentAppUserId = { "current_user" },
         customerInfo = { customerInfo },
     )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
@@ -22,6 +22,7 @@ import java.util.Date
 class DeviceDimensionProviderTest {
 
     private val date = Date(1_700_000_000_000)
+    private val context = RulesDimensionContext(date, "current_user")
     private var languageTags = "en-US"
 
     private val localeProvider = object : LocaleProvider {
@@ -31,7 +32,7 @@ class DeviceDimensionProviderTest {
 
     @Test
     fun `provides the device dimensions`() = runTest {
-        val dimensions = provider().dimensions(date)
+        val dimensions = provider().dimensions(context)
 
         assertThat(dimensions).isEqualTo(
             mapOf(
@@ -46,7 +47,7 @@ class DeviceDimensionProviderTest {
 
     @Test
     fun `platform reflects the store`() = runTest {
-        val dimensions = provider(store = Store.AMAZON).dimensions(date)
+        val dimensions = provider(store = Store.AMAZON).dimensions(context)
 
         assertThat(dimensions["platform"]).isEqualTo(RulesDimensionValue.StringValue("amazon"))
     }
@@ -55,7 +56,7 @@ class DeviceDimensionProviderTest {
     fun `only the preferred locale of the preference list is exposed`() = runTest {
         languageTags = "es-ES,en-US"
 
-        val dimensions = provider().dimensions(date)
+        val dimensions = provider().dimensions(context)
 
         assertThat(dimensions["locale"]).isEqualTo(RulesDimensionValue.StringValue("es_es"))
     }
@@ -63,18 +64,18 @@ class DeviceDimensionProviderTest {
     @Test
     fun `locale is re-read on every evaluation`() = runTest {
         val provider = provider()
-        assertThat(provider.dimensions(date)["locale"]).isEqualTo(RulesDimensionValue.StringValue("en_us"))
+        assertThat(provider.dimensions(context)["locale"]).isEqualTo(RulesDimensionValue.StringValue("en_us"))
 
         languageTags = "fr-FR"
 
-        assertThat(provider.dimensions(date)["locale"]).isEqualTo(RulesDimensionValue.StringValue("fr_fr"))
+        assertThat(provider.dimensions(context)["locale"]).isEqualTo(RulesDimensionValue.StringValue("fr_fr"))
     }
 
     @Test
     fun `locale falls back to the configured language tag when no locale is preferred`() = runTest {
         languageTags = ""
 
-        val dimensions = provider(languageTag = "de-DE").dimensions(date)
+        val dimensions = provider(languageTag = "de-DE").dimensions(context)
 
         assertThat(dimensions["locale"]).isEqualTo(RulesDimensionValue.StringValue("de_de"))
     }
@@ -83,7 +84,7 @@ class DeviceDimensionProviderTest {
     fun `dimensions the device has no value for are omitted`() = runTest {
         languageTags = ""
 
-        val dimensions = provider(languageTag = "", versionName = "").dimensions(date)
+        val dimensions = provider(languageTag = "", versionName = "").dimensions(context)
 
         assertThat(dimensions).containsOnlyKeys("platform", "platformVersion", "sdkVersion")
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -19,7 +19,7 @@ class LocalRulesEvaluatorTest {
     private var snapshotsTaken = 0
     private val deviceProvider = object : RulesDimensionProvider {
         override val namespace = RulesDimensionNamespace.Device
-        override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+        override suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> {
             snapshotsTaken++
             return mapOf("platform" to RulesDimensionValue.StringValue("android"))
         }
@@ -93,7 +93,7 @@ class LocalRulesEvaluatorTest {
     fun `a failed dimension snapshot fails the evaluation`() = runTest {
         val failing = object : RulesDimensionProvider {
             override val namespace = RulesDimensionNamespace.Device
-            override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+            override suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> =
                 throw IllegalStateException("nope")
         }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -375,114 +375,59 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `a collection the app user changed underneath is taken again`() = runTest {
+    fun `a collection the app user changed underneath fails the snapshot`() = runTest {
         var appUserId = "before_login"
-        var collections = 0
-        val resolver = retryingResolver({ appUserId }) {
-            collections++
-            val collectedFor = appUserId
-            // The app logs in during the first collection only.
-            if (collections == 1) appUserId = "after_login"
-            mapOf("platform" to string(collectedFor))
-        }
-
-        val values = resolver.snapshot().getOrThrow().values
-
-        assertThat(collections).isEqualTo(2)
-        // Reporting the first pass would describe a customer nobody is: these are the second pass's values,
-        // collected for an app user that then stayed put.
-        assertThat(values["device"])
-            .isEqualTo(Value.ObjectValue(mapOf("platform" to Value.StringValue("after_login"))))
-    }
-
-    @Test
-    fun `an app user that will not stay still fails the snapshot`() = runTest {
-        var collections = 0
-        // A different user on every read, so the retry cannot settle either.
-        val resolver = retryingResolver({ "user_$collections" }) {
-            collections++
+        val resolver = identifiedResolver({ appUserId }) {
+            // The app logs in while the dimensions are being collected.
+            appUserId = "after_login"
             mapOf("platform" to string("android"))
         }
 
         val error = resolver.snapshot().exceptionOrNull()
 
-        // Nothing here is worth reporting: an absence rule would match a customer whose purchases were simply
-        // never read, which is indistinguishable from one who has none.
+        // Reporting what survived would let an absence rule match a customer whose purchases were simply never
+        // read, which is indistinguishable from one who has none.
         assertThat(error).isEqualTo(RulesDimensionResolutionException.AppUserChanged)
-        assertThat(collections).isEqualTo(2)
     }
 
     @Test
-    fun `an app user that stays put is collected once`() = runTest {
-        var collections = 0
-        val resolver = retryingResolver({ "user_a" }) {
-            collections++
-            mapOf("platform" to string("android"))
-        }
+    fun `an app user that stays put is reported`() = runTest {
+        val resolver = identifiedResolver({ "user_a" }) { mapOf("platform" to string("android")) }
 
-        assertThat(resolver.snapshot().isSuccess).isTrue()
-        assertThat(collections).isEqualTo(1)
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values["device"])
+            .isEqualTo(Value.ObjectValue(mapOf("platform" to Value.StringValue("android"))))
     }
 
     @Test
-    fun `a provider that failed is not asked again`() = runTest {
-        var collections = 0
+    fun `a provider that could not answer says more than the user change on top of it`() = runTest {
         var appUserId = "before_login"
-        val resolver = retryingResolver({ appUserId }) {
-            collections++
-            // Changing on top of the failure, so a retry would be visible if one happened.
+        val resolver = identifiedResolver({ appUserId }) {
             appUserId = "after_login"
             throw IllegalStateException("Nope.")
         }
 
         val error = resolver.snapshot().exceptionOrNull()
 
-        // A provider that cannot produce its values is a configuration bug, and asking again does not fix it.
         assertThat(error).isInstanceOf(RulesDimensionResolutionException.ProviderFailed::class.java)
-        assertThat(collections).isEqualTo(1)
     }
 
-    @Test
-    fun `the retry is taken against its own reference instant`() = runTest {
-        val retryDate = Date(evaluationDate.time + 1_000)
-        var appUserId = "before_login"
-        var collections = 0
-        val resolver = RulesDimensionResolver(
-            providers = listOf(
-                countingProvider {
-                    collections++
-                    if (collections == 1) appUserId = "after_login"
-                    mapOf("platform" to string("android"))
-                },
-            ),
-            dateProvider = object : DateProvider {
-                override val now: Date get() = if (collections == 0) evaluationDate else retryDate
-            },
-            currentAppUserId = { appUserId },
-        )
-
-        val values = resolver.snapshot().getOrThrow().values
-
-        // The instant describes the pass that actually produced these values, not the one that was discarded.
-        assertThat(values["evaluatedAt"]).isEqualTo(Value.IntValue(retryDate.time))
-    }
-
-    private fun retryingResolver(
+    private fun identifiedResolver(
         currentAppUserId: () -> String,
         values: () -> Map<String, RulesDimensionValue>,
     ) = RulesDimensionResolver(
-        providers = listOf(countingProvider(values)),
+        providers = listOf(
+            object : RulesDimensionProvider {
+                override val namespace = RulesDimensionNamespace.Device
+                override suspend fun dimensions(date: Date) = values()
+            },
+        ),
         dateProvider = object : DateProvider {
             override val now: Date = evaluationDate
         },
         currentAppUserId = currentAppUserId,
     )
-
-    private fun countingProvider(values: () -> Map<String, RulesDimensionValue>) =
-        object : RulesDimensionProvider {
-            override val namespace = RulesDimensionNamespace.Device
-            override suspend fun dimensions(date: Date) = values()
-        }
 
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
         providers = providers.toList(),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -91,7 +91,7 @@ class RulesDimensionResolverTest {
             provider(RulesDimensionNamespace.Store, "country" to string("USA")),
             object : RulesDimensionProvider {
                 override val namespace = RulesDimensionNamespace.Device
-                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+                override suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> =
                     throw IllegalStateException("nope")
             },
         )
@@ -107,7 +107,7 @@ class RulesDimensionResolverTest {
         val resolver = resolver(
             object : RulesDimensionProvider {
                 override val namespace = RulesDimensionNamespace.Device
-                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
+                override suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> =
                     throw CancellationException("cancelled")
             },
         )
@@ -128,8 +128,8 @@ class RulesDimensionResolverTest {
         val recordingProvider = {
             object : RulesDimensionProvider {
                 override val namespace = RulesDimensionNamespace.Device
-                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
-                    dates += date
+                override suspend fun dimensions(context: RulesDimensionContext): Map<String, RulesDimensionValue> {
+                    dates += context.date
                     return emptyMap()
                 }
             }
@@ -420,7 +420,7 @@ class RulesDimensionResolverTest {
         providers = listOf(
             object : RulesDimensionProvider {
                 override val namespace = RulesDimensionNamespace.Device
-                override suspend fun dimensions(date: Date) = values()
+                override suspend fun dimensions(context: RulesDimensionContext) = values()
             },
         ),
         dateProvider = object : DateProvider {
@@ -443,6 +443,6 @@ class RulesDimensionResolverTest {
         vararg values: Pair<String, RulesDimensionValue>,
     ) = object : RulesDimensionProvider {
         override val namespace = dimensionNamespace
-        override suspend fun dimensions(date: Date) = values.toMap()
+        override suspend fun dimensions(context: RulesDimensionContext) = values.toMap()
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -374,6 +374,116 @@ class RulesDimensionResolverTest {
         assertThat(matches.getOrThrow()).isTrue()
     }
 
+    @Test
+    fun `a collection the app user changed underneath is taken again`() = runTest {
+        var appUserId = "before_login"
+        var collections = 0
+        val resolver = retryingResolver({ appUserId }) {
+            collections++
+            val collectedFor = appUserId
+            // The app logs in during the first collection only.
+            if (collections == 1) appUserId = "after_login"
+            mapOf("platform" to string(collectedFor))
+        }
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(collections).isEqualTo(2)
+        // Reporting the first pass would describe a customer nobody is: these are the second pass's values,
+        // collected for an app user that then stayed put.
+        assertThat(values["device"])
+            .isEqualTo(Value.ObjectValue(mapOf("platform" to Value.StringValue("after_login"))))
+    }
+
+    @Test
+    fun `an app user that will not stay still fails the snapshot`() = runTest {
+        var collections = 0
+        // A different user on every read, so the retry cannot settle either.
+        val resolver = retryingResolver({ "user_$collections" }) {
+            collections++
+            mapOf("platform" to string("android"))
+        }
+
+        val error = resolver.snapshot().exceptionOrNull()
+
+        // Nothing here is worth reporting: an absence rule would match a customer whose purchases were simply
+        // never read, which is indistinguishable from one who has none.
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.AppUserChanged)
+        assertThat(collections).isEqualTo(2)
+    }
+
+    @Test
+    fun `an app user that stays put is collected once`() = runTest {
+        var collections = 0
+        val resolver = retryingResolver({ "user_a" }) {
+            collections++
+            mapOf("platform" to string("android"))
+        }
+
+        assertThat(resolver.snapshot().isSuccess).isTrue()
+        assertThat(collections).isEqualTo(1)
+    }
+
+    @Test
+    fun `a provider that failed is not asked again`() = runTest {
+        var collections = 0
+        var appUserId = "before_login"
+        val resolver = retryingResolver({ appUserId }) {
+            collections++
+            // Changing on top of the failure, so a retry would be visible if one happened.
+            appUserId = "after_login"
+            throw IllegalStateException("Nope.")
+        }
+
+        val error = resolver.snapshot().exceptionOrNull()
+
+        // A provider that cannot produce its values is a configuration bug, and asking again does not fix it.
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.ProviderFailed::class.java)
+        assertThat(collections).isEqualTo(1)
+    }
+
+    @Test
+    fun `the retry is taken against its own reference instant`() = runTest {
+        val retryDate = Date(evaluationDate.time + 1_000)
+        var appUserId = "before_login"
+        var collections = 0
+        val resolver = RulesDimensionResolver(
+            providers = listOf(
+                countingProvider {
+                    collections++
+                    if (collections == 1) appUserId = "after_login"
+                    mapOf("platform" to string("android"))
+                },
+            ),
+            dateProvider = object : DateProvider {
+                override val now: Date get() = if (collections == 0) evaluationDate else retryDate
+            },
+            currentAppUserId = { appUserId },
+        )
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        // The instant describes the pass that actually produced these values, not the one that was discarded.
+        assertThat(values["evaluatedAt"]).isEqualTo(Value.IntValue(retryDate.time))
+    }
+
+    private fun retryingResolver(
+        currentAppUserId: () -> String,
+        values: () -> Map<String, RulesDimensionValue>,
+    ) = RulesDimensionResolver(
+        providers = listOf(countingProvider(values)),
+        dateProvider = object : DateProvider {
+            override val now: Date = evaluationDate
+        },
+        currentAppUserId = currentAppUserId,
+    )
+
+    private fun countingProvider(values: () -> Map<String, RulesDimensionValue>) =
+        object : RulesDimensionProvider {
+            override val namespace = RulesDimensionNamespace.Device
+            override suspend fun dimensions(date: Date) = values()
+        }
+
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
         providers = providers.toList(),
         dateProvider = object : DateProvider {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -32,7 +32,10 @@ class RulesDimensionResolverTest {
         val values = resolver.snapshot().getOrThrow().values
 
         assertThat(values).isEqualTo(
-            mapOf("device" to Value.ObjectValue(mapOf("appVersion" to Value.StringValue("1.2.3")))),
+            mapOf(
+                "device" to Value.ObjectValue(mapOf("appVersion" to Value.StringValue("1.2.3"))),
+                "evaluatedAt" to Value.IntValue(evaluationDate.time),
+            ),
         )
     }
 
@@ -65,6 +68,7 @@ class RulesDimensionResolverTest {
                         "locale" to Value.StringValue("en-US"),
                     ),
                 ),
+                "evaluatedAt" to Value.IntValue(evaluationDate.time),
             ),
         )
     }
@@ -119,7 +123,7 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `every provider sees the same evaluation date`() = runTest {
+    fun `every provider sees the same evaluation date, and so does a predicate`() = runTest {
         val dates = mutableListOf<Date>()
         val recordingProvider = {
             object : RulesDimensionProvider {
@@ -136,6 +140,7 @@ class RulesDimensionResolverTest {
 
         assertThat(dates).containsExactly(evaluationDate, evaluationDate)
         assertThat(snapshot.evaluationDate).isEqualTo(evaluationDate)
+        assertThat(snapshot.values["evaluatedAt"]).isEqualTo(Value.IntValue(evaluationDate.time))
     }
 
     @Test
@@ -288,7 +293,7 @@ class RulesDimensionResolverTest {
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).containsOnlyKeys("device")
+        assertThat(values).containsOnlyKeys("device", "evaluatedAt")
         // An empty object would be truthy, so an absent namespace is what makes this a non-match.
         assertThat(RulesEngine.evaluate("""{"!!": [{"var": "custom"}]}""", values).getOrThrow()).isFalse()
     }
@@ -311,7 +316,7 @@ class RulesDimensionResolverTest {
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).containsOnlyKeys("device")
+        assertThat(values).containsOnlyKeys("device", "evaluatedAt")
         // An empty object would be truthy, which is what makes the absence matter.
         assertThat(RulesEngine.evaluate("""{"!!": [{"var": "store"}]}""", values).getOrThrow()).isFalse()
     }
@@ -345,15 +350,28 @@ class RulesDimensionResolverTest {
         val values = resolver.snapshot().getOrThrow().values
 
         // Filtering the names inside the namespace would leave an empty object behind, which is truthy.
-        assertThat(values).containsOnlyKeys("device")
+        assertThat(values).containsOnlyKeys("device", "evaluatedAt")
         assertThat(
             RulesEngine.evaluate("""{"!!": [{"var": "subscriberAttributes"}]}""", values).getOrThrow(),
         ).isFalse()
     }
 
     @Test
-    fun `no providers yields an empty scope`() = runTest {
-        assertThat(resolver().snapshot().getOrThrow().values).isEmpty()
+    fun `no providers yields a scope of nothing but the evaluation instant`() = runTest {
+        assertThat(resolver().snapshot().getOrThrow().values)
+            .isEqualTo(mapOf("evaluatedAt" to Value.IntValue(evaluationDate.time)))
+    }
+
+    @Test
+    fun `the evaluation instant is readable by a predicate at the root of the scope`() = runTest {
+        val values = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+            .snapshot()
+            .getOrThrow()
+            .values
+
+        val matches = RulesEngine.evaluate("""{"==": [{"var": "evaluatedAt"}, ${evaluationDate.time}]}""", values)
+
+        assertThat(matches.getOrThrow()).isTrue()
     }
 
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -102,7 +102,7 @@ class RulesDimensionScopeTest {
                   }
                 ],
                 "firstSeenAt": 1640995200000,
-                "lastSeenAt": 1717200000000,
+                "lastSeenAt": 1716163200000,
                 "originalAppUserId": "original_user",
                 "originalPurchasedAt": 1609459200000,
                 "purchases": [
@@ -302,6 +302,7 @@ class RulesDimensionScopeTest {
               "subscriber": {
                 "original_app_user_id": "original_user",
                 "first_seen": "2022-01-01T00:00:00Z",
+                "last_seen": "2024-05-20T00:00:00Z",
                 "original_purchase_date": "2021-01-01T00:00:00Z",
                 "management_url": "https://play.google.com/store/account/subscriptions",
                 "subscriptions": {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -224,15 +224,16 @@ class RulesDimensionScopeTest {
             providers = listOf(
                 DeviceDimensionProvider(appConfig, localeProvider),
                 StoreDimensionProvider { "US" },
-                CustomerInfoDimensionProvider(
-                    currentAppUserId = { "current_user" },
-                    customerInfo = { customerInfo },
-                ),
-                SubscriberAttributesDimensionProvider { SUBSCRIBER_ATTRIBUTES },
+                CustomerInfoDimensionProvider { customerInfo },
+                // Keyed by app user in the real cache, so the id the snapshot is about is the one it reads for.
+                SubscriberAttributesDimensionProvider { appUserId ->
+                    SUBSCRIBER_ATTRIBUTES.takeIf { appUserId == APP_USER_ID }.orEmpty()
+                },
             ),
             dateProvider = object : DateProvider {
                 override val now: Date get() = evaluationDate
             },
+            currentAppUserId = { APP_USER_ID },
         )
     }
 
@@ -263,6 +264,8 @@ class RulesDimensionScopeTest {
     }
 
     private companion object {
+
+        const val APP_USER_ID = "current_user"
 
         /**
          * A reserved name, custom ones, a value that looks like a number but stays the string it was set as, and

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -151,8 +151,7 @@ class RulesDimensionScopeTest {
                     "storeTransactionId": "amzn.1234",
                     "transactionIdentifier": "abc123"
                   }
-                ],
-                "verification": "verified"
+                ]
               },
               "device": {
                 "appVersion": "1.2.3",
@@ -196,6 +195,8 @@ class RulesDimensionScopeTest {
         val localeProvider = object : LocaleProvider {
             override val currentLocalesLanguageTags: String get() = "en-US"
         }
+        // Verified on purpose, and deliberately absent from the scope below: entitlement verification is not
+        // something a rule is evaluated against.
         val customerInfo = CustomerInfoFactory.buildCustomerInfo(
             JSONObject(SUBSCRIBER_RESPONSE),
             null,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -132,6 +132,7 @@ class RulesDimensionScopeTest {
                     "purchasedAt": 1714521600000,
                     "purchasedProductIdentifier": "premium:monthly",
                     "refundedAt": 1714867200000,
+                    "status": "paused",
                     "store": "play_store",
                     "storeTransactionId": "GPA.0000-0000-0000-00000",
                     "unsubscribeDetectedAt": 1714694400000,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.LocaleProvider
 import com.revenuecat.purchases.rules.RulesEngine
 import com.revenuecat.purchases.rules.Value
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
 import com.revenuecat.purchases.utils.Iso8601Utils
 import io.mockk.every
 import io.mockk.mockk
@@ -30,7 +31,7 @@ import org.robolectric.annotation.Config as RobolectricConfig
  *
  * Every other test in this package covers one source in isolation. This one wires all of them together the way
  * [com.revenuecat.purchases.PurchasesFactory] does and writes down the whole result, so the answer to "what can a
- * rule actually read?" is one file rather than a survey of five providers — for whoever authors a predicate, and
+ * rule actually read?" is one file rather than a survey of every provider — for whoever authors a predicate, and
  * for the platform that has to expose the same scope under the same names.
  *
  * The customer is deliberately not a realistic one: they are refunded *and* renewing, in a trial *and* paused, so
@@ -162,6 +163,23 @@ class RulesDimensionScopeTest {
               },
               "store": {
                 "country": "USA"
+              },
+              "subscriberAttributes": {
+                "${'$'}email": {
+                  "evaluatedAt": 1718452800000,
+                  "updatedAt": 1714521600000,
+                  "value": "jane@example.com"
+                },
+                "goal": {
+                  "evaluatedAt": 1718452800000,
+                  "updatedAt": 1718366400000,
+                  "value": "lose_weight"
+                },
+                "seats": {
+                  "evaluatedAt": 1718452800000,
+                  "updatedAt": 1714780800000,
+                  "value": "3"
+                }
               }
             }
             """.trimIndent(),
@@ -179,6 +197,9 @@ class RulesDimensionScopeTest {
             """{"==": [{"var": "customerInfo.appUserId"}, "current_user"]}""",
             """{"some": [{"var": "customerInfo.purchases"}, {"==": [{"var": "periodType"}, "trial"]}]}""",
             """{"some": [{"var": "customerInfo.entitlements"}, {"var": "isActive"}]}""",
+            """{"==": [{"var": "subscriberAttributes.${'$'}email.value"}, "jane@example.com"]}""",
+            """{"<": [{"-": [{"var": "subscriberAttributes.goal.evaluatedAt"},
+                {"var": "subscriberAttributes.goal.updatedAt"}]}, 604800000]}""",
         )
 
         for (predicate in predicates) {
@@ -210,6 +231,7 @@ class RulesDimensionScopeTest {
                     appUserId = { "current_user" },
                     customerInfo = { customerInfo },
                 ),
+                SubscriberAttributesDimensionProvider { SUBSCRIBER_ATTRIBUTES },
             ),
             dateProvider = object : DateProvider {
                 override val now: Date get() = evaluationDate
@@ -244,6 +266,25 @@ class RulesDimensionScopeTest {
     }
 
     private companion object {
+
+        /**
+         * A reserved name, custom ones, a value that looks like a number but stays the string it was set as, and
+         * two the scope leaves out: a deleted attribute, and a name a dot-path could not reach.
+         */
+        val SUBSCRIBER_ATTRIBUTES = listOf(
+            subscriberAttribute("\$email", "jane@example.com", setAt = "2024-05-01T00:00:00Z"),
+            subscriberAttribute("goal", "lose_weight", setAt = "2024-06-14T12:00:00Z"),
+            subscriberAttribute("seats", "3", setAt = "2024-05-04T00:00:00Z"),
+            subscriberAttribute("tier", null, setAt = "2024-05-04T00:00:00Z"),
+            subscriberAttribute("user.tier", "gold", setAt = "2024-05-04T00:00:00Z"),
+        ).associateBy { attribute -> attribute.key.backendKey }
+
+        private fun subscriberAttribute(key: String, value: String?, setAt: String) = SubscriberAttribute(
+            key = key,
+            value = value,
+            setTime = Iso8601Utils.parse(setAt),
+            isSynced = true,
+        )
 
         val CUSTOM_VARIABLES = mapOf(
             "plan" to RulesDimensionValue.StringValue("gold"),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -225,7 +225,7 @@ class RulesDimensionScopeTest {
                 DeviceDimensionProvider(appConfig, localeProvider),
                 StoreDimensionProvider { "US" },
                 CustomerInfoDimensionProvider(
-                    appUserId = { "current_user" },
+                    currentAppUserId = { "current_user" },
                     customerInfo = { customerInfo },
                 ),
                 SubscriberAttributesDimensionProvider { SUBSCRIBER_ATTRIBUTES },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -68,7 +68,6 @@ class RulesDimensionScopeTest {
                 "entitlements": [
                   {
                     "billingIssueDetectedAt": 1714780800000,
-                    "evaluatedAt": 1718452800000,
                     "expiresAt": 4102444800000,
                     "identifier": "extra",
                     "isActive": true,
@@ -86,7 +85,6 @@ class RulesDimensionScopeTest {
                   },
                   {
                     "billingIssueDetectedAt": 1714780800000,
-                    "evaluatedAt": 1718452800000,
                     "expiresAt": 4102444800000,
                     "identifier": "premium",
                     "isActive": true,
@@ -103,7 +101,6 @@ class RulesDimensionScopeTest {
                     "willRenew": false
                   }
                 ],
-                "evaluatedAt": 1718452800000,
                 "firstSeenAt": 1640995200000,
                 "lastSeenAt": 1717200000000,
                 "originalAppUserId": "original_user",
@@ -113,7 +110,6 @@ class RulesDimensionScopeTest {
                     "autoResumeAt": 1717200000000,
                     "billingIssueDetectedAt": 1714780800000,
                     "displayName": "Premium Monthly",
-                    "evaluatedAt": 1718452800000,
                     "expiresAt": 4102444800000,
                     "gracePeriodExpiresAt": 1715299200000,
                     "isActive": true,
@@ -140,7 +136,6 @@ class RulesDimensionScopeTest {
                   },
                   {
                     "displayName": "100 Coins",
-                    "evaluatedAt": 1718452800000,
                     "isSandbox": false,
                     "kind": "nonSubscription",
                     "originalPurchasedAt": 1677801600000,
@@ -162,22 +157,20 @@ class RulesDimensionScopeTest {
                 "platformVersion": 34,
                 "sdkVersion": "${Config.frameworkVersion}"
               },
+              "evaluatedAt": 1718452800000,
               "store": {
                 "country": "USA"
               },
               "subscriberAttributes": {
                 "${'$'}email": {
-                  "evaluatedAt": 1718452800000,
                   "updatedAt": 1714521600000,
                   "value": "jane@example.com"
                 },
                 "goal": {
-                  "evaluatedAt": 1718452800000,
                   "updatedAt": 1718366400000,
                   "value": "lose_weight"
                 },
                 "seats": {
-                  "evaluatedAt": 1718452800000,
                   "updatedAt": 1714780800000,
                   "value": "3"
                 }
@@ -199,8 +192,11 @@ class RulesDimensionScopeTest {
             """{"some": [{"var": "customerInfo.purchases"}, {"==": [{"var": "periodType"}, "trial"]}]}""",
             """{"some": [{"var": "customerInfo.entitlements"}, {"var": "isActive"}]}""",
             """{"==": [{"var": "subscriberAttributes.${'$'}email.value"}, "jane@example.com"]}""",
-            """{"<": [{"-": [{"var": "subscriberAttributes.goal.evaluatedAt"},
+            """{"<": [{"-": [{"var": "evaluatedAt"},
                 {"var": "subscriberAttributes.goal.updatedAt"}]}, 604800000]}""",
+            // The root instant is not in scope inside an iteration operator, so a purchase compared against it is
+            // read by index.
+            """{">": [{"var": "customerInfo.purchases.0.expiresAt"}, {"var": "evaluatedAt"}]}""",
         )
 
         for (predicate in predicates) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -1,0 +1,317 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.AppConfig
+import com.revenuecat.purchases.common.Config
+import com.revenuecat.purchases.common.CustomerInfoFactory
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.LocaleProvider
+import com.revenuecat.purchases.rules.RulesEngine
+import com.revenuecat.purchases.rules.Value
+import com.revenuecat.purchases.utils.Iso8601Utils
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Date
+import org.robolectric.annotation.Config as RobolectricConfig
+
+/**
+ * The complete scope a predicate is evaluated against, spelled out.
+ *
+ * Every other test in this package covers one source in isolation. This one wires all of them together the way
+ * [com.revenuecat.purchases.PurchasesFactory] does and writes down the whole result, so the answer to "what can a
+ * rule actually read?" is one file rather than a survey of five providers — for whoever authors a predicate, and
+ * for the platform that has to expose the same scope under the same names.
+ *
+ * The customer is deliberately not a realistic one: they are refunded *and* renewing, in a trial *and* paused, so
+ * that every key appears once. A customer who really is any of those things has the absent keys left out.
+ *
+ * Dates are epoch milliseconds, which is the only form the engine has. The ISO instants they were built from are
+ * in [SUBSCRIBER_RESPONSE] below; the evaluation instant is 2024-06-15T12:00:00Z.
+ *
+ * When this fails after an intended change, the assertion message contains the new scope verbatim.
+ *
+ * It does not verify that [com.revenuecat.purchases.PurchasesFactory] wires exactly these providers, since that
+ * would mean configuring an SDK instance: a provider added there and not here goes unnoticed by this test.
+ */
+@RunWith(AndroidJUnit4::class)
+@RobolectricConfig(manifest = RobolectricConfig.NONE, sdk = [34])
+class RulesDimensionScopeTest {
+
+    private val evaluationDate = Iso8601Utils.parse("2024-06-15T12:00:00Z")
+
+    @Test
+    fun `the whole evaluation scope`() = runTest {
+        val scope = resolver().snapshot(CUSTOM_VARIABLES).getOrThrow().values
+
+        assertThat(scope.render()).isEqualTo(
+            """
+            {
+              "custom": {
+                "plan": "gold",
+                "seats": 3,
+                "trialEligible": true
+              },
+              "customerInfo": {
+                "appUserId": "current_user",
+                "entitlements": [
+                  {
+                    "billingIssueDetectedAt": 1714780800000,
+                    "evaluatedAt": 1718452800000,
+                    "expiresAt": 4102444800000,
+                    "identifier": "extra",
+                    "isActive": true,
+                    "isSandbox": true,
+                    "latestPurchasedAt": 1714521600000,
+                    "originalPurchasedAt": 1609459200000,
+                    "ownershipType": "PURCHASED",
+                    "periodType": "trial",
+                    "productIdentifier": "premium",
+                    "productPlanIdentifier": "monthly",
+                    "purchasedProductIdentifier": "premium:monthly",
+                    "store": "play_store",
+                    "unsubscribeDetectedAt": 1714694400000,
+                    "willRenew": false
+                  },
+                  {
+                    "billingIssueDetectedAt": 1714780800000,
+                    "evaluatedAt": 1718452800000,
+                    "expiresAt": 4102444800000,
+                    "identifier": "premium",
+                    "isActive": true,
+                    "isSandbox": true,
+                    "latestPurchasedAt": 1714521600000,
+                    "originalPurchasedAt": 1609459200000,
+                    "ownershipType": "PURCHASED",
+                    "periodType": "trial",
+                    "productIdentifier": "premium",
+                    "productPlanIdentifier": "monthly",
+                    "purchasedProductIdentifier": "premium:monthly",
+                    "store": "play_store",
+                    "unsubscribeDetectedAt": 1714694400000,
+                    "willRenew": false
+                  }
+                ],
+                "evaluatedAt": 1718452800000,
+                "firstSeenAt": 1640995200000,
+                "lastSeenAt": 1717200000000,
+                "originalAppUserId": "original_user",
+                "originalPurchasedAt": 1609459200000,
+                "purchases": [
+                  {
+                    "autoResumeAt": 1717200000000,
+                    "billingIssueDetectedAt": 1714780800000,
+                    "displayName": "Premium Monthly",
+                    "evaluatedAt": 1718452800000,
+                    "expiresAt": 4102444800000,
+                    "gracePeriodExpiresAt": 1715299200000,
+                    "isActive": true,
+                    "isInGracePeriod": false,
+                    "isPaused": true,
+                    "isRefunded": true,
+                    "isSandbox": true,
+                    "kind": "subscription",
+                    "originalPurchasedAt": 1609459200000,
+                    "ownershipType": "PURCHASED",
+                    "periodType": "trial",
+                    "priceAmountMicros": 4990000,
+                    "priceCurrency": "USD",
+                    "productIdentifier": "premium",
+                    "productPlanIdentifier": "monthly",
+                    "purchasedAt": 1714521600000,
+                    "purchasedProductIdentifier": "premium:monthly",
+                    "refundedAt": 1714867200000,
+                    "store": "play_store",
+                    "storeTransactionId": "GPA.0000-0000-0000-00000",
+                    "unsubscribeDetectedAt": 1714694400000,
+                    "willRenew": false
+                  },
+                  {
+                    "displayName": "100 Coins",
+                    "evaluatedAt": 1718452800000,
+                    "isSandbox": false,
+                    "kind": "nonSubscription",
+                    "originalPurchasedAt": 1677801600000,
+                    "priceAmountMicros": 1990000,
+                    "priceCurrency": "EUR",
+                    "productIdentifier": "coins",
+                    "purchasedAt": 1677801600000,
+                    "purchasedProductIdentifier": "coins",
+                    "store": "amazon",
+                    "storeTransactionId": "amzn.1234",
+                    "transactionIdentifier": "abc123"
+                  }
+                ],
+                "verification": "verified"
+              },
+              "device": {
+                "appVersion": "1.2.3",
+                "locale": "en_us",
+                "platform": "android",
+                "platformVersion": 34,
+                "sdkVersion": "${Config.frameworkVersion}"
+              },
+              "store": {
+                "country": "USA"
+              }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `every root of the scope is readable by a predicate`() = runTest {
+        val scope = resolver().snapshot(CUSTOM_VARIABLES).getOrThrow().values
+
+        val predicates = listOf(
+            """{"==": [{"var": "device.platform"}, "android"]}""",
+            """{"==": [{"var": "store.country"}, "USA"]}""",
+            """{"==": [{"var": "custom.plan"}, "gold"]}""",
+            """{"==": [{"var": "customerInfo.appUserId"}, "current_user"]}""",
+            """{"some": [{"var": "customerInfo.purchases"}, {"==": [{"var": "periodType"}, "trial"]}]}""",
+            """{"some": [{"var": "customerInfo.entitlements"}, {"var": "isActive"}]}""",
+        )
+
+        for (predicate in predicates) {
+            assertThat(RulesEngine.evaluate(predicate, scope).getOrThrow()).describedAs(predicate).isTrue()
+        }
+    }
+
+    private fun resolver(): RulesDimensionResolver {
+        val appConfig = mockk<AppConfig>().also {
+            every { it.store } returns Store.PLAY_STORE
+            every { it.languageTag } returns "en-US"
+            every { it.versionName } returns "1.2.3"
+        }
+        val localeProvider = object : LocaleProvider {
+            override val currentLocalesLanguageTags: String get() = "en-US"
+        }
+        val customerInfo = CustomerInfoFactory.buildCustomerInfo(
+            JSONObject(SUBSCRIBER_RESPONSE),
+            null,
+            VerificationResult.VERIFIED,
+        )
+        return RulesDimensionResolver(
+            providers = listOf(
+                DeviceDimensionProvider(appConfig, localeProvider),
+                StoreDimensionProvider { "US" },
+                CustomerInfoDimensionProvider(
+                    appUserId = { "current_user" },
+                    customerInfo = { customerInfo },
+                ),
+            ),
+            dateProvider = object : DateProvider {
+                override val now: Date get() = evaluationDate
+            },
+        )
+    }
+
+    /**
+     * Renders the scope the way the engine holds it, with object keys sorted so the shape is readable and stable.
+     * Array order is left alone: it is part of the contract, since `purchases.0` is the most recent purchase.
+     */
+    private fun Map<String, Value>.render(): String = Value.ObjectValue(this).render(indent = "")
+
+    private fun Value.render(indent: String): String = when (this) {
+        is Value.ObjectValue -> entries.entries
+            .sortedBy { (key, _) -> key }
+            .joinToString(separator = ",\n", prefix = "{\n", postfix = "\n$indent}") { (key, value) ->
+                """$indent  "$key": ${value.render("$indent  ")}"""
+            }
+            .takeIf { entries.isNotEmpty() } ?: "{}"
+        is Value.ArrayValue -> items
+            .joinToString(separator = ",\n", prefix = "[\n", postfix = "\n$indent]") { item ->
+                "$indent  ${item.render("$indent  ")}"
+            }
+            .takeIf { items.isNotEmpty() } ?: "[]"
+        is Value.StringValue -> "\"$value\""
+        is Value.BoolValue -> value.toString()
+        is Value.IntValue -> value.toString()
+        is Value.FloatValue -> value.toString()
+        Value.Null -> "null"
+        Value.Undefined -> "undefined"
+    }
+
+    private companion object {
+
+        val CUSTOM_VARIABLES = mapOf(
+            "plan" to RulesDimensionValue.StringValue("gold"),
+            "seats" to RulesDimensionValue.IntValue(3),
+            "trialEligible" to RulesDimensionValue.BoolValue(true),
+        )
+
+        /**
+         * One Google subscription with every field the backend can send, one Amazon one-time purchase, and two
+         * entitlements unlocked by the subscription.
+         */
+        val SUBSCRIBER_RESPONSE = """
+            {
+              "request_date": "2024-06-01T00:00:00Z",
+              "subscriber": {
+                "original_app_user_id": "original_user",
+                "first_seen": "2022-01-01T00:00:00Z",
+                "original_purchase_date": "2021-01-01T00:00:00Z",
+                "management_url": "https://play.google.com/store/account/subscriptions",
+                "subscriptions": {
+                  "premium": {
+                    "store": "play_store",
+                    "product_plan_identifier": "monthly",
+                    "purchase_date": "2024-05-01T00:00:00Z",
+                    "original_purchase_date": "2021-01-01T00:00:00Z",
+                    "expires_date": "2100-01-01T00:00:00Z",
+                    "period_type": "trial",
+                    "ownership_type": "PURCHASED",
+                    "is_sandbox": true,
+                    "unsubscribe_detected_at": "2024-05-03T00:00:00Z",
+                    "billing_issues_detected_at": "2024-05-04T00:00:00Z",
+                    "grace_period_expires_date": "2024-05-10T00:00:00Z",
+                    "refunded_at": "2024-05-05T00:00:00Z",
+                    "auto_resume_date": "2024-06-01T00:00:00Z",
+                    "display_name": "Premium Monthly",
+                    "price": { "amount": 4.99, "currency": "USD" },
+                    "store_transaction_id": "GPA.0000-0000-0000-00000"
+                  }
+                },
+                "non_subscriptions": {
+                  "coins": [
+                    {
+                      "id": "abc123",
+                      "is_sandbox": false,
+                      "original_purchase_date": "2023-03-03T00:00:00Z",
+                      "purchase_date": "2023-03-03T00:00:00Z",
+                      "store": "amazon",
+                      "display_name": "100 Coins",
+                      "price": { "amount": 1.99, "currency": "EUR" },
+                      "store_transaction_id": "amzn.1234"
+                    }
+                  ]
+                },
+                "entitlements": {
+                  "premium": {
+                    "expires_date": "2100-01-01T00:00:00Z",
+                    "product_identifier": "premium",
+                    "product_plan_identifier": "monthly",
+                    "purchase_date": "2024-05-01T00:00:00Z"
+                  },
+                  "extra": {
+                    "expires_date": "2100-01-01T00:00:00Z",
+                    "product_identifier": "premium",
+                    "product_plan_identifier": "monthly",
+                    "purchase_date": "2024-05-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+        """
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
@@ -63,7 +63,7 @@ class StoreDimensionProviderTest {
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
             assertThat(snapshot.getOrThrow().values)
                 .describedAs("%s", failure)
-                .containsOnlyKeys("device")
+                .containsOnlyKeys("device", "evaluatedAt")
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
@@ -22,12 +22,13 @@ import java.util.Date
 class StoreDimensionProviderTest {
 
     private val date = Date(1_700_000_000_000)
+    private val context = RulesDimensionContext(date, "current_user")
 
     @Test
     fun `the store country is exposed as a three-letter code`() = runTest {
-        assertThat(provider("US").dimensions(date))
+        assertThat(provider("US").dimensions(context))
             .isEqualTo(mapOf("country" to RulesDimensionValue.StringValue("USA")))
-        assertThat(provider("ES").dimensions(date))
+        assertThat(provider("ES").dimensions(context))
             .isEqualTo(mapOf("country" to RulesDimensionValue.StringValue("ESP")))
     }
 
@@ -36,7 +37,7 @@ class StoreDimensionProviderTest {
         // "UK" is what the Amazon Appstore reports for the United Kingdom, and it is not an ISO region. Region
         // subtags are two letters, so a store already reporting an alpha-3 code would be dropped too.
         for (countryCode in listOf(null, "", "UK", "ZZ", "abc", "1", "USA")) {
-            assertThat(provider(countryCode).dimensions(date))
+            assertThat(provider(countryCode).dimensions(context))
                 .describedAs("country code '%s'", countryCode)
                 .isEmpty()
         }
@@ -72,7 +73,7 @@ class StoreDimensionProviderTest {
         val cancelling = StoreDimensionProvider { throw CancellationException("cancelled") }
 
         val thrown = try {
-            cancelling.dimensions(date)
+            cancelling.dimensions(context)
             null
         } catch (e: CancellationException) {
             e
@@ -86,11 +87,11 @@ class StoreDimensionProviderTest {
         var countryCode: String? = "US"
         val provider = StoreDimensionProvider { countryCode }
 
-        assertThat(provider.dimensions(date)["country"]).isEqualTo(RulesDimensionValue.StringValue("USA"))
+        assertThat(provider.dimensions(context)["country"]).isEqualTo(RulesDimensionValue.StringValue("USA"))
 
         countryCode = "ES"
 
-        assertThat(provider.dimensions(date)["country"]).isEqualTo(RulesDimensionValue.StringValue("ESP"))
+        assertThat(provider.dimensions(context)["country"]).isEqualTo(RulesDimensionValue.StringValue("ESP"))
     }
 
     @Test
@@ -109,7 +110,7 @@ class StoreDimensionProviderTest {
         vararg values: Pair<String, String>,
     ) = object : RulesDimensionProvider {
         override val namespace = dimensionNamespace
-        override suspend fun dimensions(date: Date) =
+        override suspend fun dimensions(context: RulesDimensionContext) =
             values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
@@ -9,7 +9,6 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
-import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_EVALUATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_UPDATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_VALUE
 import com.revenuecat.purchases.rules.RulesEngine
@@ -89,7 +88,7 @@ class SubscriberAttributesDimensionIntegrationTest {
 
         val goal = values.recordFor("goal")
         assertThat(goal[KEY_VALUE]).isEqualTo(Value.StringValue("lose_weight"))
-        assertThat(goal[KEY_EVALUATED_AT]).isEqualTo(Value.IntValue(evaluationDate.time))
+        assertThat(values[RulesDimensionResolver.KEY_EVALUATED_AT]).isEqualTo(Value.IntValue(evaluationDate.time))
         // Set by this device just now, so it survived the round-trip through JSON with the value.
         assertThat((goal[KEY_UPDATED_AT] as Value.IntValue).value).isBetween(before.time, Date().time)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
@@ -66,15 +66,16 @@ class SubscriberAttributesDimensionIntegrationTest {
         )
         resolver = RulesDimensionResolver(
             providers = listOf(
-                // The same expression PurchasesFactory builds, with the app user ID read from the cache the
-                // identity manager reads it from.
-                SubscriberAttributesDimensionProvider {
-                    attributesCache.getAllStoredSubscriberAttributes(cache.getCachedAppUserID() ?: "")
+                // The same expression PurchasesFactory builds: the provider reads for whichever app user the
+                // resolver pinned, which is the one the identity manager reads from this cache.
+                SubscriberAttributesDimensionProvider { appUserId ->
+                    attributesCache.getAllStoredSubscriberAttributes(appUserId)
                 },
             ),
             dateProvider = object : DateProvider {
                 override val now: Date get() = evaluationDate
             },
+            currentAppUserId = { cache.getCachedAppUserID() ?: "" },
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -22,6 +22,11 @@ import java.util.Date
 class SubscriberAttributesDimensionProviderTest {
 
     private val evaluationDate = Date(1_718_452_800_000)
+    private val context = RulesDimensionContext(evaluationDate, APP_USER_ID)
+
+    private companion object {
+        const val APP_USER_ID = "current_user"
+    }
 
     // Six weeks before the evaluation.
     private val setDate = Date(1_714_780_800_000)
@@ -32,7 +37,7 @@ class SubscriberAttributesDimensionProviderTest {
         val dimensions = provider(
             attribute("\$email", "jane@example.com"),
             attribute("goal", "lose_weight"),
-        ).dimensions(evaluationDate)
+        ).dimensions(context)
 
         // Reserved names keep their '$': it is what the app set, what the dashboard shows, and what keeps a custom
         // "email" from colliding with the reserved one. Only '.' means anything to the engine.
@@ -41,7 +46,7 @@ class SubscriberAttributesDimensionProviderTest {
 
     @Test
     fun `an attribute is a record of its value and when it was set`() = runTest {
-        val dimensions = provider(attribute("goal", "lose_weight")).dimensions(evaluationDate)
+        val dimensions = provider(attribute("goal", "lose_weight")).dimensions(context)
 
         assertThat(dimensions).isEqualTo(
             mapOf(
@@ -61,7 +66,7 @@ class SubscriberAttributesDimensionProviderTest {
             attribute("seats", "3"),
             attribute("betaOptIn", "true"),
             attribute("sku", "0123"),
-        ).dimensions(evaluationDate)
+        ).dimensions(context)
 
         assertThat(dimensions.valueOf("seats")).isEqualTo(RulesDimensionValue.StringValue("3"))
         assertThat(dimensions.valueOf("betaOptIn")).isEqualTo(RulesDimensionValue.StringValue("true"))
@@ -77,7 +82,7 @@ class SubscriberAttributesDimensionProviderTest {
             attribute("pending", null, isSynced = false),
             attribute("posted", null, isSynced = true),
             attribute("goal", "lose_weight"),
-        ).dimensions(evaluationDate)
+        ).dimensions(context)
 
         assertThat(dimensions).containsOnlyKeys("goal")
     }
@@ -86,7 +91,7 @@ class SubscriberAttributesDimensionProviderTest {
     fun `an attribute set to an empty value is left out`() = runTest {
         // The SDK's other spelling of a deletion, and an empty string would compare equal to an absent value
         // anyway.
-        val dimensions = provider(attribute("goal", ""), attribute("tier", "gold")).dimensions(evaluationDate)
+        val dimensions = provider(attribute("goal", ""), attribute("tier", "gold")).dimensions(context)
 
         assertThat(dimensions).containsOnlyKeys("tier")
     }
@@ -126,12 +131,12 @@ class SubscriberAttributesDimensionProviderTest {
         var attributes = mapOf("goal" to attribute("goal", "lose_weight"))
         val provider = SubscriberAttributesDimensionProvider { attributes }
 
-        assertThat(provider.dimensions(evaluationDate).valueOf("goal"))
+        assertThat(provider.dimensions(context).valueOf("goal"))
             .isEqualTo(RulesDimensionValue.StringValue("lose_weight"))
 
         attributes = mapOf("goal" to attribute("goal", "gain_muscle"))
 
-        assertThat(provider.dimensions(evaluationDate).valueOf("goal"))
+        assertThat(provider.dimensions(context).valueOf("goal"))
             .isEqualTo(RulesDimensionValue.StringValue("gain_muscle"))
     }
 
@@ -180,20 +185,23 @@ class SubscriberAttributesDimensionProviderTest {
         setTime: Date = setDate,
     ) = SubscriberAttribute(key = key, value = value, setTime = setTime, isSynced = isSynced)
 
-    private fun provider(vararg attributes: SubscriberAttribute) = SubscriberAttributesDimensionProvider {
-        attributes.associateBy { attribute -> attribute.key.backendKey }
-    }
+    private fun provider(vararg attributes: SubscriberAttribute) =
+        SubscriberAttributesDimensionProvider { appUserId ->
+            // The real cache is keyed by app user, so anyone else's attributes are not this customer's.
+            if (appUserId == APP_USER_ID) attributes.associateBy { it.key.backendKey } else emptyMap()
+        }
 
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
         providers = providers.toList(),
         dateProvider = object : DateProvider {
             override val now: Date = evaluationDate
         },
+        currentAppUserId = { APP_USER_ID },
     )
 
     private fun deviceProvider(vararg values: Pair<String, String>) = object : RulesDimensionProvider {
         override val namespace = RulesDimensionNamespace.Device
-        override suspend fun dimensions(date: Date) =
+        override suspend fun dimensions(context: RulesDimensionContext) =
             values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -5,7 +5,6 @@ package com.revenuecat.purchases.common.localrules
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
-import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_EVALUATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_UPDATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_VALUE
 import com.revenuecat.purchases.rules.RulesEngine
@@ -41,7 +40,7 @@ class SubscriberAttributesDimensionProviderTest {
     }
 
     @Test
-    fun `an attribute is a record of its value, when it was set, and when it was read`() = runTest {
+    fun `an attribute is a record of its value and when it was set`() = runTest {
         val dimensions = provider(attribute("goal", "lose_weight")).dimensions(evaluationDate)
 
         assertThat(dimensions).isEqualTo(
@@ -50,7 +49,6 @@ class SubscriberAttributesDimensionProviderTest {
                     mapOf(
                         KEY_VALUE to RulesDimensionValue.StringValue("lose_weight"),
                         KEY_UPDATED_AT to RulesDimensionValue.DateValue(setDate),
-                        KEY_EVALUATED_AT to RulesDimensionValue.DateValue(evaluationDate),
                     ),
                 ),
             ),
@@ -117,7 +115,9 @@ class SubscriberAttributesDimensionProviderTest {
             ).snapshot()
 
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
-            assertThat(snapshot.getOrThrow().values).describedAs("%s", failure).containsOnlyKeys("device")
+            assertThat(snapshot.getOrThrow().values)
+                .describedAs("%s", failure)
+                .containsOnlyKeys("device", "evaluatedAt")
         }
     }
 
@@ -151,8 +151,8 @@ class SubscriberAttributesDimensionProviderTest {
             // The loose operators coerce, so a value the app set as a string is still comparable to a number.
             """{"==": [{"var": "subscriberAttributes.seats.value"}, 3]}""",
             """{">": [{"var": "subscriberAttributes.seats.value"}, 2]}""",
-            // Each record carries the evaluation instant, so "set in the last 7 days" needs nothing else in scope.
-            """{"<": [{"-": [{"var": "subscriberAttributes.tier.evaluatedAt"},
+            // The scope carries the evaluation instant at its root, so "set in the last 7 days" is expressible.
+            """{"<": [{"-": [{"var": "evaluatedAt"},
                 {"var": "subscriberAttributes.tier.updatedAt"}]}, 604800000]}""",
         )
         val notMatching = listOf(
@@ -161,7 +161,7 @@ class SubscriberAttributesDimensionProviderTest {
             """{"!!": {"var": "subscriberAttributes.favoriteColor.value"}}""",
             """{"!!": {"var": "subscriberAttributes.goal.isSynced"}}""",
             // The same window, for an attribute set six weeks ago.
-            """{"<": [{"-": [{"var": "subscriberAttributes.goal.evaluatedAt"},
+            """{"<": [{"-": [{"var": "evaluatedAt"},
                 {"var": "subscriberAttributes.goal.updatedAt"}]}, 604800000]}""",
         )
 


### PR DESCRIPTION
### Description

This PR adds a new dimension provider for customer info information that will contain all purchases facts themselves, without any processing, so the rules that come from the backend can use this info to process the data as needed.

The evaluation instant is a single `evaluatedAt` at the root of the scope, alongside the namespaces, rather than repeated on every record. Note that `some`/`all`/`none`/`filter`/`map` rebind `var` to the current item with no parent scope, so a predicate comparing a purchase against the instant reads that purchase by index (`customerInfo.purchases.0.expiresAt`) instead of iterating.

The app user ID is read once per evaluation and used both to request the customer info and as the reported `appUserId`, so a login or logout while the request is in flight cannot file one customer's purchases under another's ID. Same fix as iOS: https://github.com/RevenueCat/purchases-ios/pull/7461.

This ends up added to the rules engine like:
```
{
  "customerInfo": {
    "appUserId": "current_user",
    "entitlements": [
      {
        "billingIssueDetectedAt": 1714780800000,
        "expiresAt": 4102444800000,
        "identifier": "extra",
        "isActive": true,
        "isSandbox": true,
        "latestPurchasedAt": 1714521600000,
        "originalPurchasedAt": 1609459200000,
        "ownershipType": "PURCHASED",
        "periodType": "trial",
        "productIdentifier": "premium",
        "productPlanIdentifier": "monthly",
        "purchasedProductIdentifier": "premium:monthly",
        "store": "play_store",
        "unsubscribeDetectedAt": 1714694400000,
        "willRenew": false
      },
      {
        "billingIssueDetectedAt": 1714780800000,
        "expiresAt": 4102444800000,
        "identifier": "premium",
        "isActive": true,
        "isSandbox": true,
        "latestPurchasedAt": 1714521600000,
        "originalPurchasedAt": 1609459200000,
        "ownershipType": "PURCHASED",
        "periodType": "trial",
        "productIdentifier": "premium",
        "productPlanIdentifier": "monthly",
        "purchasedProductIdentifier": "premium:monthly",
        "store": "play_store",
        "unsubscribeDetectedAt": 1714694400000,
        "willRenew": false
      }
    ],
    "firstSeenAt": 1640995200000,
    "lastSeenAt": 1717200000000,
    "originalAppUserId": "original_user",
    "originalPurchasedAt": 1609459200000,
    "purchases": [
      {
        "autoResumeAt": 1717200000000,
        "billingIssueDetectedAt": 1714780800000,
        "displayName": "Premium Monthly",
        "expiresAt": 4102444800000,
        "gracePeriodExpiresAt": 1715299200000,
        "isActive": true,
        "isInGracePeriod": false,
        "isPaused": true,
        "isRefunded": true,
        "isSandbox": true,
        "kind": "subscription",
        "originalPurchasedAt": 1609459200000,
        "ownershipType": "PURCHASED",
        "periodType": "trial",
        "priceAmountMicros": 4990000,
        "priceCurrency": "USD",
        "productIdentifier": "premium",
        "productPlanIdentifier": "monthly",
        "purchasedAt": 1714521600000,
        "purchasedProductIdentifier": "premium:monthly",
        "refundedAt": 1714867200000,
        "status": "paused",
        "store": "play_store",
        "storeTransactionId": "GPA.0000-0000-0000-00000",
        "unsubscribeDetectedAt": 1714694400000,
        "willRenew": false
      },
      {
        "displayName": "100 Coins",
        "isSandbox": false,
        "kind": "nonSubscription",
        "originalPurchasedAt": 1677801600000,
        "priceAmountMicros": 1990000,
        "priceCurrency": "EUR",
        "productIdentifier": "coins",
        "purchasedAt": 1677801600000,
        "purchasedProductIdentifier": "coins",
        "store": "amazon",
        "storeTransactionId": "amzn.1234",
        "transactionIdentifier": "abc123"
      }
    ]
  },
  "evaluatedAt": 1718452800000
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint targeting and CustomerInfo lookup during rule evaluation, including identity pinning so a login mid-snapshot cannot mix two customers. Failures degrade to missing customer dimensions rather than changing purchase or auth flows.
> 
> **Overview**
> Local checkpoint rules can now target the current customer: identity, last-seen, purchases (newest first), and entitlements, under `customerInfo`. Fetch failures omit those fields instead of failing the whole snapshot; `appUserId` is still available without a network round-trip.
> 
> Snapshots pin one app user and one `evaluatedAt` at the root. Subscriber attributes are read for that same ID, and a login/logout mid-collection discards the snapshot. `last_seen` is parsed internally (not part of `CustomerInfo` equality) so “time since last open” is not the SDK’s own refresh time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4876e0b1f8eb9af0d8dd5dd6ee699e7277df6ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->