### PR TITLE
chore: don't run danger on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -973,6 +973,9 @@ workflows:
             - run:
                 name: Run api diff report unit tests
                 command: ruby danger/api_diff_report_test.rb
+          filters:
+            branches:
+              ignore: main
 
   snapshot-deploy-manual:
     when:


### PR DESCRIPTION
Danger runs on every push to `main`, but there's no PR there for it to comment on.

Added a branch filter to the danger job so it skips `main`. `cordova-plugin-purchases` already did this, this brings the rest of the SDK repos in line. Release and snapshot branches are unchanged.

### Verification
- [x] `circleci config validate .circleci/config.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only branch filter on the Danger job; no application or release pipeline behavior changes.
> 
> **Overview**
> The **`danger`** workflow’s `revenuecat/danger` job now has **`branches: ignore: main`**, so CircleCI no longer runs Danger (and the post-step **`api_diff_report_test.rb`**) on pushes to **`main`**.
> 
> Danger is meant to comment on pull requests; on **`main`** there is no PR, so those runs were wasted. Feature and release branches are unaffected unless they are **`main`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35843e3aed9866a6e56d06e0fb766eabaa6b3de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->