### PR TITLE
Validate checkpoint identifiers

### DIFF
--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointResultAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointResultAPI.kt
@@ -45,5 +45,7 @@ private class CheckpointResultAPI {
             CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE
         val disabled: CheckpointResult.NoAction.Reason = CheckpointResult.NoAction.Reason.DISABLED
         val unknownCheckpoint: CheckpointResult.NoAction.Reason = CheckpointResult.NoAction.Reason.UNKNOWN_CHECKPOINT
+        val invalidCheckpointIdentifier: CheckpointResult.NoAction.Reason =
+            CheckpointResult.NoAction.Reason.INVALID_CHECKPOINT_IDENTIFIER
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidator.kt
@@ -1,0 +1,24 @@
+package com.revenuecat.purchases.ui.revenuecatui.checkpoints
+
+internal object CheckpointIdentifierValidator {
+
+    const val MAX_LENGTH = 255
+
+    fun isValid(identifier: String): Boolean {
+        if (identifier.length !in 1..MAX_LENGTH || !identifier.first().isAsciiLetter()) {
+            return false
+        }
+
+        return identifier.drop(1).all { it.isAllowedCharacter() }
+    }
+
+    fun invalidIdentifierLogMessage(identifier: String): String =
+        "Dropping invalid checkpoint identifier '$identifier'. Identifiers must start with a letter, " +
+            "contain only ASCII letters, numbers, underscores, and hyphens, and be no more than " +
+            "$MAX_LENGTH characters."
+
+    private fun Char.isAllowedCharacter(): Boolean =
+        isAsciiLetter() || this in '0'..'9' || this == '_' || this == '-'
+
+    private fun Char.isAsciiLetter(): Boolean = this in 'a'..'z' || this in 'A'..'Z'
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidator.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.checkpoints
 internal object CheckpointIdentifierValidator {
 
     fun isValid(identifier: String): Boolean {
-        if (identifier.firstOrNull()?.isAsciiLetter() != true) {
+        if (identifier.length > MAX_IDENTIFIER_LENGTH || identifier.firstOrNull()?.isAsciiLetter() != true) {
             return false
         }
 
@@ -12,10 +12,13 @@ internal object CheckpointIdentifierValidator {
 
     fun invalidIdentifierLogMessage(identifier: String): String =
         "Dropping invalid checkpoint identifier '$identifier'. Identifiers must start with a letter, " +
-            "and contain only ASCII letters, numbers, underscores, and hyphens."
+            "contain only ASCII letters, numbers, underscores, and hyphens, and be no more than " +
+            "$MAX_IDENTIFIER_LENGTH characters."
 
     private fun Char.isAllowedCharacter(): Boolean =
         isAsciiLetter() || this in '0'..'9' || this == '_' || this == '-'
 
     private fun Char.isAsciiLetter(): Boolean = this in 'a'..'z' || this in 'A'..'Z'
+
+    private const val MAX_IDENTIFIER_LENGTH = 255
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidator.kt
@@ -2,10 +2,8 @@ package com.revenuecat.purchases.ui.revenuecatui.checkpoints
 
 internal object CheckpointIdentifierValidator {
 
-    const val MAX_LENGTH = 255
-
     fun isValid(identifier: String): Boolean {
-        if (identifier.length !in 1..MAX_LENGTH || !identifier.first().isAsciiLetter()) {
+        if (identifier.firstOrNull()?.isAsciiLetter() != true) {
             return false
         }
 
@@ -14,8 +12,7 @@ internal object CheckpointIdentifierValidator {
 
     fun invalidIdentifierLogMessage(identifier: String): String =
         "Dropping invalid checkpoint identifier '$identifier'. Identifiers must start with a letter, " +
-            "contain only ASCII letters, numbers, underscores, and hyphens, and be no more than " +
-            "$MAX_LENGTH characters."
+            "and contain only ASCII letters, numbers, underscores, and hyphens."
 
     private fun Char.isAllowedCharacter(): Boolean =
         isAsciiLetter() || this in '0'..'9' || this == '_' || this == '-'

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointResult.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointResult.kt
@@ -58,6 +58,10 @@ public abstract class CheckpointResult internal constructor() {
 
                 @JvmField
                 public val UNKNOWN_CHECKPOINT: Reason = Reason("UNKNOWN_CHECKPOINT")
+
+                /** The checkpoint identifier is invalid. */
+                @JvmField
+                public val INVALID_CHECKPOINT_IDENTIFIER: Reason = Reason("INVALID_CHECKPOINT_IDENTIFIER")
             }
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsExtensions.kt
@@ -9,7 +9,9 @@ import com.revenuecat.purchases.PurchasesException
  * Registers that [checkpointIdentifier] was hit. Depending on the configured targeting rules, this may
  * auto-present an experience (the call resolves when it finishes) or do nothing.
  *
- * @param checkpointIdentifier The checkpoint identifier, as configured in the RevenueCat dashboard.
+ * @param checkpointIdentifier The checkpoint identifier, as configured in the RevenueCat dashboard. It must start
+ * with an ASCII letter, contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 255
+ * characters.
  * @param params Optional per-call parameters, like custom properties usable in targeting rules.
  * @throws [PurchasesException] with a [PurchasesError] if the checkpoint could not be handled.
  * @return The [CheckpointResult] for this checkpoint.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsExtensions.kt
@@ -10,7 +10,8 @@ import com.revenuecat.purchases.PurchasesException
  * auto-present an experience (the call resolves when it finishes) or do nothing.
  *
  * @param checkpointIdentifier The checkpoint identifier, as configured in the RevenueCat dashboard. It must start
- * with an ASCII letter and contain only ASCII letters, numbers, underscores, and hyphens.
+ * with an ASCII letter, contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 255
+ * characters.
  * @param params Optional per-call parameters, like custom properties usable in targeting rules.
  * @throws [PurchasesException] with a [PurchasesError] if the checkpoint could not be handled.
  * @return The [CheckpointResult] for this checkpoint.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsExtensions.kt
@@ -10,8 +10,7 @@ import com.revenuecat.purchases.PurchasesException
  * auto-present an experience (the call resolves when it finishes) or do nothing.
  *
  * @param checkpointIdentifier The checkpoint identifier, as configured in the RevenueCat dashboard. It must start
- * with an ASCII letter, contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 255
- * characters.
+ * with an ASCII letter and contain only ASCII letters, numbers, underscores, and hyphens.
  * @param params Optional per-call parameters, like custom properties usable in targeting rules.
  * @throws [PurchasesException] with a [PurchasesError] if the checkpoint could not be handled.
  * @return The [CheckpointResult] for this checkpoint.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
@@ -71,15 +71,17 @@ internal class CheckpointsManager {
         params: CheckpointParams?,
     ): CheckpointResult = withContext(Dispatchers.Main) {
         val checkpoint = CheckpointInfo(identifier, params ?: CheckpointParams())
+        checkpointListener?.onCheckpointHit(checkpoint)
         if (!CheckpointIdentifierValidator.isValid(identifier)) {
             Logger.e(CheckpointIdentifierValidator.invalidIdentifierLogMessage(identifier))
-            return@withContext CheckpointResult.NoAction(
+            val result = CheckpointResult.NoAction(
                 checkpoint,
                 CheckpointResult.NoAction.Reason.INVALID_CHECKPOINT_IDENTIFIER,
             )
+            checkpointListener?.onCheckpointCompleted(checkpoint, result)
+            return@withContext result
         }
 
-        checkpointListener?.onCheckpointHit(checkpoint)
         val resolution = purchases.resolveCheckpoint(
             identifier,
             checkpoint.params.customVariables.mapValues { (_, value) -> value.asRulesDimensionValue },

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
@@ -71,6 +71,14 @@ internal class CheckpointsManager {
         params: CheckpointParams?,
     ): CheckpointResult = withContext(Dispatchers.Main) {
         val checkpoint = CheckpointInfo(identifier, params ?: CheckpointParams())
+        if (!CheckpointIdentifierValidator.isValid(identifier)) {
+            Logger.e(CheckpointIdentifierValidator.invalidIdentifierLogMessage(identifier))
+            return@withContext CheckpointResult.NoAction(
+                checkpoint,
+                CheckpointResult.NoAction.Reason.INVALID_CHECKPOINT_IDENTIFIER,
+            )
+        }
+
         checkpointListener?.onCheckpointHit(checkpoint)
         val resolution = purchases.resolveCheckpoint(
             identifier,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidatorTest.kt
@@ -1,0 +1,50 @@
+package com.revenuecat.purchases.ui.revenuecatui.checkpoints
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class CheckpointIdentifierValidatorTest {
+
+    @Test
+    fun `valid checkpoint identifiers pass validation`() {
+        val validIdentifiers = listOf(
+            "a",
+            "Z",
+            "checkout",
+            "checkout_123",
+            "checkout-complete",
+            "A-1_b",
+            "a" + "1".repeat(CheckpointIdentifierValidator.MAX_LENGTH - 1),
+        )
+
+        validIdentifiers.forEach { identifier ->
+            assertThat(CheckpointIdentifierValidator.isValid(identifier))
+                .describedAs("Expected '%s' to be valid", identifier)
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun `invalid checkpoint identifiers fail validation`() {
+        val invalidIdentifiers = listOf(
+            "",
+            "1checkout",
+            "_checkout",
+            "-checkout",
+            "check out",
+            " checkout",
+            "checkout ",
+            "checkout\n",
+            "check.out",
+            "chéckout",
+            "checkout😀",
+            "a" + "1".repeat(CheckpointIdentifierValidator.MAX_LENGTH),
+        )
+
+        invalidIdentifiers.forEach { identifier ->
+            assertThat(CheckpointIdentifierValidator.isValid(identifier))
+                .describedAs("Expected '%s' to be invalid", identifier)
+                .isFalse()
+        }
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidatorTest.kt
@@ -24,10 +24,17 @@ class CheckpointIdentifierValidatorTest {
     }
 
     @Test
-    fun `checkpoint identifier longer than 255 characters passes local validation`() {
-        val identifier = "a" + "1".repeat(255)
+    fun `checkpoint identifier with 255 characters passes validation`() {
+        val identifier = "a" + "1".repeat(254)
 
         assertThat(CheckpointIdentifierValidator.isValid(identifier)).isTrue()
+    }
+
+    @Test
+    fun `checkpoint identifier longer than 255 characters fails validation`() {
+        val identifier = "a" + "1".repeat(255)
+
+        assertThat(CheckpointIdentifierValidator.isValid(identifier)).isFalse()
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointIdentifierValidatorTest.kt
@@ -14,7 +14,6 @@ class CheckpointIdentifierValidatorTest {
             "checkout_123",
             "checkout-complete",
             "A-1_b",
-            "a" + "1".repeat(CheckpointIdentifierValidator.MAX_LENGTH - 1),
         )
 
         validIdentifiers.forEach { identifier ->
@@ -22,6 +21,13 @@ class CheckpointIdentifierValidatorTest {
                 .describedAs("Expected '%s' to be valid", identifier)
                 .isTrue()
         }
+    }
+
+    @Test
+    fun `checkpoint identifier longer than 255 characters passes local validation`() {
+        val identifier = "a" + "1".repeat(255)
+
+        assertThat(CheckpointIdentifierValidator.isValid(identifier)).isTrue()
     }
 
     @Test
@@ -38,7 +44,6 @@ class CheckpointIdentifierValidatorTest {
             "check.out",
             "chéckout",
             "checkout😀",
-            "a" + "1".repeat(CheckpointIdentifierValidator.MAX_LENGTH),
         )
 
         invalidIdentifiers.forEach { identifier ->

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
@@ -14,13 +14,16 @@ import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.checkpoints.CheckpointResolution
 import com.revenuecat.purchases.common.localrules.RulesDimensionValue
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.unmockkObject
 import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.coroutines.Dispatchers
@@ -54,6 +57,8 @@ class CheckpointsManagerTest {
     @Before
     fun setup() {
         Dispatchers.setMain(dispatcher)
+        mockkObject(Logger)
+        every { Logger.e(any()) } just runs
         startedIntents.clear()
         mockActivity = mockk(relaxed = true)
         capturesStartedIntents()
@@ -67,7 +72,40 @@ class CheckpointsManagerTest {
 
     @After
     fun tearDown() {
+        unmockkObject(Logger)
         Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `valid checkpoint identifier reaches listener and resolution`() = runTest(dispatcher) {
+        resolvesTo(CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.NO_MATCH))
+
+        manager.checkpoint(mockPurchases, "A-1_b", null)
+
+        coVerify(exactly = 1) { mockPurchases.resolveCheckpoint("A-1_b", emptyMap()) }
+        verify(exactly = 1) { mockListener.onCheckpointHit(match { it.identifier == "A-1_b" }) }
+        verify(exactly = 1) {
+            mockListener.onCheckpointCompleted(
+                match { it.identifier == "A-1_b" },
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `invalid checkpoint identifier is logged and dropped before listener or resolution`() = runTest(dispatcher) {
+        val invalidIdentifier = " checkout😀"
+
+        val result = manager.checkpoint(mockPurchases, invalidIdentifier, null) as CheckpointResult.NoAction
+
+        assertThat(result.reason).isEqualTo(CheckpointResult.NoAction.Reason.INVALID_CHECKPOINT_IDENTIFIER)
+        assertThat(result.checkpoint.identifier).isEqualTo(invalidIdentifier)
+        coVerify(exactly = 0) { mockPurchases.resolveCheckpoint(any(), any()) }
+        verify(exactly = 0) { mockListener.onCheckpointHit(any()) }
+        verify(exactly = 0) { mockListener.onCheckpointCompleted(any(), any()) }
+        verify(exactly = 1) {
+            Logger.e(CheckpointIdentifierValidator.invalidIdentifierLogMessage(invalidIdentifier))
+        }
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
@@ -93,7 +93,7 @@ class CheckpointsManagerTest {
     }
 
     @Test
-    fun `invalid checkpoint identifier is logged and dropped before listener or resolution`() = runTest(dispatcher) {
+    fun `invalid checkpoint identifier is logged and reported to listener without resolution`() = runTest(dispatcher) {
         val invalidIdentifier = " checkout😀"
 
         val result = manager.checkpoint(mockPurchases, invalidIdentifier, null) as CheckpointResult.NoAction
@@ -101,8 +101,10 @@ class CheckpointsManagerTest {
         assertThat(result.reason).isEqualTo(CheckpointResult.NoAction.Reason.INVALID_CHECKPOINT_IDENTIFIER)
         assertThat(result.checkpoint.identifier).isEqualTo(invalidIdentifier)
         coVerify(exactly = 0) { mockPurchases.resolveCheckpoint(any(), any()) }
-        verify(exactly = 0) { mockListener.onCheckpointHit(any()) }
-        verify(exactly = 0) { mockListener.onCheckpointCompleted(any(), any()) }
+        verifyOrder {
+            mockListener.onCheckpointHit(result.checkpoint)
+            mockListener.onCheckpointCompleted(result.checkpoint, result)
+        }
         verify(exactly = 1) {
             Logger.e(CheckpointIdentifierValidator.invalidIdentifierLogMessage(invalidIdentifier))
         }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
Invalid checkpoint identifiers should return a local no-action result instead of reaching resolution. [WFL-478](https://linear.app/revenuecat/issue/WFL-478/android-validate-checkpoint-identifiers)

https://github.com/RevenueCat/purchases-ios/pull/7441

Validate checkpoint identifier characters, then log and return `INVALID_CHECKPOINT_IDENTIFIER` before resolution or UI work. Length validation is left to the backend. Tested with the checkpoint unit tests, `detektAll`, API tester compilation, and `scripts/api-check.sh`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b4db5419ca9f6e6fa63bf517f37407a3f53b3309. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->