### PR TITLE
Disable refused remote config subdomains per session and prune dropped ones

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -105,6 +105,13 @@ internal class RemoteConfigManager(
     // 4xx disables the session even when the requesting pass was cancelled meanwhile.
     private val domainFetcher = RemoteConfigDomainFetcher(backend, diskCache, blobStore, ::disableForSession)
 
+    // Session kill-switches for individual subdomains that answered 4xx: their fetch is skipped (last-good
+    // persisted data keeps serving) until app restart, an identity change, or the domain dropping out of the
+    // tree. Unlike the root [disabled] flag, [clearCache] DOES clear these: subdomain trees are config- and
+    // user-derived, and a stale disable would outlive the last-good state the wipe destroys, turning into a
+    // session-long block of the parent's commits for the new user. Guarded by [cacheLock].
+    private val disabledDomains = mutableSetOf<String>()
+
     // Bumped by clearCache() on every identity change. A request captures the epoch when it starts; once it
     // changes, the in-flight request's callbacks drop their result (the /v1/config request itself cannot be
     // socket-cancelled), so an old user's response can never persist over the wiped cache.
@@ -295,8 +302,9 @@ internal class RemoteConfigManager(
         return try {
             val fetch = domainFetcher.fetch(domain, isRoot, ctx.appInBackground, ctx.appUserID, ctx.fetchContext)
             val outcome = when (fetch.outcome) {
-                // The 4xx side effects (the root's session kill-switch) already ran at callback time.
-                FetchOutcome.ClientError -> DomainSyncOutcome.Failed
+                // The root's 4xx side effect (the session kill-switch) already ran at callback time.
+                FetchOutcome.ClientError ->
+                    if (isRoot) DomainSyncOutcome.Failed else subdomainClientErrorOutcome(domain)
                 FetchOutcome.FailedRetryable ->
                     if (isRoot) rootRetryableFailureOutcome(ctx, domain) else DomainSyncOutcome.Failed
                 FetchOutcome.Success -> syncFetchedDomain(ctx, domain, depth, isRoot, fetch)
@@ -308,7 +316,10 @@ internal class RemoteConfigManager(
         }
     }
 
-    /** The outcomes that resolve without a fetch: already synced this pass, a cycle, or beyond the depth cap. */
+    /**
+     * The outcomes that resolve without a fetch: already synced this pass, a cycle, beyond the depth cap, or
+     * disabled for the session after an earlier 4xx.
+     */
     private fun shortCircuitOutcome(ctx: TreePassContext, domain: String, depth: Int): DomainSyncOutcome? = when {
         domain in ctx.outcomes -> ctx.outcomes.getValue(domain)
         domain in ctx.inProgress -> {
@@ -322,8 +333,42 @@ internal class RemoteConfigManager(
             }
             DomainSyncOutcome.Skipped
         }
+        isSessionDisabled(domain) -> {
+            verboseLog { "Remote config domain '$domain' is disabled for this session (4xx); skipping its fetch." }
+            disabledSubdomainOutcome(domain)
+        }
         else -> null
     }
+
+    private fun isSessionDisabled(domain: String): Boolean = synchronized(cacheLock) { domain in disabledDomains }
+
+    /**
+     * A subdomain answered 4xx: disable it for the session and keep serving its last-good persisted data —
+     * fresh for the commit rule, so the rest of the tree keeps updating. The disable clears on app restart, on
+     * an identity change ([clearCache]), or when the domain drops out of the tree (prune), so a later re-add
+     * starts over.
+     */
+    private fun subdomainClientErrorOutcome(domain: String): DomainSyncOutcome {
+        synchronized(cacheLock) { disabledDomains += domain }
+        return disabledSubdomainOutcome(domain)
+    }
+
+    /**
+     * Without last-good data a refused subdomain fails instead of being skipped, deferring its parent's commit:
+     * committing would vanish any topic that migrated into the refused domain. The block self-heals — the
+     * commit rule evaluates each pass's fresh parent response, so it ends as soon as the server stops listing
+     * the refused domain.
+     */
+    private fun disabledSubdomainOutcome(domain: String): DomainSyncOutcome =
+        if (diskCache.read()?.domains?.get(domain) != null) {
+            DomainSyncOutcome.DisabledLastGood
+        } else {
+            log(LogIntent.RC_ERROR) {
+                "Remote config subdomain '$domain' is refused (4xx) and has no cached data; deferring its " +
+                    "parent's updates until the server stops listing it."
+            }
+            DomainSyncOutcome.Failed
+        }
 
     private suspend fun syncFetchedDomain(
         ctx: TreePassContext,
@@ -464,7 +509,9 @@ internal class RemoteConfigManager(
             lastRefreshAttemptAt = null
             completeRefresh()
             // Intentionally NOT resetting `disabled`: a 4xx is an endpoint/app-level fact that outlives an
-            // identity change. It clears only on app restart.
+            // identity change. It clears only on app restart. The per-subdomain disables DO clear (see
+            // [disabledDomains]): they are config/user-derived and their last-good data is being wiped.
+            disabledDomains.clear()
             diskCache.clear()
             blobStore.clear()
             sourceProvider.clear()
@@ -879,7 +926,16 @@ internal class RemoteConfigManager(
             .filterKeys { it in response.activeTopics }
         // Blobs this domain's config still wants: the prefetch set plus any active-topic blob ref.
         val domainBlobRefs = response.prefetchBlobs.toSet() + mergedTopics.toTopicBlobRefs().values.flatten()
-        val newState = committedState(ctx, domainKey, isRoot, response, previousState, mergedTopics, requestDate)
+        val newState = previousState.withCommittedDomain(
+            domainKey = domainKey,
+            isRoot = isRoot,
+            fallbackRootDomain = ctx.rootDomainName,
+            response = response,
+            mergedTopics = mergedTopics,
+            // Server time only: a response without it carries the last server-supplied value forward rather
+            // than substituting a device-clock reading the server cannot compare against its own.
+            lastRefreshTime = requestDate?.time ?: previousDomainState?.lastRefreshTime,
+        )
         val persisted = diskCache.write(newState)
 
         if (persisted) {
@@ -895,39 +951,6 @@ internal class RemoteConfigManager(
             errorLog { "Skipping remote config blob sync: failed to persist the configuration." }
         }
         persisted
-    }
-
-    private fun committedState(
-        ctx: TreePassContext,
-        domainKey: String,
-        isRoot: Boolean,
-        response: RemoteConfiguration,
-        previousState: PersistedRemoteConfigurationState?,
-        mergedTopics: Map<String, ConfigTopic>,
-        requestDate: Date?,
-    ): PersistedRemoteConfigurationState {
-        // A root rename replaces the whole tree (old entries would be unreachable stale state, not history).
-        val carriedDomains = when {
-            !isRoot -> previousState?.domains ?: emptyMap()
-            previousState?.rootDomain == response.domain -> previousState.domains
-            else -> emptyMap()
-        }
-        return PersistedRemoteConfigurationState(
-            rootDomain = if (isRoot) response.domain else previousState?.rootDomain ?: ctx.rootDomainName,
-            domains = carriedDomains + (
-                domainKey to PersistedDomainState(
-                    manifest = response.manifest,
-                    subdomains = response.subdomains,
-                    activeTopics = response.activeTopics,
-                    prefetchBlobs = response.prefetchBlobs,
-                    topics = mergedTopics,
-                    // Server time only: a response without it carries the last server-supplied value forward
-                    // rather than substituting a device-clock reading the server cannot compare against its own.
-                    lastRefreshTime = requestDate?.time
-                        ?: previousState?.domains?.get(domainKey)?.lastRefreshTime,
-                )
-                ),
-        )
     }
 
     /**
@@ -956,56 +979,43 @@ internal class RemoteConfigManager(
                 )
                 if (diskCache.write(updated)) state = updated
             }
-            if (ctx.committedCount > 0) {
-                state?.let { blobStore.retainOnly(it.liveBlobRefs) }
-                val committedGeneration = generation.incrementAndGet()
-                listeners.forEach { it.onConfigCommitted(committedGeneration) }
-            }
             if (ctx.allFresh) {
+                state = state?.let { pruneUnreachableDomains(it) }
                 // The staleness gate measures elapsed *local* time (isCacheStale subtracts from
                 // dateProvider.now), so it stays on the device clock, unlike the persisted server refresh times.
                 lastRefreshedAt = dateProvider.now
                 lastRefreshAttemptAt = null
                 hasCommittedInitialConfig = true
             }
+            if (ctx.committedCount > 0) {
+                state?.let { blobStore.retainOnly(it.liveBlobRefs) }
+                val committedGeneration = generation.incrementAndGet()
+                listeners.forEach { it.onConfigCommitted(committedGeneration) }
+            }
         }
     }
 
-    /** The mutable state of one tree pass; touched only by the pass coroutine (domains sync sequentially). */
-    private class TreePassContext(
-        val requestEpoch: Int,
-        val appInBackground: Boolean,
-        val appUserID: String,
-        val fetchContext: RemoteConfigFetchContext,
-        /** The root name this pass synced, for a child commit landing before any root state exists. */
-        val rootDomainName: String,
-    ) {
-        /** Terminal outcome per synced domain; doubles as the "already synced this pass" dedupe. */
-        val outcomes = mutableMapOf<String, DomainSyncOutcome>()
-
-        /** Domains whose sync is on the recursion stack; a re-listing inside its own subtree is a cycle. */
-        val inProgress = mutableSetOf<String>()
-
-        /** Server refresh times confirmed by per-domain 204s, written in one batch at pass end. */
-        val pending204RefreshTimes = mutableMapOf<String, Long>()
-
-        var committedCount = 0
-
-        /** The tree as of this pass's most recent successful commit; null when nothing committed yet. */
-        var lastPersistedState: PersistedRemoteConfigurationState? = null
-
-        val allFresh: Boolean get() = outcomes.values.all { it.isFresh }
-    }
-
-    private enum class DomainSyncOutcome {
-        Committed,
-        Unchanged,
-        Skipped,
-        Failed,
-        ;
-
-        /** Whether the domain's subtree is safe to apply a parent's deletions against. */
-        val isFresh: Boolean get() = this != Failed
+    /**
+     * Drops domain entries no longer reachable from the root, clearing any session disable with them so a
+     * later re-add starts over. Runs only after a fully-fresh pass: after a partial pass a freshly-committed
+     * child can be unreachable merely because the parent that links it deferred its commit, and after a crashed
+     * first pass children can be persisted before any root state exists — pruning in either state would discard
+     * fresh data the next pass reuses. Called within [cacheLock]; falls back to the unpruned state on a failed
+     * write (the entries stay inert for reads and merely pin their blobs until a later pass prunes them).
+     */
+    private fun pruneUnreachableDomains(
+        state: PersistedRemoteConfigurationState,
+    ): PersistedRemoteConfigurationState {
+        val unreachable = if (state.rootState == null) {
+            emptySet()
+        } else {
+            state.domains.keys - state.domainsInPrecedenceOrder.toSet()
+        }
+        if (unreachable.isEmpty()) return state
+        debugLog { "Pruning remote config domain(s) no longer part of the tree: $unreachable." }
+        disabledDomains -= unreachable
+        val pruned = state.copy(domains = state.domains - unreachable)
+        return if (diskCache.write(pruned)) pruned else state
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigTreePass.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigTreePass.kt
@@ -1,0 +1,79 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+/**
+ * The mutable state of one tree sync pass ([RemoteConfigManager.runTreePass]); touched only by the pass
+ * coroutine (domains sync sequentially).
+ */
+internal class TreePassContext(
+    val requestEpoch: Int,
+    val appInBackground: Boolean,
+    val appUserID: String,
+    val fetchContext: RemoteConfigFetchContext,
+    /** The root name this pass synced, for a child commit landing before any root state exists. */
+    val rootDomainName: String,
+) {
+    /** Terminal outcome per synced domain; doubles as the "already synced this pass" dedupe. */
+    val outcomes = mutableMapOf<String, DomainSyncOutcome>()
+
+    /** Domains whose sync is on the recursion stack; a re-listing inside its own subtree is a cycle. */
+    val inProgress = mutableSetOf<String>()
+
+    /** Server refresh times confirmed by per-domain 204s, written in one batch at pass end. */
+    val pending204RefreshTimes = mutableMapOf<String, Long>()
+
+    var committedCount = 0
+
+    /** The tree as of this pass's most recent successful commit; null when nothing committed yet. */
+    var lastPersistedState: PersistedRemoteConfigurationState? = null
+
+    val allFresh: Boolean get() = outcomes.values.all { it.isFresh }
+}
+
+internal enum class DomainSyncOutcome {
+    Committed,
+    Unchanged,
+    Skipped,
+
+    /** Refused (4xx) this session but its last-good persisted entry keeps serving the merged view. */
+    DisabledLastGood,
+    Failed,
+    ;
+
+    /** Whether the domain's subtree is safe to apply a parent's deletions against. */
+    val isFresh: Boolean get() = this != Failed
+}
+
+/**
+ * The tree after committing one domain's `200` [response] into its entry. Children stay keyed by
+ * [domainKey] — the name their parent listed; only the root follows the response's echoed domain, and a root
+ * rename replaces the whole tree (old entries would be unreachable stale state, not history).
+ * [fallbackRootDomain] names the root when a child commits before any state exists.
+ */
+@Suppress("LongParameterList")
+internal fun PersistedRemoteConfigurationState?.withCommittedDomain(
+    domainKey: String,
+    isRoot: Boolean,
+    fallbackRootDomain: String,
+    response: RemoteConfiguration,
+    mergedTopics: Map<String, ConfigTopic>,
+    lastRefreshTime: Long?,
+): PersistedRemoteConfigurationState {
+    val carriedDomains = when {
+        !isRoot -> this?.domains ?: emptyMap()
+        this?.rootDomain == response.domain -> this.domains
+        else -> emptyMap()
+    }
+    return PersistedRemoteConfigurationState(
+        rootDomain = if (isRoot) response.domain else this?.rootDomain ?: fallbackRootDomain,
+        domains = carriedDomains + (
+            domainKey to PersistedDomainState(
+                manifest = response.manifest,
+                subdomains = response.subdomains,
+                activeTopics = response.activeTopics,
+                prefetchBlobs = response.prefetchBlobs,
+                topics = mergedTopics,
+                lastRefreshTime = lastRefreshTime,
+            )
+            ),
+    )
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerIntegrationTest.kt
@@ -56,6 +56,7 @@ class RemoteConfigManagerIntegrationTest {
     private var capturedLastRefreshTime: Date? = null
     private var capturedPrefetchedBlobs: List<String>? = null
     private lateinit var onSuccess: (RCContainer?, Date?, VerificationResult) -> Unit
+    private val onSuccessByDomain = mutableMapOf<String, (RCContainer?, Date?, VerificationResult) -> Unit>()
 
     @Before
     fun setup() {
@@ -94,6 +95,7 @@ class RemoteConfigManagerIntegrationTest {
             capturedLastRefreshTime = arg(5)
             capturedPrefetchedBlobs = arg(6)
             onSuccess = arg(7)
+            onSuccessByDomain[arg(3)] = arg(7)
         }
     }
 
@@ -326,6 +328,70 @@ class RemoteConfigManagerIntegrationTest {
         assertThat(missing).isNull()
     }
 
+    @Test
+    fun `a subdomain tree pass persists both domains, merges topics, and prunes a dropped subdomain`() {
+        val rootBlob = """{"workflow":"wfRoot"}""".toByteArray()
+        val rootRef = RCContainerTestData.refOf(rootBlob)
+        val childBlob = """{"ui":"config"}""".toByteArray()
+        val childRef = RCContainerTestData.refOf(childBlob)
+        // language=json
+        val rootConfig = """
+            {
+              "domain": "app",
+              "manifest": "v1.1.workflows:etag1",
+              "subdomains": ["app_ui"],
+              "active_topics": ["workflows"],
+              "prefetch_blobs": ["$rootRef"],
+              "topics": { "workflows": { "wf1": { "blob_ref": "$rootRef" } } }
+            }
+        """.trimIndent()
+        // language=json
+        val childConfig = """
+            {
+              "domain": "app_ui",
+              "manifest": "v1.1.ui_config:etagU",
+              "active_topics": ["ui_config"],
+              "prefetch_blobs": ["$childRef"],
+              "topics": { "ui_config": { "app": { "blob_ref": "$childRef" } } }
+            }
+        """.trimIndent()
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = RemoteConfigFetchContext.AppStart)
+        settleFor("app", container(rootConfig, rootBlob))
+        settleFor("app_ui", container(childConfig, childBlob))
+
+        // Both domains persisted with their own manifests; the merged view unions their topics; both inline
+        // blobs landed in the shared store and the subdomain's topic reads transparently through the facade.
+        val state = diskCache.read()!!
+        assertThat(state.domains).containsOnlyKeys("app", "app_ui")
+        assertThat(state.domains.getValue("app_ui").manifest).isEqualTo("v1.1.ui_config:etagU")
+        assertThat(state.mergedTopics).containsOnlyKeys("workflows", "ui_config")
+        assertThat(blobStore.read(rootRef)).isEqualTo(rootBlob)
+        assertThat(blobStore.read(childRef)).isEqualTo(childBlob)
+        val uiTopic = runBlocking { manager.topic(RemoteConfigTopic.UiConfig) }
+        assertThat(uiTopic!!["app"]!!.blobRef).isEqualTo(childRef)
+
+        // Next pass: the root drops the subdomain. Its entry is pruned and its blob evicted; the root's
+        // carried-forward topic keeps its own blob alive.
+        // language=json
+        val rootConfig2 = """
+            {
+              "domain": "app",
+              "manifest": "v1.2.workflows:etag1",
+              "active_topics": ["workflows"],
+              "prefetch_blobs": ["$rootRef"],
+              "topics": {}
+            }
+        """.trimIndent()
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = RemoteConfigFetchContext.Foreground)
+        settleFor("app", container(rootConfig2))
+
+        assertThat(diskCache.read()!!.domains).containsOnlyKeys("app")
+        assertThat(blobStore.contains(rootRef)).isTrue
+        assertThat(blobStore.contains(childRef)).isFalse
+        assertThat(runBlocking { manager.topic(RemoteConfigTopic.UiConfig) }).isNull()
+    }
+
     /** Builds a workflows-topic config. Each item maps an item key to its `blob_ref`, or `null` for inline-only. */
     private fun workflowsConfig(
         manifest: String = "v1.1.workflows:etag1",
@@ -387,6 +453,11 @@ class RemoteConfigManagerIntegrationTest {
 
     private fun settle(container: RCContainer?) {
         onSuccess.invoke(container, Date(), VerificationResult.VERIFIED)
+    }
+
+    /** Settles the request issued for [domain] during a tree pass (null = a 204). */
+    private fun settleFor(domain: String, container: RCContainer?) {
+        onSuccessByDomain.getValue(domain).invoke(container, Date(), VerificationResult.VERIFIED)
     }
 
     private companion object {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -694,32 +694,35 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `a root sync retains blobs referenced by other persisted domains`() {
-        val cached = persisted(manifest = "v1.1.sources:etag1").withDomain(
-            "app_workflows",
-            PersistedDomainState(
-                manifest = "v1.1.workflows:etagW",
-                activeTopics = listOf("workflows"),
-                prefetchBlobs = listOf("subPrefetchBlob"),
-                topics = mapOf(
-                    "workflows" to ConfigTopic(
-                        mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = "subTopicBlob")),
+        statefulDiskCache(
+            persisted(manifest = "v1.1.sources:etag1")
+                .withRootSubdomains("app_workflows")
+                .withDomain(
+                    "app_workflows",
+                    PersistedDomainState(
+                        manifest = "v1.1.workflows:etagW",
+                        activeTopics = listOf("workflows"),
+                        prefetchBlobs = listOf("subPrefetchBlob"),
+                        topics = mapOf(
+                            "workflows" to ConfigTopic(
+                                mapOf("wf1" to RemoteConfiguration.ConfigItem(blobRef = "subTopicBlob")),
+                            ),
+                        ),
                     ),
                 ),
-            ),
         )
-        every { diskCache.read() } returns cached
-        val response = """
-            {
-              "domain": "app",
-              "manifest": "v1.200.sources:etag2",
-              "active_topics": ["sources"],
-              "prefetch_blobs": ["rootBlob"],
-              "topics": { "sources": { "default": { "blob_ref": "rootBlob" } } }
-            }
-        """.trimIndent()
+        val response = configJson(
+            "app",
+            "v1.200.sources:etag2",
+            subdomains = listOf("app_workflows"),
+            activeTopics = listOf("sources"),
+            prefetchBlobs = listOf("rootBlob"),
+            topics = """{ "sources": { "default": { "blob_ref": "rootBlob" } } }""",
+        )
 
         manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
-        deliverSuccess(containerWithConfig(response))
+        deliverSuccessFor("app", containerWithConfig(response))
+        deliverSuccessFor("app_workflows", null)
 
         val retained = slot<Set<String>>()
         verify(exactly = 1) { blobStore.retainOnly(capture(retained)) }
@@ -3000,6 +3003,151 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `a subdomain 4xx with last-good data is skipped for the session and lets the parent commit`() {
+        statefulDiskCache(
+            persisted(manifest = "v1.root.old")
+                .withRootSubdomains("app_workflows")
+                .withDomain(
+                    "app_workflows",
+                    PersistedDomainState(
+                        manifest = "v1.child.old",
+                        activeTopics = listOf("workflows"),
+                        topics = mapOf(
+                            "workflows" to ConfigTopic(mapOf("wf1" to RemoteConfiguration.ConfigItem())),
+                        ),
+                    ),
+                ),
+        )
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("app_workflows"))))
+        deliverErrorFor("app_workflows", GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE)
+
+        // The refused child keeps serving its last-good data and the root still commits.
+        assertThat(manager.isDisabled).isFalse
+        assertThat(writtenStates.last().domains.getValue("app").manifest).isEqualTo("v1.root.new")
+        assertThat(diskCache.read()!!.mergedTopics).containsKey("workflows")
+
+        // The next pass skips the disabled child without a request; the root keeps updating.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.newer", subdomains = listOf("app_workflows"))))
+
+        assertThat(requestedDomains.count { it == "app_workflows" }).isEqualTo(1)
+        assertThat(writtenStates.last().domains.getValue("app").manifest).isEqualTo("v1.root.newer")
+    }
+
+    @Test
+    fun `a subdomain 4xx without cached data defers the parent's commit for the session`() {
+        statefulDiskCache(persisted(manifest = "v1.root.old"))
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("app_workflows"))))
+        deliverErrorFor("app_workflows", GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE)
+
+        assertThat(manager.isDisabled).isFalse
+        assertThat(writtenStates).isEmpty()
+
+        // The next pass skips the refused child without a request; the root still cannot apply its deletions.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("app_workflows"))))
+        assertThat(requestedDomains.count { it == "app_workflows" }).isEqualTo(1)
+        assertThat(writtenStates).isEmpty()
+
+        // The block self-heals once the server stops listing the refused child.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.final")))
+        assertThat(writtenStates.last().domains.getValue("app").manifest).isEqualTo("v1.root.final")
+    }
+
+    @Test
+    fun `an identity change clears the per-subdomain session disables`() {
+        statefulDiskCache(persisted(manifest = "v1.root.old"))
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("app_workflows"))))
+        deliverErrorFor("app_workflows", GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE)
+
+        manager.clearCache("new-user")
+
+        // The new user's pass fetches the previously disabled subdomain again.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("app_workflows"))))
+        assertThat(requestedDomains.count { it == "app_workflows" }).isEqualTo(2)
+    }
+
+    @Test
+    fun `a domain dropped from its parent's list is pruned and its blobs evicted`() {
+        statefulDiskCache(
+            persisted(manifest = "v1.root.old", prefetchBlobs = listOf("rootBlob"))
+                .withRootSubdomains("app_workflows")
+                .withDomain(
+                    "app_workflows",
+                    PersistedDomainState(manifest = "v1.child.old", prefetchBlobs = listOf("childBlob")),
+                ),
+        )
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", prefetchBlobs = listOf("rootBlob"))))
+
+        assertThat(diskCache.read()!!.domains).containsOnlyKeys("app")
+        val retained = slot<Set<String>>()
+        verify(exactly = 1) { blobStore.retainOnly(capture(retained)) }
+        assertThat(retained.captured).containsExactly("rootBlob")
+    }
+
+    @Test
+    fun `pruning a dropped domain clears its session disable so a re-add starts over`() {
+        statefulDiskCache(
+            persisted(manifest = "v1.root.old")
+                .withRootSubdomains("app_workflows")
+                .withDomain("app_workflows", PersistedDomainState(manifest = "v1.child.old")),
+        )
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.a", subdomains = listOf("app_workflows"))))
+        deliverErrorFor("app_workflows", GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE)
+
+        // The server drops the disabled child: the pass prunes it (state and disable together)...
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.b")))
+        assertThat(diskCache.read()!!.domains).containsOnlyKeys("app")
+
+        // ...so a later re-add fetches it again instead of trusting the stale disable.
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.c", subdomains = listOf("app_workflows"))))
+        assertThat(requestedDomains.count { it == "app_workflows" }).isEqualTo(2)
+    }
+
+    @Test
+    fun `a freshly committed child survives when its parent's commit is deferred`() {
+        statefulDiskCache(persisted(manifest = "v1.root.old"))
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", containerWithConfig(configJson("app", "v1.root.new", subdomains = listOf("child_a", "child_b"))))
+        deliverSuccessFor("child_a", containerWithConfig(configJson("child_a", "v1.a.new")))
+        deliverErrorFor("child_b")
+
+        // child_a is unreachable from the persisted (old) root list, but a partial pass never prunes: the next
+        // pass re-fetches the root and child_a answers with a cheap 204.
+        assertThat(diskCache.read()!!.domains).containsOnlyKeys("app", "child_a")
+    }
+
+    @Test
+    fun `children persisted without root state are not pruned`() {
+        // A crash between a child's commit and the root's first commit leaves child-only state on disk.
+        statefulDiskCache(
+            PersistedRemoteConfigurationState(
+                rootDomain = "app",
+                domains = mapOf("app_workflows" to PersistedDomainState(manifest = "v1.child.old")),
+            ),
+        )
+
+        manager.refreshRemoteConfig(appInBackground = false, appUserID = TEST_APP_USER_ID, fetchContext = DEFAULT_FETCH_CONTEXT)
+        deliverSuccessFor("app", null)
+
+        assertThat(diskCache.read()!!.domains).containsOnlyKeys("app_workflows")
+        verify(exactly = 0) { blobStore.retainOnly(any()) }
+    }
+
+    @Test
     fun `a multi-commit pass bumps the generation once and prunes blobs once with the cross-domain union`() {
         statefulDiskCache(persisted(manifest = "v1.root.old"))
         val listener = RecordingCommitListener()
@@ -3059,6 +3207,7 @@ class RemoteConfigManagerTest {
             writtenStates += written
             true
         }
+        every { diskCache.clear() } answers { state = null }
     }
 
     private fun configJson(


### PR DESCRIPTION
### Description

Part 3 of 3 of subdomain support for `/v1/config` (stacked on #4056). This completes the failure semantics and cleanup.

- **Domain-scoped session disable.** A subdomain answering 4xx is added to a memory-only `disabledDomains` set: later passes skip its fetch and its last-good persisted entry keeps serving the merged view, counting as fresh for the commit rule so the rest of the tree keeps updating. A refused subdomain with **no** cached data instead keeps deferring its parent's commit — committing would vanish any topic that migrated into the refused domain — and the block self-heals as soon as the server stops listing it. The root 4xx keeps the existing whole-system session kill-switch.
- **Disable lifecycle.** The per-domain disables clear on app restart, on identity change (`clearCache`) — unlike the root flag, because subdomain trees are config/user-derived and the wipe destroys the last-good data a disable relies on — and when the domain is pruned, so a later re-add starts over.
- **Unreachable-domain prune.** After a fully-fresh pass, `finalizePass` drops domain entries no longer reachable from the root, and blob cleanup runs on the pruned tree, so a dropped subdomain's state and blobs go away in the same pass. Pruning never runs after a partial pass (a freshly-committed child can be unreachable merely because its parent's commit deferred) nor without root state (a crashed first pass persists children before any root entry), so fresh data always survives.
- The pure tree-pass types and commit-state math moved to `RemoteConfigTreePass.kt`.

Tests cover the failure matrix (4xx with/without last-good across passes, self-heal on delisting, identity-change reset), prune + blob eviction, re-add after prune, partial-pass and crash-artifact protection, plus an end-to-end integration test driving a real two-domain tree through commit, merged reads, drop, prune, and blob eviction on the real disk cache and blob store.
