### PR TITLE
feat(admob): demonstrate fullscreen ads

### DIFF
--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/FullScreenScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/FullScreenScreens.kt
@@ -22,7 +22,6 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.loadAndTrackAppOpenAd
 import com.revenuecat.purchases.admob.nextgen.loadAndTrackInterstitialAd
 import com.revenuecat.purchases.admob.nextgen.pollAndTrackAd
-import com.revenuecat.purchases.admob.nextgen.setTrackingAdEventCallback
 import com.revenuecat.purchases.admob.nextgen.show
 import com.revenuecat.purchases.admob.nextgen.startAndTrack
 import com.revenuecat.sample.admob.nextgen.BuildConfig
@@ -87,10 +86,11 @@ internal fun InterstitialScreen(activity: Activity, onBack: () -> Unit) {
                             val result = Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
                                 AdRequest.Builder(BuildConfig.ADMOB_INTERSTITIAL_AD_UNIT_ID).build(),
                                 placement = "interstitial_load",
+                                adEventCallback = directEventCallback,
                             )
                         ) {
                             is AdLoadResult.Success -> {
-                                directAd = result.ad.also { it.setTrackingAdEventCallback(directEventCallback) }
+                                directAd = result.ad
                                 directStatus = "Direct interstitial ready"
                             }
                             is AdLoadResult.Failure -> directStatus = "Load failed: ${result.error.message}"

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/FullScreenScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/FullScreenScreens.kt
@@ -1,0 +1,279 @@
+package com.revenuecat.sample.admob.nextgen.ui
+
+import android.app.Activity
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd
+import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdPreloader
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdPreloader
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.loadAndTrackAppOpenAd
+import com.revenuecat.purchases.admob.nextgen.loadAndTrackInterstitialAd
+import com.revenuecat.purchases.admob.nextgen.pollAndTrackAd
+import com.revenuecat.purchases.admob.nextgen.setTrackingAdEventCallback
+import com.revenuecat.purchases.admob.nextgen.show
+import com.revenuecat.purchases.admob.nextgen.startAndTrack
+import com.revenuecat.sample.admob.nextgen.BuildConfig
+import kotlinx.coroutines.launch
+
+private const val INTERSTITIAL_PRELOAD_ID = "sample-interstitial"
+private const val APP_OPEN_PRELOAD_ID = "sample-app-open"
+
+@Composable
+@Suppress("CyclomaticComplexMethod", "LongMethod")
+internal fun InterstitialScreen(activity: Activity, onBack: () -> Unit) {
+    var directStatus by remember { mutableStateOf("No direct interstitial loaded") }
+    var directAd by remember { mutableStateOf<InterstitialAd?>(null) }
+    val preloadState = rememberPreloaderUiState(
+        INTERSTITIAL_PRELOAD_ID,
+        getConfiguration = { InterstitialAdPreloader.getConfiguration(INTERSTITIAL_PRELOAD_ID) },
+        getNumAdsAvailable = { InterstitialAdPreloader.getNumAdsAvailable(INTERSTITIAL_PRELOAD_ID) },
+    )
+    val scope = rememberCoroutineScope()
+    val directEventCallback = remember {
+        object : InterstitialAdEventCallback {
+            override fun onAdDismissedFullScreenContent() {
+                scope.launch {
+                    directAd = null
+                    directStatus = "Direct interstitial dismissed"
+                }
+            }
+
+            override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
+                scope.launch {
+                    directAd = null
+                    directStatus = "Show failed: ${error.message}"
+                }
+            }
+        }
+    }
+    val preloadedEventCallback = remember {
+        object : InterstitialAdEventCallback {
+            override fun onAdDismissedFullScreenContent() {
+                scope.launch {
+                    preloadState.message = "Preloaded interstitial dismissed"
+                }
+            }
+
+            override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
+                scope.launch {
+                    preloadState.message = "Show failed: ${error.message}"
+                }
+            }
+        }
+    }
+
+    AdScreen("Interstitial", onBack) { mode ->
+        Text("Load placement and show placement are deliberately different to demonstrate show-time overrides.")
+        if (mode == LoadMode.DIRECT) {
+            StatusCard(directStatus)
+            ActionRow(
+                "Load" to {
+                    scope.launch {
+                        directStatus = "Loading directly..."
+                        when (
+                            val result = Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
+                                AdRequest.Builder(BuildConfig.ADMOB_INTERSTITIAL_AD_UNIT_ID).build(),
+                                placement = "interstitial_load",
+                            )
+                        ) {
+                            is AdLoadResult.Success -> {
+                                directAd = result.ad.also { it.setTrackingAdEventCallback(directEventCallback) }
+                                directStatus = "Direct interstitial ready"
+                            }
+                            is AdLoadResult.Failure -> directStatus = "Load failed: ${result.error.message}"
+                        }
+                    }
+                },
+                "Show" to { showInterstitial(directAd, activity) { directStatus = it } },
+                enabled = mapOf("Show" to (directAd != null)),
+            )
+        } else {
+            PreloaderPanel(
+                state = preloadState,
+                actions = listOf(
+                    PreloaderAction(
+                        label = "Poll + Show",
+                        enabled = preloadState.started && preloadState.adsAvailable > 0,
+                        onClick = {
+                            val ad = InterstitialAdPreloader.pollAndTrackAd(
+                                INTERSTITIAL_PRELOAD_ID,
+                                placement = "interstitial_poll",
+                                adEventCallback = preloadedEventCallback,
+                            )
+                            preloadState.refresh()
+                            if (ad == null) {
+                                preloadState.message = "No buffered ad available"
+                            } else {
+                                showInterstitial(ad, activity) { preloadState.message = it }
+                            }
+                        },
+                    ),
+                ),
+                onToggle = {
+                    if (preloadState.started) {
+                        preloadState.updateAfterStop(
+                            InterstitialAdPreloader.destroy(INTERSTITIAL_PRELOAD_ID),
+                        )
+                    } else {
+                        preloadState.updateAfterStart(
+                            InterstitialAdPreloader.startAndTrack(
+                                preloadId = INTERSTITIAL_PRELOAD_ID,
+                                preloadConfiguration = PreloadConfiguration(
+                                    AdRequest.Builder(BuildConfig.ADMOB_INTERSTITIAL_AD_UNIT_ID).build(),
+                                    preloadState.bufferSize,
+                                ),
+                                placement = "interstitial_preload",
+                                preloadCallback = preloadState.preloadCallback(scope),
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+    }
+}
+
+private fun showInterstitial(ad: InterstitialAd?, activity: Activity, updateStatus: (String) -> Unit) {
+    if (ad == null) {
+        updateStatus("Load or poll an interstitial first")
+    } else {
+        updateStatus("Showing with a placement override")
+        ad.show(activity, placement = "interstitial_show")
+    }
+}
+
+@Composable
+@Suppress("CyclomaticComplexMethod", "LongMethod")
+internal fun AppOpenScreen(activity: Activity, onBack: () -> Unit) {
+    var directStatus by remember { mutableStateOf("No direct app-open ad loaded") }
+    var directAd by remember { mutableStateOf<AppOpenAd?>(null) }
+    val preloadState = rememberPreloaderUiState(
+        APP_OPEN_PRELOAD_ID,
+        getConfiguration = { AppOpenAdPreloader.getConfiguration(APP_OPEN_PRELOAD_ID) },
+        getNumAdsAvailable = { AppOpenAdPreloader.getNumAdsAvailable(APP_OPEN_PRELOAD_ID) },
+    )
+    val scope = rememberCoroutineScope()
+    val directEventCallback = remember {
+        object : AppOpenAdEventCallback {
+            override fun onAdDismissedFullScreenContent() {
+                scope.launch {
+                    directAd = null
+                    directStatus = "Direct app-open ad dismissed"
+                }
+            }
+
+            override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
+                scope.launch {
+                    directAd = null
+                    directStatus = "Show failed: ${error.message}"
+                }
+            }
+        }
+    }
+    val preloadedEventCallback = remember {
+        object : AppOpenAdEventCallback {
+            override fun onAdDismissedFullScreenContent() {
+                scope.launch {
+                    preloadState.message = "Preloaded app-open ad dismissed"
+                }
+            }
+
+            override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
+                scope.launch {
+                    preloadState.message = "Show failed: ${error.message}"
+                }
+            }
+        }
+    }
+
+    AdScreen("App open", onBack) { mode ->
+        Text("The sample exposes app-open loading explicitly instead of tying it to process lifecycle.")
+        if (mode == LoadMode.DIRECT) {
+            StatusCard(directStatus)
+            ActionRow(
+                "Load" to {
+                    scope.launch {
+                        directStatus = "Loading directly..."
+                        when (
+                            val result = Purchases.sharedInstance.adTracker.loadAndTrackAppOpenAd(
+                                AdRequest.Builder(BuildConfig.ADMOB_APP_OPEN_AD_UNIT_ID).build(),
+                                placement = "app_open_load",
+                                adEventCallback = directEventCallback,
+                            )
+                        ) {
+                            is AdLoadResult.Success -> {
+                                directAd = result.ad
+                                directStatus = "Direct app-open ad ready"
+                            }
+                            is AdLoadResult.Failure -> directStatus = "Load failed: ${result.error.message}"
+                        }
+                    }
+                },
+                "Show" to { showAppOpen(directAd, activity) { directStatus = it } },
+                enabled = mapOf("Show" to (directAd != null)),
+            )
+        } else {
+            PreloaderPanel(
+                state = preloadState,
+                actions = listOf(
+                    PreloaderAction(
+                        label = "Poll + Show",
+                        enabled = preloadState.started && preloadState.adsAvailable > 0,
+                        onClick = {
+                            val ad = AppOpenAdPreloader.pollAndTrackAd(
+                                APP_OPEN_PRELOAD_ID,
+                                placement = "app_open_poll",
+                                adEventCallback = preloadedEventCallback,
+                            )
+                            preloadState.refresh()
+                            if (ad == null) {
+                                preloadState.message = "No buffered ad available"
+                            } else {
+                                showAppOpen(ad, activity) { preloadState.message = it }
+                            }
+                        },
+                    ),
+                ),
+                onToggle = {
+                    if (preloadState.started) {
+                        preloadState.updateAfterStop(AppOpenAdPreloader.destroy(APP_OPEN_PRELOAD_ID))
+                    } else {
+                        preloadState.updateAfterStart(
+                            AppOpenAdPreloader.startAndTrack(
+                                APP_OPEN_PRELOAD_ID,
+                                PreloadConfiguration(
+                                    AdRequest.Builder(BuildConfig.ADMOB_APP_OPEN_AD_UNIT_ID).build(),
+                                    preloadState.bufferSize,
+                                ),
+                                placement = "app_open_preload",
+                                preloadCallback = preloadState.preloadCallback(scope),
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+    }
+}
+
+private fun showAppOpen(ad: AppOpenAd?, activity: Activity, updateStatus: (String) -> Unit) {
+    if (ad == null) {
+        updateStatus("Load or poll an app-open ad first")
+    } else {
+        updateStatus("Showing with a placement override")
+        ad.show(activity, placement = "app_open_show")
+    }
+}

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/FullScreenScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/FullScreenScreens.kt
@@ -8,14 +8,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdPreloader
+import com.google.android.libraries.ads.mobile.sdk.common.Ad
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
 import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
 import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
-import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdPreloader
 import com.revenuecat.purchases.Purchases
@@ -31,198 +31,175 @@ private const val INTERSTITIAL_PRELOAD_ID = "sample-interstitial"
 private const val APP_OPEN_PRELOAD_ID = "sample-app-open"
 
 @Composable
-@Suppress("CyclomaticComplexMethod", "LongMethod")
-internal fun InterstitialScreen(activity: Activity, onBack: () -> Unit) {
-    var directStatus by remember { mutableStateOf("No direct interstitial loaded") }
-    var directAd by remember { mutableStateOf<InterstitialAd?>(null) }
-    val preloadState = rememberPreloaderUiState(
-        INTERSTITIAL_PRELOAD_ID,
-        getConfiguration = { InterstitialAdPreloader.getConfiguration(INTERSTITIAL_PRELOAD_ID) },
-        getNumAdsAvailable = { InterstitialAdPreloader.getNumAdsAvailable(INTERSTITIAL_PRELOAD_ID) },
-    )
-    val scope = rememberCoroutineScope()
-    val directEventCallback = remember {
+internal fun InterstitialScreen(activity: Activity, onBack: () -> Unit) = FullScreenAdScreen(
+    title = "Interstitial",
+    description = "Load placement and show placement are deliberately different to demonstrate show-time overrides.",
+    adName = "interstitial",
+    preloadId = INTERSTITIAL_PRELOAD_ID,
+    onBack = onBack,
+    getConfiguration = { InterstitialAdPreloader.getConfiguration(INTERSTITIAL_PRELOAD_ID) },
+    getNumAdsAvailable = { InterstitialAdPreloader.getNumAdsAvailable(INTERSTITIAL_PRELOAD_ID) },
+    createEventCallback = { onDismissed, onFailedToShow ->
         object : InterstitialAdEventCallback {
-            override fun onAdDismissedFullScreenContent() {
-                scope.launch {
-                    directAd = null
-                    directStatus = "Direct interstitial dismissed"
-                }
-            }
+            override fun onAdDismissedFullScreenContent() = onDismissed()
 
             override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
-                scope.launch {
-                    directAd = null
-                    directStatus = "Show failed: ${error.message}"
-                }
+                onFailedToShow(error)
             }
         }
-    }
-    val preloadedEventCallback = remember {
-        object : InterstitialAdEventCallback {
-            override fun onAdDismissedFullScreenContent() {
-                scope.launch {
-                    preloadState.message = "Preloaded interstitial dismissed"
-                }
-            }
-
-            override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
-                scope.launch {
-                    preloadState.message = "Show failed: ${error.message}"
-                }
-            }
-        }
-    }
-
-    AdScreen("Interstitial", onBack) { mode ->
-        Text("Load placement and show placement are deliberately different to demonstrate show-time overrides.")
-        if (mode == LoadMode.DIRECT) {
-            StatusCard(directStatus)
-            ActionRow(
-                "Load" to {
-                    scope.launch {
-                        directStatus = "Loading directly..."
-                        when (
-                            val result = Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
-                                AdRequest.Builder(BuildConfig.ADMOB_INTERSTITIAL_AD_UNIT_ID).build(),
-                                placement = "interstitial_load",
-                                adEventCallback = directEventCallback,
-                            )
-                        ) {
-                            is AdLoadResult.Success -> {
-                                directAd = result.ad
-                                directStatus = "Direct interstitial ready"
-                            }
-                            is AdLoadResult.Failure -> directStatus = "Load failed: ${result.error.message}"
-                        }
-                    }
-                },
-                "Show" to { showInterstitial(directAd, activity) { directStatus = it } },
-                enabled = mapOf("Show" to (directAd != null)),
-            )
-        } else {
-            PreloaderPanel(
-                state = preloadState,
-                actions = listOf(
-                    PreloaderAction(
-                        label = "Poll + Show",
-                        enabled = preloadState.started && preloadState.adsAvailable > 0,
-                        onClick = {
-                            val ad = InterstitialAdPreloader.pollAndTrackAd(
-                                INTERSTITIAL_PRELOAD_ID,
-                                placement = "interstitial_poll",
-                                adEventCallback = preloadedEventCallback,
-                            )
-                            preloadState.refresh()
-                            if (ad == null) {
-                                preloadState.message = "No buffered ad available"
-                            } else {
-                                showInterstitial(ad, activity) { preloadState.message = it }
-                            }
-                        },
-                    ),
-                ),
-                onToggle = {
-                    if (preloadState.started) {
-                        preloadState.updateAfterStop(
-                            InterstitialAdPreloader.destroy(INTERSTITIAL_PRELOAD_ID),
-                        )
-                    } else {
-                        preloadState.updateAfterStart(
-                            InterstitialAdPreloader.startAndTrack(
-                                preloadId = INTERSTITIAL_PRELOAD_ID,
-                                preloadConfiguration = PreloadConfiguration(
-                                    AdRequest.Builder(BuildConfig.ADMOB_INTERSTITIAL_AD_UNIT_ID).build(),
-                                    preloadState.bufferSize,
-                                ),
-                                placement = "interstitial_preload",
-                                preloadCallback = preloadState.preloadCallback(scope),
-                            ),
-                        )
-                    }
-                },
-            )
-        }
-    }
-}
-
-private fun showInterstitial(ad: InterstitialAd?, activity: Activity, updateStatus: (String) -> Unit) {
-    if (ad == null) {
-        updateStatus("Load or poll an interstitial first")
-    } else {
-        updateStatus("Showing with a placement override")
-        ad.show(activity, placement = "interstitial_show")
-    }
-}
+    },
+    loadAd = { callback ->
+        Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
+            AdRequest.Builder(BuildConfig.ADMOB_INTERSTITIAL_AD_UNIT_ID).build(),
+            placement = "interstitial_load",
+            adEventCallback = callback,
+        )
+    },
+    pollAd = { callback ->
+        InterstitialAdPreloader.pollAndTrackAd(
+            INTERSTITIAL_PRELOAD_ID,
+            placement = "interstitial_poll",
+            adEventCallback = callback,
+        )
+    },
+    startPreloader = { bufferSize, callback ->
+        InterstitialAdPreloader.startAndTrack(
+            preloadId = INTERSTITIAL_PRELOAD_ID,
+            preloadConfiguration = PreloadConfiguration(
+                AdRequest.Builder(BuildConfig.ADMOB_INTERSTITIAL_AD_UNIT_ID).build(),
+                bufferSize,
+            ),
+            placement = "interstitial_preload",
+            preloadCallback = callback,
+        )
+    },
+    stopPreloader = { InterstitialAdPreloader.destroy(INTERSTITIAL_PRELOAD_ID) },
+    showAd = { ad -> ad.show(activity, placement = "interstitial_show") },
+)
 
 @Composable
-@Suppress("CyclomaticComplexMethod", "LongMethod")
-internal fun AppOpenScreen(activity: Activity, onBack: () -> Unit) {
-    var directStatus by remember { mutableStateOf("No direct app-open ad loaded") }
-    var directAd by remember { mutableStateOf<AppOpenAd?>(null) }
+internal fun AppOpenScreen(activity: Activity, onBack: () -> Unit) = FullScreenAdScreen(
+    title = "App open",
+    description = "The sample exposes app-open loading explicitly instead of tying it to process lifecycle.",
+    adName = "app-open ad",
+    preloadId = APP_OPEN_PRELOAD_ID,
+    onBack = onBack,
+    getConfiguration = { AppOpenAdPreloader.getConfiguration(APP_OPEN_PRELOAD_ID) },
+    getNumAdsAvailable = { AppOpenAdPreloader.getNumAdsAvailable(APP_OPEN_PRELOAD_ID) },
+    createEventCallback = { onDismissed, onFailedToShow ->
+        object : AppOpenAdEventCallback {
+            override fun onAdDismissedFullScreenContent() = onDismissed()
+
+            override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
+                onFailedToShow(error)
+            }
+        }
+    },
+    loadAd = { callback ->
+        Purchases.sharedInstance.adTracker.loadAndTrackAppOpenAd(
+            AdRequest.Builder(BuildConfig.ADMOB_APP_OPEN_AD_UNIT_ID).build(),
+            placement = "app_open_load",
+            adEventCallback = callback,
+        )
+    },
+    pollAd = { callback ->
+        AppOpenAdPreloader.pollAndTrackAd(
+            APP_OPEN_PRELOAD_ID,
+            placement = "app_open_poll",
+            adEventCallback = callback,
+        )
+    },
+    startPreloader = { bufferSize, callback ->
+        AppOpenAdPreloader.startAndTrack(
+            APP_OPEN_PRELOAD_ID,
+            PreloadConfiguration(
+                AdRequest.Builder(BuildConfig.ADMOB_APP_OPEN_AD_UNIT_ID).build(),
+                bufferSize,
+            ),
+            placement = "app_open_preload",
+            preloadCallback = callback,
+        )
+    },
+    stopPreloader = { AppOpenAdPreloader.destroy(APP_OPEN_PRELOAD_ID) },
+    showAd = { ad -> ad.show(activity, placement = "app_open_show") },
+)
+
+@Composable
+@Suppress("LongMethod", "LongParameterList")
+private fun <AdT : Ad, EventCallbackT> FullScreenAdScreen(
+    title: String,
+    description: String,
+    adName: String,
+    preloadId: String,
+    onBack: () -> Unit,
+    getConfiguration: () -> PreloadConfiguration?,
+    getNumAdsAvailable: () -> Int,
+    createEventCallback: (() -> Unit, (FullScreenContentError) -> Unit) -> EventCallbackT,
+    loadAd: suspend (EventCallbackT) -> AdLoadResult<AdT>,
+    pollAd: (EventCallbackT) -> AdT?,
+    startPreloader: (Int, PreloadCallback) -> Boolean,
+    stopPreloader: () -> Boolean,
+    showAd: (AdT) -> Unit,
+) {
+    var directStatus by remember { mutableStateOf("No direct $adName loaded") }
+    var directAd by remember { mutableStateOf<AdT?>(null) }
     val preloadState = rememberPreloaderUiState(
-        APP_OPEN_PRELOAD_ID,
-        getConfiguration = { AppOpenAdPreloader.getConfiguration(APP_OPEN_PRELOAD_ID) },
-        getNumAdsAvailable = { AppOpenAdPreloader.getNumAdsAvailable(APP_OPEN_PRELOAD_ID) },
+        preloadId,
+        getConfiguration = getConfiguration,
+        getNumAdsAvailable = getNumAdsAvailable,
     )
     val scope = rememberCoroutineScope()
     val directEventCallback = remember {
-        object : AppOpenAdEventCallback {
-            override fun onAdDismissedFullScreenContent() {
+        createEventCallback(
+            {
                 scope.launch {
                     directAd = null
-                    directStatus = "Direct app-open ad dismissed"
+                    directStatus = "Direct $adName dismissed"
                 }
-            }
-
-            override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
+            },
+            { error ->
                 scope.launch {
                     directAd = null
                     directStatus = "Show failed: ${error.message}"
                 }
-            }
-        }
+            },
+        )
     }
     val preloadedEventCallback = remember {
-        object : AppOpenAdEventCallback {
-            override fun onAdDismissedFullScreenContent() {
+        createEventCallback(
+            {
                 scope.launch {
-                    preloadState.message = "Preloaded app-open ad dismissed"
+                    preloadState.message = "Preloaded $adName dismissed"
                 }
-            }
-
-            override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
+            },
+            { error ->
                 scope.launch {
                     preloadState.message = "Show failed: ${error.message}"
                 }
-            }
-        }
+            },
+        )
     }
 
-    AdScreen("App open", onBack) { mode ->
-        Text("The sample exposes app-open loading explicitly instead of tying it to process lifecycle.")
+    AdScreen(title, onBack) { mode ->
+        Text(description)
         if (mode == LoadMode.DIRECT) {
             StatusCard(directStatus)
             ActionRow(
                 "Load" to {
                     scope.launch {
                         directStatus = "Loading directly..."
-                        when (
-                            val result = Purchases.sharedInstance.adTracker.loadAndTrackAppOpenAd(
-                                AdRequest.Builder(BuildConfig.ADMOB_APP_OPEN_AD_UNIT_ID).build(),
-                                placement = "app_open_load",
-                                adEventCallback = directEventCallback,
-                            )
-                        ) {
+                        when (val result = loadAd(directEventCallback)) {
                             is AdLoadResult.Success -> {
                                 directAd = result.ad
-                                directStatus = "Direct app-open ad ready"
+                                directStatus = "Direct $adName ready"
                             }
                             is AdLoadResult.Failure -> directStatus = "Load failed: ${result.error.message}"
                         }
                     }
                 },
-                "Show" to { showAppOpen(directAd, activity) { directStatus = it } },
+                "Show" to {
+                    showFullScreenAd(directAd, adName, showAd) { directStatus = it }
+                },
                 enabled = mapOf("Show" to (directAd != null)),
             )
         } else {
@@ -233,34 +210,22 @@ internal fun AppOpenScreen(activity: Activity, onBack: () -> Unit) {
                         label = "Poll + Show",
                         enabled = preloadState.started && preloadState.adsAvailable > 0,
                         onClick = {
-                            val ad = AppOpenAdPreloader.pollAndTrackAd(
-                                APP_OPEN_PRELOAD_ID,
-                                placement = "app_open_poll",
-                                adEventCallback = preloadedEventCallback,
-                            )
+                            val ad = pollAd(preloadedEventCallback)
                             preloadState.refresh()
                             if (ad == null) {
                                 preloadState.message = "No buffered ad available"
                             } else {
-                                showAppOpen(ad, activity) { preloadState.message = it }
+                                showFullScreenAd(ad, adName, showAd) { preloadState.message = it }
                             }
                         },
                     ),
                 ),
                 onToggle = {
                     if (preloadState.started) {
-                        preloadState.updateAfterStop(AppOpenAdPreloader.destroy(APP_OPEN_PRELOAD_ID))
+                        preloadState.updateAfterStop(stopPreloader())
                     } else {
                         preloadState.updateAfterStart(
-                            AppOpenAdPreloader.startAndTrack(
-                                APP_OPEN_PRELOAD_ID,
-                                PreloadConfiguration(
-                                    AdRequest.Builder(BuildConfig.ADMOB_APP_OPEN_AD_UNIT_ID).build(),
-                                    preloadState.bufferSize,
-                                ),
-                                placement = "app_open_preload",
-                                preloadCallback = preloadState.preloadCallback(scope),
-                            ),
+                            startPreloader(preloadState.bufferSize, preloadState.preloadCallback(scope)),
                         )
                     }
                 },
@@ -269,11 +234,16 @@ internal fun AppOpenScreen(activity: Activity, onBack: () -> Unit) {
     }
 }
 
-private fun showAppOpen(ad: AppOpenAd?, activity: Activity, updateStatus: (String) -> Unit) {
+private fun <AdT : Ad> showFullScreenAd(
+    ad: AdT?,
+    adName: String,
+    showAd: (AdT) -> Unit,
+    updateStatus: (String) -> Unit,
+) {
     if (ad == null) {
-        updateStatus("Load or poll an app-open ad first")
+        updateStatus("Load or poll an $adName first")
     } else {
         updateStatus("Showing with a placement override")
-        ad.show(activity, placement = "app_open_show")
+        showAd(ad)
     }
 }

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/SampleUi.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/SampleUi.kt
@@ -55,8 +55,8 @@ fun AdMobNextGenSample(
 
     when (selectedScreen) {
         SampleScreen.BANNER -> BannerScreen(activity, onBack)
-        SampleScreen.INTERSTITIAL -> PlaceholderAdScreen(selectedScreen.title, onBack)
-        SampleScreen.APP_OPEN -> PlaceholderAdScreen(selectedScreen.title, onBack)
+        SampleScreen.INTERSTITIAL -> InterstitialScreen(activity, onBack)
+        SampleScreen.APP_OPEN -> AppOpenScreen(activity, onBack)
         SampleScreen.REWARDED -> PlaceholderAdScreen(selectedScreen.title, onBack)
         SampleScreen.REWARDED_INTERSTITIAL -> PlaceholderAdScreen(selectedScreen.title, onBack)
         SampleScreen.NATIVE -> PlaceholderAdScreen(selectedScreen.title, onBack)


### PR DESCRIPTION
## Summary

Expands the Google Mobile Ads Next-Gen example app with full-screen ad workflows:

- add direct and preloaded interstitial examples
- add direct and preloaded app-open examples
- demonstrate show-time placement overrides

## Screenshots

![Interstitial direct-loading screen with show-time placement guidance](https://github.com/RevenueCat/purchases-android/blob/c8b88fe2a12c614d612e9f45892b2484aaae5743/gh-pr-images/pr-4096/1787759324-27985-1-05-fullscreen-interstitial.png?raw=true)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the example app’s UI and documentation-style ad integration; no SDK or production code paths are modified.
> 
> **Overview**
> Replaces **interstitial** and **app open** placeholders in the AdMob Next-Gen sample with real Compose flows wired through RevenueCat’s `adTracker` and Next-Gen preload helpers.
> 
> Adds a shared **`FullScreenAdScreen`** that mirrors the banner sample’s **direct load** vs **preload** modes: tracked load (`loadAndTrackInterstitialAd` / `loadAndTrackAppOpenAd`), `startAndTrack` / `pollAndTrackAd`, show/dismiss handling, and status UI. Each format uses **different placement strings** at load, poll, preload, and show so reviewers can see **show-time placement overrides** (called out explicitly on the interstitial screen). App-open loading is **manual** in the sample rather than tied to process lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e773e0c5538d40606436f3820b6c0c875ee92ccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->