### PR TITLE
Announce a public API change in the SDK API feed once per PR

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -112,8 +112,7 @@ begin
 
   if api_diff
     markdown(api_diff[:comment])
-    warn("The public API changed, but it was not announced in the SDK API feed: #{api_diff[:slack_error]}.") if api_diff[:slack_error]
-    warn("Could not read the SDK API feed channel, so this change may be announced twice: #{api_diff[:degraded_dedupe]}.") if api_diff[:degraded_dedupe]
+    warn(api_diff[:warning]) if api_diff[:warning]
   end
 rescue StandardError => e
   # `warn` is Danger's DSL: surfaces on the PR without failing the run.

--- a/Dangerfile
+++ b/Dangerfile
@@ -102,11 +102,18 @@ begin
     changed_files: git.modified_files + git.added_files + git.deleted_files,
     patch_for: ->(file) { git.diff_for_file(file)&.patch },
     pull_request_link: "<#{github.pr_json['html_url']}|##{github.pr_json['number']}>",
+    announced_in_comment: lambda do |marker|
+      github.api.issue_comments(github.pr_json["base"]["repo"]["full_name"], github.pr_json["number"])
+            .any? { |comment| comment.body.to_s.include?(marker) }
+    rescue StandardError
+      false
+    end,
   )
 
   if api_diff
     markdown(api_diff[:comment])
     warn("The public API changed, but it was not announced in the SDK API feed: #{api_diff[:slack_error]}.") if api_diff[:slack_error]
+    warn("Could not read the SDK API feed channel, so this change may be announced twice: #{api_diff[:degraded_dedupe]}.") if api_diff[:degraded_dedupe]
   end
 rescue StandardError => e
   # `warn` is Danger's DSL: surfaces on the PR without failing the run.

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -114,8 +114,10 @@ module ApiDiffReport
     shown
   end
 
-  def fingerprint(report)
-    Digest::SHA256.hexdigest((report[:modules] + report[:added] + report[:removed]).join("\n"))[0, 12]
+  # Of the rendered summary, not the report: joining the declaration lists would hash an addition of
+  # a declaration the same as its removal.
+  def fingerprint(message)
+    Digest::SHA256.hexdigest(message.to_s)[0, 12]
   end
 
   def fingerprint_marker(fingerprint)
@@ -238,16 +240,15 @@ module ApiDiffReport
   end
 
   # Returns [:posted | :duplicate | :failed, reason_or_nil].
-  def announce(report, pull_request_link, credentials, poster, getter, announced_in_comment)
+  def announce(message, pull_request_link, credentials, poster, getter, announced_in_comment)
     return [:failed, "no Slack credentials were reachable"] if credentials.nil?
 
     bot_token, channel = credentials
-    message = slack_message(report, pull_request_link)
 
     state, history_error = announcement_state(message, channel, bot_token, getter, pull_request_link)
     return [:duplicate, nil] if state == :same
 
-    if state == :unknown && announced_in_comment&.call(fingerprint_marker(fingerprint(report)))
+    if state == :unknown && announced_in_comment&.call(fingerprint_marker(fingerprint(message)))
       return [:duplicate, nil]
     end
 
@@ -275,10 +276,11 @@ module ApiDiffReport
     report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
     return nil if empty?(report)
 
-    outcome, reason = announce(report, pull_request_link, credentials, poster, getter, announced_in_comment)
+    message = slack_message(report, pull_request_link)
+    outcome, reason = announce(message, pull_request_link, credentials, poster, getter, announced_in_comment)
 
     {
-      comment: markdown_section(report, announced_fingerprint: (fingerprint(report) unless outcome == :failed)),
+      comment: markdown_section(report, announced_fingerprint: (fingerprint(message) unless outcome == :failed)),
       warning: warning(outcome, reason)
     }
   end

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -1,5 +1,6 @@
 # Reports the public API a PR changes, from the metalava signature diffs. Loaded by the Dangerfile.
 
+require 'digest'
 require 'json'
 require 'net/http'
 require 'uri'
@@ -113,11 +114,19 @@ module ApiDiffReport
     shown
   end
 
-  def markdown_section(report)
+  def fingerprint(report)
+    Digest::SHA256.hexdigest((report[:modules] + report[:added] + report[:removed]).join("\n"))[0, 12]
+  end
+
+  def fingerprint_marker(fingerprint)
+    "<!-- api-diff:#{fingerprint} -->"
+  end
+
+  def markdown_section(report, announced_fingerprint: nil)
     summary = "Public API changes in #{report[:modules].join(', ')} (#{counts(report)})"
     body = capped_lines(diff_lines(report), limit: MARKDOWN_LIMIT, width: MARKDOWN_WIDTH)
 
-    [
+    lines = [
       "<details><summary>#{summary}</summary>",
       "",
       "```diff",
@@ -125,7 +134,10 @@ module ApiDiffReport
       "```",
       "",
       "</details>"
-    ].join("\n")
+    ]
+    lines << fingerprint_marker(announced_fingerprint) if announced_fingerprint
+
+    lines.join("\n")
   end
 
   def slack_message(report, pull_request_link)
@@ -160,6 +172,57 @@ module ApiDiffReport
     }
   end
 
+  SLACK_HISTORY_LIMIT = 100
+
+  # conversations.history takes a channel ID, never a `#name`.
+  CHANNEL_ID = /\A[CGD][A-Z0-9]+\z/.freeze
+
+  def history_request(channel, bot_token:, limit: SLACK_HISTORY_LIMIT)
+    {
+      url: "https://slack.com/api/conversations.history?channel=#{channel}&limit=#{limit}",
+      headers: { "Authorization" => "Bearer #{bot_token}" }
+    }
+  end
+
+  def recent_messages(request, getter: nil)
+    getter ||= ->(url, headers) { Net::HTTP.get_response(URI.parse(url), headers) }
+
+    response = getter.call(request[:url], request[:headers])
+    raise "Slack returned #{response.code}: #{response.body}" unless (200..299).cover?(response.code.to_i)
+
+    parsed = JSON.parse(response.body.to_s)
+    raise "Slack rejected conversations.history: #{parsed['error']}" unless parsed["ok"]
+
+    parsed["messages"].to_a.map { |message| message["text"].to_s }
+  end
+
+  # conversations.history answers newest first, so the first match is the channel's last word about
+  # this PR. The module list is not part of the identity: it changes with what the PR touches.
+  def last_announcement(texts, pull_request_link)
+    return nil if pull_request_link.to_s.empty?
+
+    texts.find { |text| text.include?(pull_request_link) && text.include?(PLATFORM_LABEL) }
+  end
+
+  # Each push starts two pipelines, and the auto-canceled one still posts before it dies, so the
+  # channel is the only store the sibling run can see in time. Comparing against the last
+  # announcement rather than the whole window keeps a PR that reverts to an earlier surface
+  # announced: the channel's newest word on it has to be the current one.
+  # Returns [:same | :different | :unknown, why_unknown].
+  def announcement_state(message, channel, bot_token, getter, pull_request_link)
+    unless CHANNEL_ID.match?(channel.to_s)
+      return [:unknown, "#{channel} is a channel name, and conversations.history needs the channel ID"]
+    end
+
+    texts = recent_messages(history_request(channel, bot_token: bot_token), getter: getter)
+    last = last_announcement(texts, pull_request_link)
+    return [:unknown, nil] if last.nil?
+
+    [last == message ? :same : :different, nil]
+  rescue StandardError => e
+    [:unknown, e.message]
+  end
+
   def post(request, poster: nil)
     poster ||= ->(url, body, headers) { Net::HTTP.post(URI.parse(url), body, headers) }
 
@@ -178,26 +241,42 @@ module ApiDiffReport
   end
 
   # The PR comment is the report and Slack only mirrors it, so a failed announcement must not cost
-  # us the comment. Returns the reason it was not announced, or nil.
-  def announce(report, pull_request_link, credentials, poster)
-    return "no Slack credentials were reachable" if credentials.nil?
+  # us the comment. Returns [:posted | :duplicate | :failed, reason_or_nil].
+  def announce(report, pull_request_link, credentials, poster, getter, announced_in_comment)
+    return [:failed, "no Slack credentials were reachable"] if credentials.nil?
 
     bot_token, channel = credentials
-    post(slack_request(slack_message(report, pull_request_link), bot_token: bot_token, channel: channel), poster: poster)
-    nil
+    message = slack_message(report, pull_request_link)
+
+    state, history_error = announcement_state(message, channel, bot_token, getter, pull_request_link)
+    return [:duplicate, nil] if state == :same
+
+    # Nothing the channel can tell us: the marker the last announcement left on the PR is all we
+    # have, and it records the same thing, the last summary that made it out.
+    if state == :unknown && announced_in_comment&.call(fingerprint_marker(fingerprint(report)))
+      return [:duplicate, nil]
+    end
+
+    post(slack_request(message, bot_token: bot_token, channel: channel), poster: poster)
+    [:posted, history_error]
   rescue StandardError => e
-    e.message
+    [:failed, e.message]
   end
 
-  # Returns { comment:, slack_error: }, or nil when the public API did not change.
-  def run(changed_files:, patch_for:, pull_request_link:, credentials: slack_credentials, poster: nil)
+  # Returns { comment:, slack_error:, degraded_dedupe: }, or nil when the public API did not change.
+  def run(changed_files:, patch_for:, pull_request_link:, credentials: slack_credentials, poster: nil,
+          getter: nil, announced_in_comment: nil)
     signature_files = changed_files.uniq.select { |file| signature_file?(file) }
     report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
     return nil if empty?(report)
 
+    outcome, reason = announce(report, pull_request_link, credentials, poster, getter, announced_in_comment)
+
     {
-      comment: markdown_section(report),
-      slack_error: announce(report, pull_request_link, credentials, poster)
+      # Recording the fingerprint after a failed announcement would silence the next run too.
+      comment: markdown_section(report, announced_fingerprint: (fingerprint(report) unless outcome == :failed)),
+      slack_error: (reason if outcome == :failed),
+      degraded_dedupe: (reason if outcome == :posted)
     }
   end
 end

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -196,8 +196,7 @@ module ApiDiffReport
     parsed["messages"].to_a.map { |message| message["text"].to_s }
   end
 
-  # conversations.history answers newest first, so the first match is the channel's last word about
-  # this PR. The module list is not part of the identity: it changes with what the PR touches.
+  # conversations.history answers newest first, so the first match is the channel's last word.
   def last_announcement(texts, pull_request_link)
     return nil if pull_request_link.to_s.empty?
 
@@ -205,9 +204,7 @@ module ApiDiffReport
   end
 
   # Each push starts two pipelines, and the auto-canceled one still posts before it dies, so the
-  # channel is the only store the sibling run can see in time. Comparing against the last
-  # announcement rather than the whole window keeps a PR that reverts to an earlier surface
-  # announced: the channel's newest word on it has to be the current one.
+  # channel is the only store the sibling run can see in time.
   # Returns [:same | :different | :unknown, why_unknown].
   def announcement_state(message, channel, bot_token, getter, pull_request_link)
     unless CHANNEL_ID.match?(channel.to_s)
@@ -240,8 +237,7 @@ module ApiDiffReport
     nil
   end
 
-  # The PR comment is the report and Slack only mirrors it, so a failed announcement must not cost
-  # us the comment. Returns [:posted | :duplicate | :failed, reason_or_nil].
+  # Returns [:posted | :duplicate | :failed, reason_or_nil].
   def announce(report, pull_request_link, credentials, poster, getter, announced_in_comment)
     return [:failed, "no Slack credentials were reachable"] if credentials.nil?
 
@@ -251,8 +247,6 @@ module ApiDiffReport
     state, history_error = announcement_state(message, channel, bot_token, getter, pull_request_link)
     return [:duplicate, nil] if state == :same
 
-    # Nothing the channel can tell us: the marker the last announcement left on the PR is all we
-    # have, and it records the same thing, the last summary that made it out.
     if state == :unknown && announced_in_comment&.call(fingerprint_marker(fingerprint(report)))
       return [:duplicate, nil]
     end
@@ -263,7 +257,18 @@ module ApiDiffReport
     [:failed, e.message]
   end
 
-  # Returns { comment:, slack_error:, degraded_dedupe: }, or nil when the public API did not change.
+  def warning(outcome, reason)
+    return nil if reason.to_s.empty?
+
+    case outcome
+    when :failed
+      "The public API changed, but it was not announced in the SDK API feed: #{reason}."
+    when :posted
+      "Could not read the SDK API feed channel, so this change may be announced twice: #{reason}."
+    end
+  end
+
+  # Returns { comment:, warning: }, or nil when the public API did not change.
   def run(changed_files:, patch_for:, pull_request_link:, credentials: slack_credentials, poster: nil,
           getter: nil, announced_in_comment: nil)
     signature_files = changed_files.uniq.select { |file| signature_file?(file) }
@@ -273,10 +278,8 @@ module ApiDiffReport
     outcome, reason = announce(report, pull_request_link, credentials, poster, getter, announced_in_comment)
 
     {
-      # Recording the fingerprint after a failed announcement would silence the next run too.
       comment: markdown_section(report, announced_fingerprint: (fingerprint(report) unless outcome == :failed)),
-      slack_error: (reason if outcome == :failed),
-      degraded_dedupe: (reason if outcome == :posted)
+      warning: warning(outcome, reason)
     }
   end
 end

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -208,6 +208,25 @@ class ApiDiffReportTest < Minitest::Test
     "purchases/src/main/kotlin/Purchases.kt" => "irrelevant"
   }.freeze
 
+  CHANNEL_CREDENTIALS = ["xoxb-1", "C0BLWE7VBS4"].freeze
+
+  def history_getter(texts)
+    lambda do |_url, _headers|
+      Struct.new(:code, :body).new("200", { ok: true, messages: texts.map { |text| { "text" => text } } }.to_json)
+    end
+  end
+
+  def collecting_poster(posted)
+    lambda do |_url, request_body, _headers|
+      posted << JSON.parse(request_body)
+      Struct.new(:code, :body).new("200", '{"ok":true}')
+    end
+  end
+
+  def announcement_for(link)
+    ApiDiffReport.slack_message(ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH), link)
+  end
+
   def test_run_returns_the_comment_body_and_posts_to_slack
     posted = []
 
@@ -215,17 +234,174 @@ class ApiDiffReportTest < Minitest::Test
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
       pull_request_link: "<url|#42>",
-      credentials: ["xoxb-1", "#some-channel"],
-      poster: lambda do |_url, request_body, _headers|
-        posted << JSON.parse(request_body)
-        Struct.new(:code, :body).new("200", '{"ok":true}')
-      end
+      credentials: CHANNEL_CREDENTIALS,
+      getter: history_getter([]),
+      poster: collecting_poster(posted)
     )
 
     assert_includes body[:comment], "+ method public void apiDiffDemoPong"
     assert_nil body[:slack_error]
+    assert_nil body[:degraded_dedupe]
     assert_equal 1, posted.count
     assert_includes posted.first["text"], "<url|#42>"
+  end
+
+  def test_run_skips_slack_when_the_last_word_on_this_pull_request_is_this_summary
+    body = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      pull_request_link: "<url|#42>",
+      credentials: CHANNEL_CREDENTIALS,
+      getter: history_getter([announcement_for("<url|#42>"), "unrelated"]),
+      poster: ->(*) { raise "must not post" }
+    )
+
+    assert_includes body[:comment], "+ method public void apiDiffDemoPong"
+    assert_nil body[:slack_error]
+  end
+
+  # A PR that changes the API, changes it again, then reverts to the first state: the channel's
+  # newest word on it must be the current one, so this announces again.
+  def test_run_reannounces_a_surface_the_pull_request_had_already_left_behind
+    posted = []
+    superseded = ApiDiffReport.slack_message(
+      ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH.gsub("Pong", "Pang")), "<url|#42>"
+    )
+
+    ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      pull_request_link: "<url|#42>",
+      credentials: CHANNEL_CREDENTIALS,
+      getter: history_getter([superseded, announcement_for("<url|#42>")]),
+      poster: collecting_poster(posted)
+    )
+
+    assert_equal 1, posted.count
+  end
+
+  # Only messages about this PR, from this platform, say anything about what it announced.
+  def test_last_announcement_ignores_other_pull_requests_and_platforms
+    ours = announcement_for("<url|#42>")
+    texts = ["#{ours.sub(ApiDiffReport::PLATFORM_LABEL, 'iOS :ios:')}", announcement_for("<url|#41>"), ours]
+
+    assert_equal ours, ApiDiffReport.last_announcement(texts, "<url|#42>")
+  end
+
+  # The same declaration on another PR is news; the link is part of the message for that reason.
+  def test_run_posts_when_the_channel_holds_another_pull_requests_summary
+    posted = []
+
+    ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      pull_request_link: "<url|#42>",
+      credentials: CHANNEL_CREDENTIALS,
+      getter: history_getter([announcement_for("<url|#41>")]),
+      poster: collecting_poster(posted)
+    )
+
+    assert_equal 1, posted.count
+  end
+
+  # The marker written into the comment is what the next run looks for, so the helper owns its shape.
+  def test_run_falls_back_to_the_marker_on_the_pull_request_when_history_is_unreadable
+    markers = []
+
+    body = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      pull_request_link: "<url|#42>",
+      credentials: CHANNEL_CREDENTIALS,
+      getter: ->(*) { Struct.new(:code, :body).new("200", '{"ok":false,"error":"missing_scope"}') },
+      announced_in_comment: ->(marker) { markers << marker; true },
+      poster: ->(*) { raise "must not post" }
+    )
+
+    assert_match(/\A<!-- api-diff:[0-9a-f]{12} -->\z/, markers.first)
+    assert_includes body[:comment], markers.first
+    assert_nil body[:slack_error]
+  end
+
+  def test_run_posts_and_reports_degraded_dedupe_when_neither_store_is_readable
+    posted = []
+
+    body = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      pull_request_link: "<url|#42>",
+      credentials: CHANNEL_CREDENTIALS,
+      getter: ->(*) { raise "slack is down" },
+      announced_in_comment: ->(_marker) { false },
+      poster: collecting_poster(posted)
+    )
+
+    assert_equal 1, posted.count
+    assert_equal "slack is down", body[:degraded_dedupe]
+    assert_nil body[:slack_error]
+  end
+
+  # A recorded fingerprint would make the next run treat the failure as already announced.
+  def test_run_records_the_fingerprint_only_once_announced
+    announced = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      pull_request_link: "<url|#42>",
+      credentials: CHANNEL_CREDENTIALS,
+      getter: history_getter([]),
+      poster: ->(*) { Struct.new(:code, :body).new("200", '{"ok":true}') }
+    )
+    failed = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      pull_request_link: "<url|#42>",
+      credentials: CHANNEL_CREDENTIALS,
+      getter: history_getter([]),
+      poster: ->(*) { raise "slack is down" }
+    )
+
+    assert_match(/<!-- api-diff:[0-9a-f]{12} -->/, announced[:comment])
+    refute_match(/<!-- api-diff:/, failed[:comment])
+  end
+
+  def test_fingerprint_survives_a_rerun_and_moves_with_the_report
+    unchanged = ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH)
+    changed = ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH.gsub("Pong", "Pang"))
+
+    assert_equal ApiDiffReport.fingerprint(unchanged), ApiDiffReport.fingerprint(unchanged)
+    refute_equal ApiDiffReport.fingerprint(unchanged), ApiDiffReport.fingerprint(changed)
+  end
+
+  # chat.postMessage takes a `#name`, conversations.history does not.
+  def test_announcement_state_needs_the_channel_id
+    state, reason = ApiDiffReport.announcement_state("hi", "#feed", "xoxb-1", ->(*) { raise "must not read" }, "<url|#42>")
+
+    assert_equal :unknown, state
+    assert_includes reason, "channel ID"
+  end
+
+  # Past the history window there is nothing to compare against, which is not an error.
+  def test_announcement_state_is_unknown_without_a_reason_when_the_pull_request_is_not_in_the_window
+    state, reason = ApiDiffReport.announcement_state("hi", "C1", "xoxb-1", history_getter(["unrelated"]), "<url|#42>")
+
+    assert_equal :unknown, state
+    assert_nil reason
+  end
+
+  def test_recent_messages_returns_the_texts_newest_first
+    request = ApiDiffReport.history_request("C1", bot_token: "xoxb-1")
+
+    assert_includes request[:url], "channel=C1"
+    assert_equal "Bearer xoxb-1", request[:headers]["Authorization"]
+    assert_equal ["new", "old"], ApiDiffReport.recent_messages(request, getter: history_getter(["new", "old"]))
+  end
+
+  def test_recent_messages_raises_when_the_token_cannot_read_the_channel
+    response = Struct.new(:code, :body).new("200", '{"ok":false,"error":"missing_scope"}')
+    request = ApiDiffReport.history_request("C1", bot_token: "xoxb-1")
+
+    error = assert_raises(RuntimeError) { ApiDiffReport.recent_messages(request, getter: ->(*) { response }) }
+    assert_includes error.message, "missing_scope"
   end
 
   def test_run_reports_a_skipped_announcement_without_credentials

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -240,8 +240,7 @@ class ApiDiffReportTest < Minitest::Test
     )
 
     assert_includes body[:comment], "+ method public void apiDiffDemoPong"
-    assert_nil body[:slack_error]
-    assert_nil body[:degraded_dedupe]
+    assert_nil body[:warning]
     assert_equal 1, posted.count
     assert_includes posted.first["text"], "<url|#42>"
   end
@@ -257,11 +256,9 @@ class ApiDiffReportTest < Minitest::Test
     )
 
     assert_includes body[:comment], "+ method public void apiDiffDemoPong"
-    assert_nil body[:slack_error]
+    assert_nil body[:warning]
   end
 
-  # A PR that changes the API, changes it again, then reverts to the first state: the channel's
-  # newest word on it must be the current one, so this announces again.
   def test_run_reannounces_a_surface_the_pull_request_had_already_left_behind
     posted = []
     superseded = ApiDiffReport.slack_message(
@@ -280,7 +277,15 @@ class ApiDiffReportTest < Minitest::Test
     assert_equal 1, posted.count
   end
 
-  # Only messages about this PR, from this platform, say anything about what it announced.
+  # What the PR touches changes the module list, so the modules cannot be part of the identity.
+  def test_last_announcement_matches_a_previous_announcement_of_other_modules
+    previous = ApiDiffReport.slack_message(
+      ApiDiffReport.build("ui/revenuecatui/api.txt" => SIGNATURE_CHANGE_PATCH), "<url|#42>"
+    )
+
+    assert_equal previous, ApiDiffReport.last_announcement([previous], "<url|#42>")
+  end
+
   def test_last_announcement_ignores_other_pull_requests_and_platforms
     ours = announcement_for("<url|#42>")
     texts = ["#{ours.sub(ApiDiffReport::PLATFORM_LABEL, 'iOS :ios:')}", announcement_for("<url|#41>"), ours]
@@ -288,7 +293,6 @@ class ApiDiffReportTest < Minitest::Test
     assert_equal ours, ApiDiffReport.last_announcement(texts, "<url|#42>")
   end
 
-  # The same declaration on another PR is news; the link is part of the message for that reason.
   def test_run_posts_when_the_channel_holds_another_pull_requests_summary
     posted = []
 
@@ -304,7 +308,6 @@ class ApiDiffReportTest < Minitest::Test
     assert_equal 1, posted.count
   end
 
-  # The marker written into the comment is what the next run looks for, so the helper owns its shape.
   def test_run_falls_back_to_the_marker_on_the_pull_request_when_history_is_unreadable
     markers = []
 
@@ -320,10 +323,10 @@ class ApiDiffReportTest < Minitest::Test
 
     assert_match(/\A<!-- api-diff:[0-9a-f]{12} -->\z/, markers.first)
     assert_includes body[:comment], markers.first
-    assert_nil body[:slack_error]
+    assert_nil body[:warning]
   end
 
-  def test_run_posts_and_reports_degraded_dedupe_when_neither_store_is_readable
+  def test_run_warns_about_a_possible_duplicate_when_neither_store_is_readable
     posted = []
 
     body = ApiDiffReport.run(
@@ -337,11 +340,9 @@ class ApiDiffReportTest < Minitest::Test
     )
 
     assert_equal 1, posted.count
-    assert_equal "slack is down", body[:degraded_dedupe]
-    assert_nil body[:slack_error]
+    assert_includes body[:warning], "may be announced twice: slack is down"
   end
 
-  # A recorded fingerprint would make the next run treat the failure as already announced.
   def test_run_records_the_fingerprint_only_once_announced
     announced = ApiDiffReport.run(
       changed_files: PATCHES.keys,
@@ -380,7 +381,6 @@ class ApiDiffReportTest < Minitest::Test
     assert_includes reason, "channel ID"
   end
 
-  # Past the history window there is nothing to compare against, which is not an error.
   def test_announcement_state_is_unknown_without_a_reason_when_the_pull_request_is_not_in_the_window
     state, reason = ApiDiffReport.announcement_state("hi", "C1", "xoxb-1", history_getter(["unrelated"]), "<url|#42>")
 
@@ -414,10 +414,9 @@ class ApiDiffReportTest < Minitest::Test
     )
 
     assert_includes body[:comment], "+ method public void apiDiffDemoPong"
-    assert_equal "no Slack credentials were reachable", body[:slack_error]
+    assert_includes body[:warning], "no Slack credentials were reachable"
   end
 
-  # The comment is the report; Slack only mirrors it.
   def test_run_still_returns_the_comment_when_slack_fails
     body = ApiDiffReport.run(
       changed_files: PATCHES.keys,
@@ -428,7 +427,7 @@ class ApiDiffReportTest < Minitest::Test
     )
 
     assert_includes body[:comment], "+ method public void apiDiffDemoPong"
-    assert_equal "slack is down", body[:slack_error]
+    assert_includes body[:warning], "not announced in the SDK API feed: slack is down"
   end
 
   def test_slack_credentials_accepts_the_legacy_ios_token_name

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -365,12 +365,28 @@ class ApiDiffReportTest < Minitest::Test
     refute_match(/<!-- api-diff:/, failed[:comment])
   end
 
-  def test_fingerprint_survives_a_rerun_and_moves_with_the_report
-    unchanged = ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH)
-    changed = ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH.gsub("Pong", "Pang"))
+  def test_fingerprint_survives_a_rerun_and_moves_with_the_summary
+    unchanged = announcement_for("<url|#42>")
+    changed = ApiDiffReport.slack_message(
+      ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH.gsub("Pong", "Pang")), "<url|#42>"
+    )
 
     assert_equal ApiDiffReport.fingerprint(unchanged), ApiDiffReport.fingerprint(unchanged)
     refute_equal ApiDiffReport.fingerprint(unchanged), ApiDiffReport.fingerprint(changed)
+  end
+
+  # Hashing the declaration lists gave an addition and its removal the same fingerprint, which let
+  # the marker path swallow a removal.
+  def test_fingerprint_separates_an_addition_from_its_removal
+    added = ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH)
+    removed = ApiDiffReport.build(
+      "purchases/api-defauts.txt" => ADDED_METHOD_PATCH.sub("+    method public void apiDiffDemoPong();",
+                                                            "-    method public void apiDiffDemoPong();")
+    )
+
+    assert_equal ["method public void apiDiffDemoPong();"], removed[:removed]
+    refute_equal ApiDiffReport.fingerprint(ApiDiffReport.slack_message(added, "<url|#42>")),
+                 ApiDiffReport.fingerprint(ApiDiffReport.slack_message(removed, "<url|#42>"))
   end
 
   # chat.postMessage takes a `#name`, conversations.history does not.


### PR DESCRIPTION
- The feed announced the same summary on every CI run of a PR touching a signature file. Now it announces once per distinct summary.
- Dedup compares against the channel's newest message about this PR, so a PR that reverts to a surface it announced earlier is announced again.
- When the channel says nothing , a `<!-- api-diff:<hash> -->` marker on the PR comment decides. It is written only after the post succeeds, so a Slack outage cannot silence the next run.
- Needs `channels:history` on the bot token and the channel ID, not `#name`, in `SLACK_CHANNEL_SDK_NEW_API`. Without either, dedup still works across pushes through the marker and the PR gets a warning naming the reason.

- Companion change on `purchases-ios`: https://github.com/RevenueCat/purchases-ios/pull/7431

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

`#3976` shipped the announcement without the dedup: `run` posted whenever the diff against the PR base was non-empty, which is every run of a PR that already changed the API surface. `#3884` was announced three times with byte-identical content, twice within seven seconds.

Those seven seconds are a second cause. Each push creates two pipelines (26535 and 26537, 26496 and 26498, and so on): `build-test-deploy` on the older one is auto-canceled, but `danger` finishes in ~25s and posts first. That rules out the PR comment as the only store, since Danger writes it at the end of the run and two concurrent runs would both read the previous push's state.

### Description

- `announcement_state` returns `:same` / `:different` / `:unknown`. Identity is the PR link plus the platform label, both already in the message; modules are excluded because they change with what the PR touches.
- `:unknown` is the only state that consults the comment marker, so both stores answer one question: what was announced last.
- `announce` returns `[:posted | :duplicate | :failed, reason]`, and the marker is recorded for the first two only.
- The comment lookup is injected from the `Dangerfile`, since Danger's Octokit client is the only thing that can list comments, and it receives the marker text rather than the bare hash so the helper owns the marker shape on both sides.

Not visible in the diff: the marker sits in the `<details>` block Danger rewrites every run, so it always reflects the last announcement rather than accumulating.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI Danger behavior and Slack integration for API announcements; misconfiguration (channel name vs ID or missing scopes) can cause duplicate posts or warnings, but no runtime SDK or auth impact.
> 
> **Overview**
> Stops **duplicate Slack posts** to the SDK API feed when Danger reruns on the same public API diff. Announcements now go out **once per distinct summary** for a PR, while still **re-announcing** if the API surface changes again (including reverting to an earlier announced state).
> 
> Dedup first checks Slack **`conversations.history`** for this PR’s latest message (matched by PR link and Android platform label) and skips posting when the text matches. When history is unavailable—wrong channel format, missing `channels:history`, errors, or concurrent CI siblings—it falls back to a **`<!-- api-diff:<hash> -->`** marker on the PR comment (lookup injected from the `Dangerfile`). The hash fingerprints the **full Slack message**, not raw declaration lists, so removals and additions don’t collide. The marker is recorded only after a **successful** post so a Slack outage doesn’t block a later announcement.
> 
> Operational notes: **`SLACK_CHANNEL_SDK_NEW_API` must be a channel ID** (not `#name`) for history. Warnings replace the old `slack_error` field when Slack fails or when a post may duplicate because neither Slack nor the comment marker could confirm prior announcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4c48909a304a8be82c1becc170f20622b0f605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->