### PR TITLE
docs: document CHECKPOINT_TESTER_API_KEY in local.properties.example

### DIFF
--- a/local.properties.example
+++ b/local.properties.example
@@ -19,6 +19,13 @@
 #PURCHASE_TESTER_API_KEY=your_key
 
 ## ──────────────────────────────────────────────
+## Checkpoint Tester (examples/checkpointtester)
+## Falls back to PAYWALL_TESTER_API_KEY_A when unset, since both apps
+## share the same applicationId and store project.
+## ──────────────────────────────────────────────
+#CHECKPOINT_TESTER_API_KEY=your_key
+
+## ──────────────────────────────────────────────
 ## E2E Tester — workflow Maestro flows (maestro/workflows/)
 ## Test-store key for the dedicated E2E project that hosts the `default_workflows`
 ## offering. When set, the e2etests app configures against it with workflows enabled.


### PR DESCRIPTION
## What changed

`examples/checkpointtester` reads `CHECKPOINT_TESTER_API_KEY` at build time (`examples/checkpointtester/build.gradle.kts:44-48`), falling back to `PAYWALL_TESTER_API_KEY_A` when it isn't set. It was the only tester key with no entry in `local.properties.example`, so there was nothing pointing at it outside the app's own README.

Adds a commented entry in the same style as the neighboring tester sections, noting the fallback.

## Verification
- [ ] :purchases:testDefaultsDebugUnitTest
- [ ] :purchases:testCustomEntitlementComputationDebugUnitTest (shared :purchases code)
- [ ] :ui:revenuecatui:testDefaultsDebugUnitTest (if UI module touched)
- [ ] detektAll
- [ ] scripts/api-check.sh