### PR TITLE
Clear paywall web view storage when the user logs out or switches

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -381,6 +381,7 @@ internal class PurchasesFactory(
                 backend,
                 offlineEntitlementsManager,
                 dispatcher,
+                paywallAssetWarming,
                 uiPreviewMode = appConfig.uiPreviewMode,
             )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -168,7 +168,7 @@ internal class IdentityManager(
                         deviceCache.cacheAppUserID(newAppUserID)
                         deviceCache.cacheCustomerInfo(newAppUserID, customerInfo)
                         copySubscriberAttributesToNewUserIfOldIsAnonymous(oldAppUserID, newAppUserID)
-                        clearPaywallWebViewStorageIfOldIsIdentified(oldAppUserID)
+                        clearPaywallWebViewStorageIfUserChanged(oldAppUserID, newAppUserID)
                         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     }
                     onSuccess(customerInfo, created)
@@ -248,8 +248,8 @@ internal class IdentityManager(
     }
 
     // Anonymous is exempt: signing in mid-flow is the multipage paywall case, same customer either side.
-    private fun clearPaywallWebViewStorageIfOldIsIdentified(oldAppUserID: String) {
-        if (!isUserIDAnonymous(oldAppUserID)) {
+    private fun clearPaywallWebViewStorageIfUserChanged(oldAppUserID: String, newAppUserID: String) {
+        if (oldAppUserID != newAppUserID && !isUserIDAnonymous(oldAppUserID)) {
             paywallAssetWarming.clearWebViewStorage()
         }
     }
@@ -289,7 +289,7 @@ internal class IdentityManager(
 
     @Synchronized
     private fun resetAndSaveUserID(newUserID: String) {
-        clearPaywallWebViewStorageIfOldIsIdentified(currentAppUserID)
+        clearPaywallWebViewStorageIfUserChanged(currentAppUserID, newUserID)
         deviceCache.clearCachesForAppUserID(currentAppUserID)
         clearRemoteConfigThenOfferingsCaches(newUserID)
         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(currentAppUserID)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.safeResumeWithException
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
+import com.revenuecat.purchases.paywalls.PaywallAssetWarming
 import com.revenuecat.purchases.strings.IdentityStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
@@ -41,6 +42,7 @@ internal class IdentityManager(
     private val backend: Backend,
     private val offlineEntitlementsManager: OfflineEntitlementsManager,
     private val dispatcher: Dispatcher,
+    private val paywallAssetWarming: PaywallAssetWarming,
     private val uiPreviewMode: Boolean = false,
 ) {
     companion object {
@@ -166,6 +168,7 @@ internal class IdentityManager(
                         deviceCache.cacheAppUserID(newAppUserID)
                         deviceCache.cacheCustomerInfo(newAppUserID, customerInfo)
                         copySubscriberAttributesToNewUserIfOldIsAnonymous(oldAppUserID, newAppUserID)
+                        clearPaywallWebViewStorageIfOldIsIdentified(oldAppUserID)
                         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     }
                     onSuccess(customerInfo, created)
@@ -244,6 +247,13 @@ internal class IdentityManager(
         offeringsCache.clearCache()
     }
 
+    // Anonymous is exempt: signing in mid-flow is the multipage paywall case, same customer either side.
+    private fun clearPaywallWebViewStorageIfOldIsIdentified(oldAppUserID: String) {
+        if (!isUserIDAnonymous(oldAppUserID)) {
+            paywallAssetWarming.clearWebViewStorage()
+        }
+    }
+
     private fun copySubscriberAttributesToNewUserIfOldIsAnonymous(oldAppUserId: String, newAppUserId: String) {
         if (isUserIDAnonymous(oldAppUserId)) {
             subscriberAttributesManager.copyUnsyncedSubscriberAttributes(oldAppUserId, newAppUserId)
@@ -279,6 +289,7 @@ internal class IdentityManager(
 
     @Synchronized
     private fun resetAndSaveUserID(newUserID: String) {
+        clearPaywallWebViewStorageIfOldIsIdentified(currentAppUserID)
         deviceCache.clearCachesForAppUserID(currentAppUserID)
         clearRemoteConfigThenOfferingsCaches(newUserID)
         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(currentAppUserID)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarmer.kt
@@ -5,11 +5,11 @@ import android.net.Uri
 import com.revenuecat.purchases.InternalRevenueCatAPI
 
 /**
- * Warms paywall assets ahead of display, using facilities only the RevenueCat UI module has.
+ * Manages paywall assets ahead of display, using facilities only the RevenueCat UI module has.
  *
  * Discovered through [java.util.ServiceLoader]: an implementation declares its fully qualified name in
  * `META-INF/services/com.revenuecat.purchases.paywalls.PaywallAssetWarmer` and needs a public no-argument
- * constructor. Warming is best-effort: implementations must return promptly and must not throw.
+ * constructor. Every method is best-effort: implementations must return promptly and must not throw.
  */
 @InternalRevenueCatAPI
 public interface PaywallAssetWarmer {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarmer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarmer.kt
@@ -21,4 +21,7 @@ public interface PaywallAssetWarmer {
 
     /** Loads bundles offscreen into the http cache. Bounded concurrency, so it returns before they finish. */
     public fun warmWebViewUrls(context: Context, urls: List<String>)
+
+    /** Drops the browsing data the outgoing user left behind, as far as the System WebView allows. */
+    public fun clearWebViewStorage(context: Context)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarming.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallAssetWarming.kt
@@ -60,6 +60,17 @@ internal class PaywallAssetWarming(
         }
     }
 
+    fun clearWebViewStorage() {
+        // The lookup is posted too: callers hold the identity lock, and these WebView APIs want the main thread.
+        mainHandler.post {
+            val warmer = warmer ?: return@post
+            debugLog { "Clearing Paywalls V2 web_view storage for the outgoing user." }
+            runCatching { warmer.clearWebViewStorage(context) }.onFailure { error ->
+                errorLog(error) { "Paywalls V2 web_view storage could not be cleared." }
+            }
+        }
+    }
+
     private companion object {
         fun loadWarmer(): PaywallAssetWarmer? {
             // A missing descriptor yields nothing rather than throwing; only one naming an unloadable class throws.

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -869,7 +869,6 @@ class IdentityManagerTests {
     @Test
     fun `logOut clears the paywall web view storage`() {
         val identifiedUserID = "Waldo"
-        every { mockDeviceCache.cleanupOldAttributionData() } just Runs
         mockIdentifiedUser(identifiedUserID)
         mockSubscriberAttributesManagerSynchronize(identifiedUserID)
 
@@ -880,21 +879,36 @@ class IdentityManagerTests {
 
     @Test
     fun `switching users clears the paywall web view storage`() {
-        val newAppUserID = "new"
         mockIdentifiedUser("cesar")
-        every { mockDeviceCache.cacheCustomerInfo(any(), any()) } just Runs
-        mockSubscriberAttributesManagerSynchronize(newAppUserID)
 
-        identityManager.switchUser(newAppUserID)
+        identityManager.switchUser("new")
 
         verify(exactly = 1) { mockPaywallAssetWarming.clearWebViewStorage() }
     }
 
     @Test
+    fun `switching from an anonymous user keeps the paywall web view storage`() {
+        mockCachedAnonymousUser()
+
+        identityManager.switchUser("new")
+
+        verify(exactly = 0) { mockPaywallAssetWarming.clearWebViewStorage() }
+    }
+
+    @Test
+    fun `switching to the same user keeps the paywall web view storage`() {
+        val identifiedUserID = "cesar"
+        mockIdentifiedUser(identifiedUserID)
+
+        identityManager.switchUser(identifiedUserID)
+
+        verify(exactly = 0) { mockPaywallAssetWarming.clearWebViewStorage() }
+    }
+
+    @Test
     fun `login from an identified user clears the paywall web view storage`() {
-        val oldAppUserID = "cesar"
         val newAppUserID = "new"
-        mockLogInSuccess(oldAppUserID, newAppUserID)
+        mockLogInSuccess(oldAppUserID = "cesar", newAppUserID = newAppUserID)
 
         identityManager.logIn(newAppUserID, { _, _ -> }, { })
 
@@ -904,7 +918,7 @@ class IdentityManagerTests {
     @Test
     fun `login from an anonymous user keeps the paywall web view storage`() {
         val newAppUserID = "new"
-        mockLogInSuccess(stubAnonymousID, newAppUserID, anonymous = true)
+        mockLogInSuccess(oldAppUserID = stubAnonymousID, newAppUserID = newAppUserID)
 
         identityManager.logIn(newAppUserID, { _, _ -> }, { })
 
@@ -935,8 +949,12 @@ class IdentityManagerTests {
         identityManager = createIdentityManager()
     }
 
-    private fun mockLogInSuccess(oldAppUserID: String, newAppUserID: String, anonymous: Boolean = false) {
-        if (anonymous) mockCachedAnonymousUser() else mockIdentifiedUser(oldAppUserID)
+    private fun mockLogInSuccess(oldAppUserID: String, newAppUserID: String) {
+        if (IdentityManager.isUserIDAnonymous(oldAppUserID)) {
+            mockCachedAnonymousUser()
+        } else {
+            mockIdentifiedUser(oldAppUserID)
+        }
         every {
             mockBackend.logIn(oldAppUserID, newAppUserID, captureLambda(), any())
         } answers {

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.common.offerings.OfferingsCache
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
+import com.revenuecat.purchases.paywalls.PaywallAssetWarming
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
 import com.revenuecat.purchases.utils.SyncDispatcher
@@ -49,6 +50,7 @@ class IdentityManagerTests {
     private lateinit var mockRemoteConfigManager: RemoteConfigManager
     private lateinit var mockBackend: Backend
     private lateinit var mockOfflineEntitlementsManager: OfflineEntitlementsManager
+    private lateinit var mockPaywallAssetWarming: PaywallAssetWarming
     private lateinit var identityManager: IdentityManager
     private lateinit var mockEditor: Editor
     private val stubAnonymousID = "\$RCAnonymousID:ff68f26e432648369a713849a9f93b58"
@@ -92,6 +94,9 @@ class IdentityManagerTests {
         }
         mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>().apply {
             every { resetOfflineCustomerInfoCache() } just Runs
+        }
+        mockPaywallAssetWarming = mockk<PaywallAssetWarming>().apply {
+            every { clearWebViewStorage() } just Runs
         }
         identityManager = createIdentityManager()
     }
@@ -859,6 +864,55 @@ class IdentityManagerTests {
 
     // endregion aliasCurrentUserIdTo
 
+    // region paywall web view storage
+
+    @Test
+    fun `logOut clears the paywall web view storage`() {
+        val identifiedUserID = "Waldo"
+        every { mockDeviceCache.cleanupOldAttributionData() } just Runs
+        mockIdentifiedUser(identifiedUserID)
+        mockSubscriberAttributesManagerSynchronize(identifiedUserID)
+
+        identityManager.logOut { }
+
+        verify(exactly = 1) { mockPaywallAssetWarming.clearWebViewStorage() }
+    }
+
+    @Test
+    fun `switching users clears the paywall web view storage`() {
+        val newAppUserID = "new"
+        mockIdentifiedUser("cesar")
+        every { mockDeviceCache.cacheCustomerInfo(any(), any()) } just Runs
+        mockSubscriberAttributesManagerSynchronize(newAppUserID)
+
+        identityManager.switchUser(newAppUserID)
+
+        verify(exactly = 1) { mockPaywallAssetWarming.clearWebViewStorage() }
+    }
+
+    @Test
+    fun `login from an identified user clears the paywall web view storage`() {
+        val oldAppUserID = "cesar"
+        val newAppUserID = "new"
+        mockLogInSuccess(oldAppUserID, newAppUserID)
+
+        identityManager.logIn(newAppUserID, { _, _ -> }, { })
+
+        verify(exactly = 1) { mockPaywallAssetWarming.clearWebViewStorage() }
+    }
+
+    @Test
+    fun `login from an anonymous user keeps the paywall web view storage`() {
+        val newAppUserID = "new"
+        mockLogInSuccess(stubAnonymousID, newAppUserID, anonymous = true)
+
+        identityManager.logIn(newAppUserID, { _, _ -> }, { })
+
+        verify(exactly = 0) { mockPaywallAssetWarming.clearWebViewStorage() }
+    }
+
+    // endregion paywall web view storage
+
     // region helper functions
 
     private fun setupCustomerInfoCacheInvalidationTest(
@@ -879,6 +933,18 @@ class IdentityManagerTests {
         }
         every { mockBackend.verificationMode } returns verificationMode
         identityManager = createIdentityManager()
+    }
+
+    private fun mockLogInSuccess(oldAppUserID: String, newAppUserID: String, anonymous: Boolean = false) {
+        if (anonymous) mockCachedAnonymousUser() else mockIdentifiedUser(oldAppUserID)
+        every {
+            mockBackend.logIn(oldAppUserID, newAppUserID, captureLambda(), any())
+        } answers {
+            lambda<(CustomerInfo, Boolean) -> Unit>().captured.invoke(mockk(), false)
+        }
+        every { mockDeviceCache.cacheCustomerInfo(any(), any()) } just Runs
+        mockSubscriberAttributesManagerSynchronize(newAppUserID)
+        mockSubscriberAttributesManagerCopyAttributes(oldAppUserID, newAppUserID)
     }
 
     private fun mockIdentifiedUser(identifiedUserID: String) {
@@ -950,6 +1016,7 @@ class IdentityManagerTests {
         remoteConfigManager: RemoteConfigManager = mockRemoteConfigManager,
         backend: Backend = mockBackend,
         offlineEntitlementsManager: OfflineEntitlementsManager = mockOfflineEntitlementsManager,
+        paywallAssetWarming: PaywallAssetWarming = mockPaywallAssetWarming,
         uiPreviewMode: Boolean = false,
     ): IdentityManager {
         return IdentityManager(
@@ -962,6 +1029,7 @@ class IdentityManagerTests {
             backend,
             offlineEntitlementsManager,
             SyncDispatcher(),
+            paywallAssetWarming,
             uiPreviewMode = uiPreviewMode,
         )
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallAssetWarmingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallAssetWarmingTest.kt
@@ -26,6 +26,7 @@ class PaywallAssetWarmingTest {
         val warmed = mutableListOf<Uri>()
         var prebootCount = 0
         val warmedWebViewUrls = mutableListOf<String>()
+        var clearedStorageCount = 0
         override fun warmImages(context: Context, imageUris: List<Uri>) {
             warmed.addAll(imageUris)
         }
@@ -36,6 +37,10 @@ class PaywallAssetWarmingTest {
 
         override fun warmWebViewUrls(context: Context, urls: List<String>) {
             warmedWebViewUrls.addAll(urls)
+        }
+
+        override fun clearWebViewStorage(context: Context) {
+            clearedStorageCount++
         }
     }
 
@@ -118,16 +123,37 @@ class PaywallAssetWarmingTest {
     }
 
     @Test
+    fun `clears web_view storage off the caller's frame`() {
+        val warmer = RecordingWarmer()
+
+        warming(warmer).clearWebViewStorage()
+
+        assertThat(warmer.clearedStorageCount).isZero()
+
+        idle()
+
+        assertThat(warmer.clearedStorageCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `does not clear web_view storage when nothing is registered`() {
+        warming(warmer = null).clearWebViewStorage()
+        idle()
+    }
+
+    @Test
     fun `does not propagate a failure from the warmer`() {
         val throwingWarmer = object : PaywallAssetWarmer {
             override fun warmImages(context: Context, imageUris: List<Uri>) = throw RuntimeException("boom")
             override fun prebootWebView(context: Context) = throw RuntimeException("boom")
             override fun warmWebViewUrls(context: Context, urls: List<String>) = throw RuntimeException("boom")
+            override fun clearWebViewStorage(context: Context) = throw RuntimeException("boom")
         }
 
         warming(throwingWarmer).warmImages(listOf(uri))
         warming(throwingWarmer).prebootWebView()
         warming(throwingWarmer).warmWebViewUrls(listOf("https://example.com/index.html"))
+        warming(throwingWarmer).clearWebViewStorage()
         idle()
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallAssetWarmingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallAssetWarmingTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.Looper
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.utils.RecordingPaywallAssetWarmer
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -22,28 +23,6 @@ class PaywallAssetWarmingTest {
 
     private fun idle() = shadowOf(Looper.getMainLooper()).idle()
 
-    private class RecordingWarmer : PaywallAssetWarmer {
-        val warmed = mutableListOf<Uri>()
-        var prebootCount = 0
-        val warmedWebViewUrls = mutableListOf<String>()
-        var clearedStorageCount = 0
-        override fun warmImages(context: Context, imageUris: List<Uri>) {
-            warmed.addAll(imageUris)
-        }
-
-        override fun prebootWebView(context: Context) {
-            prebootCount++
-        }
-
-        override fun warmWebViewUrls(context: Context, urls: List<String>) {
-            warmedWebViewUrls.addAll(urls)
-        }
-
-        override fun clearWebViewStorage(context: Context) {
-            clearedStorageCount++
-        }
-    }
-
     @Test
     fun `reports unavailable when nothing is registered`() {
         assertThat(warming(warmer = null).isAvailable).isFalse()
@@ -51,16 +30,16 @@ class PaywallAssetWarmingTest {
 
     @Test
     fun `reports available when a warmer is registered`() {
-        assertThat(warming(RecordingWarmer()).isAvailable).isTrue()
+        assertThat(warming(RecordingPaywallAssetWarmer()).isAvailable).isTrue()
     }
 
     @Test
     fun `hands the uris to the registered warmer`() {
-        val warmer = RecordingWarmer()
+        val warmer = RecordingPaywallAssetWarmer()
 
         warming(warmer).warmImages(listOf(uri))
 
-        assertThat(warmer.warmed).containsExactly(uri)
+        assertThat(warmer.warmedImages).containsExactly(uri)
     }
 
     @Test
@@ -70,17 +49,17 @@ class PaywallAssetWarmingTest {
 
     @Test
     fun `does not call the warmer with an empty list`() {
-        val warmer = RecordingWarmer()
+        val warmer = RecordingPaywallAssetWarmer()
 
         warming(warmer).warmImages(emptyList())
 
-        assertThat(warmer.warmed).isEmpty()
+        assertThat(warmer.warmedImages).isEmpty()
     }
 
     // Posted, so nothing warms on the caller's frame.
     @Test
     fun `warms web_view urls after preboot, not inline with it`() {
-        val warmer = RecordingWarmer()
+        val warmer = RecordingPaywallAssetWarmer()
 
         warming(warmer).warmWebViewUrls(listOf(webViewUrl))
 
@@ -99,7 +78,7 @@ class PaywallAssetWarmingTest {
 
     @Test
     fun `neither warms nor preboots for an empty url list`() {
-        val warmer = RecordingWarmer()
+        val warmer = RecordingPaywallAssetWarmer()
 
         warming(warmer).warmWebViewUrls(emptyList())
         idle()
@@ -110,7 +89,7 @@ class PaywallAssetWarmingTest {
 
     @Test
     fun `preboots the web view through the registered warmer`() {
-        val warmer = RecordingWarmer()
+        val warmer = RecordingPaywallAssetWarmer()
 
         warming(warmer).prebootWebView()
 
@@ -124,7 +103,7 @@ class PaywallAssetWarmingTest {
 
     @Test
     fun `clears web_view storage off the caller's frame`() {
-        val warmer = RecordingWarmer()
+        val warmer = RecordingPaywallAssetWarmer()
 
         warming(warmer).clearWebViewStorage()
 

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
@@ -52,7 +52,7 @@ import java.net.URL
 @RunWith(AndroidJUnit4::class)
 class OfferingImagePreDownloaderTest {
 
-    private val warmer = RecordingWarmer()
+    private val warmer = RecordingPaywallAssetWarmer()
 
     private lateinit var preDownloader: OfferingImagePreDownloader
 
@@ -60,29 +60,7 @@ class OfferingImagePreDownloaderTest {
 
     @Before
     fun setUp() {
-        preDownloader = OfferingImagePreDownloader(warming(warmer))
-    }
-
-    private fun warming(warmer: PaywallAssetWarmer?) =
-        PaywallAssetWarming(context = mockk(relaxed = true), warmerProvider = { warmer })
-
-    private class RecordingWarmer : PaywallAssetWarmer {
-        val warmed = mutableListOf<Uri>()
-        var prebootCount = 0
-        val warmedWebViewUrls = mutableListOf<String>()
-        override fun warmImages(context: Context, imageUris: List<Uri>) {
-            warmed.addAll(imageUris)
-        }
-
-        override fun prebootWebView(context: Context) {
-            prebootCount++
-        }
-
-        override fun warmWebViewUrls(context: Context, urls: List<String>) {
-            warmedWebViewUrls.addAll(urls)
-        }
-
-        override fun clearWebViewStorage(context: Context) = Unit
+        preDownloader = OfferingImagePreDownloader(paywallAssetWarming(warmer))
     }
 
     @Test
@@ -94,14 +72,14 @@ class OfferingImagePreDownloaderTest {
             }
         )
 
-        assertThat(warmer.warmed).isEmpty()
+        assertThat(warmer.warmedImages).isEmpty()
     }
 
     @Test
     fun `if disabled, it does not download anything`() {
         val offering = mockk<Offering>()
 
-        OfferingImagePreDownloader(warming(warmer = null)).preDownloadOfferingImages(offering)
+        OfferingImagePreDownloader(paywallAssetWarming(warmer = null)).preDownloadOfferingImages(offering)
 
         verify(exactly = 0) { offering.paywall }
         verify(exactly = 0) { offering.paywallComponents }
@@ -113,7 +91,7 @@ class OfferingImagePreDownloaderTest {
     fun `downloads images from offering paywall data`() {
         preDownloader.preDownloadOfferingImages(createOfferings())
 
-        assertThat(warmer.warmed).containsExactlyInAnyOrder(
+        assertThat(warmer.warmedImages).containsExactlyInAnyOrder(
             Uri.parse("https://www.revenuecat.com/test_header.png"),
             Uri.parse("https://www.revenuecat.com/test_background.png"),
             Uri.parse("https://www.revenuecat.com/test_icon.png"),
@@ -124,7 +102,7 @@ class OfferingImagePreDownloaderTest {
     fun `if no images, it does not download anything`() {
         preDownloader.preDownloadOfferingImages(createOfferings(null, null, null))
 
-        assertThat(warmer.warmed).isEmpty()
+        assertThat(warmer.warmedImages).isEmpty()
     }
 
     // endregion Paywalls V1
@@ -144,7 +122,7 @@ class OfferingImagePreDownloaderTest {
     fun `paywalls V2 - preboots the engine for a web_view without warming it`() {
         preDownloader.preDownloadOfferingImages(offeringWithWebView())
 
-        assertThat(warmer.warmed).isEmpty()
+        assertThat(warmer.warmedImages).isEmpty()
         assertThat(warmer.prebootCount).isEqualTo(1)
         assertThat(warmer.warmedWebViewUrls).isEmpty()
     }
@@ -169,7 +147,7 @@ class OfferingImagePreDownloaderTest {
     fun `paywalls V2 - if no images, it does not download anything`() {
         preDownloader.preDownloadOfferingImages(createOfferingWithV2Paywall())
 
-        assertThat(warmer.warmed).isEmpty()
+        assertThat(warmer.warmedImages).isEmpty()
     }
 
     @Test
@@ -189,7 +167,7 @@ class OfferingImagePreDownloaderTest {
         // offerings success/caching path that invokes this.
         preDownloader.preDownloadOfferingImages(offering)
 
-        assertThat(warmer.warmed).isEmpty()
+        assertThat(warmer.warmedImages).isEmpty()
     }
 
     @Test
@@ -439,7 +417,7 @@ class OfferingImagePreDownloaderTest {
             ),
         ))
 
-        assertThat(warmer.warmed)
+        assertThat(warmer.warmedImages)
             .containsExactlyInAnyOrderElementsOf(expectedImageDownloads.map { Uri.parse(it) })
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
@@ -81,6 +81,8 @@ class OfferingImagePreDownloaderTest {
         override fun warmWebViewUrls(context: Context, urls: List<String>) {
             warmedWebViewUrls.addAll(urls)
         }
+
+        override fun clearWebViewStorage(context: Context) = Unit
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingWebViewPrewarmerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingWebViewPrewarmerTest.kt
@@ -36,40 +36,22 @@ import java.net.URL
 @RunWith(AndroidJUnit4::class)
 internal class OfferingWebViewPrewarmerTest {
 
-    private lateinit var warmer: RecordingWarmer
+    private lateinit var warmer: RecordingPaywallAssetWarmer
     private lateinit var prewarmer: OfferingWebViewPrewarmer
 
     @Before
     fun setUp() {
-        warmer = RecordingWarmer()
+        warmer = RecordingPaywallAssetWarmer()
         prewarmer = prewarmerWith(warmer)
     }
 
-    private fun prewarmerWith(warmer: PaywallAssetWarmer?) = OfferingWebViewPrewarmer(
-        PaywallAssetWarming(context = mockk(relaxed = true), warmerProvider = { warmer }),
-    )
+    private fun prewarmerWith(warmer: PaywallAssetWarmer?) =
+        OfferingWebViewPrewarmer(paywallAssetWarming(warmer))
 
     // The warm is posted to the main thread, so tests need a pump to see it.
     private fun OfferingWebViewPrewarmer.prewarmAndIdle(offerings: Offerings) {
         prewarmWebViews(offerings.prewarmTargetOfferings())
         shadowOf(Looper.getMainLooper()).idle()
-    }
-
-    private class RecordingWarmer : PaywallAssetWarmer {
-        val warmedWebViewUrls = mutableListOf<String>()
-        var prebootCount = 0
-
-        override fun warmImages(context: Context, imageUris: List<Uri>) = Unit
-
-        override fun prebootWebView(context: Context) {
-            prebootCount++
-        }
-
-        override fun warmWebViewUrls(context: Context, urls: List<String>) {
-            warmedWebViewUrls.addAll(urls)
-        }
-
-        override fun clearWebViewStorage(context: Context) = Unit
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingWebViewPrewarmerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingWebViewPrewarmerTest.kt
@@ -68,6 +68,8 @@ internal class OfferingWebViewPrewarmerTest {
         override fun warmWebViewUrls(context: Context, urls: List<String>) {
             warmedWebViewUrls.addAll(urls)
         }
+
+        override fun clearWebViewStorage(context: Context) = Unit
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/paywallAssetWarmerStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/paywallAssetWarmerStubs.kt
@@ -1,0 +1,39 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.utils
+
+import android.content.Context
+import android.net.Uri
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.PaywallAssetWarmer
+import com.revenuecat.purchases.paywalls.PaywallAssetWarming
+import io.mockk.mockk
+
+internal class RecordingPaywallAssetWarmer : PaywallAssetWarmer {
+
+    val warmedImages = mutableListOf<Uri>()
+    val warmedWebViewUrls = mutableListOf<String>()
+    var prebootCount = 0
+    var clearedStorageCount = 0
+
+    override fun warmImages(context: Context, imageUris: List<Uri>) {
+        warmedImages.addAll(imageUris)
+    }
+
+    override fun prebootWebView(context: Context) {
+        prebootCount++
+    }
+
+    override fun warmWebViewUrls(context: Context, urls: List<String>) {
+        warmedWebViewUrls.addAll(urls)
+    }
+
+    override fun clearWebViewStorage(context: Context) {
+        clearedStorageCount++
+    }
+}
+
+internal fun paywallAssetWarming(
+    warmer: PaywallAssetWarmer?,
+    context: Context = mockk(relaxed = true),
+) = PaywallAssetWarming(context, warmerProvider = { warmer })

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -97,8 +97,12 @@ internal class PaywallWebViewPrewarmer(
     @MainThread
     fun onCacheCleared() {
         warmedUrls.clear()
-        // These loaded against the storage that just went away, so nothing they cached can be trusted.
+        // These loaded against the storage that just went away, so they start over rather than being trusted.
+        queue.addAll(0, inFlight.keys)
         releaseInFlight()
+        // Posted so a settle or finishWarm already queued against a released warm runs first, while its
+        // url is still absent from inFlight and it is the no-op finishWarm documents.
+        mainHandler.post(::startAvailable)
     }
 
     /** Counterpart to [onDisplayStarted]. Warming resumes once the last component is gone. */

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -98,10 +98,11 @@ internal class PaywallWebViewPrewarmer(
     fun onCacheCleared() {
         warmedUrls.clear()
         // These loaded against the storage that just went away, so they start over rather than being trusted.
-        queue.addAll(0, inFlight.keys)
+        queue.addAll(0, inFlight.keys.filterNot { it in queue })
         releaseInFlight()
-        // Posted so a settle or finishWarm already queued against a released warm runs first, while its
-        // url is still absent from inFlight and it is the no-op finishWarm documents.
+        // Posted so a settle already queued for a released warm runs first and no-ops on its absent url;
+        // inline it would settle the restarted warm instead. Released views post nothing new, because
+        // destroyPaywallWebView drops their client.
         mainHandler.post(::startAvailable)
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmer.kt
@@ -94,6 +94,13 @@ internal class PaywallWebViewPrewarmer(
         warmedUrls.add(resolvedUrl)
     }
 
+    @MainThread
+    fun onCacheCleared() {
+        warmedUrls.clear()
+        // These loaded against the storage that just went away, so nothing they cached can be trusted.
+        releaseInFlight()
+    }
+
     /** Counterpart to [onDisplayStarted]. Warming resumes once the last component is gone. */
     @MainThread
     fun onDisplayEnded() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.ProfileStore
+import androidx.webkit.WebStorageCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.revenuecat.purchases.LogLevel
@@ -471,5 +472,30 @@ internal fun WebView.applyPaywallProfile() {
         WebViewCompat.setProfile(this, PAYWALL_PROFILE_NAME)
     } catch (error: RuntimeException) {
         Logger.w("Paywalls V2 web_view could not use an isolated profile; using the default. $error")
+    }
+}
+
+@Suppress("TooGenericExceptionCaught")
+internal fun clearPaywallProfileStorage() {
+    if (!WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE)) {
+        Logger.d("Paywalls V2 web_view storage was not cleared: this System WebView has no isolated profile.")
+        return
+    }
+    try {
+        val profile = ProfileStore.getInstance().getOrCreateProfile(PAYWALL_PROFILE_NAME)
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.DELETE_BROWSING_DATA)) {
+            WebStorageCompat.deleteBrowsingData(profile.webStorage) {
+                Logger.d("Cleared the paywall web_view profile's browsing data.")
+            }
+        } else {
+            // Nothing clears this profile's network cache without DELETE_BROWSING_DATA, and deleteAllData
+            // documents only Web SQL and Web Storage, so IndexedDB and CacheStorage survive here.
+            profile.cookieManager.removeAllCookies(null)
+            profile.cookieManager.flush()
+            profile.webStorage.deleteAllData()
+            Logger.d("Cleared the paywall web_view profile's cookies and web storage.")
+        }
+    } catch (error: RuntimeException) {
+        Logger.w("Paywalls V2 web_view storage could not be cleared. $error")
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -493,8 +493,9 @@ internal fun clearPaywallProfileStorage() {
         } else {
             // Nothing clears this profile's network cache without DELETE_BROWSING_DATA, and deleteAllData
             // documents only Web SQL and Web Storage, so IndexedDB and CacheStorage survive here.
-            profile.cookieManager.removeAllCookies(null)
-            profile.cookieManager.flush()
+            // removeAllCookies is asynchronous, so the flush that persists it goes in its callback.
+            val cookieManager = profile.cookieManager
+            cookieManager.removeAllCookies { cookieManager.flush() }
             profile.webStorage.deleteAllData()
             Logger.d("Cleared the paywall web_view profile's cookies and web storage.")
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -482,9 +482,12 @@ internal fun clearPaywallProfileStorage() {
         return
     }
     try {
-        val profile = ProfileStore.getInstance().getOrCreateProfile(PAYWALL_PROFILE_NAME)
+        // getProfile, not getOrCreateProfile: an app that never rendered a web_view has nothing to clear.
+        val profile = ProfileStore.getInstance().getProfile(PAYWALL_PROFILE_NAME) ?: return
         if (WebViewFeature.isFeatureSupported(WebViewFeature.DELETE_BROWSING_DATA)) {
+            // Deletion can also drop data written while it runs, so the prewarmer is told once it finishes.
             WebStorageCompat.deleteBrowsingData(profile.webStorage) {
+                PaywallWebViewPrewarmer.shared.onCacheCleared()
                 Logger.d("Cleared the paywall web_view profile's browsing data.")
             }
         } else {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/paywalls/PaywallAssetWarmerImpl.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/paywalls/PaywallAssetWarmerImpl.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.PaywallAssetWarmer
 import com.revenuecat.purchases.ui.revenuecatui.components.webview.PaywallWebViewPrewarmer
 import com.revenuecat.purchases.ui.revenuecatui.components.webview.PaywallWebViewStartUp
+import com.revenuecat.purchases.ui.revenuecatui.components.webview.clearPaywallProfileStorage
 
 @OptIn(InternalRevenueCatAPI::class)
 internal class PaywallAssetWarmerImpl : PaywallAssetWarmer {
@@ -24,5 +25,9 @@ internal class PaywallAssetWarmerImpl : PaywallAssetWarmer {
 
     override fun warmWebViewUrls(context: Context, urls: List<String>) {
         urls.forEach { url -> PaywallWebViewPrewarmer.shared.prewarm(context, url) }
+    }
+
+    override fun clearWebViewStorage(context: Context) {
+        clearPaywallProfileStorage()
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -104,6 +104,31 @@ internal class PaywallWebViewPrewarmerTest {
     }
 
     @Test
+    fun `warms a url again once the cache it was warmed into is cleared`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarm(context, URL)
+        finishMainFrameLoad(warmed.first())
+        idleFor(PaywallWebViewPrewarmer.SETTLE_GRACE_MS)
+
+        prewarmer.onCacheCleared()
+        prewarmer.prewarm(context, URL)
+
+        assertWarmCount(2)
+        assertThat(lastLoadedUrl()).isEqualTo(URL)
+    }
+
+    @Test
+    fun `clearing the cache abandons the warms in flight`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarm(context, URL)
+
+        prewarmer.onCacheCleared()
+        idle()
+
+        assertThat(prewarmer.warmingCount).isZero()
+    }
+
+    @Test
     fun `ignores a url already in flight or queued`() {
         val prewarmer = prewarmer()
         prewarmer.prewarmAll(URL, OTHER_URL)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -117,15 +117,46 @@ internal class PaywallWebViewPrewarmerTest {
         assertThat(lastLoadedUrl()).isEqualTo(URL)
     }
 
+    // A warm that straddles the clear cached against storage that is now gone, so it starts over.
     @Test
-    fun `clearing the cache abandons the warms in flight`() {
+    fun `clearing the cache restarts the warms in flight`() {
         val prewarmer = prewarmer()
         prewarmer.prewarm(context, URL)
 
         prewarmer.onCacheCleared()
         idle()
 
-        assertThat(prewarmer.warmingCount).isZero()
+        assertThat(prewarmer.warmingCount).isEqualTo(1)
+        assertWarmCount(2)
+        assertThat(lastLoadedUrl()).isEqualTo(URL)
+    }
+
+    @Test
+    fun `a load that finished before the clear does not settle the restarted warm`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarm(context, URL)
+        // Arms settle(URL) without draining it, so it lands on the warm that replaces this one.
+        val released = warmed.first()
+        shadowOf(released).webViewClient.onPageFinished(released, URL)
+
+        prewarmer.onCacheCleared()
+        idle()
+        idleFor(PaywallWebViewPrewarmer.SETTLE_GRACE_MS)
+
+        assertWarmCount(2)
+        assertThat(prewarmer.warmingCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `clearing the cache keeps draining the queue`() {
+        val prewarmer = prewarmer()
+        prewarmer.prewarmAll(URL, OTHER_URL)
+
+        prewarmer.onCacheCleared()
+        idle()
+
+        assertThat(prewarmer.queuedCount).isEqualTo(1)
+        assertThat(prewarmer.warmingCount).isEqualTo(1)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewPrewarmerTest.kt
@@ -119,16 +119,29 @@ internal class PaywallWebViewPrewarmerTest {
 
     // A warm that straddles the clear cached against storage that is now gone, so it starts over.
     @Test
-    fun `clearing the cache restarts the warms in flight`() {
+    fun `clearing the cache restarts the warms in flight ahead of the queue`() {
         val prewarmer = prewarmer()
-        prewarmer.prewarm(context, URL)
+        prewarmer.prewarmAll(URL, OTHER_URL)
 
         prewarmer.onCacheCleared()
         idle()
 
-        assertThat(prewarmer.warmingCount).isEqualTo(1)
         assertWarmCount(2)
         assertThat(lastLoadedUrl()).isEqualTo(URL)
+        assertThat(prewarmer.warmingCount).isEqualTo(1)
+        assertThat(prewarmer.queuedCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `clearing the cache does not requeue a url that is already waiting`() {
+        val prewarmer = prewarmer(maxConcurrent = 2)
+        prewarmer.prewarmAll(URL, OTHER_URL)
+        prewarmer.onDisplayStarted(THIRD_URL)
+
+        prewarmer.onCacheCleared()
+        idle()
+
+        assertThat(prewarmer.queuedCount + prewarmer.warmingCount).isEqualTo(2)
     }
 
     @Test
@@ -144,18 +157,6 @@ internal class PaywallWebViewPrewarmerTest {
         idleFor(PaywallWebViewPrewarmer.SETTLE_GRACE_MS)
 
         assertWarmCount(2)
-        assertThat(prewarmer.warmingCount).isEqualTo(1)
-    }
-
-    @Test
-    fun `clearing the cache keeps draining the queue`() {
-        val prewarmer = prewarmer()
-        prewarmer.prewarmAll(URL, OTHER_URL)
-
-        prewarmer.onCacheCleared()
-        idle()
-
-        assertThat(prewarmer.queuedCount).isEqualTo(1)
         assertThat(prewarmer.warmingCount).isEqualTo(1)
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.webkit.CookieManager
+import android.webkit.ValueCallback
 import android.webkit.WebStorage
 import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -14,6 +15,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
@@ -79,9 +81,14 @@ internal class WebViewProfileTest {
         every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
         every { WebViewFeature.isFeatureSupported(WebViewFeature.DELETE_BROWSING_DATA) } returns false
 
+        val removalDone = slot<ValueCallback<Boolean>>()
+        every { cookieManager.removeAllCookies(capture(removalDone)) } just Runs
+
         clearPaywallProfileStorage()
 
-        verify { cookieManager.removeAllCookies(null) }
+        // Flushing before the removal reports back would persist the outgoing user's cookies.
+        verify(exactly = 0) { cookieManager.flush() }
+        removalDone.captured.onReceiveValue(true)
         verify { cookieManager.flush() }
         verify { webStorage.deleteAllData() }
         verify(exactly = 0) { WebStorageCompat.deleteBrowsingData(any(), any<Runnable>()) }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
@@ -36,7 +36,6 @@ internal class WebViewProfileTest {
     fun setUp() {
         mockkStatic(WebViewFeature::class, WebViewCompat::class, ProfileStore::class, WebStorageCompat::class)
         every { ProfileStore.getInstance() } returns profileStore
-        every { profileStore.getOrCreateProfile(PAYWALL_PROFILE_NAME) } returns profile
         every { profileStore.getProfile(PAYWALL_PROFILE_NAME) } returns profile
         every { profile.cookieManager } returns cookieManager
         every { profile.webStorage } returns webStorage

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
@@ -1,11 +1,17 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import android.webkit.CookieManager
+import android.webkit.WebStorage
 import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.webkit.Profile
 import androidx.webkit.ProfileStore
+import androidx.webkit.WebStorageCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
@@ -19,11 +25,25 @@ import org.junit.runner.RunWith
 internal class WebViewProfileTest {
 
     private val webView = mockk<WebView>(relaxed = true)
+    private val cookieManager = mockk<CookieManager>(relaxed = true)
 
     @Before
     fun setUp() {
-        mockkStatic(WebViewFeature::class, WebViewCompat::class, ProfileStore::class)
+        mockkStatic(WebViewFeature::class, WebViewCompat::class, ProfileStore::class, WebStorageCompat::class)
         every { ProfileStore.getInstance() } returns mockk(relaxed = true)
+        every { WebStorageCompat.deleteBrowsingData(any(), any<Runnable>()) } just Runs
+    }
+
+    private fun mockProfileStorage(): WebStorage {
+        val webStorage = mockk<WebStorage>(relaxed = true)
+        val profile = mockk<Profile>(relaxed = true)
+        val profileStore = mockk<ProfileStore>()
+        every { ProfileStore.getInstance() } returns profileStore
+        every { profileStore.getOrCreateProfile(PAYWALL_PROFILE_NAME) } returns profile
+        every { profile.cookieManager } returns cookieManager
+        every { profile.webStorage } returns webStorage
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
+        return webStorage
     }
 
     @After
@@ -47,6 +67,52 @@ internal class WebViewProfileTest {
         webView.applyPaywallProfile()
 
         verify(exactly = 0) { WebViewCompat.setProfile(any(), any()) }
+    }
+
+    @Test
+    fun `clears the profile's browsing data when deleting browsing data is supported`() {
+        val webStorage = mockProfileStorage()
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.DELETE_BROWSING_DATA) } returns true
+
+        clearPaywallProfileStorage()
+
+        verify { WebStorageCompat.deleteBrowsingData(webStorage, any<Runnable>()) }
+    }
+
+    @Test
+    fun `falls back to cookies and web storage when deleting browsing data is unsupported`() {
+        val webStorage = mockProfileStorage()
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.DELETE_BROWSING_DATA) } returns false
+
+        clearPaywallProfileStorage()
+
+        verify { cookieManager.removeAllCookies(null) }
+        verify { cookieManager.flush() }
+        verify { webStorage.deleteAllData() }
+        verify(exactly = 0) { WebStorageCompat.deleteBrowsingData(any(), any<Runnable>()) }
+    }
+
+    @Test
+    fun `leaves storage alone when multi-profile is unsupported`() {
+        val profileStore = mockk<ProfileStore>(relaxed = true)
+        every { ProfileStore.getInstance() } returns profileStore
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns false
+
+        clearPaywallProfileStorage()
+
+        verify(exactly = 0) { profileStore.getOrCreateProfile(any()) }
+    }
+
+    @Test
+    fun `does not throw when clearing storage fails`() {
+        val profileStore = mockk<ProfileStore>()
+        every { ProfileStore.getInstance() } returns profileStore
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
+        every { profileStore.getOrCreateProfile(any()) } throws IllegalStateException("profile deleted")
+
+        clearPaywallProfileStorage()
+
+        verify { profileStore.getOrCreateProfile(PAYWALL_PROFILE_NAME) }
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewProfileTest.kt
@@ -26,24 +26,19 @@ internal class WebViewProfileTest {
 
     private val webView = mockk<WebView>(relaxed = true)
     private val cookieManager = mockk<CookieManager>(relaxed = true)
+    private val webStorage = mockk<WebStorage>(relaxed = true)
+    private val profile = mockk<Profile>(relaxed = true)
+    private val profileStore = mockk<ProfileStore>(relaxed = true)
 
     @Before
     fun setUp() {
         mockkStatic(WebViewFeature::class, WebViewCompat::class, ProfileStore::class, WebStorageCompat::class)
-        every { ProfileStore.getInstance() } returns mockk(relaxed = true)
-        every { WebStorageCompat.deleteBrowsingData(any(), any<Runnable>()) } just Runs
-    }
-
-    private fun mockProfileStorage(): WebStorage {
-        val webStorage = mockk<WebStorage>(relaxed = true)
-        val profile = mockk<Profile>(relaxed = true)
-        val profileStore = mockk<ProfileStore>()
         every { ProfileStore.getInstance() } returns profileStore
         every { profileStore.getOrCreateProfile(PAYWALL_PROFILE_NAME) } returns profile
+        every { profileStore.getProfile(PAYWALL_PROFILE_NAME) } returns profile
         every { profile.cookieManager } returns cookieManager
         every { profile.webStorage } returns webStorage
-        every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
-        return webStorage
+        every { WebStorageCompat.deleteBrowsingData(any(), any<Runnable>()) } just Runs
     }
 
     @After
@@ -71,7 +66,7 @@ internal class WebViewProfileTest {
 
     @Test
     fun `clears the profile's browsing data when deleting browsing data is supported`() {
-        val webStorage = mockProfileStorage()
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
         every { WebViewFeature.isFeatureSupported(WebViewFeature.DELETE_BROWSING_DATA) } returns true
 
         clearPaywallProfileStorage()
@@ -81,7 +76,7 @@ internal class WebViewProfileTest {
 
     @Test
     fun `falls back to cookies and web storage when deleting browsing data is unsupported`() {
-        val webStorage = mockProfileStorage()
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
         every { WebViewFeature.isFeatureSupported(WebViewFeature.DELETE_BROWSING_DATA) } returns false
 
         clearPaywallProfileStorage()
@@ -94,31 +89,36 @@ internal class WebViewProfileTest {
 
     @Test
     fun `leaves storage alone when multi-profile is unsupported`() {
-        val profileStore = mockk<ProfileStore>(relaxed = true)
-        every { ProfileStore.getInstance() } returns profileStore
         every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns false
 
         clearPaywallProfileStorage()
 
-        verify(exactly = 0) { profileStore.getOrCreateProfile(any()) }
+        verify(exactly = 0) { profileStore.getProfile(any()) }
+    }
+
+    @Test
+    fun `does nothing when the profile was never created`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
+        every { profileStore.getProfile(PAYWALL_PROFILE_NAME) } returns null
+
+        clearPaywallProfileStorage()
+
+        verify(exactly = 0) { WebStorageCompat.deleteBrowsingData(any(), any<Runnable>()) }
+        verify(exactly = 0) { cookieManager.removeAllCookies(any()) }
     }
 
     @Test
     fun `does not throw when clearing storage fails`() {
-        val profileStore = mockk<ProfileStore>()
-        every { ProfileStore.getInstance() } returns profileStore
         every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
-        every { profileStore.getOrCreateProfile(any()) } throws IllegalStateException("profile deleted")
+        every { profileStore.getProfile(any()) } throws IllegalStateException("profile deleted")
 
         clearPaywallProfileStorage()
 
-        verify { profileStore.getOrCreateProfile(PAYWALL_PROFILE_NAME) }
+        verify { profileStore.getProfile(PAYWALL_PROFILE_NAME) }
     }
 
     @Test
     fun `does not fail the render when profile setup throws`() {
-        val profileStore = mockk<ProfileStore>()
-        every { ProfileStore.getInstance() } returns profileStore
         every { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) } returns true
         every { profileStore.getOrCreateProfile(any()) } throws IllegalArgumentException("invalid profile name")
 


### PR DESCRIPTION
- Clears the paywall WebView profile's browsing data when an identified user leaves: `logOut`, `switchUser`, and `logIn` away from an already identified user.
- Keeps the data when an anonymous user signs in. That transition is the middle of a multipage paywall or workflow flow, so the storage belongs to the same customer and dropping it would break the flow they are in.
- Headline caveat: on System WebViews without `DELETE_BROWSING_DATA` the fallback clears cookies and `WebStorage.deleteAllData` only, so that profile's network cache, IndexedDB and CacheStorage survive. Those devices get less than the guarantee the first bullet implies.
- Goes further than iOS on one path: `purchases-ios#7470` clears on `logOut` and the customEntitlementComputation `switchUser`, so `logIn(A)` then `logIn(B)` keeps A's data there. This clears it.
- Resets `PaywallWebViewPrewarmer`'s warmed set after a successful clear, since the deleted data includes the network cache that set is a memo of.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

[PWENG-221](https://linear.app/revenuecat/issue/PWENG-221/android-clear-the-paywall-webview-profile-on-identity-change). Paywall WebViews have had an isolated `com.revenuecat.paywall` profile since #3816, but nothing ever cleared it: no `CookieManager`, `WebStorage` or `ServiceWorkerController` reference existed anywhere in the repo. So one user's paywall cookies and DOM storage survived into the next user's session. Isolated from the host app, not isolated between users.

The policy is narrower than "on identity change", and comes from [Jake's comment on purchases-ios#7470](https://github.com/RevenueCat/purchases-ios/pull/7470#discussion_r3847188423): clear on log out or on a switch from user A to user B, not on anonymous to known, because most multipage flows are an anonymous customer starting a flow, getting identified, then continuing it. Clearing there would destroy the warm cache mid-conversion.

### Description

- Adds `clearWebViewStorage(context)` to the existing `PaywallAssetWarmer` `ServiceLoader` SPI, which is the only push channel from `:purchases` to `:ui:revenuecatui` and already carries the "return promptly, do not throw" contract with `runCatching` isolation on the core side.
- `clearPaywallProfileStorage()` calls `WebStorageCompat.deleteBrowsingData` on `Profile.getWebStorage()`. Scoped to our profile, so the host app's `Default` profile is untouched.
- Hooks two sites in `IdentityManager`: `logIn`'s backend-success block, and `resetAndSaveUserID`, which is the sole funnel for `logOut` and `switchUser` including the customEntitlementComputation flavor's public `switchUser`.
- Guard is `oldAppUserID != newAppUserID && !isUserIDAnonymous(oldAppUserID)`, so the helper owns the whole rule rather than depending on `PurchasesOrchestrator`'s same-id guards upstream.
- `getProfile`, not `getOrCreateProfile`: an app that never rendered a `web_view` paywall has nothing to clear, and should not get a profile created on disk in order to wipe it.

Not visible in the diff:

- `deleteBrowsingData` is documented as deleting "network cache, cookies, and any JavaScript-readable storage", which is the same outcome iOS gets from `WKWebsiteDataStore.remove(forIdentifier:)`. Verified against the `androidx.webkit` 1.16.0 sources, not the docs site.
- `DELETE_BROWSING_DATA` is negotiated separately from `MULTI_PROFILE`, so a device can have the isolated profile without the delete API. Hence the fallback branch rather than a single call.
- androidx documents the deletion as non-atomic: it "may also delete data that is stored during deletion". That is why the prewarmer reset runs in the done callback instead of inline, so a re-warm cannot start into a deletion that is still running.
- Everything touched is `@InternalRevenueCatAPI` or internal, and those members are excluded from the metalava dumps, so `api-*.txt` is unchanged.
- The reset is wired into the `deleteBrowsingData` branch only. The fallback does not touch the network cache, so `warmedUrls` stays accurate there.

### Regression gates

- `login from an anonymous user keeps the paywall web view storage` in `IdentityManagerTests`: the test that fails if the anonymity exemption is ever dropped, which is the whole policy.
- `falls back to cookies and web storage when deleting browsing data is unsupported` in `WebViewProfileTest`, for the older-WebView branch.
- `warms a url again once the cache it was warmed into is cleared` in `PaywallWebViewPrewarmerTest`, for the stale-memo bug.

**Limitations:**

- Pre-113 System WebViews have no isolated profile at all: paywalls fall back to the host app's `Default` profile, which is not ours to wipe, so nothing is cleared there. Logged at debug.
- Clearing runs even with a paywall on screen, so a live page loses its cookies underneath it. Logging out with a paywall visible is not a flow we support, and the alternative costs the store-rotation machinery below.
- The first qualifying identity change in a process can pay the WebView provider load on a main-thread frame, since `WebViewFeature.isFeatureSupported` is what triggers that load. It lands even on apps whose paywalls contain no `web_view` component, which get no benefit from the clear. Gating on "this process already touched the paywall WebView" would skip it but would be wrong: the profile is persistent, so a previous process's data has to be clearable.
- `IdentityManager.configure()` with an explicit app user ID that differs from the cached one still clears nothing. It never captures the old id, so no cache is dropped on that path today, not just this one. Worth its own issue; it is the same leak for an app that manages sign-in by reconfiguring.

**Rejected:**

- `ProfileStore.deleteProfile`: throws both for a profile any WebView is live on and for one that `getOrCreateProfile` has loaded, and `applyPaywallProfile` always loads it. Unusable here.
- Rotating profile names with a delete-on-next-start sweep, which is what iOS does with data store identifiers. Needs a persisted generation counter plus a startup sweep, and `deleteBrowsingData` reaches the same end state in one call.
- `WebView.clearCache(true)`: clears the host app's WebView cache too, so it breaks the isolation the profile exists for.
- Clearing only cookies and DOM storage to preserve the prewarmed bundles. `WebStorage.deleteAllData` documents only Web SQL and Web Storage, so the network cache, IndexedDB and CacheStorage would keep the previous user's data. The bundle is server-authored, so which stores it uses is not ours to assume.
- Hooking `PurchasesOrchestrator` instead: three call sites rather than two, and a future identity path added inside `IdentityManager` would silently miss the clear.

</details>
