### PR TITLE
feat(paywalls): send offering and package details to custom components

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
@@ -242,7 +242,9 @@ public enum class Store {
     GALAXY,
     ;
 
-    internal val stringValue: String
+    /** Wire name for this store, as used by the backend and by the paywall web_view context. */
+    @InternalRevenueCatAPI
+    public val stringValue: String
         get() = when (this) {
             APP_STORE -> "app_store"
             MAC_APP_STORE -> "mac_app_store"
@@ -288,6 +290,7 @@ public enum class Store {
     }
 }
 
+@OptIn(InternalRevenueCatAPI::class)
 internal object StoreSerializer : EnumDeserializerWithDefault<Store>(
     defaultValue = Store.UNKNOWN_STORE,
     typeForValue = { value -> value.stringValue },

--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/PaywallWebViewMediaPolicyTest.kt
@@ -44,13 +44,7 @@ class PaywallWebViewMediaPolicyTest {
                     sizeToContentHeight = false,
                 ),
                 onLoadFailed = {},
-                contextSnapshotProvider = {
-                    webViewContextSnapshot(
-                        customVariables = emptyMap(),
-                        locale = "en-US",
-                        darkMode = false,
-                    )
-                },
+                contextSnapshotProvider = { deviceContextSnapshot() },
             )
             built = configured != null
             configured?.let {

--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextBridgeTest.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextBridgeTest.kt
@@ -42,11 +42,7 @@ class WebViewContextBridgeTest {
                 ),
                 onLoadFailed = {},
                 contextSnapshotProvider = {
-                    webViewContextSnapshot(
-                        customVariables = mapOf("org" to CustomVariableValue.String("RevenueCat")),
-                        locale = "en-US",
-                        darkMode = false,
-                    )
+                    deviceContextSnapshot(mapOf("org" to CustomVariableValue.String("RevenueCat")))
                 },
             )
         }

--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewTestSupport.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewTestSupport.kt
@@ -1,9 +1,27 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import androidx.test.platform.app.InstrumentationRegistry
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import kotlinx.serialization.json.JsonObject
 
 /** A WebView may only be created and driven from the main thread. */
 internal fun onMain(block: () -> Unit) =
     InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
 
 internal const val TEST_BUNDLE_URL = "https://assets.example.com/promo/index.html"
+
+internal fun deviceContextSnapshot(
+    customVariables: Map<String, CustomVariableValue> = emptyMap(),
+): JsonObject = webViewContextSnapshot(
+    WebViewContextInput(
+        customVariables = customVariables,
+        offering = null,
+        componentPackage = null,
+        selectedPackage = null,
+        store = Store.PLAY_STORE,
+        storefrontCountryCode = "US",
+        locale = "en-US",
+        darkMode = false,
+    ),
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.viewinterop.AndroidView
@@ -44,6 +45,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.trackMainAxisUnbounded
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import kotlinx.coroutines.flow.drop
 import kotlinx.serialization.json.JsonObject
 
 @JvmSynthetic
@@ -81,7 +83,10 @@ internal fun WebViewComponentView(
     // PaywallState instance on every rebuild, so both reads go through State to stay current.
     val darkMode by rememberUpdatedState(isSystemInDarkTheme())
     val currentState by rememberUpdatedState(state)
-    val contextSnapshotProvider: () -> JsonObject = { webViewContextSnapshot(currentState, darkMode) }
+    val currentStyle by rememberUpdatedState(style)
+    val contextSnapshotProvider: () -> JsonObject = {
+        webViewContextSnapshot(currentState, currentStyle, darkMode)
+    }
 
     val identity = WebViewIdentity(
         resolvedUrl = resolvedUrl,
@@ -98,6 +103,15 @@ internal fun WebViewComponentView(
         var loadFailed by remember { mutableStateOf(false) }
         // Remembered inside key(identity) so a stale onRelease can only release its own view's bridge.
         val bridgeHolder = remember { WebViewBridgeHolder() }
+
+        // The handshake seeds the first snapshot, so only later changes need a push. The state
+        // instance is part of the key because the view model replaces it for some changes and
+        // mutates it in place for others.
+        LaunchedEffect(bridgeHolder) {
+            snapshotFlow { listOf(currentState, currentState.selectedPackageInfo?.uniqueId) }
+                .drop(1)
+                .collect { bridgeHolder.bridge?.pushContextNow() }
+        }
 
         // A `fill` axis genuinely unbounded at measure time (e.g. an ancestor scrolls, or a `Fit`-sized
         // container sits under one that does) would otherwise collapse to zero — `fillMaxWidth/Height`

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextInput.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextInput.kt
@@ -1,0 +1,20 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+
+/** Every field is required, so a section added later cannot be left empty at a call site. */
+internal data class WebViewContextInput(
+    val customVariables: Map<String, CustomVariableValue>,
+    val offering: Offering?,
+    /** Its own when the component sits inside a package, else the selection. */
+    val componentPackage: Package?,
+    val selectedPackage: Package?,
+    val store: Store,
+    val storefrontCountryCode: String?,
+    /** A BCP-47 tag. The content SDK feeds it to `Intl`, which rejects the underscored form. */
+    val locale: String,
+    val darkMode: Boolean,
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
@@ -1,12 +1,21 @@
 @file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
 
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.common.SharedConstants.MICRO_MULTIPLIER
+import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
@@ -15,42 +24,88 @@ import kotlinx.serialization.json.putJsonObject
 @JvmSynthetic
 internal fun webViewContextSnapshot(
     state: PaywallState.Loaded.Components,
+    style: WebViewComponentStyle,
     darkMode: Boolean,
-): JsonObject = webViewContextSnapshot(
-    customVariables = state.mergedCustomVariables,
-    locale = state.locale.toLanguageTag(),
-    darkMode = darkMode,
-)
+): JsonObject {
+    val selectedPackage = state.selectedPackageInfo?.rcPackage
+    return webViewContextSnapshot(
+        WebViewContextInput(
+            customVariables = state.mergedCustomVariables,
+            offering = state.offering,
+            // Inside a package component the values describe that package; elsewhere they follow
+            // the selection, matching what a text component resolves.
+            componentPackage = style.rcPackage ?: selectedPackage,
+            selectedPackage = selectedPackage,
+            store = state.store,
+            storefrontCountryCode = state.storefrontCountryCode,
+            locale = state.locale.toLanguageTag(),
+            darkMode = darkMode,
+        ),
+    )
+}
 
 /**
  * Builds the payload the handshake seeds and later `context` pushes replace, per the
  * custom component variables contract (RevenueCat/docs#1874): absent structured sections are
  * literal `null`, empty maps are `{}`, and `workflow` is omitted entirely outside a funnel.
  *
- * @param locale a BCP-47 language tag. The content SDK feeds it to `Intl`, which rejects the
- * underscored `LocaleId` form with a `RangeError`.
+ * `packages[].display_name` is omitted: the offerings endpoint does not serve package display names.
  */
 @JvmSynthetic
-internal fun webViewContextSnapshot(
-    customVariables: Map<String, CustomVariableValue>,
-    locale: String,
-    darkMode: Boolean,
-): JsonObject = buildJsonObject {
+internal fun webViewContextSnapshot(input: WebViewContextInput): JsonObject = buildJsonObject {
     putJsonObject(Keys.CUSTOM) {
-        customVariables.forEach { (name, value) -> put(name, value.asJsonPrimitive) }
+        input.customVariables.forEach { (name, value) -> put(name, value.asJsonPrimitive) }
     }
-    put(Keys.OFFERING, JsonNull)
-    putJsonArray(Keys.PACKAGES) {}
-    put(Keys.PACKAGE, JsonNull)
-    put(Keys.SELECTED_PACKAGE, JsonNull)
+    put(Keys.OFFERING, input.offering?.asJson() ?: JsonNull)
+    putJsonArray(Keys.PACKAGES) {
+        input.offering?.availablePackages?.forEach { add(it.asJson(input)) }
+    }
+    put(Keys.PACKAGE, input.componentPackage?.asJson(input) ?: JsonNull)
+    put(Keys.SELECTED_PACKAGE, input.selectedPackage?.asJson(input) ?: JsonNull)
     putJsonObject(Keys.INPUTS) {}
     putJsonObject(Keys.DEVICE_META) {
         put(Keys.IS_PREVIEW, false)
-        put(Keys.LOCALE, locale)
-        put(Keys.DARK_MODE, darkMode)
+        put(Keys.LOCALE, input.locale)
+        put(Keys.DARK_MODE, input.darkMode)
         put(Keys.UPDATED_AT, System.currentTimeMillis())
     }
 }
+
+private fun Offering.asJson(): JsonObject = buildJsonObject {
+    put(Keys.IDENTIFIER, identifier)
+    // The offerings endpoint serves the dashboard display name under the `description` key.
+    put(Keys.DISPLAY_NAME, serverDescription)
+}
+
+private fun Package.asJson(input: WebViewContextInput): JsonObject = buildJsonObject {
+    put(Keys.IDENTIFIER, identifier)
+    // One product per package on Android; the contract carries a list for stores serving more.
+    putJsonArray(Keys.PRODUCTS) { add(product.asJson(input)) }
+}
+
+private fun StoreProduct.asJson(input: WebViewContextInput): JsonObject = buildJsonObject {
+    put(Keys.IDENTIFIER, id)
+    putJsonObject(Keys.STORE) {
+        put(Keys.STORE_TYPE, input.store.stringValue)
+        input.storefrontCountryCode?.let { put(Keys.COUNTRY, it) }
+    }
+    put(Keys.DISPLAY_NAME, name)
+    put(Keys.IS_SUBSCRIPTION, period != null)
+    period?.let { put(Keys.PERIOD, it.iso8601) }
+    isAutoRenewing?.let { put(Keys.IS_AUTO_RENEWING, it) }
+    putJsonObject(Keys.PRICE) {
+        put(Keys.AMOUNT, price.amountMicros / MICRO_MULTIPLIER)
+        put(Keys.CURRENCY, price.currencyCode)
+    }
+}
+
+/** Google reports renewal on the base pricing phase, which trial and intro phases precede. */
+private val StoreProduct.isAutoRenewing: Boolean?
+    get() = when (defaultOption?.fullPricePhase?.recurrenceMode) {
+        RecurrenceMode.INFINITE_RECURRING -> true
+        RecurrenceMode.NON_RECURRING -> false
+        else -> null
+    }
 
 /** Wire keys from the contract (RevenueCat/docs#1874), in the order its table lists them. */
 private object Keys {
@@ -66,6 +121,19 @@ private object Keys {
     const val LOCALE = "locale"
     const val DARK_MODE = "dark_mode"
     const val UPDATED_AT = "updated_at"
+
+    const val IDENTIFIER = "identifier"
+    const val DISPLAY_NAME = "display_name"
+    const val PRODUCTS = "products"
+    const val STORE = "store"
+    const val STORE_TYPE = "store_type"
+    const val COUNTRY = "country"
+    const val IS_SUBSCRIPTION = "is_subscription"
+    const val PERIOD = "period"
+    const val IS_AUTO_RENEWING = "is_auto_renewing"
+    const val PRICE = "price"
+    const val AMOUNT = "amount"
+    const val CURRENCY = "currency"
 }
 
 private val CustomVariableValue.asJsonPrimitive: JsonPrimitive

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridge.kt
@@ -228,6 +228,26 @@ internal class WebViewJavaScriptBridge(
         sendFitIfNeeded()
     }
 
+    /** Re-sends the current snapshot; a no-op until the handshake has seeded the content's cache. */
+    @MainThread
+    fun pushContextNow() {
+        if (released || !channelOpen) return
+        sendContext()
+    }
+
+    private fun sendContext() {
+        deliverEnvelopeNow(
+            WebViewEnvelope(
+                kind = WebViewEnvelope.Kind.MESSAGE,
+                protocolVersion = protocolVersion,
+                componentId = componentId,
+                type = WebViewMessageType.CONTEXT,
+                payload = contextSnapshotProvider(),
+            ),
+            allowBeforeNavigation = false,
+        )
+    }
+
     private fun sendFitIfNeeded() {
         if (!sizeToContentWidth && !sizeToContentHeight) return
         val payload = buildJsonObject {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.PurchaseResult
 import com.revenuecat.purchases.PurchasesAreCompletedBy
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
@@ -26,6 +27,7 @@ internal class MockPurchasesType(
     override val preferredUILocaleOverride: String? = null,
     override val purchasesAreCompletedBy: PurchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
     override val storefrontCountryCode: String? = null,
+    override val store: Store = Store.PLAY_STORE,
     override val customerCenterListener: CustomerCenterListener? = null,
 ) : PurchasesType {
     override suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.intl.LocaleList
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.UiConfig.VariableConfig
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
@@ -112,7 +113,7 @@ internal sealed interface PaywallState {
              * All locales that this paywall supports, with `locales.head` being the default one.
              */
             private val locales: NonEmptySet<LocaleId>,
-            private val storefrontCountryCode: String?,
+            val storefrontCountryCode: String?,
             private val dateProvider: () -> Date,
             private val packages: AvailablePackages,
             /**
@@ -141,6 +142,8 @@ internal sealed interface PaywallState {
              */
             val mergedCustomVariables: Map<String, CustomVariableValue> =
                 defaultCustomVariables + customVariables
+
+            val store: Store get() = purchases.store
 
             data class AvailablePackages(
                 val packagesOutsideTabs: List<Info>,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.PurchaseResult
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.awaitCreateSupportTicket
 import com.revenuecat.purchases.awaitCustomerCenterConfigData
@@ -62,6 +63,8 @@ internal interface PurchasesType {
     suspend fun awaitSyncPurchases(): CustomerInfo
 
     val storefrontCountryCode: String?
+
+    val store: Store
 
     val customerCenterListener: CustomerCenterListener?
 
@@ -137,6 +140,9 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
 
     override val storefrontCountryCode: String?
         get() = purchases.storefrontCountryCode
+
+    override val store: Store
+        get() = purchases.store
 
     override val customerCenterListener: CustomerCenterListener?
         get() = purchases.customerCenterListener

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
@@ -1,11 +1,14 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.double
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -17,11 +20,7 @@ internal class WebViewContextSnapshotTest {
 
     @Test
     fun `contains every section with its empty shape and no workflow key`() {
-        val snapshot = webViewContextSnapshot(
-            customVariables = emptyMap(),
-            locale = "en-US",
-            darkMode = true,
-        )
+        val snapshot = testContextSnapshot(darkMode = true)
 
         assertThat(snapshot.keys).containsExactly(
             "custom",
@@ -39,6 +38,8 @@ internal class WebViewContextSnapshotTest {
         assertThat(snapshot.getValue("selected_package")).isEqualTo(JsonNull)
         assertThat(snapshot.getValue("inputs").jsonObject).isEmpty()
     }
+
+    // --- custom ---
 
     @Test
     fun `custom carries every variable with its type intact`() {
@@ -67,23 +68,154 @@ internal class WebViewContextSnapshotTest {
         assertThat(Json.encodeToString(JsonObject.serializer(), custom)).isEqualTo("""{"broken":"NaN"}""")
     }
 
-    private fun snapshotWith(vararg variables: Pair<String, CustomVariableValue>) =
-        webViewContextSnapshot(
-            customVariables = variables.toMap(),
-            locale = "en-US",
-            darkMode = false,
-        ).getValue("custom").jsonObject
+    // --- offering, packages, selection ---
+
+    @Test
+    fun `offering carries its identifier and display name`() {
+        val offering = TestData.template7CustomPackageOffering
+
+        val snapshot = testContextSnapshot(offering = offering).getValue("offering").jsonObject
+
+        assertThat(snapshot.getValue("identifier").jsonPrimitive.content).isEqualTo(offering.identifier)
+        assertThat(snapshot.getValue("display_name").jsonPrimitive.content)
+            .isEqualTo(offering.serverDescription)
+    }
+
+    @Test
+    fun `packages carries every available package in order`() {
+        val offering = TestData.template7CustomPackageOffering
+
+        val packages = testContextSnapshot(offering = offering).getValue("packages").jsonArray
+
+        assertThat(packages.map { it.jsonObject.getValue("identifier").jsonPrimitive.content })
+            .isEqualTo(offering.availablePackages.map { it.identifier })
+    }
+
+    @Test
+    fun `packages omits display_name, which the offerings endpoint does not serve`() {
+        val packages = testContextSnapshot(offering = TestData.template7CustomPackageOffering)
+            .getValue("packages").jsonArray
+
+        assertThat(packages.first().jsonObject.keys).containsExactly("identifier", "products")
+    }
+
+    @Test
+    fun `package and selected_package differ when the component sits inside a package`() {
+        val offering = TestData.template7CustomPackageOffering
+        val componentPackage = offering.availablePackages.first()
+        val selected = offering.availablePackages.last()
+
+        val snapshot = testContextSnapshot(
+            offering = offering,
+            componentPackage = componentPackage,
+            selectedPackage = selected,
+        )
+
+        assertThat(identifierOf(snapshot, "package")).isEqualTo(componentPackage.identifier)
+        assertThat(identifierOf(snapshot, "selected_package")).isEqualTo(selected.identifier)
+    }
+
+    @Test
+    fun `selected_package is null when nothing is selected`() {
+        val snapshot = testContextSnapshot(offering = TestData.template7CustomPackageOffering)
+
+        assertThat(snapshot.getValue("selected_package")).isEqualTo(JsonNull)
+    }
+
+    // --- products ---
+
+    @Test
+    fun `product carries store, period and price`() {
+        val offering = TestData.template7CustomPackageOffering
+        val monthly = offering.monthly!!
+
+        val product = testContextSnapshot(
+            offering = offering,
+            componentPackage = monthly,
+            storefrontCountryCode = "ES",
+        ).productOfPackage()
+
+        assertThat(product.getValue("identifier").jsonPrimitive.content).isEqualTo(monthly.product.id)
+        assertThat(product.getValue("display_name").jsonPrimitive.content).isEqualTo(monthly.product.name)
+        assertThat(product.getValue("is_subscription").jsonPrimitive.boolean).isTrue()
+        assertThat(product.getValue("period").jsonPrimitive.content).isEqualTo(monthly.product.period!!.iso8601)
+        val store = product.getValue("store").jsonObject
+        assertThat(store.getValue("store_type").jsonPrimitive.content).isEqualTo("play_store")
+        assertThat(store.getValue("country").jsonPrimitive.content).isEqualTo("ES")
+        val price = product.getValue("price").jsonObject
+        assertThat(price.getValue("currency").jsonPrimitive.content).isEqualTo(monthly.product.price.currencyCode)
+        assertThat(price.getValue("amount").jsonPrimitive.double)
+            .isEqualTo(monthly.product.price.amountMicros / 1_000_000.0)
+    }
+
+    @Test
+    fun `store country is omitted until the storefront is known`() {
+        val offering = TestData.template7CustomPackageOffering
+
+        val store = testContextSnapshot(
+            offering = offering,
+            componentPackage = offering.monthly,
+            storefrontCountryCode = null,
+        ).productOfPackage().getValue("store").jsonObject
+
+        assertThat(store.keys).containsExactly("store_type")
+    }
+
+    @Test
+    fun `store type follows the configured store`() {
+        val offering = TestData.template7CustomPackageOffering
+
+        val store = testContextSnapshot(
+            offering = offering,
+            componentPackage = offering.monthly,
+            store = Store.AMAZON,
+        ).productOfPackage().getValue("store").jsonObject
+
+        assertThat(store.getValue("store_type").jsonPrimitive.content).isEqualTo("amazon")
+    }
+
+    @Test
+    fun `is_auto_renewing follows the base plan's recurrence mode`() {
+        val offering = TestData.template7CustomPackageOffering
+
+        val product = testContextSnapshot(
+            offering = offering,
+            componentPackage = offering.monthly,
+        ).productOfPackage()
+
+        assertThat(product.getValue("is_auto_renewing").jsonPrimitive.boolean).isTrue()
+    }
+
+    @Test
+    fun `is_auto_renewing is false for a prepaid base plan`() {
+        val product = testContextSnapshot(
+            componentPackage = prepaidPackage(),
+        ).productOfPackage()
+
+        assertThat(product.getValue("is_auto_renewing").jsonPrimitive.boolean).isFalse()
+    }
+
+    @Test
+    fun `a non-subscription reports no period and no renewal`() {
+        val offering = TestData.template7CustomPackageOffering
+
+        val product = testContextSnapshot(
+            offering = offering,
+            componentPackage = offering.lifetime,
+        ).productOfPackage()
+
+        assertThat(product.getValue("is_subscription").jsonPrimitive.boolean).isFalse()
+        assertThat(product).doesNotContainKey("period")
+        assertThat(product).doesNotContainKey("is_auto_renewing")
+    }
+
+    // --- device_meta ---
 
     @Test
     fun `device_meta carries host details`() {
         val before = System.currentTimeMillis()
 
-        val deviceMeta = webViewContextSnapshot(
-            customVariables = emptyMap(),
-            locale = "en-US",
-            darkMode = true,
-        )
-            .getValue("device_meta").jsonObject
+        val deviceMeta = testContextSnapshot(darkMode = true).getValue("device_meta").jsonObject
 
         assertThat(deviceMeta.getValue("is_preview").jsonPrimitive.boolean).isFalse()
         assertThat(deviceMeta.getValue("locale").jsonPrimitive.content).isEqualTo("en-US")
@@ -93,13 +225,39 @@ internal class WebViewContextSnapshotTest {
     }
 
     @Test
+    fun `package is the component's own when it sits inside a package, ignoring the selection`() {
+        val offering = TestData.template7CustomPackageOffering
+        val own = offering.availablePackages.first()
+        val selected = offering.availablePackages.last()
+        val state = FakePaywallState(packages = offering.availablePackages)
+            .apply { update(selectedPackageUniqueId = selected.identifier) }
+
+        val snapshot = webViewContextSnapshot(state, testWebViewStyle(rcPackage = own), darkMode = false)
+
+        assertThat(identifierOf(snapshot, "package")).isEqualTo(own.identifier)
+        assertThat(identifierOf(snapshot, "selected_package")).isEqualTo(selected.identifier)
+    }
+
+    @Test
+    fun `package follows the selection when the component is outside a package`() {
+        val offering = TestData.template7CustomPackageOffering
+        val selected = offering.availablePackages.last()
+        val state = FakePaywallState(packages = offering.availablePackages)
+            .apply { update(selectedPackageUniqueId = selected.identifier) }
+
+        val snapshot = webViewContextSnapshot(state, testWebViewStyle(rcPackage = null), darkMode = false)
+
+        assertThat(identifierOf(snapshot, "package")).isEqualTo(selected.identifier)
+    }
+
+    @Test
     fun `derives the custom variables from the paywall state`() {
         val state = FakePaywallState(
             components = emptyList(),
             customVariables = mapOf("org" to CustomVariableValue.String("RevenueCat")),
         )
 
-        val custom = webViewContextSnapshot(state, darkMode = false).getValue("custom").jsonObject
+        val custom = webViewContextSnapshot(state, testWebViewStyle(), darkMode = false).getValue("custom").jsonObject
 
         assertThat(custom.getValue("org").jsonPrimitive.content).isEqualTo("RevenueCat")
     }
@@ -107,9 +265,18 @@ internal class WebViewContextSnapshotTest {
     @Test
     fun `derives the locale from the paywall state as a BCP-47 tag`() {
         // The state carries the locale as an underscored `LocaleId`; the wire needs a tag.
-        val deviceMeta = webViewContextSnapshot(FakePaywallState(components = emptyList()), darkMode = false)
+        val deviceMeta = webViewContextSnapshot(FakePaywallState(components = emptyList()), testWebViewStyle(), darkMode = false)
             .getValue("device_meta").jsonObject
 
         assertThat(deviceMeta.getValue("locale").jsonPrimitive.content).isEqualTo("en-US")
     }
+
+    private fun snapshotWith(vararg variables: Pair<String, CustomVariableValue>) =
+        testContextSnapshot(customVariables = variables.toMap()).getValue("custom").jsonObject
+
+    private fun identifierOf(snapshot: JsonObject, key: String) =
+        snapshot.getValue(key).jsonObject.getValue("identifier").jsonPrimitive.content
+
+    private fun JsonObject.productOfPackage(): JsonObject =
+        getValue("package").jsonObject.getValue("products").jsonArray.single().jsonObject
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewJavaScriptBridgeTest.kt
@@ -610,7 +610,33 @@ internal class WebViewJavaScriptBridgeTest {
     }
 
     @Test
-    fun `builds the snapshot once per handshake`() {
+    fun `pushContextNow re-sends the snapshot once the channel is open`() {
+        val bridge = bridge()
+        bridge.connect()
+        val afterHandshake = scripts().size
+
+        bridge.pushContextNow()
+
+        assertThat(scripts()).hasSize(afterHandshake + 1)
+        assertThat(scripts().last()).contains("\"type\":\"context\"")
+    }
+
+    @Test
+    fun `pushContextNow is a no-op before the handshake and after release`() {
+        val beforeHandshake = bridge()
+        beforeHandshake.pushContextNow()
+        assertThat(scripts()).describedAs("before handshake").isEmpty()
+
+        beforeHandshake.connect()
+        val afterHandshake = scripts().size
+        beforeHandshake.release()
+        beforeHandshake.pushContextNow()
+
+        assertThat(scripts()).describedAs("after release").hasSize(afterHandshake)
+    }
+
+    @Test
+    fun `builds a fresh snapshot per delivery`() {
         var builds = 0
         val bridge = bridge(
             contextSnapshotProvider = {
@@ -619,8 +645,11 @@ internal class WebViewJavaScriptBridgeTest {
             },
         )
         bridge.connect()
+        assertThat(builds).describedAs("handshake").isEqualTo(1)
 
-        assertThat(builds).isEqualTo(1)
+        bridge.pushContextNow()
+
+        assertThat(builds).describedAs("re-push").isEqualTo(2)
     }
 
     // --- Document lifecycle ---

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewSnapshotFixture.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewSnapshotFixture.kt
@@ -1,13 +1,87 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.PricingPhase
+import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.SubscriptionOption
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.serialization.json.JsonObject
 
-/** A snapshot for tests that care about the frames, not the payload. */
+/** A snapshot for tests that care about one section, or about the frames rather than the payload. */
 internal fun testContextSnapshot(
     customVariables: Map<String, CustomVariableValue> = emptyMap(),
+    offering: Offering? = null,
+    componentPackage: Package? = null,
+    selectedPackage: Package? = null,
+    store: Store = Store.PLAY_STORE,
+    storefrontCountryCode: String? = "US",
+    locale: String = "en-US",
+    darkMode: Boolean = false,
 ): JsonObject = webViewContextSnapshot(
-    customVariables = customVariables,
-    locale = "en-US",
-    darkMode = false,
+    WebViewContextInput(
+        customVariables = customVariables,
+        offering = offering,
+        componentPackage = componentPackage,
+        selectedPackage = selectedPackage,
+        store = store,
+        storefrontCountryCode = storefrontCountryCode,
+        locale = locale,
+        darkMode = darkMode,
+    ),
+)
+
+/**
+ * A package on a prepaid base plan. `TestStoreProduct` always builds an `INFINITE_RECURRING` base
+ * pricing phase, so the non-renewing case has no fixture to reuse.
+ */
+internal fun prepaidPackage(): Package {
+    val period = Period.create("P1M")
+    val price = Price(formatted = "$2.99", amountMicros = 2_990_000L, currencyCode = "USD")
+    val basePhase = PricingPhase(
+        billingPeriod = period,
+        recurrenceMode = RecurrenceMode.NON_RECURRING,
+        billingCycleCount = null,
+        price = price,
+    )
+    val option = mockk<SubscriptionOption>()
+    // `fullPricePhase` derives from `pricingPhases` on the interface, but mockk stubs it as its own
+    // member, so stubbing the list alone leaves it unanswered.
+    every { option.pricingPhases } returns listOf(basePhase)
+    every { option.fullPricePhase } returns basePhase
+
+    val product = mockk<StoreProduct>()
+    every { product.id } returns "prepaid_monthly"
+    every { product.name } returns "Prepaid Monthly"
+    every { product.period } returns period
+    every { product.price } returns price
+    every { product.defaultOption } returns option
+
+    return Package(
+        identifier = "prepaid",
+        packageType = PackageType.MONTHLY,
+        product = product,
+        presentedOfferingContext = PresentedOfferingContext("offering"),
+    )
+}
+
+internal fun testWebViewStyle(rcPackage: Package? = null) = WebViewComponentStyle(
+    url = "https://assets.example.com/promo/index.html",
+    visible = true,
+    size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit()),
+    componentId = "promo_web_view",
+    overrides = emptyList(),
+    rcPackage = rcPackage,
+    tabIndex = null,
 )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.PurchaseResult
 import com.revenuecat.purchases.PurchasesAreCompletedBy
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
@@ -24,6 +25,7 @@ internal class MockPurchasesType(
     override val preferredUILocaleOverride: String? = null,
     override val purchasesAreCompletedBy: PurchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
     override val storefrontCountryCode: String? = null,
+    override val store: Store = Store.PLAY_STORE,
     override val customerCenterListener: CustomerCenterListener? = null,
 ) : PurchasesType {
     override suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult {


### PR DESCRIPTION
- Fills `offering`, `packages`, `package` and `selected_package`, so a custom component can render prices and react to which package the customer picked.
- Adds the re-push seam: `pushContextNow()` on the bridge, plus a `snapshotFlow` in `WebViewComponentView`. Before this the snapshot was only ever sent once, at the handshake.
- `is_auto_renewing` is omitted rather than guessed when the store data cannot determine it.
- Widens `Store.stringValue` to `@InternalRevenueCatAPI public` so the UI module can reuse the existing mapping. The public API dump is unchanged, since metalava hides that annotation.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

PWENG-201. A custom component that shows a price has to know which package it is showing, and has to be told again when the customer selects a different one. The snapshot from #4084 sends `offering: null` and an empty `packages`, and nothing pushes a new snapshot after the handshake.

### Description

- `offering`: `identifier`, and `display_name` from `Offering.serverDescription`, the key the offerings endpoint serves the dashboard display name under.
- `packages`: every package in `offering.availablePackages`, each with a single-element `products` array. Android has one product per package; the contract carries a list for stores that serve more.
- Per product: `identifier`, `display_name`, `is_subscription`, `period` as ISO 8601, `price` as a decimal amount plus currency, and `store` with `store_type` and the optional storefront `country`.
- `package` is the component's own package when it sits inside a package scope, and the current selection otherwise, mirroring what a text component in the same position resolves via `TextComponentState.applicablePackage`.
- `WebViewContextInput` groups the builder's arguments; every field is required, so a section added later cannot be forgotten at a call site.

**Not visible in the diff:** `is_auto_renewing` reads the recurrence mode of the base pricing phase of `defaultOption`, not the product type. `INFINITE_RECURRING` maps to `true`, `NON_RECURRING` (prepaid) to `false`, anything else is omitted. Trial and intro phases precede the base phase, so reading the first phase would report a free trial as non-renewing.

**Worth noting separately:** the re-push key includes the `PaywallState` instance itself, not just the selection, because the view model hands out a new instance whenever anything it was built from changes. Keying on the instance is what makes a custom-variable or offering change reach the content at all.

**Rejected:**

- Re-implementing the `Store` to wire-string mapping in the UI module. It already exists in `EntitlementInfo.kt` and a second copy would drift the moment a store is added.
- Reading the package through `WebViewComponentState`, whose providers close over the first `PaywallState`.

**Limitations:** `store.country` is absent when the storefront is unknown; it is mostly of use on iOS.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall WebView JS bridge behavior and product/pricing JSON sent to third-party bundles; mistakes could show wrong prices or stale selection, but scope is paywall UI rather than purchase/auth core.
> 
> **Overview**
> Paywall **web_view** custom components now receive a full **context** payload (not just custom variables and device meta): **offering**, **packages**, scoped **package**, **selected_package**, and per-product fields (price, store type/country, subscription period, **is_auto_renewing** when known).
> 
> **Context updates after the handshake:** `WebViewJavaScriptBridge.pushContextNow()` sends `type: context` frames, and `WebViewComponentView` watches paywall state / package selection via `snapshotFlow` so embedded content can react when the user picks a different package.
> 
> Snapshot building is centralized in **`WebViewContextInput`**; package scope follows the component’s `rcPackage` when inside a package row, otherwise the current selection (aligned with text components). **`PurchasesType.store`** and exposed **`storefrontCountryCode`** feed store metadata; **`Store.stringValue`** is widened to `@InternalRevenueCatAPI` so the UI reuses the core wire mapping without duplicating it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e67c7eda66044efbf4e15ccbc489f337cfdc7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->