### PR TITLE
Bridge AdMob reward verification lifecycle

### DIFF
--- a/feature/admob-next-gen/consumer-rules.pro
+++ b/feature/admob-next-gen/consumer-rules.pro
@@ -1,0 +1,6 @@
+# RewardVerificationService is instantiated reflectively by java.util.ServiceLoader through the
+# META-INF/services/com.revenuecat.purchases.PurchasesService descriptor, so keep the class and its
+# no-argument constructor even though there are no direct references to it.
+-keep class com.revenuecat.purchases.admob.nextgen.rewardverification.RewardVerificationService {
+    <init>();
+}

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/Logger.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/Logger.kt
@@ -5,6 +5,10 @@ import android.util.Log
 internal object Logger {
     private const val TAG = "PurchasesAdMob"
 
+    fun e(message: String) {
+        Log.e(TAG, message)
+    }
+
     fun w(message: String) {
         Log.w(TAG, message)
     }

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManager.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManager.kt
@@ -1,0 +1,107 @@
+package com.revenuecat.purchases.admob.nextgen.rewardverification
+
+import android.os.Handler
+import android.os.Looper
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
+import com.google.android.libraries.ads.mobile.sdk.rewarded.ServerSideVerificationOptions
+import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.Logger
+import com.revenuecat.purchases.admob.nextgen.threading.runOnMainIfPresent
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+internal object RewardVerificationManager {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /**
+     * The [RewardVerificationService] for the active [Purchases] configuration, or `null` before
+     * configuration / after close. The service owns the [RewardVerificationRuntime], so the verification
+     * state is held on that instance and cleared when it is closed, rather than living on this object.
+     */
+    @Volatile
+    internal var activeService: RewardVerificationService? = null
+
+    private val runtime: RewardVerificationRuntime?
+        get() = activeService?.runtime
+
+    fun install(ad: RewardedAd) = installInternal(ad.getResponseInfo().responseId, ad::setServerSideVerificationOptions)
+
+    fun install(ad: RewardedInterstitialAd) =
+        installInternal(ad.getResponseInfo().responseId, ad::setServerSideVerificationOptions)
+
+    fun handleRewardEarned(
+        ad: RewardedAd,
+        rewardVerificationStarted: (() -> Unit)?,
+        rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
+    ) = handleRewardEarnedInternal(
+        ad.getResponseInfo().responseId,
+        rewardVerificationStarted,
+        rewardVerificationCompleted,
+    )
+
+    fun handleRewardEarned(
+        ad: RewardedInterstitialAd,
+        rewardVerificationStarted: (() -> Unit)?,
+        rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
+    ) = handleRewardEarnedInternal(
+        ad.getResponseInfo().responseId,
+        rewardVerificationStarted,
+        rewardVerificationCompleted,
+    )
+
+    private fun installInternal(adResponseId: String?, attachOptions: (ServerSideVerificationOptions) -> Unit) {
+        val runtime = runtime
+        when {
+            !Purchases.isConfigured ->
+                Logger.e("Purchases is not configured. Call Purchases.configure() before enabling reward verification.")
+            adResponseId == null ->
+                Logger.e(
+                    "Reward verification requires a loaded ad with a responseId. " +
+                        "Call enableRewardVerification() after the ad has loaded.",
+                )
+            runtime == null ->
+                Logger.e(
+                    "Reward verification setup is not ready. " +
+                        "Try enabling reward verification after Purchases is configured.",
+                )
+            else -> {
+                val token = Purchases.sharedInstance.generateRewardVerificationToken(impressionId = adResponseId)
+                runtime.setClientTransactionId(
+                    adResponseId = adResponseId,
+                    clientTransactionId = token.clientTransactionId,
+                )
+                // Correlate the ad with the backend verification through AdMob's server-side verification options. The
+                // SSV callback forwards these to RevenueCat, which keys the verification by the client transaction id.
+                attachOptions(serverSideVerificationOptions(token))
+            }
+        }
+    }
+
+    private fun serverSideVerificationOptions(token: RewardVerificationToken): ServerSideVerificationOptions =
+        ServerSideVerificationOptions(
+            userId = token.appUserID,
+            customData = token.customData,
+        )
+
+    private fun handleRewardEarnedInternal(
+        adResponseId: String?,
+        rewardVerificationStarted: (() -> Unit)?,
+        rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
+    ) {
+        val runtime = runtime
+        if (runtime == null) {
+            // Not configured (or already closed): nothing to verify, so fail on the main thread.
+            runOnMainIfPresent(mainHandler) { rewardVerificationCompleted(RewardVerificationResult.failed) }
+            return
+        }
+        runtime.handleRewardEarned(
+            adResponseId = adResponseId,
+            rewardVerificationStarted = rewardVerificationStarted,
+            rewardVerificationCompleted = rewardVerificationCompleted,
+        )
+    }
+}

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManager.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManager.kt
@@ -56,18 +56,9 @@ internal object RewardVerificationManager {
     private fun installInternal(adResponseId: String?, attachOptions: (ServerSideVerificationOptions) -> Unit) {
         val runtime = runtime
         when {
-            !Purchases.isConfigured ->
-                Logger.e("Purchases is not configured. Call Purchases.configure() before enabling reward verification.")
-            adResponseId == null ->
-                Logger.e(
-                    "Reward verification requires a loaded ad with a responseId. " +
-                        "Call enableRewardVerification() after the ad has loaded.",
-                )
-            runtime == null ->
-                Logger.e(
-                    "Reward verification setup is not ready. " +
-                        "Try enabling reward verification after Purchases is configured.",
-                )
+            !Purchases.isConfigured -> Logger.e(RewardVerificationStrings.PURCHASES_NOT_CONFIGURED)
+            adResponseId == null -> Logger.e(RewardVerificationStrings.MISSING_AD_RESPONSE_ID)
+            runtime == null -> Logger.e(RewardVerificationStrings.RUNTIME_NOT_READY)
             else -> {
                 val token = Purchases.sharedInstance.generateRewardVerificationToken(impressionId = adResponseId)
                 runtime.setClientTransactionId(

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationService.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationService.kt
@@ -1,0 +1,33 @@
+package com.revenuecat.purchases.admob.nextgen.rewardverification
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesService
+
+/**
+ * [PurchasesService] that wires AdMob reward verification into the [Purchases] lifecycle. Discovered
+ * via [java.util.ServiceLoader], so it must keep a no-argument constructor.
+ *
+ * Owns the [RewardVerificationRuntime] for one configuration: it registers itself as the active service
+ * on [initialize] and, on [close], cancels the runtime and deregisters. All verification state lives on
+ * this instance, so it is discarded when the service is closed.
+ */
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+internal class RewardVerificationService : PurchasesService {
+    var runtime: RewardVerificationRuntime? = null
+        private set
+
+    override fun initialize(purchases: Purchases) {
+        runtime = RewardVerificationRuntime()
+        RewardVerificationManager.activeService = this
+    }
+
+    override fun close(purchases: Purchases) {
+        runtime?.close()
+        runtime = null
+        if (RewardVerificationManager.activeService === this) {
+            RewardVerificationManager.activeService = null
+        }
+    }
+}

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationStrings.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationStrings.kt
@@ -10,4 +10,14 @@ internal object RewardVerificationStrings {
     const val NOT_SET_UP_FOR_AD: String =
         "Reward verification is not set up for this ad. " +
             "Call enableRewardVerification() after loading the ad and before showing it."
+
+    const val PURCHASES_NOT_CONFIGURED: String =
+        "Purchases is not configured. Call Purchases.configure() before enabling reward verification."
+
+    const val MISSING_AD_RESPONSE_ID: String =
+        "Cannot enable reward verification because the loaded ad has no response ID."
+
+    const val RUNTIME_NOT_READY: String =
+        "Reward verification setup is not ready. " +
+            "Try enabling reward verification after Purchases is configured."
 }

--- a/feature/admob-next-gen/src/main/resources/META-INF/services/com.revenuecat.purchases.PurchasesService
+++ b/feature/admob-next-gen/src/main/resources/META-INF/services/com.revenuecat.purchases.PurchasesService
@@ -1,0 +1,1 @@
+com.revenuecat.purchases.admob.nextgen.rewardverification.RewardVerificationService

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManagerTest.kt
@@ -1,0 +1,200 @@
+@file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
+package com.revenuecat.purchases.admob.nextgen.rewardverification
+
+import android.os.Looper
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
+import com.google.android.libraries.ads.mobile.sdk.rewarded.ServerSideVerificationOptions
+import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesServiceDispatcher
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
+import com.revenuecat.purchases.ads.rewardverification.Outcome
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
+import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.Shadows.shadowOf
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+internal class RewardVerificationManagerTest {
+
+    private lateinit var originalServiceDispatcher: PurchasesServiceDispatcher
+
+    @Before
+    fun setUp() {
+        originalServiceDispatcher = Purchases.serviceDispatcher
+    }
+
+    @After
+    fun tearDown() {
+        // Close through the dispatcher so the per-configuration runtime is torn down for the next test.
+        Purchases.backingFieldSharedInstance?.let { configured ->
+            originalServiceDispatcher.close(configured)
+        }
+        Purchases.backingFieldSharedInstance = null
+        unmockkAll()
+    }
+
+    @Test
+    fun `verified result flows from install through reward earned to completed callback`() {
+        val token = RewardVerificationToken(
+            customData = "custom-data",
+            clientTransactionId = "client-transaction-id",
+            appUserID = "app-user-id",
+        )
+        val mockPurchases = mockk<Purchases>(relaxed = true)
+        every { mockPurchases.generateRewardVerificationToken("ad-response-id") } returns token
+        val polledClientTransactionId = slot<String>()
+        coEvery {
+            mockPurchases.pollRewardVerification(
+                capture(polledClientTransactionId),
+                null,
+                AdCaptureMethod.MANUAL,
+                any<suspend (String) -> Outcome>(),
+            )
+        } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 7))
+
+        // Configure Purchases and drive the dispatcher so the reward verification runtime is created.
+        Purchases.backingFieldSharedInstance = mockPurchases
+        originalServiceDispatcher.initialize(mockPurchases)
+
+        val ad = mockk<RewardedAd>(relaxed = true)
+        every { ad.getResponseInfo().responseId } returns "ad-response-id"
+        val ssvOptions = slot<ServerSideVerificationOptions>()
+        every { ad.setServerSideVerificationOptions(capture(ssvOptions)) } answers {}
+
+        RewardVerificationManager.install(ad)
+
+        // install() must attach the token's custom data and user id so the backend can correlate.
+        assertTrue(ssvOptions.isCaptured)
+        assertEquals("app-user-id", ssvOptions.captured.userId)
+        assertEquals("custom-data", ssvOptions.captured.customData)
+
+        var completedResult: RewardVerificationResult? = null
+        val completed = CountDownLatch(1)
+        RewardVerificationManager.handleRewardEarned(
+            ad = ad,
+            rewardVerificationStarted = null,
+            rewardVerificationCompleted = { result ->
+                completedResult = result
+                completed.countDown()
+            },
+        )
+
+        val delivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(delivered)
+        assertNotNull(completedResult)
+        assertFalse(completedResult!!.failed)
+        assertEquals(
+            VerifiedReward.VirtualCurrency(code = "gems", amount = 7),
+            completedResult!!.verifiedReward,
+        )
+        // The id polled from the backend must match the token's client transaction id so correlation round-trips.
+        assertEquals("client-transaction-id", polledClientTransactionId.captured)
+    }
+
+    @Test
+    fun `interstitial verified result flows from install through reward earned with custom data correlation`() {
+        val token = RewardVerificationToken(
+            customData = "custom-data",
+            clientTransactionId = "client-transaction-id",
+            appUserID = "app-user-id",
+        )
+        val mockPurchases = mockk<Purchases>(relaxed = true)
+        every { mockPurchases.generateRewardVerificationToken("interstitial-response-id") } returns token
+        val polledClientTransactionId = slot<String>()
+        coEvery {
+            mockPurchases.pollRewardVerification(
+                capture(polledClientTransactionId),
+                null,
+                AdCaptureMethod.MANUAL,
+                any<suspend (String) -> Outcome>(),
+            )
+        } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 3))
+
+        Purchases.backingFieldSharedInstance = mockPurchases
+        originalServiceDispatcher.initialize(mockPurchases)
+
+        val ad = mockk<RewardedInterstitialAd>(relaxed = true)
+        every { ad.getResponseInfo().responseId } returns "interstitial-response-id"
+        val ssvOptions = slot<ServerSideVerificationOptions>()
+        every { ad.setServerSideVerificationOptions(capture(ssvOptions)) } answers {}
+
+        RewardVerificationManager.install(ad)
+
+        assertTrue(ssvOptions.isCaptured)
+        assertEquals("app-user-id", ssvOptions.captured.userId)
+        assertEquals("custom-data", ssvOptions.captured.customData)
+
+        var completedResult: RewardVerificationResult? = null
+        val completed = CountDownLatch(1)
+        RewardVerificationManager.handleRewardEarned(
+            ad = ad,
+            rewardVerificationStarted = null,
+            rewardVerificationCompleted = { result ->
+                completedResult = result
+                completed.countDown()
+            },
+        )
+
+        val delivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(delivered)
+        assertNotNull(completedResult)
+        assertFalse(completedResult!!.failed)
+        assertEquals("client-transaction-id", polledClientTransactionId.captured)
+    }
+
+    @Test
+    fun `install before Purchases is configured does not store transaction id and reward earned fails safely`() {
+        // Intentionally skip backingFieldSharedInstance and dispatcher.initialize().
+        val ad = mockk<RewardedAd>(relaxed = true)
+
+        RewardVerificationManager.install(ad)
+
+        // Without a stored client transaction id there is nothing to correlate, so no SSV data is attached.
+        verify(exactly = 0) { ad.setServerSideVerificationOptions(any()) }
+
+        var startedCount = 0
+        var completedResult: RewardVerificationResult? = null
+        RewardVerificationManager.handleRewardEarned(
+            ad = ad,
+            rewardVerificationStarted = { startedCount++ },
+            rewardVerificationCompleted = { completedResult = it },
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(0, startedCount)
+        assertNotNull(completedResult)
+        assertTrue(completedResult!!.failed)
+    }
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManagerTest.kt
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowLog
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -172,6 +173,36 @@ internal class RewardVerificationManagerTest {
         assertNotNull(completedResult)
         assertFalse(completedResult!!.failed)
         assertEquals("client-transaction-id", polledClientTransactionId.captured)
+    }
+
+    @Test
+    fun `install with configured Purchases and missing ad response id does not attach options`() {
+        val mockPurchases = mockk<Purchases>(relaxed = true)
+        Purchases.backingFieldSharedInstance = mockPurchases
+        originalServiceDispatcher.initialize(mockPurchases)
+
+        val ad = mockk<RewardedAd>(relaxed = true)
+        every { ad.getResponseInfo().responseId } returns null
+
+        RewardVerificationManager.install(ad)
+
+        verify(exactly = 0) { ad.setServerSideVerificationOptions(any()) }
+        assertTrue(ShadowLog.getLogs().any { it.msg == RewardVerificationStrings.MISSING_AD_RESPONSE_ID })
+    }
+
+    @Test
+    fun `install with configured Purchases and unavailable runtime does not attach options`() {
+        val mockPurchases = mockk<Purchases>(relaxed = true)
+        Purchases.backingFieldSharedInstance = mockPurchases
+        // Intentionally skip dispatcher.initialize() so there is no runtime for this configuration.
+
+        val ad = mockk<RewardedAd>(relaxed = true)
+        every { ad.getResponseInfo().responseId } returns "ad-response-id"
+
+        RewardVerificationManager.install(ad)
+
+        verify(exactly = 0) { ad.setServerSideVerificationOptions(any()) }
+        assertTrue(ShadowLog.getLogs().any { it.msg == RewardVerificationStrings.RUNTIME_NOT_READY })
     }
 
     @Test

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationServiceTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationServiceTest.kt
@@ -1,0 +1,25 @@
+package com.revenuecat.purchases.admob.nextgen.rewardverification
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesService
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.ServiceLoader
+
+@OptIn(InternalRevenueCatAPI::class)
+internal class RewardVerificationServiceTest {
+
+    /**
+     * Guards the META-INF/services descriptor against the class being moved or renamed: ServiceLoader must
+     * still discover and instantiate [RewardVerificationService] as a [PurchasesService].
+     */
+    @Test
+    fun `is discoverable as a PurchasesService via ServiceLoader`() {
+        val services = ServiceLoader.load(
+            PurchasesService::class.java,
+            RewardVerificationService::class.java.classLoader,
+        ).toList()
+
+        assertTrue(services.any { it is RewardVerificationService })
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
The reward verification runtime needs to connect to loaded AdMob ads and the active `Purchases` lifecycle.
This is the second reward verification layer and is stacked on the runtime PR.

### Description
Adds the internal manager that generates verification tokens, configures AdMob SSV options, and dispatches earned rewards, plus a ServiceLoader-backed `PurchasesService` that owns and clears runtime state.
Manager and service tests cover rewarded and rewarded-interstitial correlation, unconfigured fail-safe behavior, lifecycle cleanup, and service discovery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect rewarded-ad verification and Purchases lifecycle wiring; incorrect SSV or correlation could block or mis-validate grants, though fail-safe paths and tests limit exposure.
> 
> **Overview**
> Introduces the **AdMob next-gen reward verification bridge** that ties loaded rewarded ads to the active `Purchases` configuration and backend verification.
> 
> **`RewardVerificationManager`** exposes `install` and `handleRewardEarned` for `RewardedAd` and `RewardedInterstitialAd`. On install it validates configuration, generates a reward verification token from `Purchases`, stores the client transaction id on the runtime, and sets AdMob **server-side verification** options (`userId` / `customData`) keyed by the ad response id. On reward earned it delegates to the runtime or **fails safely on the main thread** when no runtime is active. Misconfiguration paths log new setup errors via an added **`Logger.e(message)`** overload.
> 
> **`RewardVerificationService`** is registered through **`META-INF/services`** as a `PurchasesService`: it creates and owns **`RewardVerificationRuntime`** on `initialize`, sets itself as the manager’s active service, and tears down on `close`. **Consumer ProGuard rules** keep the service class for `ServiceLoader` reflection.
> 
> Unit tests cover end-to-end correlation for rewarded and rewarded-interstitial ads, missing response id / runtime / unconfigured Purchases behavior, and ServiceLoader discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f396901a6e1e5a630278e5753af5e390a8e53a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->