### PR TITLE
fix(paywalls): give the in-progress flag a single owner

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -140,7 +140,7 @@ internal fun ButtonComponentView(
                     onStackClick = onStackClick@{
                         val paywallAction = buttonState.action ?: return@onStackClick
                         myActionInProgress = true
-                        state.update(actionInProgress = true)
+                        state.update(clickScopedActionInProgress = true)
                         if (style.action.isPurchaseRelated()) {
                             val currentPackage = packageForPurchaseButtonInteraction(style.action, state)
                             val componentUrl = resolvedWebCheckoutInteractionUrl(
@@ -177,7 +177,7 @@ internal fun ButtonComponentView(
                                 onClick(paywallAction)
                             } finally {
                                 myActionInProgress = false
-                                state.update(actionInProgress = false)
+                                state.update(clickScopedActionInProgress = false)
                             }
                         }
                     },

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -130,6 +131,8 @@ internal sealed interface PaywallState {
              * Presentation-session store for state-driven paywalls, seeded from the paywall's declared state defaults.
              */
             val stateStore: PaywallStateStore = PaywallStateStore(emptyMap()),
+            /** The view model's gate, so every step of a workflow reads the one flag. */
+            private val viewModelActionInProgress: State<Boolean> = mutableStateOf(false),
         ) : Loaded {
 
             /**
@@ -335,15 +338,23 @@ internal sealed interface PaywallState {
             var footerHeightPx: Int = 0
                 @JvmSynthetic internal set
 
-            var actionInProgress by mutableStateOf(false)
+            /** Raised and cleared by the button, for the actions that begin and end with the click. */
+            var clickScopedActionInProgress by mutableStateOf(false)
                 private set
+
+            /**
+             * Read live rather than mirrored, so an action that outlives the button that started it keeps
+             * the paywall disabled after [clickScopedActionInProgress] is cleared by the click's cancellation.
+             */
+            val actionInProgress: Boolean
+                get() = viewModelActionInProgress.value || clickScopedActionInProgress
 
             val sheet = initialSheetState
 
             fun update(
                 localeList: FrameworkLocaleList? = null,
                 selectedTabIndex: Int? = null,
-                actionInProgress: Boolean? = null,
+                clickScopedActionInProgress: Boolean? = null,
             ) {
                 if (localeList != null) localeId = LocaleList(localeList.toLanguageTags()).toLocaleId()
 
@@ -374,7 +385,9 @@ internal sealed interface PaywallState {
                         ?: visibleFallbackForHiddenDefaultOutsideTabs
                 }
 
-                if (actionInProgress != null) this.actionInProgress = actionInProgress
+                if (clickScopedActionInProgress != null) {
+                    this.clickScopedActionInProgress = clickScopedActionInProgress
+                }
             }
 
             fun update(selectedPackageUniqueId: String) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -1604,6 +1604,7 @@ internal class PaywallViewModelImpl(
                 customVariables = options.customVariables,
                 defaultCustomVariables = extractDefaultCustomVariables(offering),
                 stateStore = stateStore,
+                viewModelActionInProgress = _actionInProgress,
             )
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -3,6 +3,8 @@
 package com.revenuecat.purchases.ui.revenuecatui.helpers
 
 import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import com.revenuecat.purchases.FontAlias
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.PaywallData
@@ -367,6 +369,7 @@ internal fun Offering.toComponentsPaywallState(
     customVariables: Map<String, CustomVariableValue> = emptyMap(),
     defaultCustomVariables: Map<String, CustomVariableValue> = emptyMap(),
     stateStore: PaywallStateStore? = null,
+    viewModelActionInProgress: State<Boolean> = mutableStateOf(false),
 ): PaywallState.Loaded.Components {
     val showPricesWithDecimals = storefrontCountryCode?.let {
         !validationResult.zeroDecimalPlaceCountries.contains(it)
@@ -397,6 +400,7 @@ internal fun Offering.toComponentsPaywallState(
         mainStackHasHeroImage = validationResult.mainStackHasHeroImage,
         purchases = purchases,
         stateStore = resolvedStateStore,
+        viewModelActionInProgress = viewModelActionInProgress,
     )
 }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -141,7 +143,6 @@ class ButtonComponentViewTests {
                     state = state,
                     onClick = {
                         clickStarted.complete(Unit)
-                        // A billing flow still in front when the paywall goes away.
                         awaitCancellation()
                     },
                 )
@@ -159,6 +160,68 @@ class ButtonComponentViewTests {
 
         // Without the cleanup this stays true and every button on the paywall stays disabled.
         assertThat(state.actionInProgress).isFalse
+    }
+
+    @Test
+    fun `an action outliving the click keeps the paywall disabled`() {
+        val viewModelActionInProgress = mutableStateOf(false)
+        val state = FakePaywallState(
+            packages = listOf(TestData.Packages.annual),
+            viewModelActionInProgress = viewModelActionInProgress,
+        )
+        val clickStarted = CompletableDeferred<Unit>()
+        var buttonRendered by mutableStateOf(true)
+
+        composeTestRule.setContent {
+            if (buttonRendered) {
+                ButtonComponentView(
+                    style = purchaseButtonStyle,
+                    state = state,
+                    onClick = {
+                        clickStarted.complete(Unit)
+                        // The billing flow is still in front when the paywall goes away.
+                        awaitCancellation()
+                    },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Purchase").performClick()
+        composeTestRule.waitForIdle()
+        assertThat(clickStarted.isCompleted).isTrue
+
+        // The view model takes its gate for an action that outlives this composition.
+        viewModelActionInProgress.value = true
+        buttonRendered = false
+        composeTestRule.waitForIdle()
+
+        // The button cleared its own half, but the gate still holds the paywall.
+        assertThat(state.clickScopedActionInProgress).isFalse
+        assertThat(state.actionInProgress).isTrue
+
+        viewModelActionInProgress.value = false
+        assertThat(state.actionInProgress).isFalse
+    }
+
+    @Test
+    fun `the gate disables the button through recomposition`() {
+        val viewModelActionInProgress = mutableStateOf(false)
+        val state = FakePaywallState(
+            packages = listOf(TestData.Packages.annual),
+            viewModelActionInProgress = viewModelActionInProgress,
+        )
+
+        composeTestRule.setContent {
+            ButtonComponentView(style = purchaseButtonStyle, state = state, onClick = {})
+        }
+
+        val purchaseButton = composeTestRule.onNodeWithText("Purchase")
+        purchaseButton.assertIsEnabled()
+
+        // `actionInProgress` is computed, so this pins that Compose still tracks the reads inside it.
+        viewModelActionInProgress.value = true
+        composeTestRule.waitForIdle()
+        purchaseButton.assertIsNotEnabled()
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -1918,6 +1918,37 @@ class PaywallViewModelTest {
     }
 
     @Test
+    fun `the components state flag follows the action, not the caller`(): Unit = runBlocking {
+        // Arrange
+        val model = createComponentsModel()
+        val componentsState = model.state.value as PaywallState.Loaded.Components
+        val purchaseStarted = CompletableDeferred<Unit>()
+        val storeResolved = CompletableDeferred<Unit>()
+        coEvery { purchases.awaitPurchase(any()) } coAnswers {
+            purchaseStarted.complete(Unit)
+            storeResolved.await()
+            throw PurchasesException(PurchasesError(PurchasesErrorCode.PurchaseCancelledError))
+        }
+
+        // Act: the button's composition scope dies while the billing flow is in front.
+        val buttonScope = CoroutineScope(coroutineContext + Job())
+        val click = buttonScope.launch { model.handlePackagePurchase(activity, pkg = null) }
+        withTimeout(TEST_WAIT_MS) { purchaseStarted.await() }
+        click.cancelAndJoin()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        // Assert: the flag the button tree reads must still be up, otherwise the recreated paywall
+        // shows enabled buttons whose taps the gate silently refuses.
+        assertThat(componentsState.actionInProgress).isTrue
+
+        storeResolved.complete(Unit)
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertThat(componentsState.actionInProgress).isFalse
+        assertThat(model.actionInProgress.value).isFalse
+    }
+
+    @Test
     fun `purchase vetoed by the listener releases the action`(): Unit = runBlocking {
         // Arrange
         val model = create()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallState.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallState.kt
@@ -1,5 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.extensions
 
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.data.MockPurchasesType
@@ -24,6 +26,7 @@ internal fun Offering.toComponentsPaywallState(
     dateProvider: () -> Date = { Date() },
     purchases: PurchasesType = MockPurchasesType(),
     customVariables: Map<String, CustomVariableValue> = emptyMap(),
+    viewModelActionInProgress: State<Boolean> = mutableStateOf(false),
 ): PaywallState.Loaded.Components =
     actualToComponentsPaywallState(
         validationResult = validationResult,
@@ -31,6 +34,7 @@ internal fun Offering.toComponentsPaywallState(
         dateProvider = dateProvider,
         purchases = purchases,
         customVariables = customVariables,
+        viewModelActionInProgress = viewModelActionInProgress,
     )
 
 /**

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/FakePaywallState.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/FakePaywallState.kt
@@ -2,6 +2,8 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.helpers
 
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.revenuecat.purchases.Offering
@@ -61,6 +63,7 @@ internal fun FakePaywallState(
     customVariables: Map<String, CustomVariableValue> = emptyMap(),
     header: HeaderComponent? = null,
     stickyFooter: StickyFooterComponent? = null,
+    viewModelActionInProgress: State<Boolean> = mutableStateOf(false),
 ): PaywallState.Loaded.Components {
     val packageComponents = packages.map { pkg ->
         PackageComponent(
@@ -92,5 +95,9 @@ internal fun FakePaywallState(
         paywallComponents = Offering.PaywallComponents(UiConfig(), data),
     )
     val validated = offering.validatePaywallComponentsDataOrNull()?.getOrThrow()!!
-    return offering.toComponentsPaywallState(validated, customVariables = customVariables)
+    return offering.toComponentsPaywallState(
+        validated,
+        customVariables = customVariables,
+        viewModelActionInProgress = viewModelActionInProgress,
+    )
 }


### PR DESCRIPTION
## Problem

Stacked on #4071, addressing https://github.com/RevenueCat/purchases-android/pull/4071#discussion_r3851226336.

The paywall keeps two copies of "an action is running":

- `_actionInProgress` in `PaywallViewModel`, which gates purchase and restore
- `actionInProgress` on `PaywallState.Loaded.Components`, which is what the button tree reads to disable itself

The button owned the second one on both edges. That is fine for navigation, which starts and finishes with the click, but wrong for purchase and restore, which outlive it. A button torn down mid purchase (the forced rotation from #4071, a workflow step change, a tab switch) cleared the flag while the view model still held its gate, so the paywall came back with buttons that looked enabled but whose taps were silently refused.

It is most visible on restore, since nothing covers the screen while it runs.

## Fix

`Components.actionInProgress` becomes a computed read over two separately owned inputs, per @vegaro's suggestion in https://github.com/RevenueCat/purchases-android/pull/4081#discussion_r3862722709:

```kotlin
var localActionInProgress by mutableStateOf(false)   // the button's own click
    private set

val actionInProgress: Boolean
    get() = exclusiveActionInProgress.value || localActionInProgress
```

`exclusiveActionInProgress` is the view model's gate, passed in and read live rather than mirrored. A cancelled click drops the local half while the gate keeps the paywall disabled.

Neither owner has to know what the other is doing, so `ButtonComponentView` goes back to raising and clearing unconditionally, and no action needs classifying. Every step of a workflow holds the same `State<Boolean>`, so there is nothing to keep in sync.

## Tests

- `an action outliving the click keeps the paywall disabled`, the click's cancellation drops `localActionInProgress` while the gate keeps `actionInProgress` up
- `the gate disables the button through recomposition`, pins that Compose still tracks the reads inside the computed getter
- `the components state flag follows the action, not the caller`, the same thing end to end through a real purchase that outlives its caller

RED check: reverting the `|| localActionInProgress` half of the getter fails `an action outliving the click keeps the paywall disabled` and `the components state flag follows the action, not the caller`.

`./gradlew :ui:revenuecatui:testDefaultsDebugUnitTest detektAll`, 1756 tests, 1 pre-existing failure (`PaywallComponentsTemplatePreviewRecorder`, missing `paywall-preview-resources` submodule locally, fails on the base branch too), detekt clean. `./scripts/api-check.sh` clean.

<details>
<summary>AI session context</summary>

## Metadata

- Branch: `facu/paywall-action-in-progress-single-owner`
- Base: #4071 @ `afcdbe7c5`
- Agent: Claude Opus 5 (1M context), Claude Code
- Human: @facumenzella
- Scope: follow-up bug fix plus tests, no public API change

## Original request

Review of #4071, then @vegaro's comment on the `finally` block. The human asked what it would take to fix it in #4071 itself, then to open this as a stacked draft. After @vegaro pushed back on the first design, the human asked to implement his instead.

## What the agent contributed

- Confirmed the original report against the code: `state.update(actionInProgress = true)` at `ButtonComponentView.kt:143` is unconditional, before the `isPurchaseRelated()` branch (that check only picks which analytics event fires), so restore buttons set the shared flag too. Only `handlePackagePurchase` and `handleRestorePurchases` take the view model gate.
- Two corrections to that report: it is the button, not the view model, that raises `state.actionInProgress`, and the trigger is not only rotation, anything that takes the button out of composition mid action does it.
- Wrote the tests first, then the fix, then reverted the fix to confirm RED.

## Decision log

- `Decision:` adopt @vegaro's computed-getter design over the agent's first attempt. `Rejected:` an `isViewModelGated()` predicate plus a mirror in the view model, on his objection that a new `Action` would have to be added to it. `Why it is better:` the button never needed to know whether an action is gated. The OR gets the same behaviour with no classification, no mirror, and no workflow cache sweep, since every step holds the same `State<Boolean>`. It also removes a hazard the first design had introduced, where the `activity == null` path in `rememberPaywallActionHandler` never reaches the gate and would have stranded the flag permanently.
- `Decision:` pin the computed getter with a recomposition test, not just a value assertion. Reading through `by state::actionInProgress` on a computed property should still track both snapshot reads, but that is the one thing this design relies on that the old field did not.
- `Decision:` stack rather than amend #4071. #4071 is a strict improvement on its own (a permanently dead button becomes a transient one).

## Files

- `ui/revenuecatui/.../data/PaywallState.kt` — `localActionInProgress`, computed `actionInProgress`
- `ui/revenuecatui/.../helpers/OfferingToStateMapper.kt` — threads the gate through
- `ui/revenuecatui/.../data/PaywallViewModel.kt` — passes `_actionInProgress`
- `ui/revenuecatui/.../components/button/ButtonComponentViewTests.kt`, `.../data/PaywallViewModelTest.kt`, `.../helpers/FakePaywallState.kt`, `.../extensions/PaywallState.kt`

## Validation gaps

- `Not run:` on a device. The rotation repro from #4071 was not re-run against this branch.
- `Not covered:` a workflow that navigates away mid action. The design makes it correct by construction (one shared `State<Boolean>`) rather than by a sweep, but no test walks it.
- `Known gap, not fixed:` `myActionInProgress` is `remember`ed, so after a recreation mid action the paywall is correctly disabled but shows no spinner on the button that started it.
- `Not run:` Paparazzi snapshots, missing `paywall-preview-resources` submodule locally.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall purchase/restore gating and button enablement—user-visible if the OR logic or State wiring is wrong, but scope is internal UI state with strong test coverage and no public API change.
> 
> **Overview**
> Fixes a bug where **purchase and restore** could still be running in `PaywallViewModel` while the components paywall looked interactive again. The button tree used a single `actionInProgress` flag that the button raised and cleared around its click coroutine; when composition dropped mid-flow (rotation, workflow step, tab), cancellation cleared that flag even though the view model gate was still held—**enabled buttons whose taps were silently ignored** (restore was especially visible).
> 
> **`PaywallState.Loaded.Components`** now splits ownership: the button only toggles **`clickScopedActionInProgress`**, while **`actionInProgress`** is a computed read of the view model’s **`_actionInProgress`** (passed in as `viewModelActionInProgress` from `PaywallViewModel` / `OfferingToStateMapper`) OR the click-scoped flag. Long-running store actions keep the paywall disabled after the click scope dies; short navigation-only clicks still release when the button’s `finally` runs.
> 
> `ButtonComponentView` continues to drive disable/progress from `state.actionInProgress` but updates **`clickScopedActionInProgress`** only. Tests cover outliving actions, Compose recomposition on the computed getter, and end-to-end purchase when the caller scope is cancelled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc8fff772e0b6d4bd524fd83dc1e267a7bb2218b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->