### PR TITLE
Add tolerance to flaky ImageComponentView_Preview_Margin_Padding Emerge snapshot

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -306,6 +306,7 @@ private fun ImageComponentView_Preview_SmallerContainer() {
     }
 }
 
+@EmergeSnapshotConfig(precision = 0.99f)
 @Preview
 @Composable
 private fun ImageComponentView_Preview_Margin_Padding() {


### PR DESCRIPTION
For some reason it's the only one in that file that _doesn't_ have a tolerance already... and it's the only flaky one.
Failures are always below 0.01% so 0.99 is enough.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only annotation on a preview composable; no production UI or runtime behavior changes.
> 
> **Overview**
> Adds **`@EmergeSnapshotConfig(precision = 0.99f)`** to the `ImageComponentView_Preview_Margin_Padding` Compose preview so Emerge snapshot comparison allows tiny pixel drift.
> 
> That preview was the only one in `ImageComponentView.kt` without a precision config, and it was the one failing intermittently (differences under ~0.01%). The change aligns it with the other image component snapshot previews that already use **0.99** tolerance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70f0079c58fad3d5ff797b2631315aa05da1f5fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->