### PR TITLE
refactor(paywalls): share one component-config lookup across asset pre-download

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.common.debugLog
-import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.paywalls.PaywallAssetWarming
 
@@ -34,13 +33,7 @@ internal class OfferingImagePreDownloader(
     }
 
     private fun downloadV2Images(offering: Offering) {
-        val paywallComponents = offering.paywallComponents ?: return
-        // `data` decodes lazily here, and best-effort warming must not abort the offerings success/caching path.
-        val componentsConfig = paywallComponents.data.getOrElse { error ->
-            errorLog(error) { "Error deserializing paywall components data. Skipping V2 image pre-download." }
-            return
-        }.componentsConfig.base
-        val assets = componentsConfig.collectAssets()
+        val assets = offering.baseComponentsConfig()?.collectAssets() ?: return
         assetWarming.warmImages(assets.imageUris)
         if (assets.webViews.isNotEmpty()) assetWarming.prebootWebView()
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingVideoPredownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingVideoPredownloader.kt
@@ -5,7 +5,6 @@ package com.revenuecat.purchases.utils
 import android.content.Context
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
-import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.models.Checksum
 import com.revenuecat.purchases.paywalls.PaywallAssetWarming
 import com.revenuecat.purchases.paywalls.components.VideoComponent
@@ -21,26 +20,14 @@ internal class OfferingVideoPredownloader(
 ) {
 
     fun downloadVideos(offering: Offering) {
-        if (assetWarming.isAvailable) {
-            val paywallComponents = offering.paywallComponents ?: return
-            // `paywallComponents.data` is decoded lazily on first access and fails if the component tree passed
-            // the cheap parse-time shape check but is structurally invalid. Pre-downloading is best-effort, so a
-            // decode failure here must not abort the offerings success/caching path that invokes this.
-            val stack = paywallComponents.data.getOrElse { error ->
-                errorLog(error) { "Error deserializing paywall components data. Skipping video pre-download." }
-                return
-            }.componentsConfig.base.stack
-            // WIP: We will add a remote flag in the offering metadata that will indicate if we should
-            // pre-download videos or not. For now, we want to only download the low-res to ensure we
-            // don't rack up high cloudfront costs
-            stack
-                .filter { it is VideoComponent }
-                .forEach { component ->
-                    if (component is VideoComponent) {
-                        fileRepository.prefetch(component.source.checkedUrls())
-                    }
-                }
-        }
+        if (!assetWarming.isAvailable) return
+        val stack = offering.baseComponentsConfig()?.stack ?: return
+        // WIP: We will add a remote flag in the offering metadata that will indicate if we should
+        // pre-download videos or not. For now, we want to only download the low-res to ensure we
+        // don't rack up high cloudfront costs
+        stack.flatten()
+            .filterIsInstance<VideoComponent>()
+            .forEach { fileRepository.prefetch(it.source.checkedUrls()) }
     }
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentAssets.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentAssets.kt
@@ -4,6 +4,8 @@ package com.revenuecat.purchases.utils
 
 import android.net.Uri
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.CarouselComponent
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
@@ -42,6 +44,16 @@ internal data class WebViewAsset(
     val sizeToContentWidth: Boolean,
     val sizeToContentHeight: Boolean,
 )
+
+/**
+ * Null if this offering has no Paywalls V2 config or it cannot be decoded. `data` decodes lazily, so this is
+ * where that cost lands; every caller is best-effort asset warming, so a failure must not propagate.
+ */
+internal fun Offering.baseComponentsConfig(): PaywallComponentsConfig? =
+    paywallComponents?.data?.getOrElse { error ->
+        errorLog(error) { "Error deserializing paywall components data for '$identifier'. Skipping its assets." }
+        null
+    }?.componentsConfig?.base
 
 internal fun PaywallComponentsConfig.collectAssets(): PaywallComponentAssets {
     val imageUris = background.findImageUris().toMutableSet()

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
@@ -166,6 +166,7 @@ class OfferingImagePreDownloaderTest {
     fun `paywalls V2 - if the component tree fails to decode, it does not throw and downloads nothing`() {
         val offering = mockk<Offering>().apply {
             every { paywall } returns null
+            every { identifier } returns "broken"
             every { paywallComponents } returns Offering.PaywallComponents(
                 uiConfig = mockk(),
                 componentsHash = "hash",

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingVideoPredownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingVideoPredownloaderTest.kt
@@ -60,6 +60,7 @@ class OfferingVideoPredownloaderTest {
     @Test
     fun `if the component tree fails to decode, it does not throw and prefetches nothing`() {
         val offering = mockk<Offering>().apply {
+            every { identifier } returns "broken"
             every { paywallComponents } returns Offering.PaywallComponents(
                 uiConfig = mockk(),
                 componentsHash = "hash",


### PR DESCRIPTION
Deduplicates the component walk used to gather assets for prewarming. At this PR it's only for images and videos but the next one uses it for web components.

Image and video asset pre-download each inlined the same block: reach for `paywallComponents`, force the lazy `data` decode, log and bail on failure, then take `componentsConfig.base`. Both now call one `Offering.baseComponentsConfig()`.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

`Offering.paywallComponents.data` is decoded lazily, and every asset-warming caller has to handle a decode failure without propagating it: these run before the offerings success path completes, so a malformed component tree must not fail `getOfferings`. That obligation was met by copy-pasting the same `getOrElse { errorLog(...); return }` block into each pre-downloader, which meant two places to keep in sync and two different log messages for the same condition.

Consolidating it also gives the lazy decode one documented home, which matters because that decode is the expensive part of asset warming.

### Description

- Adds `internal fun Offering.baseComponentsConfig(): PaywallComponentsConfig?`, returning null when the offering has no Paywalls V2 config or its component tree cannot be decoded, logging the failure with the offering identifier.
- `OfferingImagePreDownloader.downloadV2Images` uses it. The WebView preboot call it makes when the tree contains a `web_view` is unchanged.
- `OfferingVideoPredownloader.downloadVideos` uses it, and its early return for an unavailable warmer becomes a guard clause instead of wrapping the body.
- Test mocks gain an `identifier` stub, since the shared helper reads it for the log line.
- Regression gate: the existing "component tree fails to decode" test in each pre-downloader test class. Both assert nothing is downloaded and nothing is thrown, which is the contract the shared helper has to keep.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of best-effort asset warming. Decode failures still swallow so getOfferings is not aborted; video prefetch now walks nested components.
> 
> **Overview**
> Image and video pre-download no longer each force-decode `paywallComponents.data` with their own `getOrElse` bail-out. Both now use a shared `Offering.baseComponentsConfig()` that returns null (and logs the offering id) when there is no V2 config or the lazy decode fails.
> 
> Video prefetch also walks the tree with `flatten()` instead of only top-level stack children, so nested `VideoComponent`s get prefetched. WebView preboot on image warming is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c06882d6fffc9142c9e27342e596a724d9c56b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->