### PR TITLE
Add Scope plumbing and custom operator extension point

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/Evaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/Evaluator.kt
@@ -33,7 +33,7 @@ internal object Evaluator {
         predicate: Value,
         variables: Map<String, Value>,
     ): Boolean {
-        val scope = Value.ObjectValue(variables)
+        val scope = Scope(root = Value.ObjectValue(variables))
         return evaluateValue(predicate, scope).isTruthy
     }
 
@@ -43,7 +43,7 @@ internal object Evaluator {
      */
     internal fun evaluateValue(
         predicate: Value,
-        vars: Value,
+        vars: Scope,
     ): Value = when (predicate) {
         Value.Null,
         Value.Undefined,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/Scope.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/Scope.kt
@@ -1,0 +1,19 @@
+package com.revenuecat.purchases.rules
+
+/**
+ * Evaluation scope pairing the active data ([current]) with the predicate's
+ * original [root]. Iteration operators rebind [current] to each item while
+ * preserving [root] for custom operators that need top-level data inside
+ * nested predicates.
+ */
+internal class Scope private constructor(
+    /** Data the enclosing expression reads from. Iteration operators replace this with the current item. */
+    val current: Value,
+    /** Data the predicate started with, never replaced. */
+    val root: Value,
+) {
+
+    constructor(root: Value) : this(current = root, root = root)
+
+    fun scoped(current: Value): Scope = Scope(current = current, root = root)
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/CustomOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/CustomOperators.kt
@@ -1,0 +1,23 @@
+package com.revenuecat.purchases.rules.customoperators
+
+import com.revenuecat.purchases.rules.RulesEngine.EvaluationException
+import com.revenuecat.purchases.rules.Scope
+import com.revenuecat.purchases.rules.Value
+
+/**
+ * RevenueCat-specific JSON Logic operators.
+ *
+ * Operators here are namespaced under `rc.` so they cannot collide with a
+ * future standard JSON Logic operator.
+ */
+internal object CustomOperators {
+
+    @Suppress("UnusedParameter", "UNUSED_PARAMETER", "UNUSED_EXPRESSION")
+    fun dispatch(
+        op: String,
+        args: Value,
+        vars: Scope,
+    ): Value = when (op) {
+        else -> throw EvaluationException.UnsupportedOperator(op)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/CustomOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/CustomOperators.kt
@@ -12,7 +12,7 @@ import com.revenuecat.purchases.rules.Value
  */
 internal object CustomOperators {
 
-    @Suppress("UnusedParameter", "UNUSED_PARAMETER", "UNUSED_EXPRESSION")
+    @Suppress("UnusedParameter")
     fun dispatch(
         op: String,
         args: Value,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/AccessorOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/AccessorOperators.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.rules.operators
 import com.revenuecat.purchases.rules.Evaluator
 import com.revenuecat.purchases.rules.RulesEngine
 import com.revenuecat.purchases.rules.RulesEngine.EvaluationException
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 import com.revenuecat.purchases.rules.jsString
 import com.revenuecat.purchases.rules.jsToNumber
@@ -30,11 +31,15 @@ internal object AccessorOperators {
      * Variable lookup uses **strict JSON Logic dot-path semantics on
      * nested objects**. There is no flat-key fallback (i.e. we do not also
      * try the literal dotted string as a single key in the top-level map).
+     *
+     * @param vars The JSON Logic evaluation scope — [Scope.current] is the
+     *  data `var` reads from; path/default args evaluate against
+     *  [Scope.current] as well.
      */
     @Suppress("ReturnCount")
-    fun opVar(args: Value, vars: Value): Value {
+    fun opVar(args: Value, vars: Scope): Value {
         val (path, default) = resolveVarArgs(args, vars)
-        val found = lookupVar(vars, path)
+        val found = lookupVar(vars.current, path)
         if (found != null) return found
         // json-logic-js coerces an `undefined` default to `null`.
         if (default is Value.Undefined) return Value.Null
@@ -61,7 +66,7 @@ internal object AccessorOperators {
      *   are unpacked as the key list — this is how
      *   `{"missing": {"merge": [["a"], ["b"]]}}` is meant to behave.
      */
-    fun opMissing(args: Value, vars: Value): Value {
+    fun opMissing(args: Value, vars: Scope): Value {
         val evaluatedArgs: List<Value> = when (args) {
             is Value.ArrayValue -> args.items.map { Evaluator.evaluateValue(it, vars) }
             // Singleton shorthand: `{"missing": "a"}` ≡ `{"missing": ["a"]}`.
@@ -74,7 +79,7 @@ internal object AccessorOperators {
         val missing = mutableListOf<Value>()
         for (key in keys) {
             val path = keyAsPath(key) ?: continue
-            if (isMissing(varLookup(vars, path))) {
+            if (isMissing(varLookup(vars.current, path))) {
                 missing += Value.StringValue(path)
             }
         }
@@ -89,7 +94,7 @@ internal object AccessorOperators {
      * Used to express "any 2 of these 5 fields must be present" style
      * requirements.
      */
-    fun opMissingSome(args: Value, vars: Value): Value {
+    fun opMissingSome(args: Value, vars: Scope): Value {
         val evaluated = Operators.evalArgs(args, vars)
         if (evaluated.size != 2) {
             throw EvaluationException.TypeMismatch(
@@ -168,7 +173,7 @@ internal object AccessorOperators {
      * resolve to a dynamic path string.
      *
      */
-    private fun resolveVarArgs(args: Value, vars: Value): Pair<String, Value?> {
+    private fun resolveVarArgs(args: Value, vars: Scope): Pair<String, Value?> {
         if (args is Value.ArrayValue) {
             val evaluated = args.items.map { Evaluator.evaluateValue(it, vars) }
             return parseVarArrayArgs(evaluated)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/ArithmeticOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/ArithmeticOperators.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.rules.operators
 
 import com.revenuecat.purchases.rules.RulesEngine.EvaluationException
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 import com.revenuecat.purchases.rules.jsParseFloat
 
@@ -29,7 +30,7 @@ internal object ArithmeticOperators {
      * `{"+": [a, b, ...]}` — variadic sum, seeded with `0`. 0 arguments
      * returns `0`. Each operand is coerced via JS `parseFloat`.
      */
-    fun opAdd(args: Value, vars: Value): Value {
+    fun opAdd(args: Value, vars: Scope): Value {
         val evaluated = Operators.evalArgs(args, vars)
         val sum = evaluated.fold(0.0) { acc, value -> acc + jsParseFloat(value) }
         return Value.FloatValue(sum)
@@ -42,7 +43,7 @@ internal object ArithmeticOperators {
      * arguments is a [EvaluationException.TypeMismatch] to mirror `[].reduce(fn)`
      * throwing.
      */
-    fun opMul(args: Value, vars: Value): Value {
+    fun opMul(args: Value, vars: Scope): Value {
         val evaluated = Operators.evalArgs(args, vars)
         val head = evaluated.firstOrNull()
             ?: throw EvaluationException.TypeMismatch("operator '*' requires at least 1 argument")
@@ -59,7 +60,7 @@ internal object ArithmeticOperators {
      * `NaN` (mirroring JS `-undefined`). Operands are coerced via JS
      * `Number()` ([Value.toNumberOrNull]).
      */
-    fun opSub(args: Value, vars: Value): Value {
+    fun opSub(args: Value, vars: Scope): Value {
         val evaluated = Operators.evalArgs(args, vars)
         val lhs = evaluated.firstOrNull()?.asDouble() ?: Double.NaN
         return if (evaluated.size >= 2) {
@@ -74,7 +75,7 @@ internal object ArithmeticOperators {
      * operands resolve to `NaN` (mirroring JS `undefined / x`). Division
      * by zero follows IEEE 754: `n / 0` is `±Infinity`, `0 / 0` is `NaN`.
      */
-    fun opDiv(args: Value, vars: Value): Value {
+    fun opDiv(args: Value, vars: Scope): Value {
         val (lhs, rhs) = evalDivisorPair(args, vars)
         return Value.FloatValue(lhs / rhs)
     }
@@ -83,7 +84,7 @@ internal object ArithmeticOperators {
      * `{"%": [a, b]}` — modulo. Same arity / coercion rules as `/`;
      * `n % 0` follows IEEE 754 and is `NaN`.
      */
-    fun opMod(args: Value, vars: Value): Value {
+    fun opMod(args: Value, vars: Scope): Value {
         val (lhs, rhs) = evalDivisorPair(args, vars)
         return Value.FloatValue(lhs % rhs)
     }
@@ -93,7 +94,7 @@ internal object ArithmeticOperators {
      * to [Double.NaN] (mirroring JS `undefined`). Extra operands are
      * ignored.
      */
-    private fun evalDivisorPair(args: Value, vars: Value): Pair<Double, Double> {
+    private fun evalDivisorPair(args: Value, vars: Scope): Pair<Double, Double> {
         val evaluated = Operators.evalArgs(args, vars)
         val lhs = evaluated.firstOrNull()?.asDouble() ?: Double.NaN
         val rhs = if (evaluated.size >= 2) evaluated[1].asDouble() else Double.NaN

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/ComparisonOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/ComparisonOperators.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.rules.operators
 
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 import com.revenuecat.purchases.rules.jsString
 
@@ -29,19 +30,19 @@ internal object ComparisonOperators {
     private const val RHS_OPERAND_INDEX = 2
 
     /** `{"<": [a, b]}` — `a < b`. `{"<": [a, b, c]}` — `a < b AND b < c`. */
-    fun opLt(args: Value, vars: Value): Value =
+    fun opLt(args: Value, vars: Scope): Value =
         evalChain(args, vars, Comparator.LESS)
 
     /** `{"<=": [a, b]}` — `a <= b`. `{"<=": [a, b, c]}` — `a <= b AND b <= c`. */
-    fun opLe(args: Value, vars: Value): Value =
+    fun opLe(args: Value, vars: Scope): Value =
         evalChain(args, vars, Comparator.LESS_OR_EQUAL)
 
     /** `{">": [a, b]}` — `a > b`. Strictly binary; matches the JS reference. */
-    fun opGt(args: Value, vars: Value): Value =
+    fun opGt(args: Value, vars: Scope): Value =
         evalBinary(args, vars, Comparator.GREATER)
 
     /** `{">=": [a, b]}` — `a >= b`. Strictly binary; matches the JS reference. */
-    fun opGe(args: Value, vars: Value): Value =
+    fun opGe(args: Value, vars: Scope): Value =
         evalBinary(args, vars, Comparator.GREATER_OR_EQUAL)
 
     /**
@@ -120,7 +121,7 @@ internal object ComparisonOperators {
      */
     private fun evalChain(
         args: Value,
-        vars: Value,
+        vars: Scope,
         cmp: Comparator,
     ): Value {
         val evaluated = Operators.evalArgs(args, vars)
@@ -145,7 +146,7 @@ internal object ComparisonOperators {
      */
     private fun evalBinary(
         args: Value,
-        vars: Value,
+        vars: Scope,
         cmp: Comparator,
     ): Value {
         val evaluated = Operators.evalArgs(args, vars)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/EqualityOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/EqualityOperators.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.rules.operators
 
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 import com.revenuecat.purchases.rules.looseEq
 import com.revenuecat.purchases.rules.strictEq
@@ -13,13 +14,13 @@ internal object EqualityOperators {
      * `{"==": [a, b]}` — JSON Logic loose equality. Coerces across primitive
      * types (e.g. `1 == "1"` is true). Full coercion table in [looseEq].
      */
-    fun opLooseEq(args: Value, vars: Value): Value {
+    fun opLooseEq(args: Value, vars: Scope): Value {
         val (lhs, rhs) = Operators.evalTwo(args, vars)
         return Value.BoolValue(looseEq(lhs, rhs))
     }
 
     /** `{"!=": [a, b]}` — JSON Logic loose inequality. Negation of `==`. */
-    fun opLooseNe(args: Value, vars: Value): Value {
+    fun opLooseNe(args: Value, vars: Scope): Value {
         val (lhs, rhs) = Operators.evalTwo(args, vars)
         return Value.BoolValue(!looseEq(lhs, rhs))
     }
@@ -29,13 +30,13 @@ internal object EqualityOperators {
      * (`1 === "1"` is false). See [strictEq] for the numeric subtlety
      * around `IntValue` vs `FloatValue`.
      */
-    fun opStrictEq(args: Value, vars: Value): Value {
+    fun opStrictEq(args: Value, vars: Scope): Value {
         val (lhs, rhs) = Operators.evalTwo(args, vars)
         return Value.BoolValue(strictEq(lhs, rhs))
     }
 
     /** `{"!==": [a, b]}` — JSON Logic strict inequality. Negation of `===`. */
-    fun opStrictNe(args: Value, vars: Value): Value {
+    fun opStrictNe(args: Value, vars: Scope): Value {
         val (lhs, rhs) = Operators.evalTwo(args, vars)
         return Value.BoolValue(!strictEq(lhs, rhs))
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/IterationOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/IterationOperators.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.rules.operators
 
 import com.revenuecat.purchases.rules.Evaluator
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 
 /**
@@ -13,13 +14,14 @@ import com.revenuecat.purchases.rules.Value
  *   evaluated in the outer scope and must resolve to an array; anything
  *   else is treated as an empty source. The second argument is a
  *   literal template that is evaluated per-item with `vars` rebound to
- *   the current item, with no parent-scope inheritance.
+ *   the current item, with no parent-scope inheritance for `var`; the
+ *   preserved root scope remains available to custom operators.
  * - **Shape** (`reduce`):
  *   `{"reduce": [arrayExpr, predicateExpr, initialAccumulator]}`. Both
  *   the first and third arguments are evaluated in the outer scope.
  *   The predicate is evaluated per-item with `vars` rebound to
- *   `{"current": <item>, "accumulator": <acc>}`, with no parent-scope
- *   inheritance.
+ *   `{"current": <item>, "accumulator": <acc>}`; `var` sees only that
+ *   object, but the root scope is preserved for custom operators.
  *
  * **Empty- and non-array sources** per the JSON Logic JS spec:
  * - `some` / `all` return `false`.
@@ -33,13 +35,13 @@ internal object IterationOperators {
      * `{"some": [arrayExpr, predicate]}` — `true` iff `predicate` is
      * truthy for at least one item. The array expression is evaluated in
      * the current scope; the predicate is re-evaluated per item with
-     * `vars` rebound to that item, with no parent-scope inheritance.
-     * Empty array or non-array source returns `false`. Short-circuits on
-     * the first truthy result.
+     * `vars` rebound to that item (`var` reads the item only; the root
+     * scope is preserved for custom operators). Empty array or non-array
+     * source returns `false`. Short-circuits on the first truthy result.
      */
-    fun opSome(args: Value, vars: Value): Value {
+    fun opSome(args: Value, vars: Scope): Value {
         val (items, predicate) = parseIterationArgs(args, vars)
-        val result = items?.any { Evaluator.evaluateValue(predicate, it).isTruthy } ?: false
+        val result = items?.any { Evaluator.evaluateValue(predicate, vars.scoped(it)).isTruthy } ?: false
         return Value.BoolValue(result)
     }
 
@@ -47,14 +49,15 @@ internal object IterationOperators {
      * `{"all": [arrayExpr, predicate]}` — `true` iff `predicate` is
      * truthy for every item. The array expression is evaluated in the
      * current scope; the predicate is re-evaluated per item with `vars`
-     * rebound to that item, with no parent-scope inheritance. Empty array
-     * returns `false` per the JSON Logic JS spec. Non-array source
-     * returns `false`. Short-circuits on the first non-truthy result.
+     * rebound to that item (`var` reads the item only; the root scope is
+     * preserved for custom operators). Empty array returns `false` per
+     * the JSON Logic JS spec. Non-array source returns `false`.
+     * Short-circuits on the first non-truthy result.
      */
-    fun opAll(args: Value, vars: Value): Value {
+    fun opAll(args: Value, vars: Scope): Value {
         val (items, predicate) = parseIterationArgs(args, vars)
         val result = !items.isNullOrEmpty() &&
-            items.all { Evaluator.evaluateValue(predicate, it).isTruthy }
+            items.all { Evaluator.evaluateValue(predicate, vars.scoped(it)).isTruthy }
         return Value.BoolValue(result)
     }
 
@@ -64,9 +67,9 @@ internal object IterationOperators {
      * first truthy item. Empty and non-array sources both return `true`,
      * matching the JS reference's `!Array.isArray(x) || !x.length` guard.
      */
-    fun opNone(args: Value, vars: Value): Value {
+    fun opNone(args: Value, vars: Scope): Value {
         val (items, predicate) = parseIterationArgs(args, vars)
-        val result = items?.none { Evaluator.evaluateValue(predicate, it).isTruthy } ?: true
+        val result = items?.none { Evaluator.evaluateValue(predicate, vars.scoped(it)).isTruthy } ?: true
         return Value.BoolValue(result)
     }
 
@@ -75,9 +78,9 @@ internal object IterationOperators {
      * item, return the new array of *raw* (non-truthy-coerced) results.
      * Empty or non-array source yields `[]`.
      */
-    fun opMap(args: Value, vars: Value): Value {
+    fun opMap(args: Value, vars: Scope): Value {
         val (items, predicate) = parseIterationArgs(args, vars)
-        val results = items?.map { Evaluator.evaluateValue(predicate, it) } ?: emptyList()
+        val results = items?.map { Evaluator.evaluateValue(predicate, vars.scoped(it)) } ?: emptyList()
         return Value.ArrayValue(results)
     }
 
@@ -87,9 +90,9 @@ internal object IterationOperators {
      * `[]`. The retained items are the *original* values, not the
      * predicate results.
      */
-    fun opFilter(args: Value, vars: Value): Value {
+    fun opFilter(args: Value, vars: Scope): Value {
         val (items, predicate) = parseIterationArgs(args, vars)
-        val results = items?.filter { Evaluator.evaluateValue(predicate, it).isTruthy } ?: emptyList()
+        val results = items?.filter { Evaluator.evaluateValue(predicate, vars.scoped(it)).isTruthy } ?: emptyList()
         return Value.ArrayValue(results)
     }
 
@@ -106,7 +109,7 @@ internal object IterationOperators {
      * seeds the fold with `typeof values[2] !== "undefined" ? values[2]
      * : null`. Arguments past the third are ignored.
      */
-    fun opReduce(args: Value, vars: Value): Value {
+    fun opReduce(args: Value, vars: Scope): Value {
         val raw = Operators.argsAsList(args)
         val sourceArg = raw.getOrNull(0) ?: Value.Null
         val predicate = raw.getOrNull(1) ?: Value.Undefined
@@ -114,8 +117,10 @@ internal object IterationOperators {
         var accumulator = raw.getOrNull(2)?.let { Evaluator.evaluateValue(it, vars) } ?: Value.Null
         val items = (source as? Value.ArrayValue)?.items ?: return accumulator
         for (item in items) {
-            val scope = Value.ObjectValue(mapOf("current" to item, "accumulator" to accumulator))
-            accumulator = Evaluator.evaluateValue(predicate, scope)
+            val itemScope = vars.scoped(
+                Value.ObjectValue(mapOf("current" to item, "accumulator" to accumulator)),
+            )
+            accumulator = Evaluator.evaluateValue(predicate, itemScope)
         }
         return accumulator
     }
@@ -136,7 +141,7 @@ internal object IterationOperators {
      */
     private fun parseIterationArgs(
         args: Value,
-        vars: Value,
+        vars: Scope,
     ): Pair<List<Value>?, Value> {
         val raw = Operators.argsAsList(args)
         val sourceArg = raw.getOrNull(0) ?: Value.Null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/LogicOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/LogicOperators.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.rules.operators
 
 import com.revenuecat.purchases.rules.Evaluator
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 
 /**
@@ -16,14 +17,14 @@ internal object LogicOperators {
      * `{"!": x}` — boolean negation. Coerces to bool first per JSON Logic
      * truthiness rules.
      */
-    fun opNot(args: Value, vars: Value): Value {
-        val value = firstArgEvaluated(args, vars)
+    fun opNot(args: Value, vars: Scope): Value {
+        val value = Operators.firstArgEvaluated(args, vars)
         return Value.BoolValue(!value.isTruthy)
     }
 
     /** `{"!!": x}` — boolean cast. Spec: equivalent to `!!x` in JS. */
-    fun opNotNot(args: Value, vars: Value): Value {
-        val value = firstArgEvaluated(args, vars)
+    fun opNotNot(args: Value, vars: Scope): Value {
+        val value = Operators.firstArgEvaluated(args, vars)
         return Value.BoolValue(value.isTruthy)
     }
 
@@ -34,7 +35,7 @@ internal object LogicOperators {
      * returns [Value.Undefined] (json-logic-js reduces an empty `and` to
      * `undefined`, which is falsy but `!== null`).
      */
-    fun opAnd(args: Value, vars: Value): Value {
+    fun opAnd(args: Value, vars: Scope): Value {
         var last: Value = Value.Undefined
         for (item in Operators.argsAsList(args)) {
             last = Evaluator.evaluateValue(item, vars)
@@ -48,7 +49,7 @@ internal object LogicOperators {
      * value or, if all are falsy, the last value. Empty args returns
      * [Value.Undefined] for the same reason as [opAnd].
      */
-    fun opOr(args: Value, vars: Value): Value {
+    fun opOr(args: Value, vars: Scope): Value {
         var last: Value = Value.Undefined
         for (item in Operators.argsAsList(args)) {
             last = Evaluator.evaluateValue(item, vars)
@@ -64,7 +65,7 @@ internal object LogicOperators {
      * also fall through to `Null` (the loop never enters and `index <
      * items.size` is false).
      */
-    fun opIf(args: Value, vars: Value): Value {
+    fun opIf(args: Value, vars: Scope): Value {
         val items = Operators.argsAsList(args)
         var index = 0
         while (index + 1 < items.size) {
@@ -79,11 +80,5 @@ internal object LogicOperators {
         } else {
             Value.Null
         }
-    }
-
-    private fun firstArgEvaluated(args: Value, vars: Value): Value {
-        val items = Operators.argsAsList(args)
-        val first = items.firstOrNull() ?: Value.Null
-        return Evaluator.evaluateValue(first, vars)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/MinMaxOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/MinMaxOperators.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.rules.operators
 
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 import kotlin.math.max
 import kotlin.math.min
@@ -16,17 +17,17 @@ import kotlin.math.min
  */
 internal object MinMaxOperators {
 
-    fun opMax(args: Value, vars: Value): Value {
+    fun opMax(args: Value, vars: Scope): Value {
         return reduceExtremum(args, vars, empty = Double.NEGATIVE_INFINITY) { a, b -> max(a, b) }
     }
 
-    fun opMin(args: Value, vars: Value): Value {
+    fun opMin(args: Value, vars: Scope): Value {
         return reduceExtremum(args, vars, empty = Double.POSITIVE_INFINITY) { a, b -> min(a, b) }
     }
 
     private fun reduceExtremum(
         args: Value,
-        vars: Value,
+        vars: Scope,
         empty: Double,
         combine: (Double, Double) -> Double,
     ): Value {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/MiscOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/MiscOperators.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.rules.operators
 
 import com.revenuecat.purchases.rules.RulesEngine
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 import com.revenuecat.purchases.rules.jsString
 
@@ -18,7 +19,7 @@ internal object MiscOperators {
      * [Value.Undefined] (logged as `"undefined"`); operands beyond the
      * first are ignored.
      */
-    fun opLog(args: Value, vars: Value): Value {
+    fun opLog(args: Value, vars: Scope): Value {
         val value = Operators.evalArgs(args, vars).firstOrNull() ?: Value.Undefined
         RulesEngine.logger.log(jsString(value))
         return value

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/Operators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/Operators.kt
@@ -2,7 +2,9 @@ package com.revenuecat.purchases.rules.operators
 
 import com.revenuecat.purchases.rules.Evaluator
 import com.revenuecat.purchases.rules.RulesEngine.EvaluationException
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
+import com.revenuecat.purchases.rules.customoperators.CustomOperators
 
 /**
  * JSON Logic operator dispatcher and shared helpers.
@@ -22,7 +24,7 @@ internal object Operators {
     fun dispatch(
         op: String,
         args: Value,
-        vars: Value,
+        vars: Scope,
     ): Value = when (op) {
         // Accessors
         "var" -> AccessorOperators.opVar(args, vars)
@@ -76,7 +78,7 @@ internal object Operators {
         // Miscellaneous
         "log" -> MiscOperators.opLog(args, vars)
 
-        else -> throw EvaluationException.UnsupportedOperator(op)
+        else -> CustomOperators.dispatch(op, args, vars)
     }
 
     /**
@@ -92,7 +94,7 @@ internal object Operators {
     /** Evaluate every element in an argument list. */
     fun evalArgs(
         args: Value,
-        vars: Value,
+        vars: Scope,
     ): List<Value> = argsAsList(args).map { Evaluator.evaluateValue(it, vars) }
 
     /**
@@ -104,12 +106,27 @@ internal object Operators {
      */
     fun evalTwo(
         args: Value,
-        vars: Value,
+        vars: Scope,
     ): Pair<Value, Value> {
         val evaluated = evalArgs(args, vars)
         val lhs = evaluated.firstOrNull() ?: Value.Undefined
         val rhs = if (evaluated.size >= 2) evaluated[1] else Value.Undefined
         return lhs to rhs
+    }
+
+    /**
+     * Evaluate the first argument of a unary operator. Uses [argsAsList]
+     * then takes index zero, matching `json-logic-js`'s
+     * `operations[op].apply(context, values)` spread semantics: a
+     * multi-element top-level array is a multi-argument call, not a
+     * single array operand. An empty arg list yields [Value.Null].
+     */
+    fun firstArgEvaluated(
+        args: Value,
+        vars: Scope,
+    ): Value {
+        val first = argsAsList(args).firstOrNull() ?: Value.Null
+        return Evaluator.evaluateValue(first, vars)
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/StringArrayOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/operators/StringArrayOperators.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.rules.operators
 
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 import com.revenuecat.purchases.rules.jsArrayElementString
 import com.revenuecat.purchases.rules.jsString
@@ -33,7 +34,7 @@ internal object StringArrayOperators {
      * `function(a, b)` (needle, haystack); missing or extra operands
      * short-circuit to `false`.
      */
-    fun opIn(args: Value, vars: Value): Value {
+    fun opIn(args: Value, vars: Scope): Value {
         val evaluated = Operators.evalArgs(args, vars)
         val needle = evaluated.firstOrNull() ?: Value.Null
         val haystack = if (evaluated.size >= BINARY_OPERAND_COUNT) {
@@ -63,7 +64,7 @@ internal object StringArrayOperators {
      * `Array.prototype.join` on the argument list: `null` → `""`).
      * 0 args returns `""`.
      */
-    fun opCat(args: Value, vars: Value): Value {
+    fun opCat(args: Value, vars: Scope): Value {
         val evaluated = Operators.evalArgs(args, vars)
         return Value.StringValue(evaluated.joinToString(separator = "") { jsArrayElementString(it) })
     }
@@ -80,7 +81,7 @@ internal object StringArrayOperators {
      * `source` is `undefined`, which stringifies to `"undefined"` (not
      * `"null"`).
      */
-    fun opSubstr(args: Value, vars: Value): Value {
+    fun opSubstr(args: Value, vars: Scope): Value {
         val evaluated = Operators.evalArgs(args, vars)
         val source = evaluated.firstOrNull() ?: Value.Undefined
         val start = if (evaluated.size >= BINARY_OPERAND_COUNT) {
@@ -147,7 +148,7 @@ internal object StringArrayOperators {
      * operands are spliced in; non-array operands are appended as
      * single elements.
      */
-    fun opMerge(args: Value, vars: Value): Value {
+    fun opMerge(args: Value, vars: Scope): Value {
         val evaluated = Operators.evalArgs(args, vars)
         val merged = mutableListOf<Value>()
         for (item in evaluated) {

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/rules/operators/AccessorOperatorsTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/rules/operators/AccessorOperatorsTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.rules.operators
 
 import com.revenuecat.purchases.rules.CapturingLoggerRule
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
@@ -28,25 +29,25 @@ class AccessorOperatorsTest {
 
     @Test
     fun `var empty path returns entire data`() {
-        val vars = obj("x" to Value.IntValue(1))
-        val out = AccessorOperators.opVar(s(""), vars)
-        assertThat(out).isEqualTo(vars)
+        val data = obj("x" to Value.IntValue(1))
+        val out = AccessorOperators.opVar(s(""), Scope(root = data))
+        assertThat(out).isEqualTo(data)
     }
 
     @Test
     fun `var null path returns entire data`() {
         // json-logic-js treats `undefined`, null, and "" as “return the
         // whole data object”.
-        val vars = obj("x" to Value.IntValue(1))
-        val out = AccessorOperators.opVar(Value.Null, vars)
-        assertThat(out).isEqualTo(vars)
+        val data = obj("x" to Value.IntValue(1))
+        val out = AccessorOperators.opVar(Value.Null, Scope(root = data))
+        assertThat(out).isEqualTo(data)
     }
 
     @Test
     fun `var with numeric path arg is coerced to string`() {
         // {"var": 0} on array data
-        val vars = Value.ArrayValue(listOf(s("zero"), s("one")))
-        val out = AccessorOperators.opVar(Value.IntValue(0), vars)
+        val data = Value.ArrayValue(listOf(s("zero"), s("one")))
+        val out = AccessorOperators.opVar(Value.IntValue(0), Scope(root = data))
         assertThat(out).isEqualTo(s("zero"))
     }
 
@@ -54,8 +55,8 @@ class AccessorOperatorsTest {
     fun `var with integer-valued float path looks up integer index`() {
         // {"var": 1.0} on array data must render as "1" (not "1.0") so the
         // path resolves to array index 1 — same lookup as `{"var": 1}`.
-        val vars = Value.ArrayValue(listOf(s("zero"), s("one"), s("two")))
-        val out = AccessorOperators.opVar(Value.FloatValue(1.0), vars)
+        val data = Value.ArrayValue(listOf(s("zero"), s("one"), s("two")))
+        val out = AccessorOperators.opVar(Value.FloatValue(1.0), Scope(root = data))
         assertThat(out).isEqualTo(s("one"))
         assertThat(warnings).isEmpty()
     }
@@ -66,8 +67,8 @@ class AccessorOperatorsTest {
         // rendered path is "1.5", which doesn't resolve, so the lookup
         // misses and warns. Guards against an over-eager rounding fix to
         // `formatNumber`.
-        val vars = Value.ArrayValue(listOf(s("zero"), s("one"), s("two")))
-        val out = AccessorOperators.opVar(Value.FloatValue(1.5), vars)
+        val data = Value.ArrayValue(listOf(s("zero"), s("one"), s("two")))
+        val out = AccessorOperators.opVar(Value.FloatValue(1.5), Scope(root = data))
         assertThat(out).isEqualTo(Value.Null)
         assertThat(warnings).hasSize(1)
         assertThat(warnings[0]).contains("1.5")

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/rules/operators/StringArrayOperatorsTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/rules/operators/StringArrayOperatorsTest.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.rules.operators
 
+import com.revenuecat.purchases.rules.Scope
 import com.revenuecat.purchases.rules.Value
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -19,7 +20,7 @@ class StringArrayOperatorsTest {
         // Only one level of flattening — inner arrays remain.
         val out = StringArrayOperators.opMerge(
             arr(arr(arr(Value.IntValue(1)), Value.IntValue(2))),
-            Value.Null,
+            Scope(root = Value.Null),
         )
         assertThat(out).isEqualTo(arr(arr(Value.IntValue(1)), Value.IntValue(2)))
     }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Port of RevenueCat/purchases-ios#7433, the first of the rules-engine custom operator PRs. Custom `rc.*` operators need somewhere to live, and `rc.rootVar` needs the predicate's root data to survive iteration, which today is lost as soon as `some` / `map` / `reduce` rebind the scope to the current item.

### Description
- Thread a `Scope` (current data plus the never-replaced root) through the evaluator instead of a bare `Value`, and delegate unknown operators to an empty `CustomOperators` dispatcher.
- Behavior-preserving: `var` still sees only the current item inside iteration, no fixtures were added or changed, and the pinned fixture count stays at 382.

### Notes
The `@Suppress("UnusedParameter")` on the empty dispatcher is temporary — `args` and `vars` become used as soon as the first `rc.*` operator lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the rules-engine evaluator and every operator signature, so a scope mix-up could change predicate results. Intended to be behavior-preserving for existing var/iteration semantics.
> 
> **Overview**
> Prepares the rules engine for RevenueCat `rc.*` operators by replacing a bare data `Value` with a `Scope` that keeps both **current** data and the original **root**.
> 
> Iteration (`some`/`all`/`none`/`map`/`filter`/`reduce`) now rebinds only `current` via `scoped()`, so `var` still sees the item (or reduce’s `{current, accumulator}`) while custom ops can later read top-level data. Unknown operators fall through to an empty `CustomOperators` dispatcher (still `UnsupportedOperator`). `firstArgEvaluated` moves onto `Operators`.
> 
> No new operator behavior; tests wrap existing calls in `Scope`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa1fa3c1a99686840262c89a70c0ddc5dccd79e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->