### PR TITLE
Read `zero_decimal_place_countries` from workflow screens

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.paywalls.components.common.ProductChangeConfigSe
 import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
 import com.revenuecat.purchases.paywalls.components.common.StateDeclarationMapSerializer
 import com.revenuecat.purchases.utils.serializers.EnumDeserializerWithDefault
+import com.revenuecat.purchases.utils.serializers.GoogleListSerializer
 import com.revenuecat.purchases.utils.serializers.JsonObjectToMapSerializer
 import com.revenuecat.purchases.utils.serializers.SealedDeserializerWithDefault
 import com.revenuecat.purchases.utils.serializers.URLSerializer
@@ -130,6 +131,8 @@ public data class WorkflowScreen(
     @SerialName("default_locale") val defaultLocaleIdentifier: LocaleId,
     @SerialName("config") val config: JsonObject = JsonObject(emptyMap()),
     @SerialName("offering_identifier") val offeringIdentifier: String? = null,
+    @Serializable(with = GoogleListSerializer::class)
+    @SerialName("zero_decimal_place_countries") val zeroDecimalPlaceCountries: List<String> = emptyList(),
     @SerialName("exit_offers") val exitOffers: ExitOffers? = null,
     @Serializable(with = ProductChangeConfigSerializer::class)
     @SerialName("play_store_product_change_mode") val productChangeConfig: ProductChangeConfig? = null,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -141,8 +141,8 @@ internal class WorkflowModelsDeserializationTest {
         val screen = JsonTools.json.decodeFromString(
             WorkflowScreen.serializer(),
             workflowScreenJson(
-                extraFields = """
-                    "play_store_product_change_mode": {
+                productChangeConfig = """
+                    {
                       "upgrade_replacement_mode": "charge_full_price",
                       "downgrade_replacement_mode": "deferred"
                     }
@@ -160,7 +160,7 @@ internal class WorkflowModelsDeserializationTest {
     fun `WorkflowScreen treats empty play_store_product_change_mode as absent`() {
         val screen = JsonTools.json.decodeFromString(
             WorkflowScreen.serializer(),
-            workflowScreenJson(extraFields = """"play_store_product_change_mode": {}"""),
+            workflowScreenJson(productChangeConfig = "{}"),
         )
 
         assertThat(screen.productChangeConfig).isNull()
@@ -172,7 +172,7 @@ internal class WorkflowModelsDeserializationTest {
         val screen = JsonTools.json.decodeFromString(
             WorkflowScreen.serializer(),
             workflowScreenJson(
-                extraFields = """"zero_decimal_place_countries": {"apple": ["TWN", "MEX"], "google": ["TW", "MX"]}""",
+                zeroDecimalPlaceCountries = "{\"apple\": [\"TWN\", \"MEX\"], \"google\": [\"TW\", \"MX\"]}",
             ),
         )
 
@@ -189,8 +189,16 @@ internal class WorkflowModelsDeserializationTest {
         assertThat(screen.zeroDecimalPlaceCountries).isEmpty()
     }
 
-    private fun workflowScreenJson(extraFields: String = ""): String =
-        """
+    private fun workflowScreenJson(
+        productChangeConfig: String? = null,
+        zeroDecimalPlaceCountries: String? = null,
+    ): String {
+        val optionalFields = listOfNotNull(
+            productChangeConfig?.let { "\"play_store_product_change_mode\": $it" },
+            zeroDecimalPlaceCountries?.let { "\"zero_decimal_place_countries\": $it" },
+        ).joinToString(",\n")
+
+        return """
             {
               "template_name": "components",
               "asset_base_url": "https://assets.pawwalls.com",
@@ -201,8 +209,8 @@ internal class WorkflowModelsDeserializationTest {
                 }
               },
               "components_localizations": {"en_US": {}},
-              "default_locale": "en_US"
-              ${if (extraFields.isEmpty()) "" else ",$extraFields"}
+              "default_locale": "en_US"${if (optionalFields.isEmpty()) "" else ",\n$optionalFields"}
             }
         """.trimIndent()
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -141,8 +141,8 @@ internal class WorkflowModelsDeserializationTest {
         val screen = JsonTools.json.decodeFromString(
             WorkflowScreen.serializer(),
             workflowScreenJson(
-                productChangeConfig = """
-                    {
+                extraFields = """
+                    "play_store_product_change_mode": {
                       "upgrade_replacement_mode": "charge_full_price",
                       "downgrade_replacement_mode": "deferred"
                     }
@@ -160,13 +160,36 @@ internal class WorkflowModelsDeserializationTest {
     fun `WorkflowScreen treats empty play_store_product_change_mode as absent`() {
         val screen = JsonTools.json.decodeFromString(
             WorkflowScreen.serializer(),
-            workflowScreenJson(productChangeConfig = "{}"),
+            workflowScreenJson(extraFields = """"play_store_product_change_mode": {}"""),
         )
 
         assertThat(screen.productChangeConfig).isNull()
     }
 
-    private fun workflowScreenJson(productChangeConfig: String): String =
+    @Test
+    fun `WorkflowScreen reads zero_decimal_place_countries`() {
+        // The backend posts the field keyed by store; only the Google list applies here.
+        val screen = JsonTools.json.decodeFromString(
+            WorkflowScreen.serializer(),
+            workflowScreenJson(
+                extraFields = """"zero_decimal_place_countries": {"apple": ["TWN", "MEX"], "google": ["TW", "MX"]}""",
+            ),
+        )
+
+        assertThat(screen.zeroDecimalPlaceCountries).containsExactly("TW", "MX")
+    }
+
+    @Test
+    fun `WorkflowScreen defaults zero_decimal_place_countries to empty when absent`() {
+        val screen = JsonTools.json.decodeFromString(
+            WorkflowScreen.serializer(),
+            workflowScreenJson(),
+        )
+
+        assertThat(screen.zeroDecimalPlaceCountries).isEmpty()
+    }
+
+    private fun workflowScreenJson(extraFields: String = ""): String =
         """
             {
               "template_name": "components",
@@ -178,8 +201,8 @@ internal class WorkflowModelsDeserializationTest {
                 }
               },
               "components_localizations": {"en_US": {}},
-              "default_locale": "en_US",
-              "play_store_product_change_mode": $productChangeConfig
+              "default_locale": "en_US"
+              ${if (extraFields.isEmpty()) "" else ",$extraFields"}
             }
         """.trimIndent()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapper.kt
@@ -19,6 +19,7 @@ internal object WorkflowScreenMapper {
             componentsLocalizations = screen.componentsLocalizations,
             defaultLocaleIdentifier = screen.defaultLocaleIdentifier,
             revision = screen.revision,
+            zeroDecimalPlaceCountries = screen.zeroDecimalPlaceCountries,
             exitOffers = screen.exitOffers,
             productChangeConfig = screen.productChangeConfig,
             automaticallyScaleFontSize = screen.automaticallyScaleFontSize,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
@@ -49,6 +49,8 @@ class WorkflowScreenMapperTest {
         ),
     )
 
+    private val zeroDecimalPlaceCountries = listOf("TW", "MX")
+
     private val productChangeConfig = ProductChangeConfig(
         upgradeReplacementMode = StoreReplacementMode.CHARGE_FULL_PRICE,
         downgradeReplacementMode = StoreReplacementMode.DEFERRED,
@@ -63,6 +65,7 @@ class WorkflowScreenMapperTest {
         componentsLocalizations = localizations,
         defaultLocaleIdentifier = defaultLocaleId,
         offeringIdentifier = "offering_id",
+        zeroDecimalPlaceCountries = zeroDecimalPlaceCountries,
         productChangeConfig = productChangeConfig,
         stateDeclarations = stateDeclarations,
     )
@@ -79,6 +82,7 @@ class WorkflowScreenMapperTest {
         assertThat(data.componentsLocalizations).isEqualTo(screen.componentsLocalizations)
         assertThat(data.defaultLocaleIdentifier).isEqualTo(screen.defaultLocaleIdentifier)
         assertThat(data.revision).isEqualTo(screen.revision)
+        assertThat(data.zeroDecimalPlaceCountries).isEqualTo(zeroDecimalPlaceCountries)
         assertThat(data.productChangeConfig).isEqualTo(productChangeConfig)
         assertThat(data.stateDeclarations).isEqualTo(stateDeclarations)
     }


### PR DESCRIPTION
Workflow paywalls showed decimal prices in TWN/KAZ/MEX/PHL/THA/IND. `WorkflowScreen` never decoded `zero_decimal_place_countries`, so it defaulted to empty. Backend side is RevenueCat/khepri#24207.

https://github.com/RevenueCat/purchases-ios/pull/7474

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small deserialization/mapping fix using an existing serializer; no auth or purchase-flow changes.
> 
> **Overview**
> Workflow paywalls now pick up `zero_decimal_place_countries` from the backend instead of always treating it as empty, so prices in those countries can render without decimals.
> 
> `WorkflowScreen` deserializes the store-keyed JSON via `GoogleListSerializer` (Google list only) and `WorkflowScreenMapper` forwards it into `PaywallComponentsData`. Defaults to empty when the field is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52dbf1972f39b4e6bf0e8d86fca4aa1a538b18b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->