### PR TITLE
Key the persisted remote config state by domain

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -222,7 +222,7 @@ internal class PurchasesFactory(
             val remoteConfigEnabled = !appConfig.customEntitlementComputation
             val remoteConfigDiskCache = if (remoteConfigEnabled) RemoteConfigDiskCache(contextForStorage) else null
             val remoteConfigTopicStore = RemoteConfigTopicStore {
-                remoteConfigDiskCache?.read()?.topics?.get(it.wireName)
+                remoteConfigDiskCache?.read()?.mergedTopics?.get(it.wireName)
             }
             val apiSourceProvider = DefaultRemoteConfigSourceProvider(remoteConfigTopicStore)
             val apiSourceFailover = APISourceFailover(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -102,7 +102,6 @@ internal data class PersistedRemoteConfigurationState(
             }
         }
     }
-
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -90,7 +90,9 @@ internal data class PersistedRemoteConfigurationState(
     val mergedTopics: Map<String, ConfigTopic> by lazy {
         buildMap {
             domainsInPrecedenceOrder.forEach { domain ->
-                domains[domain]?.topics?.forEach { (name, topic) -> putIfAbsent(name, topic) }
+                domains[domain]?.topics?.forEach { (name, topic) ->
+                    if (name !in this) put(name, topic)
+                }
             }
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -61,24 +61,15 @@ internal data class PersistedRemoteConfigurationState(
         get() = domains[rootDomain]
 
     /**
-     * Every persisted domain reachable from [rootDomain] through the persisted `subdomains` lists, root-first
-     * BFS (shallower domains before deeper ones, siblings in declaration order), guarded by a visited set
-     * (cycles/duplicates contribute once) and [MAX_SUBDOMAIN_DEPTH]. Domains present in [domains] but not
-     * reachable from the root are excluded: they are stale entries awaiting pruning, never part of the merged
-     * configuration.
+     * The root domain followed by its persisted `subdomains` in declaration order (duplicates and a
+     * self-reference contribute once). Only one level of subdomains is supported: a subdomain's own
+     * `subdomains` list never extends the merged configuration. Domains present in [domains] but not in the
+     * root's list are excluded: they are stale entries, never part of the merged configuration; when the root
+     * itself has no entry, nothing is.
      */
     val domainsInPrecedenceOrder: List<String> by lazy {
-        buildList {
-            val visited = mutableSetOf<String>()
-            var frontier = listOf(rootDomain)
-            var depth = 0
-            while (frontier.isNotEmpty() && depth <= MAX_SUBDOMAIN_DEPTH) {
-                val level = frontier.filter { visited.add(it) }.filter { it in domains }
-                addAll(level)
-                frontier = level.flatMap { domains.getValue(it).subdomains }
-                depth++
-            }
-        }
+        val root = rootState ?: return@lazy emptyList()
+        listOf(rootDomain) + root.subdomains.distinct().filter { it != rootDomain && it in domains }
     }
 
     /**
@@ -112,10 +103,6 @@ internal data class PersistedRemoteConfigurationState(
         }
     }
 
-    companion object {
-        /** Root sits at depth 0; subdomain lists deeper than this are ignored (logged at sync time). */
-        const val MAX_SUBDOMAIN_DEPTH = 3
-    }
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -10,36 +10,138 @@ import java.io.File
 import java.io.IOException
 
 /**
- * The sync bookkeeping the SDK persists between `/v1/config` calls.
+ * One domain's sync bookkeeping between `/v1/config` calls.
  *
- * [manifest] is the **opaque** server token, stored verbatim and replayed on the next request; the SDK never
- * parses it. [activeTopics] is the last response's full active-topic-name set (used to detect removed topics).
- * [prefetchBlobs] is the last response's prefetch set (retention input + which blobs to fetch).
+ * [manifest] is the **opaque** server token, stored verbatim and replayed on the next request for this domain;
+ * the SDK never parses it. [subdomains] is the last response's list of other domains that also contribute to the
+ * full configuration (outside the manifest, so it does not participate in change detection). [activeTopics] is
+ * the last response's full active-topic-name set (used to detect removed topics). [prefetchBlobs] is the last
+ * response's prefetch set (retention input + which blobs to fetch).
  *
  * [topics] is the full per-topic item index — the configuration itself (each item's `blob_ref` plus its inline
  * `content`), which is the **source of truth**: persisting it is the whole sync commit, and consumers read their
  * topic metadata back from it. Only the heavy blob *bytes* live elsewhere (the content-addressed blob store,
  * keyed by `blob_ref`); the index holds the small metadata map per topic (an empty map for inline-only topics).
  *
- * [lastRefreshTime] is the epoch-millis instant of the last successful config request — a `200` *or* a `204`, since
- * both confirm the cached configuration is current. It is replayed in the `X-RC-Last-Refresh-Time` request header so
- * the server can optimize its response, which is why it is persisted next to the [manifest] it pairs with: an
- * app-start request must carry it too. Unlike the topic index it is recoverable metadata, not source of truth, so a
- * failed write only costs the next request a staler value.
+ * [lastRefreshTime] is the epoch-millis instant of this domain's last successful config request — a `200` *or* a
+ * `204`, since both confirm the cached configuration is current. It is replayed in the `X-RC-Last-Refresh-Time`
+ * request header so the server can optimize its response, which is why it is persisted next to the [manifest] it
+ * pairs with: an app-start request must carry it too. Unlike the topic index it is recoverable metadata, not
+ * source of truth, so a failed write only costs the next request a staler value.
  *
  * The value is always the **server's** own `X-RevenueCat-Request-Time`, never a device-clock reading: the server
  * compares it against its own clock, so a skewed device would silently corrupt that comparison. A response without
  * the header leaves the previous value in place rather than substituting local time.
  */
 @Serializable
+internal data class PersistedDomainState(
+    val manifest: String,
+    val subdomains: List<String> = emptyList(),
+    val activeTopics: List<String> = emptyList(),
+    val prefetchBlobs: List<String> = emptyList(),
+    val topics: Map<String, ConfigTopic> = emptyMap(),
+    val lastRefreshTime: Long? = null,
+)
+
+/**
+ * The full persisted configuration: every synced domain's [PersistedDomainState], keyed by domain name, plus
+ * which domain is the tree's root. Kept as a **single atomic write** (a sync commit updates one domain's entry
+ * but always rewrites the whole file), so the persisted tree is never internally torn.
+ *
+ * The merged views ([domainsInPrecedenceOrder], [mergedTopics], [liveBlobRefs]) are derived lazily per state
+ * instance and cached — the state is immutable and the disk cache hands out one snapshot, so they compute at
+ * most once per committed state even though the topic store reads on every HTTP request.
+ */
+@Serializable
 internal data class PersistedRemoteConfigurationState(
+    val rootDomain: String,
+    val domains: Map<String, PersistedDomainState> = emptyMap(),
+) {
+    val rootState: PersistedDomainState?
+        get() = domains[rootDomain]
+
+    /**
+     * Every persisted domain reachable from [rootDomain] through the persisted `subdomains` lists, root-first
+     * BFS (shallower domains before deeper ones, siblings in declaration order), guarded by a visited set
+     * (cycles/duplicates contribute once) and [MAX_SUBDOMAIN_DEPTH]. Domains present in [domains] but not
+     * reachable from the root are excluded: they are stale entries awaiting pruning, never part of the merged
+     * configuration.
+     */
+    val domainsInPrecedenceOrder: List<String> by lazy {
+        buildList {
+            val visited = mutableSetOf<String>()
+            var frontier = listOf(rootDomain)
+            var depth = 0
+            while (frontier.isNotEmpty() && depth <= MAX_SUBDOMAIN_DEPTH) {
+                val level = frontier.filter { visited.add(it) }.filter { it in domains }
+                addAll(level)
+                frontier = level.flatMap { domains.getValue(it).subdomains }
+                depth++
+            }
+        }
+    }
+
+    /**
+     * The union of every reachable domain's topics — the configuration consumers read. On a topic-name
+     * collision the domain earlier in [domainsInPrecedenceOrder] wins (parent over child, so a topic migrating
+     * to a subdomain cuts over exactly when its parent stops serving it); topics are never merged item-wise
+     * across domains.
+     */
+    val mergedTopics: Map<String, ConfigTopic> by lazy {
+        buildMap {
+            domainsInPrecedenceOrder.forEach { domain ->
+                domains[domain]?.topics?.forEach { (name, topic) -> putIfAbsent(name, topic) }
+            }
+        }
+    }
+
+    /**
+     * Every blob ref any persisted domain still wants (its prefetch set plus its topics' `blob_ref`s) — the
+     * retention set for blob-store cleanup. Deliberately spans **all** entries in [domains], including ones not
+     * reachable from the root: an entry that survived a partial sync keeps pinning its blobs until the entry
+     * itself is pruned, so cleanup can never race ahead of the state that references the blobs.
+     */
+    val liveBlobRefs: Set<String> by lazy {
+        buildSet {
+            domains.values.forEach { state ->
+                addAll(state.prefetchBlobs)
+                addAll(state.topics.toTopicBlobRefs().values.flatten())
+            }
+        }
+    }
+
+    companion object {
+        /** Root sits at depth 0; subdomain lists deeper than this are ignored (logged at sync time). */
+        const val MAX_SUBDOMAIN_DEPTH = 3
+    }
+}
+
+/**
+ * The pre-subdomain persisted shape (a single flat domain). Kept only so an existing file written by an older
+ * SDK version lifts into [PersistedRemoteConfigurationState] instead of forcing a cold full re-fetch.
+ */
+@Serializable
+private data class LegacyPersistedRemoteConfigurationState(
     val domain: String,
     val manifest: String,
     val activeTopics: List<String> = emptyList(),
     val prefetchBlobs: List<String> = emptyList(),
     val topics: Map<String, ConfigTopic> = emptyMap(),
     val lastRefreshTime: Long? = null,
-)
+) {
+    fun migrated() = PersistedRemoteConfigurationState(
+        rootDomain = domain,
+        domains = mapOf(
+            domain to PersistedDomainState(
+                manifest = manifest,
+                activeTopics = activeTopics,
+                prefetchBlobs = prefetchBlobs,
+                topics = topics,
+                lastRefreshTime = lastRefreshTime,
+            ),
+        ),
+    )
+}
 
 /**
  * Persists [PersistedRemoteConfigurationState] to `noBackupFilesDir/RevenueCat/remote_config/`
@@ -79,19 +181,31 @@ internal class RemoteConfigDiskCache(
     private fun readFromDisk(): PersistedRemoteConfigurationState? {
         val target = targetFile()
         if (!target.exists()) return null
-        val atomicFile = AtomicFile(target)
         return try {
-            json.decodeFromString(
-                PersistedRemoteConfigurationState.serializer(),
-                atomicFile.readFully().toString(Charsets.UTF_8),
-            )
+            decode(AtomicFile(target).readFully().toString(Charsets.UTF_8))
         } catch (e: IOException) {
             errorLog(e) { "Failed to read remote config from disk." }
             null
-        } catch (e: SerializationException) {
+        }
+    }
+
+    private fun decode(content: String): PersistedRemoteConfigurationState? = try {
+        json.decodeFromString(PersistedRemoteConfigurationState.serializer(), content)
+    } catch (e: SerializationException) {
+        // Not the current shape: an older SDK version may have written the pre-subdomain single-domain shape
+        // (its missing `rootDomain` fails the decode above). Lifting it preserves the manifest, so the next
+        // sync is an incremental diff instead of a cold re-fetch. Migrated in memory only; the next successful
+        // write persists the new shape.
+        decodeLegacy(content) ?: run {
             errorLog(e) { "Failed to deserialize remote config from disk." }
             null
         }
+    }
+
+    private fun decodeLegacy(content: String): PersistedRemoteConfigurationState? = try {
+        json.decodeFromString(LegacyPersistedRemoteConfigurationState.serializer(), content).migrated()
+    } catch (_: SerializationException) {
+        null
     }
 
     private fun writeToDisk(config: PersistedRemoteConfigurationState): Boolean {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -249,7 +249,9 @@ internal class RemoteConfigManager(
     ) {
         val persisted = diskCache.read()
         val storedBlobs = blobStore.cachedRefs()
-        val domain = persisted?.domain ?: DEFAULT_DOMAIN
+        val domain = persisted?.rootDomain ?: DEFAULT_DOMAIN
+        // Request bookkeeping is domain-scoped: each domain replays its own manifest/refresh time/prefetch set.
+        val domainState = persisted?.domains?.get(domain)
         logRefreshStart(persisted, appInBackground)
         backend.getRemoteConfig(
             appInBackground = appInBackground,
@@ -257,10 +259,10 @@ internal class RemoteConfigManager(
             fetchContext = requestFetchContext,
             domain = domain,
             // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
-            manifest = persisted?.manifest,
-            lastRefreshTime = persisted?.lastRefreshTime?.let(::Date),
+            manifest = domainState?.manifest,
+            lastRefreshTime = domainState?.lastRefreshTime?.let(::Date),
             // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
-            prefetchedBlobs = persisted?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
+            prefetchedBlobs = domainState?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
             onSuccess = { container, requestDate, _ ->
                 handleMainRefreshSuccess(requestEpoch, persisted, container, requestDate)
             },
@@ -269,7 +271,7 @@ internal class RemoteConfigManager(
                     requestEpoch,
                     appInBackground,
                     domain,
-                    hasCachedConfig = persisted != null,
+                    hasCachedConfig = domainState != null,
                     error,
                     behavior,
                 )
@@ -431,7 +433,12 @@ internal class RemoteConfigManager(
                     // the previous value carries forward. Re-read instead of reusing the request's snapshot, and
                     // skip when nothing is persisted: a 204 must never resurrect a cache that was wiped meanwhile.
                     if (requestDate != null) {
-                        diskCache.read()?.let { diskCache.write(it.copy(lastRefreshTime = requestDate.time)) }
+                        diskCache.read()?.let { state ->
+                            state.rootState?.let { root ->
+                                val refreshed = root.copy(lastRefreshTime = requestDate.time)
+                                diskCache.write(state.copy(domains = state.domains + (state.rootDomain to refreshed)))
+                            }
+                        }
                     }
                 }
             } finally {
@@ -442,8 +449,8 @@ internal class RemoteConfigManager(
 
     private fun logRefreshStart(persisted: PersistedRemoteConfigurationState?, appInBackground: Boolean) {
         verboseLog {
-            "Refreshing remote config (domain=${persisted?.domain ?: DEFAULT_DOMAIN}, " +
-                "manifest present=${persisted?.manifest != null}, appInBackground=$appInBackground)."
+            "Refreshing remote config (domain=${persisted?.rootDomain ?: DEFAULT_DOMAIN}, " +
+                "manifest present=${persisted?.rootState?.manifest != null}, appInBackground=$appInBackground)."
         }
     }
 
@@ -876,30 +883,37 @@ internal class RemoteConfigManager(
             "Received remote config: active topics=${response.activeTopics}; changed topics: " +
                 "[${changed.ifEmpty { "none" }}]."
         }
-        val previousTopics = previous?.topics ?: emptyMap()
+        val previousDomainState = previous?.domains?.get(response.domain)
+        val previousTopics = previousDomainState?.topics ?: emptyMap()
         // Changed topics (present in the response) overwrite their item index; unchanged active topics keep their
         // carried-forward index (the server omits them); topics no longer active are pruned.
         val mergedTopics = (previousTopics + response.topics)
             .filterKeys { it in response.activeTopics }
-        // Blobs the current config still wants: the prefetch set plus any active-topic blob ref.
-        val blobRefsToKeep = response.prefetchBlobs.toSet() + mergedTopics.toTopicBlobRefs().values.flatten()
+        // Blobs this domain's config still wants: the prefetch set plus any active-topic blob ref.
+        val domainBlobRefs = response.prefetchBlobs.toSet() + mergedTopics.toTopicBlobRefs().values.flatten()
 
         // Persist the configuration first: the full topic index (incl. each item's inline content) plus the
         // manifest the server diffs against is the source of truth, and persisting it IS the entire commit (the
         // manifest advances unconditionally). Inline blobs are recoverable over the network, so only touch the
         // blob store once the state is durably committed — a failed persist never orphans or evicts blobs.
-        val persisted = diskCache.write(
-            PersistedRemoteConfigurationState(
-                domain = response.domain,
-                manifest = response.manifest,
-                activeTopics = response.activeTopics,
-                prefetchBlobs = response.prefetchBlobs,
-                topics = mergedTopics,
-                // Server time only: a response without it carries the last server-supplied value forward rather
-                // than substituting a device-clock reading the server cannot compare against its own.
-                lastRefreshTime = requestDate?.time ?: previous?.lastRefreshTime,
-            ),
+        // A root rename replaces the whole tree (old entries would be unreachable stale state, not history).
+        val carriedDomains = previous?.domains?.takeIf { previous.rootDomain == response.domain } ?: emptyMap()
+        val newState = PersistedRemoteConfigurationState(
+            rootDomain = response.domain,
+            domains = carriedDomains + (
+                response.domain to PersistedDomainState(
+                    manifest = response.manifest,
+                    subdomains = response.subdomains,
+                    activeTopics = response.activeTopics,
+                    prefetchBlobs = response.prefetchBlobs,
+                    topics = mergedTopics,
+                    // Server time only: a response without it carries the last server-supplied value forward
+                    // rather than substituting a device-clock reading the server cannot compare against its own.
+                    lastRefreshTime = requestDate?.time ?: previousDomainState?.lastRefreshTime,
+                )
+                ),
         )
+        val persisted = diskCache.write(newState)
 
         if (persisted) {
             // The staleness gate measures elapsed *local* time (isCacheStale subtracts from dateProvider.now), so
@@ -909,10 +923,12 @@ internal class RemoteConfigManager(
             hasCommittedInitialConfig = true
             debugLog {
                 "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +
-                    "${blobRefsToKeep.size} blobs wanted)."
+                    "${domainBlobRefs.size} blobs wanted)."
             }
-            container?.let { extractInlineBlobs(it, blobRefsToKeep) }
-            blobStore.retainOnly(blobRefsToKeep)
+            container?.let { extractInlineBlobs(it, domainBlobRefs) }
+            // Retention spans every persisted domain, never just the one that synced: another domain's blobs
+            // must survive this domain's cleanup.
+            blobStore.retainOnly(newState.liveBlobRefs)
             prefetchBlobs(response, mergedTopics)
             // A new version is committed: advance the generation and let listeners re-warm their in-memory
             // caches. Runs under cacheLock (both persist callers hold it), so the bump+notify is serialized

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigFallbackIntegrationTest.kt
@@ -170,7 +170,7 @@ internal class ProductionRemoteConfigFallbackIntegrationTest : BaseBackendIntegr
         val blobFetcher = mockk<RemoteConfigBlobFetcher>(relaxed = true)
         coEvery { blobFetcher.ensureDownloaded(any<String>()) } answers { remoteConfigBlobStore.contains(firstArg()) }
         val diskCache = RemoteConfigDiskCache(context)
-        val topicStore = RemoteConfigTopicStore { diskCache.read()?.topics?.get(it.wireName) }
+        val topicStore = RemoteConfigTopicStore { diskCache.read()?.mergedTopics?.get(it.wireName) }
         return RemoteConfigManager(
             backend = backend,
             diskCache = diskCache,

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionRemoteConfigIntegrationTest.kt
@@ -361,7 +361,7 @@ internal class ProductionRemoteConfigIntegrationTest : BaseBackendIntegrationTes
         val blobFetcher = mockk<RemoteConfigBlobFetcher>(relaxed = true)
         coEvery { blobFetcher.ensureDownloaded(any<String>()) } answers { remoteConfigBlobStore.contains(firstArg()) }
         val diskCache = RemoteConfigDiskCache(context)
-        val topicStore = RemoteConfigTopicStore { diskCache.read()?.topics?.get(it.wireName) }
+        val topicStore = RemoteConfigTopicStore { diskCache.read()?.mergedTopics?.get(it.wireName) }
         return RemoteConfigManager(
             backend = backend,
             diskCache = diskCache,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/PersistedRemoteConfigurationStateTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/PersistedRemoteConfigurationStateTest.kt
@@ -1,0 +1,145 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class PersistedRemoteConfigurationStateTest {
+
+    @Test
+    fun `merged topics union every reachable domain's topics`() {
+        val state = tree(
+            "app" to domain(subdomains = listOf("child"), topics = mapOf("sources" to topic("api"))),
+            "child" to domain(topics = mapOf("workflows" to topic("wf1"))),
+        )
+
+        assertThat(state.mergedTopics).containsOnlyKeys("sources", "workflows")
+    }
+
+    @Test
+    fun `on a topic collision the parent wins over the child`() {
+        val state = tree(
+            "app" to domain(subdomains = listOf("child"), topics = mapOf("workflows" to topic("fromParent"))),
+            "child" to domain(topics = mapOf("workflows" to topic("fromChild"))),
+        )
+
+        assertThat(state.mergedTopics.getValue("workflows")).containsOnlyKeys("fromParent")
+    }
+
+    @Test
+    fun `on a topic collision between siblings the earlier-declared sibling wins`() {
+        val state = tree(
+            "app" to domain(subdomains = listOf("first", "second")),
+            "first" to domain(topics = mapOf("workflows" to topic("fromFirst"))),
+            "second" to domain(topics = mapOf("workflows" to topic("fromSecond"))),
+        )
+
+        assertThat(state.mergedTopics.getValue("workflows")).containsOnlyKeys("fromFirst")
+    }
+
+    @Test
+    fun `on a topic collision a shallower domain wins over a deeper one`() {
+        val state = tree(
+            "app" to domain(subdomains = listOf("child", "uncle")),
+            "child" to domain(subdomains = listOf("grandchild")),
+            "grandchild" to domain(topics = mapOf("workflows" to topic("fromGrandchild"))),
+            "uncle" to domain(topics = mapOf("workflows" to topic("fromUncle"))),
+        )
+
+        assertThat(state.domainsInPrecedenceOrder).containsExactly("app", "child", "uncle", "grandchild")
+        assertThat(state.mergedTopics.getValue("workflows")).containsOnlyKeys("fromUncle")
+    }
+
+    @Test
+    fun `a domain entry not reachable from the root is excluded from the merged view`() {
+        val state = tree(
+            "app" to domain(topics = mapOf("sources" to topic("api"))),
+            "orphan" to domain(topics = mapOf("workflows" to topic("wf1"))),
+        )
+
+        assertThat(state.domainsInPrecedenceOrder).containsExactly("app")
+        assertThat(state.mergedTopics).containsOnlyKeys("sources")
+    }
+
+    @Test
+    fun `a subdomain listed without a persisted entry contributes nothing`() {
+        val state = tree(
+            "app" to domain(subdomains = listOf("notSyncedYet"), topics = mapOf("sources" to topic("api"))),
+        )
+
+        assertThat(state.domainsInPrecedenceOrder).containsExactly("app")
+        assertThat(state.mergedTopics).containsOnlyKeys("sources")
+    }
+
+    @Test
+    fun `cycles and re-listed domains terminate and contribute once`() {
+        val state = tree(
+            "app" to domain(subdomains = listOf("child", "child", "app")),
+            "child" to domain(subdomains = listOf("app"), topics = mapOf("workflows" to topic("wf1"))),
+        )
+
+        assertThat(state.domainsInPrecedenceOrder).containsExactly("app", "child")
+        assertThat(state.mergedTopics).containsOnlyKeys("workflows")
+    }
+
+    @Test
+    fun `domains deeper than the depth cap are excluded`() {
+        // Root at depth 0; d1..d3 within the cap, d4 beyond it.
+        val state = tree(
+            "app" to domain(subdomains = listOf("d1")),
+            "d1" to domain(subdomains = listOf("d2")),
+            "d2" to domain(subdomains = listOf("d3")),
+            "d3" to domain(subdomains = listOf("d4"), topics = mapOf("inCap" to topic("a"))),
+            "d4" to domain(topics = mapOf("beyondCap" to topic("b"))),
+        )
+
+        assertThat(state.domainsInPrecedenceOrder).containsExactly("app", "d1", "d2", "d3")
+        assertThat(state.mergedTopics).containsOnlyKeys("inCap")
+    }
+
+    @Test
+    fun `live blob refs span every persisted domain including unreachable entries`() {
+        val state = tree(
+            "app" to domain(
+                prefetchBlobs = listOf("rootPrefetch"),
+                topics = mapOf("sources" to ConfigTopic(mapOf("api" to item(blobRef = "rootTopicBlob")))),
+            ),
+            "orphan" to domain(
+                prefetchBlobs = listOf("orphanPrefetch"),
+                topics = mapOf("workflows" to ConfigTopic(mapOf("wf1" to item(blobRef = "orphanTopicBlob")))),
+            ),
+        )
+
+        assertThat(state.liveBlobRefs)
+            .containsExactlyInAnyOrder("rootPrefetch", "rootTopicBlob", "orphanPrefetch", "orphanTopicBlob")
+    }
+
+    @Test
+    fun `rootState is null when the root domain has no persisted entry yet`() {
+        val state = PersistedRemoteConfigurationState(
+            rootDomain = "app",
+            domains = mapOf("child" to domain()),
+        )
+
+        assertThat(state.rootState).isNull()
+        assertThat(state.domainsInPrecedenceOrder).isEmpty()
+        assertThat(state.mergedTopics).isEmpty()
+    }
+
+    private fun tree(vararg domains: Pair<String, PersistedDomainState>) =
+        PersistedRemoteConfigurationState(rootDomain = "app", domains = domains.toMap())
+
+    private fun domain(
+        subdomains: List<String> = emptyList(),
+        prefetchBlobs: List<String> = emptyList(),
+        topics: Map<String, ConfigTopic> = emptyMap(),
+    ) = PersistedDomainState(
+        manifest = "v1.0.",
+        subdomains = subdomains,
+        prefetchBlobs = prefetchBlobs,
+        topics = topics,
+    )
+
+    private fun topic(itemKey: String) = ConfigTopic(mapOf(itemKey to item()))
+
+    private fun item(blobRef: String? = null) = RemoteConfiguration.ConfigItem(blobRef = blobRef)
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/PersistedRemoteConfigurationStateTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/PersistedRemoteConfigurationStateTest.kt
@@ -37,16 +37,15 @@ class PersistedRemoteConfigurationStateTest {
     }
 
     @Test
-    fun `on a topic collision a shallower domain wins over a deeper one`() {
+    fun `a subdomain's own subdomains never extend the merged view`() {
         val state = tree(
-            "app" to domain(subdomains = listOf("child", "uncle")),
-            "child" to domain(subdomains = listOf("grandchild")),
-            "grandchild" to domain(topics = mapOf("workflows" to topic("fromGrandchild"))),
-            "uncle" to domain(topics = mapOf("workflows" to topic("fromUncle"))),
+            "app" to domain(subdomains = listOf("child")),
+            "child" to domain(subdomains = listOf("grandchild"), topics = mapOf("workflows" to topic("fromChild"))),
+            "grandchild" to domain(topics = mapOf("beyondOneLevel" to topic("x"))),
         )
 
-        assertThat(state.domainsInPrecedenceOrder).containsExactly("app", "child", "uncle", "grandchild")
-        assertThat(state.mergedTopics.getValue("workflows")).containsOnlyKeys("fromUncle")
+        assertThat(state.domainsInPrecedenceOrder).containsExactly("app", "child")
+        assertThat(state.mergedTopics).containsOnlyKeys("workflows")
     }
 
     @Test
@@ -71,29 +70,14 @@ class PersistedRemoteConfigurationStateTest {
     }
 
     @Test
-    fun `cycles and re-listed domains terminate and contribute once`() {
+    fun `duplicates and a self-reference in the root's list contribute once`() {
         val state = tree(
             "app" to domain(subdomains = listOf("child", "child", "app")),
-            "child" to domain(subdomains = listOf("app"), topics = mapOf("workflows" to topic("wf1"))),
+            "child" to domain(topics = mapOf("workflows" to topic("wf1"))),
         )
 
         assertThat(state.domainsInPrecedenceOrder).containsExactly("app", "child")
         assertThat(state.mergedTopics).containsOnlyKeys("workflows")
-    }
-
-    @Test
-    fun `domains deeper than the depth cap are excluded`() {
-        // Root at depth 0; d1..d3 within the cap, d4 beyond it.
-        val state = tree(
-            "app" to domain(subdomains = listOf("d1")),
-            "d1" to domain(subdomains = listOf("d2")),
-            "d2" to domain(subdomains = listOf("d3")),
-            "d3" to domain(subdomains = listOf("d4"), topics = mapOf("inCap" to topic("a"))),
-            "d4" to domain(topics = mapOf("beyondCap" to topic("b"))),
-        )
-
-        assertThat(state.domainsInPrecedenceOrder).containsExactly("app", "d1", "d2", "d3")
-        assertThat(state.mergedTopics).containsOnlyKeys("inCap")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
@@ -48,43 +48,46 @@ class RemoteConfigDiskCacheTest {
     }
 
     @Test
-    fun `write then read round-trips the full persisted config`() {
+    fun `write then read round-trips a multi-domain persisted config`() {
         val config = PersistedRemoteConfigurationState(
-            domain = "app",
-            manifest = "v1.1710000100.sources:etag1,product_entitlement_mapping:etag2",
-            activeTopics = listOf("sources", "product_entitlement_mapping"),
-            prefetchBlobs = listOf("blobRefA"),
-            topics = mapOf(
-                "sources" to ConfigTopic(mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = "blobRefA"))),
-                "product_entitlement_mapping" to ConfigTopic(
-                    mapOf("pem" to RemoteConfiguration.ConfigItem(blobRef = "pemBlob")),
+            rootDomain = "app",
+            domains = mapOf(
+                "app" to PersistedDomainState(
+                    manifest = "v1.1710000100.sources:etag1,product_entitlement_mapping:etag2",
+                    subdomains = listOf("app_workflows"),
+                    activeTopics = listOf("sources", "product_entitlement_mapping"),
+                    prefetchBlobs = listOf("blobRefA"),
+                    topics = mapOf(
+                        "sources" to ConfigTopic(
+                            mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = "blobRefA")),
+                        ),
+                        "product_entitlement_mapping" to ConfigTopic(
+                            mapOf("pem" to RemoteConfiguration.ConfigItem(blobRef = "pemBlob")),
+                        ),
+                    ),
+                    lastRefreshTime = 1785161502351L,
+                ),
+                "app_workflows" to PersistedDomainState(
+                    manifest = "v1.1710000200.workflows:etag3",
+                    activeTopics = listOf("workflows"),
+                    topics = mapOf(
+                        "workflows" to ConfigTopic(
+                            mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = "workflowBlob")),
+                        ),
+                    ),
                 ),
             ),
-            lastRefreshTime = 1785161502351L,
         )
 
         diskCache.write(config)
-        val read = diskCache.read()
+        val read = RemoteConfigDiskCache(applicationContext).read()
 
         assertThat(read).isEqualTo(config)
     }
 
     @Test
-    fun `a file written before the last refresh time existed reads it back as null`() {
-        val parent = File(File(testFolder, "RevenueCat"), "remote_config").apply { mkdirs() }
-        File(parent, "remote_config.json").writeText(
-            """{"domain":"app","manifest":"v1.1.sources:etag1"}""",
-        )
-
-        val read = RemoteConfigDiskCache(applicationContext).read()!!
-
-        assertThat(read.lastRefreshTime).isNull()
-        assertThat(read.manifest).isEqualTo("v1.1.sources:etag1")
-    }
-
-    @Test
     fun `read serves the in-memory snapshot without re-reading the file`() {
-        val config = PersistedRemoteConfigurationState(domain = "app", manifest = "v1.0.")
+        val config = singleDomain(manifest = "v1.0.")
         diskCache.write(config)
 
         // Remove the backing file: a read must still answer from the snapshot, proving no file re-read.
@@ -95,7 +98,7 @@ class RemoteConfigDiskCacheTest {
 
     @Test
     fun `a fresh instance reads the state from disk`() {
-        val config = PersistedRemoteConfigurationState(domain = "app", manifest = "v1.0.")
+        val config = singleDomain(manifest = "v1.0.")
         diskCache.write(config)
 
         // A new instance has no snapshot, so this proves the write actually reached the file.
@@ -108,23 +111,21 @@ class RemoteConfigDiskCacheTest {
 
         // A file appearing behind the cache's back is not picked up: the cache is the file's sole writer,
         // and the cached miss stands until a write() or clear() through this instance.
-        RemoteConfigDiskCache(applicationContext)
-            .write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.0."))
+        RemoteConfigDiskCache(applicationContext).write(singleDomain(manifest = "v1.0."))
 
         assertThat(diskCache.read()).isNull()
     }
 
     @Test
     fun `write returns true on a successful persist`() {
-        val persisted = diskCache.write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.0."))
+        val persisted = diskCache.write(singleDomain(manifest = "v1.0."))
 
         assertThat(persisted).isTrue
     }
 
     @Test
     fun `a topic with inline-only items round-trips its content with no blob ref`() {
-        val config = PersistedRemoteConfigurationState(
-            domain = "app",
+        val config = singleDomain(
             manifest = "v1.1.sources:etag1",
             activeTopics = listOf("sources"),
             topics = mapOf(
@@ -141,14 +142,59 @@ class RemoteConfigDiskCacheTest {
         diskCache.write(config)
 
         val read = diskCache.read()!!
-        assertThat(read.topics["sources"]!!["api"]!!.blobRef).isNull()
+        assertThat(read.mergedTopics["sources"]!!["api"]!!.blobRef).isNull()
         assertThat(read).isEqualTo(config)
     }
 
     @Test
-    fun `an old-format file with topicBlobRefs is read with empty topics and self-heals`() {
-        // The previous format stored "topicBlobRefs"; it is now "topics". With a string manifest the file still
-        // deserializes — the unknown key is ignored and topics defaults empty, so the next sync rebuilds the index.
+    fun `a legacy single-domain file migrates to the domain-keyed shape preserving its bookkeeping`() {
+        val parent = File(File(testFolder, "RevenueCat"), "remote_config").apply { mkdirs() }
+        // language=json
+        File(parent, "remote_config.json").writeText(
+            """
+            {
+              "domain": "app",
+              "manifest": "v1.1.sources:etag1",
+              "activeTopics": ["sources"],
+              "prefetchBlobs": ["blobRefA"],
+              "topics": { "sources": { "default": { "blob_ref": "blobRefA" } } },
+              "lastRefreshTime": 1785161502351
+            }
+            """.trimIndent(),
+        )
+
+        val read = diskCache.read()
+
+        assertThat(read).isEqualTo(
+            singleDomain(
+                manifest = "v1.1.sources:etag1",
+                activeTopics = listOf("sources"),
+                prefetchBlobs = listOf("blobRefA"),
+                topics = mapOf(
+                    "sources" to ConfigTopic(mapOf("default" to RemoteConfiguration.ConfigItem(blobRef = "blobRefA"))),
+                ),
+                lastRefreshTime = 1785161502351L,
+            ),
+        )
+    }
+
+    @Test
+    fun `a minimal legacy file migrates with a null last refresh time`() {
+        val parent = File(File(testFolder, "RevenueCat"), "remote_config").apply { mkdirs() }
+        File(parent, "remote_config.json").writeText(
+            """{"domain":"app","manifest":"v1.1.sources:etag1"}""",
+        )
+
+        val read = RemoteConfigDiskCache(applicationContext).read()!!
+
+        assertThat(read.rootState!!.lastRefreshTime).isNull()
+        assertThat(read.rootState!!.manifest).isEqualTo("v1.1.sources:etag1")
+    }
+
+    @Test
+    fun `a legacy file with unknown keys still migrates with empty topics`() {
+        // "topicBlobRefs" predates the "topics" index; the unknown key is ignored and topics defaults empty,
+        // so the next sync rebuilds the index from the (preserved) manifest diff.
         val parent = File(File(testFolder, "RevenueCat"), "remote_config").apply { mkdirs() }
         File(parent, "remote_config.json").writeText(
             """{"domain":"app","manifest":"v1.1.sources:etag1","topicBlobRefs":{"sources":["a"]}}""",
@@ -156,14 +202,15 @@ class RemoteConfigDiskCacheTest {
 
         val read = diskCache.read()
         assertThat(read).isNotNull
-        assertThat(read!!.manifest).isEqualTo("v1.1.sources:etag1")
-        assertThat(read.topics).isEmpty()
+        assertThat(read!!.rootDomain).isEqualTo("app")
+        assertThat(read.rootState!!.manifest).isEqualTo("v1.1.sources:etag1")
+        assertThat(read.mergedTopics).isEmpty()
     }
 
     @Test
     fun `read returns null for an incompatible old-format file`() {
-        // The previous format stored "manifest" as an object; it is now an opaque string. An old file no longer
-        // deserializes, so read returns null gracefully and the next sync rebuilds from scratch.
+        // An ancient format stored "manifest" as an object; it is now an opaque string. Neither the current nor
+        // the legacy shape deserializes it, so read returns null gracefully and the next sync rebuilds from scratch.
         val parent = File(File(testFolder, "RevenueCat"), "remote_config").apply { mkdirs() }
         File(parent, "remote_config.json").writeText(
             """{"manifest":{"domain":"app","topics":{"sources":"etag1"}},"topicBlobRefs":{}}""",
@@ -174,7 +221,7 @@ class RemoteConfigDiskCacheTest {
 
     @Test
     fun `write creates the remote_config directory when absent`() {
-        diskCache.write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.0."))
+        diskCache.write(singleDomain(manifest = "v1.0."))
 
         assertThat(
             File(File(File(testFolder, "RevenueCat"), "remote_config"), "remote_config.json").exists(),
@@ -183,15 +230,15 @@ class RemoteConfigDiskCacheTest {
 
     @Test
     fun `write overwrites a previous snapshot`() {
-        diskCache.write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.1.sources:old"))
-        diskCache.write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.2.sources:new"))
+        diskCache.write(singleDomain(manifest = "v1.1.sources:old"))
+        diskCache.write(singleDomain(manifest = "v1.2.sources:new"))
 
-        assertThat(diskCache.read()?.manifest).isEqualTo("v1.2.sources:new")
+        assertThat(diskCache.read()?.rootState?.manifest).isEqualTo("v1.2.sources:new")
     }
 
     @Test
     fun `clear deletes the persisted state so read returns null`() {
-        diskCache.write(PersistedRemoteConfigurationState(domain = "app", manifest = "v1.1.sources:etag1"))
+        diskCache.write(singleDomain(manifest = "v1.1.sources:etag1"))
 
         diskCache.clear()
 
@@ -218,11 +265,16 @@ class RemoteConfigDiskCacheTest {
         file.writeText(
             """
             {
-              "domain": "app",
-              "manifest": "v1.0.",
-              "activeTopics": ["sources"],
+              "rootDomain": "app",
               "future_field": { "nested": true },
-              "topics": { "sources": { "api": { "url": "https://api.revenuecat.com", "future_key": 1 } } }
+              "domains": {
+                "app": {
+                  "manifest": "v1.0.",
+                  "activeTopics": ["sources"],
+                  "future_domain_field": 1,
+                  "topics": { "sources": { "api": { "url": "https://api.revenuecat.com", "future_key": 1 } } }
+                }
+              }
             }
             """.trimIndent(),
         )
@@ -230,11 +282,11 @@ class RemoteConfigDiskCacheTest {
         val read = diskCache.read()
 
         assertThat(read).isNotNull
-        assertThat(read!!.domain).isEqualTo("app")
-        assertThat(read.manifest).isEqualTo("v1.0.")
-        assertThat(read.activeTopics).containsExactly("sources")
+        assertThat(read!!.rootDomain).isEqualTo("app")
+        assertThat(read.rootState!!.manifest).isEqualTo("v1.0.")
+        assertThat(read.rootState!!.activeTopics).containsExactly("sources")
         // Unknown item keys survive as metadata (the ConfigItem serializer keeps non-reserved keys).
-        assertThat(read.topics.getValue("sources").getValue("api").metadata).containsKey("future_key")
+        assertThat(read.mergedTopics.getValue("sources").getValue("api").metadata).containsKey("future_key")
     }
 
     @Test
@@ -244,4 +296,24 @@ class RemoteConfigDiskCacheTest {
 
         assertThat(diskCache.read()).isNull()
     }
+
+    private fun singleDomain(
+        domain: String = "app",
+        manifest: String,
+        activeTopics: List<String> = emptyList(),
+        prefetchBlobs: List<String> = emptyList(),
+        topics: Map<String, ConfigTopic> = emptyMap(),
+        lastRefreshTime: Long? = null,
+    ) = PersistedRemoteConfigurationState(
+        rootDomain = domain,
+        domains = mapOf(
+            domain to PersistedDomainState(
+                manifest = manifest,
+                activeTopics = activeTopics,
+                prefetchBlobs = prefetchBlobs,
+                topics = topics,
+                lastRefreshTime = lastRefreshTime,
+            ),
+        ),
+    )
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
@@ -75,7 +75,7 @@ class RemoteConfigManagerIntegrationTest {
         coEvery { blobFetcher.ensureDownloaded(any<String>()) } answers { blobStore.contains(firstArg()) }
         // This suite exercises the real disk/blob-store path; network prefetch is unit-tested separately, so the
         // fetcher is mocked here to keep the test hermetic (no real CDN calls from the background worker pool).
-        val topicStore = RemoteConfigTopicStore { diskCache.read()?.topics?.get(it.wireName) }
+        val topicStore = RemoteConfigTopicStore { diskCache.read()?.mergedTopics?.get(it.wireName) }
         manager = RemoteConfigManager(
             backend,
             diskCache,
@@ -115,13 +115,13 @@ class RemoteConfigManagerIntegrationTest {
         sync(container(config, blob))
 
         val persisted = diskCache.read()!!
-        assertThat(persisted.manifest).isEqualTo("v1.1.workflows:etag1")
-        assertThat(persisted.activeTopics).containsExactly("workflows")
-        assertThat(persisted.prefetchBlobs).containsExactly(ref)
-        assertThat(persisted.topics).containsOnlyKeys("workflows")
-        assertThat(persisted.topics["workflows"]!!.values.mapNotNull { it.blobRef }).containsExactly(ref)
+        assertThat(persisted.root.manifest).isEqualTo("v1.1.workflows:etag1")
+        assertThat(persisted.root.activeTopics).containsExactly("workflows")
+        assertThat(persisted.root.prefetchBlobs).containsExactly(ref)
+        assertThat(persisted.root.topics).containsOnlyKeys("workflows")
+        assertThat(persisted.root.topics["workflows"]!!.values.mapNotNull { it.blobRef }).containsExactly(ref)
         // The full config is the source of truth: the item's inline metadata is persisted too, not just its ref.
-        assertThat(persisted.topics["workflows"]!!["wf1234"]!!.metadata).containsKey("offering_identifier")
+        assertThat(persisted.root.topics["workflows"]!!["wf1234"]!!.metadata).containsKey("offering_identifier")
         assertThat(blobStore.contains(ref)).isTrue
         assertThat(blobStore.read(ref)).isEqualTo(blob)
     }
@@ -134,7 +134,7 @@ class RemoteConfigManagerIntegrationTest {
 
         // The fixture inlines WORKFLOW_BLOB and references it from the workflows topic, so it lands in the store.
         assertThat(blobStore.read(ref)).isEqualTo(RCContainerTestData.WORKFLOW_BLOB)
-        assertThat(diskCache.read()!!.activeTopics).containsExactly("workflows")
+        assertThat(diskCache.read()!!.root.activeTopics).containsExactly("workflows")
     }
 
     @Test
@@ -169,7 +169,7 @@ class RemoteConfigManagerIntegrationTest {
 
         assertThat(blobStore.contains(refA)).isFalse
         assertThat(blobStore.contains(refB)).isTrue
-        assertThat(diskCache.read()!!.topics["workflows"]!!.values.mapNotNull { it.blobRef }).containsExactly(refB)
+        assertThat(diskCache.read()!!.root.topics["workflows"]!!.values.mapNotNull { it.blobRef }).containsExactly(refB)
     }
 
     @Test
@@ -206,7 +206,7 @@ class RemoteConfigManagerIntegrationTest {
         assertThat(blobStore.contains(tamperedRef)).isFalse
         assertThat(blobStore.cachedRefs()).isEmpty()
         // The configuration itself is the source of truth and persists regardless of the blob failing validation.
-        assertThat(diskCache.read()!!.topics["workflows"]!!.values.mapNotNull { it.blobRef }).containsExactly(tamperedRef)
+        assertThat(diskCache.read()!!.root.topics["workflows"]!!.values.mapNotNull { it.blobRef }).containsExactly(tamperedRef)
     }
 
     @Test
@@ -247,7 +247,7 @@ class RemoteConfigManagerIntegrationTest {
 
         assertThat(blobStore.contains(ref)).isFalse
         assertThat(blobStore.cachedRefs()).isEmpty()
-        assertThat(diskCache.read()!!.topics.toTopicBlobRefs())
+        assertThat(diskCache.read()!!.root.topics.toTopicBlobRefs())
             .containsExactlyEntriesOf(mapOf("workflows" to listOf(ref)))
     }
 
@@ -260,7 +260,7 @@ class RemoteConfigManagerIntegrationTest {
         // A 204 surfaces as a null container: nothing changed server-side.
         sync(null)
 
-        assertThat(diskCache.read()!!.manifest).isEqualTo("v1.1.workflows:etag1")
+        assertThat(diskCache.read()!!.root.manifest).isEqualTo("v1.1.workflows:etag1")
         assertThat(blobStore.read(ref)).isEqualTo(blob)
     }
 
@@ -271,7 +271,7 @@ class RemoteConfigManagerIntegrationTest {
 
         sync(container(config))
 
-        val topics = diskCache.read()!!.topics
+        val topics = diskCache.read()!!.root.topics
         assertThat(topics).containsOnlyKeys("workflows")
         assertThat(topics["workflows"]!!["wf1234"]!!.blobRef).isNull()
         assertThat(topics["workflows"]!!.values.mapNotNull { it.blobRef }).isEmpty()
@@ -397,3 +397,7 @@ class RemoteConfigManagerIntegrationTest {
         }
     }
 }
+
+/** The root domain's persisted entry — where this suite's single-domain syncs land their bookkeeping. */
+private val PersistedRemoteConfigurationState.root: PersistedDomainState
+    get() = domains.getValue(rootDomain)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -91,7 +91,7 @@ class RemoteConfigManagerTest {
         backend = mockk()
         diskCache = mockk(relaxed = true)
         blobStore = mockk(relaxed = true)
-        topicStore = RemoteConfigTopicStore { diskCache.read()?.topics?.get(it.wireName) }
+        topicStore = RemoteConfigTopicStore { diskCache.read()?.mergedTopics?.get(it.wireName) }
         sourceProvider = mockk(relaxed = true)
         blobFetcher = mockk(relaxed = true)
         manager = RemoteConfigManager(
@@ -528,11 +528,11 @@ class RemoteConfigManagerTest {
 
         val written = slot<PersistedRemoteConfigurationState>()
         verify(exactly = 1) { diskCache.write(capture(written)) }
-        assertThat(written.captured.manifest).isEqualTo("v1.200.sources:etag2")
-        assertThat(written.captured.activeTopics).containsExactly("sources")
-        assertThat(written.captured.prefetchBlobs).containsExactly("newBlob")
-        assertThat(written.captured.topics).containsOnlyKeys("sources")
-        assertThat(written.captured.topics["sources"]!!["default"]!!.blobRef).isEqualTo("newBlob")
+        assertThat(written.captured.root.manifest).isEqualTo("v1.200.sources:etag2")
+        assertThat(written.captured.root.activeTopics).containsExactly("sources")
+        assertThat(written.captured.root.prefetchBlobs).containsExactly("newBlob")
+        assertThat(written.captured.root.topics).containsOnlyKeys("sources")
+        assertThat(written.captured.root.topics["sources"]!!["default"]!!.blobRef).isEqualTo("newBlob")
     }
 
     @Test
@@ -562,11 +562,11 @@ class RemoteConfigManagerTest {
 
         val written = slot<PersistedRemoteConfigurationState>()
         verify(exactly = 1) { diskCache.write(capture(written)) }
-        assertThat(written.captured.topics).containsOnlyKeys("sources", "workflows")
+        assertThat(written.captured.root.topics).containsOnlyKeys("sources", "workflows")
         // Changed topic overwritten with the new index.
-        assertThat(written.captured.topics["sources"]!!["default"]!!.blobRef).isEqualTo("newSources")
+        assertThat(written.captured.root.topics["sources"]!!["default"]!!.blobRef).isEqualTo("newSources")
         // Unchanged-but-active topic carried forward verbatim (the server omitted its body).
-        assertThat(written.captured.topics["workflows"]!!["wf1"]!!.blobRef).isEqualTo("wfBlob")
+        assertThat(written.captured.root.topics["workflows"]!!["wf1"]!!.blobRef).isEqualTo("wfBlob")
     }
 
     @Test
@@ -676,6 +676,60 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `a root sync retains blobs referenced by other persisted domains`() {
+        val cached = persisted(manifest = "v1.1.sources:etag1").withDomain(
+            "app_workflows",
+            PersistedDomainState(
+                manifest = "v1.1.workflows:etagW",
+                activeTopics = listOf("workflows"),
+                prefetchBlobs = listOf("subPrefetchBlob"),
+                topics = mapOf(
+                    "workflows" to ConfigTopic(
+                        mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = "subTopicBlob")),
+                    ),
+                ),
+            ),
+        )
+        every { diskCache.read() } returns cached
+        val response = """
+            {
+              "domain": "app",
+              "manifest": "v1.200.sources:etag2",
+              "active_topics": ["sources"],
+              "prefetch_blobs": ["rootBlob"],
+              "topics": { "sources": { "default": { "blob_ref": "rootBlob" } } }
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccess(containerWithConfig(response))
+
+        val retained = slot<Set<String>>()
+        verify(exactly = 1) { blobStore.retainOnly(capture(retained)) }
+        // Retention spans every persisted domain: a root sync must never evict another domain's blobs.
+        assertThat(retained.captured)
+            .containsExactlyInAnyOrder("rootBlob", "subPrefetchBlob", "subTopicBlob")
+    }
+
+    @Test
+    fun `the request reports only the root domain's held prefetch blobs`() {
+        val cached = persisted(
+            manifest = "v1.1.sources:etag1",
+            prefetchBlobs = listOf(REF_VALID),
+        ).withDomain(
+            "app_workflows",
+            PersistedDomainState(manifest = "v1.1.workflows:etagW", prefetchBlobs = listOf(REF_TAMPERED)),
+        )
+        every { diskCache.read() } returns cached
+        every { blobStore.cachedRefs() } returns setOf(REF_VALID, REF_TAMPERED)
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+
+        // prefetched_blobs is domain-scoped bookkeeping: another domain's held blobs are not this request's.
+        assertThat(capturedPrefetchedBlobs).containsExactly(REF_VALID)
+    }
+
+    @Test
     fun `a 200 response records no blob refs for an inline-only topic and does no blob work`() {
         every { diskCache.read() } returns null
         val response = """
@@ -697,8 +751,8 @@ class RemoteConfigManagerTest {
         val written = slot<PersistedRemoteConfigurationState>()
         verify(exactly = 1) { diskCache.write(capture(written)) }
         // An inline-only topic is persisted with its inline content and no blob_ref, and triggers no blob write.
-        assertThat(written.captured.topics).containsOnlyKeys("sources")
-        assertThat(written.captured.topics["sources"]!!["api"]!!.blobRef).isNull()
+        assertThat(written.captured.root.topics).containsOnlyKeys("sources")
+        assertThat(written.captured.root.topics["sources"]!!["api"]!!.blobRef).isNull()
         verify(exactly = 0) { blobStore.write(any(), any()) }
     }
 
@@ -827,7 +881,7 @@ class RemoteConfigManagerTest {
         deliverSuccess(null)
 
         // The only thing a 204 rewrites is the refresh time; the configuration itself carries forward verbatim.
-        verify(exactly = 1) { diskCache.write(cached.copy(lastRefreshTime = SERVER_MILLIS)) }
+        verify(exactly = 1) { diskCache.write(cached.withRootRefreshTime(SERVER_MILLIS)) }
         verify(exactly = 0) { blobStore.write(any(), any()) }
         verify(exactly = 0) { blobStore.retainOnly(any()) }
     }
@@ -841,7 +895,7 @@ class RemoteConfigManagerTest {
         deliverSuccess(null)
 
         // SERVER_MILLIS, not the FIXED_MILLIS device clock: the server's own time is what gets replayed.
-        verify(exactly = 1) { diskCache.write(cached.copy(lastRefreshTime = SERVER_MILLIS)) }
+        verify(exactly = 1) { diskCache.write(cached.withRootRefreshTime(SERVER_MILLIS)) }
     }
 
     @Test
@@ -891,7 +945,7 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         deliverSuccess(containerWithConfig("""{"domain":"app","manifest":"v1.2."}"""))
 
-        assertThat(slot.captured.lastRefreshTime).isEqualTo(SERVER_MILLIS)
+        assertThat(slot.captured.root.lastRefreshTime).isEqualTo(SERVER_MILLIS)
     }
 
     @Test
@@ -904,8 +958,8 @@ class RemoteConfigManagerTest {
         deliverSuccess(containerWithConfig("""{"domain":"app","manifest":"v1.2."}"""), requestDate = null)
 
         // The manifest advances, but the refresh time holds at the last value the server actually supplied.
-        assertThat(slot.captured.manifest).isEqualTo("v1.2.")
-        assertThat(slot.captured.lastRefreshTime).isEqualTo(SERVER_MILLIS - 10_000L)
+        assertThat(slot.captured.root.manifest).isEqualTo("v1.2.")
+        assertThat(slot.captured.root.lastRefreshTime).isEqualTo(SERVER_MILLIS - 10_000L)
     }
 
     @Test
@@ -917,7 +971,7 @@ class RemoteConfigManagerTest {
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
         deliverSuccess(containerWithConfig("""{"domain":"app","manifest":"v1.2."}"""), requestDate = null)
 
-        assertThat(slot.captured.lastRefreshTime).isNull()
+        assertThat(slot.captured.root.lastRefreshTime).isNull()
     }
 
     @Test
@@ -1360,11 +1414,11 @@ class RemoteConfigManagerTest {
 
         val written = slot<PersistedRemoteConfigurationState>()
         verify(exactly = 1) { diskCache.write(capture(written)) }
-        assertThat(written.captured.manifest).isEqualTo("v1.fallback.sources:etag")
-        assertThat(written.captured.activeTopics).containsExactly("sources")
-        assertThat(written.captured.topics["sources"]!!["default"]!!.blobRef).isEqualTo("newBlob")
+        assertThat(written.captured.root.manifest).isEqualTo("v1.fallback.sources:etag")
+        assertThat(written.captured.root.activeTopics).containsExactly("sources")
+        assertThat(written.captured.root.topics["sources"]!!["default"]!!.blobRef).isEqualTo("newBlob")
         // The fallback host is not the main API, so its clock is never borrowed as the refresh time.
-        assertThat(written.captured.lastRefreshTime).isNull()
+        assertThat(written.captured.root.lastRefreshTime).isNull()
     }
 
     @Test
@@ -2729,13 +2783,28 @@ class RemoteConfigManagerTest {
         topics: Map<String, ConfigTopic> = emptyMap(),
         lastRefreshTime: Long? = null,
     ) = PersistedRemoteConfigurationState(
-        domain = domain,
-        manifest = manifest,
-        activeTopics = activeTopics,
-        prefetchBlobs = prefetchBlobs,
-        topics = topics,
-        lastRefreshTime = lastRefreshTime,
+        rootDomain = domain,
+        domains = mapOf(
+            domain to PersistedDomainState(
+                manifest = manifest,
+                activeTopics = activeTopics,
+                prefetchBlobs = prefetchBlobs,
+                topics = topics,
+                lastRefreshTime = lastRefreshTime,
+            ),
+        ),
     )
+
+    /** The root domain's persisted entry — where a single-domain sync's bookkeeping lands. */
+    private val PersistedRemoteConfigurationState.root: PersistedDomainState
+        get() = domains.getValue(rootDomain)
+
+    /** The state a 204 writes: the same tree with only the root domain's refresh time advanced. */
+    private fun PersistedRemoteConfigurationState.withRootRefreshTime(time: Long) =
+        copy(domains = domains + (rootDomain to root.copy(lastRefreshTime = time)))
+
+    private fun PersistedRemoteConfigurationState.withDomain(name: String, state: PersistedDomainState) =
+        copy(domains = domains + (name to state))
 
     /**
      * A fake inline blob element for a container mock: [ref] is what the manager reads to decide whether it

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigIntegrationTest.kt
@@ -112,7 +112,7 @@ class WorkflowsConfigIntegrationTest {
             blobFetcher = fetcher,
             scope = testScope,
             ioDispatcher = testDispatcher,
-            topicStore = RemoteConfigTopicStore { diskCache.read()?.topics?.get(it.wireName) },
+            topicStore = RemoteConfigTopicStore { diskCache.read()?.mergedTopics?.get(it.wireName) },
             sourceProvider = FakeBlobSourceProvider,
             appUserIDProvider = { appUserID },
         )


### PR DESCRIPTION
### Description

Part 1 of 2 of subdomain support for the `/v1/config` endpoint. A config response can declare `subdomains`: other domains the SDK should also sync to assemble the full configuration, so the backend can move a topic to a subdomain without an SDK update. We already parse the field but drop it at commit. **Scope note: only one level of subdomains is supported** — a subdomain's own `subdomains` list is ignored.

This PR reshapes the persisted state so it can hold a domain tree, with **no behavior change** for the single-domain trees the backend serves today:

- `PersistedRemoteConfigurationState` becomes `{ rootDomain, domains: Map<domain, PersistedDomainState> }`, still one atomic file write. Each domain entry carries its own `manifest`/`subdomains`/`activeTopics`/`prefetchBlobs`/`topics`/`lastRefreshTime`.
- Lazy derived views on the state: `domainsInPrecedenceOrder` (the root followed by its subdomains in declaration order, filtered to persisted entries), `mergedTopics` (parent-wins union across those domains — what `RemoteConfigTopicStore` now serves), and `liveBlobRefs` (union over **all** persisted domains).
- `blobStore.retainOnly` now takes `liveBlobRefs`, so one domain's sync can never evict another domain's blobs (identical set with a single domain, but the critical groundwork).
- Requests replay only the requested domain's own manifest / last-refresh-time / `prefetched_blobs`.
- A legacy single-domain file lifts into the new shape on read, preserving the manifest so the next sync after an SDK update stays an incremental diff instead of a cold re-fetch.

Follow-up: PR 2 (#4056) adds the sync engine (fetch root → sync its subdomains → commit children first, root last, with deletion deferral).
