### PR TITLE
Rework CheckpointParams into a Builder with a Kotlin DSL

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/CheckpointParamsAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/CheckpointParamsAPI.java
@@ -1,5 +1,8 @@
 package com.revenuecat.apitester.java.revenuecatui;
 
+import androidx.annotation.OptIn;
+
+import com.revenuecat.purchases.InternalRevenueCatAPI;
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue;
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointParams;
 
@@ -8,6 +11,7 @@ import java.util.Map;
 @SuppressWarnings({"unused"})
 final class CheckpointParamsAPI {
 
+    @OptIn(markerClass = InternalRevenueCatAPI.class)
     static void check(CheckpointParams params) {
         Map<String, CustomVariableValue> customVariables = params.getCustomVariables();
 

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/CheckpointParamsAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/CheckpointParamsAPI.java
@@ -1,0 +1,28 @@
+package com.revenuecat.apitester.java.revenuecatui;
+
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue;
+import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointParams;
+
+import java.util.Map;
+
+@SuppressWarnings({"unused"})
+final class CheckpointParamsAPI {
+
+    static void check(CheckpointParams params) {
+        Map<String, CustomVariableValue> customVariables = params.getCustomVariables();
+
+        CheckpointParams empty = new CheckpointParams.Builder().build();
+        Map<String, CustomVariableValue> added = new CheckpointParams.CustomVariablesBuilder()
+                .add("string", "api-tester")
+                .add("int", 1)
+                .add("long", 1L)
+                .add("double", 1.0)
+                .add("float", 1.0f)
+                .add("boolean", true)
+                .add("value", new CustomVariableValue.Boolean(true))
+                .build();
+        CheckpointParams fromAdded = new CheckpointParams.Builder()
+                .setCustomVariables(added)
+                .build();
+    }
+}

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointParamsAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointParamsAPI.kt
@@ -6,24 +6,37 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointParams
 
-@Suppress("unused", "UNUSED_VARIABLE")
+@Suppress("unused", "UNUSED_VARIABLE", "LongMethod")
 private class CheckpointParamsAPI {
 
     fun check(params: CheckpointParams) {
         val customVariables: Map<String, CustomVariableValue> = params.customVariables
 
-        val empty = CheckpointParams()
-        val fromMap = CheckpointParams(
-            mapOf(
-                "source" to CustomVariableValue.String("api-tester"),
-                "count" to CustomVariableValue.Number(1),
-                "enabled" to CustomVariableValue.Boolean(true),
-            ),
-        )
-        val fromPairs = CheckpointParams(
-            "source" to CustomVariableValue.String("api-tester"),
-            "count" to CustomVariableValue.Number(1),
-            "enabled" to CustomVariableValue.Boolean(true),
-        )
+        val empty: CheckpointParams = CheckpointParams.Builder().build()
+        val emptyDsl: CheckpointParams = CheckpointParams {}
+        val fromBuilder: CheckpointParams = CheckpointParams.Builder()
+            .setCustomVariables(mapOf("source" to CustomVariableValue.String("api-tester")))
+            .build()
+        val fromDsl: CheckpointParams = CheckpointParams {
+            customVariables {
+                "string" to "api-tester"
+                "int" to 1
+                "long" to 1L
+                "double" to 1.0
+                "float" to 1.0f
+                "boolean" to true
+                "value" to CustomVariableValue.String("api-tester")
+            }
+        }
+        val added: Map<String, CustomVariableValue> = CheckpointParams.CustomVariablesBuilder()
+            .add("string", "api-tester")
+            .add("int", 1)
+            .add("long", 1L)
+            .add("double", 1.0)
+            .add("float", 1.0f)
+            .add("boolean", true)
+            .add("value", CustomVariableValue.Boolean(true))
+            .build()
+        val fromAdded: CheckpointParams = CheckpointParams.Builder().setCustomVariables(added).build()
     }
 }

--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/gate/EntitlementGateViewModel.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/gate/EntitlementGateViewModel.kt
@@ -8,7 +8,6 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.awaitCustomerInfo
-import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointParams
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointPaywallOutcome
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointResult
@@ -71,7 +70,7 @@ class EntitlementGateViewModel : ViewModel() {
             try {
                 val result = Purchases.sharedInstance.awaitCheckpoint(
                     "entitlement_gate",
-                    CheckpointParams("gate" to CustomVariableValue.String("entitlement")),
+                    CheckpointParams { customVariables { "gate" to "entitlement" } },
                 )
                 handleCheckpointResult(result)
             } catch (e: PurchasesException) {

--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/hardpaywall/HardPaywallViewModel.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/hardpaywall/HardPaywallViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesException
-import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointParams
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointPaywallOutcome
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointResult
@@ -44,10 +43,12 @@ class HardPaywallViewModel : ViewModel() {
             try {
                 val result = Purchases.sharedInstance.awaitCheckpoint(
                     "hard_paywall",
-                    CheckpointParams(
-                        "gate" to CustomVariableValue.String("hard"),
-                        "attempt" to CustomVariableValue.Number(_state.value.attempts),
-                    ),
+                    CheckpointParams {
+                        customVariables {
+                            "gate" to "hard"
+                            "attempt" to _state.value.attempts
+                        }
+                    },
                 )
                 when (result) {
                     is CheckpointResult.ReceivedOffering -> stayLocked(

--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/onboarding/OnboardingViewModel.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/ui/screens/onboarding/OnboardingViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesException
-import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointParams
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointPaywallOutcome
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointResult
@@ -76,7 +75,7 @@ class OnboardingViewModel : ViewModel() {
             val message = try {
                 val result = Purchases.sharedInstance.awaitCheckpoint(
                     "onboarding_complete",
-                    CheckpointParams("step" to CustomVariableValue.String(Step.Personalize.name)),
+                    CheckpointParams { customVariables { "step" to Step.Personalize.name } },
                 )
                 when (result) {
                     is CheckpointResult.ReceivedOffering ->

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/checkpoints/CheckpointsViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/checkpoints/CheckpointsViewModel.kt
@@ -11,7 +11,6 @@ import com.revenuecat.paywallstester.ui.screens.checkpoints.CheckpointsViewModel
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesException
-import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointParams
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointPaywallOutcome
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointResult
@@ -69,7 +68,7 @@ internal class CheckpointsViewModelImpl(
             val resultUi = try {
                 Purchases.sharedInstance.awaitCheckpoint(
                     checkpointIdentifier,
-                    CheckpointParams("source" to CustomVariableValue.String("paywall-tester")),
+                    CheckpointParams { customVariables { "source" to "paywall-tester" } },
                 ).toUi()
             } catch (e: PurchasesException) {
                 CheckpointResultUi(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointParams.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointParams.kt
@@ -6,17 +6,34 @@ import com.revenuecat.purchases.common.localrules.RulesDimensionValue
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 
 /**
+ * Marks the receivers of the [CheckpointParams] DSL, so an inner block cannot implicitly call methods of an
+ * outer one.
+ */
+@DslMarker
+@InternalRevenueCatAPI
+public annotation class CheckpointParamsDsl
+
+/**
  * Per-call parameters for [com.revenuecat.purchases.ui.revenuecatui.checkpoints.awaitCheckpoint].
  *
  * [customVariables] are both the values a checkpoint's targeting rules are evaluated against, readable as
  * `custom.<key>`, and the custom variables the presented paywall renders.
+ *
+ * Built through [Builder], or the DSL:
+ * ```kotlin
+ * val params = CheckpointParams {
+ *     customVariables {
+ *         "goal" to "lose_weight"
+ *         "step" to 3
+ *         "premium" to true
+ *     }
+ * }
+ * ```
  */
 @InternalRevenueCatAPI
-public class CheckpointParams(
-    customVariables: Map<String, CustomVariableValue> = emptyMap(),
+public class CheckpointParams private constructor(
+    customVariables: Map<String, CustomVariableValue>,
 ) {
-
-    public constructor(vararg customVariables: Pair<String, CustomVariableValue>) : this(customVariables.toMap())
 
     /**
      * Keys must start with a letter and contain only letters, numbers and underscores, since anything else cannot
@@ -33,7 +50,118 @@ public class CheckpointParams(
     override fun hashCode(): Int = customVariables.hashCode()
 
     override fun toString(): String = "CheckpointParams(customVariables=$customVariables)"
+
+    @CheckpointParamsDsl
+    public class Builder {
+
+        private var customVariables: Map<String, CustomVariableValue> = emptyMap()
+
+        /** Replaces any previously set custom variables. */
+        public fun setCustomVariables(customVariables: Map<String, CustomVariableValue>): Builder = apply {
+            this.customVariables = customVariables
+        }
+
+        /** Replaces any previously set custom variables. */
+        @JvmSynthetic
+        public fun customVariables(block: CustomVariablesBuilder.() -> Unit): Builder = apply {
+            customVariables = CustomVariablesBuilder().apply(block).build()
+        }
+
+        public fun build(): CheckpointParams = CheckpointParams(customVariables)
+    }
+
+    /**
+     * Builds a custom variables map from typed entries: fluent [add] overloads, or the equivalent infix `to`
+     * inside [Builder.customVariables] blocks. A repeated key keeps the last value.
+     */
+    @CheckpointParamsDsl
+    @Suppress("TooManyFunctions")
+    public class CustomVariablesBuilder {
+
+        private val customVariables = mutableMapOf<String, CustomVariableValue>()
+
+        public fun add(key: String, value: CustomVariableValue): CustomVariablesBuilder = apply {
+            customVariables[key] = value
+        }
+
+        public fun add(key: String, value: String): CustomVariablesBuilder =
+            add(key, CustomVariableValue.String(value))
+
+        public fun add(key: String, value: Int): CustomVariablesBuilder =
+            add(key, CustomVariableValue.Number(value))
+
+        public fun add(key: String, value: Long): CustomVariablesBuilder =
+            add(key, CustomVariableValue.Number(value))
+
+        public fun add(key: String, value: Double): CustomVariablesBuilder =
+            add(key, CustomVariableValue.Number(value))
+
+        public fun add(key: String, value: Float): CustomVariablesBuilder =
+            add(key, CustomVariableValue.Number(value))
+
+        public fun add(key: String, value: Boolean): CustomVariablesBuilder =
+            add(key, CustomVariableValue.Boolean(value))
+
+        @JvmSynthetic
+        public infix fun String.to(value: CustomVariableValue) {
+            add(this, value)
+        }
+
+        @JvmSynthetic
+        public infix fun String.to(value: String) {
+            add(this, value)
+        }
+
+        @JvmSynthetic
+        public infix fun String.to(value: Int) {
+            add(this, value)
+        }
+
+        @JvmSynthetic
+        public infix fun String.to(value: Long) {
+            add(this, value)
+        }
+
+        @JvmSynthetic
+        public infix fun String.to(value: Double) {
+            add(this, value)
+        }
+
+        @JvmSynthetic
+        public infix fun String.to(value: Float) {
+            add(this, value)
+        }
+
+        @JvmSynthetic
+        public infix fun String.to(value: Boolean) {
+            add(this, value)
+        }
+
+        /**
+         * Catches `to` with an unsupported value type at compile time. Without it, resolution would silently
+         * fall back to [kotlin.to] and build a discarded [Pair].
+         */
+        @Deprecated(
+            "Unsupported custom variable type. Supported types: String, Int, Long, Double, Float, Boolean and " +
+                "CustomVariableValue. If you really need a Pair here, use Pair(first, second).",
+            level = DeprecationLevel.ERROR,
+        )
+        @JvmSynthetic
+        public infix fun String.to(value: Any?): Unit =
+            throw UnsupportedOperationException("Unsupported custom variable type: $value")
+
+        public fun build(): Map<String, CustomVariableValue> = customVariables.toMap()
+    }
 }
+
+/**
+ * DSL entry point: `CheckpointParams { customVariables { "goal" to "lose_weight" } }`.
+ */
+@JvmSynthetic
+@InternalRevenueCatAPI
+@Suppress("FunctionName")
+public fun CheckpointParams(block: CheckpointParams.Builder.() -> Unit): CheckpointParams =
+    CheckpointParams.Builder().apply(block).build()
 
 /**
  * The rules-engine equivalent of a custom variable. Numbers stay doubles, since [CustomVariableValue.Number] holds

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
@@ -70,7 +70,7 @@ internal class CheckpointsManager {
         identifier: String,
         params: CheckpointParams?,
     ): CheckpointResult = withContext(Dispatchers.Main) {
-        val checkpoint = CheckpointInfo(identifier, params ?: CheckpointParams())
+        val checkpoint = CheckpointInfo(identifier, params ?: CheckpointParams {})
         checkpointListener?.onCheckpointHit(checkpoint)
         if (!CheckpointIdentifierValidator.isValid(identifier)) {
             Logger.e(CheckpointIdentifierValidator.invalidIdentifierLogMessage(identifier))

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointParamsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointParamsTest.kt
@@ -31,31 +31,112 @@ class CheckpointParamsTest {
 
     @Test
     fun `params are equal when their custom variables are`() {
-        val params = CheckpointParams("source" to CustomVariableValue.String("settings"))
+        val params = CheckpointParams { customVariables { "source" to "settings" } }
+        val sameFromBuilder = CheckpointParams.Builder()
+            .setCustomVariables(mapOf("source" to CustomVariableValue.String("settings")))
+            .build()
 
-        assertThat(params).isEqualTo(CheckpointParams(mapOf("source" to CustomVariableValue.String("settings"))))
-        assertThat(params.hashCode())
-            .isEqualTo(CheckpointParams(mapOf("source" to CustomVariableValue.String("settings"))).hashCode())
-        assertThat(params).isNotEqualTo(CheckpointParams("source" to CustomVariableValue.String("onboarding")))
+        assertThat(params).isEqualTo(sameFromBuilder)
+        assertThat(params.hashCode()).isEqualTo(sameFromBuilder.hashCode())
+        assertThat(params).isNotEqualTo(CheckpointParams { customVariables { "source" to "onboarding" } })
     }
 
     @Test
     fun `params default to no custom variables`() {
-        assertThat(CheckpointParams().customVariables).isEmpty()
+        assertThat(CheckpointParams {}.customVariables).isEmpty()
+        assertThat(CheckpointParams.Builder().build().customVariables).isEmpty()
+    }
+
+    @Test
+    fun `each infix overload maps to its custom variable variant`() {
+        val params = CheckpointParams {
+            customVariables {
+                "string" to "value"
+                "int" to 1
+                "long" to 2L
+                "double" to 0.5
+                "float" to 0.5f
+                "boolean" to true
+                "value" to CustomVariableValue.String("raw")
+            }
+        }
+
+        assertThat(params.customVariables).isEqualTo(
+            mapOf(
+                "string" to CustomVariableValue.String("value"),
+                "int" to CustomVariableValue.Number(1),
+                "long" to CustomVariableValue.Number(2L),
+                "double" to CustomVariableValue.Number(0.5),
+                "float" to CustomVariableValue.Number(0.5f),
+                "boolean" to CustomVariableValue.Boolean(true),
+                "value" to CustomVariableValue.String("raw"),
+            ),
+        )
+    }
+
+    @Test
+    fun `add overloads build the same map as the infix forms`() {
+        val added = CheckpointParams.CustomVariablesBuilder()
+            .add("string", "value")
+            .add("int", 1)
+            .add("long", 2L)
+            .add("double", 0.5)
+            .add("float", 0.5f)
+            .add("boolean", true)
+            .add("value", CustomVariableValue.String("raw"))
+            .build()
+
+        val infixParams = CheckpointParams {
+            customVariables {
+                "string" to "value"
+                "int" to 1
+                "long" to 2L
+                "double" to 0.5
+                "float" to 0.5f
+                "boolean" to true
+                "value" to CustomVariableValue.String("raw")
+            }
+        }
+
+        assertThat(CheckpointParams.Builder().setCustomVariables(added).build()).isEqualTo(infixParams)
+    }
+
+    @Test
+    fun `a repeated key keeps the last value`() {
+        val params = CheckpointParams {
+            customVariables {
+                "source" to "first"
+                "source" to "last"
+            }
+        }
+
+        assertThat(params.customVariables).isEqualTo(mapOf("source" to CustomVariableValue.String("last")))
+    }
+
+    @Test
+    fun `setting custom variables again replaces the previous ones`() {
+        val params = CheckpointParams {
+            customVariables { "first" to "dropped" }
+            customVariables { "second" to "kept" }
+        }
+
+        assertThat(params.customVariables).isEqualTo(mapOf("second" to CustomVariableValue.String("kept")))
     }
 
     @Test
     fun `keys that cannot be addressed as a custom variable are dropped on construction`() {
-        val params = CheckpointParams(
-            mapOf(
-                "my_property" to CustomVariableValue.String("kept"),
-                "my.property" to CustomVariableValue.String("dropped"),
-                "2fast" to CustomVariableValue.String("dropped"),
-                "has space" to CustomVariableValue.String("dropped"),
-                "my-property" to CustomVariableValue.String("dropped"),
-                "" to CustomVariableValue.String("dropped"),
-            ),
-        )
+        val params = CheckpointParams.Builder()
+            .setCustomVariables(
+                mapOf(
+                    "my_property" to CustomVariableValue.String("kept"),
+                    "my.property" to CustomVariableValue.String("dropped"),
+                    "2fast" to CustomVariableValue.String("dropped"),
+                    "has space" to CustomVariableValue.String("dropped"),
+                    "my-property" to CustomVariableValue.String("dropped"),
+                    "" to CustomVariableValue.String("dropped"),
+                ),
+            )
+            .build()
 
         assertThat(params.customVariables)
             .isEqualTo(mapOf("my_property" to CustomVariableValue.String("kept")))

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
@@ -191,7 +191,7 @@ class CheckpointsManagerTest {
 
         var result: CheckpointResult? = null
         val call = launch {
-            result = checkpoint(CheckpointParams("goal" to CustomVariableValue.String("test")))
+            result = checkpoint(CheckpointParams { customVariables { "goal" to "test" } })
         }
 
         assertThat(result).isNull()
@@ -215,11 +215,13 @@ class CheckpointsManagerTest {
         resolvesTo(CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.NO_MATCH))
 
         checkpoint(
-            CheckpointParams(
-                "goal" to CustomVariableValue.String("test"),
-                "attempt" to CustomVariableValue.Number(2),
-                "flag" to CustomVariableValue.Boolean(true),
-            ),
+            CheckpointParams {
+                customVariables {
+                    "goal" to "test"
+                    "attempt" to 2
+                    "flag" to true
+                }
+            },
         )
 
         val customVariables = slot<Map<String, RulesDimensionValue>>()
@@ -238,12 +240,14 @@ class CheckpointsManagerTest {
         resolvesToWorkflow()
         val call = launch {
             checkpoint(
-                CheckpointParams(
-                    "gate" to CustomVariableValue.String("hard"),
-                    "attempt" to CustomVariableValue.Number(2),
-                    "ratio" to CustomVariableValue.Number(0.5),
-                    "flag" to CustomVariableValue.Boolean(true),
-                ),
+                CheckpointParams {
+                    customVariables {
+                        "gate" to "hard"
+                        "attempt" to 2
+                        "ratio" to 0.5
+                        "flag" to true
+                    }
+                },
             )
         }
 


### PR DESCRIPTION
### Description

Reworks `CheckpointParams` (all `@InternalRevenueCatAPI`) from Map / vararg-Pair constructors into a Builder with a Kotlin DSL on top:

```kotlin
val params = CheckpointParams {
    customVariables {
        "goal" to "lose_weight"
        "step" to 3
        "premium" to true
    }
}
```

It additionally adds the infix `to` operators with overloads for the accepted types, to make the API nicer to use

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal checkpoint API reshaping with preserved validation and downstream behavior; no auth or payment logic changes.
> 
> **Overview**
> **`CheckpointParams`** no longer exposes map or vararg-`Pair` constructors. Instances are built via **`CheckpointParams.Builder`**, a top-level **`CheckpointParams { }`** DSL, and **`CustomVariablesBuilder`** with fluent **`add(...)`** overloads (Java) and infix **`"key" to value`** for primitives and **`CustomVariableValue`** (Kotlin). A compile-time **`@Deprecated(ERROR)`** `to(Any?)` overload blocks silent misuse of Kotlin’s **`Pair`** `to` operator.
> 
> Default empty params in **`CheckpointsManager`** use **`CheckpointParams {}`** instead of **`CheckpointParams()`**. Sample apps and api-tester call sites are migrated to the DSL; unit tests cover builder/DSL parity, duplicate keys, and replacing **`customVariables`** blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49fb3d32f63036afd403763ea944b4fc40ded33f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->