### PR TITLE
ci(danger): announce only new public API in the SDK API feed

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -93,7 +93,7 @@ end
 
 fail_on_generated_edits(["purchases/src/main/kotlin/generated/"])
 
-# Report the public API this PR changes, and mirror it into the SDK API feed channel.
+# Report the public API this PR changes, and announce what it adds in the SDK API feed channel.
 # Best effort: a raise here would take every other rule in this file down with it.
 begin
   require_relative "danger/api_diff_report"

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -54,6 +54,17 @@ module ApiDiffReport
     [added, removed]
   end
 
+  # `@kotlin.jvm.Throws(exceptionClasses=...)` puts a parameter list in front of the member's own,
+  # so annotations go before anything is read positionally.
+  ANNOTATION = /@[\w.]+(?:\((?:[^()]|\([^()]*\))*\))?\s*/.freeze
+
+  # `method public void foo(int);`, `field public static final int BAR = 3;` and
+  # `public final class Baz` all carry the member name as the last token before the parameter list
+  # or the initializer.
+  def member_name(declaration)
+    declaration.to_s.gsub(ANNOTATION, "").split(/[(=]/).first.to_s.sub(/;\s*\z/, "").split.last.to_s
+  end
+
   # A member line omits its owning type, so two types in one file can add the same text. Identity is
   # therefore the text plus how many times it has already appeared in that file.
   def occurrences(declarations)
@@ -84,8 +95,20 @@ module ApiDiffReport
     {
       added: modules.flat_map { |name| by_module[name][:added].map(&:first) },
       removed: modules.flat_map { |name| by_module[name][:removed].map(&:first) },
+      new_api: modules.flat_map { |name| new_declarations(by_module[name]) },
       modules: modules
     }
+  end
+
+  # Metalava has no notion of a changed member: it renders one as a removal plus an addition of the
+  # same name. Each removal answers one addition, so an overload added beside a changed one survives.
+  def new_declarations(bucket)
+    unanswered = bucket[:removed].map { |declaration, _occurrence| member_name(declaration) }
+
+    bucket[:added].map(&:first).reject do |declaration|
+      index = unanswered.index(member_name(declaration))
+      unanswered.delete_at(index) if index
+    end
   end
 
   def empty?(report)
@@ -97,25 +120,6 @@ module ApiDiffReport
     parts << "#{report[:added].count} new declaration#{'s' if report[:added].count != 1}" if report[:added].any?
     parts << "#{report[:removed].count} removed" if report[:removed].any?
     parts.join(", ")
-  end
-
-  # `@kotlin.jvm.Throws(exceptionClasses=...)` puts a parameter list in front of the member's own,
-  # so annotations go before anything is read positionally.
-  ANNOTATION = /@[\w.]+(?:\((?:[^()]|\([^()]*\))*\))?\s*/.freeze
-
-  # `method public void foo(int);`, `field public static final int BAR = 3;` and
-  # `public final class Baz` all carry the member name as the last token before the parameter list
-  # or the initializer.
-  def member_name(declaration)
-    declaration.to_s.gsub(ANNOTATION, "").split(/[(=]/).first.to_s.sub(/;\s*\z/, "").split.last.to_s
-  end
-
-  # Metalava has no notion of a changed member: it renders one as a removal plus an addition of the
-  # same name. Only what has no removal answering it is new API.
-  def new_api(report)
-    changed = report[:removed].map { |declaration| member_name(declaration) }
-
-    report[:added].reject { |declaration| changed.include?(member_name(declaration)) }
   end
 
   def diff_lines(report)
@@ -133,8 +137,6 @@ module ApiDiffReport
     shown
   end
 
-  # Of the rendered summary, not the report: joining the declaration lists would hash an addition of
-  # a declaration the same as its removal.
   def fingerprint(message)
     Digest::SHA256.hexdigest(message.to_s)[0, 12]
   end
@@ -162,12 +164,12 @@ module ApiDiffReport
   end
 
   def slack_message(report, pull_request_link)
-    additions = new_api(report)
+    additions = report[:new_api]
     body = capped_lines(additions.map { |declaration| "+ #{declaration}" }, limit: SLACK_LIMIT, width: SLACK_WIDTH)
 
     lines = [[":sparkles: *New public API*", PLATFORM_LABEL, *report[:modules].map { |name| "`#{name}`" }].join(" · ")]
     lines << pull_request_link unless pull_request_link.to_s.empty?
-    lines << counts(added: additions, removed: [])
+    lines << "#{additions.count} new declaration#{'s' if additions.count != 1}"
     lines << "```\n#{body.join("\n")}\n```"
 
     lines.join("\n")
@@ -293,9 +295,7 @@ module ApiDiffReport
     signature_files = changed_files.uniq.select { |file| signature_file?(file) }
     report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
     return nil if empty?(report)
-    # The feed announces new API; a PR that only takes API away or reshapes it is reported on the
-    # PR alone.
-    return { comment: markdown_section(report), warning: nil } if new_api(report).empty?
+    return { comment: markdown_section(report), warning: nil } if report[:new_api].empty?
 
     message = slack_message(report, pull_request_link)
     outcome, reason = announce(message, pull_request_link, credentials, poster, getter, announced_in_comment)

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -14,7 +14,7 @@ module ApiDiffReport
   # A metalava 4.0 file holds nothing but the banner, `package … {`, `}`, types and members.
   NOISE = %r{\A(\}|package\s|//)}.freeze
 
-  SLACK_LIMIT = 10
+  SLACK_LIMIT = 5
 
   # Slack stops wrapping code blocks past this; the full list is in the PR comment.
   SLACK_WIDTH = 160
@@ -142,14 +142,15 @@ module ApiDiffReport
     lines.join("\n")
   end
 
+  # Metalava renders a changed signature as a removal plus an addition, so the addition half of one
+  # reaches the feed on its own. The removals are in the PR comment.
   def slack_message(report, pull_request_link)
-    # Metalava renders a changed signature as a removal plus an addition.
-    headline = report[:removed].any? ? ":warning: *Public API removed or changed*" : ":sparkles: *New public API*"
-    body = capped_lines(diff_lines(report), limit: SLACK_LIMIT, width: SLACK_WIDTH)
+    body = capped_lines(report[:added].map { |declaration| "+ #{declaration}" },
+                        limit: SLACK_LIMIT, width: SLACK_WIDTH)
 
-    lines = [[headline, PLATFORM_LABEL, *report[:modules].map { |name| "`#{name}`" }].join(" · ")]
+    lines = [[":sparkles: *New public API*", PLATFORM_LABEL, *report[:modules].map { |name| "`#{name}`" }].join(" · ")]
     lines << pull_request_link unless pull_request_link.to_s.empty?
-    lines << counts(report)
+    lines << counts(added: report[:added], removed: [])
     lines << "```\n#{body.join("\n")}\n```"
 
     lines.join("\n")
@@ -275,6 +276,8 @@ module ApiDiffReport
     signature_files = changed_files.uniq.select { |file| signature_file?(file) }
     report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
     return nil if empty?(report)
+    # The feed announces new API; a PR that only takes API away is reported on the PR alone.
+    return { comment: markdown_section(report), warning: nil } if report[:added].empty?
 
     message = slack_message(report, pull_request_link)
     outcome, reason = announce(message, pull_request_link, credentials, poster, getter, announced_in_comment)

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -99,6 +99,25 @@ module ApiDiffReport
     parts.join(", ")
   end
 
+  # `@kotlin.jvm.Throws(exceptionClasses=...)` puts a parameter list in front of the member's own,
+  # so annotations go before anything is read positionally.
+  ANNOTATION = /@[\w.]+(?:\((?:[^()]|\([^()]*\))*\))?\s*/.freeze
+
+  # `method public void foo(int);`, `field public static final int BAR = 3;` and
+  # `public final class Baz` all carry the member name as the last token before the parameter list
+  # or the initializer.
+  def member_name(declaration)
+    declaration.to_s.gsub(ANNOTATION, "").split(/[(=]/).first.to_s.sub(/;\s*\z/, "").split.last.to_s
+  end
+
+  # Metalava has no notion of a changed member: it renders one as a removal plus an addition of the
+  # same name. Only what has no removal answering it is new API.
+  def new_api(report)
+    changed = report[:removed].map { |declaration| member_name(declaration) }
+
+    report[:added].reject { |declaration| changed.include?(member_name(declaration)) }
+  end
+
   def diff_lines(report)
     report[:removed].map { |declaration| "- #{declaration}" } +
       report[:added].map { |declaration| "+ #{declaration}" }
@@ -142,15 +161,13 @@ module ApiDiffReport
     lines.join("\n")
   end
 
-  # Metalava renders a changed signature as a removal plus an addition, so the addition half of one
-  # reaches the feed on its own. The removals are in the PR comment.
   def slack_message(report, pull_request_link)
-    body = capped_lines(report[:added].map { |declaration| "+ #{declaration}" },
-                        limit: SLACK_LIMIT, width: SLACK_WIDTH)
+    additions = new_api(report)
+    body = capped_lines(additions.map { |declaration| "+ #{declaration}" }, limit: SLACK_LIMIT, width: SLACK_WIDTH)
 
     lines = [[":sparkles: *New public API*", PLATFORM_LABEL, *report[:modules].map { |name| "`#{name}`" }].join(" · ")]
     lines << pull_request_link unless pull_request_link.to_s.empty?
-    lines << counts(added: report[:added], removed: [])
+    lines << counts(added: additions, removed: [])
     lines << "```\n#{body.join("\n")}\n```"
 
     lines.join("\n")
@@ -276,8 +293,9 @@ module ApiDiffReport
     signature_files = changed_files.uniq.select { |file| signature_file?(file) }
     report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
     return nil if empty?(report)
-    # The feed announces new API; a PR that only takes API away is reported on the PR alone.
-    return { comment: markdown_section(report), warning: nil } if report[:added].empty?
+    # The feed announces new API; a PR that only takes API away or reshapes it is reported on the
+    # PR alone.
+    return { comment: markdown_section(report), warning: nil } if new_api(report).empty?
 
     message = slack_message(report, pull_request_link)
     outcome, reason = announce(message, pull_request_link, credentials, poster, getter, announced_in_comment)

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -27,6 +27,9 @@ class ApiDiffReportTest < Minitest::Test
        }
   PATCH
 
+  REMOVED_METHOD_PATCH = ADDED_METHOD_PATCH.sub("+    method public void apiDiffDemoPong();",
+                                                "-    method public void apiDiffDemoPong();").freeze
+
   NEW_TYPE_PATCH = <<~PATCH.freeze
     --- a/feature/amazon/api.txt
     +++ b/feature/amazon/api.txt
@@ -142,13 +145,16 @@ class ApiDiffReportTest < Minitest::Test
     assert_includes message, "+ method public void apiDiffDemoPong"
   end
 
-  def test_slack_message_warns_when_something_was_removed
+  # The feed is the new API feed: what a signature change took away is in the PR comment.
+  def test_slack_message_lists_only_what_was_added
     report = ApiDiffReport.build("ui/revenuecatui/api.txt" => SIGNATURE_CHANGE_PATCH)
 
     message = ApiDiffReport.slack_message(report, "")
 
-    assert message.start_with?(":warning: *Public API removed or changed* · Android :android: · `ui:revenuecatui`")
-    assert_includes message, "1 new declaration, 1 removed"
+    assert message.start_with?(":sparkles: *New public API* · Android :android: · `ui:revenuecatui`")
+    assert_includes message, "1 new declaration"
+    refute_includes message, "removed"
+    refute_includes message, "- method public static void apiDiffDemoPing(String value);"
     refute_includes message, "|#"
   end
 
@@ -375,18 +381,20 @@ class ApiDiffReportTest < Minitest::Test
     refute_equal ApiDiffReport.fingerprint(unchanged), ApiDiffReport.fingerprint(changed)
   end
 
-  # Hashing the declaration lists gave an addition and its removal the same fingerprint, which let
-  # the marker path swallow a removal.
-  def test_fingerprint_separates_an_addition_from_its_removal
-    added = ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH)
-    removed = ApiDiffReport.build(
-      "purchases/api-defauts.txt" => ADDED_METHOD_PATCH.sub("+    method public void apiDiffDemoPong();",
-                                                            "-    method public void apiDiffDemoPong();")
+  # A removal reaches the PR comment and the api-check gate, never the feed.
+  def test_run_reports_a_removal_on_the_pull_request_without_announcing_it
+    body = ApiDiffReport.run(
+      changed_files: ["purchases/api-defauts.txt"],
+      patch_for: ->(_file) { REMOVED_METHOD_PATCH },
+      pull_request_link: "<url|#42>",
+      credentials: CHANNEL_CREDENTIALS,
+      getter: ->(*) { raise "must not read the channel" },
+      poster: ->(*) { raise "must not post" }
     )
 
-    assert_equal ["method public void apiDiffDemoPong();"], removed[:removed]
-    refute_equal ApiDiffReport.fingerprint(ApiDiffReport.slack_message(added, "<url|#42>")),
-                 ApiDiffReport.fingerprint(ApiDiffReport.slack_message(removed, "<url|#42>"))
+    assert_includes body[:comment], "- method public void apiDiffDemoPong"
+    refute_includes body[:comment], "<!-- api-diff:"
+    assert_nil body[:warning]
   end
 
   # chat.postMessage takes a `#name`, conversations.history does not.

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -43,28 +43,25 @@ class ApiDiffReportTest < Minitest::Test
        }
   PATCH
 
-  ANNOTATED_SWAP_PATCH = <<~PATCH.freeze
+  ANNOTATED_SWAP_PATCH = ANNOTATED_SIGNATURE_CHANGE_PATCH
+                         .sub("Purchases, optional int retries, kotlin", "Purchases, kotlin")
+                         .sub("+    method @KotlinOnly @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitShowManageSubscriptions",
+                              "+    method @KotlinOnly @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitSomethingBrandNew").freeze
+
+  RENAMED_METHOD_PATCH = ADDED_METHOD_PATCH.sub("     method public void apiDiffDemoPing();",
+                                                "-    method public void apiDiffDemoPing();").freeze
+
+  # Adding an overload beside a changed one is the shape most new API lands in.
+  OVERLOAD_PATCH = <<~PATCH.freeze
     --- a/purchases/api-defauts.txt
     +++ b/purchases/api-defauts.txt
-    @@ -38,6 +38,6 @@ package com.revenuecat.purchases {
+    @@ -10,6 +10,7 @@ package com.revenuecat.purchases {
 
-       public final class CoroutinesExtensionsCommonKt {
-    -    method @KotlinOnly @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitShowManageSubscriptions(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.lang.Void>);
-    +    method @KotlinOnly @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitSomethingBrandNew(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.lang.Void>);
+       public final class Purchases {
+    -    method public void configure(android.content.Context);
+    +    method public void configure(android.content.Context, String);
+    +    method public void configure(com.revenuecat.purchases.PurchasesConfiguration);
        }
-  PATCH
-
-  RENAMED_METHOD_PATCH = <<~PATCH.freeze
-    --- a/purchases/api-defauts.txt
-    +++ b/purchases/api-defauts.txt
-    @@ -10,6 +10,6 @@ package com.revenuecat.purchases {
-
-       public final class ApiDiffDemo {
-    -    method public void apiDiffDemoPing();
-    +    method public void apiDiffDemoPong();
-       }
-
-     }
   PATCH
 
   NEW_TYPE_PATCH = <<~PATCH.freeze
@@ -182,13 +179,11 @@ class ApiDiffReportTest < Minitest::Test
     assert_includes message, "+ method public void apiDiffDemoPong"
   end
 
-  # A changed signature is an addition of a member that was removed in the same breath, and the
-  # feed announces new API, not a reshaped one.
   def test_new_api_drops_the_addition_half_of_a_signature_change
     report = ApiDiffReport.build("ui/revenuecatui/api.txt" => SIGNATURE_CHANGE_PATCH)
 
     assert_equal 1, report[:added].count
-    assert_empty ApiDiffReport.new_api(report)
+    assert_empty report[:new_api]
   end
 
   # Reading the member name at the first `(` found the annotation's parameter list, which made every
@@ -197,20 +192,36 @@ class ApiDiffReportTest < Minitest::Test
     report = ApiDiffReport.build("purchases/api-defauts.txt" => ANNOTATED_SIGNATURE_CHANGE_PATCH)
 
     assert_equal 1, report[:added].count
-    assert_empty ApiDiffReport.new_api(report)
+    assert_empty report[:new_api]
   end
 
   def test_new_api_keeps_an_annotated_addition_a_removal_does_not_answer
     report = ApiDiffReport.build("purchases/api-defauts.txt" => ANNOTATED_SWAP_PATCH)
 
-    assert_equal 1, ApiDiffReport.new_api(report).count
-    assert_includes ApiDiffReport.new_api(report).first, "awaitSomethingBrandNew"
+    assert_equal 1, report[:new_api].count
+    assert_includes report[:new_api].first, "awaitSomethingBrandNew"
   end
 
   def test_new_api_keeps_an_addition_no_removal_answers
     report = ApiDiffReport.build("purchases/api-defauts.txt" => RENAMED_METHOD_PATCH)
 
-    assert_equal ["method public void apiDiffDemoPong();"], ApiDiffReport.new_api(report)
+    assert_equal ["method public void apiDiffDemoPong();"], report[:new_api]
+  end
+
+  def test_new_api_keeps_an_overload_added_beside_a_changed_one
+    report = ApiDiffReport.build("purchases/api-defauts.txt" => OVERLOAD_PATCH)
+
+    assert_equal ["method public void configure(com.revenuecat.purchases.PurchasesConfiguration);"], report[:new_api]
+  end
+
+  # A declaration line omits its owning type, so pairing across modules cancels unrelated members.
+  def test_new_api_does_not_answer_an_addition_with_another_modules_removal
+    report = ApiDiffReport.build(
+      "purchases/api-defauts.txt" => REMOVED_METHOD_PATCH,
+      "ui/revenuecatui/api.txt" => ADDED_METHOD_PATCH
+    )
+
+    assert_equal ["method public void apiDiffDemoPong();"], report[:new_api]
   end
 
   def test_slack_message_lists_only_what_was_added
@@ -448,7 +459,6 @@ class ApiDiffReportTest < Minitest::Test
     refute_equal ApiDiffReport.fingerprint(unchanged), ApiDiffReport.fingerprint(changed)
   end
 
-  # A removal reaches the PR comment and the api-check gate, never the feed.
   def test_run_reports_a_removal_on_the_pull_request_without_announcing_it
     body = run_without_slack(REMOVED_METHOD_PATCH)
 

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -30,6 +30,43 @@ class ApiDiffReportTest < Minitest::Test
   REMOVED_METHOD_PATCH = ADDED_METHOD_PATCH.sub("+    method public void apiDiffDemoPong();",
                                                 "-    method public void apiDiffDemoPong();").freeze
 
+  # Real declarations carry annotations, and `@kotlin.jvm.Throws(...)` opens a parameter list of its
+  # own before the member's.
+  ANNOTATED_SIGNATURE_CHANGE_PATCH = <<~PATCH.freeze
+    --- a/purchases/api-defauts.txt
+    +++ b/purchases/api-defauts.txt
+    @@ -38,6 +38,6 @@ package com.revenuecat.purchases {
+
+       public final class CoroutinesExtensionsCommonKt {
+    -    method @KotlinOnly @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitShowManageSubscriptions(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.lang.Void>);
+    +    method @KotlinOnly @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitShowManageSubscriptions(com.revenuecat.purchases.Purchases, optional int retries, kotlin.coroutines.Continuation<? super java.lang.Void>);
+       }
+  PATCH
+
+  ANNOTATED_SWAP_PATCH = <<~PATCH.freeze
+    --- a/purchases/api-defauts.txt
+    +++ b/purchases/api-defauts.txt
+    @@ -38,6 +38,6 @@ package com.revenuecat.purchases {
+
+       public final class CoroutinesExtensionsCommonKt {
+    -    method @KotlinOnly @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitShowManageSubscriptions(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.lang.Void>);
+    +    method @KotlinOnly @kotlin.jvm.Throws(exceptionClasses={com.revenuecat.purchases.PurchasesException.class}) public static suspend Object? awaitSomethingBrandNew(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.lang.Void>);
+       }
+  PATCH
+
+  RENAMED_METHOD_PATCH = <<~PATCH.freeze
+    --- a/purchases/api-defauts.txt
+    +++ b/purchases/api-defauts.txt
+    @@ -10,6 +10,6 @@ package com.revenuecat.purchases {
+
+       public final class ApiDiffDemo {
+    -    method public void apiDiffDemoPing();
+    +    method public void apiDiffDemoPong();
+       }
+
+     }
+  PATCH
+
   NEW_TYPE_PATCH = <<~PATCH.freeze
     --- a/feature/amazon/api.txt
     +++ b/feature/amazon/api.txt
@@ -145,16 +182,46 @@ class ApiDiffReportTest < Minitest::Test
     assert_includes message, "+ method public void apiDiffDemoPong"
   end
 
-  # The feed is the new API feed: what a signature change took away is in the PR comment.
-  def test_slack_message_lists_only_what_was_added
+  # A changed signature is an addition of a member that was removed in the same breath, and the
+  # feed announces new API, not a reshaped one.
+  def test_new_api_drops_the_addition_half_of_a_signature_change
     report = ApiDiffReport.build("ui/revenuecatui/api.txt" => SIGNATURE_CHANGE_PATCH)
+
+    assert_equal 1, report[:added].count
+    assert_empty ApiDiffReport.new_api(report)
+  end
+
+  # Reading the member name at the first `(` found the annotation's parameter list, which made every
+  # annotated declaration answer every other one.
+  def test_new_api_drops_an_annotated_signature_change
+    report = ApiDiffReport.build("purchases/api-defauts.txt" => ANNOTATED_SIGNATURE_CHANGE_PATCH)
+
+    assert_equal 1, report[:added].count
+    assert_empty ApiDiffReport.new_api(report)
+  end
+
+  def test_new_api_keeps_an_annotated_addition_a_removal_does_not_answer
+    report = ApiDiffReport.build("purchases/api-defauts.txt" => ANNOTATED_SWAP_PATCH)
+
+    assert_equal 1, ApiDiffReport.new_api(report).count
+    assert_includes ApiDiffReport.new_api(report).first, "awaitSomethingBrandNew"
+  end
+
+  def test_new_api_keeps_an_addition_no_removal_answers
+    report = ApiDiffReport.build("purchases/api-defauts.txt" => RENAMED_METHOD_PATCH)
+
+    assert_equal ["method public void apiDiffDemoPong();"], ApiDiffReport.new_api(report)
+  end
+
+  def test_slack_message_lists_only_what_was_added
+    report = ApiDiffReport.build("purchases/api-defauts.txt" => RENAMED_METHOD_PATCH)
 
     message = ApiDiffReport.slack_message(report, "")
 
-    assert message.start_with?(":sparkles: *New public API* · Android :android: · `ui:revenuecatui`")
+    assert message.start_with?(":sparkles: *New public API* · Android :android: · `purchases`")
     assert_includes message, "1 new declaration"
     refute_includes message, "removed"
-    refute_includes message, "- method public static void apiDiffDemoPing(String value);"
+    refute_includes message, "- method public void apiDiffDemoPing();"
     refute_includes message, "|#"
   end
 
@@ -286,7 +353,7 @@ class ApiDiffReportTest < Minitest::Test
   # What the PR touches changes the module list, so the modules cannot be part of the identity.
   def test_last_announcement_matches_a_previous_announcement_of_other_modules
     previous = ApiDiffReport.slack_message(
-      ApiDiffReport.build("ui/revenuecatui/api.txt" => SIGNATURE_CHANGE_PATCH), "<url|#42>"
+      ApiDiffReport.build("feature/amazon/api.txt" => NEW_TYPE_PATCH), "<url|#42>"
     )
 
     assert_equal previous, ApiDiffReport.last_announcement([previous], "<url|#42>")
@@ -383,18 +450,30 @@ class ApiDiffReportTest < Minitest::Test
 
   # A removal reaches the PR comment and the api-check gate, never the feed.
   def test_run_reports_a_removal_on_the_pull_request_without_announcing_it
-    body = ApiDiffReport.run(
+    body = run_without_slack(REMOVED_METHOD_PATCH)
+
+    assert_includes body[:comment], "- method public void apiDiffDemoPong"
+    refute_includes body[:comment], "<!-- api-diff:"
+    assert_nil body[:warning]
+  end
+
+  def test_run_reports_a_signature_change_on_the_pull_request_without_announcing_it
+    body = run_without_slack(SIGNATURE_CHANGE_PATCH)
+
+    assert_includes body[:comment], "- method public static void apiDiffDemoPing(String value);"
+    assert_includes body[:comment], "+ method public static void apiDiffDemoPing(String value, optional int count);"
+    refute_includes body[:comment], "<!-- api-diff:"
+  end
+
+  def run_without_slack(patch)
+    ApiDiffReport.run(
       changed_files: ["purchases/api-defauts.txt"],
-      patch_for: ->(_file) { REMOVED_METHOD_PATCH },
+      patch_for: ->(_file) { patch },
       pull_request_link: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
       getter: ->(*) { raise "must not read the channel" },
       poster: ->(*) { raise "must not post" }
     )
-
-    assert_includes body[:comment], "- method public void apiDiffDemoPong"
-    refute_includes body[:comment], "<!-- api-diff:"
-    assert_nil body[:warning]
   end
 
   # chat.postMessage takes a `#name`, conversations.history does not.


### PR DESCRIPTION
WIP

iOS counterpart: https://github.com/RevenueCat/purchases-ios/pull/7501