### PR TITLE
feat(admob): demonstrate rewarded ads and diagnostics

### DIFF
--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/DiagnosticsScreen.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/DiagnosticsScreen.kt
@@ -1,0 +1,88 @@
+@file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+
+package com.revenuecat.sample.admob.nextgen.ui
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdPreloader
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.loadAndTrackInterstitialAd
+import com.revenuecat.purchases.admob.nextgen.startAndTrack
+import kotlinx.coroutines.launch
+
+private const val INVALID_AD_UNIT_ID = "invalid-ad-unit-id"
+private const val DIAGNOSTICS_PRELOAD_ID = "sample-invalid-interstitial"
+
+@Composable
+@Suppress("LongMethod")
+internal fun DiagnosticsScreen(onBack: () -> Unit) {
+    var directStatus by remember { mutableStateOf("Trigger an expected direct-load failure") }
+    val preloadState = rememberPreloaderUiState(
+        DIAGNOSTICS_PRELOAD_ID,
+        getConfiguration = { InterstitialAdPreloader.getConfiguration(DIAGNOSTICS_PRELOAD_ID) },
+        getNumAdsAvailable = { InterstitialAdPreloader.getNumAdsAvailable(DIAGNOSTICS_PRELOAD_ID) },
+    )
+    val scope = rememberCoroutineScope()
+
+    AdScreen("Diagnostics", onBack) { mode ->
+        Text("Uses an invalid ad unit to exercise RevenueCat failed-to-load tracking.")
+        if (mode == LoadMode.DIRECT) {
+            StatusCard(directStatus)
+            ActionRow(
+                "Fail direct load" to {
+                    scope.launch {
+                        directStatus = "Starting expected direct failure..."
+                        runCatching {
+                            Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
+                                AdRequest.Builder(INVALID_AD_UNIT_ID).build(),
+                                placement = "diagnostics_direct",
+                            )
+                        }.onSuccess { result ->
+                            directStatus = when (result) {
+                                is AdLoadResult.Success -> "Unexpectedly loaded an ad"
+                                is AdLoadResult.Failure -> "Expected failure: ${result.error.message}"
+                            }
+                        }.onFailure { error ->
+                            directStatus = "Request rejected: ${error.message}"
+                        }
+                    }
+                },
+            )
+        } else {
+            PreloaderPanel(
+                state = preloadState,
+                onToggle = {
+                    if (preloadState.started) {
+                        preloadState.updateAfterStop(InterstitialAdPreloader.destroy(DIAGNOSTICS_PRELOAD_ID))
+                    } else {
+                        runCatching {
+                            InterstitialAdPreloader.startAndTrack(
+                                DIAGNOSTICS_PRELOAD_ID,
+                                PreloadConfiguration(
+                                    AdRequest.Builder(INVALID_AD_UNIT_ID).build(),
+                                    preloadState.bufferSize,
+                                ),
+                                placement = "diagnostics_preload",
+                                preloadCallback = preloadState.preloadCallback(scope),
+                            )
+                        }.onSuccess { started ->
+                            preloadState.updateAfterStart(started)
+                            if (started) preloadState.message = "Waiting for expected preload failure..."
+                        }.onFailure { error ->
+                            preloadState.message = "Preload rejected: ${error.message}"
+                        }
+                    }
+                },
+            )
+        }
+    }
+}

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/DiagnosticsScreen.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/DiagnosticsScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-
 package com.revenuecat.sample.admob.nextgen.ui
 
 import androidx.compose.material3.Text
@@ -13,7 +11,6 @@ import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
 import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdPreloader
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.loadAndTrackInterstitialAd
 import com.revenuecat.purchases.admob.nextgen.startAndTrack

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
@@ -32,6 +32,7 @@ import com.revenuecat.purchases.admob.nextgen.pollAndTrackAd
 import com.revenuecat.purchases.admob.nextgen.show
 import com.revenuecat.purchases.admob.nextgen.startAndTrack
 import com.revenuecat.sample.admob.nextgen.BuildConfig
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 private const val REWARDED_PRELOAD_ID = "sample-rewarded"
@@ -79,7 +80,9 @@ internal fun RewardedScreen(activity: Activity, onBack: () -> Unit) {
                     if (loadedAd == null) {
                         directStatus = "Load a rewarded ad first"
                     } else {
-                        showRewarded(loadedAd, activity, directLoadedWithVerification) { directStatus = it }
+                        showRewarded(loadedAd, activity, directLoadedWithVerification, scope) {
+                            directStatus = it
+                        }
                         directAd = null
                     }
                 },
@@ -103,7 +106,7 @@ internal fun RewardedScreen(activity: Activity, onBack: () -> Unit) {
                                 preloadState.message = "No buffered rewarded ad available"
                             } else {
                                 preloadState.message = "Showing rewarded ad"
-                                showRewarded(ad, activity, verify) { preloadState.message = it }
+                                showRewarded(ad, activity, verify, scope) { preloadState.message = it }
                             }
                         },
                     ),
@@ -134,6 +137,7 @@ private fun showRewarded(
     ad: RewardedAd,
     activity: Activity,
     verify: Boolean,
+    scope: CoroutineScope,
     updateStatus: (String) -> Unit,
 ) {
     if (verify) {
@@ -150,7 +154,9 @@ private fun showRewarded(
             activity,
             placement = "rewarded_show",
             onUserEarnedRewardListener = OnUserEarnedRewardListener { reward ->
-                updateStatus("Reward earned: ${reward.amount} ${reward.type}")
+                scope.launch {
+                    updateStatus("Reward earned: ${reward.amount} ${reward.type}")
+                }
             },
         )
     }

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
@@ -1,0 +1,175 @@
+@file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@file:Suppress("LongMethod")
+
+package com.revenuecat.sample.admob.nextgen.ui
+
+import android.app.Activity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
+import com.google.android.libraries.ads.mobile.sdk.rewarded.OnUserEarnedRewardListener
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdPreloader
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.enableRewardVerification
+import com.revenuecat.purchases.admob.nextgen.loadAndTrackRewardedAd
+import com.revenuecat.purchases.admob.nextgen.pollAndTrackAd
+import com.revenuecat.purchases.admob.nextgen.show
+import com.revenuecat.purchases.admob.nextgen.startAndTrack
+import com.revenuecat.sample.admob.nextgen.BuildConfig
+import kotlinx.coroutines.launch
+
+private const val REWARDED_PRELOAD_ID = "sample-rewarded"
+
+@Composable
+internal fun RewardedScreen(activity: Activity, onBack: () -> Unit) {
+    var directStatus by remember { mutableStateOf("No direct rewarded ad loaded") }
+    var useVerification by remember { mutableStateOf(false) }
+    var directLoadedWithVerification by remember { mutableStateOf(false) }
+    var directAd by remember { mutableStateOf<RewardedAd?>(null) }
+    val preloadState = rememberPreloaderUiState(
+        REWARDED_PRELOAD_ID,
+        getConfiguration = { RewardedAdPreloader.getConfiguration(REWARDED_PRELOAD_ID) },
+        getNumAdsAvailable = { RewardedAdPreloader.getNumAdsAvailable(REWARDED_PRELOAD_ID) },
+    )
+    val scope = rememberCoroutineScope()
+
+    AdScreen("Rewarded", onBack) { mode ->
+        RewardVerificationToggle(useVerification) { useVerification = it }
+        Text("The verification choice is captured when an ad is loaded or polled.")
+        if (mode == LoadMode.DIRECT) {
+            StatusCard(directStatus)
+            ActionRow(
+                "Load" to {
+                    scope.launch {
+                        val verify = useVerification
+                        directStatus = "Loading directly..."
+                        when (
+                            val result = Purchases.sharedInstance.adTracker.loadAndTrackRewardedAd(
+                                AdRequest.Builder(BuildConfig.ADMOB_REWARDED_AD_UNIT_ID).build(),
+                                placement = "rewarded_load",
+                            )
+                        ) {
+                            is AdLoadResult.Success -> {
+                                directAd = result.ad.also { if (verify) it.enableRewardVerification() }
+                                directLoadedWithVerification = verify
+                                directStatus = readyStatus(verify)
+                            }
+                            is AdLoadResult.Failure -> directStatus = "Load failed: ${result.error.message}"
+                        }
+                    }
+                },
+                "Show" to {
+                    val loadedAd = directAd
+                    if (loadedAd == null) {
+                        directStatus = "Load a rewarded ad first"
+                    } else {
+                        showRewarded(loadedAd, activity, directLoadedWithVerification) { directStatus = it }
+                        directAd = null
+                    }
+                },
+                enabled = mapOf("Show" to (directAd != null)),
+            )
+        } else {
+            PreloaderPanel(
+                state = preloadState,
+                actions = listOf(
+                    PreloaderAction(
+                        label = "Poll + Show",
+                        enabled = preloadState.started && preloadState.adsAvailable > 0,
+                        onClick = {
+                            val verify = useVerification
+                            val ad = RewardedAdPreloader.pollAndTrackAd(
+                                REWARDED_PRELOAD_ID,
+                                placement = "rewarded_poll",
+                            )?.also { if (verify) it.enableRewardVerification() }
+                            preloadState.refresh()
+                            if (ad == null) {
+                                preloadState.message = "No buffered rewarded ad available"
+                            } else {
+                                preloadState.message = "Showing rewarded ad"
+                                showRewarded(ad, activity, verify) { preloadState.message = it }
+                            }
+                        },
+                    ),
+                ),
+                onToggle = {
+                    if (preloadState.started) {
+                        preloadState.updateAfterStop(RewardedAdPreloader.destroy(REWARDED_PRELOAD_ID))
+                    } else {
+                        preloadState.updateAfterStart(
+                            RewardedAdPreloader.startAndTrack(
+                                REWARDED_PRELOAD_ID,
+                                PreloadConfiguration(
+                                    AdRequest.Builder(BuildConfig.ADMOB_REWARDED_AD_UNIT_ID).build(),
+                                    preloadState.bufferSize,
+                                ),
+                                placement = "rewarded_preload",
+                                preloadCallback = preloadState.preloadCallback(scope),
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+    }
+}
+
+private fun showRewarded(
+    ad: RewardedAd,
+    activity: Activity,
+    verify: Boolean,
+    updateStatus: (String) -> Unit,
+) {
+    if (verify) {
+        ad.show(
+            activity,
+            placement = "rewarded_show",
+            rewardVerificationStarted = { updateStatus("Verifying reward...") },
+            rewardVerificationCompleted = { result ->
+                updateStatus("Verification complete: ${result.verifiedReward ?: "failed"}")
+            },
+        )
+    } else {
+        ad.show(
+            activity,
+            placement = "rewarded_show",
+            onUserEarnedRewardListener = OnUserEarnedRewardListener { reward ->
+                updateStatus("Reward earned: ${reward.amount} ${reward.type}")
+            },
+        )
+    }
+}
+
+@Composable
+private fun RewardVerificationToggle(checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+        Text("RevenueCat reward verification")
+    }
+}
+
+private fun readyStatus(verificationEnabled: Boolean): String = if (verificationEnabled) {
+    "Ad ready with reward verification enabled"
+} else {
+    "Ad ready with Google's reward callback"
+}

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @file:Suppress("LongMethod")
 
 package com.revenuecat.sample.admob.nextgen.ui
@@ -24,7 +23,6 @@ import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
 import com.google.android.libraries.ads.mobile.sdk.rewarded.OnUserEarnedRewardListener
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdPreloader
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.enableRewardVerification
 import com.revenuecat.purchases.admob.nextgen.loadAndTrackRewardedAd

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/SampleUi.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/SampleUi.kt
@@ -57,10 +57,10 @@ fun AdMobNextGenSample(
         SampleScreen.BANNER -> BannerScreen(activity, onBack)
         SampleScreen.INTERSTITIAL -> InterstitialScreen(activity, onBack)
         SampleScreen.APP_OPEN -> AppOpenScreen(activity, onBack)
-        SampleScreen.REWARDED -> PlaceholderAdScreen(selectedScreen.title, onBack)
+        SampleScreen.REWARDED -> RewardedScreen(activity, onBack)
         SampleScreen.REWARDED_INTERSTITIAL -> PlaceholderAdScreen(selectedScreen.title, onBack)
         SampleScreen.NATIVE -> NativeScreen(onBack)
-        SampleScreen.DIAGNOSTICS -> PlaceholderAdScreen(selectedScreen.title, onBack)
+        SampleScreen.DIAGNOSTICS -> DiagnosticsScreen(onBack)
     }
 }
 


### PR DESCRIPTION
## Summary

Expands the Google Mobile Ads Next-Gen example app with rewarded-ad and diagnostics workflows:

- add direct and preloaded rewarded-ad workflows
- demonstrate optional RevenueCat reward verification
- add intentional direct and preload failures for diagnostics

## Screenshots

![Rewarded ad screen with RevenueCat reward verification enabled](https://github.com/RevenueCat/purchases-android/blob/f03462f64f1d63d0f340bf6c8eb019daaaf8bb75/gh-pr-images/pr-4098/1787759523-36608-1-07-rewarded-verification.png?raw=true)

![Diagnostics screen for direct and preloaded failures](https://github.com/RevenueCat/purchases-android/blob/8086b345654c5657ebac0caaf271841c00a678c5/gh-pr-images/pr-4098/1787759527-37108-1-08-diagnostics.png?raw=true)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app UI only; no SDK or production code changes.
> 
> **Overview**
> Replaces placeholder routes in the AdMob Next-Gen sample with **Rewarded** and **Diagnostics** screens wired through `SampleUi`.
> 
> **Rewarded** adds the same direct-vs-preloaded flow as other formats: load/show via `loadAndTrackRewardedAd`, preloader `startAndTrack` / `pollAndTrackAd`, and a toggle to enable RevenueCat reward verification on load/poll (verification vs Google’s `OnUserEarnedRewardListener` at show time).
> 
> **Diagnostics** deliberately uses an invalid interstitial ad unit to trigger expected load failures and surface RevenueCat failed-to-load tracking for both direct load and interstitial preloading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3604f1d2c4c15dcb1ff23d315271147e2061876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->