### PR TITLE
feat(paywalls): send device context to custom components

### DIFF
--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
@@ -44,7 +44,7 @@ class PaywallWebViewMediaPolicyTest {
                     sizeToContentHeight = false,
                 ),
                 onLoadFailed = {},
-                contextSnapshotProvider = { webViewContextSnapshot(locale = "en_US", darkMode = false) },
+                contextSnapshotProvider = { webViewContextSnapshot(locale = "en-US", darkMode = false) },
             )
             built = configured != null
             configured?.let {

--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assume.assumeTrue
 import org.junit.Test
@@ -14,16 +13,13 @@ class PaywallWebViewMediaPolicyTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
-    private fun onMain(block: () -> Unit) =
-        InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
-
     @Test
     fun warmingRefusesMediaAutoplay() {
         var requiresGesture: Boolean? = null
         onMain {
             val webView = createWarmingWebView(
                 context = context,
-                resolvedUrl = URL,
+                resolvedUrl = TEST_BUNDLE_URL,
                 onLoadFailed = {},
                 onLoadFinished = {},
             )
@@ -42,12 +38,13 @@ class PaywallWebViewMediaPolicyTest {
             val configured = createPaywallWebView(
                 context = context,
                 identity = WebViewIdentity(
-                    resolvedUrl = URL,
+                    resolvedUrl = TEST_BUNDLE_URL,
                     componentId = "component-1",
                     sizeToContentWidth = false,
                     sizeToContentHeight = false,
                 ),
                 onLoadFailed = {},
+                contextSnapshotProvider = { webViewContextSnapshot(locale = "en_US", darkMode = false) },
             )
             built = configured != null
             configured?.let {
@@ -58,9 +55,5 @@ class PaywallWebViewMediaPolicyTest {
 
         assumeTrue(built)
         assertThat(requiresGesture).isFalse()
-    }
-
-    private companion object {
-        const val URL = "https://assets.example.com/promo/index.html"
     }
 }

--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextBridgeTest.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextBridgeTest.kt
@@ -1,0 +1,113 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.content.Context
+import android.os.SystemClock
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.webkit.WebViewFeature
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Drives the real `rc-web-components` handshake against Chromium: a page on the expected origin
+ * connects and reads the first snapshot off `init`, the way the content SDK does.
+ *
+ * Robolectric mocks [androidx.webkit.WebViewCompat], so the message listener and its origin gating
+ * are only exercised for real here.
+ */
+@RunWith(AndroidJUnit4::class)
+class WebViewContextBridgeTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun seedsTheFirstSnapshotOnTheHandshake() {
+        assumeTrue(WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER))
+
+        var configured: ConfiguredPaywallWebView? = null
+        onMain {
+            configured = createPaywallWebView(
+                context = context,
+                identity = WebViewIdentity(
+                    resolvedUrl = TEST_BUNDLE_URL,
+                    componentId = COMPONENT_ID,
+                    sizeToContentWidth = false,
+                    sizeToContentHeight = true,
+                ),
+                onLoadFailed = {},
+                contextSnapshotProvider = { webViewContextSnapshot(locale = "en_US", darkMode = false) },
+            )
+        }
+        assumeTrue(configured != null)
+        val webView = configured!!
+
+        try {
+            onMain { webView.webView.loadDataWithBaseURL(TEST_BUNDLE_URL, PAGE, "text/html", "utf-8", null) }
+
+            val frames = awaitExchange(webView)
+
+            assertThat(frames).describedAs("frames the page received").isNotNull()
+            assertThat(frames).contains(
+                """"kind":"init"""",
+                """"type":"fit"""",
+                """"payload":{"context":{""",
+                """"is_preview":false""",
+                """"locale":"en_US"""",
+            )
+            assertThat(frames).doesNotContain("workflow")
+        } finally {
+            onMain { webView.webView.releasePaywallWebView(webView.bridge) }
+        }
+    }
+
+    private fun awaitExchange(configured: ConfiguredPaywallWebView): String? {
+        val deadline = SystemClock.uptimeMillis() + TIMEOUT_MS
+        while (SystemClock.uptimeMillis() < deadline) {
+            var recorded: String? = null
+            val latch = CountDownLatch(1)
+            onMain {
+                configured.webView.evaluateJavascript(RECORDED_FRAMES) { value ->
+                    // evaluateJavascript JSON-encodes its result, so the page's own JSON arrives
+                    // double-encoded; unwrap once to get plain JSON text back.
+                    if (value != null && value != "null") recorded = Json.decodeFromString<String>(value)
+                    latch.countDown()
+                }
+            }
+            latch.await(POLL_INTERVAL_MS, TimeUnit.MILLISECONDS)
+            recorded?.let { return it }
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        return null
+    }
+
+    private companion object {
+        const val COMPONENT_ID = "promo_web_view"
+        const val TIMEOUT_MS = 10_000L
+        const val POLL_INTERVAL_MS = 200L
+
+        const val RECORDED_FRAMES = "window.__rcDone ? JSON.stringify(window.__rcSeen) : null"
+
+        /** Stands in for a bundle: the frames `rc-sdk.js` itself exchanges during a handshake. */
+        val PAGE = """
+            <!doctype html><html><body><script>
+            window.__rcSeen = [];
+            window.__rcDone = false;
+            window.__rcWebComponentsReceive = function (frame) {
+              window.__rcSeen.push(frame);
+              // `contextFromInitPayload` in the content SDK reads the snapshot from here.
+              if (frame.kind === 'init' && frame.payload && frame.payload.context) {
+                window.__rcDone = true;
+              }
+            };
+            rcWebComponents.postMessage(JSON.stringify({
+              channel: 'rc-web-components', protocol_version: 1, kind: 'connect', component_id: ''
+            }));
+            </script></body></html>
+        """.trimIndent()
+    }
+}

--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextBridgeTest.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextBridgeTest.kt
@@ -40,7 +40,7 @@ class WebViewContextBridgeTest {
                     sizeToContentHeight = true,
                 ),
                 onLoadFailed = {},
-                contextSnapshotProvider = { webViewContextSnapshot(locale = "en_US", darkMode = false) },
+                contextSnapshotProvider = { webViewContextSnapshot(locale = "en-US", darkMode = false) },
             )
         }
         assumeTrue(configured != null)
@@ -57,7 +57,7 @@ class WebViewContextBridgeTest {
                 """"type":"fit"""",
                 """"payload":{"context":{""",
                 """"is_preview":false""",
-                """"locale":"en_US"""",
+                """"locale":"en-US"""",
             )
             assertThat(frames).doesNotContain("workflow")
         } finally {

--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewTestSupport.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewTestSupport.kt
@@ -1,0 +1,9 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import androidx.test.platform.app.InstrumentationRegistry
+
+/** A WebView may only be created and driven from the main thread. */
+internal fun onMain(block: () -> Unit) =
+    InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
+
+internal const val TEST_BUNDLE_URL = "https://assets.example.com/promo/index.html"

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -38,7 +38,6 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fi
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.ui.revenuecatui.BuildConfig
-import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toLocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
@@ -82,12 +81,7 @@ internal fun WebViewComponentView(
     // PaywallState instance on every rebuild, so both reads go through State to stay current.
     val darkMode by rememberUpdatedState(isSystemInDarkTheme())
     val currentState by rememberUpdatedState(state)
-    val contextSnapshotProvider: () -> JsonObject = {
-        webViewContextSnapshot(
-            locale = currentState.locale.toLocaleId().value,
-            darkMode = darkMode,
-        )
-    }
+    val contextSnapshotProvider: () -> JsonObject = { webViewContextSnapshot(currentState, darkMode) }
 
     val identity = WebViewIdentity(
         resolvedUrl = resolvedUrl,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -13,6 +13,7 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -20,6 +21,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -36,12 +38,14 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fi
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.ui.revenuecatui.BuildConfig
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toLocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.trackMainAxisUnbounded
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import kotlinx.serialization.json.JsonObject
 
 @JvmSynthetic
 @Composable
@@ -73,6 +77,17 @@ internal fun WebViewComponentView(
     if (componentId.isBlank()) return
     val sizeToContentWidth = style.size.width is Fit
     val sizeToContentHeight = style.size.height is Fit
+
+    // AndroidView's factory captures this lambda once, and the view model hands out a new
+    // PaywallState instance on every rebuild, so both reads go through State to stay current.
+    val darkMode by rememberUpdatedState(isSystemInDarkTheme())
+    val currentState by rememberUpdatedState(state)
+    val contextSnapshotProvider: () -> JsonObject = {
+        webViewContextSnapshot(
+            locale = currentState.locale.toLocaleId().value,
+            darkMode = darkMode,
+        )
+    }
 
     val identity = WebViewIdentity(
         resolvedUrl = resolvedUrl,
@@ -137,6 +152,7 @@ internal fun WebViewComponentView(
                             onDocumentReset = onDocumentReset,
                             onLoadFailed = onLoadFailed,
                             onLoadFinished = { PaywallWebViewPrewarmer.shared.markWarmed(resolvedUrl) },
+                            contextSnapshotProvider = contextSnapshotProvider,
                         )
                     } catch (error: Throwable) {
                         // A missing or mid-update WebView package throws Error, not Exception.
@@ -262,6 +278,7 @@ internal fun createPaywallWebView(
     onDocumentReset: () -> Unit = {},
     onLoadFailed: () -> Unit,
     onLoadFinished: () -> Unit = {},
+    contextSnapshotProvider: () -> JsonObject,
 ): ConfiguredPaywallWebView? {
     var terminalFailure = false
     val expectedOrigin = identity.resolvedUrl.toOriginOrNull()
@@ -279,6 +296,7 @@ internal fun createPaywallWebView(
                 terminalFailure = true
                 onLoadFailed()
             },
+            contextSnapshotProvider = contextSnapshotProvider,
         )
         bridge.attach()
         if (terminalFailure) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
@@ -2,6 +2,7 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -9,10 +10,22 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 
+@JvmSynthetic
+internal fun webViewContextSnapshot(
+    state: PaywallState.Loaded.Components,
+    darkMode: Boolean,
+): JsonObject = webViewContextSnapshot(
+    locale = state.locale.toLanguageTag(),
+    darkMode = darkMode,
+)
+
 /**
  * Builds the payload the handshake seeds and later `context` pushes replace, per the
  * custom component variables contract (RevenueCat/docs#1874): absent structured sections are
  * literal `null`, empty maps are `{}`, and `workflow` is omitted entirely outside a funnel.
+ *
+ * @param locale a BCP-47 language tag. The content SDK feeds it to `Intl`, which rejects the
+ * underscored `LocaleId` form with a `RangeError`.
  */
 @JvmSynthetic
 internal fun webViewContextSnapshot(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 
 /**
- * Builds the payload shared by the `context` push and the `requestContext` response, per the
+ * Builds the payload the handshake seeds and later `context` pushes replace, per the
  * custom component variables contract (RevenueCat/docs#1874): absent structured sections are
  * literal `null`, empty maps are `{}`, and `workflow` is omitted entirely outside a funnel.
  */
@@ -19,16 +19,32 @@ internal fun webViewContextSnapshot(
     locale: String,
     darkMode: Boolean,
 ): JsonObject = buildJsonObject {
-    putJsonObject("custom") {}
-    put("offering", JsonNull)
-    putJsonArray("packages") {}
-    put("package", JsonNull)
-    put("selected_package", JsonNull)
-    putJsonObject("inputs") {}
-    putJsonObject("device_meta") {
-        put("is_preview", false)
-        put("locale", locale)
-        put("dark_mode", darkMode)
-        put("updated_at", System.currentTimeMillis())
+    putJsonObject(Keys.CUSTOM) {}
+    put(Keys.OFFERING, JsonNull)
+    putJsonArray(Keys.PACKAGES) {}
+    put(Keys.PACKAGE, JsonNull)
+    put(Keys.SELECTED_PACKAGE, JsonNull)
+    putJsonObject(Keys.INPUTS) {}
+    putJsonObject(Keys.DEVICE_META) {
+        put(Keys.IS_PREVIEW, false)
+        put(Keys.LOCALE, locale)
+        put(Keys.DARK_MODE, darkMode)
+        put(Keys.UPDATED_AT, System.currentTimeMillis())
     }
+}
+
+/** Wire keys from the contract (RevenueCat/docs#1874), in the order its table lists them. */
+private object Keys {
+    const val CUSTOM = "custom"
+    const val OFFERING = "offering"
+    const val PACKAGES = "packages"
+    const val PACKAGE = "package"
+    const val SELECTED_PACKAGE = "selected_package"
+    const val INPUTS = "inputs"
+    const val DEVICE_META = "device_meta"
+
+    const val IS_PREVIEW = "is_preview"
+    const val LOCALE = "locale"
+    const val DARK_MODE = "dark_mode"
+    const val UPDATED_AT = "updated_at"
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
@@ -1,0 +1,34 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * Builds the payload shared by the `context` push and the `requestContext` response, per the
+ * custom component variables contract (RevenueCat/docs#1874): absent structured sections are
+ * literal `null`, empty maps are `{}`, and `workflow` is omitted entirely outside a funnel.
+ */
+@JvmSynthetic
+internal fun webViewContextSnapshot(
+    locale: String,
+    darkMode: Boolean,
+): JsonObject = buildJsonObject {
+    putJsonObject("custom") {}
+    put("offering", JsonNull)
+    putJsonArray("packages") {}
+    put("package", JsonNull)
+    put("selected_package", JsonNull)
+    putJsonObject("inputs") {}
+    putJsonObject("device_meta") {
+        put("is_preview", false)
+        put("locale", locale)
+        put("dark_mode", darkMode)
+        put("updated_at", System.currentTimeMillis())
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -43,6 +43,7 @@ internal class WebViewJavaScriptBridge(
     private val onContentResize: (widthCssPx: Int?, heightCssPx: Int?) -> Unit = { _, _ -> },
     private val onDocumentReset: () -> Unit = {},
     private val onSecureMessagingUnsupported: () -> Unit = {},
+    private val contextSnapshotProvider: () -> JsonObject,
 ) {
 
     private val webViewRef = WeakReference(webView)
@@ -214,6 +215,9 @@ internal class WebViewJavaScriptBridge(
                 kind = WebViewEnvelope.Kind.INIT,
                 protocolVersion = protocolVersion,
                 componentId = componentId,
+                // The content SDK reads the first snapshot from here and resolves `whenReady()` in
+                // the same task, so a separate `context` frame would arrive too late.
+                payload = buildJsonObject { put("context", contextSnapshotProvider()) },
             ),
             allowBeforeNavigation = true,
         )
@@ -257,7 +261,11 @@ internal class WebViewJavaScriptBridge(
             return
         }
 
-        // resize is the only app frame serviced in v1 (no message handler, no variables).
+        if (envelope.componentId != componentId) {
+            Logger.w("Dropping inbound web view message: component id does not match.")
+            return
+        }
+
         if (envelope.type == WebViewMessageType.RESIZE) {
             handleResize(envelope)
         } else {
@@ -267,10 +275,6 @@ internal class WebViewJavaScriptBridge(
 
     @MainThread
     private fun handleResize(envelope: WebViewEnvelope) {
-        if (envelope.componentId != componentId) {
-            Logger.w("Dropping inbound web view message: resize component id does not match.")
-            return
-        }
         val payload = envelope.payload ?: return
 
         val width = applyResize(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
@@ -12,4 +12,10 @@ internal object WebViewMessageType {
 
     /** Content → host: reported content box size in CSS pixels. */
     const val RESIZE = "resize"
+
+    /** Host → content: the current context snapshot, pushed after the handshake. */
+    const val CONTEXT = "context"
+
+    /** Content → host request: pull the latest context snapshot. */
+    const val REQUEST_CONTEXT = "requestContext"
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewMessageType.kt
@@ -1,5 +1,3 @@
-@file:JvmSynthetic
-
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 /**
@@ -13,9 +11,6 @@ internal object WebViewMessageType {
     /** Content → host: reported content box size in CSS pixels. */
     const val RESIZE = "resize"
 
-    /** Host → content: the current context snapshot, pushed after the handshake. */
+    /** Host → content: replaces the snapshot the handshake seeded, when it changes. */
     const val CONTEXT = "context"
-
-    /** Content → host request: pull the latest context snapshot. */
-    const val REQUEST_CONTEXT = "requestContext"
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
@@ -1,0 +1,48 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class WebViewContextSnapshotTest {
+
+    @Test
+    fun `contains every section with its empty shape and no workflow key`() {
+        val snapshot = webViewContextSnapshot(locale = "en_US", darkMode = true)
+
+        assertThat(snapshot.keys).containsExactly(
+            "custom",
+            "offering",
+            "packages",
+            "package",
+            "selected_package",
+            "inputs",
+            "device_meta",
+        )
+        assertThat(snapshot.getValue("custom").jsonObject).isEmpty()
+        assertThat(snapshot.getValue("offering")).isEqualTo(JsonNull)
+        assertThat(snapshot.getValue("packages").jsonArray).isEmpty()
+        assertThat(snapshot.getValue("package")).isEqualTo(JsonNull)
+        assertThat(snapshot.getValue("selected_package")).isEqualTo(JsonNull)
+        assertThat(snapshot.getValue("inputs").jsonObject).isEmpty()
+    }
+
+    @Test
+    fun `device_meta carries host details`() {
+        val before = System.currentTimeMillis()
+
+        val deviceMeta = webViewContextSnapshot(locale = "en_US", darkMode = true)
+            .getValue("device_meta").jsonObject
+
+        assertThat(deviceMeta.getValue("is_preview").jsonPrimitive.boolean).isFalse()
+        assertThat(deviceMeta.getValue("locale").jsonPrimitive.content).isEqualTo("en_US")
+        assertThat(deviceMeta.getValue("dark_mode").jsonPrimitive.boolean).isTrue()
+        assertThat(deviceMeta.getValue("updated_at").jsonPrimitive.long)
+            .isBetween(before, System.currentTimeMillis())
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonArray
@@ -13,7 +14,7 @@ internal class WebViewContextSnapshotTest {
 
     @Test
     fun `contains every section with its empty shape and no workflow key`() {
-        val snapshot = webViewContextSnapshot(locale = "en_US", darkMode = true)
+        val snapshot = webViewContextSnapshot(locale = "en-US", darkMode = true)
 
         assertThat(snapshot.keys).containsExactly(
             "custom",
@@ -36,13 +37,22 @@ internal class WebViewContextSnapshotTest {
     fun `device_meta carries host details`() {
         val before = System.currentTimeMillis()
 
-        val deviceMeta = webViewContextSnapshot(locale = "en_US", darkMode = true)
+        val deviceMeta = webViewContextSnapshot(locale = "en-US", darkMode = true)
             .getValue("device_meta").jsonObject
 
         assertThat(deviceMeta.getValue("is_preview").jsonPrimitive.boolean).isFalse()
-        assertThat(deviceMeta.getValue("locale").jsonPrimitive.content).isEqualTo("en_US")
+        assertThat(deviceMeta.getValue("locale").jsonPrimitive.content).isEqualTo("en-US")
         assertThat(deviceMeta.getValue("dark_mode").jsonPrimitive.boolean).isTrue()
         assertThat(deviceMeta.getValue("updated_at").jsonPrimitive.long)
             .isBetween(before, System.currentTimeMillis())
+    }
+
+    @Test
+    fun `derives the locale from the paywall state as a BCP-47 tag`() {
+        // The state carries the locale as an underscored `LocaleId`; the wire needs a tag.
+        val deviceMeta = webViewContextSnapshot(FakePaywallState(components = emptyList()), darkMode = false)
+            .getValue("device_meta").jsonObject
+
+        assertThat(deviceMeta.getValue("locale").jsonPrimitive.content).isEqualTo("en-US")
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
@@ -244,6 +244,7 @@ private fun TestWebViewSlot(
                         expectedUrl = identity.resolvedUrl,
                         sizeToContentWidth = identity.sizeToContentWidth,
                         sizeToContentHeight = identity.sizeToContentHeight,
+                        contextSnapshotProvider = { webViewContextSnapshot(locale = "en_US", darkMode = false) },
                     ).also { created ->
                         created.attach()
                         onBridgeCreated(created)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
@@ -244,7 +244,9 @@ private fun TestWebViewSlot(
                         expectedUrl = identity.resolvedUrl,
                         sizeToContentWidth = identity.sizeToContentWidth,
                         sizeToContentHeight = identity.sizeToContentHeight,
-                        contextSnapshotProvider = { webViewContextSnapshot(locale = "en_US", darkMode = false) },
+                        contextSnapshotProvider = {
+                            webViewContextSnapshot(locale = "en-US", darkMode = false)
+                        },
                     ).also { created ->
                         created.attach()
                         onBridgeCreated(created)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -74,7 +74,9 @@ internal class WebViewJavaScriptBridgeTest {
         sizeToContentHeight: Boolean = false,
         onDocumentReset: () -> Unit = {},
         onSecureMessagingUnsupported: () -> Unit = {},
-        contextSnapshotProvider: () -> JsonObject = { webViewContextSnapshot(locale = "en_US", darkMode = false) },
+        contextSnapshotProvider: () -> JsonObject = {
+            webViewContextSnapshot(locale = "en-US", darkMode = false)
+        },
     ): WebViewJavaScriptBridge {
         val bridge = WebViewJavaScriptBridge(
             webView = webView,
@@ -224,7 +226,7 @@ internal class WebViewJavaScriptBridgeTest {
         assertThat(script).contains("\"selected_package\":null")
         assertThat(script).contains("\"inputs\":{}")
         assertThat(script).contains("\"is_preview\":false")
-        assertThat(script).contains("\"locale\":\"en_US\"")
+        assertThat(script).contains("\"locale\":\"en-US\"")
         assertThat(script).doesNotContain("\"workflow\"")
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import android.net.Uri
 import android.os.Looper
+import android.webkit.ValueCallback
 import android.webkit.WebView
 import androidx.test.core.app.ApplicationProvider
 import androidx.webkit.WebMessageCompat
@@ -14,6 +15,11 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -21,9 +27,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadow.api.Shadow
 import org.robolectric.shadows.ShadowWebView
 
 @RunWith(RobolectricTestRunner::class)
+@Config(shadows = [RecordingShadowWebView::class])
 internal class WebViewJavaScriptBridgeTest {
 
     private val componentId = "promo_web_view"
@@ -63,6 +74,7 @@ internal class WebViewJavaScriptBridgeTest {
         sizeToContentHeight: Boolean = false,
         onDocumentReset: () -> Unit = {},
         onSecureMessagingUnsupported: () -> Unit = {},
+        contextSnapshotProvider: () -> JsonObject = { webViewContextSnapshot(locale = "en_US", darkMode = false) },
     ): WebViewJavaScriptBridge {
         val bridge = WebViewJavaScriptBridge(
             webView = webView,
@@ -73,6 +85,7 @@ internal class WebViewJavaScriptBridgeTest {
             onContentResize = { widthCssPx, heightCssPx -> resizes.add(widthCssPx to heightCssPx) },
             onDocumentReset = onDocumentReset,
             onSecureMessagingUnsupported = onSecureMessagingUnsupported,
+            contextSnapshotProvider = contextSnapshotProvider,
         )
         bridge.attach()
         navigateTo?.let { webView.loadUrl(it) }
@@ -82,6 +95,9 @@ internal class WebViewJavaScriptBridgeTest {
     private fun idleMainLooper() {
         shadowOf(Looper.getMainLooper()).idle()
     }
+
+    /** Every outbound script in delivery order; [ShadowWebView.getLastEvaluatedJavascript] keeps only the last. */
+    private fun scripts(): List<String> = Shadow.extract<RecordingShadowWebView>(webView).evaluatedScripts
 
     /**
      * Exercises the genuine production inbound path:
@@ -99,8 +115,20 @@ internal class WebViewJavaScriptBridgeTest {
         mockk(),
     )
 
-    private fun connectJson(protocolVersion: Int = 1) =
-        """{"channel":"rc-web-components","protocol_version":$protocolVersion,"kind":"connect","component_id":""}"""
+    /** Serializes an inbound frame, with the channel field every one of them carries. */
+    private fun frame(build: JsonObjectBuilder.() -> Unit): String = Json.encodeToString(
+        JsonObject.serializer(),
+        buildJsonObject {
+            put("channel", "rc-web-components")
+            build()
+        },
+    )
+
+    private fun connectJson(protocolVersion: Int = 1) = frame {
+        put("protocol_version", protocolVersion)
+        put("kind", "connect")
+        put("component_id", "")
+    }
 
     private fun WebViewJavaScriptBridge.connect(
         sourceOrigin: Uri = Uri.parse(expectedOrigin),
@@ -112,21 +140,27 @@ internal class WebViewJavaScriptBridgeTest {
 
     private fun appMessage(
         type: String,
-        payload: String? = null,
+        payload: JsonObject? = null,
         kind: String = "message",
         id: String? = null,
         componentId: String = this.componentId,
-    ): String {
-        val payloadField = payload?.let { ""","payload":$it""" } ?: ""
-        val idField = id?.let { ""","id":"$it"""" } ?: ""
-        return """
-            {"channel":"rc-web-components","protocol_version":1,"kind":"$kind","component_id":"$componentId","type":"$type"$payloadField$idField}
-            """.trimIndent()
+    ): String = frame {
+        put("protocol_version", 1)
+        put("kind", kind)
+        put("component_id", componentId)
+        put("type", type)
+        payload?.let { put("payload", it) }
+        id?.let { put("id", it) }
+    }
+
+    private fun sizePayload(width: Int? = null, height: Int? = null): JsonObject = buildJsonObject {
+        width?.let { put("width", it) }
+        height?.let { put("height", it) }
     }
 
     /** Sends a resize and pumps the looper; onContentResize lands in [resizes]. */
     private fun WebViewJavaScriptBridge.resize(heightCssPx: Int, componentId: String = this@WebViewJavaScriptBridgeTest.componentId) {
-        postFromWeb(appMessage(type = WebViewMessageType.RESIZE, payload = """{"height":$heightCssPx}""", componentId = componentId))
+        postFromWeb(appMessage(type = WebViewMessageType.RESIZE, payload = sizePayload(height = heightCssPx), componentId = componentId))
         idleMainLooper()
     }
 
@@ -137,7 +171,7 @@ internal class WebViewJavaScriptBridgeTest {
         val bridge = bridge()
         bridge.connect()
 
-        val script = shadowWebView.lastEvaluatedJavascript
+        val script = scripts().first()
         assertThat(script).contains("window.__rcWebComponentsReceive(")
         assertThat(script).contains("\"kind\":\"init\"")
         assertThat(script).contains("\"component_id\":\"promo_web_view\"")
@@ -150,9 +184,48 @@ internal class WebViewJavaScriptBridgeTest {
 
         bridge.connect()
 
-        val script = shadowWebView.lastEvaluatedJavascript
+        val script = scripts().first()
         assertThat(script).contains("\"kind\":\"init\"")
         assertThat(script).contains("\"component_id\":\"promo_web_view\"")
+    }
+
+    @Test
+    fun `handshake sends init then fit, with no separate context frame`() {
+        val bridge = bridge(sizeToContentHeight = true)
+        bridge.connect()
+
+        assertThat(scripts()).hasSize(2)
+        assertThat(scripts()[0]).contains("\"kind\":\"init\"")
+        assertThat(scripts()[1]).contains("\"type\":\"fit\"")
+        assertThat(scripts().none { it.contains("\"type\":\"context\"") }).isTrue()
+    }
+
+    @Test
+    fun `init carries the first snapshot for fixed-size components`() {
+        val bridge = bridge()
+        bridge.connect()
+
+        assertThat(scripts()).hasSize(1)
+        assertThat(scripts().single()).contains("\"kind\":\"init\"")
+    }
+
+    @Test
+    fun `init payload carries the shaped empty snapshot`() {
+        val bridge = bridge()
+        bridge.connect()
+
+        val script = scripts().single()
+        assertThat(script).contains("\"kind\":\"init\"")
+        assertThat(script).contains("\"payload\":{\"context\":{")
+        assertThat(script).contains("\"custom\":{}")
+        assertThat(script).contains("\"offering\":null")
+        assertThat(script).contains("\"packages\":[]")
+        assertThat(script).contains("\"package\":null")
+        assertThat(script).contains("\"selected_package\":null")
+        assertThat(script).contains("\"inputs\":{}")
+        assertThat(script).contains("\"is_preview\":false")
+        assertThat(script).contains("\"locale\":\"en_US\"")
+        assertThat(script).doesNotContain("\"workflow\"")
     }
 
     @Test
@@ -251,7 +324,7 @@ internal class WebViewJavaScriptBridgeTest {
             val bridge = bridge(navigateTo = case.navigateTo, sizeToContentHeight = true)
             bridge.connect()
             bridge.postFromWeb(
-                appMessage(type = WebViewMessageType.RESIZE, payload = """{"height":300}"""),
+                appMessage(type = WebViewMessageType.RESIZE, payload = sizePayload(height = 300)),
                 sourceOrigin = Uri.parse(case.sourceOrigin),
                 isMainFrame = case.isMainFrame,
             )
@@ -269,7 +342,7 @@ internal class WebViewJavaScriptBridgeTest {
         val bridge = bridge(navigateTo = "https://assets.example.com:443/promo/index.html")
         bridge.connect()
 
-        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+        assertThat(scripts().first()).contains("\"kind\":\"init\"")
     }
 
     @Test
@@ -277,7 +350,7 @@ internal class WebViewJavaScriptBridgeTest {
         val bridge = bridge(navigateTo = "https://assets.example.com/promo/step-two.html")
         bridge.connect()
 
-        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+        assertThat(scripts().first()).contains("\"kind\":\"init\"")
     }
 
     @Test
@@ -400,7 +473,7 @@ internal class WebViewJavaScriptBridgeTest {
         webView.loadUrl(expectedUrl)
         bridge.connect()
 
-        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+        assertThat(scripts().first()).contains("\"kind\":\"init\"")
     }
 
     @Test
@@ -419,8 +492,7 @@ internal class WebViewJavaScriptBridgeTest {
         val bridge = bridge(sizeToContentHeight = true)
         bridge.connect()
 
-        val script = shadowWebView.lastEvaluatedJavascript
-        assertThat(script).contains("\"type\":\"fit\"")
+        val script = scripts().single { it.contains("\"type\":\"fit\"") }
         assertThat(script).contains("\"height\":true")
         assertThat(script).doesNotContain("\"width\":true")
     }
@@ -434,16 +506,15 @@ internal class WebViewJavaScriptBridgeTest {
 
         bridge.connect()
 
-        val script = shadowWebView.lastEvaluatedJavascript
-        assertThat(script).contains("\"type\":\"fit\"")
+        val script = scripts().single { it.contains("\"type\":\"fit\"") }
         assertThat(script).contains("\"height\":true")
     }
 
     @Test
     fun `ignores resize dimensions that are not json numbers`() {
         listOf(
-            "string height" to """{"height":"300"}""",
-            "boolean height" to """{"height":true}""",
+            "string height" to buildJsonObject { put("height", "300") },
+            "boolean height" to buildJsonObject { put("height", true) },
         ).forEach { (name, payload) ->
             resizes.clear()
             val bridge = bridge(sizeToContentHeight = true)
@@ -460,22 +531,22 @@ internal class WebViewJavaScriptBridgeTest {
             val name: String,
             val fitW: Boolean,
             val fitH: Boolean,
-            val payloads: List<String>,
+            val payloads: List<JsonObject>,
             val expected: List<Pair<Int?, Int?>>,
         )
         listOf(
-            Case("both fit axes", true, true, listOf("""{"width":320,"height":480}"""), listOf(320 to 480)),
-            Case("non-fit width ignored", false, true, listOf("""{"width":400,"height":500}"""), listOf(null to 500)),
+            Case("both fit axes", true, true, listOf(sizePayload(320, 480)), listOf(320 to 480)),
+            Case("non-fit width ignored", false, true, listOf(sizePayload(400, 500)), listOf(null to 500)),
             // Invalid width (negative) + oversized height → height clamped, width dropped.
-            Case("clamp/invalid", true, true, listOf("""{"width":-1,"height":99999}"""), listOf(null to 10_000)),
+            Case("clamp/invalid", true, true, listOf(sizePayload(-1, 99999)), listOf(null to 10_000)),
             Case(
                 "threshold",
                 true,
                 true,
                 listOf(
-                    """{"width":200,"height":300}""",
-                    """{"width":200,"height":300}""", // below 1px threshold → no callback
-                    """{"width":200,"height":301}""", // only changed axis delivered
+                    sizePayload(200, 300),
+                    sizePayload(200, 300), // below 1px threshold → no callback
+                    sizePayload(200, 301), // only changed axis delivered
                 ),
                 listOf(200 to 300, null to 301),
             ),
@@ -496,7 +567,7 @@ internal class WebViewJavaScriptBridgeTest {
         bridge.postFromWeb(
             appMessage(
                 type = WebViewMessageType.RESIZE,
-                payload = """{"height":250}""",
+                payload = sizePayload(height = 250),
                 kind = "request",
                 id = "resize-1",
             ),
@@ -513,7 +584,7 @@ internal class WebViewJavaScriptBridgeTest {
         bridge.postFromWeb(
             appMessage(
                 type = WebViewMessageType.RESIZE,
-                payload = """{"height":250}""",
+                payload = sizePayload(height = 250),
                 kind = "request",
                 // no id → must be dropped for response-correlation safety
             ),
@@ -531,7 +602,7 @@ internal class WebViewJavaScriptBridgeTest {
         bridge.onMainFrameNavigationStarted()
         bridge.connect()
 
-        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"kind\":\"init\"")
+        assertThat(scripts().count { it.contains("\"kind\":\"init\"") }).isEqualTo(1)
     }
 
     @Test
@@ -539,10 +610,10 @@ internal class WebViewJavaScriptBridgeTest {
         val bridge = bridge()
         bridge.onMainFrameNavigationStarted()
         bridge.connect()
-        val afterFirst = shadowWebView.lastEvaluatedJavascript
+        val afterFirst = scripts().size
         bridge.connect()
 
-        assertThat(shadowWebView.lastEvaluatedJavascript).isEqualTo(afterFirst)
+        assertThat(scripts()).hasSize(afterFirst)
     }
 
     @Test
@@ -578,15 +649,34 @@ internal class WebViewJavaScriptBridgeTest {
         val bridge = bridge(sizeToContentHeight = true)
         bridge.onMainFrameNavigationStarted()
         bridge.connect()
-        assertThat(shadowWebView.lastEvaluatedJavascript).contains("\"type\":\"fit\"")
+        assertThat(scripts().count { it.contains("\"type\":\"fit\"") }).isEqualTo(1)
 
         bridge.onMainFrameNavigationStarted()
         webView.loadUrl("https://assets.example.com/promo/step-two.html")
         bridge.connect()
 
-        val script = shadowWebView.lastEvaluatedJavascript
-        assertThat(script).contains("\"type\":\"fit\"")
-        assertThat(script).contains("\"height\":true")
+        val fitScripts = scripts().filter { it.contains("\"type\":\"fit\"") }
+        assertThat(fitScripts).hasSize(2)
+        assertThat(fitScripts.last()).contains("\"height\":true")
+    }
+
+    @Test
+    fun `each document's init carries a fresh snapshot`() {
+        val bridge = bridge()
+        bridge.onMainFrameNavigationStarted()
+        bridge.connect()
+
+        bridge.onMainFrameNavigationStarted()
+        webView.loadUrl("https://assets.example.com/promo/step-two.html")
+        bridge.connect()
+
+        val initScripts = scripts().filter { it.contains("\"kind\":\"init\"") }
+        assertThat(initScripts).hasSize(2)
+        val timestamps = initScripts.map { script ->
+            Regex("\"updated_at\":(\\d+)").find(script)!!.groupValues[1].toLong()
+        }
+        assertThat(timestamps[0]).isGreaterThan(0)
+        assertThat(timestamps[1]).isGreaterThanOrEqualTo(timestamps[0])
     }
 
     @Test
@@ -654,5 +744,21 @@ internal class WebViewJavaScriptBridgeTest {
         bridge.connect()
         bridge.resize(300)
         assertThat(resizes).describedAs("channel reopened after reload").containsExactly(null to 300)
+    }
+}
+
+/**
+ * Records every evaluated script; [ShadowWebView] only keeps the last one. A shadow rather than a
+ * [WebView] subclass because Paparazzi's layoutlib jar shadows `android.jar` on the unit-test
+ * compile classpath with a `WebView` stub that lacks `evaluateJavascript`.
+ */
+@Implements(WebView::class)
+internal class RecordingShadowWebView : ShadowWebView() {
+    val evaluatedScripts = mutableListOf<String>()
+
+    @Implementation
+    override fun evaluateJavascript(script: String, callback: ValueCallback<String>?) {
+        evaluatedScripts += script
+        super.evaluateJavascript(script, callback)
     }
 }


### PR DESCRIPTION
- Adds the `context` message type and the snapshot builder for custom (`web_view`) components, per the contract in RevenueCat/docs#1874.
- The handshake's `init` frame carries the first snapshot on `payload.context`, so `getContext()` has an answer as soon as the content SDK is ready.
- Only `device_meta` has real values here. Every other section ships at its empty shape, and the three stacked PRs fill them in.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

PWENG-223. Custom components render arbitrary content inside a `WebView` and need to know which paywall they are sitting in: the variables the app set, the offering and package on screen, whether the device is in dark mode. The bridge already carried `resize` and the connect handshake, but had no way to describe the paywall itself.

This PR is the transport and the empty payload. The rest of the stack fills it in, split so each section can be reviewed against the contract on its own.

### Description

- `WebViewMessageType.CONTEXT` for host to content pushes.
- `webViewContextSnapshot()` emits every section at its documented empty shape, so an absent section is distinguishable from one the host forgot to send.
- `device_meta` carries `is_preview`, `locale`, `dark_mode` and `updated_at`.

**Not visible in the diff:** why the first snapshot rides on `init` rather than arriving as its own `context` frame. `@revenuecat/workflow-web-components-sdk` v0.1.7 reads it in `handleInit` and resolves `whenReady()` in the same task, so a separate frame would land after `getContext()` had already answered with an empty context, and would fire `onContextChange` a second time.

**Worth noting separately:** two test constraints. Robolectric mocks `WebViewCompat`, so the message listener and its origin gating are only exercised on device, in `WebViewContextBridgeTest`. Paparazzi's layoutlib `WebView` stub has no `evaluateJavascript`, so the unit test installs a Robolectric shadow to record outbound calls.

**Regression gate:** `WebViewJavaScriptBridgeTest` asserts the `init` frame carries `payload.context`.

**Limitations:** `inputs` is `{}`, since no native step collects answers; `{}` vs `null` is still open. `is_preview` is always `false` on native.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the web_view JS bridge handshake payload and tightens inbound message gating; incorrect snapshot shape or timing could break custom component bundles, but offering/package data is still stubbed.
> 
> **Overview**
> Paywalls V2 **web_view** custom components now receive a **variables context** snapshot over the existing `rc-web-components` bridge, aligned with the docs#1874 contract.
> 
> The handshake **`init`** frame includes **`payload.context`** (not a separate `context` message) so the content SDK can read it when `whenReady()` resolves. **`webViewContextSnapshot()`** emits every section at its documented empty shape (`null` / `{}` / omitted `workflow`); in this PR only **`device_meta`** is populated—**locale** (BCP-47 from paywall state), **dark_mode** from Compose theme, **is_preview**, and **updated_at**. **`WebViewComponentView`** passes a live snapshot provider via **`rememberUpdatedState`**.
> 
> The bridge now requires a **`contextSnapshotProvider`** when creating paywalls and validates **component_id** on all inbound app frames (not only resize). Tests add snapshot unit coverage, Robolectric recording of outbound scripts, and an on-device **`WebViewContextBridgeTest`** for the real handshake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b79f0bca1895cf41d41f860123e5e7c7934d87d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->