### PR TITLE
refactor(admob): deduplicate next-gen preloader tests

### DIFF
--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AppOpenAdPreloaderTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AppOpenAdPreloaderTest.kt
@@ -8,7 +8,6 @@ package com.revenuecat.purchases.admob.nextgen
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdPreloader
-import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingAppOpenAdEventCallback
@@ -16,15 +15,14 @@ import com.revenuecat.purchases.ads.events.types.AdFormat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 internal class AppOpenAdPreloaderTest : PreloaderTest() {
 
     @Before
@@ -38,36 +36,21 @@ internal class AppOpenAdPreloaderTest : PreloaderTest() {
     }
 
     @Test
-    fun `start installs preload tracking`() {
-        val configuration = preloadConfiguration(AD_UNIT_ID)
-        val delegate = RecordingPreloadCallback()
-        val trackingCallback = slot<PreloadCallback>()
-        every { AppOpenAdPreloader.start(PRELOAD_ID, configuration, capture(trackingCallback)) } returns true
-
-        val started = AppOpenAdPreloader.startAndTrack(
-            preloadId = PRELOAD_ID,
-            preloadConfiguration = configuration,
-            placement = START_PLACEMENT,
-            preloadCallback = delegate,
-        )
-
-        assertTrue(started)
-        assertSuccessfulPreload(
-            preloadId = PRELOAD_ID,
-            trackingCallback = trackingCallback.captured,
-            delegate = delegate,
-            expectedFormat = AdFormat.APP_OPEN,
-            expectedAdUnitId = AD_UNIT_ID,
-            expectedPlacement = START_PLACEMENT,
-        )
-    }
+    fun `start installs preload tracking`() = assertStartInstallsPreloadTracking(
+        expectedAdFormat = AdFormat.APP_OPEN,
+        stubStart = { preloadId, configuration, callback ->
+            every { AppOpenAdPreloader.start(preloadId, configuration, capture(callback)) } returns true
+        },
+        startAndTrack = { preloadId, configuration, placement, callback ->
+            AppOpenAdPreloader.startAndTrack(preloadId, configuration, placement, callback)
+        },
+    )
 
     @Test
-    fun `null poll is returned unchanged`() {
-        every { AppOpenAdPreloader.pollAd(PRELOAD_ID) } returns null
-
-        assertNullPoll(AppOpenAdPreloader.pollAndTrackAd(PRELOAD_ID))
-    }
+    fun `null poll is returned unchanged`() = assertNullPollContract(
+        stubNullPoll = { every { AppOpenAdPreloader.pollAd(it) } returns null },
+        pollAndTrackAd = { AppOpenAdPreloader.pollAndTrackAd(it) },
+    )
 
     @Test
     fun `poll installs lifecycle tracking and returns the same ad`() {
@@ -92,7 +75,6 @@ internal class AppOpenAdPreloaderTest : PreloaderTest() {
     companion object {
         private const val PRELOAD_ID = "app-open-buffer"
         private const val AD_UNIT_ID = "app-open-unit"
-        private const val START_PLACEMENT = "app-open-start-placement"
         private const val POLL_PLACEMENT = "app-open-poll-placement"
     }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/BannerAdPreloaderTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/BannerAdPreloaderTest.kt
@@ -10,7 +10,6 @@ import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdPreloader
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdEventCallback
@@ -45,36 +44,21 @@ internal class BannerAdPreloaderTest : PreloaderTest() {
     }
 
     @Test
-    fun `start installs preload tracking`() {
-        val configuration = preloadConfiguration("banner-unit")
-        val delegate = RecordingPreloadCallback()
-        val trackingCallback = slot<PreloadCallback>()
-        every { BannerAdPreloader.start("banner-buffer", configuration, capture(trackingCallback)) } returns true
-
-        val started = BannerAdPreloader.startAndTrack(
-            preloadId = "banner-buffer",
-            preloadConfiguration = configuration,
-            placement = "banner-start-placement",
-            preloadCallback = delegate,
-        )
-
-        assertTrue(started)
-        assertSuccessfulPreload(
-            preloadId = "banner-buffer",
-            trackingCallback = trackingCallback.captured,
-            delegate = delegate,
-            expectedFormat = AdFormat.BANNER,
-            expectedAdUnitId = "banner-unit",
-            expectedPlacement = "banner-start-placement",
-        )
-    }
+    fun `start installs preload tracking`() = assertStartInstallsPreloadTracking(
+        expectedAdFormat = AdFormat.BANNER,
+        stubStart = { preloadId, configuration, callback ->
+            every { BannerAdPreloader.start(preloadId, configuration, capture(callback)) } returns true
+        },
+        startAndTrack = { preloadId, configuration, placement, callback ->
+            BannerAdPreloader.startAndTrack(preloadId, configuration, placement, callback)
+        },
+    )
 
     @Test
-    fun `null poll is returned unchanged`() {
-        every { BannerAdPreloader.pollAd("banner-buffer") } returns null
-
-        assertNullPoll(BannerAdPreloader.pollAndTrackAd("banner-buffer"))
-    }
+    fun `null poll is returned unchanged`() = assertNullPollContract(
+        stubNullPoll = { every { BannerAdPreloader.pollAd(it) } returns null },
+        pollAndTrackAd = { BannerAdPreloader.pollAndTrackAd(it) },
+    )
 
     @Test
     fun `poll installs lifecycle and refresh tracking with independent placement and no load event`() {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdPreloaderTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdPreloaderTest.kt
@@ -5,7 +5,6 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
-import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdPreloader
@@ -16,15 +15,14 @@ import com.revenuecat.purchases.ads.events.types.AdFormat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 internal class InterstitialAdPreloaderTest : PreloaderTest() {
 
     @Before
@@ -38,36 +36,21 @@ internal class InterstitialAdPreloaderTest : PreloaderTest() {
     }
 
     @Test
-    fun `start installs preload tracking`() {
-        val configuration = preloadConfiguration(AD_UNIT_ID)
-        val delegate = RecordingPreloadCallback()
-        val trackingCallback = slot<PreloadCallback>()
-        every { InterstitialAdPreloader.start(PRELOAD_ID, configuration, capture(trackingCallback)) } returns true
-
-        val started = InterstitialAdPreloader.startAndTrack(
-            preloadId = PRELOAD_ID,
-            preloadConfiguration = configuration,
-            placement = START_PLACEMENT,
-            preloadCallback = delegate,
-        )
-
-        assertTrue(started)
-        assertSuccessfulPreload(
-            preloadId = PRELOAD_ID,
-            trackingCallback = trackingCallback.captured,
-            delegate = delegate,
-            expectedFormat = AdFormat.INTERSTITIAL,
-            expectedAdUnitId = AD_UNIT_ID,
-            expectedPlacement = START_PLACEMENT,
-        )
-    }
+    fun `start installs preload tracking`() = assertStartInstallsPreloadTracking(
+        expectedAdFormat = AdFormat.INTERSTITIAL,
+        stubStart = { preloadId, configuration, callback ->
+            every { InterstitialAdPreloader.start(preloadId, configuration, capture(callback)) } returns true
+        },
+        startAndTrack = { preloadId, configuration, placement, callback ->
+            InterstitialAdPreloader.startAndTrack(preloadId, configuration, placement, callback)
+        },
+    )
 
     @Test
-    fun `null poll is returned unchanged`() {
-        every { InterstitialAdPreloader.pollAd(PRELOAD_ID) } returns null
-
-        assertNullPoll(InterstitialAdPreloader.pollAndTrackAd(PRELOAD_ID))
-    }
+    fun `null poll is returned unchanged`() = assertNullPollContract(
+        stubNullPoll = { every { InterstitialAdPreloader.pollAd(it) } returns null },
+        pollAndTrackAd = { InterstitialAdPreloader.pollAndTrackAd(it) },
+    )
 
     @Test
     fun `poll installs lifecycle tracking and returns the same ad`() {
@@ -92,7 +75,6 @@ internal class InterstitialAdPreloaderTest : PreloaderTest() {
     companion object {
         private const val PRELOAD_ID = "interstitial-buffer"
         private const val AD_UNIT_ID = "interstitial-unit"
-        private const val START_PLACEMENT = "interstitial-start-placement"
         private const val POLL_PLACEMENT = "interstitial-poll-placement"
     }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdPreloaderTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdPreloaderTest.kt
@@ -8,7 +8,6 @@ package com.revenuecat.purchases.admob.nextgen
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
-import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
 import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdEventCallback
@@ -29,7 +28,6 @@ import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 internal class NativeAdPreloaderTest : PreloaderTest() {
@@ -45,36 +43,21 @@ internal class NativeAdPreloaderTest : PreloaderTest() {
     }
 
     @Test
-    fun `start installs preload tracking`() {
-        val configuration = preloadConfiguration("native-unit")
-        val delegate = RecordingPreloadCallback()
-        val trackingCallback = slot<PreloadCallback>()
-        every { NativeAdPreloader.start("native-buffer", configuration, capture(trackingCallback)) } returns true
-
-        val started = NativeAdPreloader.startAndTrack(
-            preloadId = "native-buffer",
-            preloadConfiguration = configuration,
-            placement = "native-start-placement",
-            preloadCallback = delegate,
-        )
-
-        assertTrue(started)
-        assertSuccessfulPreload(
-            preloadId = "native-buffer",
-            trackingCallback = trackingCallback.captured,
-            delegate = delegate,
-            expectedFormat = AdFormat.NATIVE,
-            expectedAdUnitId = "native-unit",
-            expectedPlacement = "native-start-placement",
-        )
-    }
+    fun `start installs preload tracking`() = assertStartInstallsPreloadTracking(
+        expectedAdFormat = AdFormat.NATIVE,
+        stubStart = { preloadId, configuration, callback ->
+            every { NativeAdPreloader.start(preloadId, configuration, capture(callback)) } returns true
+        },
+        startAndTrack = { preloadId, configuration, placement, callback ->
+            NativeAdPreloader.startAndTrack(preloadId, configuration, placement, callback)
+        },
+    )
 
     @Test
-    fun `null poll is returned unchanged`() {
-        every { NativeAdPreloader.pollAd("native-buffer") } returns null
-
-        assertNullPoll(NativeAdPreloader.pollAndTrackAd("native-buffer"))
-    }
+    fun `null poll is returned unchanged`() = assertNullPollContract(
+        stubNullPoll = { every { NativeAdPreloader.pollAd(it) } returns null },
+        pollAndTrackAd = { NativeAdPreloader.pollAndTrackAd(it) },
+    )
 
     @Test
     fun `poll installs callbacks for every success result without tracking load`() {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/PreloaderTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/PreloaderTest.kt
@@ -18,6 +18,7 @@ import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdLoadedData
+import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -27,6 +28,7 @@ import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 
 internal abstract class PreloaderTest {
@@ -45,6 +47,39 @@ internal abstract class PreloaderTest {
     @After
     fun tearDownPurchases() {
         unmockkObject(Purchases)
+    }
+
+    protected fun assertStartInstallsPreloadTracking(
+        expectedAdFormat: AdFormat,
+        stubStart: (String, PreloadConfiguration, CapturingSlot<PreloadCallback>) -> Unit,
+        startAndTrack: (String, PreloadConfiguration, String?, PreloadCallback) -> Boolean,
+    ) {
+        val configuration = preloadConfiguration(AD_UNIT_ID)
+        val delegate = RecordingPreloadCallback()
+        val trackingCallback = slot<PreloadCallback>()
+        stubStart(PRELOAD_ID, configuration, trackingCallback)
+
+        val started = startAndTrack(PRELOAD_ID, configuration, START_PLACEMENT, delegate)
+
+        assertTrue(started)
+        assertSuccessfulPreload(
+            preloadId = PRELOAD_ID,
+            trackingCallback = trackingCallback.captured,
+            delegate = delegate,
+            expectedFormat = expectedAdFormat,
+            expectedAdUnitId = AD_UNIT_ID,
+            expectedPlacement = START_PLACEMENT,
+        )
+    }
+
+    protected fun assertNullPollContract(
+        stubNullPoll: (String) -> Unit,
+        pollAndTrackAd: (String) -> Any?,
+    ) {
+        stubNullPoll(PRELOAD_ID)
+
+        assertNull(pollAndTrackAd(PRELOAD_ID))
+        verify(exactly = 0) { adTracker.trackAdLoaded(any(), any()) }
     }
 
     protected fun responseInfo(networkName: String, responseId: String): ResponseInfo = mockk(relaxed = true) {
@@ -102,11 +137,6 @@ internal abstract class PreloaderTest {
         assertEquals(LoadAdError.ErrorCode.NO_FILL.value, failedData.captured.mediatorErrorCode)
     }
 
-    protected fun assertNullPoll(result: Any?) {
-        assertNull(result)
-        verify(exactly = 0) { adTracker.trackAdLoaded(any(), any()) }
-    }
-
     protected class RecordingPreloadCallback(
         private val onPreloaded: (String) -> Unit = {},
         private val onFailedToPreload: (String) -> Unit = {},
@@ -130,5 +160,11 @@ internal abstract class PreloaderTest {
             exhaustedIds += preloadId
             onExhausted(preloadId)
         }
+    }
+
+    private companion object {
+        const val PRELOAD_ID = "preload-buffer"
+        const val AD_UNIT_ID = "preload-unit"
+        const val START_PLACEMENT = "preload-start-placement"
     }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedAdPreloaderTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedAdPreloaderTest.kt
@@ -5,7 +5,6 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
-import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdPreloader
@@ -16,15 +15,14 @@ import com.revenuecat.purchases.ads.events.types.AdFormat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 internal class RewardedAdPreloaderTest : PreloaderTest() {
 
     @Before
@@ -38,36 +36,21 @@ internal class RewardedAdPreloaderTest : PreloaderTest() {
     }
 
     @Test
-    fun `start installs preload tracking`() {
-        val configuration = preloadConfiguration(AD_UNIT_ID)
-        val delegate = RecordingPreloadCallback()
-        val trackingCallback = slot<PreloadCallback>()
-        every { RewardedAdPreloader.start(PRELOAD_ID, configuration, capture(trackingCallback)) } returns true
-
-        val started = RewardedAdPreloader.startAndTrack(
-            preloadId = PRELOAD_ID,
-            preloadConfiguration = configuration,
-            placement = START_PLACEMENT,
-            preloadCallback = delegate,
-        )
-
-        assertTrue(started)
-        assertSuccessfulPreload(
-            preloadId = PRELOAD_ID,
-            trackingCallback = trackingCallback.captured,
-            delegate = delegate,
-            expectedFormat = AdFormat.REWARDED,
-            expectedAdUnitId = AD_UNIT_ID,
-            expectedPlacement = START_PLACEMENT,
-        )
-    }
+    fun `start installs preload tracking`() = assertStartInstallsPreloadTracking(
+        expectedAdFormat = AdFormat.REWARDED,
+        stubStart = { preloadId, configuration, callback ->
+            every { RewardedAdPreloader.start(preloadId, configuration, capture(callback)) } returns true
+        },
+        startAndTrack = { preloadId, configuration, placement, callback ->
+            RewardedAdPreloader.startAndTrack(preloadId, configuration, placement, callback)
+        },
+    )
 
     @Test
-    fun `null poll is returned unchanged`() {
-        every { RewardedAdPreloader.pollAd(PRELOAD_ID) } returns null
-
-        assertNullPoll(RewardedAdPreloader.pollAndTrackAd(PRELOAD_ID))
-    }
+    fun `null poll is returned unchanged`() = assertNullPollContract(
+        stubNullPoll = { every { RewardedAdPreloader.pollAd(it) } returns null },
+        pollAndTrackAd = { RewardedAdPreloader.pollAndTrackAd(it) },
+    )
 
     @Test
     fun `poll installs lifecycle tracking and returns the same ad`() {
@@ -92,7 +75,6 @@ internal class RewardedAdPreloaderTest : PreloaderTest() {
     companion object {
         private const val PRELOAD_ID = "rewarded-buffer"
         private const val AD_UNIT_ID = "rewarded-unit"
-        private const val START_PLACEMENT = "rewarded-start-placement"
         private const val POLL_PLACEMENT = "rewarded-poll-placement"
     }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedInterstitialAdPreloaderTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedInterstitialAdPreloaderTest.kt
@@ -5,7 +5,6 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
-import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAdPreloader
@@ -16,15 +15,14 @@ import com.revenuecat.purchases.ads.events.types.AdFormat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 internal class RewardedInterstitialAdPreloaderTest : PreloaderTest() {
 
     @Before
@@ -38,38 +36,23 @@ internal class RewardedInterstitialAdPreloaderTest : PreloaderTest() {
     }
 
     @Test
-    fun `start installs preload tracking`() {
-        val configuration = preloadConfiguration(AD_UNIT_ID)
-        val delegate = RecordingPreloadCallback()
-        val trackingCallback = slot<PreloadCallback>()
-        every {
-            RewardedInterstitialAdPreloader.start(PRELOAD_ID, configuration, capture(trackingCallback))
-        } returns true
-
-        val started = RewardedInterstitialAdPreloader.startAndTrack(
-            preloadId = PRELOAD_ID,
-            preloadConfiguration = configuration,
-            placement = START_PLACEMENT,
-            preloadCallback = delegate,
-        )
-
-        assertTrue(started)
-        assertSuccessfulPreload(
-            preloadId = PRELOAD_ID,
-            trackingCallback = trackingCallback.captured,
-            delegate = delegate,
-            expectedFormat = AdFormat.REWARDED_INTERSTITIAL,
-            expectedAdUnitId = AD_UNIT_ID,
-            expectedPlacement = START_PLACEMENT,
-        )
-    }
+    fun `start installs preload tracking`() = assertStartInstallsPreloadTracking(
+        expectedAdFormat = AdFormat.REWARDED_INTERSTITIAL,
+        stubStart = { preloadId, configuration, callback ->
+            every {
+                RewardedInterstitialAdPreloader.start(preloadId, configuration, capture(callback))
+            } returns true
+        },
+        startAndTrack = { preloadId, configuration, placement, callback ->
+            RewardedInterstitialAdPreloader.startAndTrack(preloadId, configuration, placement, callback)
+        },
+    )
 
     @Test
-    fun `null poll is returned unchanged`() {
-        every { RewardedInterstitialAdPreloader.pollAd(PRELOAD_ID) } returns null
-
-        assertNullPoll(RewardedInterstitialAdPreloader.pollAndTrackAd(PRELOAD_ID))
-    }
+    fun `null poll is returned unchanged`() = assertNullPollContract(
+        stubNullPoll = { every { RewardedInterstitialAdPreloader.pollAd(it) } returns null },
+        pollAndTrackAd = { RewardedInterstitialAdPreloader.pollAndTrackAd(it) },
+    )
 
     @Test
     fun `poll installs lifecycle tracking and returns the same ad`() {
@@ -94,7 +77,6 @@ internal class RewardedInterstitialAdPreloaderTest : PreloaderTest() {
     companion object {
         private const val PRELOAD_ID = "rewarded-interstitial-buffer"
         private const val AD_UNIT_ID = "rewarded-interstitial-unit"
-        private const val START_PLACEMENT = "rewarded-interstitial-start-placement"
         private const val POLL_PLACEMENT = "rewarded-interstitial-poll-placement"
     }
 }


### PR DESCRIPTION
## Summary

A bit of clean up for the duplicated assertions on each preloader:
- move the common start-tracking and null-poll contracts into shared `PreloaderTest` helpers
- keep format-specific successful-poll coverage in each concrete preloader test
- preserve concrete companion mocking and callback/result assertions

## Verification

- `./gradlew :feature:admob-next-gen:testDefaultsDebugUnitTest`
- `./gradlew detektAll`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes. Risk is limited to possible test coverage drift if helpers diverge from format-specific behavior.
> 
> **Overview**
> Deduplicates AdMob next-gen preloader unit tests by moving the shared **start-tracking** and **null-poll** contracts into `PreloaderTest` helpers.
> 
> Each format-specific test now only stubs its SDK companion and delegates those two cases, while successful-poll / lifecycle-callback coverage stays in the concrete classes. Shared fixture IDs for start tests live on the base class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e4d9db4a6bcfcf0f4cd04f3f67d98fbeff8ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->