### PR TITLE
Refresh remote config after posting receipts

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.models.PurchaseState
@@ -31,6 +32,7 @@ internal class PostPendingTransactionsHelper(
     private val identityManager: IdentityManager,
     private val postTransactionWithProductDetailsHelper: PostTransactionWithProductDetailsHelper,
     private val postReceiptHelper: PostReceiptHelper,
+    private val remoteConfigManager: RemoteConfigManager?,
 ) {
 
     @Suppress("LongMethod")
@@ -84,13 +86,13 @@ internal class PostPendingTransactionsHelper(
                                 allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
                                 pendingTransactionsTokens = pendingTransactionsTokens,
                                 onNoTransactionsToSync = {
-                                    callback?.invoke(SyncPendingPurchaseResult.NoPendingPurchasesToSync)
+                                    completeSync(SyncPendingPurchaseResult.NoPendingPurchasesToSync, callback)
                                 },
                                 onError = {
-                                    callback?.invoke(SyncPendingPurchaseResult.Error(it))
+                                    completeSync(SyncPendingPurchaseResult.Error(it), callback)
                                 },
                                 onSuccess = {
-                                    callback?.invoke(SyncPendingPurchaseResult.Success(it))
+                                    completeSync(SyncPendingPurchaseResult.Success(it), callback)
                                 },
                             )
                         },
@@ -101,13 +103,13 @@ internal class PostPendingTransactionsHelper(
                                 pendingTransactionsTokens = pendingTransactionsTokens,
                                 onNoTransactionsToSync = {
                                     log(LogIntent.DEBUG) { PurchaseStrings.NO_PENDING_PURCHASES_TO_SYNC }
-                                    callback?.invoke(SyncPendingPurchaseResult.Error(error))
+                                    completeSync(SyncPendingPurchaseResult.Error(error), callback)
                                 },
                                 onError = {
-                                    callback?.invoke(SyncPendingPurchaseResult.Error(error))
+                                    completeSync(SyncPendingPurchaseResult.Error(error), callback)
                                 },
                                 onSuccess = {
-                                    callback?.invoke(SyncPendingPurchaseResult.Success(it))
+                                    completeSync(SyncPendingPurchaseResult.Success(it), callback)
                                 },
                             )
                         },
@@ -118,13 +120,13 @@ internal class PostPendingTransactionsHelper(
                                 pendingTransactionsTokens = pendingTransactionsTokens,
                                 onNoTransactionsToSync = {
                                     log(LogIntent.DEBUG) { PurchaseStrings.NO_PENDING_PURCHASES_TO_SYNC }
-                                    callback?.invoke(SyncPendingPurchaseResult.Success(customerInfo))
+                                    completeSync(SyncPendingPurchaseResult.Success(customerInfo), callback)
                                 },
                                 onError = {
-                                    callback?.invoke(SyncPendingPurchaseResult.Error(it))
+                                    completeSync(SyncPendingPurchaseResult.Error(it), callback)
                                 },
                                 onSuccess = {
-                                    callback?.invoke(SyncPendingPurchaseResult.Success(it))
+                                    completeSync(SyncPendingPurchaseResult.Success(it), callback)
                                 },
                             )
                         },
@@ -136,6 +138,22 @@ internal class PostPendingTransactionsHelper(
                 },
             )
         })
+    }
+
+    // Funnels every outcome that may follow successful posts, even when there is no callback to hold.
+    private fun completeSync(
+        result: SyncPendingPurchaseResult,
+        callback: ((SyncPendingPurchaseResult) -> Unit)?,
+    ) {
+        val manager = remoteConfigManager
+        if (manager == null) {
+            callback?.invoke(result)
+            return
+        }
+        manager.awaitPostReceiptRefresh(
+            appInBackground = appConfig.isAppBackgrounded,
+            appUserID = identityManager.currentAppUserID,
+        ) { callback?.invoke(result) }
     }
 
     @SuppressWarnings("LongParameterList")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
@@ -150,7 +150,7 @@ internal class PostPendingTransactionsHelper(
             callback?.invoke(result)
             return
         }
-        manager.awaitPostReceiptRefresh(
+        manager.ensurePostReceiptRefresh(
             appInBackground = appConfig.isAppBackgrounded,
             appUserID = identityManager.currentAppUserID,
         ) { callback?.invoke(result) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.common.caching.WorkflowMetadata
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.networking.PostReceiptResponse
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
@@ -39,6 +40,7 @@ constructor(
     private val offlineEntitlementsManager: OfflineEntitlementsManager,
     private val paywallPresentedCache: PaywallPresentedCache,
     private val localTransactionMetadataStore: LocalTransactionMetadataStore,
+    private val remoteConfigManager: RemoteConfigManager?,
 ) {
     private val finishTransactions: Boolean
         get() = appConfig.finishTransactions
@@ -373,6 +375,7 @@ constructor(
                         postReceiptResponse.body.getAttributeErrors(),
                     )
                     customerInfoUpdateHandler.cacheAndNotifyListeners(postReceiptResponse.customerInfo)
+                    remoteConfigManager?.onReceiptPosted()
                     onSuccess(postReceiptResponse)
                 },
                 onError = { error, errorHandlingBehavior, responseBody ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -424,6 +424,7 @@ internal class PurchasesFactory(
                 offlineEntitlementsManager,
                 paywallPresentedCache,
                 localTransactionMetadataStore,
+                remoteConfigManager,
             )
 
             val postTransactionWithProductDetailsHelper = PostTransactionWithProductDetailsHelper(
@@ -439,6 +440,7 @@ internal class PurchasesFactory(
                 identityManager,
                 postTransactionWithProductDetailsHelper,
                 postReceiptHelper,
+                remoteConfigManager,
             )
 
             val customerInfoHelper = CustomerInfoHelper(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -1487,7 +1487,7 @@ internal class PurchasesOrchestrator(
     /** Runs [onComplete] once remote config reflects any receipts this operation posted (see the manager). */
     private fun afterPostReceiptRemoteConfigRefresh(onComplete: () -> Unit) {
         val manager = remoteConfigManager ?: return onComplete()
-        manager.awaitPostReceiptRefresh(state.appInBackground, identityManager.currentAppUserID, onComplete)
+        manager.ensurePostReceiptRefresh(state.appInBackground, identityManager.currentAppUserID, onComplete)
     }
 
     private fun shouldRefreshCustomerInfo(firstTimeInForeground: Boolean): Boolean {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -546,8 +546,8 @@ internal class PurchasesOrchestrator(
         syncPurchasesHelper.syncPurchases(
             isRestore = this.allowSharingPlayStoreAccount,
             appInBackground = this.state.appInBackground,
-            onSuccess = { afterPostReceiptRemoteConfigRefresh { listener?.onSuccess(it) } },
-            onError = { afterPostReceiptRemoteConfigRefresh { listener?.onError(it) } },
+            onSuccess = { afterPostReceiptRemoteConfigRefresh { dispatch { listener?.onSuccess(it) } } },
+            onError = { afterPostReceiptRemoteConfigRefresh { dispatch { listener?.onError(it) } } },
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -546,8 +546,8 @@ internal class PurchasesOrchestrator(
         syncPurchasesHelper.syncPurchases(
             isRestore = this.allowSharingPlayStoreAccount,
             appInBackground = this.state.appInBackground,
-            onSuccess = { listener?.onSuccess(it) },
-            onError = { listener?.onError(it) },
+            onSuccess = { afterPostReceiptRemoteConfigRefresh { listener?.onSuccess(it) } },
+            onError = { afterPostReceiptRemoteConfigRefresh { listener?.onError(it) } },
         )
     }
 
@@ -591,6 +591,7 @@ internal class PurchasesOrchestrator(
                         log(LogIntent.PURCHASE) {
                             PurchaseStrings.PURCHASE_SYNCED_USER_ID.format(receiptID, amazonUserID)
                         }
+                        afterPostReceiptRemoteConfigRefresh { }
                     },
                     { error ->
                         log(LogIntent.RC_ERROR) {
@@ -857,15 +858,20 @@ internal class PurchasesOrchestrator(
                                     onSuccess = { _, info ->
                                         log(LogIntent.DEBUG) { RestoreStrings.PURCHASE_RESTORED.format(purchase) }
                                         if (sortedByTime.last() == purchase) {
-                                            dispatch { callbackWithTracking.onReceived(info) }
+                                            afterPostReceiptRemoteConfigRefresh {
+                                                dispatch { callbackWithTracking.onReceived(info) }
+                                            }
                                         }
                                     },
                                     onError = { _, error ->
                                         log(LogIntent.RC_ERROR) {
                                             RestoreStrings.RESTORING_PURCHASE_ERROR.format(purchase, error)
                                         }
+                                        // Earlier restores in this loop may have posted successfully.
                                         if (sortedByTime.last() == purchase) {
-                                            dispatch { callbackWithTracking.onError(error) }
+                                            afterPostReceiptRemoteConfigRefresh {
+                                                dispatch { callbackWithTracking.onError(error) }
+                                            }
                                         }
                                     },
                                 )
@@ -1478,6 +1484,12 @@ internal class PurchasesOrchestrator(
         dispatcher.enqueue({ command() }, Delay.NONE)
     }
 
+    /** Runs [onComplete] once remote config reflects any receipts this operation posted (see the manager). */
+    private fun afterPostReceiptRemoteConfigRefresh(onComplete: () -> Unit) {
+        val manager = remoteConfigManager ?: return onComplete()
+        manager.awaitPostReceiptRefresh(state.appInBackground, identityManager.currentAppUserID, onComplete)
+    }
+
     private fun shouldRefreshCustomerInfo(firstTimeInForeground: Boolean): Boolean {
         return !appConfig.customEntitlementComputation &&
             (firstTimeInForeground || deviceCache.isCustomerInfoCacheStale(appUserID, appInBackground = false))
@@ -1629,11 +1641,13 @@ internal class PurchasesOrchestrator(
             // This lets the backup manager know a change in data happened that would be good to backup.
             // In this case, we want to make sure that if there is a purchase, we schedule a backup.
             backupManager.dataChanged()
-            blockstoreHelper.aliasCurrentAndStoredUserIdsIfNeeded {
-                blockstoreHelper.storeUserIdIfNeeded(info)
-                getPurchaseCallback(storeTransaction.productIds[0])?.let { purchaseCallback ->
-                    dispatch {
-                        purchaseCallback.onCompleted(storeTransaction, info)
+            afterPostReceiptRemoteConfigRefresh {
+                blockstoreHelper.aliasCurrentAndStoredUserIdsIfNeeded {
+                    blockstoreHelper.storeUserIdIfNeeded(info)
+                    getPurchaseCallback(storeTransaction.productIds[0])?.let { purchaseCallback ->
+                        dispatch {
+                            purchaseCallback.onCompleted(storeTransaction, info)
+                        }
                     }
                 }
             }
@@ -1649,9 +1663,11 @@ internal class PurchasesOrchestrator(
         productChangeListener: ProductChangeCallback?,
     ): Pair<SuccessfulPurchaseCallback, ErrorPurchaseCallback> {
         val onSuccess: SuccessfulPurchaseCallback = { storeTransaction, info ->
-            productChangeListener?.let { productChangeCallback ->
-                dispatch {
-                    productChangeCallback.onCompleted(storeTransaction, info)
+            afterPostReceiptRemoteConfigRefresh {
+                productChangeListener?.let { productChangeCallback ->
+                    dispatch {
+                        productChangeCallback.onCompleted(storeTransaction, info)
+                    }
                 }
             }
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigFetchContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigFetchContext.kt
@@ -11,4 +11,5 @@ internal enum class RemoteConfigFetchContext(val wireName: String) {
     Foreground("foreground"),
     IdentityChange("identity_change"),
     Read("read"),
+    PostReceipt("post_receipt"),
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -68,7 +68,7 @@ import kotlin.time.Duration.Companion.minutes
  * Overlapping refreshes are deduped: only one [refreshRemoteConfig] runs at a time. A call made while one is
  * already in flight is skipped (the backend collapses concurrent requests but still fires every callback, which
  * would otherwise parse and persist the same response more than once). The one exception is
- * [awaitPostReceiptRefresh], which is never skipped: it waits for the in-flight sync and then issues its own.
+ * [ensurePostReceiptRefresh], which is never skipped: it waits for the in-flight sync and then issues its own.
  *
  * Consumers read through the facade: [topic] for a topic's committed item index (metadata only) and [blobData]
  * for a resolved item's blob payload (fetched on demand). Both run on [ioDispatcher] so callers never touch disk
@@ -282,7 +282,7 @@ internal class RemoteConfigManager(
         )
     }
 
-    /** Marks that a receipt was posted, so the next [awaitPostReceiptRefresh] issues a PostReceipt sync. */
+    /** Marks that a receipt was posted, so the next [ensurePostReceiptRefresh] issues a PostReceipt sync. */
     fun onReceiptPosted() {
         synchronized(cacheLock) { postReceiptRefreshPending = true }
     }
@@ -295,7 +295,7 @@ internal class RemoteConfigManager(
      * [clearCache]/[close] cancels the manager scope mid-wait; it may run synchronously on the calling thread or
      * later on a background thread.
      */
-    fun awaitPostReceiptRefresh(appInBackground: Boolean, appUserID: String, onComplete: () -> Unit) {
+    fun ensurePostReceiptRefresh(appInBackground: Boolean, appUserID: String, onComplete: () -> Unit) {
         val completeImmediately = synchronized(cacheLock) {
             disabled || (!postReceiptRefreshPending && refreshCompletion == null)
         }
@@ -303,7 +303,7 @@ internal class RemoteConfigManager(
             onComplete()
             return
         }
-        scope.launch { ensurePostReceiptRefresh(appInBackground, appUserID) }
+        scope.launch { awaitPostReceiptRefresh(appInBackground, appUserID) }
             .invokeOnCompletion { onComplete() }
     }
 
@@ -320,7 +320,7 @@ internal class RemoteConfigManager(
      * re-checks until it can acquire the guard itself (mirroring [refreshRemoteConfig]'s critical section),
      * consuming the flag atomically with the acquire. From then on the request behaves like any other sync.
      */
-    private suspend fun ensurePostReceiptRefresh(appInBackground: Boolean, appUserID: String) {
+    private suspend fun awaitPostReceiptRefresh(appInBackground: Boolean, appUserID: String) {
         while (true) {
             var inFlight: CompletableDeferred<Unit>? = null
             var retryAfterInFlight = false

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -67,7 +67,8 @@ import kotlin.time.Duration.Companion.minutes
  *
  * Overlapping refreshes are deduped: only one [refreshRemoteConfig] runs at a time. A call made while one is
  * already in flight is skipped (the backend collapses concurrent requests but still fires every callback, which
- * would otherwise parse and persist the same response more than once).
+ * would otherwise parse and persist the same response more than once). The one exception is
+ * [awaitPostReceiptRefresh], which is never skipped: it waits for the in-flight sync and then issues its own.
  *
  * Consumers read through the facade: [topic] for a topic's committed item index (metadata only) and [blobData]
  * for a resolved item's blob payload (fetched on demand). Both run on [ioDispatcher] so callers never touch disk
@@ -78,7 +79,7 @@ import kotlin.time.Duration.Companion.minutes
  * user is known yet.
  */
 @OptIn(InternalRevenueCatAPI::class)
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
 internal class RemoteConfigManager(
     private val backend: Backend,
     private val diskCache: RemoteConfigDiskCache,
@@ -129,6 +130,10 @@ internal class RemoteConfigManager(
     // refresh is in flight. isRefreshing keeps its skip semantics; this only adds an awaitable handle.
     @Volatile
     private var refreshCompletion: CompletableDeferred<Unit>? = null
+
+    // Set on a successful receipt post; cleared only when a PostReceipt-context refresh starts, or by
+    // clearCache(). Guarded by [cacheLock].
+    private var postReceiptRefreshPending = false
 
     // Session-scoped kill-switch. Set when `/v1/config` returns a 4xx (the endpoint intentionally refused the
     // request). While set, no config request is issued and — since blob prefetch only runs after a successful
@@ -275,6 +280,90 @@ internal class RemoteConfigManager(
                 )
             },
         )
+    }
+
+    /** Marks that a receipt was posted, so the next [awaitPostReceiptRefresh] issues a PostReceipt sync. */
+    fun onReceiptPosted() {
+        synchronized(cacheLock) { postReceiptRefreshPending = true }
+    }
+
+    /**
+     * Runs [onComplete] once the committed configuration reflects the receipts posted before this call: a no-op
+     * when nothing was posted, otherwise it waits for any refresh in progress and then issues a
+     * [RemoteConfigFetchContext.PostReceipt] sync — never skipped, unlike [refreshRemoteConfig]. [onComplete] is
+     * guaranteed to fire exactly once, at any refresh outcome (failure included) and even when
+     * [clearCache]/[close] cancels the manager scope mid-wait; it may run synchronously on the calling thread or
+     * later on a background thread.
+     */
+    fun awaitPostReceiptRefresh(appInBackground: Boolean, appUserID: String, onComplete: () -> Unit) {
+        val completeImmediately = synchronized(cacheLock) {
+            disabled || (!postReceiptRefreshPending && refreshCompletion == null)
+        }
+        if (completeImmediately) {
+            onComplete()
+            return
+        }
+        scope.launch { ensurePostReceiptRefresh(appInBackground, appUserID) }
+            .invokeOnCompletion { onComplete() }
+    }
+
+    private class PostReceiptRefreshRequest(
+        val epoch: Int,
+        val appUserID: String,
+        val fetchContext: RemoteConfigFetchContext,
+        val completion: CompletableDeferred<Unit>,
+    )
+
+    /**
+     * Takes one decision per loop iteration under [cacheLock], never suspending while holding it: with no
+     * pending flag it just joins any in-flight refresh; otherwise it waits for the in-flight refresh and
+     * re-checks until it can acquire the guard itself (mirroring [refreshRemoteConfig]'s critical section),
+     * consuming the flag atomically with the acquire. From then on the request behaves like any other sync.
+     */
+    private suspend fun ensurePostReceiptRefresh(appInBackground: Boolean, appUserID: String) {
+        while (true) {
+            var inFlight: CompletableDeferred<Unit>? = null
+            var retryAfterInFlight = false
+            var request: PostReceiptRefreshRequest? = null
+            synchronized(cacheLock) {
+                when {
+                    disabled -> Unit
+                    !postReceiptRefreshPending -> inFlight = refreshCompletion
+                    isRefreshing.get() -> {
+                        inFlight = refreshCompletion
+                        retryAfterInFlight = true
+                    }
+                    else -> {
+                        postReceiptRefreshPending = false
+                        isRefreshing.set(true)
+                        val completion = CompletableDeferred<Unit>()
+                        refreshCompletion = completion
+                        request = PostReceiptRefreshRequest(
+                            epoch = epoch.get(),
+                            appUserID = currentAppUserID ?: appUserID,
+                            fetchContext = fetchContextForRequest(RemoteConfigFetchContext.PostReceipt),
+                            completion = completion,
+                        )
+                    }
+                }
+            }
+            val acquired = request
+            val awaitedInFlight = inFlight
+            when {
+                acquired != null -> {
+                    verboseLog { "Refreshing remote config after a receipt post." }
+                    issueConfigRequest(appInBackground, acquired.epoch, acquired.appUserID, acquired.fetchContext)
+                    acquired.completion.await()
+                    return
+                }
+                // The completion is non-null whenever the guard is held; bail rather than spin if not.
+                retryAfterInFlight && awaitedInFlight != null -> awaitedInFlight.await()
+                else -> {
+                    awaitedInFlight?.await()
+                    return
+                }
+            }
+        }
     }
 
     private fun isRefreshAttemptCooldownElapsed(now: Date): Boolean {
@@ -491,6 +580,7 @@ internal class RemoteConfigManager(
             isRefreshing.set(false)
             lastRefreshedAt = null
             lastRefreshAttemptAt = null
+            postReceiptRefreshPending = false
             completeRefresh()
             // Intentionally NOT resetting `disabled`: a 4xx is an endpoint/app-level fact that outlives an
             // identity change. It clears only on app restart.

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -137,7 +137,7 @@ internal open class BasePurchasesTest {
 
         // The relaxed mock would swallow the completion callback, deadlocking the flows that hold on it.
         every {
-            mockRemoteConfigManager.awaitPostReceiptRefresh(any(), any(), any())
+            mockRemoteConfigManager.ensurePostReceiptRefresh(any(), any(), any())
         } answers { thirdArg<() -> Unit>().invoke() }
 
         every {

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -135,6 +135,11 @@ internal open class BasePurchasesTest {
         mockPostPendingTransactionsHelper()
         paywallPresentedCache = PaywallPresentedCache()
 
+        // The relaxed mock would swallow the completion callback, deadlocking the flows that hold on it.
+        every {
+            mockRemoteConfigManager.awaitPostReceiptRefresh(any(), any(), any())
+        } answers { thirdArg<() -> Unit>().invoke() }
+
         every {
             updatedCustomerInfoListener.onReceived(any())
         } just Runs

--- a/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.toStoreTransaction
 import com.revenuecat.purchases.identity.IdentityManager
@@ -37,6 +38,7 @@ class PostPendingTransactionsHelperTest {
     private lateinit var identityManager: IdentityManager
     private lateinit var postTransactionWithProductDetailsHelper: PostTransactionWithProductDetailsHelper
     private lateinit var postReceiptHelper: PostReceiptHelper
+    private lateinit var remoteConfigManager: RemoteConfigManager
 
     private lateinit var postPendingTransactionsHelper: PostPendingTransactionsHelper
 
@@ -51,6 +53,10 @@ class PostPendingTransactionsHelperTest {
         }
         postTransactionWithProductDetailsHelper = mockk()
         postReceiptHelper = mockk()
+        remoteConfigManager = mockk<RemoteConfigManager>().apply {
+            every { awaitPostReceiptRefresh(any(), any(), any()) } answers { thirdArg<() -> Unit>().invoke() }
+        }
+        every { appConfig.isAppBackgrounded } returns false
 
         // Default mock for postRemainingCachedTransactionMetadata
         every {
@@ -79,6 +85,7 @@ class PostPendingTransactionsHelperTest {
             identityManager,
             postTransactionWithProductDetailsHelper,
             postReceiptHelper,
+            remoteConfigManager,
         )
     }
 
@@ -438,6 +445,89 @@ class PostPendingTransactionsHelperTest {
         )
         assertThat(successCallCount).isEqualTo(1)
     }
+
+    // region post-receipt remote config refresh
+
+    @Test
+    fun `sync completion is held until the post-receipt remote config refresh completes`() {
+        val (purchase, activePurchase) = createGooglePurchaseAndTransaction()
+        mockSuccessfulQueryPurchases(
+            purchasesByHashedToken = mapOf(purchase.purchaseToken.sha1() to activePurchase),
+            notInCache = listOf(activePurchase)
+        )
+        val customerInfoMock = mockk<CustomerInfo>()
+        mockPostTransactionsSuccessful(customerInfoMock)
+
+        val refreshCompletion = slot<() -> Unit>()
+        every {
+            remoteConfigManager.awaitPostReceiptRefresh(any(), any(), capture(refreshCompletion))
+        } just Runs
+
+        var receivedResult: SyncPendingPurchaseResult? = null
+        postPendingTransactionsHelper.syncPendingPurchaseQueue(
+            allowSharingPlayStoreAccount,
+            callback = { receivedResult = it },
+        )
+
+        assertThat(receivedResult).isNull()
+        refreshCompletion.captured.invoke()
+        assertThat(receivedResult).isEqualTo(SyncPendingPurchaseResult.Success(customerInfoMock))
+    }
+
+    @Test
+    fun `sync without a callback still triggers the post-receipt remote config refresh`() {
+        val (purchase, activePurchase) = createGooglePurchaseAndTransaction()
+        mockSuccessfulQueryPurchases(
+            purchasesByHashedToken = mapOf(purchase.purchaseToken.sha1() to activePurchase),
+            notInCache = listOf(activePurchase)
+        )
+        mockPostTransactionsSuccessful(mockk())
+
+        postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
+
+        verify(exactly = 1) { remoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+    }
+
+    @Test
+    fun `sync with nothing to post still completes through the refresh gate`() {
+        mockSuccessfulQueryPurchases(
+            purchasesByHashedToken = emptyMap(),
+            notInCache = emptyList()
+        )
+
+        syncAndAssertResult(SyncPendingPurchaseResult.NoPendingPurchasesToSync)
+
+        verify(exactly = 1) { remoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+    }
+
+    @Test
+    fun `disabled autosync does not touch the remote config manager`() {
+        changeAutoSyncEnabled(false)
+
+        syncAndAssertResult(SyncPendingPurchaseResult.AutoSyncDisabled)
+
+        verify(exactly = 0) { remoteConfigManager.awaitPostReceiptRefresh(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a query purchases error does not touch the remote config manager`() {
+        val error = PurchasesError(PurchasesErrorCode.StoreProblemError, "Broken")
+        every {
+            billing.queryPurchases(
+                appUserID = appUserId,
+                onSuccess = any(),
+                onError = captureLambda()
+            )
+        } answers {
+            lambda<(PurchasesError) -> Unit>().captured(error)
+        }
+
+        syncAndAssertResult(SyncPendingPurchaseResult.Error(error))
+
+        verify(exactly = 0) { remoteConfigManager.awaitPostReceiptRefresh(any(), any(), any()) }
+    }
+
+    // endregion post-receipt remote config refresh
 
     // region postRemainingCachedTransactionMetadata tests
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
@@ -54,7 +54,7 @@ class PostPendingTransactionsHelperTest {
         postTransactionWithProductDetailsHelper = mockk()
         postReceiptHelper = mockk()
         remoteConfigManager = mockk<RemoteConfigManager>().apply {
-            every { awaitPostReceiptRefresh(any(), any(), any()) } answers { thirdArg<() -> Unit>().invoke() }
+            every { ensurePostReceiptRefresh(any(), any(), any()) } answers { thirdArg<() -> Unit>().invoke() }
         }
         every { appConfig.isAppBackgrounded } returns false
 
@@ -460,7 +460,7 @@ class PostPendingTransactionsHelperTest {
 
         val refreshCompletion = slot<() -> Unit>()
         every {
-            remoteConfigManager.awaitPostReceiptRefresh(any(), any(), capture(refreshCompletion))
+            remoteConfigManager.ensurePostReceiptRefresh(any(), any(), capture(refreshCompletion))
         } just Runs
 
         var receivedResult: SyncPendingPurchaseResult? = null
@@ -485,7 +485,7 @@ class PostPendingTransactionsHelperTest {
 
         postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
 
-        verify(exactly = 1) { remoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+        verify(exactly = 1) { remoteConfigManager.ensurePostReceiptRefresh(any(), appUserId, any()) }
     }
 
     @Test
@@ -497,7 +497,7 @@ class PostPendingTransactionsHelperTest {
 
         syncAndAssertResult(SyncPendingPurchaseResult.NoPendingPurchasesToSync)
 
-        verify(exactly = 1) { remoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+        verify(exactly = 1) { remoteConfigManager.ensurePostReceiptRefresh(any(), appUserId, any()) }
     }
 
     @Test
@@ -506,7 +506,7 @@ class PostPendingTransactionsHelperTest {
 
         syncAndAssertResult(SyncPendingPurchaseResult.AutoSyncDisabled)
 
-        verify(exactly = 0) { remoteConfigManager.awaitPostReceiptRefresh(any(), any(), any()) }
+        verify(exactly = 0) { remoteConfigManager.ensurePostReceiptRefresh(any(), any(), any()) }
     }
 
     @Test
@@ -524,7 +524,7 @@ class PostPendingTransactionsHelperTest {
 
         syncAndAssertResult(SyncPendingPurchaseResult.Error(error))
 
-        verify(exactly = 0) { remoteConfigManager.awaitPostReceiptRefresh(any(), any(), any()) }
+        verify(exactly = 0) { remoteConfigManager.ensurePostReceiptRefresh(any(), any(), any()) }
     }
 
     // endregion post-receipt remote config refresh

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.common.caching.WorkflowMetadata
 import com.revenuecat.purchases.common.networking.PostReceiptProductInfo
 import com.revenuecat.purchases.common.networking.PostReceiptResponse
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.google.toStoreTransaction
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.StoreReplacementMode
@@ -132,6 +133,7 @@ class PostReceiptHelperTest {
     private lateinit var offlineEntitlementsManager: OfflineEntitlementsManager
     private lateinit var paywallPresentedCache: PaywallPresentedCache
     private lateinit var localTransactionMetadataStore: LocalTransactionMetadataStore
+    private lateinit var remoteConfigManager: RemoteConfigManager
 
     private lateinit var postReceiptHelper: PostReceiptHelper
 
@@ -146,6 +148,8 @@ class PostReceiptHelperTest {
         offlineEntitlementsManager = mockk()
         paywallPresentedCache = PaywallPresentedCache()
         localTransactionMetadataStore = mockk()
+        remoteConfigManager = mockk()
+        every { remoteConfigManager.onReceiptPosted() } just Runs
 
         postedReceiptInfoSlot = slot()
 
@@ -159,6 +163,7 @@ class PostReceiptHelperTest {
             offlineEntitlementsManager = offlineEntitlementsManager,
             paywallPresentedCache = paywallPresentedCache,
             localTransactionMetadataStore = localTransactionMetadataStore,
+            remoteConfigManager = remoteConfigManager,
         )
 
         mockUnsyncedSubscriberAttributes()
@@ -2461,6 +2466,117 @@ class PostReceiptHelperTest {
     }
 
     // endregion pending transactions
+
+    // region post-receipt remote config marking
+
+    @Test
+    fun `postTransactionAndConsumeIfNeeded marks a receipt posted before invoking onSuccess`() {
+        mockPostReceiptSuccess()
+
+        var successCalled = false
+        postReceiptHelper.postTransactionAndConsumeIfNeeded(
+            purchase = mockStoreTransaction,
+            storeProduct = mockStoreProduct,
+            subscriptionOptionForProductIDs = null,
+            isRestore = false,
+            appUserID = appUserID,
+            initiationSource = initiationSource,
+            onSuccess = { _, _ ->
+                successCalled = true
+                verify(exactly = 1) { remoteConfigManager.onReceiptPosted() }
+            },
+            onError = { _, _ -> fail("Should succeed") },
+        )
+        assertThat(successCalled).isTrue
+    }
+
+    @Test
+    fun `postTokenWithoutConsuming marks a receipt posted before invoking onSuccess`() {
+        mockPostReceiptSuccess(postType = PostType.TOKEN_WITHOUT_CONSUMING)
+
+        var successCalled = false
+        postReceiptHelper.postTokenWithoutConsuming(
+            purchaseToken = postToken,
+            receiptInfo = testReceiptInfo,
+            isRestore = true,
+            appUserID = appUserID,
+            initiationSource = PostReceiptInitiationSource.PURCHASE,
+            onSuccess = {
+                successCalled = true
+                verify(exactly = 1) { remoteConfigManager.onReceiptPosted() }
+            },
+            onError = { fail("Should succeed") },
+        )
+        assertThat(successCalled).isTrue
+    }
+
+    @Test
+    fun `a SHOULD_BE_MARKED_SYNCED error does not mark a receipt posted`() {
+        mockPostReceiptError(PostReceiptErrorHandlingBehavior.SHOULD_BE_MARKED_SYNCED)
+
+        postReceiptHelper.postTransactionAndConsumeIfNeeded(
+            purchase = mockStoreTransaction,
+            storeProduct = null,
+            subscriptionOptionForProductIDs = null,
+            isRestore = true,
+            appUserID = appUserID,
+            initiationSource = initiationSource,
+            onSuccess = { _, _ -> fail("Should error") },
+            onError = { _, _ -> },
+        )
+
+        verify(exactly = 0) { remoteConfigManager.onReceiptPosted() }
+    }
+
+    @Test
+    fun `a server error does not mark a receipt posted`() {
+        mockPostReceiptError(PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
+
+        postReceiptHelper.postTransactionAndConsumeIfNeeded(
+            purchase = mockStoreTransaction,
+            storeProduct = null,
+            subscriptionOptionForProductIDs = null,
+            isRestore = true,
+            appUserID = appUserID,
+            initiationSource = initiationSource,
+            onSuccess = { _, _ -> fail("Should error") },
+            onError = { _, _ -> },
+        )
+
+        verify(exactly = 0) { remoteConfigManager.onReceiptPosted() }
+    }
+
+    @Test
+    fun `a successful post works without a remote config manager`() {
+        mockPostReceiptSuccess()
+        val helperWithoutRemoteConfig = PostReceiptHelper(
+            appConfig = appConfig,
+            backend = backend,
+            billing = billing,
+            customerInfoUpdateHandler = customerInfoUpdateHandler,
+            deviceCache = deviceCache,
+            subscriberAttributesManager = subscriberAttributesManager,
+            offlineEntitlementsManager = offlineEntitlementsManager,
+            paywallPresentedCache = paywallPresentedCache,
+            localTransactionMetadataStore = localTransactionMetadataStore,
+            remoteConfigManager = null,
+        )
+
+        var successCalled = false
+        helperWithoutRemoteConfig.postTransactionAndConsumeIfNeeded(
+            purchase = mockStoreTransaction,
+            storeProduct = mockStoreProduct,
+            subscriptionOptionForProductIDs = null,
+            isRestore = false,
+            appUserID = appUserID,
+            initiationSource = initiationSource,
+            onSuccess = { _, _ -> successCalled = true },
+            onError = { _, _ -> fail("Should succeed") },
+        )
+        assertThat(successCalled).isTrue
+    }
+
+    // endregion post-receipt remote config marking
 
     // region helpers
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -1595,7 +1595,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
 
         val refreshCompletion = slot<() -> Unit>()
         every {
-            mockRemoteConfigManager.awaitPostReceiptRefresh(any(), any(), capture(refreshCompletion))
+            mockRemoteConfigManager.ensurePostReceiptRefresh(any(), any(), capture(refreshCompletion))
         } just Runs
 
         val storeProduct = stubStoreProduct(productId)
@@ -1614,7 +1614,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         assertThat(callCount).isEqualTo(0)
         refreshCompletion.captured.invoke()
         assertThat(callCount).isEqualTo(1)
-        verify(exactly = 1) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+        verify(exactly = 1) { mockRemoteConfigManager.ensurePostReceiptRefresh(any(), appUserId, any()) }
     }
 
     @Test
@@ -1655,7 +1655,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         )
 
         assertThat(errorCallCount).isEqualTo(1)
-        verify(exactly = 0) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), any(), any()) }
+        verify(exactly = 0) { mockRemoteConfigManager.ensurePostReceiptRefresh(any(), any(), any()) }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -1587,6 +1587,78 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
+    fun `purchase completion is held until the post-receipt remote config refresh completes`() {
+        val productId = "onemonth_freetrial"
+        val purchaseToken = "crazy_purchase_token"
+
+        mockQueryingProductDetails(productId, ProductType.SUBS)
+
+        val refreshCompletion = slot<() -> Unit>()
+        every {
+            mockRemoteConfigManager.awaitPostReceiptRefresh(any(), any(), capture(refreshCompletion))
+        } just Runs
+
+        val storeProduct = stubStoreProduct(productId)
+        val purchaseParams = getPurchaseParams(storeProduct.subscriptionOptions!!.first())
+        var callCount = 0
+        purchases.purchaseWith(
+            purchaseParams,
+            onSuccess = { _, _ ->
+                callCount++
+            }, onError = { _, _ -> fail("should be successful") })
+
+        capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
+            getMockedPurchaseList(productId, purchaseToken, ProductType.SUBS)
+        )
+
+        assertThat(callCount).isEqualTo(0)
+        refreshCompletion.captured.invoke()
+        assertThat(callCount).isEqualTo(1)
+        verify(exactly = 1) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+    }
+
+    @Test
+    fun `a failed purchase post does not touch the post-receipt remote config refresh`() {
+        val productId = "onemonth_freetrial"
+        val purchaseToken = "crazy_purchase_token"
+
+        mockQueryingProductDetails(productId, ProductType.SUBS)
+        every {
+            mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(
+                purchase = any(),
+                storeProduct = any(),
+                subscriptionOptionForProductIDs = any(),
+                isRestore = any(),
+                appUserID = any(),
+                initiationSource = any(),
+                sdkOriginated = any(),
+                onSuccess = any(),
+                onError = captureLambda(),
+            )
+        } answers {
+            lambda<ErrorPurchaseCallback>().captured.invoke(
+                firstArg(),
+                PurchasesError(PurchasesErrorCode.UnknownBackendError),
+            )
+        }
+
+        val storeProduct = stubStoreProduct(productId)
+        val purchaseParams = getPurchaseParams(storeProduct.subscriptionOptions!!.first())
+        var errorCallCount = 0
+        purchases.purchaseWith(
+            purchaseParams,
+            onSuccess = { _, _ -> fail("should error") },
+            onError = { _, _ -> errorCallCount++ })
+
+        capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
+            getMockedPurchaseList(productId, purchaseToken, ProductType.SUBS)
+        )
+
+        assertThat(errorCallCount).isEqualTo(1)
+        verify(exactly = 0) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), any(), any()) }
+    }
+
+    @Test
     fun `when making purchase, completion block not called for different products`() {
         val productId = "onemonth_freetrial"
         val productId1 = "onemonth_freetrial_1"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -2693,6 +2693,267 @@ class RemoteConfigManagerTest {
         }
     }
 
+    // region post-receipt refresh
+
+    @Test
+    fun `awaitPostReceiptRefresh completes immediately without a request when no receipt was posted`() {
+        every { diskCache.read() } returns null
+
+        var completed = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+
+        assertThat(completed).isTrue
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `awaitPostReceiptRefresh issues a post_receipt request and completes when it is delivered`() {
+        every { diskCache.read() } returns null
+        commitInitialConfig()
+
+        manager.onReceiptPosted()
+        var completed = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.PostReceipt)
+        assertThat(completed).isFalse
+        deliverSuccess(null)
+        assertThat(completed).isTrue
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `the post-receipt request is forced to app_start until the initial config is committed`() {
+        every { diskCache.read() } returns null
+
+        manager.onReceiptPosted()
+        var completed = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
+        assertThat(completed).isFalse
+        deliverSuccess(null)
+        assertThat(completed).isTrue
+    }
+
+    @Test
+    fun `awaitPostReceiptRefresh waits for the in-flight refresh and then issues its own request`() {
+        every { diskCache.read() } returns null
+        commitInitialConfig()
+
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.Foreground,
+        )
+        val foregroundOnSuccess = onSuccess
+
+        manager.onReceiptPosted()
+        var completed = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+
+        // Not skipped like an overlapping refreshRemoteConfig would be, but not issued yet either.
+        assertThat(completed).isFalse
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+
+        // Finishing the in-flight foreground refresh lets the post-receipt request go out.
+        foregroundOnSuccess.invoke(null, Date(SERVER_MILLIS), VerificationResult.VERIFIED)
+        verify(exactly = 3) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.PostReceipt)
+        assertThat(completed).isFalse
+
+        deliverSuccess(null)
+        assertThat(completed).isTrue
+    }
+
+    @Test
+    fun `a failed post-receipt refresh still completes the waiter`() {
+        every { diskCache.read() } returns null
+        commitInitialConfig()
+
+        manager.onReceiptPosted()
+        var completed = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+        onFallbackError.invoke(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_RETRY,
+        )
+
+        assertThat(completed).isTrue
+    }
+
+    @Test
+    fun `a 4xx on the post-receipt refresh completes the waiter and disables later ones`() {
+        every { diskCache.read() } returns null
+        commitInitialConfig()
+
+        manager.onReceiptPosted()
+        var completed = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+
+        onError.invoke(
+            PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
+            GetRemoteConfigErrorHandlingBehavior.SHOULD_DISABLE,
+        )
+        assertThat(completed).isTrue
+
+        // The endpoint is disabled for the session: a later post + wait completes without any request.
+        manager.onReceiptPosted()
+        var completedWhileDisabled = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
+            completedWhileDisabled = true
+        }
+        assertThat(completedWhileDisabled).isTrue
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `one post-receipt refresh serves concurrent waiters`() {
+        every { diskCache.read() } returns null
+        commitInitialConfig()
+
+        manager.onReceiptPosted()
+        var firstCompleted = false
+        var secondCompleted = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
+            firstCompleted = true
+        }
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
+            secondCompleted = true
+        }
+
+        // The first waiter issued the post-receipt request; the second joins it instead of issuing another.
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertThat(firstCompleted).isFalse
+        assertThat(secondCompleted).isFalse
+
+        deliverSuccess(null)
+        assertThat(firstCompleted).isTrue
+        assertThat(secondCompleted).isTrue
+    }
+
+    @Test
+    fun `unrelated refreshes do not consume the pending post-receipt refresh`() {
+        every { diskCache.read() } returns null
+        commitInitialConfig()
+
+        manager.onReceiptPosted()
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.Foreground,
+        )
+        deliverSuccess(null)
+
+        var completed = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+
+        // The completed foreground refresh did not clear the flag: a post_receipt request still goes out.
+        verify(exactly = 3) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.PostReceipt)
+        deliverSuccess(null)
+        assertThat(completed).isTrue
+    }
+
+    @Test
+    fun `a receipt posted during a post-receipt refresh triggers a fresh one for the next waiter`() {
+        every { diskCache.read() } returns null
+        commitInitialConfig()
+
+        manager.onReceiptPosted()
+        var firstCompleted = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
+            firstCompleted = true
+        }
+
+        // A new receipt lands while the first post-receipt refresh is in flight.
+        manager.onReceiptPosted()
+        deliverSuccess(null)
+        assertThat(firstCompleted).isTrue
+
+        var secondCompleted = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
+            secondCompleted = true
+        }
+        verify(exactly = 3) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.PostReceipt)
+        deliverSuccess(null)
+        assertThat(secondCompleted).isTrue
+    }
+
+    @Test
+    fun `clearCache completes the waiter and drops the pending post-receipt refresh`() {
+        every { diskCache.read() } returns null
+        commitInitialConfig()
+
+        manager.onReceiptPosted()
+        var completed = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        assertThat(completed).isFalse
+
+        manager.clearCache("new-user")
+        assertThat(completed).isTrue
+
+        // The identity change reset the flag: a later wait completes without a new request.
+        var completedAfterClear = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = "new-user") {
+            completedAfterClear = true
+        }
+        assertThat(completedAfterClear).isTrue
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `clearCache while waiting on an unrelated in-flight refresh completes the waiter`() {
+        every { diskCache.read() } returns null
+        commitInitialConfig()
+
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = RemoteConfigFetchContext.Foreground,
+        )
+        manager.onReceiptPosted()
+        var completed = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        assertThat(completed).isFalse
+
+        manager.clearCache("new-user")
+        assertThat(completed).isTrue
+        // No post-receipt request was ever issued: only the initial commit and the foreground refresh went out.
+        verify(exactly = 2) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `awaitPostReceiptRefresh after close completes immediately`() {
+        every { diskCache.read() } returns null
+
+        manager.onReceiptPosted()
+        manager.close()
+
+        var completed = false
+        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        assertThat(completed).isTrue
+        verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    /** Commits the session's initial config with a 204 so later requests report their own fetch context. */
+    private fun commitInitialConfig() {
+        manager.refreshRemoteConfig(
+            appInBackground = false,
+            appUserID = TEST_APP_USER_ID,
+            fetchContext = DEFAULT_FETCH_CONTEXT,
+        )
+        deliverSuccess(null)
+    }
+
+    // endregion
+
     // A manager whose read methods run on this test's scheduler, so suspend reads are deterministic.
     private fun TestScope.readManager(appUserIDProvider: () -> String? = { null }): RemoteConfigManager {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -2696,24 +2696,24 @@ class RemoteConfigManagerTest {
     // region post-receipt refresh
 
     @Test
-    fun `awaitPostReceiptRefresh completes immediately without a request when no receipt was posted`() {
+    fun `ensurePostReceiptRefresh completes immediately without a request when no receipt was posted`() {
         every { diskCache.read() } returns null
 
         var completed = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
 
         assertThat(completed).isTrue
         verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
-    fun `awaitPostReceiptRefresh issues a post_receipt request and completes when it is delivered`() {
+    fun `ensurePostReceiptRefresh issues a post_receipt request and completes when it is delivered`() {
         every { diskCache.read() } returns null
         commitInitialConfig()
 
         manager.onReceiptPosted()
         var completed = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
 
         assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.PostReceipt)
         assertThat(completed).isFalse
@@ -2728,7 +2728,7 @@ class RemoteConfigManagerTest {
 
         manager.onReceiptPosted()
         var completed = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
 
         assertThat(capturedFetchContext).isEqualTo(RemoteConfigFetchContext.AppStart)
         assertThat(completed).isFalse
@@ -2737,7 +2737,7 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `awaitPostReceiptRefresh waits for the in-flight refresh and then issues its own request`() {
+    fun `ensurePostReceiptRefresh waits for the in-flight refresh and then issues its own request`() {
         every { diskCache.read() } returns null
         commitInitialConfig()
 
@@ -2750,7 +2750,7 @@ class RemoteConfigManagerTest {
 
         manager.onReceiptPosted()
         var completed = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
 
         // Not skipped like an overlapping refreshRemoteConfig would be, but not issued yet either.
         assertThat(completed).isFalse
@@ -2773,7 +2773,7 @@ class RemoteConfigManagerTest {
 
         manager.onReceiptPosted()
         var completed = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
 
         onError.invoke(
             PurchasesError(PurchasesErrorCode.NetworkError),
@@ -2794,7 +2794,7 @@ class RemoteConfigManagerTest {
 
         manager.onReceiptPosted()
         var completed = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
 
         onError.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError, "bad request"),
@@ -2805,7 +2805,7 @@ class RemoteConfigManagerTest {
         // The endpoint is disabled for the session: a later post + wait completes without any request.
         manager.onReceiptPosted()
         var completedWhileDisabled = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
             completedWhileDisabled = true
         }
         assertThat(completedWhileDisabled).isTrue
@@ -2820,10 +2820,10 @@ class RemoteConfigManagerTest {
         manager.onReceiptPosted()
         var firstCompleted = false
         var secondCompleted = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
             firstCompleted = true
         }
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
             secondCompleted = true
         }
 
@@ -2851,7 +2851,7 @@ class RemoteConfigManagerTest {
         deliverSuccess(null)
 
         var completed = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
 
         // The completed foreground refresh did not clear the flag: a post_receipt request still goes out.
         verify(exactly = 3) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
@@ -2867,7 +2867,7 @@ class RemoteConfigManagerTest {
 
         manager.onReceiptPosted()
         var firstCompleted = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
             firstCompleted = true
         }
 
@@ -2877,7 +2877,7 @@ class RemoteConfigManagerTest {
         assertThat(firstCompleted).isTrue
 
         var secondCompleted = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) {
             secondCompleted = true
         }
         verify(exactly = 3) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
@@ -2893,7 +2893,7 @@ class RemoteConfigManagerTest {
 
         manager.onReceiptPosted()
         var completed = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
         assertThat(completed).isFalse
 
         manager.clearCache("new-user")
@@ -2901,7 +2901,7 @@ class RemoteConfigManagerTest {
 
         // The identity change reset the flag: a later wait completes without a new request.
         var completedAfterClear = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = "new-user") {
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = "new-user") {
             completedAfterClear = true
         }
         assertThat(completedAfterClear).isTrue
@@ -2920,7 +2920,7 @@ class RemoteConfigManagerTest {
         )
         manager.onReceiptPosted()
         var completed = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
         assertThat(completed).isFalse
 
         manager.clearCache("new-user")
@@ -2930,14 +2930,14 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `awaitPostReceiptRefresh after close completes immediately`() {
+    fun `ensurePostReceiptRefresh after close completes immediately`() {
         every { diskCache.read() } returns null
 
         manager.onReceiptPosted()
         manager.close()
 
         var completed = false
-        manager.awaitPostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
+        manager.ensurePostReceiptRefresh(appInBackground = false, appUserID = TEST_APP_USER_ID) { completed = true }
         assertThat(completed).isTrue
         verify(exactly = 0) { backend.getRemoteConfig(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -976,6 +976,47 @@ internal class PurchasesTest : BasePurchasesTest() {
     }
 
     @Test
+    fun `syncing transactions holds completion until the post-receipt remote config refresh completes`() {
+        every {
+            mockSyncPurchasesHelper.syncPurchases(any(), any(), captureLambda(), any())
+        } answers {
+            lambda<(CustomerInfo) -> Unit>().captured.invoke(mockInfo)
+        }
+        val refreshCompletion = slot<() -> Unit>()
+        every {
+            mockRemoteConfigManager.awaitPostReceiptRefresh(any(), any(), capture(refreshCompletion))
+        } just Runs
+
+        var successCallCount = 0
+        purchases.syncPurchasesWith(
+            { fail("Expected to succeed") },
+            { successCallCount++ }
+        )
+
+        assertThat(successCallCount).isEqualTo(0)
+        refreshCompletion.captured.invoke()
+        assertThat(successCallCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `syncing transactions with an error still goes through the post-receipt refresh gate`() {
+        every {
+            mockSyncPurchasesHelper.syncPurchases(any(), any(), any(), captureLambda())
+        } answers {
+            lambda<(PurchasesError) -> Unit>().captured.invoke(PurchasesError(PurchasesErrorCode.UnknownError))
+        }
+
+        var errorCallCount = 0
+        purchases.syncPurchasesWith(
+            { errorCallCount++ },
+            { fail("Expected to error") }
+        )
+
+        assertThat(errorCallCount).isEqualTo(1)
+        verify(exactly = 1) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+    }
+
+    @Test
     fun `syncing transactions calls error callback when process completes with error`() {
         every {
             mockSyncPurchasesHelper.syncPurchases(any(), any(), any(), captureLambda())
@@ -1050,6 +1091,41 @@ internal class PurchasesTest : BasePurchasesTest() {
                 onError = any()
             )
         }
+    }
+
+    @Test
+    fun `syncing an Amazon transaction triggers the post-receipt remote config refresh`() {
+        purchases.finishTransactions = false
+
+        val skuParent = "sub"
+        val skuTerm = "sub.monthly"
+        val purchaseToken = "crazy_purchase_token"
+        val amazonUserID = "amazon_user_id"
+
+        every {
+            mockBillingAbstract.normalizePurchaseData(
+                productID = skuParent,
+                purchaseToken = purchaseToken,
+                storeUserID = amazonUserID,
+                captureLambda(),
+                any()
+            )
+        } answers {
+            lambda<(String) -> Unit>().captured.invoke(skuTerm)
+        }
+        every {
+            mockCache.getPreviouslySentHashedTokens()
+        } returns setOf()
+
+        purchases.syncAmazonPurchase(
+            productID = skuParent,
+            receiptID = purchaseToken,
+            amazonUserID = amazonUserID,
+            price = 10.40,
+            isoCurrencyCode = "USD"
+        )
+
+        verify(exactly = 1) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
     }
 
     @Test
@@ -1549,6 +1625,79 @@ internal class PurchasesTest : BasePurchasesTest() {
         }
 
         assertThat(callbackCalled).isTrue()
+    }
+
+    @Test
+    fun `restoring multiple purchases waits once on the post-receipt refresh before completing`() {
+        val transactions = getMockedPurchaseList("product1", "token1", ProductType.INAPP) +
+            getMockedPurchaseList("product2", "token2", ProductType.SUBS)
+        every {
+            mockBillingAbstract.queryAllPurchases(
+                appUserID = appUserId,
+                onReceivePurchaseHistory = captureLambda(),
+                onReceivePurchaseHistoryError = any()
+            )
+        } answers {
+            lambda<(List<StoreTransaction>) -> Unit>().captured.invoke(transactions)
+        }
+
+        val refreshCompletion = slot<() -> Unit>()
+        every {
+            mockRemoteConfigManager.awaitPostReceiptRefresh(any(), any(), capture(refreshCompletion))
+        } just Runs
+
+        var callbackCalled = false
+        purchases.restorePurchasesWith(onSuccess = {
+            callbackCalled = true
+        }, onError = {
+            fail("should be success")
+        })
+
+        verify(exactly = 1) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+        assertThat(callbackCalled).isFalse()
+        refreshCompletion.captured.invoke()
+        assertThat(callbackCalled).isTrue()
+    }
+
+    @Test
+    fun `a restore ending in error still goes through the post-receipt refresh gate`() {
+        val transactions = getMockedPurchaseList("product1", "token1", ProductType.INAPP)
+        every {
+            mockBillingAbstract.queryAllPurchases(
+                appUserID = appUserId,
+                onReceivePurchaseHistory = captureLambda(),
+                onReceivePurchaseHistoryError = any()
+            )
+        } answers {
+            lambda<(List<StoreTransaction>) -> Unit>().captured.invoke(transactions)
+        }
+        every {
+            mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(
+                purchase = any(),
+                storeProduct = any(),
+                subscriptionOptionForProductIDs = any(),
+                isRestore = any(),
+                appUserID = any(),
+                initiationSource = any(),
+                onSuccess = any(),
+                onError = captureLambda(),
+            )
+        } answers {
+            lambda<ErrorPurchaseCallback>().captured.invoke(
+                firstArg(),
+                PurchasesError(PurchasesErrorCode.UnknownBackendError),
+            )
+        }
+
+        var onErrorCalled = false
+        purchases.restorePurchasesWith(onSuccess = {
+            fail("should be an error")
+        }, onError = {
+            onErrorCalled = true
+        })
+
+        assertThat(onErrorCalled).isTrue()
+        verify(exactly = 1) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
     }
 
     @Test

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -984,7 +984,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         }
         val refreshCompletion = slot<() -> Unit>()
         every {
-            mockRemoteConfigManager.awaitPostReceiptRefresh(any(), any(), capture(refreshCompletion))
+            mockRemoteConfigManager.ensurePostReceiptRefresh(any(), any(), capture(refreshCompletion))
         } just Runs
 
         var successCallCount = 0
@@ -1013,7 +1013,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         )
 
         assertThat(errorCallCount).isEqualTo(1)
-        verify(exactly = 1) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+        verify(exactly = 1) { mockRemoteConfigManager.ensurePostReceiptRefresh(any(), appUserId, any()) }
     }
 
     @Test
@@ -1125,7 +1125,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             isoCurrencyCode = "USD"
         )
 
-        verify(exactly = 1) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+        verify(exactly = 1) { mockRemoteConfigManager.ensurePostReceiptRefresh(any(), appUserId, any()) }
     }
 
     @Test
@@ -1643,7 +1643,7 @@ internal class PurchasesTest : BasePurchasesTest() {
 
         val refreshCompletion = slot<() -> Unit>()
         every {
-            mockRemoteConfigManager.awaitPostReceiptRefresh(any(), any(), capture(refreshCompletion))
+            mockRemoteConfigManager.ensurePostReceiptRefresh(any(), any(), capture(refreshCompletion))
         } just Runs
 
         var callbackCalled = false
@@ -1653,7 +1653,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             fail("should be success")
         })
 
-        verify(exactly = 1) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+        verify(exactly = 1) { mockRemoteConfigManager.ensurePostReceiptRefresh(any(), appUserId, any()) }
         assertThat(callbackCalled).isFalse()
         refreshCompletion.captured.invoke()
         assertThat(callbackCalled).isTrue()
@@ -1697,7 +1697,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         })
 
         assertThat(onErrorCalled).isTrue()
-        verify(exactly = 1) { mockRemoteConfigManager.awaitPostReceiptRefresh(any(), appUserId, any()) }
+        verify(exactly = 1) { mockRemoteConfigManager.ensurePostReceiptRefresh(any(), appUserId, any()) }
     }
 
     @Test

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -99,6 +99,7 @@ class SubscriberAttributesPurchasesTests {
             identityManager,
             postTransactionHelper,
             postReceiptHelperMock,
+            remoteConfigManager = null,
         )
 
         val context = mockk<Application>(relaxed = true).also { applicationMock = it }


### PR DESCRIPTION
### Description

With this PR, after posting receipts to the backend, we will also be refreshing the SDK config, and waiting for that to be completed before returning on the POST receipt operation

For operations that may post multiple receipts (restore/syncPurchases/foreground post of unsynced purchases), we only refresh config once at the end of the process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing of purchase/sync/restore callbacks and adds non-skippable config fetches on the receipt path; failures still complete waiters, but UI/config consumers may see different ordering after purchases.
> 
> **Overview**
> After a **successful** receipt post, the SDK marks remote config stale and, before finishing purchase/sync/restore flows, waits for a dedicated **`post_receipt`** `/v1/config` fetch when needed.
> 
> **`RemoteConfigManager`** gains `onReceiptPosted()`, `ensurePostReceiptRefresh()` (not deduped like ordinary refreshes—it waits for any in-flight sync then runs its own), and a `PostReceipt` fetch context. **`PostReceiptHelper`** calls `onReceiptPosted()` only on real post success. **`PostPendingTransactionsHelper`** funnels sync outcomes through `completeSync()` so pending-purchase sync also hits that gate.
> 
> **`PurchasesOrchestrator`** wraps purchase/product-change completion, `syncPurchases`, restore (including partial success before a final error), and Amazon sync success behind the same `afterPostReceiptRemoteConfigRefresh` helper so app callbacks run after config reflects posted receipts. Multi-receipt operations still refresh once at the end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f54f2fdd6254a36d008a11910f812a313b4d3eef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->