### PR TITLE
refactor(admob): share suspended ad load result tracking

### DIFF
--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingAdLoadCallback.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingAdLoadCallback.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.admob.nextgen.tracking
 
 import com.google.android.libraries.ads.mobile.sdk.common.Ad
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
@@ -41,6 +42,23 @@ internal class TrackingAdLoadCallback<AdT : Ad>(
         trackAdFailedToLoad(adError, adFormat, placement, adUnitId)
         delegate?.onAdFailedToLoad(adError)
     }
+}
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+internal fun <AdT : Ad> AdLoadResult<AdT>.trackAndConfigureAdLoadResult(
+    adFormat: AdFormat,
+    placement: String?,
+    adUnitId: String,
+    configureAd: (AdT) -> Unit,
+): AdLoadResult<AdT> {
+    when (this) {
+        is AdLoadResult.Success -> {
+            trackAdLoaded({ ad.getResponseInfo() }, adFormat, placement, adUnitId)
+            configureAd(ad)
+        }
+        is AdLoadResult.Failure -> trackAdFailedToLoad(error, adFormat, placement, adUnitId)
+    }
+    return this
 }
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/AdLoadResultTrackingTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/AdLoadResultTrackingTest.kt
@@ -1,0 +1,175 @@
+@file:OptIn(
+    ExperimentalPreviewRevenueCatPurchasesAPI::class,
+    InternalRevenueCatAPI::class,
+)
+
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.google.android.libraries.ads.mobile.sdk.common.Ad
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
+import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdLoadedData
+import com.revenuecat.purchases.ads.events.types.AdMediatorName
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+class AdLoadResultTrackingTest {
+    private val adTracker = mockk<AdTracker>(relaxed = true)
+    private val purchases = mockk<Purchases>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        every { purchases.adTracker } returns adTracker
+        mockkObject(Purchases)
+        every { Purchases.isConfigured } returns true
+        every { Purchases.sharedInstance } returns purchases
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(Purchases)
+    }
+
+    @Test
+    fun `success tracks loaded ad before configuring and returns original result`() {
+        val responseInfo = responseInfo(adapterClassName = "test-network", responseId = "response-id")
+        val ad = mockk<Ad>()
+        every { ad.getResponseInfo() } returns responseInfo
+        val order = mutableListOf<String>()
+        every { adTracker.trackAdLoaded(any(), any()) } answers { order += "track" }
+        val result = AdLoadResult.Success(ad)
+
+        val returnedResult = result.trackAndConfigureAdLoadResult(
+            adFormat = AdFormat.BANNER,
+            placement = "home",
+            adUnitId = "ad-unit",
+            configureAd = { order += "configure" },
+        )
+
+        val trackedData = slot<AdLoadedData>()
+        verify(exactly = 1) {
+            adTracker.trackAdLoaded(capture(trackedData), AdCaptureMethod.ADAPTER)
+        }
+        assertEquals(
+            AdLoadedData(
+                networkName = "test-network",
+                mediatorName = AdMediatorName.AD_MOB,
+                adFormat = AdFormat.BANNER,
+                placement = "home",
+                adUnitId = "ad-unit",
+                impressionId = "response-id",
+            ),
+            trackedData.captured,
+        )
+        assertEquals(listOf("track", "configure"), order)
+        assertSame(result, returnedResult)
+    }
+
+    @Test
+    fun `failure tracks failed load without configuring and returns original result`() {
+        val error = mockk<LoadAdError>()
+        every { error.code } returns LoadAdError.ErrorCode.NOT_FOUND
+        var configured = false
+        val result = AdLoadResult.Failure<Ad>(error)
+
+        val returnedResult = result.trackAndConfigureAdLoadResult(
+            adFormat = AdFormat.INTERSTITIAL,
+            placement = null,
+            adUnitId = "ad-unit",
+            configureAd = { configured = true },
+        )
+
+        val trackedData = slot<AdFailedToLoadData>()
+        verify(exactly = 1) {
+            adTracker.trackAdFailedToLoad(capture(trackedData), AdCaptureMethod.ADAPTER)
+        }
+        assertEquals(
+            AdFailedToLoadData(
+                mediatorName = AdMediatorName.AD_MOB,
+                adFormat = AdFormat.INTERSTITIAL,
+                placement = null,
+                adUnitId = "ad-unit",
+                mediatorErrorCode = 7,
+            ),
+            trackedData.captured,
+        )
+        assertFalse("configureAd must not run for a failed load", configured)
+        assertSame(result, returnedResult)
+    }
+
+    @Test
+    fun `success still configures when Purchases is not configured`() {
+        every { Purchases.isConfigured } returns false
+        val ad = mockk<Ad>()
+        var configuredAd: Ad? = null
+        val result = AdLoadResult.Success(ad)
+
+        result.trackAndConfigureAdLoadResult(
+            adFormat = AdFormat.REWARDED,
+            placement = "bonus",
+            adUnitId = "ad-unit",
+            configureAd = { configuredAd = it },
+        )
+
+        verify(exactly = 0) { ad.getResponseInfo() }
+        verify(exactly = 0) { adTracker.trackAdLoaded(any(), any()) }
+        assertSame(ad, configuredAd)
+    }
+
+    @Test
+    fun `success still configures when reading response info throws`() {
+        val ad = mockk<Ad>()
+        every { ad.getResponseInfo() } throws IllegalStateException("boom")
+        var configuredAd: Ad? = null
+
+        AdLoadResult.Success(ad).trackAndConfigureAdLoadResult(
+            adFormat = AdFormat.APP_OPEN,
+            placement = null,
+            adUnitId = "ad-unit",
+            configureAd = { configuredAd = it },
+        )
+
+        assertSame(ad, configuredAd)
+    }
+
+    @Test
+    fun `success still configures when tracking throws`() {
+        every { adTracker.trackAdLoaded(any(), any()) } throws IllegalStateException("boom")
+        val ad = mockk<Ad>()
+        every { ad.getResponseInfo() } returns responseInfo("test-network", "response-id")
+        var configuredAd: Ad? = null
+
+        AdLoadResult.Success(ad).trackAndConfigureAdLoadResult(
+            adFormat = AdFormat.REWARDED_INTERSTITIAL,
+            placement = "level-end",
+            adUnitId = "ad-unit",
+            configureAd = { configuredAd = it },
+        )
+
+        assertSame(ad, configuredAd)
+    }
+
+    private fun responseInfo(adapterClassName: String, responseId: String): ResponseInfo =
+        mockk<ResponseInfo>().also {
+            every { it.adapterClassName } returns adapterClassName
+            every { it.responseId } returns responseId
+        }
+}


### PR DESCRIPTION
## Summary

- add an internal AdLoadResult helper that shares loaded/failed tracking for suspending Google Mobile Ads Next-Gen APIs
- configure successful ads after the tracking attempt while returning the exact original result instance
- preserve lazy response-info lookup and tracking-failure resilience, with focused success/failure contract tests

## Context

This is a foundation-only change for later adoption by the format-specific suspending loaders.

## Test plan

- ./gradlew :feature:admob-next-gen:testDefaultsDebugUnitTest
- ./gradlew detektAll
- ./scripts/api-check.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal tracking helper plus unit tests; no public API or production call-site changes yet.
> 
> **Overview**
> Adds `AdLoadResult.trackAndConfigureAdLoadResult` so suspending Next-Gen loaders can reuse the same loaded/failed tracking as `TrackingAdLoadCallback`.
> 
> On success it tracks then runs `configureAd`; on failure it only tracks. It always returns the original result instance, and tracking still goes through `trackIfConfigured` so missing SDK setup or tracker errors do not skip ad configuration. Unit tests cover success, failure, and those resilience cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1690bc287e8b17e98aae13903121c39b976fad93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->