### PR TITLE
feat(admob): track next-gen banner preloading

### DIFF
--- a/feature/admob-next-gen/README.md
+++ b/feature/admob-next-gen/README.md
@@ -98,6 +98,56 @@ If you use mediation, wait for the initialization callback before loading ads so
 Configure consent and any request-specific privacy flags before initialization because the SDK or a mediation partner
 may preload ads during initialization.
 
+## Preloading placement
+
+Preloading has two separate tracking stages. The optional placement passed to `startAndTrack` applies to preload
+success and failure events. The optional placement passed to `pollAndTrackAd` is independent and applies to the
+ad's later display, click, revenue, and banner-refresh events.
+
+## Preloading
+
+### Banner ads
+
+```kotlin
+val bannerPreloadConfiguration = PreloadConfiguration(
+    request = BannerAdRequest.Builder(
+        "AD_UNIT_ID",
+        AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(this, 360),
+    ).build(),
+    bufferSize = 2,
+)
+
+BannerAdPreloader.startAndTrack(
+    preloadId = "home-banner-buffer",
+    preloadConfiguration = bannerPreloadConfiguration,
+    placement = "home_banner_preload",
+    preloadCallback = object : PreloadCallback {
+        override fun onAdsExhausted(preloadId: String) {
+            // The buffer is empty. This callback is forwarded but is not a RevenueCat ad event.
+        }
+    },
+)
+
+// Later, adopt a buffered banner. This does not emit another loaded event.
+val bannerAd = BannerAdPreloader.pollAndTrackAd(
+    preloadId = "home-banner-buffer",
+    placement = "home_banner",
+    adEventCallback = bannerAdEventCallback,
+    bannerAdRefreshCallback = bannerAdRefreshCallback,
+)
+
+if (bannerAd != null) {
+    adView.registerBannerAd(bannerAd, this)
+}
+```
+
+Continue to register the returned banner with Google's normal `AdView.registerBannerAd`; the adapter intentionally
+does not combine polling and registration.
+
+If preloading was started through Google's plain `start` API, `pollAndTrackAd` still installs tracking for later
+lifecycle events. RevenueCat cannot retroactively observe the original preload completion, so it does not synthesize
+a loaded event when the ad is polled.
+
 ## Events tracked
 
 All formats — banner, interstitial, rewarded, rewarded interstitial, app open, and native — report these

--- a/feature/admob-next-gen/api.txt
+++ b/feature/admob-next-gen/api.txt
@@ -1,1 +1,10 @@
 // Signature format: 4.0
+package com.revenuecat.purchases.admob.nextgen {
+
+  public final class RCAdMobNextGenPreloaders {
+    method @KotlinOnly @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static com.google.android.libraries.ads.mobile.sdk.banner.BannerAd? pollAndTrackAd(com.google.android.libraries.ads.mobile.sdk.banner.BannerAdPreloader.Companion, String preloadId, optional String? placement, optional com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback? adEventCallback, optional com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback? bannerAdRefreshCallback);
+    method @KotlinOnly @com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI @kotlin.jvm.JvmSynthetic public static boolean startAndTrack(com.google.android.libraries.ads.mobile.sdk.banner.BannerAdPreloader.Companion, String preloadId, com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration preloadConfiguration, optional String? placement, optional com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback? preloadCallback);
+  }
+
+}
+

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/BannerAdPreloaderExtensions.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/BannerAdPreloaderExtensions.kt
@@ -1,0 +1,92 @@
+@file:JvmName("RCAdMobNextGenPreloaders")
+@file:JvmMultifileClass
+@file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+
+package com.revenuecat.purchases.admob.nextgen
+
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdPreloader
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdEventCallback
+import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdRefreshCallback
+import com.revenuecat.purchases.admob.nextgen.tracking.TrackingPreloadCallback
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import kotlin.jvm.JvmSynthetic
+
+/**
+ * Starts banner preloading and tracks every preload success or failure.
+ *
+ * The callback only represents preload completion. Call [pollAndTrackAd] later to adopt a buffered ad and install
+ * tracking for its display, click, revenue, and refresh lifecycle without emitting another loaded event.
+ *
+ * @param preloadId Identifier for Google's preloader buffer.
+ * @param preloadConfiguration Google's preload configuration. Its request ad unit ID is used for tracking.
+ * @param placement Optional placement attached to preload success and failure events.
+ * @param preloadCallback Optional callback that receives every Google preload callback.
+ * @return Google's unchanged result indicating whether preloading started.
+ */
+@ExperimentalPreviewRevenueCatPurchasesAPI
+@JvmSynthetic
+public fun BannerAdPreloader.Companion.startAndTrack(
+    preloadId: String,
+    preloadConfiguration: PreloadConfiguration,
+    placement: String? = null,
+    preloadCallback: PreloadCallback? = null,
+): Boolean = start(
+    preloadId,
+    preloadConfiguration,
+    TrackingPreloadCallback(
+        delegate = preloadCallback,
+        adFormat = AdFormat.BANNER,
+        placement = placement,
+        adUnitId = preloadConfiguration.request.adUnitId,
+    ),
+)
+
+/**
+ * Polls a buffered banner and installs RevenueCat lifecycle tracking before returning it.
+ *
+ * This does not track a loaded event because preload completion is reported by [startAndTrack]. If preloading was
+ * started through Google's plain API, later lifecycle events can still be tracked, but the original load cannot be
+ * reported retroactively. Register a returned ad with Google's normal `AdView.registerBannerAd` API.
+ *
+ * @param preloadId Identifier for Google's preloader buffer.
+ * @param placement Optional placement for lifecycle and refresh events, independent from the start-time placement.
+ * @param adEventCallback Optional callback for banner lifecycle and paid events.
+ * @param bannerAdRefreshCallback Optional callback for automatic banner refresh events.
+ */
+@ExperimentalPreviewRevenueCatPurchasesAPI
+@JvmSynthetic
+public fun BannerAdPreloader.Companion.pollAndTrackAd(
+    preloadId: String,
+    placement: String? = null,
+    adEventCallback: BannerAdEventCallback? = null,
+    bannerAdRefreshCallback: BannerAdRefreshCallback? = null,
+): BannerAd? {
+    val ad = pollAd(preloadId) ?: return null
+    ad.installPreloaderTrackingCallbacks(adEventCallback, bannerAdRefreshCallback, placement)
+    return ad
+}
+
+private fun BannerAd.installPreloaderTrackingCallbacks(
+    adEventCallback: BannerAdEventCallback?,
+    bannerAdRefreshCallback: BannerAdRefreshCallback?,
+    placement: String?,
+) {
+    this.adEventCallback = TrackingBannerAdEventCallback(
+        initialDelegate = adEventCallback,
+        initialPlacement = placement,
+        adUnitId = adUnitId,
+        responseInfoProvider = ::getResponseInfo,
+    )
+    this.bannerAdRefreshCallback = TrackingBannerAdRefreshCallback(
+        delegate = bannerAdRefreshCallback,
+        placement = placement,
+        adUnitId = adUnitId,
+        responseInfoProvider = ::getResponseInfo,
+    )
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/BannerAdPreloaderTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/BannerAdPreloaderTest.kt
@@ -1,0 +1,136 @@
+@file:OptIn(
+    ExperimentalPreviewRevenueCatPurchasesAPI::class,
+    InternalRevenueCatAPI::class,
+)
+
+package com.revenuecat.purchases.admob.nextgen
+
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdPreloader
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdEventCallback
+import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdRefreshCallback
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
+import com.revenuecat.purchases.ads.events.types.AdDisplayedData
+import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class BannerAdPreloaderTest : PreloaderTest() {
+
+    @Before
+    fun setUpPreloader() {
+        mockkObject(BannerAdPreloader.Companion)
+    }
+
+    @After
+    fun tearDownPreloader() {
+        unmockkObject(BannerAdPreloader.Companion)
+    }
+
+    @Test
+    fun `start installs preload tracking`() {
+        val configuration = preloadConfiguration("banner-unit")
+        val delegate = RecordingPreloadCallback()
+        val trackingCallback = slot<PreloadCallback>()
+        every { BannerAdPreloader.start("banner-buffer", configuration, capture(trackingCallback)) } returns true
+
+        val started = BannerAdPreloader.startAndTrack(
+            preloadId = "banner-buffer",
+            preloadConfiguration = configuration,
+            placement = "banner-start-placement",
+            preloadCallback = delegate,
+        )
+
+        assertTrue(started)
+        assertSuccessfulPreload(
+            preloadId = "banner-buffer",
+            trackingCallback = trackingCallback.captured,
+            delegate = delegate,
+            expectedFormat = AdFormat.BANNER,
+            expectedAdUnitId = "banner-unit",
+            expectedPlacement = "banner-start-placement",
+        )
+    }
+
+    @Test
+    fun `null poll is returned unchanged`() {
+        every { BannerAdPreloader.pollAd("banner-buffer") } returns null
+
+        assertNullPoll(BannerAdPreloader.pollAndTrackAd("banner-buffer"))
+    }
+
+    @Test
+    fun `poll installs lifecycle and refresh tracking with independent placement and no load event`() {
+        val responseInfo = responseInfo("banner-network", "banner-response")
+        var installedEventCallback: BannerAdEventCallback? = null
+        var installedRefreshCallback: BannerAdRefreshCallback? = null
+        val bannerAd = mockk<BannerAd>(relaxed = true) {
+            every { adUnitId } returns "banner-unit"
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback = any() } answers { installedEventCallback = firstArg() }
+            every { bannerAdRefreshCallback = any() } answers { installedRefreshCallback = firstArg() }
+        }
+        val eventDelegate = RecordingBannerAdEventCallback()
+        val refreshDelegate = RecordingBannerAdRefreshCallback()
+        val refreshError = loadError(LoadAdError.ErrorCode.NO_FILL)
+        every { BannerAdPreloader.pollAd("banner-buffer") } returns bannerAd
+
+        val result = BannerAdPreloader.pollAndTrackAd(
+            preloadId = "banner-buffer",
+            placement = "banner-poll-placement",
+            adEventCallback = eventDelegate,
+            bannerAdRefreshCallback = refreshDelegate,
+        )
+
+        assertSame(bannerAd, result)
+        val trackingEventCallback = installedEventCallback as TrackingBannerAdEventCallback
+        val trackingRefreshCallback = installedRefreshCallback as TrackingBannerAdRefreshCallback
+        assertEquals("banner-poll-placement", trackingEventCallback.placement)
+        verify(exactly = 0) { adTracker.trackAdLoaded(any(), any()) }
+
+        trackingEventCallback.onAdImpression()
+        trackingRefreshCallback.onAdFailedToRefresh(refreshError)
+
+        assertTrue(eventDelegate.impressionCalled)
+        assertSame(refreshError, refreshDelegate.refreshError)
+        val displayedData = slot<AdDisplayedData>()
+        verify(exactly = 1) { adTracker.trackAdDisplayed(capture(displayedData), AdCaptureMethod.ADAPTER) }
+        assertEquals("banner-poll-placement", displayedData.captured.placement)
+        val failedData = slot<AdFailedToLoadData>()
+        verify(exactly = 1) { adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER) }
+        assertEquals("banner-poll-placement", failedData.captured.placement)
+    }
+
+    private class RecordingBannerAdEventCallback : BannerAdEventCallback {
+        var impressionCalled = false
+
+        override fun onAdImpression() {
+            impressionCalled = true
+        }
+    }
+
+    private class RecordingBannerAdRefreshCallback : BannerAdRefreshCallback {
+        var refreshError: LoadAdError? = null
+
+        override fun onAdFailedToRefresh(adError: LoadAdError) {
+            refreshError = adError
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Banner preload completion and banner adoption happen at different times. Tracking should record the former once while still installing lifecycle tracking when the app polls the buffered banner.

This PR is stacked on #3995.

### Description

- Add `BannerAdPreloader.startAndTrack` to record every preload success or failure and forward all Google callbacks.
- Add `pollAndTrackAd` to install banner event and refresh callbacks without recording another loaded event.
- Keep preload-time and poll-time placements independent.
- Continue using Google's normal `AdView.registerBannerAd` after polling.
- Document both tracked and untracked banner preloading flows.

If preloading starts through Google's plain API, polling can track later lifecycle events but cannot retroactively report the original load.

### Validation

- `./gradlew :feature:admob-next-gen:testDefaultsDebugUnitTest`
- `./gradlew detektAll`
- `./scripts/api-check.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds optional tracking wrappers around Google's preloader APIs without changing core Purchases or auth; misconfiguration mainly affects ad analytics completeness, not app security or purchases.
> 
> **Overview**
> Adds RevenueCat ad-event tracking for Google Mobile Ads Next-Gen **banner preloading**, split across preload start and later poll/adopt.
> 
> **`BannerAdPreloader.startAndTrack`** wraps Google's `start` with `TrackingPreloadCallback` so preload success and failure are recorded once (with an optional **start-time** placement), while still forwarding all Google preload callbacks.
> 
> **`pollAndTrackAd`** polls the buffer and installs `TrackingBannerAdEventCallback` / `TrackingBannerAdRefreshCallback` for display, click, revenue, and refresh—using a separate optional **poll-time** placement—**without** emitting another Ad Loaded event. Apps still register the banner via Google's `AdView.registerBannerAd`.
> 
> Public API is exposed under `RCAdMobNextGenPreloaders` (experimental, Kotlin-only). README documents the two-stage placement model and the case where preloading used Google's plain `start` (lifecycle tracking only, no retroactive load).
> 
> Unit tests cover preload tracking, null poll, and poll-time lifecycle/refresh with independent placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e45c47aa8707717e774415ea9568228f5189a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->