### PR TITLE
docs(admob): add next-gen migration guide

### DIFF
--- a/feature/admob-next-gen/README.md
+++ b/feature/admob-next-gen/README.md
@@ -65,6 +65,79 @@ See Google's
 [migration guide](https://developers.google.com/admob/android/next-gen/migration)
 for additional mediation-specific requirements.
 
+## Migrate from the legacy adapter
+
+`purchases-admob-next-gen` is not a drop-in binary replacement for `purchases-admob`. Migrate the underlying Google
+Mobile Ads SDK and the RevenueCat adapter together. Before starting, confirm that your app meets the requirements
+above and review Google's migration guide, especially if you use mediation.
+
+### Replace the dependencies
+
+Remove both legacy artifacts and add their Next-Gen replacements. Do not keep both SDK generations in the same app:
+
+```kotlin
+dependencies {
+    // Remove these legacy dependencies:
+    // implementation("com.revenuecat.purchases:purchases-admob:$revenueCatVersion")
+    // implementation("com.google.android.gms:play-services-ads:<version>")
+
+    implementation("com.revenuecat.purchases:purchases-admob-next-gen:$revenueCatVersion")
+    implementation("com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.3.0")
+}
+```
+
+If mediation adapters pull either legacy Google artifact back into the dependency graph, add the global exclusions
+shown in [Installation](#installation).
+
+### Update imports and initialization
+
+Update RevenueCat adapter imports from `com.revenuecat.purchases.admob` to
+`com.revenuecat.purchases.admob.nextgen`. Google Mobile Ads types move from `com.google.android.gms.ads` to
+`com.google.android.libraries.ads.mobile.sdk`; most requests, ads, and callbacks also use new Next-Gen types rather
+than direct equivalents of the legacy classes.
+
+Initialization is required before loading ads or calling other `MobileAds` APIs. Pass the AdMob app ID through
+`InitializationConfig`, initialize on a background thread, and wait for the callback before loading ads when your
+mediation setup requires every adapter to be ready. See [Initialize Google Mobile Ads Next-Gen](#initialize-google-mobile-ads-next-gen).
+
+### Update RevenueCat tracking calls
+
+Most RevenueCat helper names remain the same, but their Google SDK parameters change:
+
+| Format | Legacy adapter | Next-Gen adapter |
+| ------ | -------------- | ---------------- |
+| Banner | `AdView.loadAndTrackAd(AdRequest, ...)` | `AdView.loadAndTrackAd(BannerAdRequest, ...)` |
+| App open | `AdTracker.loadAndTrackAppOpenAd(...)` | `AdTracker.loadAndTrackAppOpenAd(...)` |
+| Interstitial | `AdTracker.loadAndTrackInterstitialAd(...)` | `AdTracker.loadAndTrackInterstitialAd(...)` |
+| Rewarded | `AdTracker.loadAndTrackRewardedAd(...)` | `AdTracker.loadAndTrackRewardedAd(...)` |
+| Rewarded interstitial | `AdTracker.loadAndTrackRewardedInterstitialAd(...)` | `AdTracker.loadAndTrackRewardedInterstitialAd(...)` |
+| Native | `AdLoader.Builder.forNativeAdWithTracking(...)` | `AdTracker.loadAndTrackNativeAd(...)` or `loadAndTrackNativeAds(...)` |
+
+`BannerAdRequest` is a Next-Gen subclass of `AdRequest` that includes banner-specific configuration. Its builder
+requires the ad unit ID and an `AdSize` (or list of sizes). In the legacy SDK those values were configured directly
+on `AdView`, which then loaded a generic `AdRequest`; Next-Gen `AdView.loadAd` receives the complete
+`BannerAdRequest` instead.
+
+For full-screen formats, build the ad unit ID into the Next-Gen `AdRequest` instead of passing `context` and
+`adUnitId` separately. Replace format-specific legacy load callbacks with `AdLoadCallback<AdType>`, and replace
+`FullScreenContentCallback` plus `OnPaidEventListener` with the corresponding format event callback, such as
+`InterstitialAdEventCallback` or `RewardedAdEventCallback`. Banner and native formats have their own event callback
+types, described in the examples below.
+
+The `enableRewardVerification` and verification-aware `show` helper names are unchanged; update their imports and ad
+types to the Next-Gen packages. Keep existing RevenueCat `placement` values when they represent the same ad slots so
+reporting remains consistent across the migration.
+
+### Review callback handling
+
+Google Mobile Ads Next-Gen invokes load and event callbacks on a background thread. Dispatch to the main thread
+before updating views or other UI-confined state.
+
+Pass event callbacks to the RevenueCat load helper. Assigning a loaded ad's callback property directly replaces the
+tracking wrapper. If a callback must change after loading, use the format's `setTrackingAdEventCallback` helper (and
+`setTrackingBannerAdRefreshCallback` for banners). Test every migrated format—including load failure, display,
+click, revenue, and reward delivery—before removing the legacy implementation.
+
 ## Initialize Google Mobile Ads Next-Gen
 
 Google Mobile Ads Next-Gen must be initialized before loading ads or calling other `MobileAds` APIs. Initialize it


### PR DESCRIPTION
### Description

Adds a RevenueCat-specific migration guide for moving from the legacy `purchases-admob` adapter to `purchases-admob-next-gen`.

### Changes

- Documents the dependency and package/import replacements.
- Explains required Next-Gen initialization and mediation exclusions.
- Maps legacy tracking entry points and callback types to their Next-Gen equivalents.
- Clarifies why banners use `BannerAdRequest` instead of a generic `AdRequest`.
- Covers callback threading, tracking-safe callback replacement, reward verification, and placement continuity.

### Testing

- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README update with no runtime, API, or build changes.
> 
> **Overview**
> Adds a **Migrate from the legacy adapter** section to `feature/admob-next-gen/README.md`, positioned before the existing initialization docs.
> 
> The new guide states that `purchases-admob-next-gen` is not a drop-in replacement and walks integrators through swapping legacy `purchases-admob` and `play-services-ads` for the Next-Gen adapter and `ads-mobile-sdk`, with a pointer back to mediation exclusions. It documents package/import moves (`com.revenuecat.purchases.admob` → `nextgen`, GMS ads → `com.google.android.libraries.ads.mobile.sdk`) and ties initialization to `InitializationConfig` and the existing initialize section.
> 
> A format-by-format table maps legacy vs Next-Gen RevenueCat tracking entry points (notably banners via `BannerAdRequest`, native via `AdTracker.loadAndTrackNativeAd(s)` instead of `AdLoader.Builder.forNativeAdWithTracking`). The text explains request/callback type changes (`AdLoadCallback`, format-specific event callbacks), keeping `placement` and reward-verification helpers, background-thread callbacks with main-thread UI updates, and using RevenueCat load helpers / `setTrackingAdEventCallback` so tracking wrappers are not replaced accidentally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d30f8a62e98f711fc7b038c48ce2dc7a91cb56a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->