### PR TITLE
build: move MagicWeatherCompose and CustomEntitlementComputationSample to AGP 9

### DIFF
--- a/examples/CustomEntitlementComputationSample/gradle.properties
+++ b/examples/CustomEntitlementComputationSample/gradle.properties
@@ -21,3 +21,8 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Built-in Kotlin rejects the kotlin-android plugin, and that plugin casts the android extension
+# to BaseExtension, which the new DSL drops. Both flags go away in AGP 10.
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/CustomEntitlementComputationSample/gradle/libs.versions.toml
+++ b/examples/CustomEntitlementComputationSample/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.2"
+agp = "9.2.1"
 kotlin = "2.2.21"
 purchases = "11.0.0-SNAPSHOT"
 androidxCore = "1.10.1"

--- a/examples/CustomEntitlementComputationSample/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/CustomEntitlementComputationSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/MagicWeatherCompose/gradle.properties
+++ b/examples/MagicWeatherCompose/gradle.properties
@@ -21,3 +21,8 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Built-in Kotlin rejects the kotlin-android plugin, and that plugin casts the android extension
+# to BaseExtension, which the new DSL drops. Both flags go away in AGP 10.
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/MagicWeatherCompose/gradle/libs.versions.toml
+++ b/examples/MagicWeatherCompose/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.2"
+agp = "9.2.1"
 androidxNavigation = "2.5.3"
 kotlin = "2.2.21"
 purchases = "11.0.0-SNAPSHOT"

--- a/examples/MagicWeatherCompose/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/MagicWeatherCompose/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Moves the two standalone sample builds, `MagicWeatherCompose` and `CustomEntitlementComputationSample`, to AGP 9.2.1 and Gradle 9.4.1, catching them up with the root build.
- Both take the `android.builtInKotlin=false` and `android.newDsl=false` opt-out. #4120 removes it, stacked on top of this.

Targets integration branch (`11.0-dev`)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only version and Gradle property changes in example projects; no runtime or library code changes.
> 
> **Overview**
> Aligns the **MagicWeatherCompose** and **CustomEntitlementComputationSample** example builds with the root toolchain by bumping **AGP** from `8.13.2` to **`9.2.1`** and the Gradle wrapper from **`8.14.5`** to **`9.4.1`**.
> 
> Each sample’s `gradle.properties` adds **`android.builtInKotlin=false`** and **`android.newDsl=false`** so existing **`kotlin-android`** plugin usage keeps working until a follow-up removes those opt-outs for AGP 10.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f5db0a59e17edcc0fb0ae0c9a0f5e6ef0ab725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->