### PR TITLE
refactor(admob): add next-gen preloading foundation

### DIFF
--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingPreloadCallback.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingPreloadCallback.kt
@@ -1,0 +1,34 @@
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.ads.events.types.AdFormat
+
+/**
+ * A [PreloadCallback] wrapper that tracks every completed preload attempt before
+ * forwarding the callback to the user-provided [delegate].
+ */
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+internal class TrackingPreloadCallback(
+    private val delegate: PreloadCallback?,
+    private val adFormat: AdFormat,
+    private val placement: String?,
+    private val adUnitId: String,
+) : PreloadCallback {
+
+    override fun onAdPreloaded(preloadId: String, responseInfo: ResponseInfo) {
+        trackAdLoaded({ responseInfo }, adFormat, placement, adUnitId)
+        delegate?.onAdPreloaded(preloadId, responseInfo)
+    }
+
+    override fun onAdFailedToPreload(preloadId: String, adError: LoadAdError) {
+        trackAdFailedToLoad(adError, adFormat, placement, adUnitId)
+        delegate?.onAdFailedToPreload(preloadId, adError)
+    }
+
+    override fun onAdsExhausted(preloadId: String) {
+        delegate?.onAdsExhausted(preloadId)
+    }
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/PreloaderTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/PreloaderTest.kt
@@ -1,0 +1,134 @@
+@file:OptIn(
+    ExperimentalPreviewRevenueCatPurchasesAPI::class,
+    InternalRevenueCatAPI::class,
+)
+
+package com.revenuecat.purchases.admob.nextgen
+
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
+import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdLoadedData
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+
+internal abstract class PreloaderTest {
+
+    protected val adTracker = mockk<AdTracker>(relaxed = true)
+    private val purchases = mockk<Purchases>(relaxed = true)
+
+    @Before
+    fun setUpPurchases() {
+        every { purchases.adTracker } returns adTracker
+        mockkObject(Purchases)
+        every { Purchases.isConfigured } returns true
+        every { Purchases.sharedInstance } returns purchases
+    }
+
+    @After
+    fun tearDownPurchases() {
+        unmockkObject(Purchases)
+    }
+
+    protected fun responseInfo(networkName: String, responseId: String): ResponseInfo = mockk(relaxed = true) {
+        every { adapterClassName } returns networkName
+        every { this@mockk.responseId } returns responseId
+    }
+
+    protected fun loadError(errorCode: LoadAdError.ErrorCode): LoadAdError = mockk {
+        every { code } returns errorCode
+    }
+
+    protected fun preloadConfiguration(adUnitId: String): PreloadConfiguration {
+        val request = mockk<AdRequest> { every { this@mockk.adUnitId } returns adUnitId }
+        return PreloadConfiguration(request, 2)
+    }
+
+    protected fun assertSuccessfulPreload(
+        preloadId: String,
+        trackingCallback: PreloadCallback,
+        delegate: RecordingPreloadCallback,
+        expectedFormat: AdFormat,
+        expectedAdUnitId: String,
+        expectedPlacement: String?,
+    ) {
+        val responseInfo = responseInfo("test-network", "test-response")
+
+        trackingCallback.onAdPreloaded(preloadId, responseInfo)
+
+        assertEquals(listOf(responseInfo), delegate.responses)
+        val loadedData = slot<AdLoadedData>()
+        verify(exactly = 1) { adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER) }
+        assertEquals(expectedFormat, loadedData.captured.adFormat)
+        assertEquals(expectedAdUnitId, loadedData.captured.adUnitId)
+        assertEquals(expectedPlacement, loadedData.captured.placement)
+    }
+
+    protected fun assertFailedPreload(
+        preloadId: String,
+        trackingCallback: PreloadCallback,
+        delegate: RecordingPreloadCallback,
+        expectedFormat: AdFormat,
+        expectedAdUnitId: String,
+        expectedPlacement: String?,
+    ) {
+        val error = loadError(LoadAdError.ErrorCode.NO_FILL)
+
+        trackingCallback.onAdFailedToPreload(preloadId, error)
+
+        assertEquals(listOf(error), delegate.errors)
+        val failedData = slot<AdFailedToLoadData>()
+        verify(exactly = 1) { adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER) }
+        assertEquals(expectedFormat, failedData.captured.adFormat)
+        assertEquals(expectedAdUnitId, failedData.captured.adUnitId)
+        assertEquals(expectedPlacement, failedData.captured.placement)
+        assertEquals(LoadAdError.ErrorCode.NO_FILL.value, failedData.captured.mediatorErrorCode)
+    }
+
+    protected fun assertNullPoll(result: Any?) {
+        assertNull(result)
+        verify(exactly = 0) { adTracker.trackAdLoaded(any(), any()) }
+    }
+
+    protected class RecordingPreloadCallback(
+        private val onPreloaded: (String) -> Unit = {},
+        private val onFailedToPreload: (String) -> Unit = {},
+        private val onExhausted: (String) -> Unit = {},
+    ) : PreloadCallback {
+        val responses = mutableListOf<ResponseInfo>()
+        val errors = mutableListOf<LoadAdError>()
+        val exhaustedIds = mutableListOf<String>()
+
+        override fun onAdPreloaded(preloadId: String, responseInfo: ResponseInfo) {
+            responses += responseInfo
+            onPreloaded(preloadId)
+        }
+
+        override fun onAdFailedToPreload(preloadId: String, adError: LoadAdError) {
+            errors += adError
+            onFailedToPreload(preloadId)
+        }
+
+        override fun onAdsExhausted(preloadId: String) {
+            exhaustedIds += preloadId
+            onExhausted(preloadId)
+        }
+    }
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingPreloadCallbackTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingPreloadCallbackTest.kt
@@ -1,0 +1,94 @@
+@file:OptIn(
+    ExperimentalPreviewRevenueCatPurchasesAPI::class,
+    InternalRevenueCatAPI::class,
+)
+
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.admob.nextgen.PreloaderTest
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import io.mockk.confirmVerified
+import io.mockk.every
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class TrackingPreloadCallbackTest : PreloaderTest() {
+
+    @Test
+    fun `tracks a successful preload before forwarding it unchanged`() {
+        val order = mutableListOf<String>()
+        every { adTracker.trackAdLoaded(any(), any()) } answers { order += "track" }
+        val delegate = RecordingPreloadCallback(
+            onPreloaded = { preloadId -> order += "delegate:$preloadId" },
+        )
+        val callback = trackingCallback(delegate)
+
+        assertSuccessfulPreload(
+            preloadId = PRELOAD_ID,
+            trackingCallback = callback,
+            delegate = delegate,
+            expectedFormat = AdFormat.NATIVE,
+            expectedAdUnitId = AD_UNIT_ID,
+            expectedPlacement = PLACEMENT,
+        )
+
+        assertEquals(listOf("track", "delegate:$PRELOAD_ID"), order)
+    }
+
+    @Test
+    fun `tracks a failed preload before forwarding it unchanged`() {
+        val order = mutableListOf<String>()
+        every { adTracker.trackAdFailedToLoad(any(), any()) } answers { order += "track" }
+        val delegate = RecordingPreloadCallback(
+            onFailedToPreload = { preloadId -> order += "delegate:$preloadId" },
+        )
+        val callback = trackingCallback(delegate)
+
+        assertFailedPreload(
+            preloadId = PRELOAD_ID,
+            trackingCallback = callback,
+            delegate = delegate,
+            expectedFormat = AdFormat.NATIVE,
+            expectedAdUnitId = AD_UNIT_ID,
+            expectedPlacement = PLACEMENT,
+        )
+
+        assertEquals(listOf("track", "delegate:$PRELOAD_ID"), order)
+    }
+
+    @Test
+    fun `forwards exhaustion without tracking it`() {
+        val delegate = RecordingPreloadCallback()
+
+        trackingCallback(delegate).onAdsExhausted(PRELOAD_ID)
+
+        assertEquals(listOf(PRELOAD_ID), delegate.exhaustedIds)
+        confirmVerified(adTracker)
+    }
+
+    @Test
+    fun `tolerates a null delegate for every callback`() {
+        val callback = trackingCallback(delegate = null)
+
+        callback.onAdPreloaded(PRELOAD_ID, responseInfo("test-network", "test-response"))
+        callback.onAdFailedToPreload(PRELOAD_ID, loadError(LoadAdError.ErrorCode.NO_FILL))
+        callback.onAdsExhausted(PRELOAD_ID)
+    }
+
+    private fun trackingCallback(delegate: PreloadCallback?): TrackingPreloadCallback = TrackingPreloadCallback(
+        delegate = delegate,
+        adFormat = AdFormat.NATIVE,
+        placement = PLACEMENT,
+        adUnitId = AD_UNIT_ID,
+    )
+
+    companion object {
+        private const val PRELOAD_ID = "test-buffer"
+        private const val PLACEMENT = "test-placement"
+        private const val AD_UNIT_ID = "test-unit"
+    }
+}


### PR DESCRIPTION
### Motivation

Google reports preload completion while filling a buffer, before the app adopts an ad from that buffer. The format-specific preloader extensions need one shared callback that preserves this boundary consistently.

This is the foundation of the Next-Gen AdMob preloading stack and is stacked on #3957.

### Description

- Add an internal preload callback that records every preload success or failure before forwarding it to the app.
- Forward `onAdsExhausted` without recording a RevenueCat ad event.
- Support a missing app delegate while always giving Google the internal callback.
- Add shared tests and fixtures for callback forwarding and preload outcome tracking.

This PR adds no public API and no polling abstraction. Format-specific PRs install lifecycle tracking when an ad is polled, without synthesizing another loaded event.

### Validation

- `./gradlew :feature:admob-next-gen:testDefaultsDebugUnitTest`
- Full-stack detekt and API validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal-only tracking wrapper and tests; no public API or changes to auth, payments, or core purchase flows.
> 
> **Overview**
> Adds internal **`TrackingPreloadCallback`**, a `PreloadCallback` wrapper that records preload success and failure through the same adapter tracking path as direct loads (`trackAdLoaded` / `trackAdFailedToLoad`) **before** forwarding to an optional app delegate. **`onAdsExhausted`** is forwarded only and does not emit RevenueCat ad events.
> 
> Introduces shared test infrastructure (`PreloaderTest` fixtures and `TrackingPreloadCallbackTest`) covering tracking order, delegate forwarding, exhaustion passthrough, and null delegates. No public API or polling layer in this change—intended as the shared callback layer for upcoming format-specific preload extensions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f5181212eb88e6ff21d248ebb6deed3fe9c732b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->