### PR TITLE
feat(checkpoints): Add the app's subscriber attributes as a rules dimension

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -355,18 +355,6 @@ internal class PurchasesFactory(
             val checkpointsConfigProvider = remoteConfigManager?.let {
                 CheckpointsConfigProvider(it)
             }
-            RulesEngine.setLogger(RulesEngineLoggerBridge)
-            val localRulesEvaluator = LocalRulesEvaluator(
-                providers = listOf(
-                    DeviceDimensionProvider(appConfig, localeProvider),
-                    StoreDimensionProvider { Purchases.sharedInstance.awaitStorefrontCountryCode() },
-                    SubscriberAttributesDimensionProvider {
-                        subscriberAttributesCache.getAllStoredSubscriberAttributes(
-                            Purchases.sharedInstance.purchasesOrchestrator.appUserID,
-                        )
-                    },
-                ),
-            )
             if (remoteConfigManager != null && uiConfigProvider != null && workflowsConfigProvider != null) {
                 remoteConfigManager.registerListener(uiConfigProvider)
                 remoteConfigManager.registerListener(workflowsConfigProvider)
@@ -388,6 +376,24 @@ internal class PurchasesFactory(
                 offlineEntitlementsManager,
                 dispatcher,
                 uiPreviewMode = appConfig.uiPreviewMode,
+            )
+
+            // Built after the identity manager so a dimension source reads the app user ID from this instance
+            // rather than from whichever one is the singleton by the time a checkpoint is resolved. The evaluator
+            // is a leaf, only consumed from there, so where it is built is otherwise unconstrained.
+            RulesEngine.setLogger(RulesEngineLoggerBridge)
+            val localRulesEvaluator = LocalRulesEvaluator(
+                providers = listOf(
+                    DeviceDimensionProvider(appConfig, localeProvider),
+                    // Only read during a checkpoint evaluation, so the instance is configured by then. Same
+                    // reasoning as CheckpointWorkflowResolverImpl's getOfferings.
+                    StoreDimensionProvider { Purchases.sharedInstance.awaitStorefrontCountryCode() },
+                    SubscriberAttributesDimensionProvider {
+                        subscriberAttributesCache.getAllStoredSubscriberAttributes(
+                            identityManager.currentAppUserID,
+                        )
+                    },
+                ),
             )
 
             val customerInfoUpdateHandler = CustomerInfoUpdateHandler(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -359,11 +359,7 @@ internal class PurchasesFactory(
             val localRulesEvaluator = LocalRulesEvaluator(
                 providers = listOf(
                     DeviceDimensionProvider(appConfig, localeProvider),
-                    // Only read during a checkpoint evaluation, so the instance is configured by then. Same
-                    // reasoning as CheckpointWorkflowResolverImpl's getOfferings.
                     StoreDimensionProvider { Purchases.sharedInstance.awaitStorefrontCountryCode() },
-                    // The cache is right here, but the app user ID it is keyed on is not: `identityManager` is
-                    // built further down, so the ID is read through the configured instance like the above.
                     SubscriberAttributesDimensionProvider {
                         subscriberAttributesCache.getAllStoredSubscriberAttributes(
                             Purchases.sharedInstance.purchasesOrchestrator.appUserID,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -33,6 +33,7 @@ import com.revenuecat.purchases.common.localrules.DeviceDimensionProvider
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesEngineLoggerBridge
 import com.revenuecat.purchases.common.localrules.StoreDimensionProvider
+import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.networking.APISourceFailover
 import com.revenuecat.purchases.common.networking.DeviceConnectivityChecker
@@ -361,6 +362,13 @@ internal class PurchasesFactory(
                     // Only read during a checkpoint evaluation, so the instance is configured by then. Same
                     // reasoning as CheckpointWorkflowResolverImpl's getOfferings.
                     StoreDimensionProvider { Purchases.sharedInstance.awaitStorefrontCountryCode() },
+                    // The cache is right here, but the app user ID it is keyed on is not: `identityManager` is
+                    // built further down, so the ID is read through the configured instance like the above.
+                    SubscriberAttributesDimensionProvider {
+                        subscriberAttributesCache.getAllStoredSubscriberAttributes(
+                            Purchases.sharedInstance.purchasesOrchestrator.appUserID,
+                        )
+                    },
                 ),
             )
             if (remoteConfigManager != null && uiConfigProvider != null && workflowsConfigProvider != null) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
@@ -24,8 +24,6 @@ internal class DeviceDimensionProvider(
     private val localeProvider: LocaleProvider,
 ) : RulesDimensionProvider {
 
-    override val identifier: String = "device"
-
     override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.Device
 
     private val fixedDimensions: Map<String, RulesDimensionValue> = mapOf(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -31,10 +31,7 @@ internal enum class RulesDimensionNamespace(val key: String) {
  */
 internal interface RulesDimensionProvider {
 
-    /** Stable identifier, used only for diagnostics. */
-    val identifier: String
-
-    /** The root this provider's values are nested under. */
+    /** The root this provider's values are nested under, and the name it is reported under in diagnostics. */
     val namespace: RulesDimensionNamespace
 
     /**
@@ -42,8 +39,9 @@ internal interface RulesDimensionProvider {
      * [RulesDimensionResolver] adds the namespace.
      *
      * A value that is unavailable is omitted rather than guessed: an absent key resolves to null in the engine,
-     * which is a non-match rather than an error. Throwing is reserved for a systemic failure to produce this
-     * provider's values.
+     * which is a non-match rather than an error. A name no predicate could read is dropped by
+     * [RulesDimensionResolver], which applies that rule to every provider. Throwing is reserved for a systemic
+     * failure to produce this provider's values.
      *
      * [date] is the common reference instant for the evaluation. It does not indicate when the underlying values
      * were observed.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -18,6 +18,9 @@ internal enum class RulesDimensionNamespace(val key: String) {
     Custom("custom"),
     Device("device"),
     Store("store"),
+
+    /** What the app has told the SDK about the customer; see `Purchases.setAttributes`. */
+    SubscriberAttributes("subscriberAttributes"),
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -5,6 +5,7 @@ package com.revenuecat.purchases.common.localrules
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.rules.Value
 import kotlinx.coroutines.CancellationException
 import java.util.Date
@@ -20,9 +21,9 @@ internal data class RulesDimensionSnapshot(
 internal sealed class RulesDimensionResolutionException(message: String) : Exception(message) {
 
     internal data class ProviderFailed(
-        val identifier: String,
+        val namespace: RulesDimensionNamespace,
         val reason: String,
-    ) : RulesDimensionResolutionException("dimension provider '$identifier' failed: $reason")
+    ) : RulesDimensionResolutionException("dimension provider '${namespace.key}' failed: $reason")
 
     internal data class ConflictingDimension(
         val path: String,
@@ -64,7 +65,7 @@ internal class RulesDimensionResolver(
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
                 return Result.failure(
                     RulesDimensionResolutionException.ProviderFailed(
-                        identifier = provider.identifier,
+                        namespace = provider.namespace,
                         reason = error.message ?: error.toString(),
                     ),
                 )
@@ -93,11 +94,13 @@ private fun MutableMap<String, MutableMap<String, Value>>.addDimensions(
     namespace: RulesDimensionNamespace,
     dimensions: Map<String, RulesDimensionValue>,
 ): RulesDimensionResolutionException.ConflictingDimension? {
+    // Filtered before the check below, so a source whose every name was unreachable still contributes no namespace.
+    val reachable = dimensions.filterReachable(namespace)
     // A source with nothing to say contributes no namespace at all: an empty object is truthy in JSON Logic, so
     // `{"var": "store"}` would read as present for a customer whose store never answered.
-    if (dimensions.isEmpty()) return null
+    if (reachable.isEmpty()) return null
     val target = getOrPut(namespace.key) { mutableMapOf() }
-    for ((name, value) in dimensions) {
+    for ((name, value) in reachable) {
         if (target.containsKey(name)) {
             return RulesDimensionResolutionException.ConflictingDimension("${namespace.key}.$name")
         }
@@ -105,6 +108,31 @@ private fun MutableMap<String, MutableMap<String, Value>>.addDimensions(
     }
     return null
 }
+
+/**
+ * Drops the names no predicate could ever read. The engine's `var` walks a strict dot-path, so a name containing a
+ * `.` would be read as a path through a nested object that does not exist, and an empty one is not a name a
+ * predicate can be written against.
+ *
+ * Dropped rather than failing the snapshot, unlike this resolver's other two rejections: a namespace like
+ * [RulesDimensionNamespace.SubscriberAttributes] is named by the app, so a single attribute the SDK cannot expose
+ * must not stop every checkpoint from resolving. Same treatment `CustomVariableKeyValidator` gives the other
+ * developer-named namespace.
+ */
+private fun Map<String, RulesDimensionValue>.filterReachable(
+    namespace: RulesDimensionNamespace,
+): Map<String, RulesDimensionValue> = filterKeys { name ->
+    (name.isNotEmpty() && !name.contains(DIMENSION_PATH_SEPARATOR)).also { reachable ->
+        if (!reachable) {
+            warnLog {
+                "Ignoring dimension '${namespace.key}.$name': a dimension name can't be empty or contain " +
+                    "'$DIMENSION_PATH_SEPARATOR'."
+            }
+        }
+    }
+}
+
+private const val DIMENSION_PATH_SEPARATOR = '.'
 
 private val RulesDimensionValue.asRulesEngineValue: Value
     get() = when (this) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -116,4 +116,7 @@ private val RulesDimensionValue.asRulesEngineValue: Value
         is RulesDimensionValue.ObjectListValue -> Value.ArrayValue(
             value.map { record -> Value.ObjectValue(record.mapValues { (_, item) -> item.asRulesEngineValue }) },
         )
+        is RulesDimensionValue.ObjectValue -> Value.ObjectValue(
+            value.mapValues { (_, item) -> item.asRulesEngineValue },
+        )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValue.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValue.kt
@@ -8,8 +8,8 @@ import java.util.Date
  *
  * Keeps the sources of dimensions independent from the engine's own value representation, so a source says what a
  * dimension *is* and this package decides how JSON Logic sees it. A dimension has to be something an operator can
- * compare or search, so an object is expressible only as an element of a collection — which is what the iteration
- * operators search — and never on its own.
+ * compare, read through, or search: a scalar is compared, an object is read through by name, and only a collection
+ * is searched.
  *
  * Integers and doubles are separate so a source can say which it means — an API level is a whole number, a ratio is
  * not — even though the engine collapses both into the single number JSON Logic models, comparing and rendering
@@ -43,4 +43,17 @@ public sealed class RulesDimensionValue {
      * instant it is compared against.
      */
     public data class ObjectListValue(val value: List<Map<String, RulesDimensionValue>>) : RulesDimensionValue()
+
+    /**
+     * A named group of values, for a dimension that is one thing described several ways — a subscriber attribute
+     * and when it was set.
+     *
+     * Reaches the engine as a nested object, which `var` walks by dot-path: `subscriberAttributes.goal.value`
+     * resolves *through* `goal`. Unlike a record inside [ObjectListValue], a predicate reading one of these still
+     * sees the whole scope around it, because no iteration operator is involved.
+     *
+     * An empty group is truthy in JSON Logic, so a source with nothing to say about a name leaves the name out
+     * rather than supplying one of these with no values in it.
+     */
+    public data class ObjectValue(val value: Map<String, RulesDimensionValue>) : RulesDimensionValue()
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/StoreDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/StoreDimensionProvider.kt
@@ -22,8 +22,6 @@ internal class StoreDimensionProvider(
     private val storefrontCountryCode: suspend () -> String?,
 ) : RulesDimensionProvider {
 
-    override val identifier: String = "store"
-
     override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.Store
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
@@ -11,17 +11,15 @@ internal class SubscriberAttributesDimensionProvider(
     private val storedAttributes: () -> Map<String, SubscriberAttribute>,
 ) : RulesDimensionProvider {
 
-    override val identifier: String = "subscriberAttributes"
-
     override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.SubscriberAttributes
 
     /**
      * Read per evaluation rather than snapshotted: an app can set an attribute at any time, and an audience keyed
      * on one has to agree with what the app has said by the time the checkpoint is resolved.
      *
-     * Attributes that cannot be read contribute no dimensions instead of failing the snapshot, since the read
-     * reaches out through the configured instance, which an app can tear down mid-evaluation. That should not take
-     * an otherwise resolvable checkpoint down with it.
+     * Attributes that cannot be read contribute no dimensions instead of failing the snapshot: they are parsed out
+     * of whatever is on disk, so a payload an older version wrote differently surfaces here, and that should not
+     * take an otherwise resolvable checkpoint down with it.
      */
     override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
         val attributes = try {
@@ -33,20 +31,13 @@ internal class SubscriberAttributesDimensionProvider(
         return attributes.values.mapNotNull { attribute -> attribute.dimension(date) }.toMap()
     }
 
-    @Suppress("ReturnCount")
     private fun SubscriberAttribute.dimension(date: Date): Pair<String, RulesDimensionValue>? {
-        val name = key.backendKey
-        if (name.isEmpty() || name.contains(DIMENSION_PATH_SEPARATOR)) {
-            warnLog {
-                "Ignoring subscriber attribute '$name': a dimension name can't be empty or contain " +
-                    "'$DIMENSION_PATH_SEPARATOR'."
-            }
-            return null
-        }
         // A deleted attribute is kept as a tombstone with no value until it has been posted, and an empty value is
         // the SDK's other spelling of a deletion, so both mean the customer no longer has the attribute.
         val value = value?.takeIf { it.isNotEmpty() } ?: return null
-        return name to RulesDimensionValue.ObjectValue(
+        // A name the engine could not resolve is dropped by RulesDimensionResolver, which applies the same rule to
+        // every source.
+        return key.backendKey to RulesDimensionValue.ObjectValue(
             mapOf(
                 KEY_VALUE to RulesDimensionValue.StringValue(value),
                 KEY_UPDATED_AT to RulesDimensionValue.DateValue(setTime),
@@ -59,11 +50,5 @@ internal class SubscriberAttributesDimensionProvider(
         const val KEY_EVALUATED_AT = "evaluatedAt"
         const val KEY_UPDATED_AT = "updatedAt"
         const val KEY_VALUE = "value"
-
-        /**
-         * `var` walks a strict dot-path, so a name containing this would be read as a path through a nested object
-         * that does not exist. Such a name is left out rather than exposed as something no predicate can reach.
-         */
-        private const val DIMENSION_PATH_SEPARATOR = '.'
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
@@ -7,20 +7,6 @@ import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
 import java.util.Date
 
-/**
- * The subscriber attributes this device has stored for the current customer, named the way the app set them:
- * `subscriberAttributes.$email`, `subscriberAttributes.goal`.
- *
- * Each one is a record rather than a bare value, so a predicate can read what it is and when it was set
- * independently. Every value is a string, because that is the only thing a subscriber attribute can be — the SDK
- * does not guess a type the app never declared, and the loose operators coerce anyway, so
- * `{"==": [{"var": "subscriberAttributes.seats.value"}, 3]}` matches an attribute set to `"3"`.
- *
- * Only what this device knows: an attribute set on another device reaches the backend, not this cache, so a
- * predicate about it is an ordinary non-match here. Whether an attribute has been posted yet is deliberately not
- * exposed — it describes how far along the attribute is on its way to the backend rather than anything about the
- * customer.
- */
 internal class SubscriberAttributesDimensionProvider(
     private val storedAttributes: () -> Map<String, SubscriberAttribute>,
 ) : RulesDimensionProvider {
@@ -63,8 +49,6 @@ internal class SubscriberAttributesDimensionProvider(
         return name to RulesDimensionValue.ObjectValue(
             mapOf(
                 KEY_VALUE to RulesDimensionValue.StringValue(value),
-                // When *this device* set the value. Not refreshed by setting the same value again, since the SDK
-                // has nothing new to post in that case.
                 KEY_UPDATED_AT to RulesDimensionValue.DateValue(setTime),
                 KEY_EVALUATED_AT to RulesDimensionValue.DateValue(date),
             ),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
@@ -1,0 +1,85 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.warnLog
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
+import java.util.Date
+
+/**
+ * The subscriber attributes this device has stored for the current customer, named the way the app set them:
+ * `subscriberAttributes.$email`, `subscriberAttributes.goal`.
+ *
+ * Each one is a record rather than a bare value, so a predicate can read what it is and when it was set
+ * independently. Every value is a string, because that is the only thing a subscriber attribute can be — the SDK
+ * does not guess a type the app never declared, and the loose operators coerce anyway, so
+ * `{"==": [{"var": "subscriberAttributes.seats.value"}, 3]}` matches an attribute set to `"3"`.
+ *
+ * Only what this device knows: an attribute set on another device reaches the backend, not this cache, so a
+ * predicate about it is an ordinary non-match here. Whether an attribute has been posted yet is deliberately not
+ * exposed — it describes how far along the attribute is on its way to the backend rather than anything about the
+ * customer.
+ */
+internal class SubscriberAttributesDimensionProvider(
+    private val storedAttributes: () -> Map<String, SubscriberAttribute>,
+) : RulesDimensionProvider {
+
+    override val identifier: String = "subscriberAttributes"
+
+    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.SubscriberAttributes
+
+    /**
+     * Read per evaluation rather than snapshotted: an app can set an attribute at any time, and an audience keyed
+     * on one has to agree with what the app has said by the time the checkpoint is resolved.
+     *
+     * Attributes that cannot be read contribute no dimensions instead of failing the snapshot, since the read
+     * reaches out through the configured instance, which an app can tear down mid-evaluation. That should not take
+     * an otherwise resolvable checkpoint down with it.
+     */
+    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+        val attributes = try {
+            storedAttributes()
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            warnLog { "The subscriber attributes are unavailable, so they can't be evaluated: $e" }
+            return emptyMap()
+        }
+        return attributes.values.mapNotNull { attribute -> attribute.dimension(date) }.toMap()
+    }
+
+    @Suppress("ReturnCount")
+    private fun SubscriberAttribute.dimension(date: Date): Pair<String, RulesDimensionValue>? {
+        val name = key.backendKey
+        if (name.isEmpty() || name.contains(DIMENSION_PATH_SEPARATOR)) {
+            warnLog {
+                "Ignoring subscriber attribute '$name': a dimension name can't be empty or contain " +
+                    "'$DIMENSION_PATH_SEPARATOR'."
+            }
+            return null
+        }
+        // A deleted attribute is kept as a tombstone with no value until it has been posted, and an empty value is
+        // the SDK's other spelling of a deletion, so both mean the customer no longer has the attribute.
+        val value = value?.takeIf { it.isNotEmpty() } ?: return null
+        return name to RulesDimensionValue.ObjectValue(
+            mapOf(
+                KEY_VALUE to RulesDimensionValue.StringValue(value),
+                // When *this device* set the value. Not refreshed by setting the same value again, since the SDK
+                // has nothing new to post in that case.
+                KEY_UPDATED_AT to RulesDimensionValue.DateValue(setTime),
+                KEY_EVALUATED_AT to RulesDimensionValue.DateValue(date),
+            ),
+        )
+    }
+
+    internal companion object {
+        const val KEY_EVALUATED_AT = "evaluatedAt"
+        const val KEY_UPDATED_AT = "updatedAt"
+        const val KEY_VALUE = "value"
+
+        /**
+         * `var` walks a strict dot-path, so a name containing this would be read as a path through a nested object
+         * that does not exist. Such a name is left out rather than exposed as something no predicate can reach.
+         */
+        private const val DIMENSION_PATH_SEPARATOR = '.'
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -456,7 +456,6 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     private object FailingDimensionProvider : RulesDimensionProvider {
-        override val identifier = "failing"
         override val namespace = RulesDimensionNamespace.Device
         override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
             throw IllegalStateException("no dimensions")

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -18,7 +18,6 @@ class LocalRulesEvaluatorTest {
 
     private var snapshotsTaken = 0
     private val deviceProvider = object : RulesDimensionProvider {
-        override val identifier = "device"
         override val namespace = RulesDimensionNamespace.Device
         override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
             snapshotsTaken++
@@ -93,7 +92,6 @@ class LocalRulesEvaluatorTest {
     @Test
     fun `a failed dimension snapshot fails the evaluation`() = runTest {
         val failing = object : RulesDimensionProvider {
-            override val identifier = "failing"
             override val namespace = RulesDimensionNamespace.Device
             override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
                 throw IllegalStateException("nope")
@@ -104,7 +102,7 @@ class LocalRulesEvaluatorTest {
 
         val error = result.exceptionOrNull() as LocalRulesEvaluationException.DimensionResolution
         assertThat(error.reason)
-            .isEqualTo(RulesDimensionResolutionException.ProviderFailed("failing", "nope"))
+            .isEqualTo(RulesDimensionResolutionException.ProviderFailed(RulesDimensionNamespace.Device, "nope"))
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -2,6 +2,7 @@
 
 package com.revenuecat.purchases.common.localrules
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.rules.RulesEngine
@@ -11,8 +12,13 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 import java.util.Date
 
+// Robolectric because the resolver warns about a dimension it drops, and warnLog reaches android.util.Log.
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
 class RulesDimensionResolverTest {
 
     private val evaluationDate = Date(1_700_000_000_000)
@@ -76,11 +82,10 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `a provider that throws fails the snapshot with its identifier`() = runTest {
+    fun `a provider that throws fails the snapshot with its namespace`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
+            provider(RulesDimensionNamespace.Store, "country" to string("USA")),
             object : RulesDimensionProvider {
-                override val identifier = "failing"
                 override val namespace = RulesDimensionNamespace.Device
                 override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
                     throw IllegalStateException("nope")
@@ -89,14 +94,14 @@ class RulesDimensionResolverTest {
 
         val error = resolver.snapshot().exceptionOrNull()
 
-        assertThat(error).isEqualTo(RulesDimensionResolutionException.ProviderFailed("failing", "nope"))
+        assertThat(error)
+            .isEqualTo(RulesDimensionResolutionException.ProviderFailed(RulesDimensionNamespace.Device, "nope"))
     }
 
     @Test
     fun `cancellation propagates instead of failing the snapshot`() = runTest {
         val resolver = resolver(
             object : RulesDimensionProvider {
-                override val identifier = "cancelling"
                 override val namespace = RulesDimensionNamespace.Device
                 override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
                     throw CancellationException("cancelled")
@@ -116,9 +121,8 @@ class RulesDimensionResolverTest {
     @Test
     fun `every provider sees the same evaluation date`() = runTest {
         val dates = mutableListOf<Date>()
-        val recordingProvider = { name: String ->
+        val recordingProvider = {
             object : RulesDimensionProvider {
-                override val identifier = name
                 override val namespace = RulesDimensionNamespace.Device
                 override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
                     dates += date
@@ -126,7 +130,7 @@ class RulesDimensionResolverTest {
                 }
             }
         }
-        val resolver = resolver(recordingProvider("first"), recordingProvider("second"))
+        val resolver = resolver(recordingProvider(), recordingProvider())
 
         val snapshot = resolver.snapshot().getOrThrow()
 
@@ -313,6 +317,41 @@ class RulesDimensionResolverTest {
     }
 
     @Test
+    fun `a name no predicate could read is dropped rather than exposed`() = runTest {
+        val resolver = resolver(
+            provider(
+                RulesDimensionNamespace.SubscriberAttributes,
+                // A '.' would be walked as a path through a "user" object that does not exist, and "" is not a
+                // name a predicate can be written against.
+                "user.tier" to string("gold"),
+                "" to string("anything"),
+                "tier" to string("gold"),
+            ),
+        )
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values["subscriberAttributes"])
+            .isEqualTo(Value.ObjectValue(mapOf("tier" to Value.StringValue("gold"))))
+    }
+
+    @Test
+    fun `a provider whose every name is unreachable leaves its namespace absent`() = runTest {
+        val resolver = resolver(
+            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
+            provider(RulesDimensionNamespace.SubscriberAttributes, "user.tier" to string("gold")),
+        )
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        // Filtering the names inside the namespace would leave an empty object behind, which is truthy.
+        assertThat(values).containsOnlyKeys("device")
+        assertThat(
+            RulesEngine.evaluate("""{"!!": [{"var": "subscriberAttributes"}]}""", values).getOrThrow(),
+        ).isFalse()
+    }
+
+    @Test
     fun `no providers yields an empty scope`() = runTest {
         assertThat(resolver().snapshot().getOrThrow().values).isEmpty()
     }
@@ -330,7 +369,6 @@ class RulesDimensionResolverTest {
         dimensionNamespace: RulesDimensionNamespace,
         vararg values: Pair<String, RulesDimensionValue>,
     ) = object : RulesDimensionProvider {
-        override val identifier = dimensionNamespace.key
         override val namespace = dimensionNamespace
         override suspend fun dimensions(date: Date) = values.toMap()
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -147,6 +147,9 @@ class RulesDimensionResolverTest {
                 "records" to RulesDimensionValue.ObjectListValue(
                     listOf(mapOf("id" to RulesDimensionValue.StringValue("one"))),
                 ),
+                "record" to RulesDimensionValue.ObjectValue(
+                    mapOf("id" to RulesDimensionValue.StringValue("one")),
+                ),
             ),
         )
 
@@ -163,6 +166,7 @@ class RulesDimensionResolverTest {
                     "records" to Value.ArrayValue(
                         listOf(Value.ObjectValue(mapOf("id" to Value.StringValue("one")))),
                     ),
+                    "record" to Value.ObjectValue(mapOf("id" to Value.StringValue("one"))),
                 ),
             ),
         )
@@ -237,6 +241,31 @@ class RulesDimensionResolverTest {
             RulesEngine.evaluate("""{"none": [{"var": "device.purchases"}, {"var": "isActive"}]}""", values)
                 .getOrThrow(),
         ).isTrue()
+    }
+
+    @Test
+    fun `an object dimension is read through by name rather than searched`() = runTest {
+        val resolver = resolver(
+            provider(
+                RulesDimensionNamespace.Device,
+                "goal" to RulesDimensionValue.ObjectValue(
+                    mapOf(
+                        "value" to RulesDimensionValue.StringValue("lose_weight"),
+                        "updatedAt" to RulesDimensionValue.DateValue(Date(1_700_000_000_000)),
+                    ),
+                ),
+            ),
+        )
+        val values = resolver.snapshot().getOrThrow().values
+
+        val byName = """{"==": [{"var": "device.goal.value"}, "lose_weight"]}"""
+        assertThat(RulesEngine.evaluate(byName, values).getOrThrow()).isTrue()
+
+        // Unlike a record inside an object list, a predicate reading one of these still sees the scope around it,
+        // because no iteration operator is involved.
+        val alongsideTheRestOfTheScope = """{"and": [{"==": [{"var": "device.goal.value"}, "lose_weight"]},
+            {">": [{"var": "device.goal.updatedAt"}, 1699999999999]}]}"""
+        assertThat(RulesEngine.evaluate(alongsideTheRestOfTheScope, values).getOrThrow()).isTrue()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
@@ -108,7 +108,6 @@ class StoreDimensionProviderTest {
         dimensionNamespace: RulesDimensionNamespace,
         vararg values: Pair<String, String>,
     ) = object : RulesDimensionProvider {
-        override val identifier = dimensionNamespace.key
         override val namespace = dimensionNamespace
         override suspend fun dimensions(date: Date) =
             values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
@@ -1,0 +1,169 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
+import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_EVALUATED_AT
+import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_UPDATED_AT
+import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_VALUE
+import com.revenuecat.purchases.rules.RulesEngine
+import com.revenuecat.purchases.rules.Value
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
+import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+
+/**
+ * End-to-end from `setAttributes` to a predicate: drives the real [SubscriberAttributesManager] →
+ * [SubscriberAttributesCache] → [DeviceCache] → real `SharedPreferences` → [RulesDimensionResolver] →
+ * [RulesEngine], wired the way `PurchasesFactory` wires them. Only the poster and the device-identifier fetcher
+ * are faked, and `setAttributes` never reaches either.
+ *
+ * The unit tests around [SubscriberAttributesDimensionProvider] hand it attributes directly, so nothing there
+ * covers the parts that can silently go wrong between an app calling `setAttributes` and a rule reading the
+ * result: the cache key, the round-trip through JSON on disk, and which app user ID the attributes are keyed on.
+ *
+ * It does not prove `PurchasesFactory` passes the identity manager rather than something else — that would mean
+ * configuring an SDK instance. What it proves is that reading the app user ID out of the same [DeviceCache] the
+ * attributes were written against is enough to find them.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class SubscriberAttributesDimensionIntegrationTest {
+
+    private val evaluationDate = Date(1_718_452_800_000)
+
+    private lateinit var cache: DeviceCache
+    private lateinit var attributesCache: SubscriberAttributesCache
+    private lateinit var attributes: SubscriberAttributesManager
+    private lateinit var resolver: RulesDimensionResolver
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val preferences = context.getSharedPreferences("subscriber_attributes_dimension_test", Context.MODE_PRIVATE)
+        preferences.edit().clear().commit()
+
+        cache = DeviceCache(preferences, apiKey = "api_key")
+        attributesCache = SubscriberAttributesCache(cache)
+        attributes = SubscriberAttributesManager(
+            attributesCache,
+            backend = mockk(),
+            deviceIdentifiersFetcher = mockk(),
+            automaticDeviceIdentifierCollectionEnabled = false,
+        )
+        resolver = RulesDimensionResolver(
+            providers = listOf(
+                // The same expression PurchasesFactory builds, with the app user ID read from the cache the
+                // identity manager reads it from.
+                SubscriberAttributesDimensionProvider {
+                    attributesCache.getAllStoredSubscriberAttributes(cache.getCachedAppUserID() ?: "")
+                },
+            ),
+            dateProvider = object : DateProvider {
+                override val now: Date get() = evaluationDate
+            },
+        )
+    }
+
+    @Test
+    fun `an attribute the app set is readable by a predicate`() = runTest {
+        val before = Date()
+        cache.cacheAppUserID("user_a")
+        attributes.setAttributes(mapOf("goal" to "lose_weight", "seats" to "3"), "user_a")
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        val goal = values.recordFor("goal")
+        assertThat(goal[KEY_VALUE]).isEqualTo(Value.StringValue("lose_weight"))
+        assertThat(goal[KEY_EVALUATED_AT]).isEqualTo(Value.IntValue(evaluationDate.time))
+        // Set by this device just now, so it survived the round-trip through JSON with the value.
+        assertThat((goal[KEY_UPDATED_AT] as Value.IntValue).value).isBetween(before.time, Date().time)
+
+        assertThat(
+            RulesEngine.evaluate(
+                """{"and": [{"==": [{"var": "subscriberAttributes.goal.value"}, "lose_weight"]},
+                    {"==": [{"var": "subscriberAttributes.seats.value"}, 3]}]}""",
+                values,
+            ).getOrThrow(),
+        ).isTrue()
+    }
+
+    @Test
+    fun `a reserved attribute keeps its name all the way to the predicate`() = runTest {
+        cache.cacheAppUserID("user_a")
+        attributes.setAttribute(SubscriberAttributeKey.Email, "jane@example.com", "user_a")
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(
+            RulesEngine.evaluate(
+                """{"==": [{"var": "subscriberAttributes.${'$'}email.value"}, "jane@example.com"]}""",
+                values,
+            ).getOrThrow(),
+        ).isTrue()
+    }
+
+    @Test
+    fun `only the current customer's attributes are readable`() = runTest {
+        attributes.setAttributes(mapOf("goal" to "lose_weight"), "user_a")
+        attributes.setAttributes(mapOf("goal" to "gain_muscle"), "user_b")
+
+        cache.cacheAppUserID("user_a")
+        assertThat(resolver.snapshot().getOrThrow().values.recordFor("goal")[KEY_VALUE])
+            .isEqualTo(Value.StringValue("lose_weight"))
+
+        cache.cacheAppUserID("user_b")
+        assertThat(resolver.snapshot().getOrThrow().values.recordFor("goal")[KEY_VALUE])
+            .isEqualTo(Value.StringValue("gain_muscle"))
+    }
+
+    @Test
+    fun `a customer the app has said nothing about contributes no namespace`() = runTest {
+        attributes.setAttributes(mapOf("goal" to "lose_weight"), "user_a")
+        cache.cacheAppUserID("user_b")
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values).doesNotContainKey("subscriberAttributes")
+    }
+
+    @Test
+    fun `a deleted attribute stops being readable while its tombstone is still stored`() = runTest {
+        cache.cacheAppUserID("user_a")
+        attributes.setAttributes(mapOf("goal" to "lose_weight", "tier" to "gold"), "user_a")
+
+        attributes.setAttributes(mapOf("goal" to null), "user_a")
+
+        val values = resolver.snapshot().getOrThrow().values
+        assertThat((values["subscriberAttributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
+        // The deletion is still on disk waiting to be posted; it is the scope that leaves it out, not the cache.
+        assertThat(attributesCache.getAllStoredSubscriberAttributes("user_a")).containsKey("goal")
+    }
+
+    @Test
+    fun `an attribute a predicate could not reach never makes it into the scope`() = runTest {
+        cache.cacheAppUserID("user_a")
+        attributes.setAttributes(mapOf("user.tier" to "gold", "tier" to "gold"), "user_a")
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat((values["subscriberAttributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
+    }
+
+    private fun Map<String, Value>.recordFor(name: String): Map<String, Value> =
+        ((this["subscriberAttributes"] as Value.ObjectValue).entries[name] as Value.ObjectValue).entries
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -9,7 +9,6 @@ import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionP
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_UPDATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_VALUE
 import com.revenuecat.purchases.rules.RulesEngine
-import com.revenuecat.purchases.rules.Value
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -92,21 +91,6 @@ class SubscriberAttributesDimensionProviderTest {
         val dimensions = provider(attribute("goal", ""), attribute("tier", "gold")).dimensions(evaluationDate)
 
         assertThat(dimensions).containsOnlyKeys("tier")
-    }
-
-    @Test
-    fun `an attribute a predicate could not reach never makes it into the scope`() = runTest {
-        // Dropped by RulesDimensionResolver, which applies the rule to every source, so this asserts through it
-        // rather than on what the provider returns.
-        val values = resolver(
-            provider(
-                attribute("user.tier", "gold"),
-                attribute("", "anything"),
-                attribute("tier", "gold"),
-            ),
-        ).snapshot().getOrThrow().values
-
-        assertThat((values["subscriberAttributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionP
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_UPDATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_VALUE
 import com.revenuecat.purchases.rules.RulesEngine
+import com.revenuecat.purchases.rules.Value
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -94,16 +95,18 @@ class SubscriberAttributesDimensionProviderTest {
     }
 
     @Test
-    fun `an attribute a predicate could not reach is left out`() = runTest {
-        // `var` walks a strict dot-path, so "user.tier" would be read as a path through a "user" object that does
-        // not exist. Nothing is gained by exposing a name no predicate can name.
-        val dimensions = provider(
-            attribute("user.tier", "gold"),
-            attribute("", "anything"),
-            attribute("tier", "gold"),
-        ).dimensions(evaluationDate)
+    fun `an attribute a predicate could not reach never makes it into the scope`() = runTest {
+        // Dropped by RulesDimensionResolver, which applies the rule to every source, so this asserts through it
+        // rather than on what the provider returns.
+        val values = resolver(
+            provider(
+                attribute("user.tier", "gold"),
+                attribute("", "anything"),
+                attribute("tier", "gold"),
+            ),
+        ).snapshot().getOrThrow().values
 
-        assertThat(dimensions).containsOnlyKeys("tier")
+        assertThat((values["subscriberAttributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
     }
 
     @Test
@@ -205,7 +208,6 @@ class SubscriberAttributesDimensionProviderTest {
     )
 
     private fun deviceProvider(vararg values: Pair<String, String>) = object : RulesDimensionProvider {
-        override val identifier = RulesDimensionNamespace.Device.key
         override val namespace = RulesDimensionNamespace.Device
         override suspend fun dimensions(date: Date) =
             values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -1,0 +1,216 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_EVALUATED_AT
+import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_UPDATED_AT
+import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_VALUE
+import com.revenuecat.purchases.rules.RulesEngine
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class SubscriberAttributesDimensionProviderTest {
+
+    private val evaluationDate = Date(1_718_452_800_000)
+
+    // Six weeks before the evaluation.
+    private val setDate = Date(1_714_780_800_000)
+    private val recentSetDate = Date(evaluationDate.time - 1 * 24 * 60 * 60 * 1000L)
+
+    @Test
+    fun `every stored attribute is exposed under the name the app set it with`() = runTest {
+        val dimensions = provider(
+            attribute("\$email", "jane@example.com"),
+            attribute("goal", "lose_weight"),
+        ).dimensions(evaluationDate)
+
+        // Reserved names keep their '$': it is what the app set, what the dashboard shows, and what keeps a custom
+        // "email" from colliding with the reserved one. Only '.' means anything to the engine.
+        assertThat(dimensions).containsOnlyKeys("\$email", "goal")
+    }
+
+    @Test
+    fun `an attribute is a record of its value, when it was set, and when it was read`() = runTest {
+        val dimensions = provider(attribute("goal", "lose_weight")).dimensions(evaluationDate)
+
+        assertThat(dimensions).isEqualTo(
+            mapOf(
+                "goal" to RulesDimensionValue.ObjectValue(
+                    mapOf(
+                        KEY_VALUE to RulesDimensionValue.StringValue("lose_weight"),
+                        KEY_UPDATED_AT to RulesDimensionValue.DateValue(setDate),
+                        KEY_EVALUATED_AT to RulesDimensionValue.DateValue(evaluationDate),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `a value stays the string the app set, whatever it looks like`() = runTest {
+        val dimensions = provider(
+            attribute("seats", "3"),
+            attribute("betaOptIn", "true"),
+            attribute("sku", "0123"),
+        ).dimensions(evaluationDate)
+
+        assertThat(dimensions.valueOf("seats")).isEqualTo(RulesDimensionValue.StringValue("3"))
+        assertThat(dimensions.valueOf("betaOptIn")).isEqualTo(RulesDimensionValue.StringValue("true"))
+        // A product code the SDK guessed at would silently stop being the string it was set as.
+        assertThat(dimensions.valueOf("sku")).isEqualTo(RulesDimensionValue.StringValue("0123"))
+    }
+
+    @Test
+    fun `a deleted attribute is left out whether or not it has been posted yet`() = runTest {
+        // A deletion is stored as a tombstone with no value, and stays in the cache for the current customer even
+        // after the backend has been told about it.
+        val dimensions = provider(
+            attribute("pending", null, isSynced = false),
+            attribute("posted", null, isSynced = true),
+            attribute("goal", "lose_weight"),
+        ).dimensions(evaluationDate)
+
+        assertThat(dimensions).containsOnlyKeys("goal")
+    }
+
+    @Test
+    fun `an attribute set to an empty value is left out`() = runTest {
+        // The SDK's other spelling of a deletion, and an empty string would compare equal to an absent value
+        // anyway.
+        val dimensions = provider(attribute("goal", ""), attribute("tier", "gold")).dimensions(evaluationDate)
+
+        assertThat(dimensions).containsOnlyKeys("tier")
+    }
+
+    @Test
+    fun `an attribute a predicate could not reach is left out`() = runTest {
+        // `var` walks a strict dot-path, so "user.tier" would be read as a path through a "user" object that does
+        // not exist. Nothing is gained by exposing a name no predicate can name.
+        val dimensions = provider(
+            attribute("user.tier", "gold"),
+            attribute("", "anything"),
+            attribute("tier", "gold"),
+        ).dimensions(evaluationDate)
+
+        assertThat(dimensions).containsOnlyKeys("tier")
+    }
+
+    @Test
+    fun `a customer with no attributes contributes no namespace at all`() = runTest {
+        val values = resolver(provider()).snapshot().getOrThrow().values
+
+        // An empty object is truthy in JSON Logic, so `{"var": "subscriberAttributes"}` would read as present for a
+        // customer the app has never said anything about.
+        assertThat(values).doesNotContainKey("subscriberAttributes")
+    }
+
+    @Test
+    fun `attributes that cannot be read leave the other dimensions usable`() = runTest {
+        // The read goes through the configured instance, which an app can tear down mid-evaluation.
+        val failures = listOf(
+            UninitializedPropertyAccessException("There is no singleton instance."),
+            IllegalStateException("Something else entirely."),
+        )
+
+        for (failure in failures) {
+            val snapshot = resolver(
+                deviceProvider("platform" to "android"),
+                SubscriberAttributesDimensionProvider { throw failure },
+            ).snapshot()
+
+            assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
+            assertThat(snapshot.getOrThrow().values).describedAs("%s", failure).containsOnlyKeys("device")
+        }
+    }
+
+    @Test
+    fun `the attributes are read on every evaluation`() = runTest {
+        var attributes = mapOf("goal" to attribute("goal", "lose_weight"))
+        val provider = SubscriberAttributesDimensionProvider { attributes }
+
+        assertThat(provider.dimensions(evaluationDate).valueOf("goal"))
+            .isEqualTo(RulesDimensionValue.StringValue("lose_weight"))
+
+        attributes = mapOf("goal" to attribute("goal", "gain_muscle"))
+
+        assertThat(provider.dimensions(evaluationDate).valueOf("goal"))
+            .isEqualTo(RulesDimensionValue.StringValue("gain_muscle"))
+    }
+
+    @Test
+    fun `the attributes are readable by a predicate`() = runTest {
+        val values = resolver(
+            provider(
+                attribute("\$email", "jane@example.com"),
+                attribute("seats", "3"),
+                attribute("goal", "lose_weight"),
+                attribute("tier", "gold", setTime = recentSetDate),
+            ),
+        ).snapshot().getOrThrow().values
+
+        val matching = listOf(
+            """{"==": [{"var": "subscriberAttributes.${'$'}email.value"}, "jane@example.com"]}""",
+            // The loose operators coerce, so a value the app set as a string is still comparable to a number.
+            """{"==": [{"var": "subscriberAttributes.seats.value"}, 3]}""",
+            """{">": [{"var": "subscriberAttributes.seats.value"}, 2]}""",
+            // Each record carries the evaluation instant, so "set in the last 7 days" needs nothing else in scope.
+            """{"<": [{"-": [{"var": "subscriberAttributes.tier.evaluatedAt"},
+                {"var": "subscriberAttributes.tier.updatedAt"}]}, 604800000]}""",
+        )
+        val notMatching = listOf(
+            """{"==": [{"var": "subscriberAttributes.goal.value"}, "gain_muscle"]}""",
+            // An attribute the app never set on this device, and one the SDK does not expose.
+            """{"!!": {"var": "subscriberAttributes.favoriteColor.value"}}""",
+            """{"!!": {"var": "subscriberAttributes.goal.isSynced"}}""",
+            // The same window, for an attribute set six weeks ago.
+            """{"<": [{"-": [{"var": "subscriberAttributes.goal.evaluatedAt"},
+                {"var": "subscriberAttributes.goal.updatedAt"}]}, 604800000]}""",
+        )
+
+        for (predicate in matching) {
+            assertThat(RulesEngine.evaluate(predicate, values).getOrThrow()).describedAs(predicate).isTrue()
+        }
+        for (predicate in notMatching) {
+            assertThat(RulesEngine.evaluate(predicate, values).getOrThrow()).describedAs(predicate).isFalse()
+        }
+    }
+
+    private fun attribute(
+        key: String,
+        value: String?,
+        isSynced: Boolean = true,
+        setTime: Date = setDate,
+    ) = SubscriberAttribute(key = key, value = value, setTime = setTime, isSynced = isSynced)
+
+    private fun provider(vararg attributes: SubscriberAttribute) = SubscriberAttributesDimensionProvider {
+        attributes.associateBy { attribute -> attribute.key.backendKey }
+    }
+
+    private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
+        providers = providers.toList(),
+        dateProvider = object : DateProvider {
+            override val now: Date = evaluationDate
+        },
+    )
+
+    private fun deviceProvider(vararg values: Pair<String, String>) = object : RulesDimensionProvider {
+        override val identifier = RulesDimensionNamespace.Device.key
+        override val namespace = RulesDimensionNamespace.Device
+        override suspend fun dimensions(date: Date) =
+            values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }
+    }
+
+    private fun Map<String, RulesDimensionValue>.valueOf(name: String): RulesDimensionValue? =
+        (this[name] as? RulesDimensionValue.ObjectValue)?.value?.get(KEY_VALUE)
+}


### PR DESCRIPTION
### Description

Adds a `subscriberAttributes` dimension provider, so everything the app has told the SDK about the customer via `setAttributes` is readable by a local rule. It would look like:

```json
{
  "subscriberAttributes": {
    "$email": {
      "evaluatedAt": 1718452800000,
      "updatedAt": 1714521600000,
      "value": "jane@example.com"
    },
    "goal": {
      "evaluatedAt": 1718452800000,
      "updatedAt": 1718366400000,
      "value": "lose_weight"
    },
    "seats": {
      "evaluatedAt": 1718452800000,
      "updatedAt": 1714780800000,
      "value": "3"
    }
  }
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how checkpoint audiences resolve using live subscriber attributes and identity timing; mis-wiring could target the wrong user, but attribute read failures are isolated and do not abort evaluation.
> 
> **Overview**
> Adds a **`subscriberAttributes`** rules dimension so checkpoint audiences can target values from `Purchases.setAttributes`. Each attribute appears as a nested object (`value`, `updatedAt`, `evaluatedAt`) readable via paths like `subscriberAttributes.goal.value`.
> 
> **Rules engine plumbing:** Introduces `RulesDimensionValue.ObjectValue` for dot-path access (distinct from list iteration). `RulesDimensionResolver` drops unreachable attribute names (empty or containing `.`) with a warning instead of failing the snapshot. Provider diagnostics now use **`namespace`** instead of a separate `identifier`.
> 
> **Wiring:** `LocalRulesEvaluator` is built **after** `IdentityManager` so attributes are loaded for `identityManager.currentAppUserID`, not a stale singleton. Read failures for subscriber attributes degrade to an empty namespace (other dimensions still evaluate), matching store dimension behavior.
> 
> Unit and integration tests cover predicates, deletions/tombstones, per-user isolation, and the `setAttributes` → disk cache → resolver path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600517359fafc4a58d5a58d171f19f1223d361a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->