### PR TITLE
feat(admob): add sample preloader controls

### DIFF
--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/AdSupport.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/AdSupport.kt
@@ -1,0 +1,25 @@
+package com.revenuecat.sample.admob.nextgen.ui
+
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+internal fun preloadStatusCallback(
+    scope: CoroutineScope,
+    onAdPreloaded: () -> Unit,
+    updateStatus: (String) -> Unit,
+): PreloadCallback = object : PreloadCallback {
+    override fun onAdPreloaded(preloadId: String, responseInfo: ResponseInfo) {
+        scope.launch { onAdPreloaded() }
+    }
+
+    override fun onAdFailedToPreload(preloadId: String, adError: LoadAdError) {
+        scope.launch { updateStatus("Preload failed: ${adError.message}") }
+    }
+
+    override fun onAdsExhausted(preloadId: String) {
+        scope.launch { updateStatus("Buffer exhausted: $preloadId") }
+    }
+}

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/PreloaderUi.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/PreloaderUi.kt
@@ -45,11 +45,10 @@ internal class PreloaderUiState(
         private set
     var adsAvailable by mutableIntStateOf(0)
         private set
-    var message by mutableStateOf("Preloader not started")
+    var message by mutableStateOf<String?>(null)
 
     init {
         refresh()
-        message = if (started) "Preloader started" else "Preloader not started"
     }
 
     fun refresh() {
@@ -60,7 +59,7 @@ internal class PreloaderUiState(
         adsAvailable = if (started) getNumAdsAvailable() else 0
 
         if (wasStarted != started) {
-            message = if (started) "Preloader started" else "Preloader stopped"
+            message = null
         }
     }
 
@@ -95,7 +94,7 @@ internal class PreloaderUiState(
 
     fun updateAfterStop(stopResult: Boolean) {
         refresh()
-        message = if (stopResult) "Preloader stopped" else "Preloader was not running"
+        message = if (stopResult) null else "Preloader was not running"
     }
 }
 
@@ -138,9 +137,9 @@ internal fun PreloaderPanel(
             BufferSizeSetting(state)
             MetricRow("Ads ready", state.adsAvailable.toString())
             additionalMetrics()
-            if (!state.message.isDefaultPreloaderMessage()) {
+            state.message?.let { message ->
                 Text(
-                    text = state.message,
+                    text = message,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -238,8 +237,4 @@ private fun MetricRow(label: String, value: String) {
         Text(label, style = MaterialTheme.typography.bodyMedium)
         Text(value, style = MaterialTheme.typography.titleMedium)
     }
-}
-
-private fun String.isDefaultPreloaderMessage(): Boolean {
-    return this == "Preloader started" || this == "Preloader not started" || this == "Preloader stopped"
 }

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/PreloaderUi.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/PreloaderUi.kt
@@ -74,7 +74,10 @@ internal class PreloaderUiState(
 
     fun preloadCallback(scope: CoroutineScope): PreloadCallback = preloadStatusCallback(
         scope = scope,
-        onAdPreloaded = ::refresh,
+        onAdPreloaded = {
+            refresh()
+            message = "Ad preloaded"
+        },
         updateStatus = { status ->
             message = status
             refresh()

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/PreloaderUi.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/PreloaderUi.kt
@@ -1,0 +1,242 @@
+package com.revenuecat.sample.admob.nextgen.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+
+private const val DEFAULT_BUFFER_SIZE = 2
+private const val MIN_BUFFER_SIZE = 1
+private const val MAX_SAMPLE_BUFFER_SIZE = 5
+private const val REFRESH_INTERVAL_MILLIS = 500L
+
+@Stable
+internal class PreloaderUiState(
+    private val getConfiguration: () -> PreloadConfiguration?,
+    private val getNumAdsAvailable: () -> Int,
+) {
+    var started by mutableStateOf(false)
+        private set
+    var bufferSize by mutableIntStateOf(DEFAULT_BUFFER_SIZE)
+        private set
+    var adsAvailable by mutableIntStateOf(0)
+        private set
+    var message by mutableStateOf("Preloader not started")
+
+    init {
+        refresh()
+        message = if (started) "Preloader started" else "Preloader not started"
+    }
+
+    fun refresh() {
+        val wasStarted = started
+        val configuration = getConfiguration()
+        started = configuration != null
+        configuration?.bufferSize?.let { bufferSize = it }
+        adsAvailable = if (started) getNumAdsAvailable() else 0
+
+        if (wasStarted != started) {
+            message = if (started) "Preloader started" else "Preloader stopped"
+        }
+    }
+
+    fun decreaseBufferSize() {
+        if (!started && bufferSize > MIN_BUFFER_SIZE) bufferSize--
+    }
+
+    fun increaseBufferSize() {
+        if (!started && bufferSize < MAX_SAMPLE_BUFFER_SIZE) bufferSize++
+    }
+
+    fun preloadCallback(scope: CoroutineScope): PreloadCallback = preloadStatusCallback(
+        scope = scope,
+        onAdPreloaded = ::refresh,
+        updateStatus = { status ->
+            message = status
+            refresh()
+        },
+    )
+
+    fun updateAfterStart(startResult: Boolean) {
+        refresh()
+        message = when {
+            startResult -> "Preloader started; waiting for ads"
+            started -> "Preloader already started"
+            else -> "Preloader did not start"
+        }
+    }
+
+    fun updateAfterStop(stopResult: Boolean) {
+        refresh()
+        message = if (stopResult) "Preloader stopped" else "Preloader was not running"
+    }
+}
+
+@Composable
+internal fun rememberPreloaderUiState(
+    preloadId: String,
+    getConfiguration: () -> PreloadConfiguration?,
+    getNumAdsAvailable: () -> Int,
+): PreloaderUiState = remember(preloadId) {
+    PreloaderUiState(getConfiguration, getNumAdsAvailable)
+}
+
+internal data class PreloaderAction(
+    val label: String,
+    val enabled: Boolean,
+    val onClick: () -> Unit,
+)
+
+@Composable
+internal fun PreloaderPanel(
+    state: PreloaderUiState,
+    actions: List<PreloaderAction> = emptyList(),
+    additionalMetrics: @Composable () -> Unit = {},
+    onToggle: () -> Unit,
+) {
+    LaunchedEffect(state) {
+        while (true) {
+            state.refresh()
+            delay(REFRESH_INTERVAL_MILLIS)
+        }
+    }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            PreloaderHeader(state, onToggle)
+            HorizontalDivider()
+            BufferSizeSetting(state)
+            MetricRow("Ads ready", state.adsAvailable.toString())
+            additionalMetrics()
+            if (!state.message.isDefaultPreloaderMessage()) {
+                Text(
+                    text = state.message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (actions.isNotEmpty()) {
+                HorizontalDivider()
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    actions.forEach { action ->
+                        Button(
+                            modifier = Modifier.weight(1f),
+                            onClick = action.onClick,
+                            enabled = action.enabled,
+                        ) {
+                            Text(action.label)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreloaderHeader(state: PreloaderUiState, onToggle: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Preload buffer",
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Surface(
+            shape = CircleShape,
+            color = if (state.started) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant
+            },
+        ) {
+            Text(
+                text = if (state.started) "Running" else "Stopped",
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
+        OutlinedButton(onClick = onToggle) {
+            Text(if (state.started) "Stop" else "Start")
+        }
+    }
+}
+
+@Composable
+private fun BufferSizeSetting(state: PreloaderUiState) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Buffer capacity",
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            OutlinedButton(
+                onClick = state::decreaseBufferSize,
+                enabled = !state.started && state.bufferSize > MIN_BUFFER_SIZE,
+            ) {
+                Text("−")
+            }
+            Text(state.bufferSize.toString())
+            OutlinedButton(
+                onClick = state::increaseBufferSize,
+                enabled = !state.started && state.bufferSize < MAX_SAMPLE_BUFFER_SIZE,
+            ) {
+                Text("+")
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium)
+        Text(value, style = MaterialTheme.typography.titleMedium)
+    }
+}
+
+private fun String.isDefaultPreloaderMessage(): Boolean {
+    return this == "Preloader started" || this == "Preloader not started" || this == "Preloader stopped"
+}


### PR DESCRIPTION
## Summary

Expands the Google Mobile Ads Next-Gen example app with reusable preloader controls:

- add reusable controls for starting and stopping format preloaders
- expose buffer capacity and available-ad state
- keep buffer configuration editable only before a preloader starts

## Screenshots

![Running preloader with configurable capacity and two ads ready](https://github.com/RevenueCat/purchases-android/blob/8ea99f14bda69624087a64460ff16065f70c1432/gh-pr-images/pr-4094/1787759309-26910-1-04-preloader-started.png?raw=true)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app-only UI helpers with no changes to SDK, billing, or production ad integration paths.
> 
> **Overview**
> Adds **reusable Compose UI** for the AdMob Next-Gen sample so format screens can demo ad preloading without duplicating layout code.
> 
> **`PreloaderUi.kt`** introduces `PreloaderUiState` (backed by `PreloadConfiguration` and an ads-available provider), `rememberPreloaderUiState`, and `PreloaderPanel`: start/stop toggle, running/stopped badge, buffer capacity steppers (1–5, locked while running), live “ads ready” count with ~500ms polling, status messages after start/stop/preload events, plus optional extra metrics and action buttons.
> 
> **`AdSupport.kt`** adds `preloadStatusCallback`, a small `PreloadCallback` that hops preload success, failure, and buffer-exhausted events onto a `CoroutineScope` so the panel can update safely from SDK callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5868b707454a16a3db0ae5b2e4db134979028467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->