### PR TITLE
feat(Customer Center): Purchase History list screen (3/4)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -69,6 +69,7 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.CustomerCen
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.FeedbackSurveyView
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.NoActiveUserManagementView
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.PromotionalOfferScreen
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.PurchaseHistoryView
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.RelevantPurchasesListView
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.SelectedPurchaseDetailView
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.VirtualCurrencyBalancesScreen
@@ -198,6 +199,7 @@ internal fun InternalCustomerCenter(
                 is CustomerCenterAction.DismissSupportTicketSuccessSnackbar -> {
                     viewModel.dismissSupportTicketSuccessSnackbar()
                 }
+                is CustomerCenterAction.ShowPurchaseHistory -> viewModel.showPurchaseHistory()
             }
         },
     )
@@ -513,6 +515,7 @@ private fun CustomerCenterNavHost(
                     localization = customerCenterState.customerCenterConfigData.localization,
                     purchaseInformation = destination.purchaseInformation,
                     supportedPaths = customerCenterState.detailScreenPaths,
+                    shouldShowPurchaseHistory = customerCenterState.shouldShowPurchaseHistory,
                     onAction = onAction,
                 )
             }
@@ -527,6 +530,16 @@ private fun CustomerCenterNavHost(
             is CustomerCenterDestination.CreateSupportTicket -> {
                 CreateSupportTicketView(
                     data = destination.data,
+                    localization = customerCenterState.customerCenterConfigData.localization,
+                )
+            }
+
+            is CustomerCenterDestination.PurchaseHistory -> {
+                val purchaseHistory = customerCenterState.purchaseHistory
+                PurchaseHistoryView(
+                    activeSubscriptions = purchaseHistory.activeSubscriptions,
+                    inactiveSubscriptions = purchaseHistory.inactiveSubscriptions,
+                    nonSubscriptions = purchaseHistory.nonSubscriptions,
                     localization = customerCenterState.customerCenterConfigData.localization,
                 )
             }
@@ -572,6 +585,7 @@ private fun MainScreenContent(
                 },
                 onAction = onAction,
                 purchases = state.purchases,
+                shouldShowPurchaseHistory = state.shouldShowPurchaseHistory,
             )
         } ?: run {
             // Handle missing management screen
@@ -587,6 +601,7 @@ private fun MainScreenContent(
                 supportTickets = configuration.support.supportTickets,
                 offering = state.noActiveScreenOffering,
                 virtualCurrencies = state.virtualCurrencies,
+                shouldShowPurchaseHistory = state.shouldShowPurchaseHistory,
                 onAction = onAction,
             )
         } ?: run {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/actions/CustomerCenterAction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/actions/CustomerCenterAction.kt
@@ -23,4 +23,5 @@ internal sealed class CustomerCenterAction {
     object ShowVirtualCurrencyBalances : CustomerCenterAction()
     object ShowSupportTicketCreation : CustomerCenterAction()
     object DismissSupportTicketSuccessSnackbar : CustomerCenterAction()
+    object ShowPurchaseHistory : CustomerCenterAction()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/navigation/CustomerCenterDestination.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/navigation/CustomerCenterDestination.kt
@@ -45,4 +45,8 @@ internal sealed class CustomerCenterDestination {
         val data: CreateSupportTicketData,
         override val title: String,
     ) : CustomerCenterDestination()
+
+    data class PurchaseHistory(
+        override val title: String,
+    ) : CustomerCenterDestination()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -146,6 +146,8 @@ internal interface CustomerCenterViewModel {
 
     fun showCreateSupportTicket()
 
+    fun showPurchaseHistory()
+
     fun dismissSupportTicketSuccessSnackbar()
 
     /**
@@ -357,6 +359,24 @@ internal class CustomerCenterViewModelImpl(
                 )
                 currentState.copy(
                     navigationState = currentState.navigationState.push(virtualCurrencyBalancesDestination),
+                    navigationButtonType = CustomerCenterState.NavigationButtonType.BACK,
+                )
+            } else {
+                currentState
+            }
+        }
+    }
+
+    override fun showPurchaseHistory() {
+        _state.update { currentState ->
+            if (currentState is CustomerCenterState.Success) {
+                val title = currentState.customerCenterConfigData.localization.commonLocalizedString(
+                    CustomerCenterConfigData.Localization.CommonLocalizedString.SCREEN_PURCHASE_HISTORY_TITLE,
+                )
+                currentState.copy(
+                    navigationState = currentState.navigationState.push(
+                        CustomerCenterDestination.PurchaseHistory(title = title),
+                    ),
                     navigationButtonType = CustomerCenterState.NavigationButtonType.BACK,
                 )
             } else {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/NoActiveUserManagementView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/NoActiveUserManagementView.kt
@@ -38,7 +38,7 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.theme.CustomerCen
 import com.revenuecat.purchases.ui.revenuecatui.icons.Info
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 @Composable
 internal fun NoActiveUserManagementView(
     screen: CustomerCenterConfigData.Screen,
@@ -48,6 +48,7 @@ internal fun NoActiveUserManagementView(
     supportTickets: CustomerCenterConfigData.Support.SupportTickets,
     offering: Offering?,
     virtualCurrencies: VirtualCurrencies? = null,
+    shouldShowPurchaseHistory: Boolean = false,
     onAction: (CustomerCenterAction) -> Unit,
 ) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -90,6 +91,22 @@ internal fun NoActiveUserManagementView(
                     ),
                 )
             }
+        }
+
+        if (shouldShowPurchaseHistory) {
+            SettingsButton(
+                title = localization.commonLocalizedString(
+                    CustomerCenterConfigData.Localization.CommonLocalizedString.SCREEN_MANAGEMENT_SEE_ALL_PURCHASES,
+                ),
+                onClick = { onAction(CustomerCenterAction.ShowPurchaseHistory) },
+                config = SettingsButtonConfig(),
+                style = SettingsButtonStyle.OUTLINED,
+                modifier = Modifier.padding(
+                    top = ManagementViewHorizontalPadding,
+                    start = ManagementViewHorizontalPadding,
+                    end = ManagementViewHorizontalPadding,
+                ),
+            )
         }
 
         ManageSubscriptionsButtonsView(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseHistoryView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseHistoryView.kt
@@ -1,0 +1,191 @@
+package com.revenuecat.purchases.ui.revenuecatui.customercenter.views
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterConstants
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterUIConstants.ManagementViewHorizontalPadding
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterConfigTestData
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.ExpirationOrRenewal
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PriceDetails
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PurchaseInformation
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.theme.CustomerCenterPreviewTheme
+
+@Suppress("LongMethod")
+@Composable
+internal fun PurchaseHistoryView(
+    activeSubscriptions: List<PurchaseInformation>,
+    inactiveSubscriptions: List<PurchaseInformation>,
+    nonSubscriptions: List<PurchaseInformation>,
+    localization: CustomerCenterConfigData.Localization,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.Start,
+    ) {
+        if (activeSubscriptions.isNotEmpty()) {
+            Spacer(modifier = Modifier.size(CustomerCenterConstants.Layout.SECTION_SPACING))
+            Text(
+                text = localization.commonLocalizedString(
+                    CustomerCenterConfigData.Localization.CommonLocalizedString.SUBSCRIPTIONS_SECTION_TITLE,
+                ),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(
+                    start = ManagementViewHorizontalPadding,
+                    bottom = CustomerCenterConstants.Layout.SECTION_TITLE_BOTTOM_PADDING,
+                ),
+            )
+            PurchaseHistorySection(
+                purchases = activeSubscriptions,
+                localization = localization,
+            )
+        }
+
+        if (inactiveSubscriptions.isNotEmpty()) {
+            Spacer(modifier = Modifier.size(CustomerCenterConstants.Layout.SECTION_SPACING))
+            Text(
+                text = localization.commonLocalizedString(
+                    CustomerCenterConfigData.Localization.CommonLocalizedString.INACTIVE,
+                ),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(
+                    start = ManagementViewHorizontalPadding,
+                    bottom = CustomerCenterConstants.Layout.SECTION_TITLE_BOTTOM_PADDING,
+                ),
+            )
+            PurchaseHistorySection(
+                purchases = inactiveSubscriptions,
+                localization = localization,
+            )
+        }
+
+        if (nonSubscriptions.isNotEmpty()) {
+            Spacer(modifier = Modifier.size(CustomerCenterConstants.Layout.SECTION_SPACING))
+            Text(
+                text = localization.commonLocalizedString(
+                    CustomerCenterConfigData.Localization.CommonLocalizedString.PURCHASES_SECTION_TITLE,
+                ),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(
+                    start = ManagementViewHorizontalPadding,
+                    bottom = CustomerCenterConstants.Layout.SECTION_TITLE_BOTTOM_PADDING,
+                ),
+            )
+            PurchaseHistorySection(
+                purchases = nonSubscriptions,
+                localization = localization,
+            )
+        }
+
+        Spacer(modifier = Modifier.size(CustomerCenterConstants.Layout.SECTION_SPACING))
+    }
+}
+
+@Composable
+private fun PurchaseHistorySection(
+    purchases: List<PurchaseInformation>,
+    localization: CustomerCenterConfigData.Localization,
+) {
+    purchases.forEachIndexed { index, info ->
+        if (index > 0) {
+            Spacer(modifier = Modifier.size(CustomerCenterConstants.Layout.ITEMS_SPACING))
+        }
+
+        val position = when {
+            purchases.size == 1 -> ButtonPosition.SINGLE
+            index == 0 -> ButtonPosition.FIRST
+            index == purchases.size - 1 -> ButtonPosition.LAST
+            else -> ButtonPosition.MIDDLE
+        }
+        PurchaseInformationCardView(
+            purchaseInformation = info,
+            localization = localization,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = CustomerCenterConstants.Layout.HORIZONTAL_PADDING),
+            position = position,
+            isDetailedView = false,
+            onCardClick = null,
+        )
+    }
+}
+
+@Preview(showBackground = true, device = "spec:width=412dp,height=915dp")
+@Composable
+private fun PurchaseHistoryViewPreview() {
+    val testData = CustomerCenterConfigTestData.customerCenterData()
+    CustomerCenterPreviewTheme {
+        PurchaseHistoryView(
+            activeSubscriptions = listOf(CustomerCenterConfigTestData.purchaseInformationMonthlyRenewing),
+            inactiveSubscriptions = listOf(CustomerCenterConfigTestData.purchaseInformationYearlyExpired),
+            nonSubscriptions = listOf(
+                PurchaseInformation(
+                    title = "Lifetime Access",
+                    pricePaid = PriceDetails.Paid("$9.99"),
+                    expirationOrRenewal = null,
+                    product = null,
+                    store = Store.PLAY_STORE,
+                    isSubscription = false,
+                    managementURL = null,
+                    isExpired = false,
+                    isTrial = false,
+                    isCancelled = false,
+                    isLifetime = true,
+                    productIdentifier = "lifetime_access",
+                    purchaseHistoryEntryId = "non_subscription:lifetime_access_transaction",
+                ),
+            ),
+            localization = testData.localization,
+        )
+    }
+}
+
+@Preview(showBackground = true, device = "spec:width=412dp,height=915dp")
+@Composable
+private fun PurchaseHistoryViewOnlyExpiredPreview() {
+    val testData = CustomerCenterConfigTestData.customerCenterData()
+    CustomerCenterPreviewTheme {
+        PurchaseHistoryView(
+            activeSubscriptions = emptyList(),
+            inactiveSubscriptions = listOf(
+                CustomerCenterConfigTestData.purchaseInformationYearlyExpired,
+                PurchaseInformation(
+                    title = "Monthly Plan",
+                    pricePaid = PriceDetails.Paid("$4.99"),
+                    expirationOrRenewal = ExpirationOrRenewal.Expiration("Jan 1, 2024"),
+                    product = null,
+                    store = Store.PLAY_STORE,
+                    isSubscription = true,
+                    managementURL = null,
+                    isExpired = true,
+                    isTrial = false,
+                    isCancelled = true,
+                    isLifetime = false,
+                    productIdentifier = "monthly_plan",
+                    purchaseHistoryEntryId = "subscription:monthly_plan",
+                ),
+            ),
+            nonSubscriptions = emptyList(),
+            localization = testData.localization,
+        )
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/RelevantPurchasesListView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/RelevantPurchasesListView.kt
@@ -20,6 +20,9 @@ import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.HelpPath
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterConstants
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterUIConstants.ManagementViewHorizontalPadding
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.actions.CustomerCenterAction
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.composables.SettingsButton
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.composables.SettingsButtonConfig
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.composables.SettingsButtonStyle
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterConfigTestData
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PurchaseInformation
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.theme.CustomerCenterPreviewTheme
@@ -38,6 +41,7 @@ internal fun RelevantPurchasesListView(
     onAction: (CustomerCenterAction) -> Unit,
     modifier: Modifier = Modifier,
     purchases: List<PurchaseInformation> = emptyList(),
+    shouldShowPurchaseHistory: Boolean = false,
 ) {
     Column(
         modifier = modifier
@@ -92,6 +96,19 @@ internal fun RelevantPurchasesListView(
                         .padding(horizontal = CustomerCenterConstants.Layout.HORIZONTAL_PADDING),
                 )
             }
+        }
+
+        if (shouldShowPurchaseHistory) {
+            Spacer(modifier = Modifier.size(CustomerCenterConstants.Layout.SECTION_SPACING))
+            SettingsButton(
+                title = localization.commonLocalizedString(
+                    CustomerCenterConfigData.Localization.CommonLocalizedString.SCREEN_MANAGEMENT_SEE_ALL_PURCHASES,
+                ),
+                onClick = { onAction(CustomerCenterAction.ShowPurchaseHistory) },
+                config = SettingsButtonConfig(),
+                style = SettingsButtonStyle.OUTLINED,
+                modifier = Modifier.padding(horizontal = CustomerCenterConstants.Layout.HORIZONTAL_PADDING),
+            )
         }
 
         ManageSubscriptionsButtonsView(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/SelectedPurchaseDetailView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/SelectedPurchaseDetailView.kt
@@ -14,7 +14,11 @@ import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.HelpPath
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterConstants
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterUIConstants.ManagementViewHorizontalPadding
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.actions.CustomerCenterAction
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.composables.SettingsButton
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.composables.SettingsButtonConfig
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.composables.SettingsButtonStyle
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterConfigTestData
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PurchaseInformation
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.theme.CustomerCenterPreviewTheme
@@ -27,6 +31,7 @@ internal fun SelectedPurchaseDetailView(
     purchaseInformation: PurchaseInformation,
     supportedPaths: List<HelpPath>,
     modifier: Modifier = Modifier,
+    shouldShowPurchaseHistory: Boolean = false,
     onAction: (CustomerCenterAction) -> Unit,
 ) {
     Column(
@@ -46,6 +51,22 @@ internal fun SelectedPurchaseDetailView(
             isDetailedView = true,
             onCardClick = null,
         )
+
+        if (shouldShowPurchaseHistory) {
+            SettingsButton(
+                title = localization.commonLocalizedString(
+                    CustomerCenterConfigData.Localization.CommonLocalizedString.SCREEN_MANAGEMENT_SEE_ALL_PURCHASES,
+                ),
+                onClick = { onAction(CustomerCenterAction.ShowPurchaseHistory) },
+                config = SettingsButtonConfig(),
+                style = SettingsButtonStyle.OUTLINED,
+                modifier = Modifier.padding(
+                    top = ManagementViewHorizontalPadding,
+                    start = ManagementViewHorizontalPadding,
+                    end = ManagementViewHorizontalPadding,
+                ),
+            )
+        }
 
         ManageSubscriptionsButtonsView(
             associatedPurchaseInformation = purchaseInformation,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterViewModelTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterViewModelTests.kt
@@ -3374,4 +3374,26 @@ class CustomerCenterViewModelTests {
 
     // endregion
 
+
+    // region Purchase History navigation
+
+    @Test
+    fun `showPurchaseHistory navigates to PurchaseHistory destination`(): Unit = runBlocking {
+        setupPurchasesMock()
+        val model = setupViewModel()
+        model.state.filterIsInstance<CustomerCenterState.Success>().first()
+
+        model.showPurchaseHistory()
+
+        val updatedState = model.state.value as CustomerCenterState.Success
+        assertThat(updatedState.currentDestination)
+            .isInstanceOf(CustomerCenterDestination.PurchaseHistory::class.java)
+        assertThat(updatedState.navigationButtonType)
+            .isEqualTo(CustomerCenterState.NavigationButtonType.BACK)
+        val destination = updatedState.currentDestination as CustomerCenterDestination.PurchaseHistory
+        assertThat(destination.title).isEqualTo("Purchase History")
+    }
+
+    // endregion
+
 }


### PR DESCRIPTION
> **Stacked PR 3 of 4** (merge in order). Supersedes #3398.
>
> 1. #3997 config + model fields (175 lines)
> 2. #3998 loading + state + gate (99 lines)
> 3. #3999 history list screen (284 lines)
> 4. #4000 detail screen (295 lines)

## Summary

Stack 3 of 4 for Customer Center Purchase History. First user visible piece.

- `PurchaseHistoryView` groups purchases into Subscriptions / Inactive / Purchases using the same section titles as iOS, reusing the existing `PurchaseInformationCardView` per row.
- The "See all purchases" entry point appears in all three management surfaces, gated on `shouldShowPurchaseHistory`.

Rows are not tappable yet. The detail destination arrives in stack 4, which is also where `PurchaseHistoryView` gains its `onAction` parameter, so this PR ships no unused plumbing.

**Production churn: 284 / 300.**

<details>
<summary>AI session context</summary>

## Metadata

- Branch: see PR head
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 5, 1M context)
- Session source: current conversation
- Generated: 2026-08-18
- Context document version: 1

## Goal

Land the Customer Center Purchase History feature (iOS parity) as four small stacked PRs instead of one 863-line PR. Supersedes #3398.

## Initial Prompt

"Check https://github.com/RevenueCat/purchases-android/pull/3398. Make it up-to-date with main, and let's see if we're missing anything" (the actionable task: merge main into #3398, verify it, and report parity/CI gaps).

## Important Follow-up Prompts

- "how do you feel about splitting this pr into smaller pieces? Stacked" / "Maybe 2 prs or 3 if it's simpler", which redirected the work from "update #3398" to "replace it with a stack".

## Agent Contribution

- Merged `origin/main` into #3398 (377 commits behind, merge base 2026-05-05). Clean merge, zero conflicts.
- Verified the merge rather than trusting green CI: inspected all 5 deletions in the diff vs main and confirmed each was the PR's own refactor, and confirmed main's only Customer Center change in that window (`presentedOfferingContext = offering.presentedOfferingContext`) survived.
- Diagnosed the new `revenuecat/danger` failure as main's added 300-line production-churn rule, not a code regression. Measured #3398 at 863 lines.
- Compared against `purchases-ios` `origin/main` and found the localization keys, section titles, grouping/sorting, and the `shouldShowSeeAllPurchases` gate all match, plus one divergence (debug rows, see below).
- Carved the verified merged state into four stacked branches, compiling and testing each layer independently.

## Human Decisions

- Decision: 4 stacked PRs, no Danger bypass label on any of them.
- Decision: close #3398 and link the stack rather than rebase it into the stack.
- Decision: leave the iOS debug-rows divergence as-is and document it rather than change behavior.

## Key Implementation Decisions

- Decision: merge `main` into #3398 rather than rebase.
  - Rationale: the branch already carried four `Merge branch 'main'` commits; rebasing 15 commits across 377 would replay conflicts per commit.
  - Rejected: `git rebase origin/main` (the repo's usual cold-start step).
- Decision: split by navigation depth, not by screen file.
  - Rationale: neither the `CustomerCenterAction` nor `CustomerCenterDestination` `when` has an `else`, and Kotlin 2.0 makes a non-exhaustive `when` over a sealed subject a compile error. A destination cannot land before the view its nav branch renders.
  - Rejected: both destinations in one PR (would force both screens into it, about 530 lines).
- Decision: `PurchaseHistoryView` has no `onAction` parameter until PR 4.
  - Rationale: avoids shipping an unused parameter in PR 3.

## Validation

- Commands run (per layer):
  - `./gradlew :purchases:compileDefaultsDebugKotlin :ui:revenuecatui:compileDefaultsDebugKotlin`: BUILD SUCCESSFUL on every branch, each compiled standalone on its own base.
  - `./gradlew :ui:revenuecatui:testDefaultsDebugUnitTest`: BUILD SUCCESSFUL. Full suite run on all four branches, not just the tip.
  - `./gradlew :purchases:testDefaultsDebugUnitTest detektAll`: BUILD SUCCESSFUL.
  - `./scripts/api-check.sh`: exit 0. No `api-*.txt` change needed, `CustomerCenterConfigData` is `@InternalRevenueCatAPI` so Metalava excludes it.
- Manual verification:
  - Stack tip reconstructs the verified merged production code byte-for-byte in 12 of 13 files. The 13th, `PurchaseHistoryDetailView.kt`, differs only by the intentional preview simplification described in PR 4.
  - Each of the 8 purchase-history view model tests from #3398 appears exactly once across the stack.
  - No app run, no device or emulator verification.
- CI:
  - #3999: 32 pass, 1 skipped, `Snapshot Test | Emerge` red. Benign: 2 added, 0 removed, 0 modified, 0 errored, 339 unchanged. Emerge gates newly added snapshots on approval, and the 2 additions are this PR's `PurchaseHistoryView` previews. Needs a human approval click, not a code change.

## Validation Gaps

- No Paparazzi snapshot coverage in-repo. The two new previews ARE captured by Emerge snapshot testing (2 added, 0 errored), so the rendered output is not unverified; it is pending snapshot approval.
- `PaywallComponentsTemplatePreviewRecorder` fails in a fresh worktree until `upstream/paywall-preview-resources` is initialized. Confirmed environmental: it passes after `git submodule update --init`.
- No verification against a real backend payload for `display_purchase_history_link`.

## Risks / Reviewer Notes

- Risk: iOS gates `store`, `productID`, `sandbox`, `transactionID` and `originalPurchaseDate` behind a `#if DEBUG` section. This port renders four of those five inline and unconditionally, and has no `store` row or `Debug` header.
  - Evidence: iOS `PurchaseDetailItem.isDebugOnly` and `purchaseDetailDebugItems`. Cursor flagged the rows as missing on #3398 and the thread was resolved by adding them, which moved the port away from the source of truth.
  - Mitigation: none applied. `#if DEBUG` has no 1:1 Android equivalent, since a prebuilt AAR's `BuildConfig.DEBUG` is the library's build type rather than the consuming app's. Matching the intent would need something like `ApplicationInfo.FLAG_DEBUGGABLE`, which is a product decision.
- Risk: when `display_purchase_history_link` is on, `loadAllPurchases` runs on every Customer Center load and resolves products for active Play Store subscriptions.
  - Evidence: gated on the flag, so projects without the feature pay nothing. Product lookups run concurrently, not serially.
  - Mitigation: reviewer should sanity-check behavior for customers with large purchase histories.

## Non-goals / Out of Scope

- Changing the debug-row behavior.
- Adding snapshot coverage for the new screens.
- Any change to #3398 itself beyond the main merge.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Customer Center UI and navigation only; purchase data comes from existing state. History rows are read-only with no new purchase or auth logic in this PR.
> 
> **Overview**
> Adds the first user-visible **Purchase History** flow in Customer Center: a new navigable screen plus entry points from existing management surfaces.
> 
> When `shouldShowPurchaseHistory` is true, management, no-active, and selected-purchase-detail screens show an outlined **See all purchases** button that dispatches `CustomerCenterAction.ShowPurchaseHistory`. The view model pushes `CustomerCenterDestination.PurchaseHistory` (localized title, back navigation).
> 
> **`PurchaseHistoryView`** renders grouped lists—active subscriptions, inactive, and one-time purchases—using existing `PurchaseInformationCardView` rows with **no tap handling** (detail navigation is deferred to a follow-up PR). Nav host and action wiring are updated accordingly, with a unit test covering navigation to the new destination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2f56663ecf01138ec77d9090b16844b3cd6249c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->