### PR TITLE
Track next-gen AdMob reward verification events

### DIFF
--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManager.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManager.kt
@@ -10,8 +10,11 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.Logger
 import com.revenuecat.purchases.admob.nextgen.threading.runOnMainIfPresent
+import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedAdEventCallback
+import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedInterstitialAdEventCallback
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 internal object RewardVerificationManager {
@@ -39,6 +42,7 @@ internal object RewardVerificationManager {
         rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
     ) = handleRewardEarnedInternal(
         ad.getResponseInfo().responseId,
+        ad.rewardTrackingMetadata(),
         rewardVerificationStarted,
         rewardVerificationCompleted,
     )
@@ -49,9 +53,17 @@ internal object RewardVerificationManager {
         rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
     ) = handleRewardEarnedInternal(
         ad.getResponseInfo().responseId,
+        ad.rewardTrackingMetadata(),
         rewardVerificationStarted,
         rewardVerificationCompleted,
     )
+
+    // Null when the ad wasn't loaded through RevenueCat's tracking APIs, because no tracking callback is installed.
+    private fun RewardedAd.rewardTrackingMetadata(): RewardedAdTrackingMetadata? =
+        (adEventCallback as? TrackingRewardedAdEventCallback)?.rewardTrackingMetadata()
+
+    private fun RewardedInterstitialAd.rewardTrackingMetadata(): RewardedAdTrackingMetadata? =
+        (adEventCallback as? TrackingRewardedInterstitialAdEventCallback)?.rewardTrackingMetadata()
 
     private fun installInternal(adResponseId: String?, attachOptions: (ServerSideVerificationOptions) -> Unit) {
         val runtime = runtime
@@ -80,6 +92,7 @@ internal object RewardVerificationManager {
 
     private fun handleRewardEarnedInternal(
         adResponseId: String?,
+        trackingMetadata: RewardedAdTrackingMetadata?,
         rewardVerificationStarted: (() -> Unit)?,
         rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
     ) {
@@ -91,6 +104,7 @@ internal object RewardVerificationManager {
         }
         runtime.handleRewardEarned(
             adResponseId = adResponseId,
+            trackingMetadata = trackingMetadata,
             rewardVerificationStarted = rewardVerificationStarted,
             rewardVerificationCompleted = rewardVerificationCompleted,
         )

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntime.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntime.kt
@@ -3,10 +3,13 @@ package com.revenuecat.purchases.admob.nextgen.rewardverification
 import android.os.Handler
 import android.os.Looper
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.Logger
 import com.revenuecat.purchases.admob.nextgen.threading.runOnMainIfPresent
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 import com.revenuecat.purchases.awaitPollRewardVerification
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -20,15 +23,20 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Holds the per-configuration reward verification state. A fresh instance is created when [Purchases] is
  * configured and discarded with [close] when it closes, so no verification state outlives a configuration.
  */
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 internal class RewardVerificationRuntime(
     private val mainHandler: Handler = Handler(Looper.getMainLooper()),
     createVerificationScope: () -> CoroutineScope = {
         CoroutineScope(SupervisorJob() + Dispatchers.IO)
     },
-    private val poll: suspend (String) -> RewardVerificationResult = { clientTransactionId ->
-        Purchases.sharedInstance.awaitPollRewardVerification(clientTransactionId)
-    },
+    private val poll: suspend (String, RewardedAdTrackingMetadata?) -> RewardVerificationResult =
+        { clientTransactionId, trackingMetadata ->
+            Purchases.sharedInstance.awaitPollRewardVerification(
+                clientTransactionId,
+                trackingMetadata,
+                AdCaptureMethod.ADAPTER,
+            )
+        },
 ) {
     private val clientTransactionIdByAdResponseId = mutableMapOf<String, String>()
     private val verificationScope: CoroutineScope = createVerificationScope()
@@ -40,6 +48,7 @@ internal class RewardVerificationRuntime(
 
     fun handleRewardEarned(
         adResponseId: String?,
+        trackingMetadata: RewardedAdTrackingMetadata?,
         rewardVerificationStarted: (() -> Unit)?,
         rewardVerificationCompleted: (RewardVerificationResult) -> Unit,
     ) {
@@ -63,7 +72,7 @@ internal class RewardVerificationRuntime(
         notifyStarted(rewardVerificationStarted)
 
         val verificationTask = verificationScope.launch {
-            val result = poll(clientTransactionId)
+            val result = poll(clientTransactionId, trackingMetadata)
             deliverOnce(result)
         }
 

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingAdEventCallback.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingAdEventCallback.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.events.types.AdOpenedData
 import com.revenuecat.purchases.ads.events.types.AdRevenueData
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 
 /** The single SDK callback that represents a displayed ad for a given format. */
 internal enum class AdDisplayedTrigger {
@@ -111,6 +112,24 @@ internal abstract class TrackingAdEventCallback<CallbackT : AdEventCallback>(
                 ),
             )
         }
+    }
+
+    /**
+     * Reward-verification metadata for the ad this callback is attached to.
+     *
+     * [placement] and response info are read at reward time so show-time placement overrides and the currently
+     * displayed creative are reflected in the reward events.
+     */
+    internal fun rewardTrackingMetadata(): RewardedAdTrackingMetadata {
+        val responseInfo = responseInfoProvider()
+        return RewardedAdTrackingMetadata(
+            networkName = responseInfo.adapterClassName,
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = adFormat,
+            placement = placement,
+            adUnitId = adUnitId,
+            impressionId = responseInfo.responseId.orEmpty(),
+        )
     }
 
     /**

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManagerTest.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesServiceDispatcher
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedAdEventCallback
+import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedInterstitialAdEventCallback
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdMediatorName
@@ -280,6 +281,69 @@ internal class RewardVerificationManagerTest {
 
         verify(exactly = 0) { ad.setServerSideVerificationOptions(any()) }
         assertTrue(ShadowLog.getLogs().any { it.msg == RewardVerificationStrings.RUNTIME_NOT_READY })
+    }
+
+    @Test
+    fun `tracked interstitial forwards reward metadata with its format and latest placement to the poll`() {
+        val token = RewardVerificationToken(
+            customData = "custom-data",
+            clientTransactionId = "client-transaction-id",
+            appUserID = "app-user-id",
+        )
+        val mockPurchases = mockk<Purchases>(relaxed = true)
+        every { mockPurchases.generateRewardVerificationToken("interstitial-response-id") } returns token
+        val polledTrackingMetadata = slot<RewardedAdTrackingMetadata?>()
+        coEvery {
+            mockPurchases.pollRewardVerification(
+                any(),
+                captureNullable(polledTrackingMetadata),
+                AdCaptureMethod.ADAPTER,
+                any<suspend (String) -> Outcome>(),
+            )
+        } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 3))
+
+        Purchases.backingFieldSharedInstance = mockPurchases
+        originalServiceDispatcher.initialize(mockPurchases)
+
+        val responseInfo = mockk<ResponseInfo>()
+        every { responseInfo.responseId } returns "interstitial-response-id"
+        every { responseInfo.adapterClassName } returns "com.example.InterstitialAdapter"
+        val trackingCallback = TrackingRewardedInterstitialAdEventCallback(
+            initialDelegate = null,
+            initialPlacement = "load-time-placement",
+            adUnitId = "interstitial-ad-unit-id",
+            responseInfoProvider = { responseInfo },
+        )
+        val ad = mockk<RewardedInterstitialAd>(relaxed = true)
+        every { ad.getResponseInfo() } returns responseInfo
+        every { ad.adEventCallback } returns trackingCallback
+
+        RewardVerificationManager.install(ad)
+        trackingCallback.placement = "show-time-placement"
+
+        val completed = CountDownLatch(1)
+        RewardVerificationManager.handleRewardEarned(
+            ad = ad,
+            rewardVerificationStarted = null,
+            rewardVerificationCompleted = { completed.countDown() },
+        )
+        val delivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(delivered)
+        assertEquals(
+            RewardedAdTrackingMetadata(
+                networkName = "com.example.InterstitialAdapter",
+                mediatorName = AdMediatorName.AD_MOB,
+                adFormat = AdFormat.REWARDED_INTERSTITIAL,
+                placement = "show-time-placement",
+                adUnitId = "interstitial-ad-unit-id",
+                impressionId = "interstitial-response-id",
+            ),
+            polledTrackingMetadata.captured,
+        )
     }
 
     @Test

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationManagerTest.kt
@@ -4,6 +4,7 @@
 package com.revenuecat.purchases.admob.nextgen.rewardverification
 
 import android.os.Looper
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
 import com.google.android.libraries.ads.mobile.sdk.rewarded.ServerSideVerificationOptions
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
@@ -11,10 +12,14 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesServiceDispatcher
+import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedAdEventCallback
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.rewardverification.Outcome
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import io.mockk.coEvery
 import io.mockk.every
@@ -26,6 +31,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -68,11 +74,13 @@ internal class RewardVerificationManagerTest {
         val mockPurchases = mockk<Purchases>(relaxed = true)
         every { mockPurchases.generateRewardVerificationToken("ad-response-id") } returns token
         val polledClientTransactionId = slot<String>()
+        val polledTrackingMetadata = slot<RewardedAdTrackingMetadata?>()
+        val polledCaptureMethod = slot<AdCaptureMethod>()
         coEvery {
             mockPurchases.pollRewardVerification(
                 capture(polledClientTransactionId),
-                null,
-                AdCaptureMethod.MANUAL,
+                captureNullable(polledTrackingMetadata),
+                capture(polledCaptureMethod),
                 any<suspend (String) -> Outcome>(),
             )
         } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 7))
@@ -118,6 +126,8 @@ internal class RewardVerificationManagerTest {
         )
         // The id polled from the backend must match the token's client transaction id so correlation round-trips.
         assertEquals("client-transaction-id", polledClientTransactionId.captured)
+        assertNull(polledTrackingMetadata.captured)
+        assertEquals(AdCaptureMethod.ADAPTER, polledCaptureMethod.captured)
     }
 
     @Test
@@ -130,11 +140,13 @@ internal class RewardVerificationManagerTest {
         val mockPurchases = mockk<Purchases>(relaxed = true)
         every { mockPurchases.generateRewardVerificationToken("interstitial-response-id") } returns token
         val polledClientTransactionId = slot<String>()
+        val polledTrackingMetadata = slot<RewardedAdTrackingMetadata?>()
+        val polledCaptureMethod = slot<AdCaptureMethod>()
         coEvery {
             mockPurchases.pollRewardVerification(
                 capture(polledClientTransactionId),
-                null,
-                AdCaptureMethod.MANUAL,
+                captureNullable(polledTrackingMetadata),
+                capture(polledCaptureMethod),
                 any<suspend (String) -> Outcome>(),
             )
         } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "coins", amount = 3))
@@ -173,6 +185,71 @@ internal class RewardVerificationManagerTest {
         assertNotNull(completedResult)
         assertFalse(completedResult!!.failed)
         assertEquals("client-transaction-id", polledClientTransactionId.captured)
+        assertNull(polledTrackingMetadata.captured)
+        assertEquals(AdCaptureMethod.ADAPTER, polledCaptureMethod.captured)
+    }
+
+    @Test
+    fun `tracked ad forwards reward metadata with the latest placement to the poll`() {
+        val token = RewardVerificationToken(
+            customData = "custom-data",
+            clientTransactionId = "client-transaction-id",
+            appUserID = "app-user-id",
+        )
+        val mockPurchases = mockk<Purchases>(relaxed = true)
+        every { mockPurchases.generateRewardVerificationToken("ad-response-id") } returns token
+        val polledTrackingMetadata = slot<RewardedAdTrackingMetadata?>()
+        coEvery {
+            mockPurchases.pollRewardVerification(
+                any(),
+                captureNullable(polledTrackingMetadata),
+                AdCaptureMethod.ADAPTER,
+                any<suspend (String) -> Outcome>(),
+            )
+        } returns RewardVerificationResult.verified(VerifiedReward.VirtualCurrency(code = "gems", amount = 7))
+
+        Purchases.backingFieldSharedInstance = mockPurchases
+        originalServiceDispatcher.initialize(mockPurchases)
+
+        val responseInfo = mockk<ResponseInfo>()
+        every { responseInfo.responseId } returns "ad-response-id"
+        every { responseInfo.adapterClassName } returns "com.example.SomeAdapter"
+        val trackingCallback = TrackingRewardedAdEventCallback(
+            initialDelegate = null,
+            initialPlacement = "load-time-placement",
+            adUnitId = "ad-unit-id",
+            responseInfoProvider = { responseInfo },
+        )
+        val ad = mockk<RewardedAd>(relaxed = true)
+        every { ad.getResponseInfo() } returns responseInfo
+        every { ad.adEventCallback } returns trackingCallback
+
+        RewardVerificationManager.install(ad)
+        trackingCallback.placement = "show-time-placement"
+
+        val completed = CountDownLatch(1)
+        RewardVerificationManager.handleRewardEarned(
+            ad = ad,
+            rewardVerificationStarted = null,
+            rewardVerificationCompleted = { completed.countDown() },
+        )
+        val delivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(delivered)
+        assertEquals(
+            RewardedAdTrackingMetadata(
+                networkName = "com.example.SomeAdapter",
+                mediatorName = AdMediatorName.AD_MOB,
+                adFormat = AdFormat.REWARDED,
+                placement = "show-time-placement",
+                adUnitId = "ad-unit-id",
+                impressionId = "ad-response-id",
+            ),
+            polledTrackingMetadata.captured,
+        )
     }
 
     @Test

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntimeTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/rewardverification/RewardVerificationRuntimeTest.kt
@@ -4,7 +4,10 @@ import android.os.Handler
 import android.os.Looper
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,6 +18,7 @@ import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -37,7 +41,7 @@ internal class RewardVerificationRuntimeTest {
             createVerificationScope = {
                 CoroutineScope(SupervisorJob() + Dispatchers.Default)
             },
-            poll = {
+            poll = { _, _ ->
                 pollStarted.countDown()
                 awaitCancellation()
             },
@@ -51,6 +55,7 @@ internal class RewardVerificationRuntimeTest {
 
         runtime.handleRewardEarned(
             adResponseId = adResponseId,
+            trackingMetadata = null,
             rewardVerificationStarted = { started = true },
             rewardVerificationCompleted = {
                 completedResult = it
@@ -80,7 +85,7 @@ internal class RewardVerificationRuntimeTest {
             createVerificationScope = {
                 CoroutineScope(SupervisorJob() + Dispatchers.Default)
             },
-            poll = { RewardVerificationResult.verified(verifiedReward) },
+            poll = { _, _ -> RewardVerificationResult.verified(verifiedReward) },
         )
         val adResponseId = "ad-response-id"
         var startedThread: Thread? = null
@@ -92,6 +97,7 @@ internal class RewardVerificationRuntimeTest {
 
         runtime.handleRewardEarned(
             adResponseId = adResponseId,
+            trackingMetadata = null,
             rewardVerificationStarted = { startedThread = Thread.currentThread() },
             rewardVerificationCompleted = {
                 completedThread = Thread.currentThread()
@@ -119,7 +125,7 @@ internal class RewardVerificationRuntimeTest {
             createVerificationScope = {
                 CoroutineScope(SupervisorJob() + Dispatchers.Default)
             },
-            poll = { error("poll should not run when ad response id is missing") },
+            poll = { _, _ -> error("poll should not run when ad response id is missing") },
         )
         var startedCount = 0
         var completedResult: RewardVerificationResult? = null
@@ -127,6 +133,7 @@ internal class RewardVerificationRuntimeTest {
 
         runtime.handleRewardEarned(
             adResponseId = null,
+            trackingMetadata = null,
             rewardVerificationStarted = { startedCount++ },
             rewardVerificationCompleted = {
                 completedResult = it
@@ -152,7 +159,7 @@ internal class RewardVerificationRuntimeTest {
             createVerificationScope = {
                 CoroutineScope(SupervisorJob() + Dispatchers.Default)
             },
-            poll = { error("poll should not run when no client transaction id is registered") },
+            poll = { _, _ -> error("poll should not run when no client transaction id is registered") },
         )
         val adResponseId = "ad-response-id"
         var startedCount = 0
@@ -163,6 +170,7 @@ internal class RewardVerificationRuntimeTest {
 
         runtime.handleRewardEarned(
             adResponseId = adResponseId,
+            trackingMetadata = null,
             rewardVerificationStarted = { startedCount++ },
             rewardVerificationCompleted = {
                 completedResult = it
@@ -179,5 +187,86 @@ internal class RewardVerificationRuntimeTest {
         assertNotNull(completedResult)
         assertTrue(completedResult!!.failed)
         assertTrue(ShadowLog.getLogs().any { it.msg == RewardVerificationStrings.NOT_SET_UP_FOR_AD })
+    }
+
+    @Test
+    fun `handleRewardEarned forwards tracking metadata to poll`() {
+        val trackingMetadata = RewardedAdTrackingMetadata(
+            networkName = "Google AdMob",
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = AdFormat.REWARDED,
+            placement = "rewarded_video",
+            adUnitId = "ad-unit-999",
+            impressionId = "impression-789",
+        )
+        var receivedTrackingMetadata: RewardedAdTrackingMetadata? = null
+        val runtime = RewardVerificationRuntime(
+            mainHandler = Handler(Looper.getMainLooper()),
+            createVerificationScope = {
+                CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            },
+            poll = { _, metadata ->
+                receivedTrackingMetadata = metadata
+                RewardVerificationResult.failed
+            },
+        )
+        val adResponseId = "ad-response-id"
+        val completed = CountDownLatch(1)
+
+        runtime.setClientTransactionId(adResponseId, "client-transaction-id")
+
+        runtime.handleRewardEarned(
+            adResponseId = adResponseId,
+            trackingMetadata = trackingMetadata,
+            rewardVerificationStarted = null,
+            rewardVerificationCompleted = { completed.countDown() },
+        )
+        val completionDelivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(completionDelivered)
+        assertSame(trackingMetadata, receivedTrackingMetadata)
+    }
+
+    @Test
+    fun `handleRewardEarned forwards null tracking metadata when the ad was not tracked`() {
+        var receivedTrackingMetadata: RewardedAdTrackingMetadata? = RewardedAdTrackingMetadata(
+            networkName = null,
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = AdFormat.REWARDED,
+            placement = null,
+            adUnitId = "sentinel",
+            impressionId = "sentinel",
+        )
+        val runtime = RewardVerificationRuntime(
+            mainHandler = Handler(Looper.getMainLooper()),
+            createVerificationScope = {
+                CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            },
+            poll = { _, metadata ->
+                receivedTrackingMetadata = metadata
+                RewardVerificationResult.failed
+            },
+        )
+        val adResponseId = "ad-response-id"
+        val completed = CountDownLatch(1)
+
+        runtime.setClientTransactionId(adResponseId, "client-transaction-id")
+
+        runtime.handleRewardEarned(
+            adResponseId = adResponseId,
+            trackingMetadata = null,
+            rewardVerificationStarted = null,
+            rewardVerificationCompleted = { completed.countDown() },
+        )
+        val completionDelivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(completionDelivered)
+        assertNull(receivedTrackingMetadata)
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Core emits reward-verification events only when an adapter supplies tracking metadata, while the next-generation AdMob adapter currently polls without it.

### Description
Passes ad metadata from RevenueCat tracking callbacks into reward-verification polling with `AdCaptureMethod.ADAPTER`, preserving the latest placement while leaving untracked ads unchanged.
Tests cover tracked and untracked metadata handoff, adapter capture attribution, and runtime forwarding; validated with the full next-gen unit-test suite, `detektAll`, and `scripts/api-check.sh`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the reward-verification poll path and when analytics events fire, but verification outcomes stay the same and untracked ads are unchanged.
> 
> **Overview**
> Next-gen AdMob **reward verification polling** now supplies **`RewardedAdTrackingMetadata`** when the ad was loaded through RevenueCat’s tracking APIs, so core can emit reward-verification analytics the same way it does when adapters provide metadata.
> 
> On reward earned, **`RewardVerificationManager`** reads metadata from the installed **`TrackingRewardedAdEventCallback`** / **`TrackingRewardedInterstitialAdEventCallback`** (null for untracked ads). **`RewardVerificationRuntime`** forwards that metadata into **`awaitPollRewardVerification`** with **`AdCaptureMethod.ADAPTER`** instead of polling without metadata / manual capture. **`TrackingAdEventCallback.rewardTrackingMetadata()`** builds the payload at reward time (current placement and response info).
> 
> Tests assert untracked ads still pass null metadata, adapter capture method, and show-time placement for rewarded and rewarded-interstitial formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de00254580e3461da81109efc36022d7eac4bfd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->