### PR TITLE
Fix package selection for screen visibility overrides

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
@@ -86,7 +87,8 @@ internal fun LoadedPaywallComponents(
     componentInteractionTracker: PaywallComponentInteractionTracker = PaywallComponentInteractionTracker { _ -> },
 ) {
     val configuration = LocalConfiguration.current
-    state.update(localeList = configuration.locales)
+    val windowSize = currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass
+    state.update(localeList = configuration.locales, screenCondition = ScreenCondition.from(windowSize))
 
     val onClick: suspend (PaywallAction) -> Unit = { action ->
         handleClick(action, state, clickHandler, componentInteractionTracker)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
@@ -81,6 +82,9 @@ internal fun LoadedWorkflowPaywall(
     }
 
     val configuration = LocalConfiguration.current
+    val windowSize = currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass
+    val screenCondition = ScreenCondition.from(windowSize)
+    stepStates.values.forEach { it.update(screenCondition = screenCondition) }
     currentState.update(localeList = configuration.locales)
 
     val transitionState = rememberWorkflowTransitionState(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -189,18 +189,24 @@ internal sealed interface PaywallState {
                 val offerEligibility: OfferEligibility,
             )
 
-            private val initialSelectedPackageOutsideTabs = packages.packagesOutsideTabs
-                .firstOrNull { it.isSelectedByDefault && it.resolvesVisible(mergedCustomVariables) }
-                ?.uniqueId
+            private var screenCondition = ScreenCondition.COMPACT
+
+            private val selectedPackageOutsideTabs: String?
+                get() = packages.packagesOutsideTabs
+                    .firstOrNull {
+                        it.isSelectedByDefault && it.resolvesVisible(mergedCustomVariables, screenCondition)
+                    }
+                    ?.uniqueId
 
             /**
              * Only used when a default *is* declared outside the tabs but a rule hid it, which would
              * otherwise leave nothing selected. A paywall that declares no default still starts unselected.
              */
-            private val visibleFallbackForHiddenDefaultOutsideTabs = packages.packagesOutsideTabs
-                .takeIf { infos -> infos.any { it.isSelectedByDefault } }
-                ?.firstOrNull { it.resolvesVisible(mergedCustomVariables) }
-                ?.uniqueId
+            private val visibleFallbackForHiddenDefaultOutsideTabs: String?
+                get() = packages.packagesOutsideTabs
+                    .takeIf { infos -> infos.any { it.isSelectedByDefault } }
+                    ?.firstOrNull { it.resolvesVisible(mergedCustomVariables, screenCondition) }
+                    ?.uniqueId
             private val packagesOutsideTabsUniqueIds: Set<String> = packages.packagesOutsideTabs
                 .mapTo(mutableSetOf()) { it.uniqueId }
             private val tabsByUniqueId: Map<String, Set<Int>> = mutableMapOf<String, Set<Int>>().apply {
@@ -261,31 +267,39 @@ internal sealed interface PaywallState {
             private val selectedPackageByTab = mutableStateMapOf<Int, String?>().apply {
                 putAll(
                     packages.packagesByTab.mapValues { (_, packagesList) ->
-                        packagesList.defaultSelection(mergedCustomVariables)?.uniqueId
+                        packagesList.defaultSelection(mergedCustomVariables, screenCondition)?.uniqueId
                     },
                 )
             }
 
-            var selectedTabIndex by mutableIntStateOf(initialSelectedTabIndex ?: 0)
+            private val initialSelectedTab = initialSelectedTabIndex ?: 0
+
+            var selectedTabIndex by mutableIntStateOf(initialSelectedTab)
                 private set
 
-            private val initialSelectedPackageUniqueId: String? = initialSelectedPackageOutsideTabs
+            private val initialSelectedPackageUniqueId: String? = selectedPackageOutsideTabs
                 ?: selectedPackageByTab[selectedTabIndex]
-                ?: packages.packagesByTab[selectedTabIndex]?.defaultSelection(mergedCustomVariables)?.uniqueId
+                ?: packages.packagesByTab[selectedTabIndex]
+                    ?.defaultSelection(mergedCustomVariables, screenCondition)
+                    ?.uniqueId
                 // Last, so a default declared inside a tab still wins.
                 ?: visibleFallbackForHiddenDefaultOutsideTabs
 
             private var selectedPackageUniqueId by mutableStateOf(initialSelectedPackageUniqueId)
 
             private var defaultPackageInfo: SelectedPackageInfo? by mutableStateOf(null)
+            private var defaultPackageState: Components? = null
 
-            internal fun setDefaultPackage(info: SelectedPackageInfo) {
-                // Idempotency lock: default is set once and never overwritten, so back
-                // navigation always shows the same content as the initial render.
-                if (defaultPackageInfo == null) defaultPackageInfo = info
+            internal fun setDefaultPackage(state: Components) {
+                // Keep the initial context stable across navigation and user package changes. The source is retained
+                // only so a window-size change can replace this snapshot if its package becomes hidden.
+                if (defaultPackageState == null && state !== this) {
+                    defaultPackageState = state
+                    defaultPackageInfo = state.workflowDefaultPackageInfo(null, screenCondition)
+                }
             }
 
-            val selectedPackageInfo by derivedStateOf {
+            val selectedPackageInfo: SelectedPackageInfo? by derivedStateOf {
                 val ownSelection = selectedPackageUniqueId?.let { uniqueId ->
                     findPackageInfoByUniqueId(uniqueId)?.let { info ->
                         SelectedPackageInfo(
@@ -344,8 +358,17 @@ internal sealed interface PaywallState {
                 localeList: FrameworkLocaleList? = null,
                 selectedTabIndex: Int? = null,
                 actionInProgress: Boolean? = null,
+                screenCondition: ScreenCondition? = null,
             ) {
                 if (localeList != null) localeId = LocaleList(localeList.toLanguageTags()).toLocaleId()
+
+                if (screenCondition != null && screenCondition != this.screenCondition) {
+                    this.screenCondition = screenCondition
+                    reconcileSelectionForScreenCondition()
+                    defaultPackageState?.let { sourceState ->
+                        defaultPackageInfo = sourceState.workflowDefaultPackageInfo(defaultPackageInfo, screenCondition)
+                    }
+                }
 
                 if (selectedTabIndex != null) {
                     this.selectedTabIndex = selectedTabIndex
@@ -358,9 +381,9 @@ internal sealed interface PaywallState {
                     }
 
                     selectedPackageUniqueId = selectedPackageByTab[selectedTabIndex]
-                        ?: initialSelectedPackageOutsideTabs
+                        ?: selectedPackageOutsideTabs
                         ?: packages.packagesByTab[selectedTabIndex]
-                            ?.defaultSelection(mergedCustomVariables)
+                            ?.defaultSelection(mergedCustomVariables, this.screenCondition)
                             ?.also { selection ->
                                 if (!selection.isSelectedByDefault) {
                                     Logger.w(
@@ -376,6 +399,62 @@ internal sealed interface PaywallState {
 
                 if (actionInProgress != null) this.actionInProgress = actionInProgress
             }
+
+            private val reconcileSelectionForScreenCondition = {
+                packages.packagesByTab.forEach { (tabIndex, tabPackages) ->
+                    val selectedUniqueId = selectedPackageByTab[tabIndex]
+                    val selectionStillVisible = tabPackages.any { info ->
+                        info.uniqueId == selectedUniqueId &&
+                            info.resolvesVisible(mergedCustomVariables, screenCondition)
+                    }
+                    if (!selectionStillVisible) {
+                        selectedPackageByTab[tabIndex] =
+                            tabPackages.defaultSelection(mergedCustomVariables, screenCondition)?.uniqueId
+                    }
+                }
+
+                val currentSelectionStillVisible = selectedPackageUniqueId?.let { selectedUniqueId ->
+                    (packages.packagesOutsideTabs + packages.packagesByTab[selectedTabIndex].orEmpty())
+                        .any { info ->
+                            info.uniqueId == selectedUniqueId &&
+                                info.resolvesVisible(mergedCustomVariables, screenCondition)
+                        }
+                } == true
+                if (!currentSelectionStillVisible) {
+                    selectedPackageUniqueId = peekDefaultPackageUniqueIdAfterSheetDismiss()
+                }
+            }
+
+            private val workflowDefaultPackageInfo =
+                { currentDefault: SelectedPackageInfo?, condition: ScreenCondition ->
+                    val initialTabPackages = packages.packagesByTab[initialSelectedTab]
+                    val initialContextPackages = packages.packagesOutsideTabs + initialTabPackages.orEmpty()
+                    val currentSelection = currentDefault?.let { current ->
+                        initialContextPackages.firstOrNull { info ->
+                            info.uniqueId == current.uniqueId && info.resolvesVisible(mergedCustomVariables, condition)
+                        }
+                    }
+                    val initialSelection = initialSelectedPackageUniqueId?.let { uniqueId ->
+                        initialContextPackages.firstOrNull { info ->
+                            info.uniqueId == uniqueId && info.resolvesVisible(mergedCustomVariables, condition)
+                        }
+                    }
+                    val replacement = currentSelection
+                        ?: initialSelection
+                        ?: packages.packagesOutsideTabs.authoredDefaultIfVisible(mergedCustomVariables, condition)
+                        ?: initialTabPackages?.defaultSelection(mergedCustomVariables, condition)
+                        ?: packages.packagesOutsideTabs
+                            .takeIf { infos -> infos.any { it.isSelectedByDefault } }
+                            ?.firstVisible(mergedCustomVariables, condition)
+                    replacement?.let { info ->
+                        SelectedPackageInfo(
+                            rcPackage = info.pkg,
+                            resolvedOffer = info.resolvedOffer,
+                            uniqueId = info.uniqueId,
+                            offerEligibility = calculateOfferEligibility(info.resolvedOffer, info.pkg),
+                        )
+                    }
+                }
 
             fun update(selectedPackageUniqueId: String) {
                 this.selectedPackageUniqueId = selectedPackageUniqueId
@@ -397,10 +476,10 @@ internal sealed interface PaywallState {
                 val tabPackages = packages.packagesByTab[selectedTabIndex]
                 // A default authored outside the tabs outranks a tab package that was never authored as
                 // one, so the tab's own default is consulted first and its first visible package last.
-                return tabPackages?.authoredDefaultIfVisible(mergedCustomVariables)?.uniqueId
-                    ?: initialSelectedPackageOutsideTabs
+                return tabPackages?.authoredDefaultIfVisible(mergedCustomVariables, screenCondition)?.uniqueId
+                    ?: selectedPackageOutsideTabs
                     ?: selectedPackageByTab[selectedTabIndex]
-                    ?: tabPackages?.firstVisible(mergedCustomVariables)?.uniqueId
+                    ?: tabPackages?.firstVisible(mergedCustomVariables, screenCondition)?.uniqueId
                     ?: visibleFallbackForHiddenDefaultOutsideTabs
             }
 
@@ -496,9 +575,10 @@ internal val PaywallState.Loaded.Legacy.isInFullScreenMode: Boolean
  */
 private fun PaywallState.Loaded.Components.AvailablePackages.Info.resolvesVisible(
     customVariables: Map<String, CustomVariableValue>,
+    screenCondition: ScreenCondition,
 ): Boolean =
     visibilityOverrides.buildPresentedPartial(
-        windowSize = ScreenCondition.COMPACT,
+        windowSize = screenCondition,
         offerEligibility = offerEligibility ?: OfferEligibility.Ineligible,
         state = ComponentViewState.DEFAULT,
         conditionContext = ConditionContext(selectedPackageId = null, customVariables = customVariables),
@@ -510,16 +590,19 @@ private fun PaywallState.Loaded.Components.AvailablePackages.Info.resolvesVisibl
  */
 private fun List<PaywallState.Loaded.Components.AvailablePackages.Info>.defaultSelection(
     customVariables: Map<String, CustomVariableValue>,
+    screenCondition: ScreenCondition,
 ): PaywallState.Loaded.Components.AvailablePackages.Info? =
-    authoredDefaultIfVisible(customVariables) ?: firstVisible(customVariables)
+    authoredDefaultIfVisible(customVariables, screenCondition) ?: firstVisible(customVariables, screenCondition)
 
 /** The package authored as the default, only when it renders. */
 private fun List<PaywallState.Loaded.Components.AvailablePackages.Info>.authoredDefaultIfVisible(
     customVariables: Map<String, CustomVariableValue>,
+    screenCondition: ScreenCondition,
 ): PaywallState.Loaded.Components.AvailablePackages.Info? =
-    firstOrNull { it.isSelectedByDefault && it.resolvesVisible(customVariables) }
+    firstOrNull { it.isSelectedByDefault && it.resolvesVisible(customVariables, screenCondition) }
 
 private fun List<PaywallState.Loaded.Components.AvailablePackages.Info>.firstVisible(
     customVariables: Map<String, CustomVariableValue>,
+    screenCondition: ScreenCondition,
 ): PaywallState.Loaded.Components.AvailablePackages.Info? =
-    firstOrNull { it.resolvesVisible(customVariables) }
+    firstOrNull { it.resolvesVisible(customVariables, screenCondition) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -1224,14 +1224,13 @@ internal class PaywallViewModelImpl(
         if (cached == null && newState is PaywallState.Loaded.Components) {
             workflowStepStateCache[step.id] = newState
         }
-        // Apply the workflow's default package to all steps. setDefaultPackage is idempotent
-        // so it is safe to call on every visit — it will only take effect the first time.
-        // On steps with their own packages, ownSelection takes precedence over defaultPackageInfo.
+        // Apply the workflow's package-bearing source state to all steps. setDefaultPackage is idempotent,
+        // so it is safe to call on every visit. On steps with their own packages, ownSelection takes precedence.
         if (newState is PaywallState.Loaded.Components) {
-            val defaultPackage = workflow.singleStepFallbackId
-                ?.let { workflowStepStateCache[it]?.selectedPackageInfo }
-            if (defaultPackage != null) {
-                newState.setDefaultPackage(defaultPackage)
+            val defaultPackageState = workflow.singleStepFallbackId
+                ?.let { workflowStepStateCache[it] }
+            if (defaultPackageState != null) {
+                newState.setDefaultPackage(defaultPackageState)
             }
         }
         if (!shouldApplyState) return
@@ -1338,7 +1337,7 @@ internal class PaywallViewModelImpl(
                     workflowStepStateCache[stepId] = computed
                     computed.update(localeList = _lastLocaleList.value.toFrameworkLocaleList())
                     workflow.singleStepFallbackId
-                        ?.let { workflowStepStateCache[it]?.selectedPackageInfo }
+                        ?.let { workflowStepStateCache[it] }
                         ?.let { computed.setDefaultPackage(it) }
                 }
             }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsPackageSelectionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsPackageSelectionTests.kt
@@ -1,7 +1,9 @@
 package com.revenuecat.purchases.ui.revenuecatui.data
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.text.intl.LocaleList
+import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
@@ -10,6 +12,9 @@ import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverride
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedPackagePartial
+import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
+import com.revenuecat.purchases.ui.revenuecatui.components.LoadedPaywallComponents
+import com.revenuecat.purchases.ui.revenuecatui.components.LoadedWorkflowPaywall
 import com.revenuecat.purchases.ui.revenuecatui.components.previewStackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
@@ -18,7 +23,10 @@ import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvi
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockResourceProvider
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptySetOf
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
+import com.revenuecat.purchases.ui.revenuecatui.helpers.windowChangingTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -33,6 +41,9 @@ import java.util.Date
  */
 @RunWith(RobolectricTestRunner::class)
 internal class PaywallStateLoadedComponentsPackageSelectionTests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
     private val localeId = LocaleId("en_US")
 
@@ -197,6 +208,185 @@ internal class PaywallStateLoadedComponentsPackageSelectionTests {
         )
 
         assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
+    fun `Should move selection when an expanded screen hides the default package`() {
+        val state = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = mapOf(
+                0 to listOf(
+                    packageInfo(
+                        TestData.Packages.annual,
+                        isSelectedByDefault = true,
+                        visibilityOverrides = listOf(expandedVisibilityOverride(visible = false)),
+                    ),
+                    packageInfo(TestData.Packages.monthly, isSelectedByDefault = false),
+                ),
+            ),
+            initialSelectedTabIndex = null,
+        )
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+
+        state.update(screenCondition = ScreenCondition.EXPANDED)
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+    }
+
+    @Test
+    fun `Should update a workflow fallback when screen visibility changes its source selection`() {
+        val packageState = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = mapOf(
+                0 to listOf(
+                    packageInfo(
+                        TestData.Packages.annual,
+                        isSelectedByDefault = true,
+                        visibilityOverrides = listOf(expandedVisibilityOverride(visible = false)),
+                    ),
+                    packageInfo(TestData.Packages.monthly, isSelectedByDefault = false),
+                ),
+            ),
+            initialSelectedTabIndex = null,
+        )
+        val packageLessWorkflowStep = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+        packageLessWorkflowStep.setDefaultPackage(packageState)
+
+        packageState.update(screenCondition = ScreenCondition.EXPANDED)
+        packageLessWorkflowStep.update(screenCondition = ScreenCondition.EXPANDED)
+
+        assertThat(packageLessWorkflowStep.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+    }
+
+    @Test
+    fun `Should preserve a visible workflow fallback across later screen changes`() {
+        val packageState = paywallStateWithExpandedHiddenDefault()
+        val packageLessWorkflowStep = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+        packageLessWorkflowStep.setDefaultPackage(packageState)
+        packageLessWorkflowStep.update(screenCondition = ScreenCondition.EXPANDED)
+        assertThat(packageLessWorkflowStep.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+
+        packageLessWorkflowStep.update(screenCondition = ScreenCondition.COMPACT)
+
+        assertThat(packageLessWorkflowStep.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+    }
+
+    @Test
+    fun `Should ignore a duplicate package visible outside the workflow fallback tab`() {
+        val annualInInitialTab = packageInfo(
+            TestData.Packages.annual,
+            isSelectedByDefault = true,
+            visibilityOverrides = listOf(expandedVisibilityOverride(visible = false)),
+        )
+        val packageState = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = mapOf(
+                0 to listOf(
+                    annualInInitialTab,
+                    packageInfo(TestData.Packages.monthly, isSelectedByDefault = false),
+                ),
+                1 to listOf(packageInfo(TestData.Packages.annual, isSelectedByDefault = true)),
+            ),
+            initialSelectedTabIndex = 0,
+        )
+        val packageLessWorkflowStep = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+        packageLessWorkflowStep.setDefaultPackage(packageState)
+
+        packageState.update(screenCondition = ScreenCondition.EXPANDED)
+        packageLessWorkflowStep.update(screenCondition = ScreenCondition.EXPANDED)
+
+        assertThat(packageLessWorkflowStep.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+    }
+
+    @Test
+    fun `Should keep the initial workflow fallback when attached after a user selection`() {
+        val monthlyInfo = packageInfo(TestData.Packages.monthly, isSelectedByDefault = false)
+        val packageState = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = mapOf(
+                0 to listOf(
+                    packageInfo(TestData.Packages.annual, isSelectedByDefault = true),
+                    monthlyInfo,
+                ),
+            ),
+            initialSelectedTabIndex = null,
+        )
+        val packageLessWorkflowStep = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+        packageState.update(monthlyInfo.uniqueId)
+
+        packageLessWorkflowStep.setDefaultPackage(packageState)
+
+        assertThat(packageLessWorkflowStep.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
+    fun `Should propagate the live window size to a component paywall selection`() = with(composeTestRule) {
+        val state = paywallStateWithExpandedHiddenDefault()
+
+        windowChangingTest(
+            arrange = { state },
+            act = { LoadedPaywallComponents(state = it, clickHandler = { }) },
+            assert = { windowSizeController ->
+                windowSizeController.setWindowSizeInexact(width = 900.dp, height = 1_000.dp)
+                runOnIdle {
+                    assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+                }
+            },
+        )
+    }
+
+    @Test
+    fun `Should propagate the live window size to a workflow fallback selection`() = with(composeTestRule) {
+        val packageState = paywallStateWithExpandedHiddenDefault()
+        val packageLessWorkflowStep = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+        packageLessWorkflowStep.setDefaultPackage(packageState)
+
+        windowChangingTest(
+            arrange = {
+                WorkflowPaywallUiState(
+                    currentStepId = "package-less",
+                    stepStates = mapOf(
+                        "packages" to packageState,
+                        "package-less" to packageLessWorkflowStep,
+                    ),
+                )
+            },
+            act = { workflowState ->
+                LoadedWorkflowPaywall(
+                    workflowState = workflowState,
+                    onTransitionComplete = { },
+                    clickHandler = { },
+                    componentInteractionTracker = PaywallComponentInteractionTracker { _ -> },
+                )
+            },
+            assert = { windowSizeController ->
+                windowSizeController.setWindowSizeInexact(width = 900.dp, height = 1_000.dp)
+                runOnIdle {
+                    assertThat(packageLessWorkflowStep.selectedPackageInfo?.rcPackage)
+                        .isEqualTo(TestData.Packages.monthly)
+                }
+            },
+        )
     }
 
     @Test
@@ -411,6 +601,11 @@ internal class PaywallStateLoadedComponentsPackageSelectionTests {
         properties = PresentedPackagePartial(partial = PartialPackageComponent(visible = visible)),
     )
 
+    private fun expandedVisibilityOverride(visible: Boolean) = PresentedOverride(
+        conditions = listOf(ComponentOverride.Condition.Expanded),
+        properties = PresentedPackagePartial(partial = PartialPackageComponent(visible = visible)),
+    )
+
     private fun packageInfo(
         pkg: com.revenuecat.purchases.Package,
         isSelectedByDefault: Boolean,
@@ -421,6 +616,21 @@ internal class PaywallStateLoadedComponentsPackageSelectionTests {
         isSelectedByDefault = isSelectedByDefault,
         visible = visible,
         visibilityOverrides = visibilityOverrides,
+    )
+
+    private fun paywallStateWithExpandedHiddenDefault() = paywallState(
+        packagesOutsideTabs = emptyList(),
+        packagesByTab = mapOf(
+            0 to listOf(
+                packageInfo(
+                    TestData.Packages.annual,
+                    isSelectedByDefault = true,
+                    visibilityOverrides = listOf(expandedVisibilityOverride(visible = false)),
+                ),
+                packageInfo(TestData.Packages.monthly, isSelectedByDefault = false),
+            ),
+        ),
+        initialSelectedTabIndex = null,
     )
 
     private fun paywallState(


### PR DESCRIPTION
### Motivation

Paywalls can hide packages with medium or expanded screen overrides. Package selection was always evaluated as compact while rendering used the real window size, so a purchase button could target a package that was not shown.

### Description

- Pass the live screen condition into regular and workflow paywall state.
- Move the selection only when its package becomes hidden.
- Keep workflow fallback context stable across navigation, user selection, duplicate packages in other tabs, and later window changes.

### Testing

- `./gradlew :ui:revenuecatui:testDefaultsDebugUnitTest detektAll`
- Added state and Compose regression coverage for regular and workflow paywalls.

Device, emulator, and live-store purchase flows were not tested.
