### PR TITLE
Fall back to "en" when a paywall screen omits `default_locale`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.paywalls.components.common.ProductChangeConfig
 import com.revenuecat.purchases.paywalls.components.common.ProductChangeConfigSerializer
 import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
 import com.revenuecat.purchases.paywalls.components.common.StateDeclarationMapSerializer
+import com.revenuecat.purchases.utils.serializers.DefaultLocaleIdSerializer
 import com.revenuecat.purchases.utils.serializers.EnumDeserializerWithDefault
 import com.revenuecat.purchases.utils.serializers.GoogleListSerializer
 import com.revenuecat.purchases.utils.serializers.JsonObjectToMapSerializer
@@ -128,7 +129,8 @@ public data class WorkflowScreen(
     @SerialName("components_config") val componentsConfig: ComponentsConfig,
     @SerialName("components_localizations")
     val componentsLocalizations: Map<LocaleId, Map<LocalizationKey, LocalizationData>>,
-    @SerialName("default_locale") val defaultLocaleIdentifier: LocaleId,
+    @Serializable(with = DefaultLocaleIdSerializer::class)
+    @SerialName("default_locale") val defaultLocaleIdentifier: LocaleId = DefaultLocaleIdSerializer.FALLBACK,
     @SerialName("config") val config: JsonObject = JsonObject(emptyMap()),
     @SerialName("offering_identifier") val offeringIdentifier: String? = null,
     @Serializable(with = GoogleListSerializer::class)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/PaywallComponentsData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/PaywallComponentsData.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.paywalls.components.common
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.utils.serializers.DefaultLocaleIdSerializer
 import com.revenuecat.purchases.utils.serializers.EmptyObjectToNullSerializer
 import com.revenuecat.purchases.utils.serializers.GoogleListSerializer
 import com.revenuecat.purchases.utils.serializers.URLSerializer
@@ -30,8 +31,9 @@ public class PaywallComponentsData(
     @SerialName("components_localizations")
     public val componentsLocalizations: Map<LocaleId, Map<LocalizationKey, LocalizationData>>,
     @get:JvmSynthetic
+    @Serializable(with = DefaultLocaleIdSerializer::class)
     @SerialName("default_locale")
-    public val defaultLocaleIdentifier: LocaleId,
+    public val defaultLocaleIdentifier: LocaleId = DefaultLocaleIdSerializer.FALLBACK,
     @get:JvmSynthetic
     public val revision: Int = 0,
     @get:JvmSynthetic

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/DefaultLocaleIdSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/DefaultLocaleIdSerializer.kt
@@ -9,8 +9,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Decodes a paywall's `default_locale`, falling back to [FALLBACK] when the backend sends `null`.
@@ -33,8 +32,8 @@ internal object DefaultLocaleIdSerializer : KSerializer<LocaleId> {
     override fun deserialize(decoder: Decoder): LocaleId {
         val jsonDecoder = decoder as? JsonDecoder
             ?: error("This serializer can be used only with JSON format")
-        val element = jsonDecoder.decodeJsonElement()
-        if (element is JsonNull) return FALLBACK
-        return LocaleId(element.jsonPrimitive.content)
+        // `isString` is false for JsonNull and for unquoted primitives, so both fall back here.
+        val primitive = jsonDecoder.decodeJsonElement() as? JsonPrimitive
+        return if (primitive?.isString == true) LocaleId(primitive.content) else FALLBACK
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/DefaultLocaleIdSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/DefaultLocaleIdSerializer.kt
@@ -1,0 +1,40 @@
+package com.revenuecat.purchases.utils.serializers
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Decodes a paywall's `default_locale`, falling back to [FALLBACK] when the backend sends `null`.
+ *
+ * Pair this with a property default so a *missing* key is tolerated too; this serializer is only
+ * reached when the key is present.
+ */
+@OptIn(InternalRevenueCatAPI::class)
+internal object DefaultLocaleIdSerializer : KSerializer<LocaleId> {
+
+    val FALLBACK = LocaleId("en")
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("DefaultLocaleId", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: LocaleId) {
+        encoder.encodeString(value.value)
+    }
+
+    override fun deserialize(decoder: Decoder): LocaleId {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: error("This serializer can be used only with JSON format")
+        val element = jsonDecoder.decodeJsonElement()
+        if (element is JsonNull) return FALLBACK
+        return LocaleId(element.jsonPrimitive.content)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -260,6 +260,21 @@ internal class WorkflowModelsDeserializationTest {
     }
 
     @Test
+    fun `WorkflowScreen default_locale falls back to en for non-string values`() {
+        // iOS only accepts a JSON string here, so coercing a number or bool into LocaleId("42")
+        // would hand the renderer a locale the other platforms never produce.
+        listOf("42", "1.5", "true", "{}", """{ "value": "es_ES" }""", """["es_ES"]""").forEach { value ->
+            val screen = JsonTools.json.decodeFromString(
+                WorkflowScreen.serializer(),
+                screenJson(""""default_locale": $value,"""),
+            )
+            assertThat(screen.defaultLocaleIdentifier)
+                .`as`("default_locale was coerced from: %s", value)
+                .isEqualTo(LocaleId("en"))
+        }
+    }
+
+    @Test
     fun `WorkflowScreen default_locale falls back to en when missing`() {
         val screen = JsonTools.json.decodeFromString(WorkflowScreen.serializer(), screenJson(""))
         assertThat(screen.defaultLocaleIdentifier).isEqualTo(LocaleId("en"))
@@ -269,7 +284,14 @@ internal class WorkflowModelsDeserializationTest {
     fun `workflow and offerings paths agree on default_locale`() {
         // Both models describe the same screen; the workflow path only re-wraps what /offerings
         // serves directly. They must not diverge on a shared field.
-        listOf(""""default_locale": "es_ES",""", """"default_locale": null,""", "").forEach { fragment ->
+        listOf(
+            """"default_locale": "es_ES",""",
+            """"default_locale": null,""",
+            """"default_locale": 42,""",
+            """"default_locale": true,""",
+            """"default_locale": {},""",
+            "",
+        ).forEach { fragment ->
             val json = screenJson(fragment)
             val fromWorkflow = JsonTools.json
                 .decodeFromString(WorkflowScreen.serializer(), json).defaultLocaleIdentifier

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -5,6 +5,8 @@ package com.revenuecat.purchases.common.workflows
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.models.StoreReplacementMode
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.common.StateDeclaration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -213,4 +215,72 @@ internal class WorkflowModelsDeserializationTest {
             }
         """.trimIndent()
     }
+
+    // region default_locale
+
+    private fun screenJson(defaultLocaleFragment: String) = """
+        {
+          $defaultLocaleFragment
+          "template_name": "tmpl",
+          "asset_base_url": "https://assets.revenuecat.com",
+          "components_localizations": {},
+          "components_config": {
+            "base": {
+              "stack": {
+                "type": "stack", "components": [],
+                "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+              },
+              "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#FFFFFF" } } }
+            }
+          }
+        }
+    """.trimIndent()
+
+    @Test
+    fun `WorkflowScreen default_locale is preserved when present`() {
+        val screen = JsonTools.json.decodeFromString(
+            WorkflowScreen.serializer(),
+            screenJson(""""default_locale": "es_ES","""),
+        )
+        assertThat(screen.defaultLocaleIdentifier).isEqualTo(LocaleId("es_ES"))
+    }
+
+    @Test
+    fun `WorkflowScreen default_locale falls back to en when null`() {
+        // The backend sends null for template-derived screens. Throwing here discards the whole
+        // workflow, not just this field, taking every screen in it down with the paywall.
+        val screen = JsonTools.json.decodeFromString(
+            WorkflowScreen.serializer(),
+            screenJson(""""default_locale": null,"""),
+        )
+        assertThat(screen.defaultLocaleIdentifier).isEqualTo(LocaleId("en"))
+    }
+
+    @Test
+    fun `WorkflowScreen default_locale falls back to en when missing`() {
+        val screen = JsonTools.json.decodeFromString(WorkflowScreen.serializer(), screenJson(""))
+        assertThat(screen.defaultLocaleIdentifier).isEqualTo(LocaleId("en"))
+    }
+
+    @Test
+    fun `workflow and offerings paths agree on default_locale`() {
+        // Both models describe the same screen; the workflow path only re-wraps what /offerings
+        // serves directly. They must not diverge on a shared field.
+        listOf(""""default_locale": "es_ES",""", """"default_locale": null,""", "").forEach { fragment ->
+            val json = screenJson(fragment)
+            val fromWorkflow = JsonTools.json
+                .decodeFromString(WorkflowScreen.serializer(), json).defaultLocaleIdentifier
+            val fromOfferings = JsonTools.json
+                .decodeFromString(PaywallComponentsData.serializer(), json).defaultLocaleIdentifier
+
+            assertThat(fromWorkflow)
+                .`as`("default_locale diverged for fragment: %s", fragment.ifEmpty { "<omitted>" })
+                .isEqualTo(fromOfferings)
+        }
+    }
+
+    // endregion
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
`default_locale` was a required field on both paywall screen models. The backend serves it as `null` for template-derived screens, so those paywalls fail to decode and fall back to the default paywall. On the workflow path the failure is
not scoped to the field, it discards the entire `PublishedWorkflow`, so one bad screen takes every other screen in the workflow with it.

### Description
This needs two fixes, not one: a default handles a missing value, but an explicit null still fails. We now fall back to en in both cases.

I applied the same behavior to both paywall models. Only the workflow path is failing in production right now, but both models have the same requirement.

I verified the fix against the payload the backend actually sends. Previously, both null and a missing value failed; now present, null, and missing values all behave consistently, falling back to en when needed.

All relevant test suites and checks pass. The four existing HTTP timeout failures also reproduce on a clean HEAD, so they’re unrelated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized deserialization-only change with a safe default; no auth, billing, or persistence impact.
> 
> **Overview**
> Paywall screen JSON decoding no longer fails when the backend sends **`default_locale` as `null`** (common on template-derived screens) or omits the key. **`WorkflowScreen`** and **`PaywallComponentsData`** now use **`DefaultLocaleIdSerializer`** plus a property default of **`en`**, so valid strings are kept and null, missing, or non-string JSON values all resolve to English instead of aborting deserialization.
> 
> On the workflow path, a decode failure previously dropped the entire **`PublishedWorkflow`**, not just one screen; this change keeps those workflows loadable. Malformed **`default_locale`** values are not coerced into odd locale strings, aligning with iOS string-only behavior.
> 
> Unit tests cover present, null, missing, and invalid **`default_locale`** payloads and assert both models decode the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78cc5df10e70470f3d75fc4c0209091e7c32a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->