### PR TITLE
feat(admob): demonstrate rewarded interstitial ads

### DIFF
--- a/examples/admob-next-gen-sample/README.md
+++ b/examples/admob-next-gen-sample/README.md
@@ -1,12 +1,14 @@
 # AdMob Next-Gen sample
 
-This app demonstrates RevenueCat ad-event tracking with the Google Mobile Ads Next-Gen SDK.
+This app demonstrates RevenueCat ad-event tracking with the Google Mobile Ads Next-Gen SDK. See the
+[adapter README](../../feature/admob-next-gen/README.md) for installation instructions and complete API examples.
 
 ## Run locally
 
 1. Add `REVENUECAT_API_KEY=...` to the root `local.properties` file. That file is ignored by Git.
-2. Sync Gradle in Android Studio.
-3. Select the `admob-next-gen-sample` run configuration and wait until the home screen reports that Google Mobile Ads is ready.
+2. Connect a device or emulator running Android 7.0 (API level 24) or newer.
+3. Sync Gradle in Android Studio.
+4. Select the `admob-next-gen-sample` run configuration and wait until the home screen reports that Google Mobile Ads is ready.
 
 The app uses Google's test app and ad-unit IDs by default. You can override any of these in the root `local.properties` file without changing tracked source:
 
@@ -20,6 +22,34 @@ ADMOB_NATIVE_VIDEO_AD_UNIT_ID=...
 ADMOB_REWARDED_AD_UNIT_ID=...
 ADMOB_REWARDED_INTERSTITIAL_AD_UNIT_ID=...
 ```
+
+## Exercise the sample
+
+Each format has **Direct** and **Preloaded** modes. Start with a direct load. Then select **Preloaded**, choose a
+buffer size, select **Start**, wait until **Ads available** is greater than zero, and select **Poll + Show**. Stop a
+preloader before changing options that form part of its configuration.
+
+Use the format-specific controls to exercise behavior that is not shared by every ad type:
+
+- **Banner:** confirm the returned ad is registered with the existing `AdView` and continues reporting refreshes.
+- **Interstitial and app open:** compare the load, preload, poll, and show placement names in the resulting events.
+- **Rewarded and rewarded interstitial:** try both ordinary Google rewards and RevenueCat reward verification. The
+  verification choice is captured when an ad is loaded or polled, so change it before that step.
+- **Native:** try standard and video test ad units, then enable **Batch Flow** to collect more than one result.
+- **Diagnostics:** trigger both direct and preloaded failures with the intentionally invalid ad unit.
+
+Google's native and native-video test inventory can be inconsistent. A failed test request does not necessarily mean
+the renderer or tracking integration is broken; use your own test-enabled ad unit when you need reliable native fills.
+
+## Verify RevenueCat events
+
+After exercising a flow, background the app so the RevenueCat SDK flushes queued events. Check the RevenueCat
+dashboard for loaded, displayed, opened, revenue, and failed-to-load events with the placement shown by the sample.
+Google test ads do not always emit paid events, so absence of an ad-revenue event alone is not a tracking failure.
+
+Google Mobile Ads Next-Gen can invoke callbacks on a background thread. The sample re-enters its Compose-owned
+coroutine scope before changing UI or reward state. Preserve that main-thread boundary when adapting callback-based
+examples to UI code.
 
 ## Coverage
 

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
@@ -23,9 +23,12 @@ import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
 import com.google.android.libraries.ads.mobile.sdk.rewarded.OnUserEarnedRewardListener
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdPreloader
+import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
+import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAdPreloader
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.enableRewardVerification
 import com.revenuecat.purchases.admob.nextgen.loadAndTrackRewardedAd
+import com.revenuecat.purchases.admob.nextgen.loadAndTrackRewardedInterstitialAd
 import com.revenuecat.purchases.admob.nextgen.pollAndTrackAd
 import com.revenuecat.purchases.admob.nextgen.show
 import com.revenuecat.purchases.admob.nextgen.startAndTrack
@@ -34,6 +37,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 private const val REWARDED_PRELOAD_ID = "sample-rewarded"
+private const val REWARDED_INTERSTITIAL_PRELOAD_ID = "sample-rewarded-interstitial"
 
 @Composable
 internal fun RewardedScreen(activity: Activity, onBack: () -> Unit) {
@@ -155,6 +159,136 @@ private fun showRewarded(
                 scope.launch {
                     updateStatus("Reward earned: ${reward.amount} ${reward.type}")
                 }
+            },
+        )
+    }
+}
+
+@Composable
+internal fun RewardedInterstitialScreen(activity: Activity, onBack: () -> Unit) {
+    var directStatus by remember { mutableStateOf("No direct rewarded-interstitial ad loaded") }
+    var useVerification by remember { mutableStateOf(false) }
+    var directLoadedWithVerification by remember { mutableStateOf(false) }
+    var directAd by remember { mutableStateOf<RewardedInterstitialAd?>(null) }
+    val preloadState = rememberPreloaderUiState(
+        REWARDED_INTERSTITIAL_PRELOAD_ID,
+        getConfiguration = {
+            RewardedInterstitialAdPreloader.getConfiguration(REWARDED_INTERSTITIAL_PRELOAD_ID)
+        },
+        getNumAdsAvailable = {
+            RewardedInterstitialAdPreloader.getNumAdsAvailable(REWARDED_INTERSTITIAL_PRELOAD_ID)
+        },
+    )
+    val scope = rememberCoroutineScope()
+
+    AdScreen("Rewarded interstitial", onBack) { mode ->
+        RewardVerificationToggle(useVerification) { useVerification = it }
+        Text("Both direct and preloaded ads can opt into RevenueCat reward verification.")
+        if (mode == LoadMode.DIRECT) {
+            StatusCard(directStatus)
+            ActionRow(
+                "Load" to {
+                    scope.launch {
+                        val verify = useVerification
+                        directStatus = "Loading directly..."
+                        when (
+                            val result = Purchases.sharedInstance.adTracker.loadAndTrackRewardedInterstitialAd(
+                                AdRequest.Builder(BuildConfig.ADMOB_REWARDED_INTERSTITIAL_AD_UNIT_ID).build(),
+                                placement = "rewarded_interstitial_load",
+                            )
+                        ) {
+                            is AdLoadResult.Success -> {
+                                directAd = result.ad.also { if (verify) it.enableRewardVerification() }
+                                directLoadedWithVerification = verify
+                                directStatus = readyStatus(verify)
+                            }
+                            is AdLoadResult.Failure -> directStatus = "Load failed: ${result.error.message}"
+                        }
+                    }
+                },
+                "Show" to {
+                    val loadedAd = directAd
+                    if (loadedAd == null) {
+                        directStatus = "Load a rewarded-interstitial ad first"
+                    } else {
+                        showRewardedInterstitial(loadedAd, activity, directLoadedWithVerification) {
+                            directStatus = it
+                        }
+                        directAd = null
+                    }
+                },
+                enabled = mapOf("Show" to (directAd != null)),
+            )
+        } else {
+            PreloaderPanel(
+                state = preloadState,
+                actions = listOf(
+                    PreloaderAction(
+                        label = "Poll + Show",
+                        enabled = preloadState.started && preloadState.adsAvailable > 0,
+                        onClick = {
+                            val verify = useVerification
+                            val ad = RewardedInterstitialAdPreloader.pollAndTrackAd(
+                                REWARDED_INTERSTITIAL_PRELOAD_ID,
+                                placement = "rewarded_interstitial_poll",
+                            )?.also { if (verify) it.enableRewardVerification() }
+                            preloadState.refresh()
+                            if (ad == null) {
+                                preloadState.message = "No buffered rewarded-interstitial ad available"
+                            } else {
+                                preloadState.message = "Showing rewarded-interstitial ad"
+                                showRewardedInterstitial(ad, activity, verify) {
+                                    preloadState.message = it
+                                }
+                            }
+                        },
+                    ),
+                ),
+                onToggle = {
+                    if (preloadState.started) {
+                        preloadState.updateAfterStop(
+                            RewardedInterstitialAdPreloader.destroy(REWARDED_INTERSTITIAL_PRELOAD_ID),
+                        )
+                    } else {
+                        preloadState.updateAfterStart(
+                            RewardedInterstitialAdPreloader.startAndTrack(
+                                REWARDED_INTERSTITIAL_PRELOAD_ID,
+                                PreloadConfiguration(
+                                    AdRequest.Builder(BuildConfig.ADMOB_REWARDED_INTERSTITIAL_AD_UNIT_ID).build(),
+                                    preloadState.bufferSize,
+                                ),
+                                placement = "rewarded_interstitial_preload",
+                                preloadCallback = preloadState.preloadCallback(scope),
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+    }
+}
+
+private fun showRewardedInterstitial(
+    ad: RewardedInterstitialAd,
+    activity: Activity,
+    verify: Boolean,
+    updateStatus: (String) -> Unit,
+) {
+    if (verify) {
+        ad.show(
+            activity,
+            placement = "rewarded_interstitial_show",
+            rewardVerificationStarted = { updateStatus("Verifying reward...") },
+            rewardVerificationCompleted = { result ->
+                updateStatus("Verification complete: ${result.verifiedReward ?: "failed"}")
+            },
+        )
+    } else {
+        ad.show(
+            activity,
+            placement = "rewarded_interstitial_show",
+            onUserEarnedRewardListener = OnUserEarnedRewardListener { reward ->
+                updateStatus("Reward earned: ${reward.amount} ${reward.type}")
             },
         )
     }

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
@@ -211,7 +211,7 @@ internal fun RewardedInterstitialScreen(activity: Activity, onBack: () -> Unit) 
                     if (loadedAd == null) {
                         directStatus = "Load a rewarded-interstitial ad first"
                     } else {
-                        showRewardedInterstitial(loadedAd, activity, directLoadedWithVerification) {
+                        showRewardedInterstitial(loadedAd, activity, directLoadedWithVerification, scope) {
                             directStatus = it
                         }
                         directAd = null
@@ -237,7 +237,7 @@ internal fun RewardedInterstitialScreen(activity: Activity, onBack: () -> Unit) 
                                 preloadState.message = "No buffered rewarded-interstitial ad available"
                             } else {
                                 preloadState.message = "Showing rewarded-interstitial ad"
-                                showRewardedInterstitial(ad, activity, verify) {
+                                showRewardedInterstitial(ad, activity, verify, scope) {
                                     preloadState.message = it
                                 }
                             }
@@ -272,6 +272,7 @@ private fun showRewardedInterstitial(
     ad: RewardedInterstitialAd,
     activity: Activity,
     verify: Boolean,
+    scope: CoroutineScope,
     updateStatus: (String) -> Unit,
 ) {
     if (verify) {
@@ -288,7 +289,9 @@ private fun showRewardedInterstitial(
             activity,
             placement = "rewarded_interstitial_show",
             onUserEarnedRewardListener = OnUserEarnedRewardListener { reward ->
-                updateStatus("Reward earned: ${reward.amount} ${reward.type}")
+                scope.launch {
+                    updateStatus("Reward earned: ${reward.amount} ${reward.type}")
+                }
             },
         )
     }

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.revenuecat.sample.admob.nextgen.ui
 
 import android.app.Activity
@@ -17,8 +15,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.google.android.libraries.ads.mobile.sdk.common.Ad
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
 import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
 import com.google.android.libraries.ads.mobile.sdk.rewarded.OnUserEarnedRewardListener
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
@@ -32,6 +32,7 @@ import com.revenuecat.purchases.admob.nextgen.loadAndTrackRewardedInterstitialAd
 import com.revenuecat.purchases.admob.nextgen.pollAndTrackAd
 import com.revenuecat.purchases.admob.nextgen.show
 import com.revenuecat.purchases.admob.nextgen.startAndTrack
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.sample.admob.nextgen.BuildConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -40,150 +41,151 @@ private const val REWARDED_PRELOAD_ID = "sample-rewarded"
 private const val REWARDED_INTERSTITIAL_PRELOAD_ID = "sample-rewarded-interstitial"
 
 @Composable
-internal fun RewardedScreen(activity: Activity, onBack: () -> Unit) {
-    var directStatus by remember { mutableStateOf("No direct rewarded ad loaded") }
-    var useVerification by remember { mutableStateOf(false) }
-    var directLoadedWithVerification by remember { mutableStateOf(false) }
-    var directAd by remember { mutableStateOf<RewardedAd?>(null) }
-    val preloadState = rememberPreloaderUiState(
-        REWARDED_PRELOAD_ID,
-        getConfiguration = { RewardedAdPreloader.getConfiguration(REWARDED_PRELOAD_ID) },
-        getNumAdsAvailable = { RewardedAdPreloader.getNumAdsAvailable(REWARDED_PRELOAD_ID) },
-    )
-    val scope = rememberCoroutineScope()
-
-    AdScreen("Rewarded", onBack) { mode ->
-        RewardVerificationToggle(useVerification) { useVerification = it }
-        Text("The verification choice is captured when an ad is loaded or polled.")
-        if (mode == LoadMode.DIRECT) {
-            StatusCard(directStatus)
-            ActionRow(
-                "Load" to {
-                    scope.launch {
-                        val verify = useVerification
-                        directStatus = "Loading directly..."
-                        when (
-                            val result = Purchases.sharedInstance.adTracker.loadAndTrackRewardedAd(
-                                AdRequest.Builder(BuildConfig.ADMOB_REWARDED_AD_UNIT_ID).build(),
-                                placement = "rewarded_load",
-                            )
-                        ) {
-                            is AdLoadResult.Success -> {
-                                directAd = result.ad.also { if (verify) it.enableRewardVerification() }
-                                directLoadedWithVerification = verify
-                                directStatus = readyStatus(verify)
-                            }
-                            is AdLoadResult.Failure -> directStatus = "Load failed: ${result.error.message}"
-                        }
-                    }
-                },
-                "Show" to {
-                    val loadedAd = directAd
-                    if (loadedAd == null) {
-                        directStatus = "Load a rewarded ad first"
-                    } else {
-                        showRewarded(loadedAd, activity, directLoadedWithVerification, scope) {
-                            directStatus = it
-                        }
-                        directAd = null
-                    }
-                },
-                enabled = mapOf("Show" to (directAd != null)),
-            )
-        } else {
-            PreloaderPanel(
-                state = preloadState,
-                actions = listOf(
-                    PreloaderAction(
-                        label = "Poll + Show",
-                        enabled = preloadState.started && preloadState.adsAvailable > 0,
-                        onClick = {
-                            val verify = useVerification
-                            val ad = RewardedAdPreloader.pollAndTrackAd(
-                                REWARDED_PRELOAD_ID,
-                                placement = "rewarded_poll",
-                            )?.also { if (verify) it.enableRewardVerification() }
-                            preloadState.refresh()
-                            if (ad == null) {
-                                preloadState.message = "No buffered rewarded ad available"
-                            } else {
-                                preloadState.message = "Showing rewarded ad"
-                                showRewarded(ad, activity, verify, scope) { preloadState.message = it }
-                            }
-                        },
-                    ),
-                ),
-                onToggle = {
-                    if (preloadState.started) {
-                        preloadState.updateAfterStop(RewardedAdPreloader.destroy(REWARDED_PRELOAD_ID))
-                    } else {
-                        preloadState.updateAfterStart(
-                            RewardedAdPreloader.startAndTrack(
-                                REWARDED_PRELOAD_ID,
-                                PreloadConfiguration(
-                                    AdRequest.Builder(BuildConfig.ADMOB_REWARDED_AD_UNIT_ID).build(),
-                                    preloadState.bufferSize,
-                                ),
-                                placement = "rewarded_preload",
-                                preloadCallback = preloadState.preloadCallback(scope),
-                            ),
-                        )
-                    }
-                },
-            )
-        }
-    }
-}
-
-private fun showRewarded(
-    ad: RewardedAd,
-    activity: Activity,
-    verify: Boolean,
-    scope: CoroutineScope,
-    updateStatus: (String) -> Unit,
-) {
-    if (verify) {
-        ad.show(
-            activity,
-            placement = "rewarded_show",
-            rewardVerificationStarted = { updateStatus("Verifying reward...") },
-            rewardVerificationCompleted = { result ->
-                updateStatus("Verification complete: ${result.verifiedReward ?: "failed"}")
-            },
+internal fun RewardedScreen(activity: Activity, onBack: () -> Unit) = RewardedAdScreen(
+    title = "Rewarded",
+    description = "The verification choice is captured when an ad is loaded or polled.",
+    adName = "rewarded ad",
+    preloadId = REWARDED_PRELOAD_ID,
+    onBack = onBack,
+    getConfiguration = { RewardedAdPreloader.getConfiguration(REWARDED_PRELOAD_ID) },
+    getNumAdsAvailable = { RewardedAdPreloader.getNumAdsAvailable(REWARDED_PRELOAD_ID) },
+    loadAd = {
+        Purchases.sharedInstance.adTracker.loadAndTrackRewardedAd(
+            AdRequest.Builder(BuildConfig.ADMOB_REWARDED_AD_UNIT_ID).build(),
+            placement = "rewarded_load",
         )
-    } else {
-        ad.show(
-            activity,
-            placement = "rewarded_show",
-            onUserEarnedRewardListener = OnUserEarnedRewardListener { reward ->
-                scope.launch {
-                    updateStatus("Reward earned: ${reward.amount} ${reward.type}")
-                }
-            },
+    },
+    pollAd = {
+        RewardedAdPreloader.pollAndTrackAd(
+            REWARDED_PRELOAD_ID,
+            placement = "rewarded_poll",
         )
-    }
-}
+    },
+    startPreloader = { bufferSize, callback ->
+        RewardedAdPreloader.startAndTrack(
+            REWARDED_PRELOAD_ID,
+            PreloadConfiguration(
+                AdRequest.Builder(BuildConfig.ADMOB_REWARDED_AD_UNIT_ID).build(),
+                bufferSize,
+            ),
+            placement = "rewarded_preload",
+            preloadCallback = callback,
+        )
+    },
+    stopPreloader = { RewardedAdPreloader.destroy(REWARDED_PRELOAD_ID) },
+    showActions = RewardedShowActions<RewardedAd>(
+        enableVerification = { ad -> ad.enableRewardVerification() },
+        showVerifiedAd = { ad, onVerificationStarted, onVerificationCompleted ->
+            ad.show(
+                activity,
+                placement = "rewarded_show",
+                rewardVerificationStarted = onVerificationStarted,
+                rewardVerificationCompleted = onVerificationCompleted,
+            )
+        },
+        showUnverifiedAd = { ad, listener ->
+            ad.show(
+                activity,
+                placement = "rewarded_show",
+                onUserEarnedRewardListener = listener,
+            )
+        },
+    ),
+)
 
 @Composable
-internal fun RewardedInterstitialScreen(activity: Activity, onBack: () -> Unit) {
-    var directStatus by remember { mutableStateOf("No direct rewarded-interstitial ad loaded") }
+internal fun RewardedInterstitialScreen(activity: Activity, onBack: () -> Unit) = RewardedAdScreen(
+    title = "Rewarded interstitial",
+    description = "Both direct and preloaded ads can opt into RevenueCat reward verification.",
+    adName = "rewarded-interstitial ad",
+    preloadId = REWARDED_INTERSTITIAL_PRELOAD_ID,
+    onBack = onBack,
+    getConfiguration = {
+        RewardedInterstitialAdPreloader.getConfiguration(REWARDED_INTERSTITIAL_PRELOAD_ID)
+    },
+    getNumAdsAvailable = {
+        RewardedInterstitialAdPreloader.getNumAdsAvailable(REWARDED_INTERSTITIAL_PRELOAD_ID)
+    },
+    loadAd = {
+        Purchases.sharedInstance.adTracker.loadAndTrackRewardedInterstitialAd(
+            AdRequest.Builder(BuildConfig.ADMOB_REWARDED_INTERSTITIAL_AD_UNIT_ID).build(),
+            placement = "rewarded_interstitial_load",
+        )
+    },
+    pollAd = {
+        RewardedInterstitialAdPreloader.pollAndTrackAd(
+            REWARDED_INTERSTITIAL_PRELOAD_ID,
+            placement = "rewarded_interstitial_poll",
+        )
+    },
+    startPreloader = { bufferSize, callback ->
+        RewardedInterstitialAdPreloader.startAndTrack(
+            REWARDED_INTERSTITIAL_PRELOAD_ID,
+            PreloadConfiguration(
+                AdRequest.Builder(BuildConfig.ADMOB_REWARDED_INTERSTITIAL_AD_UNIT_ID).build(),
+                bufferSize,
+            ),
+            placement = "rewarded_interstitial_preload",
+            preloadCallback = callback,
+        )
+    },
+    stopPreloader = { RewardedInterstitialAdPreloader.destroy(REWARDED_INTERSTITIAL_PRELOAD_ID) },
+    showActions = RewardedShowActions<RewardedInterstitialAd>(
+        enableVerification = { ad -> ad.enableRewardVerification() },
+        showVerifiedAd = { ad, onVerificationStarted, onVerificationCompleted ->
+            ad.show(
+                activity,
+                placement = "rewarded_interstitial_show",
+                rewardVerificationStarted = onVerificationStarted,
+                rewardVerificationCompleted = onVerificationCompleted,
+            )
+        },
+        showUnverifiedAd = { ad, listener ->
+            ad.show(
+                activity,
+                placement = "rewarded_interstitial_show",
+                onUserEarnedRewardListener = listener,
+            )
+        },
+    ),
+)
+
+private data class RewardedShowActions<AdT : Ad>(
+    val enableVerification: (AdT) -> Unit,
+    val showVerifiedAd: (AdT, () -> Unit, (RewardVerificationResult) -> Unit) -> Unit,
+    val showUnverifiedAd: (AdT, OnUserEarnedRewardListener) -> Unit,
+)
+
+@Composable
+@Suppress("LongMethod", "LongParameterList")
+private fun <AdT : Ad> RewardedAdScreen(
+    title: String,
+    description: String,
+    adName: String,
+    preloadId: String,
+    onBack: () -> Unit,
+    getConfiguration: () -> PreloadConfiguration?,
+    getNumAdsAvailable: () -> Int,
+    loadAd: suspend () -> AdLoadResult<AdT>,
+    pollAd: () -> AdT?,
+    startPreloader: (Int, PreloadCallback) -> Boolean,
+    stopPreloader: () -> Boolean,
+    showActions: RewardedShowActions<AdT>,
+) {
+    var directStatus by remember { mutableStateOf("No direct $adName loaded") }
     var useVerification by remember { mutableStateOf(false) }
     var directLoadedWithVerification by remember { mutableStateOf(false) }
-    var directAd by remember { mutableStateOf<RewardedInterstitialAd?>(null) }
+    var directAd by remember { mutableStateOf<AdT?>(null) }
     val preloadState = rememberPreloaderUiState(
-        REWARDED_INTERSTITIAL_PRELOAD_ID,
-        getConfiguration = {
-            RewardedInterstitialAdPreloader.getConfiguration(REWARDED_INTERSTITIAL_PRELOAD_ID)
-        },
-        getNumAdsAvailable = {
-            RewardedInterstitialAdPreloader.getNumAdsAvailable(REWARDED_INTERSTITIAL_PRELOAD_ID)
-        },
+        preloadId,
+        getConfiguration = getConfiguration,
+        getNumAdsAvailable = getNumAdsAvailable,
     )
     val scope = rememberCoroutineScope()
 
-    AdScreen("Rewarded interstitial", onBack) { mode ->
+    AdScreen(title, onBack) { mode ->
         RewardVerificationToggle(useVerification) { useVerification = it }
-        Text("Both direct and preloaded ads can opt into RevenueCat reward verification.")
+        Text(description)
         if (mode == LoadMode.DIRECT) {
             StatusCard(directStatus)
             ActionRow(
@@ -191,14 +193,9 @@ internal fun RewardedInterstitialScreen(activity: Activity, onBack: () -> Unit) 
                     scope.launch {
                         val verify = useVerification
                         directStatus = "Loading directly..."
-                        when (
-                            val result = Purchases.sharedInstance.adTracker.loadAndTrackRewardedInterstitialAd(
-                                AdRequest.Builder(BuildConfig.ADMOB_REWARDED_INTERSTITIAL_AD_UNIT_ID).build(),
-                                placement = "rewarded_interstitial_load",
-                            )
-                        ) {
+                        when (val result = loadAd()) {
                             is AdLoadResult.Success -> {
-                                directAd = result.ad.also { if (verify) it.enableRewardVerification() }
+                                directAd = result.ad.also { if (verify) showActions.enableVerification(it) }
                                 directLoadedWithVerification = verify
                                 directStatus = readyStatus(verify)
                             }
@@ -209,11 +206,15 @@ internal fun RewardedInterstitialScreen(activity: Activity, onBack: () -> Unit) 
                 "Show" to {
                     val loadedAd = directAd
                     if (loadedAd == null) {
-                        directStatus = "Load a rewarded-interstitial ad first"
+                        directStatus = "Load a $adName first"
                     } else {
-                        showRewardedInterstitial(loadedAd, activity, directLoadedWithVerification, scope) {
-                            directStatus = it
-                        }
+                        showRewardedAd(
+                            ad = loadedAd,
+                            verify = directLoadedWithVerification,
+                            scope = scope,
+                            showActions = showActions,
+                            updateStatus = { directStatus = it },
+                        )
                         directAd = null
                     }
                 },
@@ -228,38 +229,29 @@ internal fun RewardedInterstitialScreen(activity: Activity, onBack: () -> Unit) 
                         enabled = preloadState.started && preloadState.adsAvailable > 0,
                         onClick = {
                             val verify = useVerification
-                            val ad = RewardedInterstitialAdPreloader.pollAndTrackAd(
-                                REWARDED_INTERSTITIAL_PRELOAD_ID,
-                                placement = "rewarded_interstitial_poll",
-                            )?.also { if (verify) it.enableRewardVerification() }
+                            val ad = pollAd()?.also { if (verify) showActions.enableVerification(it) }
                             preloadState.refresh()
                             if (ad == null) {
-                                preloadState.message = "No buffered rewarded-interstitial ad available"
+                                preloadState.message = "No buffered $adName available"
                             } else {
-                                preloadState.message = "Showing rewarded-interstitial ad"
-                                showRewardedInterstitial(ad, activity, verify, scope) {
-                                    preloadState.message = it
-                                }
+                                preloadState.message = "Showing $adName"
+                                showRewardedAd(
+                                    ad = ad,
+                                    verify = verify,
+                                    scope = scope,
+                                    showActions = showActions,
+                                    updateStatus = { preloadState.message = it },
+                                )
                             }
                         },
                     ),
                 ),
                 onToggle = {
                     if (preloadState.started) {
-                        preloadState.updateAfterStop(
-                            RewardedInterstitialAdPreloader.destroy(REWARDED_INTERSTITIAL_PRELOAD_ID),
-                        )
+                        preloadState.updateAfterStop(stopPreloader())
                     } else {
                         preloadState.updateAfterStart(
-                            RewardedInterstitialAdPreloader.startAndTrack(
-                                REWARDED_INTERSTITIAL_PRELOAD_ID,
-                                PreloadConfiguration(
-                                    AdRequest.Builder(BuildConfig.ADMOB_REWARDED_INTERSTITIAL_AD_UNIT_ID).build(),
-                                    preloadState.bufferSize,
-                                ),
-                                placement = "rewarded_interstitial_preload",
-                                preloadCallback = preloadState.preloadCallback(scope),
-                            ),
+                            startPreloader(preloadState.bufferSize, preloadState.preloadCallback(scope)),
                         )
                     }
                 },
@@ -268,27 +260,23 @@ internal fun RewardedInterstitialScreen(activity: Activity, onBack: () -> Unit) 
     }
 }
 
-private fun showRewardedInterstitial(
-    ad: RewardedInterstitialAd,
-    activity: Activity,
+private fun <AdT : Ad> showRewardedAd(
+    ad: AdT,
     verify: Boolean,
     scope: CoroutineScope,
+    showActions: RewardedShowActions<AdT>,
     updateStatus: (String) -> Unit,
 ) {
     if (verify) {
-        ad.show(
-            activity,
-            placement = "rewarded_interstitial_show",
-            rewardVerificationStarted = { updateStatus("Verifying reward...") },
-            rewardVerificationCompleted = { result ->
-                updateStatus("Verification complete: ${result.verifiedReward ?: "failed"}")
-            },
+        showActions.showVerifiedAd(
+            ad,
+            { updateStatus("Verifying reward...") },
+            { result -> updateStatus("Verification complete: ${result.verifiedReward ?: "failed"}") },
         )
     } else {
-        ad.show(
-            activity,
-            placement = "rewarded_interstitial_show",
-            onUserEarnedRewardListener = OnUserEarnedRewardListener { reward ->
+        showActions.showUnverifiedAd(
+            ad,
+            OnUserEarnedRewardListener { reward ->
                 scope.launch {
                     updateStatus("Reward earned: ${reward.amount} ${reward.type}")
                 }

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/SampleUi.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/SampleUi.kt
@@ -58,16 +58,9 @@ fun AdMobNextGenSample(
         SampleScreen.INTERSTITIAL -> InterstitialScreen(activity, onBack)
         SampleScreen.APP_OPEN -> AppOpenScreen(activity, onBack)
         SampleScreen.REWARDED -> RewardedScreen(activity, onBack)
-        SampleScreen.REWARDED_INTERSTITIAL -> PlaceholderAdScreen(selectedScreen.title, onBack)
+        SampleScreen.REWARDED_INTERSTITIAL -> RewardedInterstitialScreen(activity, onBack)
         SampleScreen.NATIVE -> NativeScreen(onBack)
         SampleScreen.DIAGNOSTICS -> DiagnosticsScreen(onBack)
-    }
-}
-
-@Composable
-private fun PlaceholderAdScreen(title: String, onBack: () -> Unit) {
-    SampleScaffold(title = title, onBack = onBack, contentPadding = PaddingValues(16.dp)) {
-        Text("This example will be added in a later layer of the sample stack.")
     }
 }
 

--- a/feature/admob-next-gen/README.md
+++ b/feature/admob-next-gen/README.md
@@ -3,6 +3,10 @@
 The `purchases-admob-next-gen` module integrates RevenueCat with the
 [Google Mobile Ads Next-Gen SDK](https://developers.google.com/admob/android/next-gen/quick-start).
 
+See the [AdMob Next-Gen sample](../../examples/admob-next-gen-sample/README.md) for a runnable Compose app that
+demonstrates direct loading and preloading for every supported format, plus placement overrides and reward
+verification.
+
 > [!IMPORTANT]
 > `purchases-admob-next-gen` and the legacy `purchases-admob` adapter are mutually exclusive.
 > Remove the legacy adapter and `com.google.android.gms:play-services-ads` before adding this module.

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/PlacementOverrideTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/PlacementOverrideTest.kt
@@ -1,0 +1,66 @@
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
+import com.revenuecat.purchases.admob.nextgen.AdMobNextGenStrings
+import com.revenuecat.purchases.admob.nextgen.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class PlacementOverrideTest {
+
+    @Before
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.w(any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(Logger)
+    }
+
+    @Test
+    fun `updates placement on tracking callback`() {
+        val callback = trackingCallback(initialPlacement = "load-placement")
+
+        callback.applyPlacementOverride("show-placement")
+
+        assertEquals("show-placement", callback.placement)
+    }
+
+    @Test
+    fun `null override clears placement on tracking callback`() {
+        val callback = trackingCallback(initialPlacement = "load-placement")
+
+        callback.applyPlacementOverride(null)
+
+        assertNull(callback.placement)
+    }
+
+    @Test
+    fun `non-tracking callback is ignored`() {
+        val callback = object : InterstitialAdEventCallback {}
+
+        callback.applyPlacementOverride("show-placement")
+
+        verify(exactly = 1) { Logger.w(AdMobNextGenStrings.PLACEMENT_OVERRIDE_IGNORED) }
+    }
+
+    private fun trackingCallback(initialPlacement: String?) = TrackingInterstitialAdEventCallback(
+        initialDelegate = null,
+        initialPlacement = initialPlacement,
+        adUnitId = "ad-unit",
+        responseInfoProvider = { mockk<ResponseInfo>() },
+    )
+}


### PR DESCRIPTION
## Summary

Completes the Google Mobile Ads Next-Gen example app with rewarded-interstitial support and regression coverage:

- add direct and preloaded rewarded-interstitial workflows
- demonstrate optional RevenueCat reward verification
- add focused regression coverage for placement override callback handling

## Screenshots

![Rewarded-interstitial preloader with reward verification enabled and two ads ready](https://github.com/RevenueCat/purchases-android/blob/b8ff8292759648e051c8bb6cf76e35f1e764fb79/gh-pr-images/pr-4045/1787759536-37402-1-09-rewarded-interstitial.png?raw=true)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the example app, documentation, and unit tests; no production adapter behavior is modified in this diff.
> 
> **Overview**
> Finishes the AdMob Next-Gen **sample app** by replacing the rewarded-interstitial placeholder with a real screen and documenting how to run and validate every format.
> 
> **Rewarded UI** is refactored into a shared generic `RewardedAdScreen` used by both **Rewarded** and **Rewarded interstitial**. Each wires RevenueCat **direct load**, **preload/poll**, and **show** with format-specific placements, plus an optional **RevenueCat reward verification** toggle (applied at load/poll time).
> 
> **Docs** cross-link the sample and adapter READMEs and add guidance on direct vs preloaded flows, dashboard event checks, native test inventory caveats, and main-thread handling for SDK callbacks.
> 
> **Tests:** new `PlacementOverrideTest` covers `applyPlacementOverride` on tracking callbacks (update, clear, ignore non-tracking wrappers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b412b0c04f032c292e42167f07b5207feaf79f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->