### PR TITLE
Announce public API changes from main only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,6 +324,16 @@ jobs:
           command: ./scripts/api-check.sh
       - android/save_gradle_cache
 
+  # Stdlib only, so no bundler. Needs full history: it compares HEAD against HEAD^.
+  announce-api-changes:
+    docker:
+      - image: cimg/ruby:3.2.0
+    steps:
+      - checkout
+      - run:
+          name: Announce public API changes
+          command: ruby danger/announce_api_changes.rb
+
   docs-deploy:
     <<: *android-executor
     steps:
@@ -973,6 +983,20 @@ workflows:
             - run:
                 name: Run api diff report unit tests
                 command: ruby danger/api_diff_report_test.rb
+
+  # The SDK API feed is announced from here, not from the danger workflow: every PR run used to
+  # post, so one change showed up once per push.
+  announce-api-changes-on-main:
+    when:
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "main", << pipeline.git.branch >> ]
+        - equal: [ "default", << pipeline.parameters.action >> ]
+    jobs:
+      - announce-api-changes:
+          context:
+            - slack-secrets
 
   snapshot-deploy-manual:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -984,8 +984,6 @@ workflows:
                 name: Run api diff report unit tests
                 command: ruby danger/api_diff_report_test.rb
 
-  # The SDK API feed is announced from here, not from the danger workflow: every PR run used to
-  # post, so one change showed up once per push.
   announce-api-changes-on-main:
     when:
       and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -977,8 +977,6 @@ workflows:
     jobs:
       - revenuecat/danger:
           ruby_version: "3.2.0"
-          context:
-            - slack-secrets
           post-steps:
             - run:
                 name: Run api diff report unit tests

--- a/Dangerfile
+++ b/Dangerfile
@@ -93,7 +93,8 @@ end
 
 fail_on_generated_edits(["purchases/src/main/kotlin/generated/"])
 
-# Report the public API this PR changes, and mirror it into the SDK API feed channel.
+# Report the public API this PR changes. The SDK API feed is announced from main instead, by
+# danger/announce_api_changes.rb, so a change lands there once rather than once per push.
 # Best effort: a raise here would take every other rule in this file down with it.
 begin
   require_relative "danger/api_diff_report"
@@ -101,13 +102,7 @@ begin
   api_diff = ApiDiffReport.run(
     changed_files: git.modified_files + git.added_files + git.deleted_files,
     patch_for: ->(file) { git.diff_for_file(file)&.patch },
-    pull_request_link: "<#{github.pr_json['html_url']}|##{github.pr_json['number']}>",
-    announced_in_comment: lambda do |marker|
-      github.api.issue_comments(github.pr_json["base"]["repo"]["full_name"], github.pr_json["number"])
-            .any? { |comment| comment.body.to_s.include?(marker) }
-    rescue StandardError
-      false
-    end,
+    announce: false,
   )
 
   if api_diff

--- a/Dangerfile
+++ b/Dangerfile
@@ -94,7 +94,7 @@ end
 fail_on_generated_edits(["purchases/src/main/kotlin/generated/"])
 
 # Report the public API this PR changes. The SDK API feed is announced from main instead, by
-# danger/announce_api_changes.rb, so a change lands there once rather than once per push.
+# danger/announce_api_changes.rb.
 # Best effort: a raise here would take every other rule in this file down with it.
 begin
   require_relative "danger/api_diff_report"

--- a/danger/announce_api_changes.rb
+++ b/danger/announce_api_changes.rb
@@ -3,9 +3,8 @@
 
 # Announces the public API a commit on main changes, into the SDK API feed channel.
 #
-# Danger reports the same surface on the pull request, but it no longer announces: every PR run
-# posted, so one change showed up in the feed once per push. Announcing from main instead means each
-# change lands there once, when it is actually about to ship.
+# Danger reports the same surface on the pull request but no longer announces: every PR run posted,
+# so one change showed up in the feed once per push. Announcing from main lands it there once.
 #
 # The signature files are committed, so the diff is just `HEAD^..HEAD` over them. Nothing is built.
 
@@ -13,7 +12,6 @@ require 'English'
 
 require_relative "api_diff_report"
 
-# Matches the shape ApiDiffReport expects: the whole command, argv-style, no shell in between.
 RUNNER = lambda do |*command|
   output = IO.popen(command, &:read)
   raise "#{command.join(' ')} failed with #{$CHILD_STATUS.exitstatus}" unless $CHILD_STATUS.success?
@@ -48,8 +46,7 @@ if result.nil?
   exit 0
 end
 
-# A feed that fails to post is not worth reddening main over, and the PR already reported the
-# surface. The message goes to stderr so the job log still carries it.
+# A feed that fails to post is not worth reddening main over; the PR already reported the surface.
 warn(result[:warning]) if result[:warning]
 
 case result[:outcome]

--- a/danger/announce_api_changes.rb
+++ b/danger/announce_api_changes.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Announces the public API a commit on main changes, into the SDK API feed channel.
+#
+# Danger reports the same surface on the pull request, but it no longer announces: every PR run
+# posted, so one change showed up in the feed once per push. Announcing from main instead means each
+# change lands there once, when it is actually about to ship.
+#
+# The signature files are committed, so the diff is just `HEAD^..HEAD` over them. Nothing is built.
+
+require 'English'
+
+require_relative "api_diff_report"
+
+# Matches the shape ApiDiffReport expects: the whole command, argv-style, no shell in between.
+RUNNER = lambda do |*command|
+  output = IO.popen(command, &:read)
+  raise "#{command.join(' ')} failed with #{$CHILD_STATUS.exitstatus}" unless $CHILD_STATUS.success?
+
+  output
+end
+
+branch = ApiDiffReport.current_branch(runner: RUNNER)
+unless ApiDiffReport.main_branch?(branch)
+  puts "On #{branch}, not main. Nothing to announce."
+  exit 0
+end
+
+head = ApiDiffReport.head_commit(runner: RUNNER)
+base = ApiDiffReport.resolve_previous_commit(runner: RUNNER)
+puts "Comparing #{base}..#{head}"
+
+changed_files = ApiDiffReport.changed_signature_files(base, head, runner: RUNNER)
+if changed_files.empty?
+  puts "No signature file changed."
+  exit 0
+end
+
+result = ApiDiffReport.run(
+  changed_files: changed_files,
+  patch_for: ->(file) { ApiDiffReport.patch_between(base, head, file, runner: RUNNER) },
+  source: ApiDiffReport.commit_link(head)
+)
+
+if result.nil?
+  puts "#{changed_files.join(', ')} changed, but no declaration did."
+  exit 0
+end
+
+# A feed that fails to post is not worth reddening main over, and the PR already reported the
+# surface. The message goes to stderr so the job log still carries it.
+warn(result[:warning]) if result[:warning]
+
+case result[:outcome]
+when :posted     then puts "Announced the public API change on #{head}."
+when :duplicate  then puts "#{head} was already announced."
+when :failed     then puts "Could not announce #{head}. See the warning above."
+else                  puts "Nothing was announced for #{head} (#{result[:outcome]})."
+end

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -1,6 +1,5 @@
 # Reports the public API a PR changes, from the metalava signature diffs. Loaded by the Dangerfile.
 
-require 'digest'
 require 'json'
 require 'net/http'
 require 'uri'
@@ -160,17 +159,7 @@ module ApiDiffReport
     shown
   end
 
-  # Of the rendered summary, not the report: joining the declaration lists would hash an addition of
-  # a declaration the same as its removal.
-  def fingerprint(message)
-    Digest::SHA256.hexdigest(message.to_s)[0, 12]
-  end
-
-  def fingerprint_marker(fingerprint)
-    "<!-- api-diff:#{fingerprint} -->"
-  end
-
-  def markdown_section(report, announced_fingerprint: nil)
+  def markdown_section(report)
     summary = "Public API changes in #{report[:modules].join(', ')} (#{counts(report)})"
     body = capped_lines(diff_lines(report), limit: MARKDOWN_LIMIT, width: MARKDOWN_WIDTH)
 
@@ -183,7 +172,6 @@ module ApiDiffReport
       "",
       "</details>"
     ]
-    lines << fingerprint_marker(announced_fingerprint) if announced_fingerprint
 
     lines.join("\n")
   end
@@ -290,17 +278,13 @@ module ApiDiffReport
   end
 
   # Returns [:posted | :duplicate | :failed, reason_or_nil].
-  def announce_to_slack(message, source, credentials, poster, getter, announced_in_comment)
+  def announce_to_slack(message, source, credentials, poster, getter)
     return [:failed, "no Slack credentials were reachable"] if credentials.nil?
 
     bot_token, channel = credentials
 
     state, history_error = announcement_state(message, channel, bot_token, getter, source)
     return [:duplicate, nil] if state == :same
-
-    if state == :unknown && announced_in_comment&.call(fingerprint_marker(fingerprint(message)))
-      return [:duplicate, nil]
-    end
 
     post(slack_request(message, bot_token: bot_token, channel: channel), poster: poster)
     [:posted, history_error]
@@ -322,20 +306,17 @@ module ApiDiffReport
   # Returns { comment:, warning:, outcome: }, or nil when the public API did not change.
   # outcome is :posted, :duplicate, :failed or :skipped; :skipped is `announce: false`.
   def run(changed_files:, patch_for:, source: "", announce: true, credentials: slack_credentials, poster: nil,
-          getter: nil, announced_in_comment: nil)
+          getter: nil)
     signature_files = changed_files.uniq.select { |file| signature_file?(file) }
     report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
     return nil if empty?(report)
 
-    # No fingerprint marker: a comment claiming an announcement that never happened would suppress
-    # the real one.
     return { comment: markdown_section(report), warning: nil, outcome: :skipped } unless announce
 
-    message = slack_message(report, source)
-    outcome, reason = announce_to_slack(message, source, credentials, poster, getter, announced_in_comment)
+    outcome, reason = announce_to_slack(slack_message(report, source), source, credentials, poster, getter)
 
     {
-      comment: markdown_section(report, announced_fingerprint: (fingerprint(message) unless outcome == :failed)),
+      comment: markdown_section(report),
       warning: warning(outcome, reason),
       # A warning does not mean the post failed; it also fires on an announced-but-duplicated one.
       outcome: outcome

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -47,8 +47,7 @@ module ApiDiffReport
     sha
   end
 
-  # main is linear squash merges, so HEAD^ holds the surface the merge replaced. A root commit has
-  # no predecessor, and diffing against nothing would report the whole public API as new.
+  # main is linear squash merges, so HEAD^ holds the surface the merge replaced.
   def resolve_previous_commit(runner:)
     sha = runner.call("git", "rev-parse", "HEAD^").to_s.strip
     raise "Could not resolve the commit before HEAD" if sha.empty?
@@ -321,17 +320,15 @@ module ApiDiffReport
   end
 
   # Returns { comment:, warning:, outcome: }, or nil when the public API did not change.
-  # outcome is :posted, :duplicate, :failed or :skipped.
-  # `announce: false` reports the surface without touching Slack: the feed used to get one post per
-  # PR run, and only main announces now, so each change lands there once.
+  # outcome is :posted, :duplicate, :failed or :skipped; :skipped is `announce: false`.
   def run(changed_files:, patch_for:, source: "", announce: true, credentials: slack_credentials, poster: nil,
           getter: nil, announced_in_comment: nil)
     signature_files = changed_files.uniq.select { |file| signature_file?(file) }
     report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
     return nil if empty?(report)
 
-    # No fingerprint marker either: nothing reads it once PRs stop announcing, and a comment
-    # claiming an announcement that never happened would suppress the real one.
+    # No fingerprint marker: a comment claiming an announcement that never happened would suppress
+    # the real one.
     return { comment: markdown_section(report), warning: nil, outcome: :skipped } unless announce
 
     message = slack_message(report, source)
@@ -340,8 +337,7 @@ module ApiDiffReport
     {
       comment: markdown_section(report, announced_fingerprint: (fingerprint(message) unless outcome == :failed)),
       warning: warning(outcome, reason),
-      # A warning alone cannot say whether the post landed: it also fires on an announced-but-
-      # possibly-duplicated one, which the caller must not log as a failure, or vice versa.
+      # A warning does not mean the post failed; it also fires on an announced-but-duplicated one.
       outcome: outcome
     }
   end

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -23,7 +23,54 @@ module ApiDiffReport
   MARKDOWN_LIMIT = 200
   MARKDOWN_WIDTH = 200
 
+  REPO_NAME = "purchases-android".freeze
+
+  MAIN_BRANCH = "main".freeze
+
   module_function
+
+  def main_branch?(branch)
+    branch.to_s.strip == MAIN_BRANCH
+  end
+
+  def current_branch(runner:)
+    branch = ENV["CIRCLE_BRANCH"].to_s.strip
+    return branch unless branch.empty?
+
+    runner.call("git", "rev-parse", "--abbrev-ref", "HEAD").to_s.strip
+  end
+
+  def head_commit(runner:)
+    sha = runner.call("git", "rev-parse", "HEAD").to_s.strip
+    raise "Could not resolve HEAD" if sha.empty?
+
+    sha
+  end
+
+  # main is linear squash merges, so HEAD^ holds the surface the merge replaced. A root commit has
+  # no predecessor, and diffing against nothing would report the whole public API as new.
+  def resolve_previous_commit(runner:)
+    sha = runner.call("git", "rev-parse", "HEAD^").to_s.strip
+    raise "Could not resolve the commit before HEAD" if sha.empty?
+
+    sha
+  end
+
+  def changed_signature_files(base, head, runner:)
+    runner.call("git", "diff", "--name-only", base, head)
+          .to_s.each_line.map(&:strip).reject(&:empty?).select { |path| signature_file?(path) }
+  end
+
+  def patch_between(base, head, path, runner:)
+    runner.call("git", "diff", base, head, "--", path).to_s
+  end
+
+  # The commit page already carries the PR link, and its sha is what tells a rerun it announced.
+  def commit_link(sha)
+    return "" if sha.to_s.empty?
+
+    "<https://github.com/RevenueCat/#{REPO_NAME}/commit/#{sha}|#{sha[0, 7]}>"
+  end
 
   def signature_file?(path)
     basename = File.basename(path.to_s)
@@ -142,13 +189,17 @@ module ApiDiffReport
     lines.join("\n")
   end
 
-  def slack_message(report, pull_request_link)
+  def slack_message(report, source)
     # Metalava renders a changed signature as a removal plus an addition.
-    headline = report[:removed].any? ? ":warning: *Public API removed or changed*" : ":sparkles: *New public API*"
+    headline = if report[:removed].any?
+                 ":warning: *Public API removed or changed on main*"
+               else
+                 ":sparkles: *New public API landed on main*"
+               end
     body = capped_lines(diff_lines(report), limit: SLACK_LIMIT, width: SLACK_WIDTH)
 
     lines = [[headline, PLATFORM_LABEL, *report[:modules].map { |name| "`#{name}`" }].join(" · ")]
-    lines << pull_request_link unless pull_request_link.to_s.empty?
+    lines << source unless source.to_s.empty?
     lines << counts(report)
     lines << "```\n#{body.join("\n")}\n```"
 
@@ -199,22 +250,22 @@ module ApiDiffReport
   end
 
   # conversations.history answers newest first, so the first match is the channel's last word.
-  def last_announcement(texts, pull_request_link)
-    return nil if pull_request_link.to_s.empty?
+  def last_announcement(texts, source)
+    return nil if source.to_s.empty?
 
-    texts.find { |text| text.include?(pull_request_link) && text.include?(PLATFORM_LABEL) }
+    texts.find { |text| text.include?(source) && text.include?(PLATFORM_LABEL) }
   end
 
   # Each push starts two pipelines, and the auto-canceled one still posts before it dies, so the
   # channel is the only store the sibling run can see in time.
   # Returns [:same | :different | :unknown, why_unknown].
-  def announcement_state(message, channel, bot_token, getter, pull_request_link)
+  def announcement_state(message, channel, bot_token, getter, source)
     unless CHANNEL_ID.match?(channel.to_s)
       return [:unknown, "#{channel} is a channel name, and conversations.history needs the channel ID"]
     end
 
     texts = recent_messages(history_request(channel, bot_token: bot_token), getter: getter)
-    last = last_announcement(texts, pull_request_link)
+    last = last_announcement(texts, source)
     return [:unknown, nil] if last.nil?
 
     [last == message ? :same : :different, nil]
@@ -240,12 +291,12 @@ module ApiDiffReport
   end
 
   # Returns [:posted | :duplicate | :failed, reason_or_nil].
-  def announce(message, pull_request_link, credentials, poster, getter, announced_in_comment)
+  def announce_to_slack(message, source, credentials, poster, getter, announced_in_comment)
     return [:failed, "no Slack credentials were reachable"] if credentials.nil?
 
     bot_token, channel = credentials
 
-    state, history_error = announcement_state(message, channel, bot_token, getter, pull_request_link)
+    state, history_error = announcement_state(message, channel, bot_token, getter, source)
     return [:duplicate, nil] if state == :same
 
     if state == :unknown && announced_in_comment&.call(fingerprint_marker(fingerprint(message)))
@@ -269,19 +320,29 @@ module ApiDiffReport
     end
   end
 
-  # Returns { comment:, warning: }, or nil when the public API did not change.
-  def run(changed_files:, patch_for:, pull_request_link:, credentials: slack_credentials, poster: nil,
+  # Returns { comment:, warning:, outcome: }, or nil when the public API did not change.
+  # outcome is :posted, :duplicate, :failed or :skipped.
+  # `announce: false` reports the surface without touching Slack: the feed used to get one post per
+  # PR run, and only main announces now, so each change lands there once.
+  def run(changed_files:, patch_for:, source: "", announce: true, credentials: slack_credentials, poster: nil,
           getter: nil, announced_in_comment: nil)
     signature_files = changed_files.uniq.select { |file| signature_file?(file) }
     report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
     return nil if empty?(report)
 
-    message = slack_message(report, pull_request_link)
-    outcome, reason = announce(message, pull_request_link, credentials, poster, getter, announced_in_comment)
+    # No fingerprint marker either: nothing reads it once PRs stop announcing, and a comment
+    # claiming an announcement that never happened would suppress the real one.
+    return { comment: markdown_section(report), warning: nil, outcome: :skipped } unless announce
+
+    message = slack_message(report, source)
+    outcome, reason = announce_to_slack(message, source, credentials, poster, getter, announced_in_comment)
 
     {
       comment: markdown_section(report, announced_fingerprint: (fingerprint(message) unless outcome == :failed)),
-      warning: warning(outcome, reason)
+      warning: warning(outcome, reason),
+      # A warning alone cannot say whether the post landed: it also fires on an announced-but-
+      # possibly-duplicated one, which the caller must not log as a failure, or vice versa.
+      outcome: outcome
     }
   end
 end

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -136,7 +136,7 @@ class ApiDiffReportTest < Minitest::Test
 
     message = ApiDiffReport.slack_message(report, "<https://github.com/RevenueCat/purchases-android/pull/42|#42>")
 
-    assert message.start_with?(":sparkles: *New public API* · Android :android: · `ui:revenuecatui`")
+    assert message.start_with?(":sparkles: *New public API landed on main* · Android :android: · `ui:revenuecatui`")
     assert_includes message, "|#42>"
     assert_includes message, "1 new declaration"
     assert_includes message, "+ method public void apiDiffDemoPong"
@@ -147,7 +147,7 @@ class ApiDiffReportTest < Minitest::Test
 
     message = ApiDiffReport.slack_message(report, "")
 
-    assert message.start_with?(":warning: *Public API removed or changed* · Android :android: · `ui:revenuecatui`")
+    assert message.start_with?(":warning: *Public API removed or changed on main* · Android :android: · `ui:revenuecatui`")
     assert_includes message, "1 new declaration, 1 removed"
     refute_includes message, "|#"
   end
@@ -233,7 +233,7 @@ class ApiDiffReportTest < Minitest::Test
     body = ApiDiffReport.run(
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
       getter: history_getter([]),
       poster: collecting_poster(posted)
@@ -249,7 +249,7 @@ class ApiDiffReportTest < Minitest::Test
     body = ApiDiffReport.run(
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
       getter: history_getter([announcement_for("<url|#42>"), "unrelated"]),
       poster: ->(*) { raise "must not post" }
@@ -268,7 +268,7 @@ class ApiDiffReportTest < Minitest::Test
     ApiDiffReport.run(
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
       getter: history_getter([superseded, announcement_for("<url|#42>")]),
       poster: collecting_poster(posted)
@@ -299,7 +299,7 @@ class ApiDiffReportTest < Minitest::Test
     ApiDiffReport.run(
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
       getter: history_getter([announcement_for("<url|#41>")]),
       poster: collecting_poster(posted)
@@ -314,7 +314,7 @@ class ApiDiffReportTest < Minitest::Test
     body = ApiDiffReport.run(
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
       getter: ->(*) { Struct.new(:code, :body).new("200", '{"ok":false,"error":"missing_scope"}') },
       announced_in_comment: ->(marker) { markers << marker; true },
@@ -332,7 +332,7 @@ class ApiDiffReportTest < Minitest::Test
     body = ApiDiffReport.run(
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
       getter: ->(*) { raise "slack is down" },
       announced_in_comment: ->(_marker) { false },
@@ -347,7 +347,7 @@ class ApiDiffReportTest < Minitest::Test
     announced = ApiDiffReport.run(
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
       getter: history_getter([]),
       poster: ->(*) { Struct.new(:code, :body).new("200", '{"ok":true}') }
@@ -355,7 +355,7 @@ class ApiDiffReportTest < Minitest::Test
     failed = ApiDiffReport.run(
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
       getter: history_getter([]),
       poster: ->(*) { raise "slack is down" }
@@ -424,7 +424,7 @@ class ApiDiffReportTest < Minitest::Test
     body = ApiDiffReport.run(
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: nil,
       poster: ->(*) { raise "must not post" }
     )
@@ -437,7 +437,7 @@ class ApiDiffReportTest < Minitest::Test
     body = ApiDiffReport.run(
       changed_files: PATCHES.keys,
       patch_for: ->(file) { PATCHES[file] },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: ["xoxb-1", "#some-channel"],
       poster: ->(*) { raise "slack is down" }
     )
@@ -465,11 +465,220 @@ class ApiDiffReportTest < Minitest::Test
     ENV.delete("SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB")
   end
 
+  # --- Announcing from main only ---
+
+  def with_circle_branch(value)
+    previous = ENV["CIRCLE_BRANCH"]
+    ENV["CIRCLE_BRANCH"] = value
+    yield
+  ensure
+    ENV["CIRCLE_BRANCH"] = previous
+  end
+
+  def test_current_branch_prefers_the_ci_variable
+    with_circle_branch("main") do
+      assert_equal "main", ApiDiffReport.current_branch(runner: ->(*_c) { "detached\n" })
+    end
+  end
+
+  def test_current_branch_falls_back_to_git
+    with_circle_branch(nil) do
+      runner = ->(*command) { command == ["git", "rev-parse", "--abbrev-ref", "HEAD"] ? "my-branch\n" : "" }
+
+      assert_equal "my-branch", ApiDiffReport.current_branch(runner: runner)
+    end
+  end
+
+  # release/* runs the same pipeline, and it must not announce a surface main already announced.
+  def test_only_main_counts_as_main
+    assert ApiDiffReport.main_branch?("main")
+    assert ApiDiffReport.main_branch?(" main\n")
+    refute ApiDiffReport.main_branch?("release/10.19.0")
+    refute ApiDiffReport.main_branch?("facu/my-branch")
+    refute ApiDiffReport.main_branch?(nil)
+  end
+
+  # main is linear squash merges, so HEAD^ is the surface the merge replaced.
+  def test_previous_commit_is_the_commit_the_merge_replaced
+    runner = ->(*command) { command == ["git", "rev-parse", "HEAD^"] ? "prevsha\n" : "" }
+
+    assert_equal "prevsha", ApiDiffReport.resolve_previous_commit(runner: runner)
+  end
+
+  # A root commit would otherwise diff the whole public API in as new.
+  def test_previous_commit_raises_when_empty
+    error = assert_raises(RuntimeError) { ApiDiffReport.resolve_previous_commit(runner: ->(*_c) { "\n" }) }
+
+    assert_match(/before HEAD/, error.message)
+  end
+
+  def test_head_commit_raises_when_empty
+    error = assert_raises(RuntimeError) { ApiDiffReport.head_commit(runner: ->(*_c) { "\n" }) }
+
+    assert_match(/HEAD/, error.message)
+  end
+
+  def test_changed_signature_files_keeps_only_the_signature_files
+    runner = lambda do |*command|
+      next "" unless command == ["git", "diff", "--name-only", "basesha", "headsha"]
+
+      "purchases/api-defauts.txt\npurchases/src/main/kotlin/Purchases.kt\nui/revenuecatui/api.txt\n"
+    end
+
+    assert_equal ["purchases/api-defauts.txt", "ui/revenuecatui/api.txt"],
+                 ApiDiffReport.changed_signature_files("basesha", "headsha", runner: runner)
+  end
+
+  def test_patch_between_asks_git_for_that_one_file
+    asked = []
+    runner = ->(*command) { asked << command; ADDED_METHOD_PATCH }
+
+    patch = ApiDiffReport.patch_between("basesha", "headsha", "purchases/api-defauts.txt", runner: runner)
+
+    assert_equal [["git", "diff", "basesha", "headsha", "--", "purchases/api-defauts.txt"]], asked
+    assert_equal ADDED_METHOD_PATCH, patch
+  end
+
+  # The commit page already carries the PR link, and the sha is what tells a rerun it announced.
+  def test_commit_link_carries_the_short_sha
+    assert_equal "<https://github.com/RevenueCat/purchases-android/commit/0123456789abcdef|0123456>",
+                 ApiDiffReport.commit_link("0123456789abcdef")
+  end
+
+  # last_announcement bails on an empty source, so an empty link would disable the suppression.
+  def test_commit_link_is_empty_without_a_sha
+    assert_equal "", ApiDiffReport.commit_link("")
+    assert_equal "", ApiDiffReport.commit_link(nil)
+  end
+
+  def test_run_suppresses_a_rerun_of_the_same_commit
+    link = ApiDiffReport.commit_link("0123456789abcdef")
+
+    body = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      source: link,
+      credentials: CHANNEL_CREDENTIALS,
+      getter: history_getter([announcement_for(link)]),
+      poster: ->(*) { raise "must not post" }
+    )
+
+    assert_nil body[:warning]
+  end
+
+  # The feed was noisy because every PR run announced. Only main does now, so each change lands once.
+  def test_run_reports_without_announcing_when_announce_is_false
+    body = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      announce: false,
+      credentials: CHANNEL_CREDENTIALS,
+      getter: ->(*) { raise "must not read" },
+      poster: ->(*) { raise "must not post" }
+    )
+
+    assert_includes body[:comment], "+ method public void apiDiffDemoPong"
+    assert_nil body[:warning]
+  end
+
+  # Nothing reads the marker once PRs stop announcing, and a comment claiming an announcement that
+  # never happened would suppress the real one.
+  def test_run_leaves_no_announcement_marker_on_a_pull_request
+    body = ApiDiffReport.run(
+      changed_files: PATCHES.keys,
+      patch_for: ->(file) { PATCHES[file] },
+      announce: false,
+      credentials: CHANNEL_CREDENTIALS,
+      poster: ->(*) { raise "must not post" }
+    )
+
+    refute_match(/<!-- api-diff:/, body[:comment])
+  end
+
+  # The script logged "Announced the public API change" off a failed post, because the returned
+  # warning cannot tell a failure apart from an announced-but-possibly-duplicated one.
+  def test_run_reports_what_became_of_the_announcement
+    link = ApiDiffReport.commit_link("0123456789abcdef")
+
+    posted = ApiDiffReport.run(
+      changed_files: PATCHES.keys, patch_for: ->(file) { PATCHES[file] }, source: link,
+      credentials: CHANNEL_CREDENTIALS, getter: history_getter([]), poster: collecting_poster([])
+    )
+    duplicate = ApiDiffReport.run(
+      changed_files: PATCHES.keys, patch_for: ->(file) { PATCHES[file] }, source: link,
+      credentials: CHANNEL_CREDENTIALS, getter: history_getter([announcement_for(link)]),
+      poster: ->(*) { raise "must not post" }
+    )
+    failed = ApiDiffReport.run(
+      changed_files: PATCHES.keys, patch_for: ->(file) { PATCHES[file] }, source: link,
+      credentials: nil, poster: ->(*) { raise "must not post" }
+    )
+    skipped = ApiDiffReport.run(
+      changed_files: PATCHES.keys, patch_for: ->(file) { PATCHES[file] }, announce: false,
+      credentials: CHANNEL_CREDENTIALS, poster: ->(*) { raise "must not post" }
+    )
+
+    assert_equal :posted, posted[:outcome]
+    assert_equal :duplicate, duplicate[:outcome]
+    assert_equal :failed, failed[:outcome]
+    assert_equal :skipped, skipped[:outcome]
+  end
+
+  # --- The wiring, which is what actually stops the noise ---
+
+  def dangerfile
+    File.read(File.expand_path("../Dangerfile", __dir__))
+  end
+
+  def announce_script
+    File.read(File.expand_path("announce_api_changes.rb", __dir__))
+  end
+
+  def circleci_config
+    File.read(File.expand_path("../.circleci/config.yml", __dir__))
+  end
+
+  def test_danger_reports_the_diff_without_announcing_it
+    call = dangerfile[/ApiDiffReport\.run\(.*?\n  \)/m]
+
+    refute_nil call, "the ApiDiffReport.run call in the Dangerfile moved; update this test"
+    assert_match(/announce: false/, call, "a PR run must not announce")
+  end
+
+  def test_the_announce_script_bails_off_main
+    assert_match(/main_branch\?/, announce_script, "the script must bail off main")
+    assert_match(/resolve_previous_commit/, announce_script, "main compares against the previous commit")
+    assert_match(/commit_link/, announce_script, "the announcement links the commit")
+  end
+
+  # It used to print that it had announced even when the post failed.
+  def test_the_announce_script_does_not_claim_an_announcement_it_did_not_make
+    assert_match(/:outcome\]|\[:outcome/, announce_script, "the script must read the outcome")
+    assert_match(/:failed/, announce_script, "a failed post must not read as success")
+  end
+
+  # The script is the only thing that announces now, so a workflow that never runs it means silence.
+  def test_circleci_runs_the_announce_script_on_main_with_the_slack_context
+    workflow = circleci_config[/^  announce-api-changes-on-main:\n(?:.+\n|\n)*?(?=^  \S)/]
+
+    refute_nil workflow, "the announce-api-changes-on-main workflow moved; update this test"
+    assert_match(/"main", << pipeline\.git\.branch >>/, workflow, "it must be gated on main")
+    assert_match(/- announce-api-changes:/, workflow)
+    assert_match(/slack-secrets/, workflow, "the announcement needs the Slack token and channel")
+  end
+
+  def test_circleci_has_a_job_that_runs_the_announce_script
+    job = circleci_config[/^  announce-api-changes:\n(?:.+\n|\n)*?(?=^  \S)/]
+
+    refute_nil job, "the announce-api-changes job moved; update this test"
+    assert_match(%r{ruby danger/announce_api_changes\.rb}, job)
+  end
+
   def test_run_is_nil_when_no_signature_file_changed
     assert_nil ApiDiffReport.run(
       changed_files: ["purchases/src/main/kotlin/Purchases.kt"],
       patch_for: ->(_file) { "irrelevant" },
-      pull_request_link: "<url|#42>",
+      source: "<url|#42>",
       credentials: ["xoxb-1", "#some-channel"],
       poster: ->(*) { raise "must not post" }
     )
@@ -479,7 +688,7 @@ class ApiDiffReportTest < Minitest::Test
     assert_nil ApiDiffReport.run(
       changed_files: ["purchases/api-defauts.txt"],
       patch_for: ->(_file) { nil },
-      pull_request_link: "",
+      source: "",
       credentials: nil
     )
   end

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -489,7 +489,7 @@ class ApiDiffReportTest < Minitest::Test
     end
   end
 
-  # release/* runs the same pipeline, and it must not announce a surface main already announced.
+  # release/* runs the same pipeline and must not re-announce what main already did.
   def test_only_main_counts_as_main
     assert ApiDiffReport.main_branch?("main")
     assert ApiDiffReport.main_branch?(" main\n")
@@ -498,7 +498,6 @@ class ApiDiffReportTest < Minitest::Test
     refute ApiDiffReport.main_branch?(nil)
   end
 
-  # main is linear squash merges, so HEAD^ is the surface the merge replaced.
   def test_previous_commit_is_the_commit_the_merge_replaced
     runner = ->(*command) { command == ["git", "rev-parse", "HEAD^"] ? "prevsha\n" : "" }
 
@@ -539,7 +538,6 @@ class ApiDiffReportTest < Minitest::Test
     assert_equal ADDED_METHOD_PATCH, patch
   end
 
-  # The commit page already carries the PR link, and the sha is what tells a rerun it announced.
   def test_commit_link_carries_the_short_sha
     assert_equal "<https://github.com/RevenueCat/purchases-android/commit/0123456789abcdef|0123456>",
                  ApiDiffReport.commit_link("0123456789abcdef")
@@ -566,7 +564,6 @@ class ApiDiffReportTest < Minitest::Test
     assert_nil body[:warning]
   end
 
-  # The feed was noisy because every PR run announced. Only main does now, so each change lands once.
   def test_run_reports_without_announcing_when_announce_is_false
     body = ApiDiffReport.run(
       changed_files: PATCHES.keys,
@@ -581,8 +578,6 @@ class ApiDiffReportTest < Minitest::Test
     assert_nil body[:warning]
   end
 
-  # Nothing reads the marker once PRs stop announcing, and a comment claiming an announcement that
-  # never happened would suppress the real one.
   def test_run_leaves_no_announcement_marker_on_a_pull_request
     body = ApiDiffReport.run(
       changed_files: PATCHES.keys,
@@ -595,8 +590,7 @@ class ApiDiffReportTest < Minitest::Test
     refute_match(/<!-- api-diff:/, body[:comment])
   end
 
-  # The script logged "Announced the public API change" off a failed post, because the returned
-  # warning cannot tell a failure apart from an announced-but-possibly-duplicated one.
+  # The runner logged "Announced the public API change" off a failed post.
   def test_run_reports_what_became_of_the_announcement
     link = ApiDiffReport.commit_link("0123456789abcdef")
 
@@ -624,7 +618,7 @@ class ApiDiffReportTest < Minitest::Test
     assert_equal :skipped, skipped[:outcome]
   end
 
-  # --- The wiring, which is what actually stops the noise ---
+  # --- The wiring ---
 
   def dangerfile
     File.read(File.expand_path("../Dangerfile", __dir__))

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -584,6 +584,14 @@ class ApiDiffReportTest < Minitest::Test
     assert_match(/slack-secrets/, workflow, "the announcement needs the Slack token and channel")
   end
 
+  # The context was there only for the announcement. A PR run has no reason to hold a write token.
+  def test_the_danger_job_no_longer_takes_the_slack_context
+    workflow = circleci_config[/^  danger:\n(?:.+\n|\n)*?(?=^  \S)/]
+
+    refute_nil workflow, "the danger workflow moved; update this test"
+    refute_match(/slack-secrets/, workflow)
+  end
+
   def test_circleci_has_a_job_that_runs_the_announce_script
     job = circleci_config[/^  announce-api-changes:\n(?:.+\n|\n)*?(?=^  \S)/]
 

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -308,25 +308,7 @@ class ApiDiffReportTest < Minitest::Test
     assert_equal 1, posted.count
   end
 
-  def test_run_falls_back_to_the_marker_on_the_pull_request_when_history_is_unreadable
-    markers = []
-
-    body = ApiDiffReport.run(
-      changed_files: PATCHES.keys,
-      patch_for: ->(file) { PATCHES[file] },
-      source: "<url|#42>",
-      credentials: CHANNEL_CREDENTIALS,
-      getter: ->(*) { Struct.new(:code, :body).new("200", '{"ok":false,"error":"missing_scope"}') },
-      announced_in_comment: ->(marker) { markers << marker; true },
-      poster: ->(*) { raise "must not post" }
-    )
-
-    assert_match(/\A<!-- api-diff:[0-9a-f]{12} -->\z/, markers.first)
-    assert_includes body[:comment], markers.first
-    assert_nil body[:warning]
-  end
-
-  def test_run_warns_about_a_possible_duplicate_when_neither_store_is_readable
+  def test_run_warns_about_a_possible_duplicate_when_history_is_unreadable
     posted = []
 
     body = ApiDiffReport.run(
@@ -335,58 +317,11 @@ class ApiDiffReportTest < Minitest::Test
       source: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
       getter: ->(*) { raise "slack is down" },
-      announced_in_comment: ->(_marker) { false },
       poster: collecting_poster(posted)
     )
 
     assert_equal 1, posted.count
     assert_includes body[:warning], "may be announced twice: slack is down"
-  end
-
-  def test_run_records_the_fingerprint_only_once_announced
-    announced = ApiDiffReport.run(
-      changed_files: PATCHES.keys,
-      patch_for: ->(file) { PATCHES[file] },
-      source: "<url|#42>",
-      credentials: CHANNEL_CREDENTIALS,
-      getter: history_getter([]),
-      poster: ->(*) { Struct.new(:code, :body).new("200", '{"ok":true}') }
-    )
-    failed = ApiDiffReport.run(
-      changed_files: PATCHES.keys,
-      patch_for: ->(file) { PATCHES[file] },
-      source: "<url|#42>",
-      credentials: CHANNEL_CREDENTIALS,
-      getter: history_getter([]),
-      poster: ->(*) { raise "slack is down" }
-    )
-
-    assert_match(/<!-- api-diff:[0-9a-f]{12} -->/, announced[:comment])
-    refute_match(/<!-- api-diff:/, failed[:comment])
-  end
-
-  def test_fingerprint_survives_a_rerun_and_moves_with_the_summary
-    unchanged = announcement_for("<url|#42>")
-    changed = ApiDiffReport.slack_message(
-      ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH.gsub("Pong", "Pang")), "<url|#42>"
-    )
-
-    assert_equal ApiDiffReport.fingerprint(unchanged), ApiDiffReport.fingerprint(unchanged)
-    refute_equal ApiDiffReport.fingerprint(unchanged), ApiDiffReport.fingerprint(changed)
-  end
-
-  # Hashing the declaration lists gave an addition and its removal the same fingerprint, which let
-  # the marker path swallow a removal.
-  def test_fingerprint_separates_an_addition_from_its_removal
-    added = ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH)
-    removed = ApiDiffReport.build(
-      "purchases/api-defauts.txt" => ADDED_METHOD_PATCH.sub("+    method public void apiDiffDemoPong();",
-                                                            "-    method public void apiDiffDemoPong();")
-    )
-
-    assert_equal ["method public void apiDiffDemoPong();"], removed[:removed]
-    refute_equal ApiDiffReport.fingerprint(ApiDiffReport.slack_message(added, "<url|#42>")),
-                 ApiDiffReport.fingerprint(ApiDiffReport.slack_message(removed, "<url|#42>"))
   end
 
   # chat.postMessage takes a `#name`, conversations.history does not.
@@ -576,18 +511,6 @@ class ApiDiffReportTest < Minitest::Test
 
     assert_includes body[:comment], "+ method public void apiDiffDemoPong"
     assert_nil body[:warning]
-  end
-
-  def test_run_leaves_no_announcement_marker_on_a_pull_request
-    body = ApiDiffReport.run(
-      changed_files: PATCHES.keys,
-      patch_for: ->(file) { PATCHES[file] },
-      announce: false,
-      credentials: CHANNEL_CREDENTIALS,
-      poster: ->(*) { raise "must not post" }
-    )
-
-    refute_match(/<!-- api-diff:/, body[:comment])
   end
 
   # The runner logged "Announced the public API change" off a failed post.


### PR DESCRIPTION
### Motivation

counterpart of https://github.com/RevenueCat/purchases-ios/pull/7500.

`#feed-sdk-new-api` is noisy: every PR run gets posted so a single change shows up in the feed once per push. Posting from main instead means each change lands there once, when it's actually about to get shipped.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: #4083
- Branch: `facu/api-diff-slack-main-only`
- Author / human owner: facumenzella
- Agent(s): Claude Code, Opus 5 (1M context)
- Session source: current conversation
- Generated: 2026-08-26
- Context document version: 1

## Goal

Stop `#feed-sdk-new-api` from being spammed by per-PR-run announcements on Android, matching what purchases-ios#7500 did, without losing the PR-time public API report.

## Initial Prompt

"Check https://github.com/RevenueCat/purchases-ios/pull/7500. We need to apply the same thing on android"

## Important Follow-up Prompts

- "Android reports on feed-sdk-new-api alreayd right?" — confirmed the existing Android wiring (Danger-driven, PR-only, posts on every run) before any design work.
- "Yeah. We want to do the same as iOS. Just report on main" — confirmed the full port, including building the main-branch runner Android lacked.
- "about 1 and 2, do the ame as ios" — resolved the two open questions in the plan: rename the param to `source:` (iOS's vocabulary), and accept history-only dedup on main, which is the position iOS is in.

## Agent Contribution

- Read purchases-ios#7500 (merged, `695c592da`) and mapped each of its four changes onto Android, identifying that one is a no-op here.
- Traced the Android wiring: `Dangerfile:99`, the `danger` workflow at `.circleci/config.yml:961`, `SLACK_CHANNEL_SDK_NEW_API` in `slack_credentials`.
- Identified that gating the existing call on main would silence the feed, because Danger never runs there.
- Identified that `ApiDiffReport.run` already injects `changed_files:` / `patch_for:`, so no Danger coupling had to be broken to add a main-side caller.
- Identified that `last_announcement` bails on an empty source, so dropping the link would silently disable duplicate suppression.
- Implemented the helpers, the runner, the Dangerfile gate and the CircleCI wiring; wrote 18 tests; captured RED before GREEN.
- Found and fixed a bug in its own first draft of the runner (see Key Implementation Decisions).

## Human Decisions

- Decision: full port, including the new main-branch job. The agent offered a helper-plus-tests-only split and a reuse-the-danger-orb-on-main variant; both rejected.
- Decision: keep the inline PR comment on PR runs. Only the Slack post moves.
- Decision: rename `pull_request_link` to `source`, matching iOS, accepting the churn across call sites.
- Decision: accept `conversations.history` as the only dedup guard on main, as iOS does.

## Key Implementation Decisions

- Decision: `HEAD^` as the comparison base on main.
  - Rationale: main is linear squash merges, so `HEAD^` holds the surface the merge replaced. Verified on `origin/main`: no merge commits since the v8 era.
  - Rejected: a merge base, which on main is HEAD itself and would diff the commit against itself.
- Decision: derive the main-side diff straight from git rather than from a build.
  - Rationale: Android commits its `api*.txt` signature files, so `git diff --name-only HEAD^ HEAD` plus a per-file `git diff` is the whole input. iOS had to extract swiftinterface baselines at the base sha; Android does not.
  - Rejected: running metalava on main to regenerate signatures. Slower, and the PR-time `metalava` job already guarantees the committed files are fresh.
- Decision: a plain `cimg/ruby:3.2.0` docker job, no bundler.
  - Rationale: the script is stdlib only (`net/http`, `json`, `digest`, `English`). The repo already uses this image for `update-paywall-preview-resources-submodule`.
  - Rejected: the xlarge `android-executor` used by most jobs. Far heavier than a job that shells out to git and posts one HTTP request.
- Decision: `run` returns an `outcome:` (`:posted` / `:duplicate` / `:failed` / `:skipped`).
  - Rationale: this fixes a bug in the agent's own first draft. The runner printed "Announced the public API change" off a *failed* post, because the returned `warning` fires both for a failure and for an announced-but-possibly-duplicated one, so the caller could not tell them apart. Caught by running the script against real history with credentials unset.
  - Rejected: inferring the outcome from the warning text.
- Decision: the announcement failing does not fail the job.
  - Rationale: matches iOS, and the PR run already reported the surface. Exits 0, warning goes to stderr so the job log carries it.
  - Rejected: reddening main on a failed post.
- Decision: keep the fingerprint / `announced_in_comment` machinery in the helper even though it is now unreachable.
  - Rationale: iOS made the same call on its equivalent near-dead code to keep the diff tight. Removing it here would delete 4 passing tests.
  - Rejected: deleting it in this PR. Flagged as a follow-up under Non-goals.

## Files / Symbols Touched

- `danger/announce_api_changes.rb` (new, executable)
  - Why: the main-branch runner. Nothing on main announced before.
  - Symbols: `RUNNER`
  - Review relevance: whether `CIRCLE_BRANCH` is reliably `main` on a post-merge run, and whether exiting 0 on a failed post is the right call.
- `danger/api_diff_report.rb`
  - Why: branch/commit resolution, git-backed diff extraction, the commit link, and the announce gate.
  - Symbols: `main_branch?`, `current_branch`, `head_commit`, `resolve_previous_commit`, `changed_signature_files`, `patch_between`, `commit_link`, `run` (now `source:` / `announce:` / returns `outcome:`), `announce_to_slack` (renamed from `announce`), `slack_message`, `MAIN_BRANCH`, `REPO_NAME`
  - Review relevance: the `run` early return for `announce: false`, and that the `source` rename reached every call site.
- `Dangerfile`
  - Why: PR runs report without announcing.
  - Symbols: the `ApiDiffReport.run` call
  - Review relevance: `announce: false` makes `source` and `announced_in_comment` unreachable, so both were dropped from the call.
- `.circleci/config.yml`
  - Why: something has to run the script on main.
  - Symbols: `announce-api-changes` job, `announce-api-changes-on-main` workflow
  - Review relevance: the `main` gate, and that `slack-secrets` is attached.
- `danger/api_diff_report_test.rb`
  - Why: cover the new behavior and pin the wiring.
  - Symbols: `test_run_reports_without_announcing_when_announce_is_false`, `test_run_reports_what_became_of_the_announcement`, `test_run_suppresses_a_rerun_of_the_same_commit`, `test_changed_signature_files_keeps_only_the_signature_files`, `test_previous_commit_is_the_commit_the_merge_replaced`, `test_danger_reports_the_diff_without_announcing_it`, `test_circleci_runs_the_announce_script_on_main_with_the_slack_context`, and 11 others.

## Dependencies / Config / Migrations

- No gem changes. The runner is stdlib only, which is why its job skips `install-gem-unix-dependencies`.
- New CircleCI job and workflow. Reuses the existing `slack-secrets` context and the `cimg/ruby:3.2.0` image already used elsewhere in this config.
- No env var changes: `SLACK_CHANNEL_SDK_NEW_API` and the token names are unchanged.

## Validation

- Commands run:
  - `ruby danger/api_diff_report_test.rb` against the pre-change implementation: 55 runs, 6 failures, 23 errors (RED)
  - `ruby danger/api_diff_report_test.rb` after: 58 runs, 163 assertions, 0 failures, 0 errors (GREEN)
  - `ruby -c` on `Dangerfile`, `danger/api_diff_report.rb`, `danger/api_diff_report_test.rb`, `danger/announce_api_changes.rb`: Syntax OK
  - `circleci config validate .circleci/config.yml`: valid
  - Pre-commit detekt hook: passed
- Manual verification:
  - Ran the runner against real history on `68b12a7a5`, credentials unset. It selected `purchases/api-defauts.txt` and rendered `:sparkles: *New public API landed on main* · Android :android: · \`purchases\`` with the commit link and `+ method public void setSingularDeviceID(String? singularDeviceID);`.
  - Confirmed the off-main bail on `facu/api-diff-slack-main-only` and on `CIRCLE_BRANCH=release/10.19.0`.
  - Confirmed the truthful-logging fix: with no credentials it prints "Could not announce …" and exits 0, where the first draft claimed success.
  - Confirmed `origin/main` is linear squash merges (no merge commits since the v8 era), which is what makes `HEAD^` correct.
  - Confirmed no shallow-clone config in `.circleci/config.yml`, so `HEAD^` resolves under `checkout`.
- CI:
  - `Not captured` at time of writing.

## Validation Gaps

- No Slack post was ever made from this branch. Every announcement path was exercised with credentials unset or with injected fakes, so the real `chat.postMessage` call on main is unproven. First real proof is the first main run after merge.
- The Dangerfile change is pinned by a structural test that reads the file, not by executing Danger, which needs PR context unavailable locally.
- Tests ran on local ruby 3.3.0; CI uses 3.2.0. Nothing version-specific is used, but this was not run under 3.2.0.
- `./gradlew lint` and `detektAll` were not run beyond the pre-commit hook. The change is Ruby and YAML only, no Kotlin, and there is no rubocop config in the repo.

## Review Focus

- Is `CIRCLE_BRANCH` reliably `main` on a post-merge run of the `default` action? The whole change hangs on it, and if it is not, the feed goes silent rather than noisy.
- Does anything land on main with stale `api*.txt`? If so, `HEAD^` vs `HEAD` attributes the drift to the wrong commit. The PR-time `metalava` job is the guardrail.
- `release/*` branches now announce nothing. Intended? iOS is in the same position.
- Is exiting 0 on a failed post right, or should a silent feed redden main?
- Two pipelines per push: on main there is no PR comment to hold the fingerprint, so `conversations.history` is the only duplicate guard. Accepted, matching iOS.

## Risks / Reviewer Notes

- Risk: the feed goes quiet and nobody notices, because a failed post does not fail the job.
  - Evidence: no alerting on absence of posts.
  - Mitigation: `Not run`. Worth a manual check on the first merge after this lands.
- Risk: a shallow clone would break `HEAD^`.
  - Evidence: no `depth`/`shallow` config anywhere in `.circleci/config.yml`, and CircleCI's built-in `checkout` clones full history.
  - Mitigation: fails loudly rather than silently. `resolve_previous_commit` raises, the runner exits non-zero, the job goes red.
- Risk: a commit lands on main with stale signature files, misattributing the drift.
  - Evidence: the PR-time `metalava` job fails any PR whose committed signatures do not match its build, so this requires that check to be bypassed.
  - Mitigation: none added; the existing PR-time freshness check is the guardrail.

## Non-goals / Out of Scope

- Removing the public API report from PR runs. The inline comment stays.
- Any change to the `metalava` binary-compatibility job.
- Removing the now-unreachable `fingerprint` / `fingerprint_marker` / `announced_in_comment` machinery. Left in place to keep the diff tight, same call iOS made, flagged as a follow-up.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how the SDK API Slack feed is updated; a mis-gated main job or failed post exits successfully, so the channel could go quiet without a red build.
> 
> **Overview**
> Stops posting every Danger run to `#feed-sdk-new-api` (one message per push). **PR runs** still get the collapsible public API diff on the PR via `ApiDiffReport.run(..., announce: false)`; **`slack-secrets` is removed** from the Danger workflow so PR jobs no longer need Slack write access.
> 
> **Main** gets a new CircleCI job (`announce-api-changes`) and workflow that runs `danger/announce_api_changes.rb` with `slack-secrets`. That script diffs committed metalava `api*.txt` files between `HEAD^` and `HEAD`, links the commit (not the PR), and posts once per merge. Duplicate suppression uses Slack channel history keyed on the commit link; PR comment fingerprint / `announced_in_comment` dedup is removed.
> 
> `ApiDiffReport` gains git/branch helpers, renames `pull_request_link` → `source`, returns an **`outcome`** (`:posted` / `:duplicate` / `:failed` / `:skipped`), and updates Slack copy to *landed on main*. Failed Slack posts on main **do not fail the job** (warning only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f048665e2cf8e61287b803d3d307768dfeff9e39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->