### PR TITLE
refactor(admob): centralize next-gen log messages and placement override

### DIFF
--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/AdMobNextGenStrings.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/AdMobNextGenStrings.kt
@@ -1,0 +1,17 @@
+package com.revenuecat.purchases.admob.nextgen
+
+internal object AdMobNextGenStrings {
+
+    // Configuration
+    const val PURCHASES_NOT_CONFIGURED: String =
+        "Purchases is not configured. " +
+            "Call Purchases.configure() before loading ads to enable RevenueCat ad tracking."
+
+    // Tracking
+    const val TRACKING_FAILED: String = "Failed to track a RevenueCat ad event."
+
+    // Placement
+    const val PLACEMENT_OVERRIDE_IGNORED: String =
+        "Placement override ignored: this ad was not loaded via a loadAndTrack function, " +
+            "or its adEventCallback was reassigned directly."
+}

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/PlacementOverride.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/PlacementOverride.kt
@@ -1,0 +1,19 @@
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.google.android.libraries.ads.mobile.sdk.common.AdEventCallback
+import com.revenuecat.purchases.admob.nextgen.AdMobNextGenStrings
+import com.revenuecat.purchases.admob.nextgen.Logger
+
+/**
+ * Redirects the placement RevenueCat reports for this ad's display, click and revenue events.
+ *
+ * Passing `null` clears the placement recorded at load time rather than keeping it.
+ */
+internal fun AdEventCallback?.applyPlacementOverride(placement: String?) {
+    val trackingCallback = this as? TrackingAdEventCallback<*>
+    if (trackingCallback == null) {
+        Logger.w(AdMobNextGenStrings.PLACEMENT_OVERRIDE_IGNORED)
+        return
+    }
+    trackingCallback.placement = placement
+}

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackIfConfigured.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackIfConfigured.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.admob.nextgen.tracking
 
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.AdMobNextGenStrings
 import com.revenuecat.purchases.admob.nextgen.Logger
 
 /**
@@ -16,12 +17,9 @@ import com.revenuecat.purchases.admob.nextgen.Logger
  */
 internal inline fun trackIfConfigured(block: Purchases.() -> Unit) {
     if (!Purchases.isConfigured) {
-        Logger.w(
-            "Purchases is not configured. " +
-                "Call Purchases.configure() before loading ads to enable RevenueCat ad tracking.",
-        )
+        Logger.w(AdMobNextGenStrings.PURCHASES_NOT_CONFIGURED)
         return
     }
     runCatching { Purchases.sharedInstance.block() }
-        .onFailure { Logger.e("Failed to track a RevenueCat ad event.", it) }
+        .onFailure { Logger.e(AdMobNextGenStrings.TRACKING_FAILED, it) }
 }


### PR DESCRIPTION
### Motivation

Two related bits of drift in the next-gen module.

**Log messages were inline literals.** The rest of the SDK keeps them in a strings object — `purchases` has fifteen under `com.revenuecat.purchases.strings`, and `feature/galaxy` has `GalaxyStrings`. The two AdMob adapters are the exception, and legacy only half follows it: `RewardVerificationStrings` holds a single constant while six other call sites inline their text.

**The placement override is copy-pasted per format.** Every full-screen format resolves a show-time override the same way — cast `adEventCallback` to the tracking wrapper, assign `placement`, warn when the cast fails. There are six copies across five branches (`InterstitialAdExtensions.kt` #3985, `RewardedAdExtensions.kt` #4011, `RewardedInterstitialAdExtensions.kt` #4012, `AppOpenAdExtensions.kt` #4013, and two in `RewardVerificationExtensions.kt` #4017), and the warning text already differs between them.

Nothing pulls those copies back together. Because they live in **separate files**, git merges every one cleanly when those branches land here, and the divergent wording survives silently — there is no conflict to catch it.

Worth noting the legacy adapter already routes its four formats through a single `applyPlacementOverride`. Next-gen dropped that shape; this restores it rather than inventing something new, and keeps the same name.

### Description

Two commits:

1. **`AdMobNextGenStrings`** — holds the module's three log messages (the not-configured warning, the tracking-failure message, and the new placement-override warning). Existing `TrackIfConfigured` call sites route through it.
2. **`AdEventCallback?.applyPlacementOverride(placement)`** — holds the cast condition and the warning. All six call sites collapse to one line:
   ```kotlin
   adEventCallback.applyPlacementOverride(placement)
   ```

The receiver is the shared `AdEventCallback` supertype rather than each format's callback interface — every format callback (`RewardedAdEventCallback`, `InterstitialAdEventCallback`, `AppOpenAdEventCallback`, `RewardedInterstitialAdEventCallback`) extends it, and the per-format cast was never load-bearing: an ad's `adEventCallback` can only ever hold its own format's wrapper.

The KDoc also records that passing `null` clears the load-time placement, which was previously documented only per-format.

### Adoption

The helper is intentionally unused here — the extensions that call it live on the format branches, not on this base. Once this merges, each format PR swaps its inline block for the one-liner as it rebases. Verified that an unused `internal` function passes `detektAll` on this branch, so this lands green on its own.

`TrackIfConfigured.kt` is byte-identical across all ten format/preload/SSV branches, so moving its strings conflicts with none of them.

### Validation

- `./gradlew :feature:admob-next-gen:testDefaultsDebugUnitTest`
- `./gradlew detektAll`
- `./scripts/api-check.sh` — no public API change; both additions are `internal`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of logging and duplicated placement logic with no public API or runtime behavior change beyond unified warning text.
> 
> **Overview**
> Introduces **`AdMobNextGenStrings`** with three shared log messages (Purchases not configured, tracking failure, placement override ignored) and routes **`trackIfConfigured`** through them instead of inline literals.
> 
> Adds **`AdEventCallback?.applyPlacementOverride(placement)`** so show-time placement override logic (cast to `TrackingAdEventCallback`, assign placement, warn on failure) lives in one place, aligned with the legacy AdMob adapter. The helper is **`internal`** and not wired from format extension files on this branch; those branches are expected to replace duplicated blocks with a single call after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a56d2eed3fe4a52eb8c5b25550b75cd5550156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->