### PR TITLE
feat(admob): demonstrate banner ads

### DIFF
--- a/examples/admob-next-gen-sample/README.md
+++ b/examples/admob-next-gen-sample/README.md
@@ -24,7 +24,7 @@ ADMOB_REWARDED_INTERSTITIAL_AD_UNIT_ID=...
 
 Each ad-format screen owns its direct and preloaded examples:
 
-- Banner: callback-based direct loading, preload/poll/register, refresh callbacks, and tracking-safe callback replacement.
+- Banner: callback-based direct loading, preload/poll/register, and banner lifecycle and refresh callbacks.
 - Interstitial and app open: suspending direct loads, preload buffers, and show-time placement overrides.
 - Rewarded and rewarded interstitial: direct/preloaded loading, ordinary reward callbacks, and RevenueCat reward verification.
 - Native: suspending single load, multi-ad `Flow`, preloading, and result-specific handling.

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/BannerScreen.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/BannerScreen.kt
@@ -1,0 +1,170 @@
+package com.revenuecat.sample.admob.nextgen.ui
+
+import android.app.Activity
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
+import com.google.android.libraries.ads.mobile.sdk.banner.AdView
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdPreloader
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
+import com.revenuecat.purchases.admob.nextgen.loadAndTrackAd
+import com.revenuecat.purchases.admob.nextgen.pollAndTrackAd
+import com.revenuecat.purchases.admob.nextgen.setTrackingAdEventCallback
+import com.revenuecat.purchases.admob.nextgen.setTrackingBannerAdRefreshCallback
+import com.revenuecat.purchases.admob.nextgen.startAndTrack
+import com.revenuecat.sample.admob.nextgen.BuildConfig
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
+
+private const val BANNER_PRELOAD_ID = "sample-banner"
+
+@Composable
+@Suppress("LongMethod")
+internal fun BannerScreen(activity: Activity, onBack: () -> Unit) {
+    var status by remember { mutableStateOf("Banner view is ready") }
+    val preloadState = rememberPreloaderUiState(
+        BANNER_PRELOAD_ID,
+        getConfiguration = { BannerAdPreloader.getConfiguration(BANNER_PRELOAD_ID) },
+        getNumAdsAvailable = { BannerAdPreloader.getNumAdsAvailable(BANNER_PRELOAD_ID) },
+    )
+    val scope = rememberCoroutineScope()
+
+    AdScreen("Banner", onBack) { mode ->
+        key(mode) {
+            val active = remember { AtomicBoolean(true) }
+            val adView = remember(activity, mode) { AdView(activity) }
+            val updateStatus: (String) -> Unit = { message ->
+                if (mode == LoadMode.DIRECT) status = message else preloadState.message = message
+            }
+            val eventCallback = remember {
+                object : BannerAdEventCallback {
+                    override fun onAdImpression() {
+                        if (active.get()) scope.launch { updateStatus("Banner impression") }
+                    }
+
+                    override fun onAdClicked() {
+                        if (active.get()) scope.launch { updateStatus("Banner clicked") }
+                    }
+                }
+            }
+            val refreshCallback = remember {
+                object : BannerAdRefreshCallback {
+                    override fun onAdRefreshed() {
+                        if (active.get()) scope.launch { updateStatus("Banner refreshed") }
+                    }
+
+                    override fun onAdFailedToRefresh(error: LoadAdError) {
+                        if (active.get()) scope.launch { updateStatus("Refresh failed: ${error.message}") }
+                    }
+                }
+            }
+
+            DisposableEffect(adView) {
+                onDispose {
+                    active.set(false)
+                    adView.destroy()
+                }
+            }
+            LaunchedEffect(mode) {
+                status = "${mode.label} banner view is ready"
+            }
+
+            Text("Preloaded banners are polled first, then registered with the existing AdView.")
+            if (mode == LoadMode.DIRECT) {
+                StatusCard(status)
+                ActionRow(
+                    "Load" to {
+                        status = "Loading directly..."
+                        adView.loadAndTrackAd(
+                            adRequest = bannerRequest(),
+                            placement = "banner_direct",
+                            loadCallback = object : AdLoadCallback<BannerAd> {
+                                override fun onAdLoaded(ad: BannerAd) {
+                                    ad.setTrackingAdEventCallback(eventCallback)
+                                    ad.setTrackingBannerAdRefreshCallback(refreshCallback)
+                                    if (active.get()) {
+                                        scope.launch { updateStatus("Banner ready") }
+                                    }
+                                }
+
+                                override fun onAdFailedToLoad(error: LoadAdError) {
+                                    if (active.get()) scope.launch { updateStatus("Load failed: ${error.message}") }
+                                }
+                            },
+                        )
+                    },
+                )
+            } else {
+                PreloaderPanel(
+                    state = preloadState,
+                    actions = listOf(
+                        PreloaderAction(
+                            label = "Poll + Show",
+                            enabled = preloadState.started && preloadState.adsAvailable > 0,
+                            onClick = {
+                                val ad = BannerAdPreloader.pollAndTrackAd(
+                                    BANNER_PRELOAD_ID,
+                                    placement = "banner_poll",
+                                    adEventCallback = eventCallback,
+                                    bannerAdRefreshCallback = refreshCallback,
+                                )
+                                preloadState.refresh()
+                                if (ad == null) {
+                                    preloadState.message = "No buffered banner available"
+                                } else {
+                                    adView.registerBannerAd(ad, activity)
+                                    preloadState.message = "Buffered banner registered"
+                                }
+                            },
+                        ),
+                    ),
+                    onToggle = {
+                        if (preloadState.started) {
+                            preloadState.updateAfterStop(BannerAdPreloader.destroy(BANNER_PRELOAD_ID))
+                        } else {
+                            preloadState.updateAfterStart(
+                                BannerAdPreloader.startAndTrack(
+                                    BANNER_PRELOAD_ID,
+                                    PreloadConfiguration(bannerRequest(), preloadState.bufferSize),
+                                    placement = "banner_preload",
+                                    preloadCallback = preloadState.preloadCallback(scope),
+                                ),
+                            )
+                        }
+                    },
+                )
+            }
+
+            AndroidView(
+                factory = { adView },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp),
+            )
+        }
+    }
+}
+
+private fun bannerRequest(): BannerAdRequest = BannerAdRequest.Builder(
+    BuildConfig.ADMOB_BANNER_AD_UNIT_ID,
+    AdSize.BANNER,
+).build()

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/BannerScreen.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/BannerScreen.kt
@@ -86,6 +86,7 @@ internal fun BannerScreen(activity: Activity, onBack: () -> Unit) {
             }
             LaunchedEffect(mode) {
                 status = "${mode.label} banner view is ready"
+                preloadState.message = null
             }
 
             Text("Preloaded banners are polled first, then registered with the existing AdView.")

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/BannerScreen.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/BannerScreen.kt
@@ -28,8 +28,6 @@ import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
 import com.revenuecat.purchases.admob.nextgen.loadAndTrackAd
 import com.revenuecat.purchases.admob.nextgen.pollAndTrackAd
-import com.revenuecat.purchases.admob.nextgen.setTrackingAdEventCallback
-import com.revenuecat.purchases.admob.nextgen.setTrackingBannerAdRefreshCallback
 import com.revenuecat.purchases.admob.nextgen.startAndTrack
 import com.revenuecat.sample.admob.nextgen.BuildConfig
 import kotlinx.coroutines.launch
@@ -98,10 +96,10 @@ internal fun BannerScreen(activity: Activity, onBack: () -> Unit) {
                         adView.loadAndTrackAd(
                             adRequest = bannerRequest(),
                             placement = "banner_direct",
+                            adEventCallback = eventCallback,
+                            bannerAdRefreshCallback = refreshCallback,
                             loadCallback = object : AdLoadCallback<BannerAd> {
                                 override fun onAdLoaded(ad: BannerAd) {
-                                    ad.setTrackingAdEventCallback(eventCallback)
-                                    ad.setTrackingBannerAdRefreshCallback(refreshCallback)
                                     if (active.get()) {
                                         scope.launch { updateStatus("Banner ready") }
                                     }

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/SampleUi.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/SampleUi.kt
@@ -54,7 +54,7 @@ fun AdMobNextGenSample(
     }
 
     when (selectedScreen) {
-        SampleScreen.BANNER -> PlaceholderAdScreen(selectedScreen.title, onBack)
+        SampleScreen.BANNER -> BannerScreen(activity, onBack)
         SampleScreen.INTERSTITIAL -> PlaceholderAdScreen(selectedScreen.title, onBack)
         SampleScreen.APP_OPEN -> PlaceholderAdScreen(selectedScreen.title, onBack)
         SampleScreen.REWARDED -> PlaceholderAdScreen(selectedScreen.title, onBack)


### PR DESCRIPTION
## Summary

Expands the Google Mobile Ads Next-Gen example app with banner workflows:

- add direct and preloaded banner workflows
- reset rendered banner state when switching load modes
- demonstrate registration and refresh callbacks

## Screenshots

![Banner direct-loading screen](https://github.com/RevenueCat/purchases-android/blob/ad50aeae8f85add900cde71a826177c8bc42424e/gh-pr-images/pr-4095/1787759316-27587-1-02-banner-direct.png?raw=true)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app and documentation changes only; no production SDK or auth/data-path changes.
> 
> **Overview**
> Replaces the **Banner** placeholder in the AdMob Next-Gen sample with a working **Banner** screen that shows RevenueCat-tracked banner flows end to end.
> 
> **Direct** mode loads into an `AdView` via `loadAndTrackAd`, with status for load success/failure plus **impression**, **click**, and **refresh** callbacks. **Preloaded** mode uses the shared preloader UI to **start/stop** buffering, then **poll + register** a buffered ad on the same view with distinct placements (`banner_direct`, `banner_preload`, `banner_poll`). Switching load modes recreates the `AdView` (`key(mode)`) and resets status so banner state does not leak across modes.
> 
> The sample README **Coverage** line for banners is updated to describe lifecycle/refresh callbacks instead of callback-replacement wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1035d0b0421f562ad0f6568a76b0b8ebeeb92f9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->