### PR TITLE
Sync the remote config subdomain tree

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDomainFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDomainFetcher.kt
@@ -1,0 +1,119 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
+import com.revenuecat.purchases.common.LogIntent
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCContainer
+import com.revenuecat.purchases.common.verboseLog
+import com.revenuecat.purchases.common.warnLog
+import kotlinx.coroutines.CompletableDeferred
+import java.util.Date
+
+/**
+ * The suspend bridge between a tree pass and the callback-based [Backend] config endpoints: issues one domain's
+ * `/v1/config` request (or the root's fallback request) and classifies the answer. Holds none of the manager's
+ * commit state — it only reads each domain's persisted request bookkeeping and the blob store's held refs.
+ */
+internal class RemoteConfigDomainFetcher(
+    private val backend: Backend,
+    private val diskCache: RemoteConfigDiskCache,
+    private val blobStore: RemoteConfigBlobStore,
+    /**
+     * Invoked at classification (callback) time on a root/fallback 4xx — even when the requesting pass was
+     * cancelled meanwhile, since a late response is still a valid signal that the endpoint refuses this app.
+     */
+    private val onRootClientError: (PurchasesError) -> Unit,
+) {
+    internal enum class FetchOutcome { Success, FailedRetryable, ClientError }
+
+    internal class DomainFetchResult(
+        val outcome: FetchOutcome,
+        /** The `200` payload; null on a `204` and on failures. */
+        val container: RCContainer? = null,
+        val requestDate: Date? = null,
+    )
+
+    /**
+     * Issues the `/v1/config` request for [domain], replaying that domain's own persisted sync bookkeeping (the
+     * opaque manifest, the last successful refresh time, and the prefetch blobs actually held), and suspends
+     * until the backend answers.
+     */
+    suspend fun fetch(
+        domain: String,
+        isRoot: Boolean,
+        appInBackground: Boolean,
+        appUserID: String,
+        fetchContext: RemoteConfigFetchContext,
+    ): DomainFetchResult {
+        val domainState = diskCache.read()?.domains?.get(domain)
+        val storedBlobs = blobStore.cachedRefs()
+        verboseLog {
+            "Refreshing remote config (domain=$domain, manifest present=${domainState?.manifest != null}, " +
+                "appInBackground=$appInBackground)."
+        }
+        val result = CompletableDeferred<DomainFetchResult>()
+        backend.getRemoteConfig(
+            appInBackground = appInBackground,
+            appUserID = appUserID,
+            fetchContext = fetchContext,
+            domain = domain,
+            // Opaque manifest replayed verbatim; null on this domain's first sync.
+            manifest = domainState?.manifest,
+            lastRefreshTime = domainState?.lastRefreshTime?.let(::Date),
+            // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
+            prefetchedBlobs = domainState?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
+            onSuccess = { container, requestDate, _ ->
+                if (requestDate == null) {
+                    // Not fatal — the previous value carries forward — but it means the server stopped telling
+                    // us its own time, so the refresh time replayed on later requests is frozen. Surfaced here
+                    // rather than swallowed because nothing else makes this observable in the field.
+                    warnLog {
+                        "Remote config response carried no ${HTTPResult.REQUEST_TIME_HEADER_NAME} header. " +
+                            "Keeping the previous refresh time; the server cannot see how fresh this client's " +
+                            "configuration is."
+                    }
+                }
+                result.complete(DomainFetchResult(FetchOutcome.Success, container, requestDate))
+            },
+            onError = { error, behavior ->
+                result.complete(DomainFetchResult(classifyFailure(error, behavior, isRoot)))
+            },
+        )
+        return result.await()
+    }
+
+    /** The root's cold-start fallback request (plain JSON, no container); null when it fails. */
+    suspend fun fetchFallback(appInBackground: Boolean, domain: String): RemoteConfiguration? {
+        val result = CompletableDeferred<RemoteConfiguration?>()
+        backend.getRemoteConfigFallback(
+            appInBackground = appInBackground,
+            domain = domain,
+            onSuccess = { response, _ -> result.complete(response) },
+            onError = { error, behavior ->
+                classifyFailure(error, behavior, isRoot = true)
+                result.complete(null)
+            },
+        )
+        return result.await()
+    }
+
+    private fun classifyFailure(
+        error: PurchasesError,
+        behavior: GetRemoteConfigErrorHandlingBehavior,
+        isRoot: Boolean,
+    ): FetchOutcome = if (behavior == GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE) {
+        if (isRoot) {
+            onRootClientError(error)
+        } else {
+            log(LogIntent.RC_ERROR) { "Remote config subdomain request was refused (4xx). Error: $error" }
+        }
+        FetchOutcome.ClientError
+    } else {
+        errorLog(error)
+        FetchOutcome.FailedRetryable
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -43,13 +43,14 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 /**
- * Orchestrates `/v1/config` syncs over the domain tree: a sync pass fetches the root domain, unfolds the
- * subdomains each response declares ([RemoteConfiguration.subdomains]), and syncs every domain the same way —
- * a `204` keeps that domain's cached entry untouched, a `200` persists its fresh server manifest plus its full
- * per-topic item index. The persisted configuration (incl. each item's inline content) is the source of truth,
- * and persisting it is a domain's **entire** commit, advancing that domain's manifest unconditionally. Commits
- * run post-order — children before their parent, the root last — so a parent's topic/subdomain deletions never
- * land before the subdomains that may have absorbed the moved data; consumers read the parent-wins merged view
+ * Orchestrates `/v1/config` syncs over the domain tree: a sync pass fetches the root domain, then syncs the
+ * subdomains it declares ([RemoteConfiguration.subdomains]) the same way — a `204` keeps that domain's cached
+ * entry untouched, a `200` persists its fresh server manifest plus its full per-topic item index. Only one
+ * level of subdomains is supported: a subdomain's own list is ignored. The persisted configuration (incl. each
+ * item's inline content) is the source of truth, and persisting it is a domain's **entire** commit, advancing
+ * that domain's manifest unconditionally. The subdomains commit before the root, and a failed subdomain defers
+ * the root's commit — so the root's topic/subdomain deletions never land before the subdomains that may have
+ * absorbed the moved data; consumers read the parent-wins merged view
  * across the tree ([PersistedRemoteConfigurationState.mergedTopics]), so a topic can move between domains
  * without consumers noticing. Each commit writes the inlined blobs its config still wants; once per pass, gated
  * on at least one successful commit, the blob store is pruned against every persisted domain's live refs and
@@ -258,11 +259,11 @@ internal class RemoteConfigManager(
 
     /**
      * One sync pass over the domain tree for a refresh that already owns the in-flight guard: fetch the root,
-     * unfold and sync the subdomains each response declares, and commit post-order (children before their
-     * parent) so a parent's topic/subdomain deletions never land before the domains that may have absorbed the
-     * moved data. Per-domain commits are individually atomic writes of the one persisted tree; the pass-wide
-     * work (batched 204 refresh times, blob retention, the generation bump, and the staleness bookkeeping) runs
-     * once in [finalizePass].
+     * sync the subdomains it declares (one level — a subdomain's own list is ignored), and commit the children
+     * before the root so the root's topic/subdomain deletions never land before the domains that may have
+     * absorbed the moved data. Per-domain commits are individually atomic writes of the one persisted tree; the
+     * pass-wide work (batched 204 refresh times, blob retention, the generation bump, and the staleness
+     * bookkeeping) runs once in [finalizePass].
      */
     private suspend fun runTreePass(
         appInBackground: Boolean,
@@ -272,73 +273,43 @@ internal class RemoteConfigManager(
     ) {
         val rootDomain = diskCache.read()?.rootDomain ?: DEFAULT_DOMAIN
         val ctx = TreePassContext(requestEpoch, appInBackground, requestAppUserID, requestFetchContext, rootDomain)
-        syncDomainTree(ctx, rootDomain, depth = 0, isRoot = true)
-        finalizePass(ctx)
+        val rootOutcome = syncDomain(ctx, rootDomain, isRoot = true)
+        // The root's outcome already reflects its subdomains (a failed child fails the root), so it is the
+        // whole pass's freshness.
+        finalizePass(ctx, passFresh = rootOutcome.isFresh)
     }
 
-    /**
-     * Syncs [domain] and, recursively, the subdomains its response declares, committing the children before the
-     * domain itself. Returns the domain's terminal outcome for this pass. A domain already synced this pass
-     * returns its recorded outcome without a second fetch; a cycle (a domain re-listed inside its own subtree)
-     * and a domain beyond [PersistedRemoteConfigurationState.MAX_SUBDOMAIN_DEPTH] are skipped, which counts as
-     * fresh — stalling commits on a malformed server tree would freeze configuration updates indefinitely.
-     */
-    private suspend fun syncDomainTree(
-        ctx: TreePassContext,
-        domain: String,
-        depth: Int,
-        isRoot: Boolean,
-    ): DomainSyncOutcome {
-        val shortCircuit = shortCircuitOutcome(ctx, domain, depth)
-        if (shortCircuit != null) return shortCircuit
-        ctx.inProgress += domain
-        return try {
-            val fetch = domainFetcher.fetch(domain, isRoot, ctx.appInBackground, ctx.appUserID, ctx.fetchContext)
-            val outcome = when (fetch.outcome) {
-                // The 4xx side effects (the root's session kill-switch) already ran at callback time.
-                FetchOutcome.ClientError -> DomainSyncOutcome.Failed
-                FetchOutcome.FailedRetryable ->
-                    if (isRoot) rootRetryableFailureOutcome(ctx, domain) else DomainSyncOutcome.Failed
-                FetchOutcome.Success -> syncFetchedDomain(ctx, domain, depth, isRoot, fetch)
-            }
-            ctx.outcomes[domain] = outcome
-            outcome
-        } finally {
-            ctx.inProgress -= domain
+    /** Syncs one domain; for the root this includes its subdomains, whose outcomes gate the root's commit. */
+    private suspend fun syncDomain(ctx: TreePassContext, domain: String, isRoot: Boolean): DomainSyncOutcome {
+        val fetch = domainFetcher.fetch(domain, isRoot, ctx.appInBackground, ctx.appUserID, ctx.fetchContext)
+        return when (fetch.outcome) {
+            // The 4xx side effects (the root's session kill-switch) already ran at callback time.
+            FetchOutcome.ClientError -> DomainSyncOutcome.Failed
+            FetchOutcome.FailedRetryable ->
+                if (isRoot) rootRetryableFailureOutcome(ctx, domain) else DomainSyncOutcome.Failed
+            FetchOutcome.Success -> syncFetchedDomain(ctx, domain, isRoot, fetch)
         }
-    }
-
-    /** The outcomes that resolve without a fetch: already synced this pass, a cycle, or beyond the depth cap. */
-    private fun shortCircuitOutcome(ctx: TreePassContext, domain: String, depth: Int): DomainSyncOutcome? = when {
-        domain in ctx.outcomes -> ctx.outcomes.getValue(domain)
-        domain in ctx.inProgress -> {
-            warnLog { "Remote config domain '$domain' is re-listed inside its own subtree; ignoring the cycle." }
-            DomainSyncOutcome.Skipped
-        }
-        depth > PersistedRemoteConfigurationState.MAX_SUBDOMAIN_DEPTH -> {
-            warnLog {
-                "Remote config domain '$domain' is deeper than the supported subdomain depth " +
-                    "(${PersistedRemoteConfigurationState.MAX_SUBDOMAIN_DEPTH}); skipping it."
-            }
-            DomainSyncOutcome.Skipped
-        }
-        else -> null
     }
 
     private suspend fun syncFetchedDomain(
         ctx: TreePassContext,
         domain: String,
-        depth: Int,
         isRoot: Boolean,
         fetch: DomainFetchResult,
     ): DomainSyncOutcome {
         val container = fetch.container
-            ?: return domainNotModifiedOutcome(ctx, domain, depth, isRoot, fetch.requestDate)
+            ?: return domainNotModifiedOutcome(ctx, domain, isRoot, fetch.requestDate)
         val response = parseConfigResponse(container)
+        if (!isRoot && response?.subdomains?.isNotEmpty() == true) {
+            verboseLog {
+                "Remote config domain '$domain' declares subdomains of its own; only one level is supported, " +
+                    "so they are ignored."
+            }
+        }
         return when {
             response == null -> DomainSyncOutcome.Failed
-            !syncSubdomains(ctx, response.subdomains, depth) -> {
-                warnLog { "Not committing remote config domain '$domain': part of its subtree failed to sync." }
+            isRoot && !syncSubdomains(ctx, response.subdomains) -> {
+                warnLog { "Not committing the remote config root domain: part of its tree failed to sync." }
                 DomainSyncOutcome.Failed
             }
             commitDomain(ctx, domain, isRoot, response, container, fetch.requestDate) -> DomainSyncOutcome.Committed
@@ -357,29 +328,31 @@ internal class RemoteConfigManager(
     }
 
     /**
-     * Syncs a domain's listed subdomains before its own commit: the commit applies its response's
+     * Syncs the root's listed subdomains before its commit: the root's commit applies its response's
      * topic/subdomain deletions, which must not land before the subdomains that may now carry the moved data
-     * have synced. Every child is synced even when a sibling fails (a successful child's commit is additive and
-     * safe); a failure only defers the parent's commit — old state and manifest are kept, so the next pass
-     * re-diffs cheaply. Returns whether every child ended the pass fresh.
+     * have synced. Only one level is supported, so duplicates and a self-reference are dropped here and a
+     * subdomain's own list is never followed. Every child is synced even when a sibling fails (a successful
+     * child's commit is additive and safe); a failure only defers the root's commit — old state and manifest
+     * are kept, so the next pass re-diffs cheaply. Returns whether every child ended the pass fresh.
      */
-    private suspend fun syncSubdomains(ctx: TreePassContext, subdomains: List<String>, depth: Int): Boolean =
+    private suspend fun syncSubdomains(ctx: TreePassContext, subdomains: List<String>): Boolean =
         subdomains
-            .map { child -> syncDomainTree(ctx, child, depth + 1, isRoot = false) }
+            .distinct()
+            .filter { it != ctx.rootDomainName }
+            .map { child -> syncDomain(ctx, child, isRoot = false) }
             .all { it.isFresh }
 
     /**
      * Handles a domain's `204 Not Modified`: its cached entry is confirmed current, so record the confirmed
-     * refresh time for the pass-end batch write — but still recurse, because a domain's 204 says nothing about
-     * its subtree's freshness. Without a persisted entry there is nothing the 204 can confirm or update (a 204
-     * must never resurrect state that was wiped meanwhile): the root still counts as unchanged — the pass
-     * bookkeeping advances like any confirmed-current sync — but a child fails, because a missing child entry
-     * is exactly the gap its parent's commit must not paper over.
+     * refresh time for the pass-end batch write — and for the root, still sync its subdomains, because its 204
+     * says nothing about their freshness. Without a persisted entry there is nothing the 204 can confirm or
+     * update (a 204 must never resurrect state that was wiped meanwhile): the root still counts as unchanged —
+     * the pass bookkeeping advances like any confirmed-current sync — but a child fails, because a missing
+     * child entry is exactly the gap the root's commit must not paper over.
      */
     private suspend fun domainNotModifiedOutcome(
         ctx: TreePassContext,
         domain: String,
-        depth: Int,
         isRoot: Boolean,
         requestDate: Date?,
     ): DomainSyncOutcome {
@@ -391,7 +364,7 @@ internal class RemoteConfigManager(
         }
         // Only the server's own time is worth recording; a response without it carries the old value forward.
         requestDate?.let { ctx.pending204RefreshTimes[domain] = it.time }
-        val childrenFresh = syncSubdomains(ctx, persistedDomain.subdomains, depth)
+        val childrenFresh = !isRoot || syncSubdomains(ctx, persistedDomain.subdomains)
         return if (childrenFresh) DomainSyncOutcome.Unchanged else DomainSyncOutcome.Failed
     }
 
@@ -937,11 +910,12 @@ internal class RemoteConfigManager(
      *    every persisted domain, never a single domain's set — and advances the generation once for the whole
      *    pass, so listeners re-warm from a tree-consistent state. Both only when this pass committed something,
      *    mirroring the "blob work only after a successful persist" gating.
-     * 3. Advances the staleness bookkeeping only when every synced domain ended fresh: a partial pass leaves the
-     *    cache stale so the next trigger retries the tree (already-committed domains answer with cheap 204s,
-     *    and the attempt cooldown keeps retries from hammering).
+     * 3. Advances the staleness bookkeeping only when the pass ended fresh ([passFresh] — the root's outcome,
+     *    which its subdomains cascade into): a partial pass leaves the cache stale so the next trigger retries
+     *    the tree (already-committed domains answer with cheap 204s, and the attempt cooldown keeps retries
+     *    from hammering).
      */
-    private fun finalizePass(ctx: TreePassContext) {
+    private fun finalizePass(ctx: TreePassContext, passFresh: Boolean) {
         synchronized(cacheLock) {
             if (epoch.get() != ctx.requestEpoch) return
             // The last commit's write is the current tree; falling back to a read covers all-204 passes.
@@ -961,7 +935,7 @@ internal class RemoteConfigManager(
                 val committedGeneration = generation.incrementAndGet()
                 listeners.forEach { it.onConfigCommitted(committedGeneration) }
             }
-            if (ctx.allFresh) {
+            if (passFresh) {
                 // The staleness gate measures elapsed *local* time (isCacheStale subtracts from
                 // dateProvider.now), so it stays on the device clock, unlike the persisted server refresh times.
                 lastRefreshedAt = dateProvider.now
@@ -980,12 +954,6 @@ internal class RemoteConfigManager(
         /** The root name this pass synced, for a child commit landing before any root state exists. */
         val rootDomainName: String,
     ) {
-        /** Terminal outcome per synced domain; doubles as the "already synced this pass" dedupe. */
-        val outcomes = mutableMapOf<String, DomainSyncOutcome>()
-
-        /** Domains whose sync is on the recursion stack; a re-listing inside its own subtree is a cycle. */
-        val inProgress = mutableSetOf<String>()
-
         /** Server refresh times confirmed by per-domain 204s, written in one batch at pass end. */
         val pending204RefreshTimes = mutableMapOf<String, Long>()
 
@@ -993,18 +961,15 @@ internal class RemoteConfigManager(
 
         /** The tree as of this pass's most recent successful commit; null when nothing committed yet. */
         var lastPersistedState: PersistedRemoteConfigurationState? = null
-
-        val allFresh: Boolean get() = outcomes.values.all { it.isFresh }
     }
 
     private enum class DomainSyncOutcome {
         Committed,
         Unchanged,
-        Skipped,
         Failed,
         ;
 
-        /** Whether the domain's subtree is safe to apply a parent's deletions against. */
+        /** Whether the domain is safe to apply the root's deletions against. */
         val isFresh: Boolean get() = this != Failed
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -6,7 +6,6 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
-import com.revenuecat.purchases.common.GetRemoteConfigErrorHandlingBehavior
 import com.revenuecat.purchases.common.JsonProvider
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.between
@@ -15,9 +14,10 @@ import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
-import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCContainer
 import com.revenuecat.purchases.common.networking.RCContainerFormatException
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDomainFetcher.DomainFetchResult
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDomainFetcher.FetchOutcome
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.common.warnLog
 import kotlinx.coroutines.CompletableDeferred
@@ -43,21 +43,28 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 /**
- * Orchestrates a single `/v1/config` sync: replays the persisted opaque manifest, then on `204` keeps the cache
- * untouched and on `200` persists the fresh server manifest plus the full per-topic item index — the
- * configuration (incl. each item's inline content) is the source of truth, and persisting it is the **entire**
- * sync commit, advancing the manifest unconditionally. Only then, gated on a successful persist, it writes the
- * inlined blobs the resolved config still wants, prunes the rest, and best-effort prefetches the remaining
- * wanted blobs over the network ([RemoteConfigBlobFetcher], resolving blob source URLs through
- * [RemoteConfigSourceProvider]); a missing or un-parseable blob is recoverable later (re-fetched next sync / on
- * demand) and never blocks the commit. It reports which prefetch blobs are now cached locally on the next
- * request. (Live API base-URL rerouting from the `sources` topic is out of scope — a future phase.)
+ * Orchestrates `/v1/config` syncs over the domain tree: a sync pass fetches the root domain, unfolds the
+ * subdomains each response declares ([RemoteConfiguration.subdomains]), and syncs every domain the same way —
+ * a `204` keeps that domain's cached entry untouched, a `200` persists its fresh server manifest plus its full
+ * per-topic item index. The persisted configuration (incl. each item's inline content) is the source of truth,
+ * and persisting it is a domain's **entire** commit, advancing that domain's manifest unconditionally. Commits
+ * run post-order — children before their parent, the root last — so a parent's topic/subdomain deletions never
+ * land before the subdomains that may have absorbed the moved data; consumers read the parent-wins merged view
+ * across the tree ([PersistedRemoteConfigurationState.mergedTopics]), so a topic can move between domains
+ * without consumers noticing. Each commit writes the inlined blobs its config still wants; once per pass, gated
+ * on at least one successful commit, the blob store is pruned against every persisted domain's live refs and
+ * the remaining wanted blobs are best-effort prefetched over the network ([RemoteConfigBlobFetcher], resolving
+ * blob source URLs through [RemoteConfigSourceProvider]); a missing or un-parseable blob is recoverable later
+ * (re-fetched next sync / on demand) and never blocks a commit. Each domain's request reports which of its
+ * prefetch blobs are now cached locally. (Live API base-URL rerouting from the `sources` topic is out of scope
+ * — a future phase.)
  *
- * The manifest is opaque (stored and replayed verbatim); the active-topic set and removed-topic detection come
- * from the response's [RemoteConfiguration.activeTopics]. The manager is topic-agnostic: it never interprets item
- * shapes or branches on topic name — consumer topics are read lazily by providers through the manager.
+ * Manifests are opaque (stored and replayed verbatim) and domain-scoped; the active-topic set and removed-topic
+ * detection come from each response's [RemoteConfiguration.activeTopics]. The manager is topic-agnostic: it
+ * never interprets item shapes or branches on topic name — consumer topics are read lazily by providers through
+ * the manager.
  *
- * The `200` path runs on [scope]: persistence is synchronous, but the launch lets [clearCache] cancel the
+ * The pass runs on [scope]: persistence is synchronous, but the launch lets [clearCache] cancel the
  * in-flight parse/persist. Blob prefetch runs on the fetcher's own worker pool (not [scope]). Identity changes
  * call [clearCache], which bumps an epoch so a late `/v1/config` response (its HTTP request cannot be
  * socket-cancelled) is dropped instead of persisting over the freshly wiped cache. [clearCache] also rebinds
@@ -94,14 +101,19 @@ internal class RemoteConfigManager(
 ) {
     private val isRefreshing = AtomicBoolean(false)
 
+    // The suspend bridge to the callback-based backend endpoints. The 4xx hook runs at callback time so a root
+    // 4xx disables the session even when the requesting pass was cancelled meanwhile.
+    private val domainFetcher = RemoteConfigDomainFetcher(backend, diskCache, blobStore, ::disableForSession)
+
     // Bumped by clearCache() on every identity change. A request captures the epoch when it starts; once it
     // changes, the in-flight request's callbacks drop their result (the /v1/config request itself cannot be
     // socket-cancelled), so an old user's response can never persist over the wiped cache.
     private val epoch = AtomicInteger(0)
 
-    // Serializes a sync's "re-check epoch + persist" against clearCache()'s "bump epoch + wipe". persist() is
-    // synchronous, so cancellation can't interrupt it; this lock makes the two critical sections atomic so a
-    // late persist either runs fully before the wipe or sees the bumped epoch and skips — never writes after it.
+    // Serializes a sync's "re-check epoch + persist" against clearCache()'s "bump epoch + wipe". commitDomain()
+    // and finalizePass() are synchronous, so cancellation can't interrupt them; this lock makes the critical
+    // sections atomic so a late commit either runs fully before the wipe or sees the bumped epoch and skips —
+    // never writes after it.
     private val cacheLock = Any()
 
     @Volatile
@@ -233,50 +245,194 @@ internal class RemoteConfigManager(
         if (!shouldRefresh) {
             return
         }
-        issueConfigRequest(appInBackground, requestEpoch, requestAppUserID, requestFetchContext)
+        // The whole tree pass runs on [scope] so clearCache() can cancel it, and the guard is released at the
+        // pass's single terminal point — reads waiting on [refreshCompletion] wake when the full tree settles.
+        scope.launch {
+            try {
+                runTreePass(appInBackground, requestEpoch, requestAppUserID, requestFetchContext)
+            } finally {
+                releaseGuardIfOwned(requestEpoch)
+            }
+        }
     }
 
     /**
-     * Issues the `/v1/config` request for a sync that already owns the in-flight guard, replaying the persisted
-     * sync bookkeeping the server diffs against: the opaque manifest, the last successful refresh time, and the
-     * prefetch blobs actually held.
+     * One sync pass over the domain tree for a refresh that already owns the in-flight guard: fetch the root,
+     * unfold and sync the subdomains each response declares, and commit post-order (children before their
+     * parent) so a parent's topic/subdomain deletions never land before the domains that may have absorbed the
+     * moved data. Per-domain commits are individually atomic writes of the one persisted tree; the pass-wide
+     * work (batched 204 refresh times, blob retention, the generation bump, and the staleness bookkeeping) runs
+     * once in [finalizePass].
      */
-    private fun issueConfigRequest(
+    private suspend fun runTreePass(
         appInBackground: Boolean,
         requestEpoch: Int,
         requestAppUserID: String,
         requestFetchContext: RemoteConfigFetchContext,
     ) {
-        val persisted = diskCache.read()
-        val storedBlobs = blobStore.cachedRefs()
-        val domain = persisted?.rootDomain ?: DEFAULT_DOMAIN
-        // Request bookkeeping is domain-scoped: each domain replays its own manifest/refresh time/prefetch set.
-        val domainState = persisted?.domains?.get(domain)
-        logRefreshStart(persisted, appInBackground)
-        backend.getRemoteConfig(
-            appInBackground = appInBackground,
-            appUserID = requestAppUserID,
-            fetchContext = requestFetchContext,
-            domain = domain,
-            // Opaque manifest replayed verbatim; null on the first run when nothing is persisted yet.
-            manifest = domainState?.manifest,
-            lastRefreshTime = domainState?.lastRefreshTime?.let(::Date),
-            // Report only the prefetch blobs we actually hold, so the server stops re-inlining them.
-            prefetchedBlobs = domainState?.prefetchBlobs?.filter { storedBlobs.contains(it) } ?: emptyList(),
-            onSuccess = { container, requestDate, _ ->
-                handleMainRefreshSuccess(requestEpoch, persisted, container, requestDate)
-            },
-            onError = { error, behavior ->
-                handleMainRefreshError(
-                    requestEpoch,
-                    appInBackground,
-                    domain,
-                    hasCachedConfig = domainState != null,
-                    error,
-                    behavior,
-                )
-            },
-        )
+        val rootDomain = diskCache.read()?.rootDomain ?: DEFAULT_DOMAIN
+        val ctx = TreePassContext(requestEpoch, appInBackground, requestAppUserID, requestFetchContext, rootDomain)
+        syncDomainTree(ctx, rootDomain, depth = 0, isRoot = true)
+        finalizePass(ctx)
+    }
+
+    /**
+     * Syncs [domain] and, recursively, the subdomains its response declares, committing the children before the
+     * domain itself. Returns the domain's terminal outcome for this pass. A domain already synced this pass
+     * returns its recorded outcome without a second fetch; a cycle (a domain re-listed inside its own subtree)
+     * and a domain beyond [PersistedRemoteConfigurationState.MAX_SUBDOMAIN_DEPTH] are skipped, which counts as
+     * fresh — stalling commits on a malformed server tree would freeze configuration updates indefinitely.
+     */
+    private suspend fun syncDomainTree(
+        ctx: TreePassContext,
+        domain: String,
+        depth: Int,
+        isRoot: Boolean,
+    ): DomainSyncOutcome {
+        val shortCircuit = shortCircuitOutcome(ctx, domain, depth)
+        if (shortCircuit != null) return shortCircuit
+        ctx.inProgress += domain
+        return try {
+            val fetch = domainFetcher.fetch(domain, isRoot, ctx.appInBackground, ctx.appUserID, ctx.fetchContext)
+            val outcome = when (fetch.outcome) {
+                // The 4xx side effects (the root's session kill-switch) already ran at callback time.
+                FetchOutcome.ClientError -> DomainSyncOutcome.Failed
+                FetchOutcome.FailedRetryable ->
+                    if (isRoot) rootRetryableFailureOutcome(ctx, domain) else DomainSyncOutcome.Failed
+                FetchOutcome.Success -> syncFetchedDomain(ctx, domain, depth, isRoot, fetch)
+            }
+            ctx.outcomes[domain] = outcome
+            outcome
+        } finally {
+            ctx.inProgress -= domain
+        }
+    }
+
+    /** The outcomes that resolve without a fetch: already synced this pass, a cycle, or beyond the depth cap. */
+    private fun shortCircuitOutcome(ctx: TreePassContext, domain: String, depth: Int): DomainSyncOutcome? = when {
+        domain in ctx.outcomes -> ctx.outcomes.getValue(domain)
+        domain in ctx.inProgress -> {
+            warnLog { "Remote config domain '$domain' is re-listed inside its own subtree; ignoring the cycle." }
+            DomainSyncOutcome.Skipped
+        }
+        depth > PersistedRemoteConfigurationState.MAX_SUBDOMAIN_DEPTH -> {
+            warnLog {
+                "Remote config domain '$domain' is deeper than the supported subdomain depth " +
+                    "(${PersistedRemoteConfigurationState.MAX_SUBDOMAIN_DEPTH}); skipping it."
+            }
+            DomainSyncOutcome.Skipped
+        }
+        else -> null
+    }
+
+    private suspend fun syncFetchedDomain(
+        ctx: TreePassContext,
+        domain: String,
+        depth: Int,
+        isRoot: Boolean,
+        fetch: DomainFetchResult,
+    ): DomainSyncOutcome {
+        val container = fetch.container
+            ?: return domainNotModifiedOutcome(ctx, domain, depth, isRoot, fetch.requestDate)
+        val response = parseConfigResponse(container)
+        return when {
+            response == null -> DomainSyncOutcome.Failed
+            !syncSubdomains(ctx, response.subdomains, depth) -> {
+                warnLog { "Not committing remote config domain '$domain': part of its subtree failed to sync." }
+                DomainSyncOutcome.Failed
+            }
+            commitDomain(ctx, domain, isRoot, response, container, fetch.requestDate) -> DomainSyncOutcome.Committed
+            else -> DomainSyncOutcome.Failed
+        }
+    }
+
+    private fun parseConfigResponse(container: RCContainer): RemoteConfiguration? = try {
+        RemoteConfiguration.parse(container.config)
+    } catch (e: SerializationException) {
+        errorLog(e) { "Failed to parse remote config response. Keeping the cached configuration." }
+        null
+    } catch (e: RCContainerFormatException) {
+        errorLog(e) { "Failed to decode remote config response. Keeping the cached configuration." }
+        null
+    }
+
+    /**
+     * Syncs a domain's listed subdomains before its own commit: the commit applies its response's
+     * topic/subdomain deletions, which must not land before the subdomains that may now carry the moved data
+     * have synced. Every child is synced even when a sibling fails (a successful child's commit is additive and
+     * safe); a failure only defers the parent's commit — old state and manifest are kept, so the next pass
+     * re-diffs cheaply. Returns whether every child ended the pass fresh.
+     */
+    private suspend fun syncSubdomains(ctx: TreePassContext, subdomains: List<String>, depth: Int): Boolean =
+        subdomains
+            .map { child -> syncDomainTree(ctx, child, depth + 1, isRoot = false) }
+            .all { it.isFresh }
+
+    /**
+     * Handles a domain's `204 Not Modified`: its cached entry is confirmed current, so record the confirmed
+     * refresh time for the pass-end batch write — but still recurse, because a domain's 204 says nothing about
+     * its subtree's freshness. Without a persisted entry there is nothing the 204 can confirm or update (a 204
+     * must never resurrect state that was wiped meanwhile): the root still counts as unchanged — the pass
+     * bookkeeping advances like any confirmed-current sync — but a child fails, because a missing child entry
+     * is exactly the gap its parent's commit must not paper over.
+     */
+    private suspend fun domainNotModifiedOutcome(
+        ctx: TreePassContext,
+        domain: String,
+        depth: Int,
+        isRoot: Boolean,
+        requestDate: Date?,
+    ): DomainSyncOutcome {
+        debugLog { "Remote config unchanged (204 Not Modified)." }
+        val persistedDomain = diskCache.read()?.domains?.get(domain)
+        if (persistedDomain == null) {
+            warnLog { "Remote config domain '$domain' returned 204 but nothing is persisted for it." }
+            return if (isRoot) DomainSyncOutcome.Unchanged else DomainSyncOutcome.Failed
+        }
+        // Only the server's own time is worth recording; a response without it carries the old value forward.
+        requestDate?.let { ctx.pending204RefreshTimes[domain] = it.time }
+        val childrenFresh = syncSubdomains(ctx, persistedDomain.subdomains, depth)
+        return if (childrenFresh) DomainSyncOutcome.Unchanged else DomainSyncOutcome.Failed
+    }
+
+    /**
+     * A retryable root failure prefers cached data over the fallback: only a cold start (nothing persisted for
+     * the root) tries the fallback endpoint, and only for the root — the fallback host is the emergency,
+     * least-capable endpoint, so its load is not multiplied by a tree of cold requests. A fallback-committed
+     * root still persists its subdomains list, so the next regular pass completes the tree once the main API
+     * recovers.
+     */
+    private suspend fun rootRetryableFailureOutcome(ctx: TreePassContext, domain: String): DomainSyncOutcome {
+        if (diskCache.read()?.domains?.get(domain) != null) return DomainSyncOutcome.Failed
+        verboseLog { "Main remote config request failed with no cached config; trying the fallback endpoint." }
+        val response = domainFetcher.fetchFallback(ctx.appInBackground, domain)
+        // No persisted state exists on this path, and the fallback host's request time is not borrowed as the
+        // refresh time: the value is only meaningful to the endpoint that issued it.
+        return when {
+            response == null -> DomainSyncOutcome.Failed
+            commitDomain(ctx, domain, isRoot = true, response, container = null, requestDate = null) ->
+                DomainSyncOutcome.Committed
+            else -> DomainSyncOutcome.Failed
+        }
+    }
+
+    /**
+     * The root's 4xx session kill-switch. Applied regardless of epoch ownership (a late response for an old
+     * identity is still a valid signal that the endpoint refuses this app's requests). Reads now return null,
+     * so in-memory caches are dropped too.
+     */
+    private fun disableForSession(error: PurchasesError) {
+        if (!disabled) {
+            disabled = true
+            val invalidatedGeneration = generation.incrementAndGet()
+            listeners.forEach { it.onConfigInvalidated(invalidatedGeneration) }
+            // Distinct one-shot signal (guarded by !disabled): lets consumers refetch offerings so paywall
+            // components — skipped while the endpoint was live — get decoded for the fallback render path.
+            listeners.forEach { it.onRemoteConfigDisabled(invalidatedGeneration) }
+        }
+        log(LogIntent.RC_ERROR) {
+            "Disabling remote config for this session after receiving a 4xx response. Error: $error"
+        }
     }
 
     private fun isRefreshAttemptCooldownElapsed(now: Date): Boolean {
@@ -288,198 +444,6 @@ internal class RemoteConfigManager(
     // [cacheLock].
     private fun fetchContextForRequest(requested: RemoteConfigFetchContext): RemoteConfigFetchContext {
         return if (hasCommittedInitialConfig) requested else RemoteConfigFetchContext.AppStart
-    }
-
-    /**
-     * Handles a successful **main** `/v1/config` response: a `204` keeps the cache (bookkeeping only), a `200`
-     * parses the config element and commits it (on [scope] so [clearCache] can cancel the parse/persist). Drops
-     * the result if the epoch changed meanwhile (an identity change already reset the guard via [clearCache]).
-     *
-     * [requestDate] is the server's own request time, which is what gets persisted and replayed as the refresh
-     * time — never a device-clock value the server cannot interpret. Null when the response carried no such header.
-     */
-    private fun handleMainRefreshSuccess(
-        requestEpoch: Int,
-        persisted: PersistedRemoteConfigurationState?,
-        container: RCContainer?,
-        requestDate: Date?,
-    ) {
-        if (epoch.get() != requestEpoch) {
-            // The cache was cleared (identity change) after this request started. Drop the stale
-            // response and leave isRefreshing alone: clearCache() reset it, or a newer refresh owns it.
-            return
-        }
-        if (requestDate == null) {
-            // Not fatal — the previous value carries forward — but it means the server stopped telling us its own
-            // time, so the refresh time replayed on later requests is frozen. Surfaced here rather than swallowed
-            // because nothing else makes this observable in the field.
-            warnLog {
-                "Remote config response carried no ${HTTPResult.REQUEST_TIME_HEADER_NAME} header. Keeping the " +
-                    "previous refresh time; the server cannot see how fresh this client's configuration is."
-            }
-        }
-        if (container == null) {
-            handleNotModified(requestEpoch, requestDate)
-            return
-        }
-        scope.launch {
-            try {
-                val response = RemoteConfiguration.parse(container.config)
-                synchronized(cacheLock) {
-                    if (epoch.get() != requestEpoch) return@launch
-                    persist(
-                        previous = persisted,
-                        response = response,
-                        container = container,
-                        requestDate = requestDate,
-                    )
-                }
-            } catch (e: SerializationException) {
-                errorLog(e) {
-                    "Failed to parse remote config response. Keeping the cached configuration."
-                }
-            } catch (e: RCContainerFormatException) {
-                errorLog(e) {
-                    "Failed to decode remote config response. Keeping the cached configuration."
-                }
-            } finally {
-                releaseGuardIfOwned(requestEpoch)
-            }
-        }
-    }
-
-    /**
-     * Handles a failure of the **main** `/v1/config` request. Prefers cached data over the fallback: only when
-     * the request fails with a retryable error AND nothing is cached yet (cold start) is the fallback endpoint
-     * tried, using the same [domain] the main request used. Any cached config wins (keep it), and a 4xx
-     * (`SHOULD_DISABLE`) still disables the endpoint without a fallback.
-     */
-    private fun handleMainRefreshError(
-        requestEpoch: Int,
-        appInBackground: Boolean,
-        domain: String,
-        hasCachedConfig: Boolean,
-        error: PurchasesError,
-        behavior: GetRemoteConfigErrorHandlingBehavior,
-    ) {
-        if (behavior == GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY && !hasCachedConfig) {
-            fetchFromFallback(requestEpoch, appInBackground, domain)
-        } else {
-            handleRefreshError(requestEpoch, error, behavior)
-        }
-    }
-
-    /**
-     * The cold-start fallback: the main `/v1/config` request failed with a retryable error and no config is
-     * cached, so fetch the plain-JSON [RemoteConfiguration] from the fallback endpoint (for the same [domain] the
-     * main request used) and commit it. There is never persisted state on this path, so the commit passes
-     * `previous = null`. The in-flight guard captured by the originating [refreshRemoteConfig] is **kept held**
-     * across this call — the fallback continues that same sync/epoch and releases the guard at its own terminal
-     * points (success `finally` / `onError`). Does nothing if the epoch changed meanwhile (an identity change
-     * already reset the guard via [clearCache]).
-     */
-    private fun fetchFromFallback(
-        requestEpoch: Int,
-        appInBackground: Boolean,
-        domain: String,
-    ) {
-        if (epoch.get() != requestEpoch) return
-        verboseLog { "Main remote config request failed with no cached config; trying the fallback endpoint." }
-        backend.getRemoteConfigFallback(
-            appInBackground = appInBackground,
-            domain = domain,
-            onSuccess = { response, _ ->
-                if (epoch.get() != requestEpoch) {
-                    // Identity changed after the fallback started; clearCache() reset the guard. Drop the result.
-                    return@getRemoteConfigFallback
-                }
-                scope.launch {
-                    try {
-                        synchronized(cacheLock) {
-                            if (epoch.get() != requestEpoch) return@launch
-                            // No persisted state exists on the fallback path (it only runs on a cold start). The
-                            // fallback host is not the main API, so its request time is not borrowed as the refresh
-                            // time: the value is only meaningful to the endpoint that issued it.
-                            persist(previous = null, response = response, container = null, requestDate = null)
-                        }
-                    } finally {
-                        releaseGuardIfOwned(requestEpoch)
-                    }
-                }
-            },
-            onError = { error, behavior -> handleRefreshError(requestEpoch, error, behavior) },
-        )
-    }
-
-    /**
-     * Handles a `204 Not Modified`: the cached configuration is confirmed current, so keep it and advance the refresh
-     * bookkeeping — including the persisted refresh time, since a 204 is as much a successful refresh as a 200. Runs
-     * on [scope] (like the 200 path) because that persist must not happen on the backend callback thread.
-     *
-     * The in-memory bookkeeping is unconditional: the configuration is already durably committed from an earlier
-     * request, so a failed timestamp write must not hold back [hasCommittedInitialConfig], nor [lastRefreshedAt]
-     * (which would re-arm the staleness gate immediately). It only costs the next request a staler header value.
-     */
-    private fun handleNotModified(requestEpoch: Int, requestDate: Date?) {
-        debugLog { "Remote config unchanged (204 Not Modified)." }
-        scope.launch {
-            try {
-                synchronized(cacheLock) {
-                    if (epoch.get() != requestEpoch) return@launch
-                    lastRefreshedAt = dateProvider.now
-                    lastRefreshAttemptAt = null
-                    hasCommittedInitialConfig = true
-                    // Only the server's own time is worth persisting, so a response without it writes nothing and
-                    // the previous value carries forward. Re-read instead of reusing the request's snapshot, and
-                    // skip when nothing is persisted: a 204 must never resurrect a cache that was wiped meanwhile.
-                    if (requestDate != null) {
-                        diskCache.read()?.let { state ->
-                            state.rootState?.let { root ->
-                                val refreshed = root.copy(lastRefreshTime = requestDate.time)
-                                diskCache.write(state.copy(domains = state.domains + (state.rootDomain to refreshed)))
-                            }
-                        }
-                    }
-                }
-            } finally {
-                releaseGuardIfOwned(requestEpoch)
-            }
-        }
-    }
-
-    private fun logRefreshStart(persisted: PersistedRemoteConfigurationState?, appInBackground: Boolean) {
-        verboseLog {
-            "Refreshing remote config (domain=${persisted?.rootDomain ?: DEFAULT_DOMAIN}, " +
-                "manifest present=${persisted?.rootState?.manifest != null}, appInBackground=$appInBackground)."
-        }
-    }
-
-    private fun handleRefreshError(
-        requestEpoch: Int,
-        error: PurchasesError,
-        behavior: GetRemoteConfigErrorHandlingBehavior,
-    ) {
-        if (behavior == GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE && !disabled) {
-            // A 4xx: disable the endpoint for the rest of the session. This is an endpoint-level fact, so set it
-            // regardless of epoch ownership (a late response for an old identity is still a valid signal that the
-            // endpoint refuses this app's requests). Reads now return null, so drop any in-memory caches too.
-            disabled = true
-            val invalidatedGeneration = generation.incrementAndGet()
-            listeners.forEach { it.onConfigInvalidated(invalidatedGeneration) }
-            // Distinct one-shot signal (this branch runs once, guarded by !disabled): lets consumers refetch
-            // offerings so paywall components — skipped while the endpoint was live — get decoded for the
-            // fallback render path.
-            listeners.forEach { it.onRemoteConfigDisabled(invalidatedGeneration) }
-        }
-        if (releaseGuardIfOwned(requestEpoch)) {
-            if (behavior == GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE) {
-                log(LogIntent.RC_ERROR) {
-                    "Disabling remote config for this session after receiving a 4xx response. Error: $error"
-                }
-            } else {
-                errorLog(error)
-            }
-        }
     }
 
     /**
@@ -867,15 +831,39 @@ internal class RemoteConfigManager(
         }
     }
 
-    private fun persist(
-        previous: PersistedRemoteConfigurationState?,
+    /**
+     * Commits one domain's `200` response into its entry of the persisted tree. Persisting the updated tree IS
+     * this domain's commit — the full topic index plus the manifest the server diffs against is the source of
+     * truth, and the manifest advances unconditionally with the write. Inline blobs are recoverable over the
+     * network, so the blob store is only touched once the state is durably committed (a failed persist never
+     * orphans blobs); blob retention and the generation bump are pass-wide and deferred to [finalizePass].
+     *
+     * Runs under [cacheLock] with an epoch re-check, so a commit racing [clearCache] either lands fully before
+     * the wipe or sees the bumped epoch and skips. Returns whether the state was durably persisted.
+     *
+     * [container] is null on the fallback path (plain-JSON response with no inlined blob elements to extract);
+     * the wanted blobs are then fetched over the network by [prefetchBlobs] instead. [requestDate] is the
+     * server's own request time — never a device-clock value — and is null when the response carried no such
+     * header (the previous value carries forward), or on the fallback path.
+     */
+    private fun commitDomain(
+        ctx: TreePassContext,
+        requestedDomain: String,
+        isRoot: Boolean,
         response: RemoteConfiguration,
-        // Null on the fallback path (plain-JSON response with no inlined blob elements to extract); the wanted
-        // blobs are then fetched over the network by prefetchBlobs instead.
         container: RCContainer?,
-        // The server's own request time. Null when the response carried no such header, or on the fallback path.
         requestDate: Date?,
-    ) {
+    ): Boolean = synchronized(cacheLock) {
+        if (epoch.get() != ctx.requestEpoch) return false
+        // Children stay keyed by the name their parent listed — the linkage the parent's subdomains list is
+        // resolved against. Only the root follows the response's echoed domain.
+        if (!isRoot && response.domain != requestedDomain) {
+            warnLog {
+                "Remote config response for domain '$requestedDomain' echoed domain '${response.domain}'; " +
+                    "keeping the requested name."
+            }
+        }
+        val domainKey = if (isRoot) response.domain else requestedDomain
         debugLog {
             val changed = response.topics.entries.joinToString { (name, topic) ->
                 "$name -> items=${topic.keys}"
@@ -883,25 +871,51 @@ internal class RemoteConfigManager(
             "Received remote config: active topics=${response.activeTopics}; changed topics: " +
                 "[${changed.ifEmpty { "none" }}]."
         }
-        val previousDomainState = previous?.domains?.get(response.domain)
-        val previousTopics = previousDomainState?.topics ?: emptyMap()
+        val previousState = diskCache.read()
+        val previousDomainState = previousState?.domains?.get(domainKey)
         // Changed topics (present in the response) overwrite their item index; unchanged active topics keep their
         // carried-forward index (the server omits them); topics no longer active are pruned.
-        val mergedTopics = (previousTopics + response.topics)
+        val mergedTopics = ((previousDomainState?.topics ?: emptyMap()) + response.topics)
             .filterKeys { it in response.activeTopics }
         // Blobs this domain's config still wants: the prefetch set plus any active-topic blob ref.
         val domainBlobRefs = response.prefetchBlobs.toSet() + mergedTopics.toTopicBlobRefs().values.flatten()
+        val newState = committedState(ctx, domainKey, isRoot, response, previousState, mergedTopics, requestDate)
+        val persisted = diskCache.write(newState)
 
-        // Persist the configuration first: the full topic index (incl. each item's inline content) plus the
-        // manifest the server diffs against is the source of truth, and persisting it IS the entire commit (the
-        // manifest advances unconditionally). Inline blobs are recoverable over the network, so only touch the
-        // blob store once the state is durably committed — a failed persist never orphans or evicts blobs.
+        if (persisted) {
+            ctx.committedCount++
+            ctx.lastPersistedState = newState
+            debugLog {
+                "Persisted remote config (domain=$domainKey, ${response.activeTopics.size} active topics, " +
+                    "${domainBlobRefs.size} blobs wanted)."
+            }
+            container?.let { extractInlineBlobs(it, domainBlobRefs) }
+            prefetchBlobs(response, mergedTopics)
+        } else {
+            errorLog { "Skipping remote config blob sync: failed to persist the configuration." }
+        }
+        persisted
+    }
+
+    private fun committedState(
+        ctx: TreePassContext,
+        domainKey: String,
+        isRoot: Boolean,
+        response: RemoteConfiguration,
+        previousState: PersistedRemoteConfigurationState?,
+        mergedTopics: Map<String, ConfigTopic>,
+        requestDate: Date?,
+    ): PersistedRemoteConfigurationState {
         // A root rename replaces the whole tree (old entries would be unreachable stale state, not history).
-        val carriedDomains = previous?.domains?.takeIf { previous.rootDomain == response.domain } ?: emptyMap()
-        val newState = PersistedRemoteConfigurationState(
-            rootDomain = response.domain,
+        val carriedDomains = when {
+            !isRoot -> previousState?.domains ?: emptyMap()
+            previousState?.rootDomain == response.domain -> previousState.domains
+            else -> emptyMap()
+        }
+        return PersistedRemoteConfigurationState(
+            rootDomain = if (isRoot) response.domain else previousState?.rootDomain ?: ctx.rootDomainName,
             domains = carriedDomains + (
-                response.domain to PersistedDomainState(
+                domainKey to PersistedDomainState(
                     manifest = response.manifest,
                     subdomains = response.subdomains,
                     activeTopics = response.activeTopics,
@@ -909,35 +923,89 @@ internal class RemoteConfigManager(
                     topics = mergedTopics,
                     // Server time only: a response without it carries the last server-supplied value forward
                     // rather than substituting a device-clock reading the server cannot compare against its own.
-                    lastRefreshTime = requestDate?.time ?: previousDomainState?.lastRefreshTime,
+                    lastRefreshTime = requestDate?.time
+                        ?: previousState?.domains?.get(domainKey)?.lastRefreshTime,
                 )
                 ),
         )
-        val persisted = diskCache.write(newState)
+    }
 
-        if (persisted) {
-            // The staleness gate measures elapsed *local* time (isCacheStale subtracts from dateProvider.now), so
-            // it stays on the device clock and is deliberately not the value persisted above.
-            lastRefreshedAt = dateProvider.now
-            lastRefreshAttemptAt = null
-            hasCommittedInitialConfig = true
-            debugLog {
-                "Persisted remote config (domain=${response.domain}, ${response.activeTopics.size} active topics, " +
-                    "${domainBlobRefs.size} blobs wanted)."
+    /**
+     * The pass-wide epilogue, run once after the tree settles, under [cacheLock] with an epoch re-check:
+     * 1. Writes the 204-confirmed refresh times in one batch (skipped when nothing was confirmed).
+     * 2. Prunes the blob store against [PersistedRemoteConfigurationState.liveBlobRefs] — the union across
+     *    every persisted domain, never a single domain's set — and advances the generation once for the whole
+     *    pass, so listeners re-warm from a tree-consistent state. Both only when this pass committed something,
+     *    mirroring the "blob work only after a successful persist" gating.
+     * 3. Advances the staleness bookkeeping only when every synced domain ended fresh: a partial pass leaves the
+     *    cache stale so the next trigger retries the tree (already-committed domains answer with cheap 204s,
+     *    and the attempt cooldown keeps retries from hammering).
+     */
+    private fun finalizePass(ctx: TreePassContext) {
+        synchronized(cacheLock) {
+            if (epoch.get() != ctx.requestEpoch) return
+            // The last commit's write is the current tree; falling back to a read covers all-204 passes.
+            var state = ctx.lastPersistedState ?: diskCache.read()
+            if (state != null && ctx.pending204RefreshTimes.isNotEmpty()) {
+                val updated = state.copy(
+                    domains = state.domains.mapValues { (name, domainState) ->
+                        ctx.pending204RefreshTimes[name]
+                            ?.let { domainState.copy(lastRefreshTime = it) }
+                            ?: domainState
+                    },
+                )
+                if (diskCache.write(updated)) state = updated
             }
-            container?.let { extractInlineBlobs(it, domainBlobRefs) }
-            // Retention spans every persisted domain, never just the one that synced: another domain's blobs
-            // must survive this domain's cleanup.
-            blobStore.retainOnly(newState.liveBlobRefs)
-            prefetchBlobs(response, mergedTopics)
-            // A new version is committed: advance the generation and let listeners re-warm their in-memory
-            // caches. Runs under cacheLock (both persist callers hold it), so the bump+notify is serialized
-            // against clearCache()'s bump+notify.
-            val committedGeneration = generation.incrementAndGet()
-            listeners.forEach { it.onConfigCommitted(committedGeneration) }
-        } else {
-            errorLog { "Skipping remote config blob sync: failed to persist the configuration." }
+            if (ctx.committedCount > 0) {
+                state?.let { blobStore.retainOnly(it.liveBlobRefs) }
+                val committedGeneration = generation.incrementAndGet()
+                listeners.forEach { it.onConfigCommitted(committedGeneration) }
+            }
+            if (ctx.allFresh) {
+                // The staleness gate measures elapsed *local* time (isCacheStale subtracts from
+                // dateProvider.now), so it stays on the device clock, unlike the persisted server refresh times.
+                lastRefreshedAt = dateProvider.now
+                lastRefreshAttemptAt = null
+                hasCommittedInitialConfig = true
+            }
         }
+    }
+
+    /** The mutable state of one tree pass; touched only by the pass coroutine (domains sync sequentially). */
+    private class TreePassContext(
+        val requestEpoch: Int,
+        val appInBackground: Boolean,
+        val appUserID: String,
+        val fetchContext: RemoteConfigFetchContext,
+        /** The root name this pass synced, for a child commit landing before any root state exists. */
+        val rootDomainName: String,
+    ) {
+        /** Terminal outcome per synced domain; doubles as the "already synced this pass" dedupe. */
+        val outcomes = mutableMapOf<String, DomainSyncOutcome>()
+
+        /** Domains whose sync is on the recursion stack; a re-listing inside its own subtree is a cycle. */
+        val inProgress = mutableSetOf<String>()
+
+        /** Server refresh times confirmed by per-domain 204s, written in one batch at pass end. */
+        val pending204RefreshTimes = mutableMapOf<String, Long>()
+
+        var committedCount = 0
+
+        /** The tree as of this pass's most recent successful commit; null when nothing committed yet. */
+        var lastPersistedState: PersistedRemoteConfigurationState? = null
+
+        val allFresh: Boolean get() = outcomes.values.all { it.isFresh }
+    }
+
+    private enum class DomainSyncOutcome {
+        Committed,
+        Unchanged,
+        Skipped,
+        Failed,
+        ;
+
+        /** Whether the domain's subtree is safe to apply a parent's deletions against. */
+        val isFresh: Boolean get() = this != Failed
     }
 
     /**
@@ -945,7 +1013,7 @@ internal class RemoteConfigManager(
      * [RemoteConfiguration.prefetchBlobs] plus any item flagged `prefetch`. Re-arms the blob source provider
      * first **only if a prior cycle exhausted its sources** (otherwise failover progress is kept, so a
      * known-bad higher-priority source isn't re-tried every sync), then hands the not-yet-cached refs to the
-     * fetcher's LOW-priority queue. Runs on the manager's IO scope (inside [persist]), so it never blocks the
+     * fetcher's LOW-priority queue. Runs on the manager's IO scope (inside [commitDomain]), so it never blocks the
      * main thread; a failed download is tolerated (re-fetched next sync / on demand).
      */
     private fun prefetchBlobs(response: RemoteConfiguration, mergedTopics: Map<String, ConfigTopic>) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
@@ -56,6 +56,7 @@ class RemoteConfigManagerIntegrationTest {
     private var capturedLastRefreshTime: Date? = null
     private var capturedPrefetchedBlobs: List<String>? = null
     private lateinit var onSuccess: (RCContainer?, Date?, VerificationResult) -> Unit
+    private val onSuccessByDomain = mutableMapOf<String, (RCContainer?, Date?, VerificationResult) -> Unit>()
 
     @Before
     fun setup() {
@@ -94,6 +95,7 @@ class RemoteConfigManagerIntegrationTest {
             capturedLastRefreshTime = arg(5)
             capturedPrefetchedBlobs = arg(6)
             onSuccess = arg(7)
+            onSuccessByDomain[arg(3)] = arg(7)
         }
     }
 
@@ -326,6 +328,71 @@ class RemoteConfigManagerIntegrationTest {
         assertThat(missing).isNull()
     }
 
+    @Test
+    fun `a subdomain tree pass persists both domains and merges their topics for reads`() {
+        val rootBlob = """{"workflow":"wfRoot"}""".toByteArray()
+        val rootRef = RCContainerTestData.refOf(rootBlob)
+        val childBlob = """{"ui":"config"}""".toByteArray()
+        val childRef = RCContainerTestData.refOf(childBlob)
+        // language=json
+        val rootConfig = """
+            {
+              "domain": "app",
+              "manifest": "v1.1.workflows:etag1",
+              "subdomains": ["app_ui"],
+              "active_topics": ["workflows"],
+              "prefetch_blobs": ["$rootRef"],
+              "topics": { "workflows": { "wf1": { "blob_ref": "$rootRef" } } }
+            }
+        """.trimIndent()
+        // language=json
+        val childConfig = """
+            {
+              "domain": "app_ui",
+              "manifest": "v1.1.ui_config:etagU",
+              "active_topics": ["ui_config"],
+              "prefetch_blobs": ["$childRef"],
+              "topics": { "ui_config": { "app": { "blob_ref": "$childRef" } } }
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = RemoteConfigFetchContext.AppStart)
+        settleFor("app", container(rootConfig, rootBlob))
+        settleFor("app_ui", container(childConfig, childBlob))
+
+        // Both domains persisted with their own manifests; the merged view unions their topics; both inline
+        // blobs landed in the shared store and the subdomain's topic reads transparently through the facade.
+        val state = diskCache.read()!!
+        assertThat(state.domains).containsOnlyKeys("app", "app_ui")
+        assertThat(state.domains.getValue("app_ui").manifest).isEqualTo("v1.1.ui_config:etagU")
+        assertThat(state.mergedTopics).containsOnlyKeys("workflows", "ui_config")
+        assertThat(blobStore.read(rootRef)).isEqualTo(rootBlob)
+        assertThat(blobStore.read(childRef)).isEqualTo(childBlob)
+        val uiTopic = runBlocking { manager.topic(RemoteConfigTopic.UiConfig) }
+        assertThat(uiTopic!!["app"]!!.blobRef).isEqualTo(childRef)
+
+        // Next pass: the root drops the subdomain. The entry lingers (nothing prunes it) but leaves the merged
+        // view, so its topic reads null; its blob stays pinned by the lingering entry.
+        // language=json
+        val rootConfig2 = """
+            {
+              "domain": "app",
+              "manifest": "v1.2.workflows:etag1",
+              "active_topics": ["workflows"],
+              "prefetch_blobs": ["$rootRef"],
+              "topics": {}
+            }
+        """.trimIndent()
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = RemoteConfigFetchContext.Foreground)
+        settleFor("app", container(rootConfig2))
+
+        assertThat(diskCache.read()!!.domains).containsOnlyKeys("app", "app_ui")
+        assertThat(diskCache.read()!!.mergedTopics).containsOnlyKeys("workflows")
+        assertThat(runBlocking { manager.topic(RemoteConfigTopic.UiConfig) }).isNull()
+        assertThat(blobStore.contains(rootRef)).isTrue
+        assertThat(blobStore.contains(childRef)).isTrue
+    }
+
     /** Builds a workflows-topic config. Each item maps an item key to its `blob_ref`, or `null` for inline-only. */
     private fun workflowsConfig(
         manifest: String = "v1.1.workflows:etag1",
@@ -387,6 +454,11 @@ class RemoteConfigManagerIntegrationTest {
 
     private fun settle(container: RCContainer?) {
         onSuccess.invoke(container, Date(), VerificationResult.VERIFIED)
+    }
+
+    /** Settles the request issued for [domain] during a tree pass (null = a 204). */
+    private fun settleFor(domain: String, container: RCContainer?) {
+        onSuccessByDomain.getValue(domain).invoke(container, Date(), VerificationResult.VERIFIED)
     }
 
     private companion object {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
@@ -82,6 +83,16 @@ class RemoteConfigManagerTest {
     private var capturedPrefetchedBlobs: List<String>? = null
     private lateinit var onSuccess: (RCContainer?, Date?, VerificationResult) -> Unit
     private lateinit var onError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit
+
+    // Per-domain views of the same captures, for tree-sync tests that answer more than one domain's request.
+    private val requestedDomains = mutableListOf<String>()
+    private val capturedManifestByDomain = mutableMapOf<String, String?>()
+    private val capturedPrefetchedBlobsByDomain = mutableMapOf<String, List<String>>()
+    private val onSuccessByDomain = mutableMapOf<String, (RCContainer?, Date?, VerificationResult) -> Unit>()
+    private val onErrorByDomain = mutableMapOf<String, (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit>()
+
+    // Every state handed to diskCache.write(), in order, for tests asserting per-domain commit ordering.
+    private val writtenStates = mutableListOf<PersistedRemoteConfigurationState>()
 
     private lateinit var onFallbackSuccess: (RemoteConfiguration, VerificationResult) -> Unit
     private lateinit var onFallbackError: (PurchasesError, GetRemoteConfigErrorHandlingBehavior) -> Unit
@@ -120,6 +131,12 @@ class RemoteConfigManagerTest {
             capturedPrefetchedBlobs = arg(6)
             onSuccess = arg(7)
             onError = arg(8)
+            val domain = arg<String>(3)
+            requestedDomains += domain
+            capturedManifestByDomain[domain] = arg(4)
+            capturedPrefetchedBlobsByDomain[domain] = arg(6)
+            onSuccessByDomain[domain] = arg(7)
+            onErrorByDomain[domain] = arg(8)
         }
 
         every {
@@ -2767,12 +2784,302 @@ class RemoteConfigManagerTest {
 
     // endregion
 
+    // region Subdomain tree sync
+
+    @Test
+    fun `a root response with subdomains syncs each subdomain with its own request bookkeeping`() {
+        statefulDiskCache(
+            persisted(manifest = "v1.root.old", domain = "app").withDomain(
+                "app_workflows",
+                PersistedDomainState(manifest = "v1.child.old", prefetchBlobs = listOf(REF_VALID)),
+            ),
+        )
+        every { blobStore.cachedRefs() } returns setOf(REF_VALID)
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        assertThat(capturedManifestByDomain["app"]).isEqualTo("v1.root.old")
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("app_workflows"))))
+
+        // The child request replays the child's own manifest and held prefetch blobs, not the root's.
+        assertThat(requestedDomains).containsExactly("app", "app_workflows")
+        assertThat(capturedManifestByDomain["app_workflows"]).isEqualTo("v1.child.old")
+        assertThat(capturedPrefetchedBlobsByDomain["app_workflows"]).containsExactly(REF_VALID)
+    }
+
+    @Test
+    fun `a brand-new subdomain is synced without a manifest`() {
+        statefulDiskCache(persisted(manifest = "v1.root.old", domain = "app"))
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("app_workflows"))))
+
+        assertThat(capturedManifestByDomain["app_workflows"]).isNull()
+    }
+
+    @Test
+    fun `subdomains commit before their parent so a migrating topic never leaves the merged view`() {
+        // The root currently serves "workflows"; this pass moves it to the app_workflows subdomain.
+        statefulDiskCache(
+            persisted(
+                manifest = "v1.root.old",
+                activeTopics = listOf("workflows"),
+                topics = mapOf(
+                    "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = "rootCopy"))),
+                ),
+            ),
+        )
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("app_workflows"))))
+        deliverSuccessFor(
+            "app_workflows",
+            containerWithConfig(
+                configJson(
+                    "app_workflows",
+                    "v1.child.new",
+                    activeTopics = listOf("workflows"),
+                    topics = """{ "workflows": { "wf1": { "blob_ref": "childCopy" } } }""",
+                ),
+            ),
+        )
+
+        // Child first, root second — and the intermediate state (child committed, root not yet) still resolves
+        // the topic to the root's copy via parent-wins, so no read interleaving ever sees the topic vanish.
+        assertThat(writtenStates).hasSize(2)
+        val intermediate = writtenStates.first()
+        assertThat(intermediate.domains).containsOnlyKeys("app", "app_workflows")
+        assertThat(intermediate.mergedTopics.getValue("workflows").getValue("wf1").blobRef).isEqualTo("rootCopy")
+        val final = writtenStates.last()
+        assertThat(final.domains.getValue("app").manifest).isEqualTo("v1.root.new")
+        assertThat(final.mergedTopics.getValue("workflows").getValue("wf1").blobRef).isEqualTo("childCopy")
+    }
+
+    @Test
+    fun `a failed subdomain sync defers the parent's commit and keeps the pass retryable`() {
+        statefulDiskCache(
+            persisted(
+                manifest = "v1.root.old",
+                activeTopics = listOf("workflows"),
+                topics = mapOf("workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem()))),
+            ),
+        )
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("app_workflows"))))
+        deliverErrorFor("app_workflows")
+
+        // The root's deletions are deferred: nothing was written, its manifest did not advance, and the merged
+        // view still serves the topic the root response dropped.
+        assertThat(writtenStates).isEmpty()
+        assertThat(diskCache.read()!!.mergedTopics).containsKey("workflows")
+        verify(exactly = 0) { blobStore.retainOnly(any()) }
+
+        // The pass settled (guard released) and stayed stale, so the next stale-gated refresh fires again.
+        currentTimeMillis += 6.minutes.inWholeMilliseconds
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        assertThat(requestedDomains).containsExactly("app", "app_workflows", "app")
+    }
+
+    @Test
+    fun `a failed subdomain does not block its committed siblings`() {
+        statefulDiskCache(persisted(manifest = "v1.root.old"))
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor(
+            "app",
+            containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("child_a", "child_b"))),
+        )
+        deliverSuccessFor("child_a", containerWithConfig(configJson("child_a", "v1.a.new")))
+        deliverErrorFor("child_b")
+
+        // child_a's commit is additive and safe; only the root (whose response's deletions need the full
+        // subtree) is deferred.
+        assertThat(writtenStates).hasSize(1)
+        assertThat(writtenStates.single().domains).containsOnlyKeys("app", "child_a")
+        assertThat(writtenStates.single().domains.getValue("app").manifest).isEqualTo("v1.root.old")
+    }
+
+    @Test
+    fun `a subdomain 4xx does not disable remote config but defers the parent's commit`() {
+        statefulDiskCache(persisted(manifest = "v1.root.old"))
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("app_workflows"))))
+        deliverErrorFor("app_workflows", GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE)
+
+        assertThat(manager.isDisabled).isFalse
+        assertThat(writtenStates).isEmpty()
+    }
+
+    @Test
+    fun `a root 204 still syncs the persisted subdomains`() {
+        statefulDiskCache(
+            persisted(manifest = "v1.root.old", lastRefreshTime = SERVER_MILLIS - 10_000L)
+                .withRootSubdomains("app_workflows")
+                .withDomain("app_workflows", PersistedDomainState(manifest = "v1.child.old")),
+        )
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", null)
+        deliverSuccessFor("app_workflows", containerWithConfig(configJson("app_workflows", "v1.child.new")))
+
+        // The child commits, then the pass-end batch write lands the root's 204-confirmed refresh time.
+        assertThat(writtenStates).hasSize(2)
+        assertThat(writtenStates.first().domains.getValue("app_workflows").manifest).isEqualTo("v1.child.new")
+        assertThat(writtenStates.last().domains.getValue("app").lastRefreshTime).isEqualTo(SERVER_MILLIS)
+        assertThat(writtenStates.last().domains.getValue("app").manifest).isEqualTo("v1.root.old")
+    }
+
+    @Test
+    fun `an all-204 tree pass batches the refresh times into a single write`() {
+        statefulDiskCache(
+            persisted(manifest = "v1.root.old")
+                .withRootSubdomains("app_workflows")
+                .withDomain("app_workflows", PersistedDomainState(manifest = "v1.child.old")),
+        )
+        val listener = RecordingCommitListener()
+        manager.registerListener(listener)
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", null)
+        deliverSuccessFor("app_workflows", null)
+
+        assertThat(writtenStates).hasSize(1)
+        assertThat(writtenStates.single().domains.getValue("app").lastRefreshTime).isEqualTo(SERVER_MILLIS)
+        assertThat(writtenStates.single().domains.getValue("app_workflows").lastRefreshTime).isEqualTo(SERVER_MILLIS)
+        // Nothing committed: no blob work, no re-warm — but the pass counts as a successful refresh.
+        verify(exactly = 0) { blobStore.retainOnly(any()) }
+        assertThat(listener.committed).isEmpty()
+        manager.refreshRemoteConfigIfStale(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        assertThat(requestedDomains).containsExactly("app", "app_workflows")
+    }
+
+    @Test
+    fun `sub-subdomains commit deepest-first`() {
+        statefulDiskCache(persisted(manifest = "v1.root.old"))
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("child"))))
+        deliverSuccessFor(
+            "child",
+            containerWithConfig(configJson("child", "v1.child.new", subdomains = listOf("grandchild"))),
+        )
+        deliverSuccessFor("grandchild", containerWithConfig(configJson("grandchild", "v1.grandchild.new")))
+
+        assertThat(writtenStates).hasSize(3)
+        assertThat(writtenStates[0].domains).containsOnlyKeys("app", "grandchild")
+        assertThat(writtenStates[1].domains).containsOnlyKeys("app", "grandchild", "child")
+        assertThat(writtenStates[2].domains.getValue("app").manifest).isEqualTo("v1.root.new")
+    }
+
+    @Test
+    fun `a cycle back to an ancestor is skipped and the pass still commits`() {
+        statefulDiskCache(persisted(manifest = "v1.root.old"))
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("child"))))
+        deliverSuccessFor("child", containerWithConfig(configJson("child", "v1.child.new", subdomains = listOf("app"))))
+
+        // One fetch per domain per pass; the bogus edge back to the root is ignored rather than deadlocking.
+        assertThat(requestedDomains).containsExactly("app", "child")
+        assertThat(writtenStates.last().domains.getValue("app").manifest).isEqualTo("v1.root.new")
+    }
+
+    @Test
+    fun `domains beyond the depth cap are not fetched and their parent still commits`() {
+        statefulDiskCache(persisted(manifest = "v1.root.old"))
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("d1"))))
+        deliverSuccessFor("d1", containerWithConfig(configJson("d1", "v1.d1", subdomains = listOf("d2"))))
+        deliverSuccessFor("d2", containerWithConfig(configJson("d2", "v1.d2", subdomains = listOf("d3"))))
+        deliverSuccessFor("d3", containerWithConfig(configJson("d3", "v1.d3", subdomains = listOf("d4"))))
+
+        assertThat(requestedDomains).containsExactly("app", "d1", "d2", "d3")
+        assertThat(writtenStates.last().domains.getValue("app").manifest).isEqualTo("v1.root.new")
+    }
+
+    @Test
+    fun `a multi-commit pass bumps the generation once and prunes blobs once with the cross-domain union`() {
+        statefulDiskCache(persisted(manifest = "v1.root.old"))
+        val listener = RecordingCommitListener()
+        manager.registerListener(listener)
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor(
+            "app",
+            containerWithConfig(
+                configJson("app", "v1.root.new", subdomains = listOf("app_workflows"), prefetchBlobs = listOf("rootBlob")),
+            ),
+        )
+        deliverSuccessFor(
+            "app_workflows",
+            containerWithConfig(configJson("app_workflows", "v1.child.new", prefetchBlobs = listOf("childBlob"))),
+        )
+
+        assertThat(listener.committed).hasSize(1)
+        val retained = slot<Set<String>>()
+        verify(exactly = 1) { blobStore.retainOnly(capture(retained)) }
+        assertThat(retained.captured).containsExactlyInAnyOrder("rootBlob", "childBlob")
+    }
+
+    // endregion
+
     /**
      * Delivers a successful config response. [requestDate] defaults to the server's request time, deliberately a
      * different instant from the [dateProvider] clock so an assertion on the persisted value proves which one won.
      */
     private fun deliverSuccess(container: RCContainer?, requestDate: Date? = Date(SERVER_MILLIS)) {
         onSuccess.invoke(container, requestDate, VerificationResult.VERIFIED)
+    }
+
+    /** Delivers a successful config response to the request issued for [domain] during a tree pass. */
+    private fun deliverSuccessFor(domain: String, container: RCContainer?, requestDate: Date? = Date(SERVER_MILLIS)) {
+        onSuccessByDomain.getValue(domain).invoke(container, requestDate, VerificationResult.VERIFIED)
+    }
+
+    private fun deliverErrorFor(
+        domain: String,
+        behavior: GetRemoteConfigErrorHandlingBehavior = GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+    ) {
+        onErrorByDomain.getValue(domain)
+            .invoke(PurchasesError(PurchasesErrorCode.UnknownBackendError, "request failed"), behavior)
+    }
+
+    /**
+     * Makes the mocked disk cache behave like the real one across a multi-commit pass: a write becomes visible
+     * to subsequent reads, and every written state is recorded in [writtenStates] for ordering assertions.
+     */
+    private fun statefulDiskCache(initial: PersistedRemoteConfigurationState?) {
+        var state = initial
+        every { diskCache.read() } answers { state }
+        every { diskCache.write(any()) } answers {
+            val written = firstArg<PersistedRemoteConfigurationState>()
+            state = written
+            writtenStates += written
+            true
+        }
+    }
+
+    private fun configJson(
+        domain: String,
+        manifest: String,
+        subdomains: List<String> = emptyList(),
+        activeTopics: List<String> = emptyList(),
+        prefetchBlobs: List<String> = emptyList(),
+        topics: String = "{}",
+    ): String {
+        fun jsonArray(values: List<String>) = values.joinToString(prefix = "[", postfix = "]") { "\"$it\"" }
+        return """
+            {
+              "domain": "$domain",
+              "manifest": "$manifest",
+              "subdomains": ${jsonArray(subdomains)},
+              "active_topics": ${jsonArray(activeTopics)},
+              "prefetch_blobs": ${jsonArray(prefetchBlobs)},
+              "topics": $topics
+            }
+        """.trimIndent()
     }
 
     private fun persisted(
@@ -2805,6 +3112,9 @@ class RemoteConfigManagerTest {
 
     private fun PersistedRemoteConfigurationState.withDomain(name: String, state: PersistedDomainState) =
         copy(domains = domains + (name to state))
+
+    private fun PersistedRemoteConfigurationState.withRootSubdomains(vararg subdomains: String) =
+        copy(domains = domains + (rootDomain to root.copy(subdomains = subdomains.toList())))
 
     /**
      * A fake inline blob element for a container mock: [ref] is what the manager reads to decide whether it

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -2955,47 +2955,19 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `sub-subdomains commit deepest-first`() {
+    fun `a subdomain's declared subdomains are ignored and the pass still commits`() {
         statefulDiskCache(persisted(manifest = "v1.root.old"))
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("child"))))
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("child", "child", "app"))))
         deliverSuccessFor(
             "child",
-            containerWithConfig(configJson("child", "v1.child.new", subdomains = listOf("grandchild"))),
+            containerWithConfig(configJson("child", "v1.child.new", subdomains = listOf("grandchild", "app"))),
         )
-        deliverSuccessFor("grandchild", containerWithConfig(configJson("grandchild", "v1.grandchild.new")))
 
-        assertThat(writtenStates).hasSize(3)
-        assertThat(writtenStates[0].domains).containsOnlyKeys("app", "grandchild")
-        assertThat(writtenStates[1].domains).containsOnlyKeys("app", "grandchild", "child")
-        assertThat(writtenStates[2].domains.getValue("app").manifest).isEqualTo("v1.root.new")
-    }
-
-    @Test
-    fun `a cycle back to an ancestor is skipped and the pass still commits`() {
-        statefulDiskCache(persisted(manifest = "v1.root.old"))
-
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("child"))))
-        deliverSuccessFor("child", containerWithConfig(configJson("child", "v1.child.new", subdomains = listOf("app"))))
-
-        // One fetch per domain per pass; the bogus edge back to the root is ignored rather than deadlocking.
+        // One level only: duplicates and a self-reference in the root's list are dropped, and the child's own
+        // list (nesting, even a cycle back to the root) is never followed.
         assertThat(requestedDomains).containsExactly("app", "child")
-        assertThat(writtenStates.last().domains.getValue("app").manifest).isEqualTo("v1.root.new")
-    }
-
-    @Test
-    fun `domains beyond the depth cap are not fetched and their parent still commits`() {
-        statefulDiskCache(persisted(manifest = "v1.root.old"))
-
-        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("d1"))))
-        deliverSuccessFor("d1", containerWithConfig(configJson("d1", "v1.d1", subdomains = listOf("d2"))))
-        deliverSuccessFor("d2", containerWithConfig(configJson("d2", "v1.d2", subdomains = listOf("d3"))))
-        deliverSuccessFor("d3", containerWithConfig(configJson("d3", "v1.d3", subdomains = listOf("d4"))))
-
-        assertThat(requestedDomains).containsExactly("app", "d1", "d2", "d3")
         assertThat(writtenStates.last().domains.getValue("app").manifest).isEqualTo("v1.root.new")
     }
 


### PR DESCRIPTION
### Description

Part 2 of 2 of subdomain support for `/v1/config` (stacked on #4054). This adds the sync engine. It is inert against the current backend, which declares no `subdomains` yet: a single-domain tree behaves exactly as before.

A refresh is now one pass over the domain tree:

- **Fetch root → sync its subdomains → commit children first, root last.** Only one level is supported: duplicates and self-references in the root's list are dropped, and a subdomain's own list is ignored (logged). Each subdomain syncs with its own manifest/refresh-time/`prefetched_blobs`. `RemoteConfigDomainFetcher` is the new suspend bridge over the callback-based backend endpoints; a root 4xx still applies the session kill-switch at callback time even if the pass was cancelled.
- **Deletion deferral (the migration-no-gap guarantee).** The root's 200 commits only when every subdomain it lists ended the pass fresh. Otherwise the root keeps its old state and old manifest, so the next pass re-diffs cheaply and committed subdomains answer 204. Combined with parent-wins merging, a topic migrating from the root to a subdomain never disappears from the merged view at any read interleaving (there's a test asserting the intermediate state).
- **Pass-wide finalize.** Per-domain 204 refresh times land in one batched write; `blobStore.retainOnly` runs once per pass with the cross-domain union; the generation bumps once per pass so listeners only re-warm from tree-consistent states; staleness bookkeeping advances only when the pass ended fresh, so a partial pass retries on the next trigger.
- **Failure rules.** Any subdomain failure — retryable or 4xx — defers the root's commit; a subdomain 4xx does *not* trip the whole-system kill-switch and self-heals once the server stops listing the refused domain. The cold-start fallback stays root-only (the fallback response's subdomains list is persisted, and the next regular pass completes the tree once the main API recovers).

Known limitations (deliberate, to keep the change small): a 4xx-ing subdomain is refetched once per pass (bounded by the staleness gate and the 1-minute attempt cooldown) rather than session-disabled, and a subdomain dropped from the root's list keeps its inert persisted entry (invisible to reads, blobs pinned) until an identity change wipes the cache.
