### PR TITLE
refactor(admob): add next-gen tracking foundation

### DIFF
--- a/feature/admob-next-gen/build.gradle.kts
+++ b/feature/admob-next-gen/build.gradle.kts
@@ -12,9 +12,15 @@ android {
     defaultConfig {
         missingDimensionStrategy("apis", "defaults")
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {
     implementation(project(":purchases"))
     implementation(libs.google.mobile.ads.next.gen)
+
+    testImplementation(libs.bundles.test)
 }

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/Logger.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/Logger.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.admob.nextgen
+
+import android.util.Log
+
+internal object Logger {
+    private const val TAG = "PurchasesAdMob"
+
+    fun w(message: String) {
+        Log.w(TAG, message)
+    }
+
+    fun e(message: String, throwable: Throwable) {
+        Log.e(TAG, message, throwable)
+    }
+}

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/AdapterTracking.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/AdapterTracking.kt
@@ -1,0 +1,33 @@
+@file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
+import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.events.types.AdDisplayedData
+import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
+import com.revenuecat.purchases.ads.events.types.AdLoadedData
+import com.revenuecat.purchases.ads.events.types.AdOpenedData
+import com.revenuecat.purchases.ads.events.types.AdRevenueData
+
+/**
+ * Adapter-internal wrappers around the public [AdTracker] `trackAd*` API that stamp
+ * [AdCaptureMethod.ADAPTER], so events auto-captured by the AdMob adapter are
+ * distinguishable from developer-invoked (`manual`) events.
+ */
+internal fun AdTracker.trackFromAdapter(data: AdLoadedData) =
+    trackAdLoaded(data, AdCaptureMethod.ADAPTER)
+
+internal fun AdTracker.trackFromAdapter(data: AdDisplayedData) =
+    trackAdDisplayed(data, AdCaptureMethod.ADAPTER)
+
+internal fun AdTracker.trackFromAdapter(data: AdOpenedData) =
+    trackAdOpened(data, AdCaptureMethod.ADAPTER)
+
+internal fun AdTracker.trackFromAdapter(data: AdRevenueData) =
+    trackAdRevenue(data, AdCaptureMethod.ADAPTER)
+
+internal fun AdTracker.trackFromAdapter(data: AdFailedToLoadData) =
+    trackAdFailedToLoad(data, AdCaptureMethod.ADAPTER)

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackIfConfigured.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackIfConfigured.kt
@@ -1,0 +1,27 @@
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.Logger
+
+/**
+ * Executes [block] with the [Purchases] ad tracker if the SDK is configured.
+ * If [Purchases] has not been configured yet, logs a warning and skips the block.
+ *
+ * This prevents crashes in ad callbacks when the developer has not yet called
+ * [Purchases.configure].
+ *
+ * Every tracking path runs inside a Google Mobile Ads callback that the application is also waiting on, so a failure
+ * while tracking is logged and swallowed rather than propagated: losing a RevenueCat event must never take down the
+ * app's own ad handling.
+ */
+internal inline fun trackIfConfigured(block: Purchases.() -> Unit) {
+    if (!Purchases.isConfigured) {
+        Logger.w(
+            "Purchases is not configured. " +
+                "Call Purchases.configure() before loading ads to enable RevenueCat ad tracking.",
+        )
+        return
+    }
+    runCatching { Purchases.sharedInstance.block() }
+        .onFailure { Logger.e("Failed to track a RevenueCat ad event.", it) }
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/AdapterTrackingTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/AdapterTrackingTest.kt
@@ -1,0 +1,65 @@
+@file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
+import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.events.types.AdDisplayedData
+import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
+import com.revenuecat.purchases.ads.events.types.AdLoadedData
+import com.revenuecat.purchases.ads.events.types.AdOpenedData
+import com.revenuecat.purchases.ads.events.types.AdRevenueData
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class AdapterTrackingTest {
+    private val adTracker = mockk<AdTracker>(relaxed = true)
+
+    @Test
+    fun `loaded events use adapter capture`() {
+        val data = mockk<AdLoadedData>()
+
+        adTracker.trackFromAdapter(data)
+
+        verify(exactly = 1) { adTracker.trackAdLoaded(data, AdCaptureMethod.ADAPTER) }
+    }
+
+    @Test
+    fun `failed-to-load events use adapter capture`() {
+        val data = mockk<AdFailedToLoadData>()
+
+        adTracker.trackFromAdapter(data)
+
+        verify(exactly = 1) { adTracker.trackAdFailedToLoad(data, AdCaptureMethod.ADAPTER) }
+    }
+
+    @Test
+    fun `displayed events use adapter capture`() {
+        val data = mockk<AdDisplayedData>()
+
+        adTracker.trackFromAdapter(data)
+
+        verify(exactly = 1) { adTracker.trackAdDisplayed(data, AdCaptureMethod.ADAPTER) }
+    }
+
+    @Test
+    fun `opened events use adapter capture`() {
+        val data = mockk<AdOpenedData>()
+
+        adTracker.trackFromAdapter(data)
+
+        verify(exactly = 1) { adTracker.trackAdOpened(data, AdCaptureMethod.ADAPTER) }
+    }
+
+    @Test
+    fun `revenue events use adapter capture`() {
+        val data = mockk<AdRevenueData>()
+
+        adTracker.trackFromAdapter(data)
+
+        verify(exactly = 1) { adTracker.trackAdRevenue(data, AdCaptureMethod.ADAPTER) }
+    }
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/CallbackContractAssertions.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/CallbackContractAssertions.kt
@@ -1,0 +1,25 @@
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import org.junit.Assert.assertTrue
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+internal fun assertOverridesAllSdkCallbacks(sdkCallback: Class<*>, trackingCallback: Class<*>) {
+    val sdkMethods = sdkCallback.methods
+        .filter { Modifier.isPublic(it.modifiers) && !Modifier.isStatic(it.modifiers) }
+        .map { it.signature() }
+        .toSet()
+    val trackingMethods = generateSequence(trackingCallback) { it.superclass }
+        .flatMap { it.declaredMethods.asSequence() }
+        .filter { Modifier.isPublic(it.modifiers) }
+        .map { it.signature() }
+        .toSet()
+    val missing = sdkMethods - trackingMethods
+
+    assertTrue(
+        "${trackingCallback.simpleName} is missing overrides for: ${missing.joinToString()}",
+        missing.isEmpty(),
+    )
+}
+
+private fun Method.signature(): String = "$name(${parameterTypes.joinToString { it.name }})"

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackIfConfiguredTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackIfConfiguredTest.kt
@@ -1,0 +1,60 @@
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.revenuecat.purchases.Purchases
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class TrackIfConfiguredTest {
+    private val purchases = mockk<Purchases>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        mockkObject(Purchases)
+        every { Purchases.isConfigured } returns true
+        every { Purchases.sharedInstance } returns purchases
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(Purchases)
+    }
+
+    @Test
+    fun `executes block when Purchases is configured`() {
+        var blockExecuted = false
+        trackIfConfigured { blockExecuted = true }
+
+        assertTrue(blockExecuted)
+    }
+
+    @Test
+    fun `skips block when Purchases is not configured`() {
+        every { Purchases.isConfigured } returns false
+
+        var blockExecuted = false
+        trackIfConfigured { blockExecuted = true }
+
+        assertFalse(blockExecuted)
+    }
+
+    @Test
+    fun `block receives Purchases sharedInstance as receiver`() {
+        var receivedInstance: Purchases? = null
+        trackIfConfigured { receivedInstance = this }
+
+        assertEquals(purchases, receivedInstance)
+    }
+
+    @Test
+    fun `swallows a failure raised by the block`() {
+        trackIfConfigured { throw IllegalStateException("boom") }
+    }
+}


### PR DESCRIPTION
### Motivation

Create the shared internal runtime needed by both load tracking and post-load event tracking before those implementations split into sibling pull requests.

### Description

- Add a failure-isolated guard that skips tracking until `Purchases` is configured.
- Centralize adapter capture stamping for loaded, failed, displayed, opened, and revenue events.
- Add shared callback contract assertions for the load and event tracking layers.
- Add focused tests for configuration handling, failure isolation, and every adapter capture overload.
- Remove the obsolete source placeholder now that the module contains implementation code.

This PR intentionally contains no load or event callback wrappers, format-specific behavior, public API, or usage documentation.

### Validation

- `./gradlew :feature:admob-next-gen:testDefaultsDebugUnitTest`
- `./gradlew :feature:admob-next-gen:lintDefaultsDebug detektAll`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal-only scaffolding with no public surface or live ad callback wiring; behavior is covered by unit tests.
> 
> **Overview**
> Adds **internal shared runtime** for the upcoming AdMob next-gen load and post-load tracking PRs—no callback wrappers, public API, or format-specific behavior yet.
> 
> **`trackIfConfigured`** gates all future tracking on `Purchases.isConfigured`, warns when skipped, and **swallows** tracking failures inside `runCatching` so RevenueCat analytics never break app ad callbacks.
> 
> **`AdTracker.trackFromAdapter`** overloads centralize stamping **`AdCaptureMethod.ADAPTER`** for loaded, failed-to-load, displayed, opened, and revenue events.
> 
> Module **build** enables unit test defaults and **`libs.bundles.test`**; adds a small internal **`Logger`**. Tests cover configuration gating, failure isolation, adapter capture, and **`assertOverridesAllSdkCallbacks`** for future callback contract checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4b3952feb2cf0a1359473f9c2e83be471e803f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->