### PR TITLE
Rename `session_id` to `app_session_id` in checkpoint events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -242,8 +242,8 @@ internal sealed class BackendEvent : Event {
         val identifier: String,
         @SerialName("app_user_id")
         val appUserID: String,
-        @SerialName("session_id")
-        val sessionID: String,
+        @SerialName("app_session_id")
+        val appSessionID: String,
         val timestamp: Long,
     ) : BackendEvent()
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -98,7 +98,7 @@ internal fun BackendStoredEvent.toBackendEvent(): BackendEvent {
 @JvmSynthetic
 internal fun CheckpointEvent.toBackendStoredEvent(
     appUserID: String,
-    sessionID: String,
+    appSessionID: String,
 ): BackendStoredEvent.Checkpoint = BackendStoredEvent.Checkpoint(
     BackendEvent.Checkpoint(
         id = id.toString(),
@@ -106,7 +106,7 @@ internal fun CheckpointEvent.toBackendStoredEvent(
         type = BackendEvent.CHECKPOINT_EVENT_TYPE,
         identifier = identifier,
         appUserID = appUserID,
-        sessionID = sessionID,
+        appSessionID = appSessionID,
         timestamp = timestamp.time,
     ),
 )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/CheckpointEventsRequestSerializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/CheckpointEventsRequestSerializationTest.kt
@@ -20,7 +20,7 @@ class CheckpointEventsRequestSerializationTest {
                 type = BackendEvent.CHECKPOINT_EVENT_TYPE,
                 identifier = "onboarding_complete",
                 appUserID = "app_user_id",
-                sessionID = "315107f4-98bf-4b68-a582-eb27bcb6e111",
+                appSessionID = "315107f4-98bf-4b68-a582-eb27bcb6e111",
                 timestamp = 1699270688995,
             ),
         ),
@@ -40,7 +40,7 @@ class CheckpointEventsRequestSerializationTest {
                         "\"type\":\"checkpoint_hit\"," +
                         "\"identifier\":\"onboarding_complete\"," +
                         "\"app_user_id\":\"app_user_id\"," +
-                        "\"session_id\":\"315107f4-98bf-4b68-a582-eb27bcb6e111\"," +
+                        "\"app_session_id\":\"315107f4-98bf-4b68-a582-eb27bcb6e111\"," +
                         "\"timestamp\":1699270688995" +
                     "}" +
                 "]" +

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/EventsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/EventsManagerTest.kt
@@ -188,7 +188,7 @@ class EventsManagerTest {
         eventsManager.track(checkpointEvent)
 
         checkFileContents(
-            """{"type":"checkpoint","event":{"id":"498207f4-87af-4b57-a581-eb27bcc6e009","version":1,"type":"checkpoint_hit","identifier":"onboarding_complete","app_user_id":"testAppUserId","session_id":"$appSessionID","timestamp":1699270688995}}""" +
+            """{"type":"checkpoint","event":{"id":"498207f4-87af-4b57-a581-eb27bcc6e009","version":1,"type":"checkpoint_hit","identifier":"onboarding_complete","app_user_id":"testAppUserId","app_session_id":"$appSessionID","timestamp":1699270688995}}""" +
                 "\n",
         )
     }


### PR DESCRIPTION
Equivalent iOS https://github.com/RevenueCat/purchases-ios/pull/7459
Khepri PR https://github.com/RevenueCat/khepri/pull/24141

Rename `session_id` to `app_session_id` in checkpoint events


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the wire schema for checkpoint events; backend and Khepri must accept `app_session_id` before or with this SDK release to avoid dropped or mis-parsed checkpoint data.
> 
> **Overview**
> Renames the checkpoint backend event field from **`session_id`** to **`app_session_id`** on `BackendEvent.Checkpoint`, with the Kotlin property **`sessionID`** → **`appSessionID`**.
> 
> The **`CheckpointEvent.toBackendStoredEvent`** mapper takes **`appSessionID`** instead of **`sessionID`**, so serialized checkpoint payloads and persisted event lines use the new key. Tests for khepri-compatible JSON and **`EventsManager`** checkpoint file output were updated accordingly.
> 
> Paywall events still use **`session_id`**; only checkpoint events change in this PR (aligned with iOS and Khepri).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c7e31d426fe04594832eb38b7cb07a4781a9ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->