### PR TITLE
fix(checkpoints): Fix checkpoint resolution config races

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesDimensionValue
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
+import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowManager
@@ -34,6 +35,11 @@ import kotlinx.serialization.json.JsonPrimitive
  * absent from the fetched offerings, or its body unavailable — the checkpoint resolves to
  * [CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE] rather than falling through to a rule the
  * customer was not the first choice for.
+ *
+ * Resolution reads config across several suspension points, so a commit (or an identity change) can land halfway
+ * through and leave the rules the winner was picked from stale. That answer is discarded and resolution starts
+ * over against the new state, once — a second stale attempt reports
+ * [CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE] rather than spinning on a burst of commits.
  *
  * [SIMULATED_ERROR_CHECKPOINT_ID] is the one piece of PoC scaffolding left: it is the only way for the tester
  * apps to exercise the throw path, since nothing in the config-driven path throws.
@@ -59,14 +65,22 @@ internal class CheckpointWorkflowResolverImpl(
             errorLog(error)
             throw PurchasesException(error)
         }
-        return resolveConfiguredWorkflow(identifier, customVariables)
+        attemptResolve(identifier, customVariables)?.let { return it }
+        verboseLog { "Remote config changed while resolving checkpoint '$identifier'; resolving it again." }
+        return attemptResolve(identifier, customVariables)
+            ?: configurationUnavailable("Remote config kept changing while resolving checkpoint '$identifier'.")
     }
 
+    /**
+     * One resolution attempt against a single config generation, or `null` if the generation moved under it — the
+     * rules the winning rule came from are no longer the committed ones, so the answer can't be reported as if it
+     * were. [resolve] retries such an attempt exactly once, so resolution never runs more than twice.
+     */
     @Suppress("ReturnCount", "CyclomaticComplexMethod", "ComplexCondition")
-    private suspend fun resolveConfiguredWorkflow(
+    private suspend fun attemptResolve(
         identifier: String,
         customVariables: Map<String, RulesDimensionValue>,
-    ): CheckpointResolution {
+    ): CheckpointResolution? {
         if (
             workflowManager == null ||
             uiConfigProvider == null ||
@@ -98,9 +112,7 @@ internal class CheckpointWorkflowResolverImpl(
                 "The audiences for checkpoint '$identifier' could not be evaluated: ${error.message}",
             )
         }
-        if (!checkpointsConfigProvider.isCurrent(rulesResolution)) {
-            return configurationUnavailable("Remote config changed while resolving checkpoint '$identifier'.")
-        }
+        if (!checkpointsConfigProvider.isCurrent(rulesResolution)) return null
         if (rule == null) return noMatch(identifier)
         val uiConfig = try {
             uiConfigProvider.getUiConfig()
@@ -111,11 +123,7 @@ internal class CheckpointWorkflowResolverImpl(
             null
         } ?: return configurationUnavailable("UI config is unavailable for checkpoint '$identifier'.")
         val result = resolveRule(identifier, workflowManager, rule, uiConfig)
-        return if (checkpointsConfigProvider.isCurrent(rulesResolution)) {
-            result
-        } else {
-            configurationUnavailable("Remote config changed while resolving checkpoint '$identifier'.")
-        }
+        return result.takeIf { checkpointsConfigProvider.isCurrent(rulesResolution) }
     }
 
     @Suppress("ReturnCount")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -75,8 +75,8 @@ internal class CheckpointWorkflowResolverImpl(
         ) {
             return CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.DISABLED)
         }
-        val checkpoint = when (val resolution = checkpointsConfigProvider.resolveCheckpoint(identifier)) {
-            is CheckpointRulesResolution.Found -> resolution.checkpoint
+        val rulesResolution = when (val resolution = checkpointsConfigProvider.resolveCheckpoint(identifier)) {
+            is CheckpointRulesResolution.Found -> resolution
             CheckpointRulesResolution.NotConfigured -> return unknownCheckpoint(identifier)
             CheckpointRulesResolution.Disabled ->
                 return CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.DISABLED)
@@ -84,7 +84,7 @@ internal class CheckpointWorkflowResolverImpl(
                 return configurationUnavailable("The rules for checkpoint '$identifier' could not be read.")
         }
         val matchResult = localRulesEvaluator.match(
-            rules = checkpoint.rules,
+            rules = rulesResolution.checkpoint.rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
         ) { rule ->
             audiencesConfigProvider.getAudience(rule.audienceId)
@@ -97,7 +97,11 @@ internal class CheckpointWorkflowResolverImpl(
             return configurationUnavailable(
                 "The audiences for checkpoint '$identifier' could not be evaluated: ${error.message}",
             )
-        } ?: return noMatch(identifier)
+        }
+        if (!checkpointsConfigProvider.isCurrent(rulesResolution)) {
+            return configurationUnavailable("Remote config changed while resolving checkpoint '$identifier'.")
+        }
+        if (rule == null) return noMatch(identifier)
         val uiConfig = try {
             uiConfigProvider.getUiConfig()
         } catch (e: CancellationException) {
@@ -106,7 +110,12 @@ internal class CheckpointWorkflowResolverImpl(
             errorLog(e) { "UI config could not be fetched for checkpoint '$identifier'." }
             null
         } ?: return configurationUnavailable("UI config is unavailable for checkpoint '$identifier'.")
-        return resolveRule(identifier, workflowManager, rule, uiConfig)
+        val result = resolveRule(identifier, workflowManager, rule, uiConfig)
+        return if (checkpointsConfigProvider.isCurrent(rulesResolution)) {
+            result
+        } else {
+            configurationUnavailable("Remote config changed while resolving checkpoint '$identifier'.")
+        }
     }
 
     @Suppress("ReturnCount")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/checkpoints/CheckpointRulesResolution.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/checkpoints/CheckpointRulesResolution.kt
@@ -15,7 +15,10 @@ package com.revenuecat.purchases.common.checkpoints
  *   sync), or the checkpoint is published but its rules could not be resolved or did not parse.
  */
 internal sealed class CheckpointRulesResolution {
-    data class Found(val checkpoint: CheckpointResponse) : CheckpointRulesResolution()
+    data class Found(
+        val checkpoint: CheckpointResponse,
+        val configGeneration: Int,
+    ) : CheckpointRulesResolution()
 
     object NotConfigured : CheckpointRulesResolution()
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/checkpoints/CheckpointsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/checkpoints/CheckpointsConfigProvider.kt
@@ -21,16 +21,22 @@ internal class CheckpointsConfigProvider(
      * change under it: an identity change wipes the cache (the rules just read may belong to the previous user)
      * and an ordinary commit can publish fresher rules. Either advances [RemoteConfigManager.configGeneration],
      * and since there is no in-memory cache to fall back on the answer is to read once more against the new
-     * state rather than to discard. Bounded to a single retry so a burst of commits can't spin here.
+     * state rather than to discard. Only once, so a burst of commits can't spin here.
      */
     suspend fun resolveCheckpoint(identifier: String): CheckpointRulesResolution {
-        repeat(MAX_READ_ATTEMPTS) {
-            val generation = manager.configGeneration
-            val resolution = readCheckpoint(identifier, generation)
-            if (manager.configGeneration == generation) return resolution
-            verboseLog { "Remote config changed while resolving checkpoint '$identifier'; reading it again." }
-        }
-        return CheckpointRulesResolution.Unavailable
+        attemptRead(identifier)?.let { return it }
+        verboseLog { "Remote config changed while resolving checkpoint '$identifier'; reading it again." }
+        return attemptRead(identifier) ?: CheckpointRulesResolution.Unavailable
+    }
+
+    /**
+     * One read, or `null` if the committed state moved under it and the answer can no longer be trusted.
+     * [resolveCheckpoint] retries such a read exactly once, so it never reads more than twice.
+     */
+    private suspend fun attemptRead(identifier: String): CheckpointRulesResolution? {
+        val generation = manager.configGeneration
+        val resolution = readCheckpoint(identifier, generation)
+        return resolution.takeIf { manager.configGeneration == generation }
     }
 
     fun isCurrent(resolution: CheckpointRulesResolution.Found): Boolean =
@@ -73,9 +79,5 @@ internal class CheckpointsConfigProvider(
                 CheckpointRulesResolution.NotConfigured
             }
         }
-    }
-
-    private companion object {
-        const val MAX_READ_ATTEMPTS = 2
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/checkpoints/CheckpointsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/checkpoints/CheckpointsConfigProvider.kt
@@ -24,16 +24,21 @@ internal class CheckpointsConfigProvider(
      * state rather than to discard. Bounded to a single retry so a burst of commits can't spin here.
      */
     suspend fun resolveCheckpoint(identifier: String): CheckpointRulesResolution {
-        val generation = manager.configGeneration
-        val resolution = readCheckpoint(identifier)
-        if (manager.configGeneration == generation) return resolution
-        verboseLog { "Remote config changed while resolving checkpoint '$identifier'; reading it again." }
-        return readCheckpoint(identifier)
+        repeat(MAX_READ_ATTEMPTS) {
+            val generation = manager.configGeneration
+            val resolution = readCheckpoint(identifier, generation)
+            if (manager.configGeneration == generation) return resolution
+            verboseLog { "Remote config changed while resolving checkpoint '$identifier'; reading it again." }
+        }
+        return CheckpointRulesResolution.Unavailable
     }
 
-    private suspend fun readCheckpoint(identifier: String): CheckpointRulesResolution =
+    fun isCurrent(resolution: CheckpointRulesResolution.Found): Boolean =
+        manager.configGeneration == resolution.configGeneration
+
+    private suspend fun readCheckpoint(identifier: String, generation: Int): CheckpointRulesResolution =
         manager.blobData<CheckpointResponse>(RemoteConfigTopic.CheckpointRules, identifier)
-            ?.let { CheckpointRulesResolution.Found(it) }
+            ?.let { CheckpointRulesResolution.Found(it, generation) }
             ?: classifyUnresolved(identifier)
 
     /**
@@ -68,5 +73,9 @@ internal class CheckpointsConfigProvider(
                 CheckpointRulesResolution.NotConfigured
             }
         }
+    }
+
+    private companion object {
+        const val MAX_READ_ATTEMPTS = 2
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -221,53 +221,59 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
-    fun `config changing during audience evaluation is configuration unavailable`() = runTest {
+    fun `config changing once during audience evaluation is retried`() = runTest {
         val generation = AtomicInteger(1)
-        val manager = mockk<RemoteConfigManager>()
-        every { manager.configGeneration } answers { generation.get() }
-        coEvery {
-            manager.blobData(
-                RemoteConfigTopic.CheckpointRules,
-                checkpointId,
-                any<(ByteArray) -> CheckpointResponse?>(),
-            )
-        } returns CheckpointResponse(rules = listOf(rule("wf1234")))
-        coEvery { manager.topic(RemoteConfigTopic.Audiences) } answers {
-            generation.incrementAndGet()
-            ConfigTopic(
-                mapOf(
-                    "aud_wf1234" to RemoteConfiguration.ConfigItem(
-                        metadata = JsonTools.json.parseToJsonElement(
-                            """{"id":"aud_wf1234","rules":{"==":[1,1]}}""",
-                        ).jsonObject,
-                    ),
-                ),
-            )
-        }
-        resolver = CheckpointWorkflowResolverImpl(
-            workflowManager = mockWorkflowManager,
-            uiConfigProvider = mockUiConfigProvider,
-            checkpointsConfigProvider = CheckpointsConfigProvider(manager),
-            audiencesConfigProvider = AudiencesConfigProvider(manager),
-            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
-            getOfferings = { mockOfferings },
+        val audienceReads = AtomicInteger(0)
+        resolver = resolverBackedBy(
+            stalenessManager(generation) { if (audienceReads.getAndIncrement() == 0) generation.incrementAndGet() },
         )
 
-        assertThat((resolve() as? CheckpointResolution.NoAction)?.reason)
-            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        assertThat(resolve()).isInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
     }
 
     @Test
-    fun `config changing while resolving the workflow is configuration unavailable`() = runTest {
+    fun `config changing on every audience evaluation is configuration unavailable after one retry`() = runTest {
+        val generation = AtomicInteger(1)
+        val audienceReads = AtomicInteger(0)
+        resolver = resolverBackedBy(
+            stalenessManager(generation) {
+                audienceReads.incrementAndGet()
+                generation.incrementAndGet()
+            },
+        )
+
+        assertThat(noActionReason(resolve()))
+            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        // Two resolution attempts, no more: a burst of commits can't keep resolution spinning.
+        assertThat(audienceReads.get()).isEqualTo(2)
+    }
+
+    @Test
+    fun `config changing once while resolving the workflow is retried`() = runTest {
         var generation = 0
-        every { mockCheckpointsConfigProvider.isCurrent(any()) } answers { generation == 0 }
+        var workflowFetches = 0
+        configureRulesReadAt { generation }
+        coEvery { mockWorkflowManager.getWorkflowBody("wf1234") } answers {
+            if (workflowFetches++ == 0) generation++
+            mockWorkflow
+        }
+
+        assertThat(resolve()).isInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
+    }
+
+    @Test
+    fun `config changing on every workflow resolution is configuration unavailable after one retry`() = runTest {
+        var generation = 0
+        configureRulesReadAt { generation }
         coEvery { mockWorkflowManager.getWorkflowBody("wf1234") } answers {
             generation++
             mockWorkflow
         }
 
-        assertThat((resolve() as? CheckpointResolution.NoAction)?.reason)
+        assertThat(noActionReason(resolve()))
             .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        // Two resolution attempts, no more: a burst of commits can't keep resolution spinning.
+        coVerify(exactly = 2) { mockWorkflowManager.getWorkflowBody("wf1234") }
     }
 
     @Test
@@ -600,6 +606,56 @@ class CheckpointWorkflowResolverImplTest {
     private fun configureResolution(resolution: CheckpointRulesResolution) {
         coEvery { mockCheckpointsConfigProvider.resolveCheckpoint(checkpointId) } returns resolution
     }
+
+    /**
+     * Rules that are always read against whatever [generation] is current, so an attempt only looks stale if the
+     * generation moves after its own read.
+     */
+    private fun configureRulesReadAt(generation: () -> Int) {
+        coEvery { mockCheckpointsConfigProvider.resolveCheckpoint(checkpointId) } answers {
+            CheckpointRulesResolution.Found(
+                checkpoint = CheckpointResponse(rules = listOf(rule("wf1234"))),
+                configGeneration = generation(),
+            )
+        }
+        every { mockCheckpointsConfigProvider.isCurrent(any()) } answers {
+            firstArg<CheckpointRulesResolution.Found>().configGeneration == generation()
+        }
+    }
+
+    /** A manager serving one checkpoint and one always-matching audience, running [onAudienceRead] on each read. */
+    private fun stalenessManager(generation: AtomicInteger, onAudienceRead: () -> Unit): RemoteConfigManager =
+        mockk<RemoteConfigManager>().also { manager ->
+            every { manager.configGeneration } answers { generation.get() }
+            coEvery {
+                manager.blobData(
+                    RemoteConfigTopic.CheckpointRules,
+                    checkpointId,
+                    any<(ByteArray) -> CheckpointResponse?>(),
+                )
+            } returns CheckpointResponse(rules = listOf(rule("wf1234")))
+            coEvery { manager.topic(RemoteConfigTopic.Audiences) } answers {
+                onAudienceRead()
+                ConfigTopic(
+                    mapOf(
+                        "aud_wf1234" to RemoteConfiguration.ConfigItem(
+                            metadata = JsonTools.json.parseToJsonElement(
+                                """{"id":"aud_wf1234","rules":{"==":[1,1]}}""",
+                            ).jsonObject,
+                        ),
+                    ),
+                )
+            }
+        }
+
+    private fun resolverBackedBy(manager: RemoteConfigManager) = CheckpointWorkflowResolverImpl(
+        workflowManager = mockWorkflowManager,
+        uiConfigProvider = mockUiConfigProvider,
+        checkpointsConfigProvider = CheckpointsConfigProvider(manager),
+        audiencesConfigProvider = AudiencesConfigProvider(manager),
+        localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+        getOfferings = { mockOfferings },
+    )
 
     private suspend fun resolve(): CheckpointResolution = resolver.resolve(checkpointId, emptyMap())
 

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -4,6 +4,7 @@ package com.revenuecat.purchases.checkpoints
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.PurchasesError
@@ -20,6 +21,10 @@ import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesDimensionNamespace
 import com.revenuecat.purchases.common.localrules.RulesDimensionProvider
 import com.revenuecat.purchases.common.localrules.RulesDimensionValue
+import com.revenuecat.purchases.common.remoteconfig.ConfigTopic
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowManager
@@ -39,12 +44,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.Date
+import java.util.concurrent.atomic.AtomicInteger
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -86,6 +93,7 @@ class CheckpointWorkflowResolverImplTest {
             val audienceId = firstArg<String>()
             Audience(id = audienceId, rules = "true")
         }
+        every { mockCheckpointsConfigProvider.isCurrent(any()) } returns true
         configureRules(rule("wf1234"))
         resolver = CheckpointWorkflowResolverImpl(
             workflowManager = mockWorkflowManager,
@@ -210,6 +218,56 @@ class CheckpointWorkflowResolverImplTest {
         val resolution = resolve() as CheckpointResolution.MatchedWorkflow
 
         assertThat(resolution.workflow).isEqualTo(mockWorkflow)
+    }
+
+    @Test
+    fun `config changing during audience evaluation is configuration unavailable`() = runTest {
+        val generation = AtomicInteger(1)
+        val manager = mockk<RemoteConfigManager>()
+        every { manager.configGeneration } answers { generation.get() }
+        coEvery {
+            manager.blobData(
+                RemoteConfigTopic.CheckpointRules,
+                checkpointId,
+                any<(ByteArray) -> CheckpointResponse?>(),
+            )
+        } returns CheckpointResponse(rules = listOf(rule("wf1234")))
+        coEvery { manager.topic(RemoteConfigTopic.Audiences) } answers {
+            generation.incrementAndGet()
+            ConfigTopic(
+                mapOf(
+                    "aud_wf1234" to RemoteConfiguration.ConfigItem(
+                        metadata = JsonTools.json.parseToJsonElement(
+                            """{"id":"aud_wf1234","rules":{"==":[1,1]}}""",
+                        ).jsonObject,
+                    ),
+                ),
+            )
+        }
+        resolver = CheckpointWorkflowResolverImpl(
+            workflowManager = mockWorkflowManager,
+            uiConfigProvider = mockUiConfigProvider,
+            checkpointsConfigProvider = CheckpointsConfigProvider(manager),
+            audiencesConfigProvider = AudiencesConfigProvider(manager),
+            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+            getOfferings = { mockOfferings },
+        )
+
+        assertThat((resolve() as? CheckpointResolution.NoAction)?.reason)
+            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+    }
+
+    @Test
+    fun `config changing while resolving the workflow is configuration unavailable`() = runTest {
+        var generation = 0
+        every { mockCheckpointsConfigProvider.isCurrent(any()) } answers { generation == 0 }
+        coEvery { mockWorkflowManager.getWorkflowBody("wf1234") } answers {
+            generation++
+            mockWorkflow
+        }
+
+        assertThat((resolve() as? CheckpointResolution.NoAction)?.reason)
+            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
     }
 
     @Test
@@ -531,7 +589,12 @@ class CheckpointWorkflowResolverImplTest {
     )
 
     private fun configureRules(vararg rules: CheckpointRule) {
-        configureResolution(CheckpointRulesResolution.Found(CheckpointResponse(rules = rules.toList())))
+        configureResolution(
+            CheckpointRulesResolution.Found(
+                checkpoint = CheckpointResponse(rules = rules.toList()),
+                configGeneration = 0,
+            ),
+        )
     }
 
     private fun configureResolution(resolution: CheckpointRulesResolution) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/checkpoints/CheckpointsConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/checkpoints/CheckpointsConfigProviderTest.kt
@@ -234,6 +234,15 @@ internal class CheckpointsConfigProviderTest {
         coVerify(exactly = 2) { blobRead("missing") }
     }
 
+    @Test
+    fun `resolveCheckpoint reports Unavailable when the config changes during both reads`() = runTest {
+        every { manager.configGeneration } returnsMany listOf(0, 1, 1, 2)
+        returnBlob("app_open", """{ "rules": [] }""")
+
+        assertThat(provider.resolveCheckpoint("app_open")).isEqualTo(CheckpointRulesResolution.Unavailable)
+        coVerify(exactly = 2) { blobRead("app_open") }
+    }
+
     private suspend fun checkpoint(identifier: String): CheckpointResponse =
         (provider.resolveCheckpoint(identifier) as CheckpointRulesResolution.Found).checkpoint
 


### PR DESCRIPTION
A remote config refresh can land after checkpoint rules are read but before their audience or workflow is resolved. That can mix config generations and show the old workflow to a customer matched by the new audience.

Carry the remote config generation with checkpoint rules and return `CONFIGURATION_UNAVAILABLE` if it changes during resolution. This is the same logic as in `purchases-ios`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint presentation logic during concurrent remote config updates; bounded retries may surface CONFIGURATION_UNAVAILABLE where a mixed-generation workflow might have been shown before.
> 
> **Overview**
> Fixes a race where a remote config commit or identity change can land **after** checkpoint rules are read but **before** audience matching or workflow loading finishes, so the SDK could present a workflow from an older generation than the rule that matched.
> 
> **Checkpoint rules reads** now stamp `CheckpointRulesResolution.Found` with the current `configGeneration`, and `CheckpointsConfigProvider.isCurrent()` lets callers detect staleness. Reads that complete under a moved generation are treated as untrusted (`null`) and retried **once**; a second stale read yields `Unavailable` at the provider layer.
> 
> **Full checkpoint resolution** mirrors that pattern: `attemptResolve` aborts with `null` if the generation changes after audience evaluation or after `resolveRule`, and `resolve` retries exactly once before returning **`CONFIGURATION_UNAVAILABLE`** so bursts of commits cannot spin resolution indefinitely.
> 
> Tests cover single-change retries and repeated-change failure paths for both config reads and end-to-end resolver behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d0021120fbc01a4fd389c4caef0b22cfd824c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->