### PR TITLE
refactor(admob): reuse suspended load tracking for interstitial ads

### DIFF
--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/AdTrackerAdMobExtensions.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/AdTrackerAdMobExtensions.kt
@@ -9,8 +9,7 @@ import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingAdLoadCallback
-import com.revenuecat.purchases.admob.nextgen.tracking.trackAdFailedToLoad
-import com.revenuecat.purchases.admob.nextgen.tracking.trackAdLoaded
+import com.revenuecat.purchases.admob.nextgen.tracking.trackAndConfigureAdLoadResult
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import kotlin.jvm.JvmSynthetic
@@ -71,23 +70,18 @@ public suspend fun AdTracker.loadAndTrackInterstitialAd(
     adEventCallback: InterstitialAdEventCallback? = null,
 ): AdLoadResult<InterstitialAd> {
     val adUnitId = adRequest.adUnitId
-    val result = InterstitialAd.load(adRequest)
-
-    when (result) {
-        is AdLoadResult.Success -> {
-            trackAdLoaded(result.ad::getResponseInfo, AdFormat.INTERSTITIAL, placement, adUnitId)
-            result.ad.installTrackingEventCallback(
+    return InterstitialAd.load(adRequest).trackAndConfigureAdLoadResult(
+        adFormat = AdFormat.INTERSTITIAL,
+        placement = placement,
+        adUnitId = adUnitId,
+        configureAd = { ad ->
+            ad.installTrackingEventCallback(
                 delegate = adEventCallback,
                 placement = placement,
                 adUnitId = adUnitId,
             )
-        }
-        is AdLoadResult.Failure -> {
-            trackAdFailedToLoad(result.error, AdFormat.INTERSTITIAL, placement, adUnitId)
-        }
-    }
-
-    return result
+        },
+    )
 }
 
 /**


### PR DESCRIPTION
## Summary

I jumped the gun and merged the approved PR for interstitial ads before adopting the new helper.

- #4053 introduced the shared `AdLoadResult.trackAndConfigureAdLoadResult` foundation helper.
- Adopt that helper at the existing suspending interstitial load call site while preserving result identity, tracking order, and callback installation.

## Test plan

- [x] `./gradlew :feature:admob-next-gen:testDefaultsDebugUnitTest`
- [x] `./gradlew detektAll`
- [x] `./scripts/api-check.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor to a shared helper with equivalent tracking and callback wiring; no API or auth changes.
> 
> **Overview**
> The suspending **`AdTracker.loadAndTrackInterstitialAd`** path no longer inlines success/failure tracking with **`trackAdLoaded`** / **`trackAdFailedToLoad`**. It now chains **`InterstitialAd.load`** through the shared **`trackAndConfigureAdLoadResult`** helper (from #4053), passing interstitial format metadata and a **`configureAd`** block that installs the tracking event callback.
> 
> Behavior is intended to stay the same: the original **`AdLoadResult`** is returned, load success/failure events are still tracked, and tracking is installed on successful loads before the suspend function completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a4b7f0db4917dca40285dd29d2d7db26953fa3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->