### PR TITLE
Add rc.semverCompare custom operator

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/CustomOperators.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/CustomOperators.kt
@@ -24,6 +24,8 @@ internal object CustomOperators {
 
         "rc.rootVar" -> RootVarOperator.opRootVar(args, vars)
 
+        "rc.semverCompare" -> SemverOperator.opSemverCompare(args, vars)
+
         else -> throw EvaluationException.UnsupportedOperator(op)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/SemverOperator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/SemverOperator.kt
@@ -51,9 +51,10 @@ internal object SemverOperator {
  * identifiers (empty for a release version). Build metadata is dropped, since
  * semver §10 excludes it from precedence.
  *
- * Two deliberate concessions to real-world version strings: a missing minor or
- * patch is `0` (`"2.1"` ≡ `"2.1.0"`), and leading zeros are accepted
- * (`"1.02.0"` ≡ `"1.2.0"`) even though the spec forbids them.
+ * Three deliberate concessions to real-world version strings: a missing minor
+ * or patch is `0` (`"2.1"` ≡ `"2.1.0"`), leading zeros are accepted
+ * (`"1.02.0"` ≡ `"1.2.0"`) even though the spec forbids them, and build
+ * metadata is dropped without being validated.
  */
 private class SemanticVersion(
     val core: List<Long>,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/SemverOperator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/SemverOperator.kt
@@ -1,0 +1,185 @@
+package com.revenuecat.purchases.rules.customoperators
+
+import com.revenuecat.purchases.rules.RulesEngine.EvaluationException
+import com.revenuecat.purchases.rules.Scope
+import com.revenuecat.purchases.rules.Value
+import com.revenuecat.purchases.rules.operators.Operators
+
+/** Name used in this operator's error messages. */
+private const val OPERATOR_NAME = "rc.semverCompare"
+
+/** Number of components in a semver core, once padded. */
+private const val CORE_COMPONENTS = 3
+
+/**
+ * `rc.semverCompare` — three-way version comparison following
+ * Semantic Versioning 2.0.0 precedence.
+ */
+internal object SemverOperator {
+
+    private const val ARGUMENT_COUNT = 2
+
+    /**
+     * `{"rc.semverCompare": [left, right]}` — `-1`, `0`, or `1`, so rules
+     * compare with the existing operators:
+     * `{">=": [{"rc.semverCompare": [{"var": "appVersion"}, "2.1.0"]}, 0]}`.
+     *
+     * The built-in `<` / `>` compare version strings lexicographically,
+     * which puts `"10.0.0"` below `"9.0.0"`.
+     *
+     * Both operands must be strings that parse, otherwise
+     * [EvaluationException.TypeMismatch]. Returning `0` for a malformed
+     * version or an explicit null would report "equal", which satisfies a
+     * `>= 0` gate and so matches every rule built on it. Arity is exact for
+     * the same reason.
+     */
+    fun opSemverCompare(args: Value, vars: Scope): Value {
+        val evaluated = Operators.evalArgs(args, vars)
+
+        if (evaluated.size != ARGUMENT_COUNT) {
+            throw EvaluationException.TypeMismatch(
+                "operator '$OPERATOR_NAME' expects $ARGUMENT_COUNT arguments, " +
+                    "got ${evaluated.size}",
+            )
+        }
+
+        val left = SemanticVersion.parse(evaluated[0])
+        val right = SemanticVersion.parse(evaluated[1])
+        return Value.IntValue(left.compare(right).toLong())
+    }
+}
+
+/**
+ * A parsed version: core components padded to three, plus prerelease
+ * identifiers (empty for a release version). Build metadata is dropped, since
+ * semver §10 excludes it from precedence.
+ *
+ * Two deliberate concessions to real-world version strings: a missing minor or
+ * patch is `0` (`"2.1"` ≡ `"2.1.0"`), and leading zeros are accepted
+ * (`"1.02.0"` ≡ `"1.2.0"`) even though the spec forbids them.
+ */
+private class SemanticVersion(
+    val core: List<Long>,
+    val prerelease: List<String>,
+) {
+
+    fun compare(other: SemanticVersion): Int {
+        core.zip(other.core).forEach { (lhs, rhs) ->
+            if (lhs != rhs) return if (lhs < rhs) -1 else 1
+        }
+
+        return when {
+            prerelease.isEmpty() && other.prerelease.isEmpty() -> 0
+            // A release outranks any prerelease of the same core.
+            prerelease.isEmpty() -> 1
+            other.prerelease.isEmpty() -> -1
+            else -> comparePrerelease(prerelease, other.prerelease)
+        }
+    }
+
+    companion object {
+
+        fun parse(value: Value): SemanticVersion {
+            if (value !is Value.StringValue) {
+                throw EvaluationException.TypeMismatch(
+                    "operator '$OPERATOR_NAME' expected version strings, got $value",
+                )
+            }
+
+            val original = value.value
+            val withoutBuild = original.substringBefore('+')
+            val separator = withoutBuild.indexOf('-')
+
+            val coreText: String
+            val prereleaseText: String?
+            if (separator < 0) {
+                coreText = withoutBuild
+                prereleaseText = null
+            } else {
+                coreText = withoutBuild.substring(0, separator)
+                prereleaseText = withoutBuild.substring(separator + 1)
+            }
+
+            return SemanticVersion(
+                core = parseCore(coreText, original),
+                prerelease = parsePrerelease(prereleaseText, original),
+            )
+        }
+
+        private fun parseCore(text: String, original: String): List<Long> {
+            val components = text.split(".")
+
+            if (components.isEmpty() || components.size > CORE_COMPONENTS) {
+                throw invalid(original)
+            }
+
+            val core = components.map { component ->
+                numericIdentifier(component) ?: throw invalid(original)
+            }
+
+            return core + List(CORE_COMPONENTS - core.size) { 0L }
+        }
+
+        private fun parsePrerelease(text: String?, original: String): List<String> {
+            if (text == null) return emptyList()
+
+            return text.split(".").map { identifier ->
+                if (identifier.isEmpty() || !identifier.all(::isIdentifierCharacter)) {
+                    throw invalid(original)
+                }
+                identifier
+            }
+        }
+
+        /**
+         * Semver §11: identifiers are compared field by field. When every
+         * shared field ties, the version with more fields wins.
+         */
+        private fun comparePrerelease(lhs: List<String>, rhs: List<String>): Int {
+            lhs.zip(rhs).forEach { (left, right) ->
+                val ordering = compareIdentifiers(left, right)
+                if (ordering != 0) return ordering
+            }
+
+            return if (lhs.size == rhs.size) 0 else if (lhs.size < rhs.size) -1 else 1
+        }
+
+        /**
+         * Numeric identifiers compare numerically, alphanumeric ones by ASCII
+         * order, and a numeric identifier always ranks below an alphanumeric one.
+         */
+        private fun compareIdentifiers(left: String, right: String): Int {
+            val leftNumber = numericIdentifier(left)
+            val rightNumber = numericIdentifier(right)
+
+            return when {
+                leftNumber != null && rightNumber != null ->
+                    if (leftNumber == rightNumber) 0 else if (leftNumber < rightNumber) -1 else 1
+                leftNumber != null -> -1
+                rightNumber != null -> 1
+                left == right -> 0
+                else -> if (left < right) -1 else 1
+            }
+        }
+
+        /**
+         * A numeric identifier is digits only. [String.toLongOrNull] alone would
+         * also accept a signed identifier like `-1`, which is alphanumeric here.
+         *
+         * `Long` rather than `Int` so a component wider than 32 bits, such as a
+         * timestamp-shaped build number, still parses as it does on iOS.
+         */
+        private fun numericIdentifier(text: String): Long? {
+            if (text.isEmpty() || !text.all { it in '0'..'9' }) return null
+            return text.toLongOrNull()
+        }
+
+        private fun isIdentifierCharacter(character: Char): Boolean =
+            character in 'a'..'z' || character in 'A'..'Z' || character in '0'..'9' || character == '-'
+
+        private fun invalid(version: String): EvaluationException.TypeMismatch =
+            EvaluationException.TypeMismatch(
+                "operator '$OPERATOR_NAME' could not parse version '$version'",
+            )
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/SemverOperator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/rules/customoperators/SemverOperator.kt
@@ -27,11 +27,8 @@ internal object SemverOperator {
      * The built-in `<` / `>` compare version strings lexicographically,
      * which puts `"10.0.0"` below `"9.0.0"`.
      *
-     * Both operands must be strings that parse, otherwise
-     * [EvaluationException.TypeMismatch]. Returning `0` for a malformed
-     * version or an explicit null would report "equal", which satisfies a
-     * `>= 0` gate and so matches every rule built on it. Arity is exact for
-     * the same reason.
+     * Requires exactly two operands, both strings that parse, otherwise
+     * [EvaluationException.TypeMismatch].
      */
     fun opSemverCompare(args: Value, vars: Scope): Value {
         val evaluated = Operators.evalArgs(args, vars)

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/rules/PredicateFixtureLoaderTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/rules/PredicateFixtureLoaderTest.kt
@@ -21,7 +21,7 @@ internal class PredicateFixtureLoaderTest {
     fun `fixture count matches expected`() {
         // Bump this when adding or removing fixtures. Guards against a fixture
         // file silently failing to load and shrinking the suite.
-        val expectedCount = 482
+        val expectedCount = 483
         assertThat(PredicateConformanceFixtureLoader.allCases).hasSize(expectedCount)
     }
 }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/rules/PredicateFixtureLoaderTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/rules/PredicateFixtureLoaderTest.kt
@@ -21,7 +21,7 @@ internal class PredicateFixtureLoaderTest {
     fun `fixture count matches expected`() {
         // Bump this when adding or removing fixtures. Guards against a fixture
         // file silently failing to load and shrinking the suite.
-        val expectedCount = 449
+        val expectedCount = 482
         assertThat(PredicateConformanceFixtureLoader.allCases).hasSize(expectedCount)
     }
 }

--- a/purchases/src/testDefaults/resources/predicate-fixtures/rc_semver.json
+++ b/purchases/src/testDefaults/resources/predicate-fixtures/rc_semver.json
@@ -138,6 +138,13 @@
       "expected": true
     },
     {
+      "id": "semver_build_metadata_is_dropped_unvalidated",
+      "description": "Everything from the first + on is discarded without being checked, so a malformed tail still compares on its core",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0++not a valid identifier", "1.0.0"]}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
       "id": "semver_non_string_left_is_type_error",
       "description": "A bare number is not a version; 1 is not \"1.0.0\"",
       "predicate": {"rc.semverCompare": [1, "1.0.0"]},

--- a/purchases/src/testDefaults/resources/predicate-fixtures/rc_semver.json
+++ b/purchases/src/testDefaults/resources/predicate-fixtures/rc_semver.json
@@ -1,0 +1,222 @@
+{
+  "fixtures": [
+    {
+      "id": "semver_equal_versions",
+      "predicate": {"===": [{"rc.semverCompare": ["1.2.3", "1.2.3"]}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_major_takes_precedence",
+      "predicate": {"===": [{"rc.semverCompare": ["2.0.0", "1.9.9"]}, 1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_minor_breaks_major_tie",
+      "predicate": {"===": [{"rc.semverCompare": ["1.3.0", "1.2.9"]}, 1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_patch_breaks_minor_tie",
+      "predicate": {"===": [{"rc.semverCompare": ["1.2.4", "1.2.3"]}, 1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_compares_numerically_not_lexicographically",
+      "description": "Motivating case: the built-in < / > compare strings, which rank \"10.0.0\" below \"9.0.0\"",
+      "predicate": {"===": [{"rc.semverCompare": ["10.0.0", "9.0.0"]}, 1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_returns_minus_one_when_left_is_lower",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0", "2.0.0"]}, -1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_missing_patch_defaults_to_zero",
+      "description": "Concession to real-world version strings: rule authors and app versions often omit components",
+      "predicate": {"===": [{"rc.semverCompare": ["1.2", "1.2.0"]}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_missing_minor_and_patch_default_to_zero",
+      "predicate": {"===": [{"rc.semverCompare": ["1", "1.0.0"]}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_missing_component_is_zero_not_wildcard",
+      "description": "An omitted component is 0, not \"any\": \"1.2\" does not match every 1.2.x",
+      "predicate": {"===": [{"rc.semverCompare": ["1.2", "1.2.1"]}, -1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_leading_zeros_compare_numerically",
+      "description": "Semver forbids leading zeros; comparing numerically accepts them instead of failing the rule",
+      "predicate": {"===": [{"rc.semverCompare": ["1.02.0", "1.2.0"]}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_prerelease_ranks_below_release",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0-alpha", "1.0.0"]}, -1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_release_ranks_above_prerelease",
+      "description": "Mirror of the previous case: the release/prerelease test is asymmetric in the implementation",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0", "1.0.0-alpha"]}, 1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_prerelease_numeric_identifiers_compare_numerically",
+      "description": "By ASCII these would be reversed, since \"10\" sorts before \"2\"",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0-2", "1.0.0-10"]}, -1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_prerelease_alphanumeric_compares_by_ascii",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0-alpha", "1.0.0-beta"]}, -1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_prerelease_ascii_puts_uppercase_first",
+      "description": "ASCII order, not case-insensitive collation, which would call these equal",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0-RC1", "1.0.0-rc1"]}, -1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_prerelease_numeric_ranks_below_alphanumeric",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0-1", "1.0.0-alpha"]}, -1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_prerelease_more_fields_wins_tie",
+      "description": "When every shared identifier ties, the longer identifier list has higher precedence",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0-alpha", "1.0.0-alpha.1"]}, -1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_equal_prereleases",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0-alpha.1", "1.0.0-alpha.1"]}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_core_decides_before_prerelease",
+      "description": "A prerelease only lowers precedence against an otherwise equal core",
+      "predicate": {"===": [{"rc.semverCompare": ["2.0.0-alpha", "1.0.0"]}, 1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_build_metadata_ignored",
+      "description": "Semver §10: build metadata is not part of precedence",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0+build.1", "1.0.0+build.2"]}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_build_metadata_stripped_before_prerelease",
+      "description": "Build metadata is removed before the prerelease comparison, not treated as part of it",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0-alpha+b1", "1.0.0-alpha"]}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "semver_non_string_left_is_type_error",
+      "description": "A bare number is not a version; 1 is not \"1.0.0\"",
+      "predicate": {"rc.semverCompare": [1, "1.0.0"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.semverCompare"}
+    },
+    {
+      "id": "semver_non_string_right_is_type_error",
+      "description": "Both operands are validated, not just the first",
+      "predicate": {"rc.semverCompare": ["1.0.0", 2]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.semverCompare"}
+    },
+    {
+      "id": "semver_missing_variable_fails_at_the_lookup",
+      "description": "A typo'd path is caught by var before rc.semverCompare ever sees it, so the error names the unresolved path rather than blaming the operator",
+      "predicate": {"rc.semverCompare": [{"var": "missing"}, "1.0.0"]},
+      "variables": {},
+      "expected": {"error": "unresolvedVariable", "path": "missing"}
+    },
+    {
+      "id": "semver_explicit_null_is_still_a_type_error",
+      "description": "A key that is present but null is a known value, not an unresolved one, so it reaches rc.semverCompare and is refused there rather than reporting \"equal\" to a >= 0 gate",
+      "predicate": {"rc.semverCompare": [{"var": "maybe"}, "1.0.0"]},
+      "variables": {"maybe": null},
+      "expected": {"error": "typeMismatch", "operator": "rc.semverCompare"}
+    },
+    {
+      "id": "semver_empty_string_is_type_error",
+      "predicate": {"rc.semverCompare": ["", "1.0.0"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.semverCompare"}
+    },
+    {
+      "id": "semver_non_numeric_core_is_type_error",
+      "predicate": {"rc.semverCompare": ["1.x.0", "1.0.0"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.semverCompare"}
+    },
+    {
+      "id": "semver_four_components_is_type_error",
+      "description": "Truncating to three components would silently ignore data the author considered meaningful",
+      "predicate": {"rc.semverCompare": ["1.2.3.4", "1.2.3"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.semverCompare"}
+    },
+    {
+      "id": "semver_empty_prerelease_is_type_error",
+      "predicate": {"rc.semverCompare": ["1.0.0-", "1.0.0"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.semverCompare"}
+    },
+    {
+      "id": "semver_invalid_prerelease_character_is_type_error",
+      "description": "Prerelease identifiers are ASCII alphanumerics and hyphens only",
+      "predicate": {"rc.semverCompare": ["1.0.0-beta_1", "1.0.0"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.semverCompare"}
+    },
+    {
+      "id": "semver_missing_operand_is_type_error",
+      "description": "A one-sided comparison is a lowering bug, so it fails instead of comparing against null",
+      "predicate": {"rc.semverCompare": ["1.0.0"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.semverCompare"}
+    },
+    {
+      "id": "semver_extra_operand_is_type_error",
+      "description": "Unlike the unary custom operators, which ignore extra arguments, arity is exact here",
+      "predicate": {"rc.semverCompare": ["1.0.0", "1.0.0", "1.0.0"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.semverCompare"}
+    },
+    {
+      "id": "semver_minimum_version_gate",
+      "description": "Motivating case: a minimum-version audience built from the three-way result",
+      "predicate": {">=": [{"rc.semverCompare": [{"var": "appVersion"}, "2.1.0"]}, 0]},
+      "variables": {"appVersion": "2.1.3"},
+      "expected": true
+    }
+  ]
+}


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

Port of RevenueCat/purchases-ios#7472. Version targeting is the most common audience condition, and the built-in `<` / `>` compare strings, so they rank `"10.0.0"` below `"9.0.0"`.

### Description

`{"rc.semverCompare": [left, right]}` returns `-1`, `0`, or `1`, composing with the existing comparison operators:

```json
{">=": [{"rc.semverCompare": [{"var": "appVersion"}, "2.1.0"]}, 0]}
```

Precedence follows semver 2.0.0 §11, with build metadata excluded. Unparseable input and inexact arity throw `typeMismatch`; partial versions (`"2.1"` ≡ `"2.1.0"`) and leading zeros are accepted.

### Notes

- Thirty-three fixtures copied byte-for-byte from iOS (482 total).
- Components parse as `Long`, not `Int`, so one wider than 32 bits compares as it does on iOS, where Swift's `Int` is 64-bit.
- The iOS PR is still in review, so its fixtures could still change; this file must be re-synced if they do.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes audience/rule evaluation behavior for version gates; incorrect semver logic could mis-target users, but scope is isolated to a new operator with broad fixture coverage.
> 
> **Overview**
> Adds **`rc.semverCompare`** to the rules engine so audience predicates can compare app versions by **semver 2.0.0 precedence** instead of lexicographic string order (e.g. `10.0.0` vs `9.0.0`).
> 
> The operator takes two version **strings**, returns **`-1` / `0` / `1`**, and composes with existing comparators—for example `{">=": [{"rc.semverCompare": [{"var": "appVersion"}, "2.1.0"]}, 0]}`. Implementation strips build metadata, pads short cores (`"2.1"` → `2.1.0`), and rejects bad arity or unparseable input with **`typeMismatch`**.
> 
> **`CustomOperators`** dispatches the new op; **`rc_semver.json`** adds 33 conformance fixtures (fixture count guard bumped to **501**), aligned with the iOS port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60a7b39070518f70e75878425d1d197c27be419f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->