### PR TITLE
Cache web purchase redemption CustomerInfo for the initiating App User ID

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoUpdateHandler.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoUpdateHandler.kt
@@ -38,7 +38,11 @@ internal class CustomerInfoUpdateHandler constructor(
     private var lastSentCustomerInfo: CustomerInfo? = null
 
     fun cacheAndNotifyListeners(customerInfo: CustomerInfo) {
-        deviceCache.cacheCustomerInfo(identityManager.currentAppUserID, customerInfo)
+        cacheAndNotifyListeners(customerInfo, identityManager.currentAppUserID)
+    }
+
+    fun cacheAndNotifyListeners(customerInfo: CustomerInfo, appUserID: String) {
+        deviceCache.cacheCustomerInfo(appUserID, customerInfo)
         notifyListeners(customerInfo)
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelper.kt
@@ -23,15 +23,16 @@ internal class WebPurchaseRedemptionHelper(
         listener: RedeemWebPurchaseListener,
     ) {
         debugLog { "Starting web purchase redemption." }
+        val appUserID = identityManager.currentAppUserID
         backend.postRedeemWebPurchase(
-            identityManager.currentAppUserID,
+            appUserID,
             webPurchaseRedemption.redemptionToken,
             onResultHandler = { result ->
                 when (result) {
                     is RedeemWebPurchaseListener.Result.Success -> {
                         debugLog { "Successfully redeemed web purchase. Updating customer info." }
                         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
-                        customerInfoUpdateHandler.cacheAndNotifyListeners(result.customerInfo)
+                        customerInfoUpdateHandler.cacheAndNotifyListeners(result.customerInfo, appUserID)
                         dispatchResult(listener, result)
                     }
                     else -> {

--- a/purchases/src/test/java/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelperTest.kt
@@ -7,7 +7,9 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.WebPurchaseRedemption
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.interfaces.RedeemWebPurchaseListener
@@ -48,7 +50,7 @@ class WebPurchaseRedemptionHelperTest {
 
         every { identityManager.currentAppUserID } returns userId
         every { offlineEntitlementsManager.resetOfflineCustomerInfoCache() } just Runs
-        every { customerInfoUpdateHandler.cacheAndNotifyListeners(customerInfo) } just Runs
+        every { customerInfoUpdateHandler.cacheAndNotifyListeners(customerInfo, userId) } just Runs
 
         webPurchaseRedemptionHelper = WebPurchaseRedemptionHelper(
             backend = backend,
@@ -80,7 +82,38 @@ class WebPurchaseRedemptionHelperTest {
     fun `handleRedeemWebPurchase posts token and notifies listener on success`() {
         mockBackendResult()
         webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption) {}
-        verify(exactly = 1) { customerInfoUpdateHandler.cacheAndNotifyListeners(customerInfo) }
+        verify(exactly = 1) { customerInfoUpdateHandler.cacheAndNotifyListeners(customerInfo, userId) }
+    }
+
+    @Test
+    fun `handleRedeemWebPurchase caches customer info for user that started request`() {
+        val newUserId = "new-user-id"
+        val deviceCache = mockk<DeviceCache>()
+        val appConfig = mockk<AppConfig>()
+        val realCustomerInfoUpdateHandler = CustomerInfoUpdateHandler(
+            deviceCache,
+            identityManager,
+            offlineEntitlementsManager,
+            appConfig,
+            diagnosticsTracker = null,
+        )
+        val helper = WebPurchaseRedemptionHelper(
+            backend,
+            identityManager,
+            offlineEntitlementsManager,
+            realCustomerInfoUpdateHandler,
+        )
+        every { deviceCache.cacheCustomerInfo(any(), customerInfo) } just Runs
+        every { backend.postRedeemWebPurchase(userId, redemptionToken, captureLambda()) } answers {
+            every { identityManager.currentAppUserID } returns newUserId
+            lambda<(RedeemWebPurchaseListener.Result) -> Unit>().captured.invoke(
+                RedeemWebPurchaseListener.Result.Success(customerInfo),
+            )
+        }
+
+        helper.handleRedeemWebPurchase(webPurchaseRedemption) {}
+
+        verify(exactly = 1) { deviceCache.cacheCustomerInfo(userId, customerInfo) }
     }
 
     @Test
@@ -94,7 +127,7 @@ class WebPurchaseRedemptionHelperTest {
         assertTrue(result is RedeemWebPurchaseListener.Result.Error)
         assertThat((result as RedeemWebPurchaseListener.Result.Error).error).isEqualTo(expectedError)
         verify(exactly = 0) { offlineEntitlementsManager.resetOfflineCustomerInfoCache() }
-        verify(exactly = 0) { customerInfoUpdateHandler.cacheAndNotifyListeners(any()) }
+        verify(exactly = 0) { customerInfoUpdateHandler.cacheAndNotifyListeners(any(), any()) }
     }
 
     @Test
@@ -106,7 +139,7 @@ class WebPurchaseRedemptionHelperTest {
         }
         assertTrue(result is RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser)
         verify(exactly = 0) { offlineEntitlementsManager.resetOfflineCustomerInfoCache() }
-        verify(exactly = 0) { customerInfoUpdateHandler.cacheAndNotifyListeners(any()) }
+        verify(exactly = 0) { customerInfoUpdateHandler.cacheAndNotifyListeners(any(), any()) }
     }
 
     @Test
@@ -119,7 +152,7 @@ class WebPurchaseRedemptionHelperTest {
         }
         assertThat(result).isEqualTo(expectedResult)
         verify(exactly = 0) { offlineEntitlementsManager.resetOfflineCustomerInfoCache() }
-        verify(exactly = 0) { customerInfoUpdateHandler.cacheAndNotifyListeners(any()) }
+        verify(exactly = 0) { customerInfoUpdateHandler.cacheAndNotifyListeners(any(), any()) }
     }
 
     @Test
@@ -132,7 +165,7 @@ class WebPurchaseRedemptionHelperTest {
         }
         assertThat(result).isEqualTo(expectedResult)
         verify(exactly = 0) { offlineEntitlementsManager.resetOfflineCustomerInfoCache() }
-        verify(exactly = 0) { customerInfoUpdateHandler.cacheAndNotifyListeners(any()) }
+        verify(exactly = 0) { customerInfoUpdateHandler.cacheAndNotifyListeners(any(), any()) }
     }
 
     private fun mockBackendResult(


### PR DESCRIPTION
## Description

After making the API request to POST redeem web purchase, and receiving the response with the updated `CustomerInfo`, we reached back into the identityManager to get the current appUserID in order to cache the updated `CustomerInfo` for this app user ID. However theoretically the user ID could have changed between initiating the request and receiving the response. Possibly saving the updated `CustomerInfo` of user A under the cache key for user `B`, resulting in `CustomerInfo` data being shared between app user IDs

## Changes

We're now capturing the initiating `appUserID` and reusing that value when storing the `CustomerInfo` in the cache. Ensuring that it's saved for the app user that originally initiated the request.

Equivalent iOS PR: https://github.com/RevenueCat/purchases-ios/pull/7533

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes customer-info cache keying for web redemption, which could affect entitlement data if wrong; the fix is narrowly scoped and covered by a regression test.
> 
> **Overview**
> Fixes a race where **web purchase redemption** could cache updated `CustomerInfo` under the wrong app user if `identityManager.currentAppUserID` changed between starting the redeem request and handling the async success.
> 
> `CustomerInfoUpdateHandler` now exposes `cacheAndNotifyListeners(customerInfo, appUserID)`; the existing single-argument method delegates to the current ID. `WebPurchaseRedemptionHelper` captures `appUserID` when redemption starts and passes that same ID when caching after success.
> 
> Tests were updated to expect the explicit user ID, plus a new case that simulates a user switch during the async callback and verifies cache writes use the **original** user ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817d1221db7bde5304029a640d932c8862911650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->