### PR TITLE
ci: build next-gen AdMob sample app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,23 @@ jobs:
           command: bundle exec fastlane android build_admob_integration_sample
       - android/save_build_cache
 
+  assemble-admob-next-gen-integration-sample-app:
+    <<: *android-executor
+    shell: /bin/bash --login -o pipefail
+    steps:
+      - checkout
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - android/accept_licenses
+      - android-dependencies
+      - android/restore_build_cache
+      - run:
+          name: Build sample app
+          command: bundle exec fastlane android build_admob_next_gen_integration_sample
+      - android/save_build_cache
+
   prepare-tests:
     <<: *android-executor
     shell: /bin/bash --login -o pipefail
@@ -1021,6 +1038,7 @@ workflows:
           requires:
             - deploy-snapshot
       - assemble-admob-integration-sample-app
+      - assemble-admob-next-gen-integration-sample-app
 
   build-test-deploy:
     when:
@@ -1075,6 +1093,9 @@ workflows:
           requires:
             - prepare-tests
       - assemble-admob-integration-sample-app:
+          requires:
+            - prepare-tests
+      - assemble-admob-next-gen-integration-sample-app:
           requires:
             - prepare-tests
       - assemble-checkpoint-tester:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -581,6 +581,13 @@ platform :android do
     )
   end
 
+  desc "Builds an AdMob Next-Gen Integration Sample APK"
+  lane :build_admob_next_gen_integration_sample do |options|
+    gradle(
+      task: ":examples:admob-next-gen-sample:assembleDebug",
+    )
+  end
+
   desc <<-DESC
 Builds a Magic Weather APK and prompts for:
 * Gradle task


### PR DESCRIPTION
## Summary

Adds CI coverage for the Google Mobile Ads Next-Gen example app:

- add a Fastlane lane that assembles the Next-Gen AdMob sample
- add a dedicated CircleCI job for the sample build
- run the job in pull-request and main-branch snapshot workflows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Fastlane and CircleCI wiring; no SDK, auth, or runtime behavior is modified.
> 
> **Overview**
> Adds **CI coverage** for the Google Mobile Ads Next-Gen example (`examples:admob-next-gen-sample`), mirroring the existing AdMob integration sample pipeline.
> 
> A new Fastlane lane **`build_admob_next_gen_integration_sample`** assembles the debug APK via `:examples:admob-next-gen-sample:assembleDebug`. CircleCI gets a matching **`assemble-admob-next-gen-integration-sample-app`** job (same setup as the current AdMob sample job), wired into **`build-test-deploy`** after `prepare-tests` and into **`snapshot-deploy-sample-app-tests`** on main alongside the legacy AdMob sample build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274017e5af97236b1fc515d25d55e8e24ec53355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->