### PR TITLE
Set or unset subscriber attributes from the checkpoint tester

### DIFF
--- a/examples/checkpointtester/README.md
+++ b/examples/checkpointtester/README.md
@@ -64,6 +64,8 @@ gated on the outcome, so this is how you exercise a checkpoint configured in the
 **No action / Simulated error** — run inline from the use-case list, using an identifier the dashboard doesn't
 know about and the `error_checkpoint` identifier above.
 
+**Subscriber attribute** — the person icon in the top bar opens a dialog that sets or unsets a single subscriber attribute. Attributes are part of the checkpoint rule evaluation scope, so this is how you flip which rule matches without rebuilding. *Unset* passes a `null` value, which is how the SDK deletes an attribute.
+
 **Listener log** — the second tab renders everything the app-wide `CheckpointListener` (registered in
 `MainApplication` as `CheckpointEventLog`) observed: an `onCheckpointHit` and an `onCheckpointCompleted` entry per
 run, regardless of which screen triggered it. Events are also written to logcat under the `CheckpointEventLog`

--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/CheckpointTesterApp.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/CheckpointTesterApp.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -15,6 +16,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -24,6 +28,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.revenuecat.checkpointtester.ui.Screen
+import com.revenuecat.checkpointtester.ui.dialogs.SetAttributeDialog
 import com.revenuecat.checkpointtester.ui.screens.custom.CustomCheckpointScreen
 import com.revenuecat.checkpointtester.ui.screens.gate.EntitlementGateScreen
 import com.revenuecat.checkpointtester.ui.screens.hardpaywall.HardPaywallScreen
@@ -57,6 +62,7 @@ fun CheckpointTesterApp(
     val currentScreen = ALL_SCREENS.firstOrNull { it.route == backStackEntry?.destination?.route }
         ?: Screen.UseCases
     val isTab = TABS.any { (screen, _) -> screen == currentScreen }
+    var showAttributeDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         modifier = modifier,
@@ -68,6 +74,11 @@ fun CheckpointTesterApp(
                         IconButton(onClick = { navController.popBackStack() }) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                         }
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showAttributeDialog = true }) {
+                        Icon(Icons.Filled.Person, contentDescription = "Set subscriber attribute")
                     }
                 },
             )
@@ -100,6 +111,9 @@ fun CheckpointTesterApp(
             composable(Screen.CustomCheckpoint.route) {
                 CustomCheckpointScreen(modifier = contentModifier)
             }
+        }
+        if (showAttributeDialog) {
+            SetAttributeDialog(onDismiss = { showAttributeDialog = false })
         }
     }
 }

--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/dialogs/SetAttributeDialog.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/dialogs/SetAttributeDialog.kt
@@ -1,0 +1,112 @@
+package com.revenuecat.checkpointtester.ui.dialogs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.revenuecat.checkpointtester.ui.theme.CheckpointTesterTheme
+import com.revenuecat.purchases.Purchases
+
+@Composable
+fun SetAttributeDialog(
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var key by rememberSaveable { mutableStateOf("") }
+    var value by rememberSaveable { mutableStateOf("") }
+    val hasKey = key.isNotBlank()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        title = { Text(text = "Subscriber attribute") },
+        text = {
+            AttributeFields(
+                key = key,
+                value = value,
+                onKeyChange = { key = it },
+                onValueChange = { value = it },
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    Purchases.sharedInstance.setAttributes(mapOf(key.trim() to value))
+                    onDismiss()
+                },
+                enabled = hasKey,
+            ) {
+                Text(text = "Set")
+            }
+        },
+        dismissButton = {
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                TextButton(onClick = onDismiss) {
+                    Text(text = "Cancel")
+                }
+                TextButton(
+                    onClick = {
+                        Purchases.sharedInstance.setAttributes(mapOf(key.trim() to null))
+                        onDismiss()
+                    },
+                    enabled = hasKey,
+                ) {
+                    Text(text = "Unset")
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun AttributeFields(
+    key: String,
+    value: String,
+    onKeyChange: (String) -> Unit,
+    onValueChange: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = "Subscriber attributes are part of the checkpoint rule evaluation scope, so changing one " +
+                "here changes which rule can match on the next checkpoint. Unset deletes the attribute and " +
+                "ignores the value field.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OutlinedTextField(
+            value = key,
+            onValueChange = onKeyChange,
+            label = { Text(text = "Attribute key") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(text = "Attribute value") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SetAttributeDialogPreview() {
+    CheckpointTesterTheme {
+        SetAttributeDialog(onDismiss = {})
+    }
+}


### PR DESCRIPTION
### Motivation

Checkpoint rules can be evaluated against subscriber attributes, but the checkpoint tester had no way to set them, so exercising an attribute-driven rule meant editing and rebuilding the app.

Adds an action to allow to set custom attributes to the app
<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/1b3f3a7e-1ff1-4835-a43a-26cc9690eb19" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app UI only. It calls the existing public setAttributes API and does not change SDK, auth, or production behavior.
> 
> **Overview**
> Lets testers change a subscriber attribute at runtime so checkpoint rules that depend on attributes can be exercised without rebuilding.
> 
> Adds a person icon in the top bar that opens a dialog with key/value fields. **Set** calls `Purchases.sharedInstance.setAttributes`; **Unset** sends `null` for that key (SDK delete). Documented in the checkpoint tester README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2197c8aaa0402aecaf7e4876476957789f790d70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->