### PR TITLE
Expose a root now on local-rule snapshots

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -35,6 +35,8 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
  * under the provider's namespace.
  *
  * All providers see the same reference instant, so every dimension in one snapshot is consistent with the others.
+ * That instant is also exposed at the root as [RULES_NOW_KEY] (Unix epoch milliseconds). The clock is read once,
+ * before providers run, so every predicate in the evaluation sees the same value.
  *
  * Both failure modes are configuration bugs rather than runtime conditions — a provider that cannot produce its
  * values, and two providers claiming the same path — so they fail the whole snapshot instead of silently
@@ -81,7 +83,10 @@ internal class RulesDimensionResolver(
 
         return Result.success(
             RulesDimensionSnapshot(
-                values = values.mapValues { (_, dimensions) -> Value.ObjectValue(dimensions) },
+                values = buildMap {
+                    put(RULES_NOW_KEY, Value.IntValue(date.time))
+                    putAll(values.mapValues { (_, dimensions) -> Value.ObjectValue(dimensions) })
+                },
                 evaluationDate = date,
             ),
         )
@@ -131,6 +136,8 @@ private fun Map<String, RulesDimensionValue>.filterReachable(
         }
     }
 }
+
+internal const val RULES_NOW_KEY = "now"
 
 private const val DIMENSION_PATH_SEPARATOR = '.'
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -3,6 +3,7 @@
 package com.revenuecat.purchases.common.localrules
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.rules.RulesEngine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -173,6 +174,26 @@ class LocalRulesEvaluatorTest {
         }
 
         assertThat(snapshotsTaken).isEqualTo(1)
+    }
+
+    @Test
+    fun `every rule in a match sees the same now`() = runTest {
+        val first = Date(100_000)
+        val later = Date(200_000)
+        val clock = object : DateProvider {
+            private var reads = 0
+            override val now: Date
+                get() = if (reads++ == 0) first else later
+        }
+
+        val result = LocalRulesEvaluator(providers = emptyList(), dateProvider = clock).match(
+            listOf(
+                TestRule("later-clock", """{"==": [{"var": "now"}, ${later.time}]}"""),
+                TestRule("gathering-clock", """{"==": [{"var": "now"}, ${first.time}]}"""),
+            ),
+        )
+
+        assertThat(result.getOrThrow()?.name).isEqualTo("gathering-clock")
     }
 
     private fun evaluator() = LocalRulesEvaluator(providers = listOf(deviceProvider))

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -32,7 +32,10 @@ class RulesDimensionResolverTest {
         val values = resolver.snapshot().getOrThrow().values
 
         assertThat(values).isEqualTo(
-            mapOf("device" to Value.ObjectValue(mapOf("appVersion" to Value.StringValue("1.2.3")))),
+            mapOf(
+                RULES_NOW_KEY to Value.IntValue(evaluationDate.time),
+                "device" to Value.ObjectValue(mapOf("appVersion" to Value.StringValue("1.2.3"))),
+            ),
         )
     }
 
@@ -59,6 +62,7 @@ class RulesDimensionResolverTest {
 
         assertThat(values).isEqualTo(
             mapOf(
+                RULES_NOW_KEY to Value.IntValue(evaluationDate.time),
                 "device" to Value.ObjectValue(
                     mapOf(
                         "platform" to Value.StringValue("android"),
@@ -136,6 +140,43 @@ class RulesDimensionResolverTest {
 
         assertThat(dates).containsExactly(evaluationDate, evaluationDate)
         assertThat(snapshot.evaluationDate).isEqualTo(evaluationDate)
+        assertThat(snapshot.values[RULES_NOW_KEY]).isEqualTo(Value.IntValue(evaluationDate.time))
+    }
+
+    @Test
+    fun `now is the gathering instant, not a later clock read`() = runTest {
+        val later = Date(evaluationDate.time + 60_000)
+        val clock = CountingDateProvider(evaluationDate, later)
+        val resolver = RulesDimensionResolver(
+            providers = listOf(provider(RulesDimensionNamespace.Device, "platform" to string("android"))),
+            dateProvider = clock,
+        )
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(clock.reads).isEqualTo(1)
+        assertThat(values[RULES_NOW_KEY]).isEqualTo(Value.IntValue(evaluationDate.time))
+        assertThat(
+            RulesEngine.evaluate("""{"==": [{"var": "now"}, ${evaluationDate.time}]}""", values).getOrThrow(),
+        ).isTrue()
+    }
+
+    @Test
+    fun `now is readable by every predicate against the snapshot`() = runTest {
+        val resolver = resolver(
+            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
+        )
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(
+            RulesEngine.evaluate(
+                """{"and": [
+                    {"==": [{"var": "device.platform"}, "android"]},
+                    {">": [{"var": "now"}, ${evaluationDate.time - 1}]}
+                ]}""",
+                values,
+            ).getOrThrow(),
+        ).isTrue()
     }
 
     @Test
@@ -288,7 +329,7 @@ class RulesDimensionResolverTest {
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).containsOnlyKeys("device")
+        assertThat(values).containsOnlyKeys(RULES_NOW_KEY, "device")
         // An empty object would be truthy, so an absent namespace is what makes this a non-match.
         assertThat(RulesEngine.evaluate("""{"!!": [{"var": "custom"}]}""", values).getOrThrow()).isFalse()
     }
@@ -311,7 +352,7 @@ class RulesDimensionResolverTest {
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).containsOnlyKeys("device")
+        assertThat(values).containsOnlyKeys(RULES_NOW_KEY, "device")
         // An empty object would be truthy, which is what makes the absence matter.
         assertThat(RulesEngine.evaluate("""{"!!": [{"var": "store"}]}""", values).getOrThrow()).isFalse()
     }
@@ -345,15 +386,16 @@ class RulesDimensionResolverTest {
         val values = resolver.snapshot().getOrThrow().values
 
         // Filtering the names inside the namespace would leave an empty object behind, which is truthy.
-        assertThat(values).containsOnlyKeys("device")
+        assertThat(values).containsOnlyKeys(RULES_NOW_KEY, "device")
         assertThat(
             RulesEngine.evaluate("""{"!!": [{"var": "subscriberAttributes"}]}""", values).getOrThrow(),
         ).isFalse()
     }
 
     @Test
-    fun `no providers yields an empty scope`() = runTest {
-        assertThat(resolver().snapshot().getOrThrow().values).isEmpty()
+    fun `no providers still exposes now`() = runTest {
+        assertThat(resolver().snapshot().getOrThrow().values)
+            .isEqualTo(mapOf(RULES_NOW_KEY to Value.IntValue(evaluationDate.time)))
     }
 
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
@@ -362,6 +404,18 @@ class RulesDimensionResolverTest {
             override val now: Date = evaluationDate
         },
     )
+
+    private class CountingDateProvider(vararg instants: Date) : DateProvider {
+        private val instants = instants.toList()
+        var reads = 0
+            private set
+        override val now: Date
+            get() {
+                val date = instants[reads.coerceAtMost(instants.lastIndex)]
+                reads++
+                return date
+            }
+    }
 
     private fun string(value: String) = RulesDimensionValue.StringValue(value)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
@@ -63,7 +63,7 @@ class StoreDimensionProviderTest {
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
             assertThat(snapshot.getOrThrow().values)
                 .describedAs("%s", failure)
-                .containsOnlyKeys("device")
+                .containsOnlyKeys(RULES_NOW_KEY, "device")
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -117,7 +117,9 @@ class SubscriberAttributesDimensionProviderTest {
             ).snapshot()
 
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
-            assertThat(snapshot.getOrThrow().values).describedAs("%s", failure).containsOnlyKeys("device")
+            assertThat(snapshot.getOrThrow().values)
+                .describedAs("%s", failure)
+                .containsOnlyKeys(RULES_NOW_KEY, "device")
         }
     }
 


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Predicates that compare timestamps to `now` had nothing to read. Providers already share one snapshot instant; that value never reached the engine.

### Description
iOS counterpart: https://github.com/RevenueCat/purchases-ios/pull/7475