### PR TITLE
Add reward verification runtime

### DIFF
--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntime.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntime.kt
@@ -44,7 +44,6 @@ internal class RewardVerificationRuntime(
         rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
     ) {
         val clientTransactionId = adResponseId?.let { getClientTransactionId(it) }
-        warnAndAssertIfMissingClientTransactionId(clientTransactionId)
 
         val completionDelivered = AtomicBoolean(false)
         fun deliverOnce(result: RewardVerificationResult) {
@@ -53,7 +52,8 @@ internal class RewardVerificationRuntime(
             }
         }
 
-        if (adResponseId == null || clientTransactionId == null) {
+        if (clientTransactionId == null) {
+            Logger.w(RewardVerificationStrings.NOT_SET_UP_FOR_AD)
             deliverOnce(RewardVerificationResult.failed)
             return
         }
@@ -91,12 +91,6 @@ internal class RewardVerificationRuntime(
         runOnMainIfPresent(mainHandler) {
             rewardVerificationCompleted(result)
         }
-    }
-
-    private fun warnAndAssertIfMissingClientTransactionId(clientTransactionId: String?) {
-        if (clientTransactionId != null) return
-
-        Logger.w(RewardVerificationStrings.ENABLE_REQUIRED_BEFORE_SHOW)
     }
 
     @Synchronized

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntime.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntime.kt
@@ -1,0 +1,117 @@
+package com.revenuecat.purchases.admob.nextgen.rewardverification
+
+import android.os.Handler
+import android.os.Looper
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.Logger
+import com.revenuecat.purchases.admob.nextgen.threading.runOnMainIfPresent
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.awaitPollRewardVerification
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Holds the per-configuration reward verification state. A fresh instance is created when [Purchases] is
+ * configured and discarded with [close] when it closes, so no verification state outlives a configuration.
+ */
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+internal class RewardVerificationRuntime(
+    private val mainHandler: Handler = Handler(Looper.getMainLooper()),
+    createVerificationScope: () -> CoroutineScope = {
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    },
+    private val poll: suspend (String) -> RewardVerificationResult = { clientTransactionId ->
+        Purchases.sharedInstance.awaitPollRewardVerification(clientTransactionId)
+    },
+) {
+    private val clientTransactionIdByAdResponseId = mutableMapOf<String, String>()
+    private val verificationScope: CoroutineScope = createVerificationScope()
+
+    @Synchronized
+    fun setClientTransactionId(adResponseId: String, clientTransactionId: String) {
+        clientTransactionIdByAdResponseId[adResponseId] = clientTransactionId
+    }
+
+    fun handleRewardEarned(
+        adResponseId: String?,
+        rewardVerificationStarted: (() -> Unit)?,
+        rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
+    ) {
+        val clientTransactionId = adResponseId?.let { getClientTransactionId(it) }
+        warnAndAssertIfMissingClientTransactionId(clientTransactionId)
+
+        val completionDelivered = AtomicBoolean(false)
+        fun deliverOnce(result: RewardVerificationResult) {
+            if (completionDelivered.compareAndSet(false, true)) {
+                notifyCompleted(result, rewardVerificationCompleted)
+            }
+        }
+
+        if (adResponseId == null || clientTransactionId == null) {
+            deliverOnce(RewardVerificationResult.failed)
+            return
+        }
+
+        // Notify started before launching so that on a non-main caller, the started post
+        // is enqueued on the main handler before any completed post from the IO coroutine.
+        notifyStarted(rewardVerificationStarted)
+
+        val verificationTask = verificationScope.launch {
+            val result = poll(clientTransactionId)
+            deliverOnce(result)
+        }
+
+        verificationTask.invokeOnCompletion { cause ->
+            removeClientTransactionId(adResponseId)
+            if (cause != null) {
+                // poll() swallows every non-cancellation failure into a failed result, so a non-null cause
+                // here is the verification scope being cancelled (caller teardown / Purchases.close()).
+                if (cause is CancellationException) {
+                    Logger.w(RewardVerificationStrings.CANCELLED)
+                }
+                deliverOnce(RewardVerificationResult.failed)
+            }
+        }
+    }
+
+    private fun notifyStarted(block: (() -> Unit)?) {
+        runOnMainIfPresent(mainHandler, block)
+    }
+
+    private fun notifyCompleted(
+        result: RewardVerificationResult,
+        rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
+    ) {
+        runOnMainIfPresent(mainHandler) {
+            rewardVerificationCompleted(result)
+        }
+    }
+
+    private fun warnAndAssertIfMissingClientTransactionId(clientTransactionId: String?) {
+        if (clientTransactionId != null) return
+
+        Logger.w("Reward verification callback requires enableRewardVerification() before show().")
+    }
+
+    @Synchronized
+    private fun getClientTransactionId(adResponseId: String): String? {
+        return clientTransactionIdByAdResponseId[adResponseId]
+    }
+
+    @Synchronized
+    private fun removeClientTransactionId(adResponseId: String) {
+        clientTransactionIdByAdResponseId.remove(adResponseId)
+    }
+
+    @Synchronized
+    fun close() {
+        verificationScope.cancel()
+        clientTransactionIdByAdResponseId.clear()
+    }
+}

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntime.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntime.kt
@@ -96,7 +96,7 @@ internal class RewardVerificationRuntime(
     private fun warnAndAssertIfMissingClientTransactionId(clientTransactionId: String?) {
         if (clientTransactionId != null) return
 
-        Logger.w("Reward verification callback requires enableRewardVerification() before show().")
+        Logger.w(RewardVerificationStrings.ENABLE_REQUIRED_BEFORE_SHOW)
     }
 
     @Synchronized

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationStrings.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationStrings.kt
@@ -1,0 +1,7 @@
+package com.revenuecat.purchases.admob.nextgen.rewardverification
+
+internal object RewardVerificationStrings {
+
+    const val CANCELLED: String =
+        "Reward verification was cancelled before completion."
+}

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationStrings.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationStrings.kt
@@ -2,6 +2,11 @@ package com.revenuecat.purchases.admob.nextgen.rewardverification
 
 internal object RewardVerificationStrings {
 
+    // Verification lifecycle
     const val CANCELLED: String =
         "Reward verification was cancelled before completion."
+
+    // Setup
+    const val ENABLE_REQUIRED_BEFORE_SHOW: String =
+        "Reward verification callback requires enableRewardVerification() before show()."
 }

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationStrings.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationStrings.kt
@@ -7,6 +7,7 @@ internal object RewardVerificationStrings {
         "Reward verification was cancelled before completion."
 
     // Setup
-    const val ENABLE_REQUIRED_BEFORE_SHOW: String =
-        "Reward verification callback requires enableRewardVerification() before show()."
+    const val NOT_SET_UP_FOR_AD: String =
+        "Reward verification is not set up for this ad. " +
+            "Call enableRewardVerification() after loading the ad and before showing it."
 }

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/threading/MainThreadDelivery.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/threading/MainThreadDelivery.kt
@@ -1,0 +1,16 @@
+package com.revenuecat.purchases.admob.nextgen.threading
+
+import android.os.Handler
+import android.os.Looper
+
+internal fun runOnMainIfPresent(
+    mainHandler: Handler,
+    block: (() -> Unit)?,
+) {
+    if (block == null) return
+    if (Thread.currentThread() != Looper.getMainLooper().thread) {
+        mainHandler.post { block() }
+    } else {
+        block()
+    }
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntimeTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntimeTest.kt
@@ -142,6 +142,7 @@ internal class RewardVerificationRuntimeTest {
         assertEquals(0, startedCount)
         assertNotNull(completedResult)
         assertTrue(completedResult!!.failed)
+        assertTrue(ShadowLog.getLogs().any { it.msg == RewardVerificationStrings.NOT_SET_UP_FOR_AD })
     }
 
     @Test
@@ -177,5 +178,6 @@ internal class RewardVerificationRuntimeTest {
         assertEquals(0, startedCount)
         assertNotNull(completedResult)
         assertTrue(completedResult!!.failed)
+        assertTrue(ShadowLog.getLogs().any { it.msg == RewardVerificationStrings.NOT_SET_UP_FOR_AD })
     }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntimeTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntimeTest.kt
@@ -113,6 +113,38 @@ internal class RewardVerificationRuntimeTest {
     }
 
     @Test
+    fun `missing ad response id skips started callback and delivers failed`() {
+        val runtime = RewardVerificationRuntime(
+            mainHandler = Handler(Looper.getMainLooper()),
+            createVerificationScope = {
+                CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            },
+            poll = { error("poll should not run when ad response id is missing") },
+        )
+        var startedCount = 0
+        var completedResult: RewardVerificationResult? = null
+        val completed = CountDownLatch(1)
+
+        runtime.handleRewardEarned(
+            adResponseId = null,
+            rewardVerificationStarted = { startedCount++ },
+            rewardVerificationCompleted = {
+                completedResult = it
+                completed.countDown()
+            },
+        )
+        val completionDelivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(completionDelivered)
+        assertEquals(0, startedCount)
+        assertNotNull(completedResult)
+        assertTrue(completedResult!!.failed)
+    }
+
+    @Test
     fun `missing client transaction id skips started callback and delivers failed`() {
         val runtime = RewardVerificationRuntime(
             mainHandler = Handler(Looper.getMainLooper()),

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntimeTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntimeTest.kt
@@ -1,0 +1,149 @@
+package com.revenuecat.purchases.admob.nextgen.rewardverification
+
+import android.os.Handler
+import android.os.Looper
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+internal class RewardVerificationRuntimeTest {
+
+    @Test
+    fun `cancelling runtime while verification is in flight completes with failed result`() {
+        val pollStarted = CountDownLatch(1)
+        val runtime = RewardVerificationRuntime(
+            mainHandler = Handler(Looper.getMainLooper()),
+            createVerificationScope = {
+                CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            },
+            poll = {
+                pollStarted.countDown()
+                awaitCancellation()
+            },
+        )
+        val adResponseId = "ad-response-id"
+        var started = false
+        var completedResult: RewardVerificationResult? = null
+        val completed = CountDownLatch(1)
+
+        runtime.setClientTransactionId(adResponseId, "client-transaction-id")
+
+        runtime.handleRewardEarned(
+            adResponseId = adResponseId,
+            rewardVerificationStarted = { started = true },
+            rewardVerificationCompleted = {
+                completedResult = it
+                completed.countDown()
+            },
+        )
+        assertTrue(pollStarted.await(1, TimeUnit.SECONDS))
+        runtime.close()
+        val completionDelivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(started)
+        assertTrue(completionDelivered)
+        assertNotNull(completedResult)
+        assertTrue(completedResult!!.failed)
+        // Cancellation is logged so it isn't bucketed as a silent failure.
+        assertTrue(ShadowLog.getLogs().any { it.msg == RewardVerificationStrings.CANCELLED })
+    }
+
+    @Test
+    fun `verified poll result delivers started and verified reward on main thread`() {
+        val verifiedReward = VerifiedReward.VirtualCurrency(code = "gems", amount = 5)
+        val runtime = RewardVerificationRuntime(
+            mainHandler = Handler(Looper.getMainLooper()),
+            createVerificationScope = {
+                CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            },
+            poll = { RewardVerificationResult.verified(verifiedReward) },
+        )
+        val adResponseId = "ad-response-id"
+        var startedThread: Thread? = null
+        var completedThread: Thread? = null
+        var completedResult: RewardVerificationResult? = null
+        val completed = CountDownLatch(1)
+
+        runtime.setClientTransactionId(adResponseId, "client-transaction-id")
+
+        runtime.handleRewardEarned(
+            adResponseId = adResponseId,
+            rewardVerificationStarted = { startedThread = Thread.currentThread() },
+            rewardVerificationCompleted = {
+                completedThread = Thread.currentThread()
+                completedResult = it
+                completed.countDown()
+            },
+        )
+        val completionDelivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(completionDelivered)
+        assertSame(Looper.getMainLooper().thread, startedThread)
+        assertSame(Looper.getMainLooper().thread, completedThread)
+        assertNotNull(completedResult)
+        assertFalse(completedResult!!.failed)
+        assertEquals(verifiedReward, completedResult!!.verifiedReward)
+    }
+
+    @Test
+    fun `missing client transaction id skips started callback and delivers failed`() {
+        val runtime = RewardVerificationRuntime(
+            mainHandler = Handler(Looper.getMainLooper()),
+            createVerificationScope = {
+                CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            },
+            poll = { error("poll should not run when no client transaction id is registered") },
+        )
+        val adResponseId = "ad-response-id"
+        var startedCount = 0
+        var completedResult: RewardVerificationResult? = null
+        val completed = CountDownLatch(1)
+
+        // Intentionally skip setClientTransactionId.
+
+        runtime.handleRewardEarned(
+            adResponseId = adResponseId,
+            rewardVerificationStarted = { startedCount++ },
+            rewardVerificationCompleted = {
+                completedResult = it
+                completed.countDown()
+            },
+        )
+        val completionDelivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(completionDelivered)
+        assertEquals(0, startedCount)
+        assertNotNull(completedResult)
+        assertTrue(completedResult!!.failed)
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Reward verification needs lifecycle-safe state and polling before the next-generation AdMob adapter can expose it publicly.
This is the first reward verification layer and targets `next-gen-admob-sdk`.

### Description
Adds a per-configuration runtime that correlates AdMob response IDs with client transaction IDs, polls RevenueCat, delivers callbacks once on the main thread, and fails safely on cancellation or missing correlation.
Runtime tests cover verified results, missing IDs, callback threading, and cancellation cleanup; validated with the focused runtime test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New reward-verification flow affects when developers grant rewards, but behavior is internal, fails closed, and is covered by unit tests; full adapter integration is still ahead.
> 
> **Overview**
> Introduces **lifecycle-scoped reward verification** for the next-gen AdMob module: a new `RewardVerificationRuntime` that ties each ad response ID to a client transaction ID, polls RevenueCat via `awaitPollRewardVerification` on a background coroutine scope, and reports **started/completed** callbacks **once** on the main thread.
> 
> If verification was never set up (missing ad response ID or unregistered transaction ID), it logs guidance and completes with **failed** without starting the poll. **Teardown** via `close()` cancels in-flight work, clears mappings, and still delivers a single failed completion when verification was cancelled mid-poll.
> 
> Adds a small **`runOnMainIfPresent`** helper for main-thread delivery and shared log strings. **Robolectric tests** cover happy path threading, missing setup, and cancellation during poll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097bf2e90dbb7bea1c806e40388d1011570006c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->