### PR TITLE
ci(danger): Clean up API notifications after move to main-only posts

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -105,10 +105,7 @@ begin
     announce: false,
   )
 
-  if api_diff
-    markdown(api_diff[:comment])
-    warn(api_diff[:warning]) if api_diff[:warning]
-  end
+  markdown(api_diff[:comment]) if api_diff
 rescue StandardError => e
   # `warn` is Danger's DSL: surfaces on the PR without failing the run.
   warn("Could not report the public API changes: #{e.message}")

--- a/danger/announce_api_changes.rb
+++ b/danger/announce_api_changes.rb
@@ -50,8 +50,7 @@ end
 warn(result[:warning]) if result[:warning]
 
 case result[:outcome]
-when :posted     then puts "Announced the public API change on #{head}."
-when :duplicate  then puts "#{head} was already announced."
-when :failed     then puts "Could not announce #{head}. See the warning above."
-else                  puts "Nothing was announced for #{head} (#{result[:outcome]})."
+when :posted    then puts "Announced the public API change on #{head}."
+when :duplicate then puts "#{head} was already announced."
+when :failed    then puts "Could not announce #{head}. See the warning above."
 end

--- a/danger/announce_api_changes.rb
+++ b/danger/announce_api_changes.rb
@@ -50,7 +50,6 @@ end
 warn(result[:warning]) if result[:warning]
 
 case result[:outcome]
-when :posted    then puts "Announced the public API change on #{head}."
-when :duplicate then puts "#{head} was already announced."
-when :failed    then puts "Could not announce #{head}. See the warning above."
+when :posted then puts "Announced the public API change on #{head}."
+when :failed then puts "Could not announce #{head}. See the warning above."
 end

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -65,7 +65,7 @@ module ApiDiffReport
     runner.call("git", "diff", "--no-ext-diff", base, head, "--", path).to_s
   end
 
-  # The commit page already carries the PR link, and its sha is what tells a rerun it announced.
+  # The commit page already carries the PR link, so the message needs only the commit.
   def commit_link(sha)
     return "" if sha.to_s.empty?
 

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -59,8 +59,10 @@ module ApiDiffReport
           .to_s.each_line.map(&:strip).reject(&:empty?).select { |path| signature_file?(path) }
   end
 
+  # --no-ext-diff: a `diff.external` in the caller's git config replaces the unified patch this
+  # parses, and an unparseable patch reads as "nothing changed" rather than as an error.
   def patch_between(base, head, path, runner:)
-    runner.call("git", "diff", base, head, "--", path).to_s
+    runner.call("git", "diff", "--no-ext-diff", base, head, "--", path).to_s
   end
 
   # The commit page already carries the PR link, and its sha is what tells a rerun it announced.

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -303,15 +303,15 @@ module ApiDiffReport
     end
   end
 
-  # Returns { comment:, warning:, outcome: }, or nil when the public API did not change.
-  # outcome is :posted, :duplicate, :failed or :skipped; :skipped is `announce: false`.
+  # Returns nil when the public API did not change, { comment: } for `announce: false`, and
+  # { comment:, warning:, outcome: } otherwise. outcome is :posted, :duplicate or :failed.
   def run(changed_files:, patch_for:, source: "", announce: true, credentials: slack_credentials, poster: nil,
           getter: nil)
     signature_files = changed_files.uniq.select { |file| signature_file?(file) }
     report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
     return nil if empty?(report)
 
-    return { comment: markdown_section(report), warning: nil, outcome: :skipped } unless announce
+    return { comment: markdown_section(report) } unless announce
 
     outcome, reason = announce_to_slack(slack_message(report, source), source, credentials, poster, getter)
 

--- a/danger/api_diff_report.rb
+++ b/danger/api_diff_report.rb
@@ -214,54 +214,6 @@ module ApiDiffReport
     }
   end
 
-  SLACK_HISTORY_LIMIT = 100
-
-  # conversations.history takes a channel ID, never a `#name`.
-  CHANNEL_ID = /\A[CGD][A-Z0-9]+\z/.freeze
-
-  def history_request(channel, bot_token:, limit: SLACK_HISTORY_LIMIT)
-    {
-      url: "https://slack.com/api/conversations.history?channel=#{channel}&limit=#{limit}",
-      headers: { "Authorization" => "Bearer #{bot_token}" }
-    }
-  end
-
-  def recent_messages(request, getter: nil)
-    getter ||= ->(url, headers) { Net::HTTP.get_response(URI.parse(url), headers) }
-
-    response = getter.call(request[:url], request[:headers])
-    raise "Slack returned #{response.code}: #{response.body}" unless (200..299).cover?(response.code.to_i)
-
-    parsed = JSON.parse(response.body.to_s)
-    raise "Slack rejected conversations.history: #{parsed['error']}" unless parsed["ok"]
-
-    parsed["messages"].to_a.map { |message| message["text"].to_s }
-  end
-
-  # conversations.history answers newest first, so the first match is the channel's last word.
-  def last_announcement(texts, source)
-    return nil if source.to_s.empty?
-
-    texts.find { |text| text.include?(source) && text.include?(PLATFORM_LABEL) }
-  end
-
-  # Each push starts two pipelines, and the auto-canceled one still posts before it dies, so the
-  # channel is the only store the sibling run can see in time.
-  # Returns [:same | :different | :unknown, why_unknown].
-  def announcement_state(message, channel, bot_token, getter, source)
-    unless CHANNEL_ID.match?(channel.to_s)
-      return [:unknown, "#{channel} is a channel name, and conversations.history needs the channel ID"]
-    end
-
-    texts = recent_messages(history_request(channel, bot_token: bot_token), getter: getter)
-    last = last_announcement(texts, source)
-    return [:unknown, nil] if last.nil?
-
-    [last == message ? :same : :different, nil]
-  rescue StandardError => e
-    [:unknown, e.message]
-  end
-
   def post(request, poster: nil)
     poster ||= ->(url, body, headers) { Net::HTTP.post(URI.parse(url), body, headers) }
 
@@ -279,49 +231,35 @@ module ApiDiffReport
     nil
   end
 
-  # Returns [:posted | :duplicate | :failed, reason_or_nil].
-  def announce_to_slack(message, source, credentials, poster, getter)
+  # Returns [:posted | :failed, reason_or_nil].
+  def announce_to_slack(message, credentials, poster)
     return [:failed, "no Slack credentials were reachable"] if credentials.nil?
 
     bot_token, channel = credentials
 
-    state, history_error = announcement_state(message, channel, bot_token, getter, source)
-    return [:duplicate, nil] if state == :same
-
     post(slack_request(message, bot_token: bot_token, channel: channel), poster: poster)
-    [:posted, history_error]
+    [:posted, nil]
   rescue StandardError => e
     [:failed, e.message]
   end
 
   def warning(outcome, reason)
-    return nil if reason.to_s.empty?
+    return nil unless outcome == :failed
 
-    case outcome
-    when :failed
-      "The public API changed, but it was not announced in the SDK API feed: #{reason}."
-    when :posted
-      "Could not read the SDK API feed channel, so this change may be announced twice: #{reason}."
-    end
+    "The public API changed, but it was not announced in the SDK API feed: #{reason}."
   end
 
   # Returns nil when the public API did not change, { comment: } for `announce: false`, and
-  # { comment:, warning:, outcome: } otherwise. outcome is :posted, :duplicate or :failed.
-  def run(changed_files:, patch_for:, source: "", announce: true, credentials: slack_credentials, poster: nil,
-          getter: nil)
+  # { comment:, warning:, outcome: } otherwise. outcome is :posted or :failed.
+  def run(changed_files:, patch_for:, source: "", announce: true, credentials: slack_credentials, poster: nil)
     signature_files = changed_files.uniq.select { |file| signature_file?(file) }
     report = build(signature_files.to_h { |file| [file, patch_for.call(file)] })
     return nil if empty?(report)
 
     return { comment: markdown_section(report) } unless announce
 
-    outcome, reason = announce_to_slack(slack_message(report, source), source, credentials, poster, getter)
+    outcome, reason = announce_to_slack(slack_message(report, source), credentials, poster)
 
-    {
-      comment: markdown_section(report),
-      warning: warning(outcome, reason),
-      # A warning does not mean the post failed; it also fires on an announced-but-duplicated one.
-      outcome: outcome
-    }
+    { comment: markdown_section(report), warning: warning(outcome, reason), outcome: outcome }
   end
 end

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -463,13 +463,14 @@ class ApiDiffReportTest < Minitest::Test
                  ApiDiffReport.changed_signature_files("basesha", "headsha", runner: runner)
   end
 
-  def test_patch_between_asks_git_for_that_one_file
+  # A `diff.external` in the caller's config silently empties the patch, so the flag is the test.
+  def test_patch_between_asks_git_for_that_one_file_ignoring_any_external_differ
     asked = []
     runner = ->(*command) { asked << command; ADDED_METHOD_PATCH }
 
     patch = ApiDiffReport.patch_between("basesha", "headsha", "purchases/api-defauts.txt", runner: runner)
 
-    assert_equal [["git", "diff", "basesha", "headsha", "--", "purchases/api-defauts.txt"]], asked
+    assert_equal [["git", "diff", "--no-ext-diff", "basesha", "headsha", "--", "purchases/api-defauts.txt"]], asked
     assert_equal ADDED_METHOD_PATCH, patch
   end
 

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -510,7 +510,8 @@ class ApiDiffReportTest < Minitest::Test
     )
 
     assert_includes body[:comment], "+ method public void apiDiffDemoPong"
-    assert_nil body[:warning]
+    # Nothing was attempted, so there is no outcome to report and nothing to warn about.
+    assert_equal [:comment], body.keys
   end
 
   # The runner logged "Announced the public API change" off a failed post.
@@ -530,15 +531,9 @@ class ApiDiffReportTest < Minitest::Test
       changed_files: PATCHES.keys, patch_for: ->(file) { PATCHES[file] }, source: link,
       credentials: nil, poster: ->(*) { raise "must not post" }
     )
-    skipped = ApiDiffReport.run(
-      changed_files: PATCHES.keys, patch_for: ->(file) { PATCHES[file] }, announce: false,
-      credentials: CHANNEL_CREDENTIALS, poster: ->(*) { raise "must not post" }
-    )
-
     assert_equal :posted, posted[:outcome]
     assert_equal :duplicate, duplicate[:outcome]
     assert_equal :failed, failed[:outcome]
-    assert_equal :skipped, skipped[:outcome]
   end
 
   # --- The wiring ---

--- a/danger/api_diff_report_test.rb
+++ b/danger/api_diff_report_test.rb
@@ -210,21 +210,11 @@ class ApiDiffReportTest < Minitest::Test
 
   CHANNEL_CREDENTIALS = ["xoxb-1", "C0BLWE7VBS4"].freeze
 
-  def history_getter(texts)
-    lambda do |_url, _headers|
-      Struct.new(:code, :body).new("200", { ok: true, messages: texts.map { |text| { "text" => text } } }.to_json)
-    end
-  end
-
   def collecting_poster(posted)
     lambda do |_url, request_body, _headers|
       posted << JSON.parse(request_body)
       Struct.new(:code, :body).new("200", '{"ok":true}')
     end
-  end
-
-  def announcement_for(link)
-    ApiDiffReport.slack_message(ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH), link)
   end
 
   def test_run_returns_the_comment_body_and_posts_to_slack
@@ -235,7 +225,6 @@ class ApiDiffReportTest < Minitest::Test
       patch_for: ->(file) { PATCHES[file] },
       source: "<url|#42>",
       credentials: CHANNEL_CREDENTIALS,
-      getter: history_getter([]),
       poster: collecting_poster(posted)
     )
 
@@ -243,116 +232,6 @@ class ApiDiffReportTest < Minitest::Test
     assert_nil body[:warning]
     assert_equal 1, posted.count
     assert_includes posted.first["text"], "<url|#42>"
-  end
-
-  def test_run_skips_slack_when_the_last_word_on_this_pull_request_is_this_summary
-    body = ApiDiffReport.run(
-      changed_files: PATCHES.keys,
-      patch_for: ->(file) { PATCHES[file] },
-      source: "<url|#42>",
-      credentials: CHANNEL_CREDENTIALS,
-      getter: history_getter([announcement_for("<url|#42>"), "unrelated"]),
-      poster: ->(*) { raise "must not post" }
-    )
-
-    assert_includes body[:comment], "+ method public void apiDiffDemoPong"
-    assert_nil body[:warning]
-  end
-
-  def test_run_reannounces_a_surface_the_pull_request_had_already_left_behind
-    posted = []
-    superseded = ApiDiffReport.slack_message(
-      ApiDiffReport.build("purchases/api-defauts.txt" => ADDED_METHOD_PATCH.gsub("Pong", "Pang")), "<url|#42>"
-    )
-
-    ApiDiffReport.run(
-      changed_files: PATCHES.keys,
-      patch_for: ->(file) { PATCHES[file] },
-      source: "<url|#42>",
-      credentials: CHANNEL_CREDENTIALS,
-      getter: history_getter([superseded, announcement_for("<url|#42>")]),
-      poster: collecting_poster(posted)
-    )
-
-    assert_equal 1, posted.count
-  end
-
-  # What the PR touches changes the module list, so the modules cannot be part of the identity.
-  def test_last_announcement_matches_a_previous_announcement_of_other_modules
-    previous = ApiDiffReport.slack_message(
-      ApiDiffReport.build("ui/revenuecatui/api.txt" => SIGNATURE_CHANGE_PATCH), "<url|#42>"
-    )
-
-    assert_equal previous, ApiDiffReport.last_announcement([previous], "<url|#42>")
-  end
-
-  def test_last_announcement_ignores_other_pull_requests_and_platforms
-    ours = announcement_for("<url|#42>")
-    texts = ["#{ours.sub(ApiDiffReport::PLATFORM_LABEL, 'iOS :ios:')}", announcement_for("<url|#41>"), ours]
-
-    assert_equal ours, ApiDiffReport.last_announcement(texts, "<url|#42>")
-  end
-
-  def test_run_posts_when_the_channel_holds_another_pull_requests_summary
-    posted = []
-
-    ApiDiffReport.run(
-      changed_files: PATCHES.keys,
-      patch_for: ->(file) { PATCHES[file] },
-      source: "<url|#42>",
-      credentials: CHANNEL_CREDENTIALS,
-      getter: history_getter([announcement_for("<url|#41>")]),
-      poster: collecting_poster(posted)
-    )
-
-    assert_equal 1, posted.count
-  end
-
-  def test_run_warns_about_a_possible_duplicate_when_history_is_unreadable
-    posted = []
-
-    body = ApiDiffReport.run(
-      changed_files: PATCHES.keys,
-      patch_for: ->(file) { PATCHES[file] },
-      source: "<url|#42>",
-      credentials: CHANNEL_CREDENTIALS,
-      getter: ->(*) { raise "slack is down" },
-      poster: collecting_poster(posted)
-    )
-
-    assert_equal 1, posted.count
-    assert_includes body[:warning], "may be announced twice: slack is down"
-  end
-
-  # chat.postMessage takes a `#name`, conversations.history does not.
-  def test_announcement_state_needs_the_channel_id
-    state, reason = ApiDiffReport.announcement_state("hi", "#feed", "xoxb-1", ->(*) { raise "must not read" }, "<url|#42>")
-
-    assert_equal :unknown, state
-    assert_includes reason, "channel ID"
-  end
-
-  def test_announcement_state_is_unknown_without_a_reason_when_the_pull_request_is_not_in_the_window
-    state, reason = ApiDiffReport.announcement_state("hi", "C1", "xoxb-1", history_getter(["unrelated"]), "<url|#42>")
-
-    assert_equal :unknown, state
-    assert_nil reason
-  end
-
-  def test_recent_messages_returns_the_texts_newest_first
-    request = ApiDiffReport.history_request("C1", bot_token: "xoxb-1")
-
-    assert_includes request[:url], "channel=C1"
-    assert_equal "Bearer xoxb-1", request[:headers]["Authorization"]
-    assert_equal ["new", "old"], ApiDiffReport.recent_messages(request, getter: history_getter(["new", "old"]))
-  end
-
-  def test_recent_messages_raises_when_the_token_cannot_read_the_channel
-    response = Struct.new(:code, :body).new("200", '{"ok":false,"error":"missing_scope"}')
-    request = ApiDiffReport.history_request("C1", bot_token: "xoxb-1")
-
-    error = assert_raises(RuntimeError) { ApiDiffReport.recent_messages(request, getter: ->(*) { response }) }
-    assert_includes error.message, "missing_scope"
   end
 
   def test_run_reports_a_skipped_announcement_without_credentials
@@ -479,25 +358,10 @@ class ApiDiffReportTest < Minitest::Test
                  ApiDiffReport.commit_link("0123456789abcdef")
   end
 
-  # last_announcement bails on an empty source, so an empty link would disable the suppression.
+  # slack_message omits the link line entirely for an empty source.
   def test_commit_link_is_empty_without_a_sha
     assert_equal "", ApiDiffReport.commit_link("")
     assert_equal "", ApiDiffReport.commit_link(nil)
-  end
-
-  def test_run_suppresses_a_rerun_of_the_same_commit
-    link = ApiDiffReport.commit_link("0123456789abcdef")
-
-    body = ApiDiffReport.run(
-      changed_files: PATCHES.keys,
-      patch_for: ->(file) { PATCHES[file] },
-      source: link,
-      credentials: CHANNEL_CREDENTIALS,
-      getter: history_getter([announcement_for(link)]),
-      poster: ->(*) { raise "must not post" }
-    )
-
-    assert_nil body[:warning]
   end
 
   def test_run_reports_without_announcing_when_announce_is_false
@@ -506,7 +370,6 @@ class ApiDiffReportTest < Minitest::Test
       patch_for: ->(file) { PATCHES[file] },
       announce: false,
       credentials: CHANNEL_CREDENTIALS,
-      getter: ->(*) { raise "must not read" },
       poster: ->(*) { raise "must not post" }
     )
 
@@ -521,19 +384,13 @@ class ApiDiffReportTest < Minitest::Test
 
     posted = ApiDiffReport.run(
       changed_files: PATCHES.keys, patch_for: ->(file) { PATCHES[file] }, source: link,
-      credentials: CHANNEL_CREDENTIALS, getter: history_getter([]), poster: collecting_poster([])
-    )
-    duplicate = ApiDiffReport.run(
-      changed_files: PATCHES.keys, patch_for: ->(file) { PATCHES[file] }, source: link,
-      credentials: CHANNEL_CREDENTIALS, getter: history_getter([announcement_for(link)]),
-      poster: ->(*) { raise "must not post" }
+      credentials: CHANNEL_CREDENTIALS, poster: collecting_poster([])
     )
     failed = ApiDiffReport.run(
       changed_files: PATCHES.keys, patch_for: ->(file) { PATCHES[file] }, source: link,
       credentials: nil, poster: ->(*) { raise "must not post" }
     )
     assert_equal :posted, posted[:outcome]
-    assert_equal :duplicate, duplicate[:outcome]
     assert_equal :failed, failed[:outcome]
   end
 


### PR DESCRIPTION
- Removes the now-unreachable `else` arm of the outcome `case` in `danger/announce_api_changes.rb`.
- Drops dedup entirely. One pipeline runs `announce-api-changes` per main commit, so we'll only get notifications for changes to main.
- Other small related cleanups
- iOS counterpart: https://github.com/RevenueCat/purchases-ios/pull/7516

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

Follow-up to #4083, which moved the `#feed-sdk-new-api` announcement to `main` only and flagged its leftovers. On Android the leftovers are two unreachable lines, so this PR is small.

The `--no-ext-diff` fix was found while verifying the rest. Driving the runner on real history (`68b12a7a5`, the `setSingularDeviceID` merge) with credentials unset returned nil instead of a report. The cause was a local `diff.external = difft`: `patch_between` shells out to `git diff`, git substitutes the external differ, and the resulting output has no `+`/`-` prefixes for `declarations` to find. The runner then prints "changed, but no declaration did" and exits 0.

That is the same failure mode #4083 called out under risks, a quiet feed with a green job, reachable through a developer's git config rather than through Slack being down.

### Description

- `danger/api_diff_report.rb`: `patch_between` passes `--no-ext-diff`. Deletes `history_request`, `recent_messages`, `last_announcement`, `announcement_state`, `CHANNEL_ID` and `SLACK_HISTORY_LIMIT`; `announce_to_slack` loses its `source` and `getter` params and returns `:posted` or `:failed`, never `:duplicate`. The `announce: false` early return is now `{ comment: }` only, since nothing was attempted, so there is no outcome and nothing to warn about.
- `Dangerfile`: the `if api_diff` block collapses to one `markdown` call.
- `danger/announce_api_changes.rb`: the outcome `case` is down to `:posted` and `:failed`.
- `changed_signature_files` needs no flag: `--name-only` does not go through an external differ.

### Regression gates

`test_patch_between_asks_git_for_that_one_file_ignoring_any_external_differ` asserts the flag is in the argv. That is the whole fix, and nothing else would catch its removal: with an external differ configured the report silently empties, and without one the tests pass either way.

**Not visible in the diff:** one webhook pipeline runs per main commit. The daily `api`-triggered pipeline lands on an already-built commit (`68b12a7`) without running the announce job, so nothing fires the announcement twice on its own. The runner has nothing after the post that can fail, so it needs no reordering, unlike iOS.

After the `--no-ext-diff` fix the runner reproduces the real message locally, `New public API landed on main · Android :android: · purchases` with `+ method public void setSingularDeviceID(String? singularDeviceID);`, which matches what #4083 reported from CI.

**Rejected:**
- Keeping dedup as rerun insurance. It only made a manual rerun idempotent, and it did so through a token scope and a channel-ID format that fail silently: with either wrong, `announcement_state` returned `:unknown` and posted anyway.
- Setting `GIT_EXTERNAL_DIFF=` or unsetting the config in the runner. Wider blast radius than one flag on the one call that parses a patch, and it would not survive someone adding a second `git diff` caller.
- Raising when the patch parses to nothing. `changed_signature_files` legitimately reports a signature file whose diff holds no declaration (whitespace, a moved comment), so "no declarations" cannot be treated as an error by itself.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/Danger tooling only; removes dedup (acceptable with one announce job per main commit) and fixes a quiet false-negative when external diff tools are configured.
> 
> **Overview**
> **Cleans up public API Slack announcements** after moving them to main-only: duplicate detection via `conversations.history` is removed, so each run posts once and outcomes are only `:posted` or `:failed` (no `:duplicate` / `:skipped` on announce paths).
> 
> **`patch_between` now runs `git diff --no-ext-diff`** so a developer’s `diff.external` config cannot yield unparseable output and silently skip API declaration detection.
> 
> **Dangerfile** only adds the API diff markdown comment when a report exists; it no longer surfaces `api_diff[:warning]`. **`announce: false`** returns `{ comment: }` only; failed Slack posts still warn via `announce_api_changes.rb`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33c86c50afdc9aceb7fb2a5086f3ff9217185d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->