### PR TITLE
Skip test suite on main branch pushes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,11 @@ aliases:
       branches:
         only: main
 
+  non-main-branches: &non-main-branches
+    filters:
+      branches:
+        ignore: main
+
   android-executor: &android-executor
     executor:
       name: android/android_docker
@@ -1036,6 +1041,7 @@ workflows:
           build_type: "debug"
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - test:
           name: test_cec_<< matrix.build_type >>
           flavor: "customEntitlementComputation"
@@ -1045,6 +1051,7 @@ workflows:
           matrix:
             parameters:
               build_type: ["debug", "release"]
+          <<: *non-main-branches
       # Special case for defaults release with kover
       - test:
           name: test_defaults_release
@@ -1056,45 +1063,58 @@ workflows:
       - verify-compatibility:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - lint:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - detekt:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - metalava:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - assemble-purchase-tester:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - assemble-paywall-tester-release:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - assemble-rct-tester-release:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - assemble-admob-integration-sample-app:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - assemble-checkpoint-tester:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - test_dokka_hide_internal:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - test_detekt_rules:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - run-backend-integration-tests:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - record-and-upload-paparazzi-revenuecatui-snapshots:
           requires:
             - prepare-tests
       - run-revenuecatui-ui-tests:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - emerge_purchases_ui_snapshot_tests:
           requires:
             - prepare-tests
@@ -1104,23 +1124,28 @@ workflows:
       - run-maestro-e2e-tests:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - run-maestro-workflow-tests:
           context:
             - maestro
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - run-integration-tests:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - run-purchases-cec-integration-tests:
           requires:
             - prepare-tests
+          <<: *non-main-branches
       - run-purchases-integration-tests:
           requires:
             - prepare-tests
           matrix:
             parameters:
               backend_environment: ["production", "load_shedder_us_east_1", "load_shedder_us_east_2"]
+          <<: *non-main-branches
       - hold:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,6 @@ aliases:
       branches:
         only: /^release\/.*/
 
-  only-main-branch: &only-main-branch
-    filters:
-      tags:
-        ignore: /.*/
-      branches:
-        only: main
-
   non-main-branches: &non-main-branches
     filters:
       branches:


### PR DESCRIPTION
### Description

Every push to `main` runs the full test suite, but we already run them on merge queue branches in Android. So it's not really needed and wastes CI credits. This PR disables most jobs from running on `main` except a few:
- `test_defaults_release` to keep Codecov coverage (Maybe we want to disable this?)
- Emerge/Paparazzi baseline-upload jobs (So we get diffs in the paywalls and size checks from main
- prepare-tests (mostly because the other jobs depend on this one)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Direct pushes to main no longer run lint, most tests, or integration jobs, so regressions could slip through if code reaches main outside the merge queue.
> 
> **Overview**
> Reduces CircleCI spend on **`main`** by skipping most of the **`build-test-deploy`** workflow while PR/merge-queue branches still run the full suite.
> 
> The **`only-main-branch`** anchor is replaced with **`non-main-branches`** (`branches: ignore: main`), and that filter is merged into unit tests, lint/detekt/metalava, sample app assembles, backend/integration/Maestro/UI jobs, and related checks. **`main`** still runs **`prepare-tests`**, **`test_defaults_release`** (Kover/Codecov), and the Paparazzi/Emerge baseline jobs (**`record-and-upload-paparazzi-revenuecatui-snapshots`**, **`emerge_purchases_ui_snapshot_tests`**, **`emerge_size_analysis_tests`**) so coverage uploads and snapshot/size baselines stay current.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e3099b74b92270bdf74e44cd1b31a6b9fb3fbb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->