### PR TITLE
fix(admob): publish next-gen tracking state across threads

### DIFF
--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingAdEventCallback.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingAdEventCallback.kt
@@ -25,12 +25,17 @@ internal enum class AdDisplayedTrigger {
  * [responseInfoProvider] is read at event time rather than captured up front, so that
  * formats whose response info changes over the callback's lifetime (auto-refreshing
  * banners) report the currently displayed creative instead of the first-loaded one.
+ *
+ * [delegate] and [placement] are `@Volatile` because the app replaces them from whatever
+ * thread it calls a tracking setter, a `show` extension or `pollAd` on, while the SDK reads
+ * them on the background thread it invokes ad event callbacks from. Without it the callback
+ * thread has no guarantee it ever observes those writes.
  */
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal abstract class TrackingAdEventCallback<CallbackT : AdEventCallback>(
-    internal var delegate: CallbackT?,
+    @Volatile internal var delegate: CallbackT?,
     private val adFormat: AdFormat,
-    internal var placement: String?,
+    @Volatile internal var placement: String?,
     private val adUnitId: String,
     private val responseInfoProvider: () -> ResponseInfo,
     private val adDisplayedTrigger: AdDisplayedTrigger,

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingBannerAdRefreshCallback.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingBannerAdRefreshCallback.kt
@@ -21,10 +21,14 @@ import com.revenuecat.purchases.ads.events.types.AdFormat
  * [placement] stays immutable, unlike [TrackingAdEventCallback.placement]. A show-time
  * placement override only exists for the full-screen formats, which have no refresh
  * callback, so a banner reports the one placement it was loaded with.
+ *
+ * [delegate] is `@Volatile` because the app replaces it from whatever thread it calls
+ * `setTrackingBannerAdRefreshCallback` on, while the SDK reads it on the background thread
+ * it invokes refresh callbacks from.
  */
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal class TrackingBannerAdRefreshCallback(
-    internal var delegate: BannerAdRefreshCallback?,
+    @Volatile internal var delegate: BannerAdRefreshCallback?,
     private val placement: String?,
     private val adUnitId: String,
     private val responseInfoProvider: () -> ResponseInfo,


### PR DESCRIPTION
### Motivation

Google Mobile Ads Next-Gen invokes ad event and refresh callbacks on a background thread. The mutable state on the tracking wrappers is written from a different thread: the app calls `setTrackingAdEventCallback`, a `show(activity, placement)` extension, or `pollAd` from wherever it happens to be, usually the main thread.

Those fields were plain (non-`@Volatile`), so the Java Memory Model gives the callback thread no guarantee it ever observes the writes. Two consequences:

- A show-time `placement` override can be missed, so the displayed / clicked / paid events it was set for are attributed to the load-time placement instead. Silent analytics corruption with nothing to alert on.
- A swapped `delegate` can be missed, so the SDK keeps invoking the app's previous callback.

Preloading widened this: tracking is now installed at `pollAd` time via `installTrackingEventCallback`, not only at load time, so more threads write these fields.

### Description

Marks the three mutable wrapper fields `@Volatile`:

- `TrackingAdEventCallback.delegate` and `.placement`
- `TrackingBannerAdRefreshCallback.delegate`

These are single reference assignments with no read-modify-write, so `@Volatile` is sufficient — `AtomicReference` would add an allocation per wrapper for a CAS nobody needs, and a lock would risk being held across an app callback. KDoc on both classes records the reasoning so the annotations don't read as cargo cult.

`@Volatile` is already the idiom in this codebase (~40 usages, including `@Volatile` on a primary-constructor property in `InMemoryCachedObject`, and `RewardVerificationManager.activeService` in the legacy `feature/admob`). These wrappers were the outlier.

Note this is visibility only, not atomicity across fields: `onAdPaid` reads `placement` and `responseInfoProvider()` separately, so a `show(placement = X)` racing an in-flight event could still mix values. In practice the app sets the placement before calling `show()` and events arrive after, so the ordering holds.

### Validation

- `./gradlew :feature:admob-next-gen:testDefaultsDebugUnitTest`
- `./gradlew detektAll`
- `./scripts/api-check.sh` — no public API change; all three fields are `internal`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal-only visibility fix on tracking wrappers; no public API or behavioral change beyond correct cross-thread reads of delegate and placement.
> 
> **Overview**
> **Fixes cross-thread visibility** for mutable state on the AdMob next-gen tracking wrappers. Google’s SDK fires ad event and banner refresh callbacks on a background thread, while the app updates the same wrapper fields from `setTrackingAdEventCallback`, show-time placement overrides, `pollAd`, and `setTrackingBannerAdRefreshCallback`—often on the main thread. Without publication, those writes were not guaranteed visible to the callback thread.
> 
> Marks **`TrackingAdEventCallback.delegate`** and **`placement`**, and **`TrackingBannerAdRefreshCallback.delegate`**, as `@Volatile`. KDoc on both classes explains the app-thread vs SDK-thread pattern. Single reference assignments only—no CAS or locks.
> 
> This addresses silent analytics mis-attribution (missed show-time placement) and stale delegate invocation after callback swaps; preloading via `pollAd` increased how often those fields are written off the callback thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a44d9d1e878d184d8863a9672c1844e753824d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->