### PR TITLE
feat(paywalls): send custom variables to custom components

### DIFF
--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
@@ -44,7 +44,13 @@ class PaywallWebViewMediaPolicyTest {
                     sizeToContentHeight = false,
                 ),
                 onLoadFailed = {},
-                contextSnapshotProvider = { webViewContextSnapshot(locale = "en-US", darkMode = false) },
+                contextSnapshotProvider = {
+                    webViewContextSnapshot(
+                        customVariables = emptyMap(),
+                        locale = "en-US",
+                        darkMode = false,
+                    )
+                },
             )
             built = configured != null
             configured?.let {

--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextBridgeTest.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextBridgeTest.kt
@@ -5,6 +5,7 @@ import android.os.SystemClock
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.webkit.WebViewFeature
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assume.assumeTrue
@@ -40,7 +41,13 @@ class WebViewContextBridgeTest {
                     sizeToContentHeight = true,
                 ),
                 onLoadFailed = {},
-                contextSnapshotProvider = { webViewContextSnapshot(locale = "en-US", darkMode = false) },
+                contextSnapshotProvider = {
+                    webViewContextSnapshot(
+                        customVariables = mapOf("org" to CustomVariableValue.String("RevenueCat")),
+                        locale = "en-US",
+                        darkMode = false,
+                    )
+                },
             )
         }
         assumeTrue(configured != null)
@@ -58,6 +65,7 @@ class WebViewContextBridgeTest {
                 """"payload":{"context":{""",
                 """"is_preview":false""",
                 """"locale":"en-US"""",
+                """"custom":{"org":"RevenueCat"}""",
             )
             assertThat(frames).doesNotContain("workflow")
         } finally {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
@@ -2,9 +2,11 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
@@ -15,6 +17,7 @@ internal fun webViewContextSnapshot(
     state: PaywallState.Loaded.Components,
     darkMode: Boolean,
 ): JsonObject = webViewContextSnapshot(
+    customVariables = state.mergedCustomVariables,
     locale = state.locale.toLanguageTag(),
     darkMode = darkMode,
 )
@@ -29,10 +32,13 @@ internal fun webViewContextSnapshot(
  */
 @JvmSynthetic
 internal fun webViewContextSnapshot(
+    customVariables: Map<String, CustomVariableValue>,
     locale: String,
     darkMode: Boolean,
 ): JsonObject = buildJsonObject {
-    putJsonObject(Keys.CUSTOM) {}
+    putJsonObject(Keys.CUSTOM) {
+        customVariables.forEach { (name, value) -> put(name, value.asJsonPrimitive) }
+    }
     put(Keys.OFFERING, JsonNull)
     putJsonArray(Keys.PACKAGES) {}
     put(Keys.PACKAGE, JsonNull)
@@ -61,3 +67,18 @@ private object Keys {
     const val DARK_MODE = "dark_mode"
     const val UPDATED_AT = "updated_at"
 }
+
+private val CustomVariableValue.asJsonPrimitive: JsonPrimitive
+    get() = map(
+        string = { JsonPrimitive(it) },
+        number = { number ->
+            // A bare NaN or Infinity is not valid JSON.
+            if (!number.isFinite()) {
+                JsonPrimitive(number.toString())
+            } else {
+                val whole = number.toLong()
+                if (number == whole.toDouble()) JsonPrimitive(whole) else JsonPrimitive(number)
+            }
+        },
+        boolean = { JsonPrimitive(it) },
+    )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
@@ -1,7 +1,10 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -14,7 +17,11 @@ internal class WebViewContextSnapshotTest {
 
     @Test
     fun `contains every section with its empty shape and no workflow key`() {
-        val snapshot = webViewContextSnapshot(locale = "en-US", darkMode = true)
+        val snapshot = webViewContextSnapshot(
+            customVariables = emptyMap(),
+            locale = "en-US",
+            darkMode = true,
+        )
 
         assertThat(snapshot.keys).containsExactly(
             "custom",
@@ -34,10 +41,48 @@ internal class WebViewContextSnapshotTest {
     }
 
     @Test
+    fun `custom carries every variable with its type intact`() {
+        val custom = snapshotWith(
+            "org" to CustomVariableValue.String("RevenueCat"),
+            "is_premium" to CustomVariableValue.Boolean(true),
+            "rating" to CustomVariableValue.Number(4.5),
+        )
+
+        assertThat(Json.encodeToString(JsonObject.serializer(), custom))
+            .isEqualTo("""{"org":"RevenueCat","is_premium":true,"rating":4.5}""")
+    }
+
+    @Test
+    fun `whole numbers keep no decimal part`() {
+        // The contract's example is `"streak_days": 12`.
+        val custom = snapshotWith("streak_days" to CustomVariableValue.Number(12))
+
+        assertThat(Json.encodeToString(JsonObject.serializer(), custom)).isEqualTo("""{"streak_days":12}""")
+    }
+
+    @Test
+    fun `non-finite numbers stay encodable`() {
+        val custom = snapshotWith("broken" to CustomVariableValue.Number(Double.NaN))
+
+        assertThat(Json.encodeToString(JsonObject.serializer(), custom)).isEqualTo("""{"broken":"NaN"}""")
+    }
+
+    private fun snapshotWith(vararg variables: Pair<String, CustomVariableValue>) =
+        webViewContextSnapshot(
+            customVariables = variables.toMap(),
+            locale = "en-US",
+            darkMode = false,
+        ).getValue("custom").jsonObject
+
+    @Test
     fun `device_meta carries host details`() {
         val before = System.currentTimeMillis()
 
-        val deviceMeta = webViewContextSnapshot(locale = "en-US", darkMode = true)
+        val deviceMeta = webViewContextSnapshot(
+            customVariables = emptyMap(),
+            locale = "en-US",
+            darkMode = true,
+        )
             .getValue("device_meta").jsonObject
 
         assertThat(deviceMeta.getValue("is_preview").jsonPrimitive.boolean).isFalse()
@@ -45,6 +90,18 @@ internal class WebViewContextSnapshotTest {
         assertThat(deviceMeta.getValue("dark_mode").jsonPrimitive.boolean).isTrue()
         assertThat(deviceMeta.getValue("updated_at").jsonPrimitive.long)
             .isBetween(before, System.currentTimeMillis())
+    }
+
+    @Test
+    fun `derives the custom variables from the paywall state`() {
+        val state = FakePaywallState(
+            components = emptyList(),
+            customVariables = mapOf("org" to CustomVariableValue.String("RevenueCat")),
+        )
+
+        val custom = webViewContextSnapshot(state, darkMode = false).getValue("custom").jsonObject
+
+        assertThat(custom.getValue("org").jsonPrimitive.content).isEqualTo("RevenueCat")
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewIdentityTest.kt
@@ -244,9 +244,7 @@ private fun TestWebViewSlot(
                         expectedUrl = identity.resolvedUrl,
                         sizeToContentWidth = identity.sizeToContentWidth,
                         sizeToContentHeight = identity.sizeToContentHeight,
-                        contextSnapshotProvider = {
-                            webViewContextSnapshot(locale = "en-US", darkMode = false)
-                        },
+                        contextSnapshotProvider = ::testContextSnapshot,
                     ).also { created ->
                         created.attach()
                         onBridgeCreated(created)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.webkit.WebMessageCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -74,9 +75,7 @@ internal class WebViewJavaScriptBridgeTest {
         sizeToContentHeight: Boolean = false,
         onDocumentReset: () -> Unit = {},
         onSecureMessagingUnsupported: () -> Unit = {},
-        contextSnapshotProvider: () -> JsonObject = {
-            webViewContextSnapshot(locale = "en-US", darkMode = false)
-        },
+        contextSnapshotProvider: () -> JsonObject = { testContextSnapshot() },
     ): WebViewJavaScriptBridge {
         val bridge = WebViewJavaScriptBridge(
             webView = webView,
@@ -594,6 +593,34 @@ internal class WebViewJavaScriptBridgeTest {
         idleMainLooper()
 
         assertThat(resizes).isEmpty()
+    }
+
+    // --- Snapshot delivery ---
+
+    @Test
+    fun `context frame carries resolved custom variables`() {
+        val bridge = bridge(
+            contextSnapshotProvider = {
+                testContextSnapshot(mapOf("org" to CustomVariableValue.String("RevenueCat")))
+            },
+        )
+        bridge.connect()
+
+        assertThat(scripts().last()).contains("\"custom\":{\"org\":\"RevenueCat\"}")
+    }
+
+    @Test
+    fun `builds the snapshot once per handshake`() {
+        var builds = 0
+        val bridge = bridge(
+            contextSnapshotProvider = {
+                builds += 1
+                testContextSnapshot()
+            },
+        )
+        bridge.connect()
+
+        assertThat(builds).isEqualTo(1)
     }
 
     // --- Document lifecycle ---

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewSnapshotFixture.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewSnapshotFixture.kt
@@ -1,0 +1,13 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import kotlinx.serialization.json.JsonObject
+
+/** A snapshot for tests that care about the frames, not the payload. */
+internal fun testContextSnapshot(
+    customVariables: Map<String, CustomVariableValue> = emptyMap(),
+): JsonObject = webViewContextSnapshot(
+    customVariables = customVariables,
+    locale = "en-US",
+    darkMode = false,
+)


### PR DESCRIPTION
- Fills the `custom` section of the snapshot from the variables the app set through `PaywallOptions`.
- Whole numbers are emitted without a decimal part, so `2.0` reaches the content as `2`, matching what the paywall's own text renders for the same variable.


### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

PWENG-200. Custom variables are the headline use case for custom components: an app sets `{"credits": 40}` and the component renders it. The builder from #4084 emits `custom: {}`, so this is the section that makes the feature useful at all.

### Description

Each variable is written into `custom`, converted through `CustomVariableValue.map(string =, number =, boolean =)` rather than a `when`, matching how the same value reaches the rules engine in `asRulesDimensionValue`. A new variant then fails to compile instead of being silently dropped.

**Not visible in the diff:** two numeric edge cases. A whole `Double` is narrowed to `Long`, without which a variable set to `40` renders as `40` in a text component and `40.0` in a custom component from the same source value. `NaN` and the infinities are serialized as strings, since a bare `NaN` is invalid JSON and would make the entire frame unparseable for the content SDK; dropping the key instead would look like the app never set the variable.

**Rejected:** routing the variables through `WebViewComponentState`. Its providers are installed inside `remember(style)` and close over the first `PaywallState`, so they go stale when the view model swaps state instances.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to WebView context JSON for custom components; no auth or purchase-path changes, with explicit handling for numeric edge cases.
> 
> **Overview**
> Populates the **`custom`** section of the paywall WebView context snapshot (handshake `init` and later context pushes) from **`PaywallOptions`** variables via `PaywallState.mergedCustomVariables`, instead of always sending `{}`.
> 
> `CustomVariableValue` is serialized to JSON primitives (string/boolean/number) using the same `map` pattern as the rules engine; whole numeric values omit a decimal part (e.g. `12` not `12.0`), and non-finite numbers are encoded as strings so frames stay valid JSON.
> 
> Tests cover snapshot encoding, bridge delivery of `custom` on connect, paywall-state derivation, and an on-device handshake assertion that includes `"custom":{"org":"RevenueCat"}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaada32bc5af4f67a940064c891944aef4405cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->