### PR TITLE
feat(paywalls): send workflow and step identity to custom components

### DIFF
--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewTestSupport.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewTestSupport.kt
@@ -21,6 +21,7 @@ internal fun deviceContextSnapshot(
         selectedPackage = null,
         store = Store.PLAY_STORE,
         storefrontCountryCode = "US",
+        workflowScreen = null,
         locale = "en-US",
         darkMode = false,
     ),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -104,11 +104,9 @@ internal fun WebViewComponentView(
         // Remembered inside key(identity) so a stale onRelease can only release its own view's bridge.
         val bridgeHolder = remember { WebViewBridgeHolder() }
 
-        // The handshake seeds the first snapshot, so only later changes need a push. The state
-        // instance is part of the key because the view model replaces it for some changes and
-        // mutates it in place for others.
+        // The handshake seeds the first snapshot, so only later changes need a push.
         LaunchedEffect(bridgeHolder) {
-            snapshotFlow { listOf(currentState, currentState.selectedPackageInfo?.uniqueId) }
+            snapshotFlow { webViewContextPushKey(currentState, darkMode) }
                 .drop(1)
                 .collect { bridgeHolder.bridge?.pushContextNow() }
         }
@@ -250,6 +248,16 @@ internal fun resolveAxis(
         }
         is Fixed -> constraint
     }
+
+/**
+ * The state instance is part of the key because the view model replaces it for some changes
+ * (custom variables, offering, storefront country) and mutates it in place for others.
+ */
+@JvmSynthetic
+internal fun webViewContextPushKey(
+    state: PaywallState.Loaded.Components,
+    darkMode: Boolean,
+): List<Any?> = listOf(state, state.selectedPackageInfo?.uniqueId, state.locale, darkMode)
 
 /** Holds the per-WebView bridge so factory and onRelease share one instance. */
 internal class WebViewBridgeHolder {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextInput.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextInput.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowScreenContext
 
 /** Every field is required, so a section added later cannot be left empty at a call site. */
 internal data class WebViewContextInput(
@@ -14,6 +15,8 @@ internal data class WebViewContextInput(
     val selectedPackage: Package?,
     val store: Store,
     val storefrontCountryCode: String?,
+    /** `null` on a standalone paywall, where the contract omits the section entirely. */
+    val workflowScreen: WorkflowScreenContext?,
     /** A BCP-47 tag. The content SDK feeds it to `Intl`, which rejects the underscored form. */
     val locale: String,
     val darkMode: Boolean,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
@@ -12,8 +12,10 @@ import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowScreenContext
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
@@ -38,6 +40,7 @@ internal fun webViewContextSnapshot(
             selectedPackage = selectedPackage,
             store = state.store,
             storefrontCountryCode = state.storefrontCountryCode,
+            workflowScreen = state.workflowScreen,
             locale = state.locale.toLanguageTag(),
             darkMode = darkMode,
         ),
@@ -63,11 +66,22 @@ internal fun webViewContextSnapshot(input: WebViewContextInput): JsonObject = bu
     put(Keys.PACKAGE, input.componentPackage?.asJson(input) ?: JsonNull)
     put(Keys.SELECTED_PACKAGE, input.selectedPackage?.asJson(input) ?: JsonNull)
     putJsonObject(Keys.INPUTS) {}
+    input.workflowScreen?.let { putWorkflow(it) }
     putJsonObject(Keys.DEVICE_META) {
         put(Keys.IS_PREVIEW, false)
         put(Keys.LOCALE, input.locale)
         put(Keys.DARK_MODE, input.darkMode)
         put(Keys.UPDATED_AT, System.currentTimeMillis())
+    }
+}
+
+private fun JsonObjectBuilder.putWorkflow(workflowScreen: WorkflowScreenContext) {
+    putJsonObject(Keys.WORKFLOW) {
+        put(Keys.WORKFLOW_ID, workflowScreen.workflowId)
+        put(Keys.STEP_ID, workflowScreen.stepId)
+        put(Keys.STEP_TYPE, workflowScreen.stepType)
+        // The wire type has no null: an untagged step and one tagged with nothing look the same.
+        putJsonArray(Keys.SCREEN_TYPE) { workflowScreen.screenType?.forEach { add(it) } }
     }
 }
 
@@ -134,6 +148,12 @@ private object Keys {
     const val PRICE = "price"
     const val AMOUNT = "amount"
     const val CURRENCY = "currency"
+
+    const val WORKFLOW = "workflow"
+    const val WORKFLOW_ID = "workflow_id"
+    const val STEP_ID = "step_id"
+    const val STEP_TYPE = "step_type"
+    const val SCREEN_TYPE = "screen_type"
 }
 
 private val CustomVariableValue.asJsonPrimitive: JsonPrimitive

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -128,6 +128,7 @@ internal sealed interface PaywallState {
             initialSelectedTabIndex: Int? = null,
             initialSheetState: SimpleSheetState = SimpleSheetState(),
             private val purchases: PurchasesType,
+            val workflowScreen: WorkflowScreenContext? = null,
             /**
              * Presentation-session store for state-driven paywalls, seeded from the paywall's declared state defaults.
              */

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -1267,6 +1267,12 @@ internal class PaywallViewModelImpl(
             storefrontCountryCode = purchases.storefrontCountryCode,
             mode = options.mode,
             stateStore = stateStore,
+            workflowScreen = WorkflowScreenContext(
+                workflowId = workflow.id,
+                stepId = step.id,
+                stepType = step.type,
+                screenType = step.stepScreenType,
+            ),
         )
     }
 
@@ -1530,6 +1536,7 @@ internal class PaywallViewModelImpl(
         storefrontCountryCode: String?,
         mode: PaywallMode,
         stateStore: PaywallStateStore? = null,
+        workflowScreen: WorkflowScreenContext? = null,
     ): PaywallState {
         if (offering.availablePackages.isEmpty()) {
             return PaywallState.Error("No packages available")
@@ -1570,6 +1577,7 @@ internal class PaywallViewModelImpl(
                 defaultCustomVariables = extractDefaultCustomVariables(offering),
                 stateStore = stateStore,
                 viewModelActionInProgress = _actionInProgress,
+                workflowScreen = workflowScreen,
             )
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowScreenContext.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowScreenContext.kt
@@ -1,0 +1,10 @@
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+/** Each step's state carries its own, so a component reads the step it belongs to. */
+internal data class WorkflowScreenContext(
+    val workflowId: String,
+    val stepId: String,
+    val stepType: String,
+    /** `null` when the backend did not tag the step; see `WorkflowStep.stepScreenType`. */
+    val screenType: List<String>?,
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -48,6 +48,7 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallStateStore
 import com.revenuecat.purchases.ui.revenuecatui.data.PurchasesType
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowScreenContext
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PackageConfigurationType
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfigurationFactory
@@ -366,6 +367,7 @@ internal fun Offering.toComponentsPaywallState(
     storefrontCountryCode: String?,
     dateProvider: () -> Date,
     purchases: PurchasesType,
+    workflowScreen: WorkflowScreenContext? = null,
     customVariables: Map<String, CustomVariableValue> = emptyMap(),
     defaultCustomVariables: Map<String, CustomVariableValue> = emptyMap(),
     stateStore: PaywallStateStore? = null,
@@ -396,6 +398,7 @@ internal fun Offering.toComponentsPaywallState(
         packages = validationResult.packages,
         customVariables = customVariables,
         defaultCustomVariables = defaultCustomVariables,
+        workflowScreen = workflowScreen,
         initialSelectedTabIndex = validationResult.initialSelectedTabIndex,
         mainStackHasHeroImage = validationResult.mainStackHasHeroImage,
         purchases = purchases,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextPushKeyTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextPushKeyTest.kt
@@ -1,0 +1,136 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.webview
+
+import android.os.LocaleList as FrameworkLocaleList
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.intl.LocaleList
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.components.previewStackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
+import com.revenuecat.purchases.ui.revenuecatui.data.MockPurchasesType
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockResourceProvider
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptySetOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.Date
+
+/** A push that never fires is invisible in the bridge's own tests: the frames it sends are correct. */
+@RunWith(RobolectricTestRunner::class)
+internal class WebViewContextPushKeyTest {
+
+    @Test
+    fun `an unchanged state produces an equal key`() {
+        val state = paywallState()
+
+        assertThat(webViewContextPushKey(state, darkMode = false))
+            .isEqualTo(webViewContextPushKey(state, darkMode = false))
+    }
+
+    @Test
+    fun `a rebuilt state produces a different key`() {
+        val before = paywallState(customVariables = emptyMap())
+        val after = paywallState(
+            customVariables = mapOf("org" to CustomVariableValue.String("RevenueCat")),
+        )
+
+        assertThat(webViewContextPushKey(before, darkMode = false))
+            .isNotEqualTo(webViewContextPushKey(after, darkMode = false))
+    }
+
+    @Test
+    fun `a dark mode change produces a different key`() {
+        val state = paywallState()
+
+        assertThat(webViewContextPushKey(state, darkMode = false))
+            .isNotEqualTo(webViewContextPushKey(state, darkMode = true))
+    }
+
+    @Test
+    fun `switching to a localized locale produces a different key`() {
+        val state = paywallState()
+        val before = webViewContextPushKey(state, darkMode = false)
+
+        mutateState { state.update(localeList = FrameworkLocaleList.forLanguageTags("es-ES")) }
+
+        assertThat(webViewContextPushKey(state, darkMode = false)).isNotEqualTo(before)
+    }
+
+    @Test
+    fun `a locale the paywall has no dictionary for produces an equal key`() {
+        // The snapshot reports the locale actually rendered, which falls back to an available one.
+        val state = paywallState()
+        val before = webViewContextPushKey(state, darkMode = false)
+
+        mutateState { state.update(localeList = FrameworkLocaleList.forLanguageTags("de-DE")) }
+
+        assertThat(webViewContextPushKey(state, darkMode = false)).isEqualTo(before)
+    }
+
+    @Test
+    fun `selecting another package produces a different key`() {
+        val state = paywallState()
+        val before = webViewContextPushKey(state, darkMode = false)
+
+        mutateState { state.update(selectedPackageUniqueId = TestData.Packages.annual.identifier) }
+
+        assertThat(webViewContextPushKey(state, darkMode = false)).isNotEqualTo(before)
+    }
+
+    /**
+     * A write outside a composition lands in the global snapshot; without an apply it stays pending
+     * and every later Compose test in this JVM fails to reach idle.
+     */
+    private fun mutateState(block: () -> Unit) = Snapshot.withMutableSnapshot(block)
+
+    private fun paywallState(
+        customVariables: Map<String, CustomVariableValue> = emptyMap(),
+    ): PaywallState.Loaded.Components {
+        val packages = listOf(TestData.Packages.monthly, TestData.Packages.annual).map { pkg ->
+            PaywallState.Loaded.Components.AvailablePackages.Info(
+                pkg = pkg,
+                isSelectedByDefault = pkg == TestData.Packages.monthly,
+            )
+        }
+        return PaywallState.Loaded.Components(
+            stack = previewStackComponentStyle(children = emptyList()),
+            header = null,
+            stickyFooter = null,
+            background = BackgroundStyles.Color(color = ColorStyles(light = ColorStyle.Solid(Color.White))),
+            showPricesWithDecimals = true,
+            variableConfig = UiConfig.VariableConfig(
+                variableCompatibilityMap = emptyMap(),
+                functionCompatibilityMap = emptyMap(),
+            ),
+            variableDataProvider = VariableDataProvider(MockResourceProvider()),
+            offering = Offering(
+                identifier = "test-offering",
+                serverDescription = "description",
+                metadata = emptyMap(),
+                availablePackages = packages.map { it.pkg },
+                paywall = null,
+                paywallComponents = null,
+            ),
+            locales = nonEmptySetOf(LocaleId("en_US"), LocaleId("es_ES")),
+            storefrontCountryCode = "US",
+            dateProvider = { Date() },
+            packages = PaywallState.Loaded.Components.AvailablePackages(
+                packagesOutsideTabs = packages,
+                packagesByTab = emptyMap(),
+            ),
+            initialLocaleList = LocaleList("en-US"),
+            initialSelectedTabIndex = null,
+            purchases = MockPurchasesType(),
+            customVariables = customVariables,
+        )
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components.webview
 
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowScreenContext
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
 import kotlinx.serialization.json.Json
@@ -15,6 +16,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+
+private val prettyJson = Json { prettyPrint = true }
 
 internal class WebViewContextSnapshotTest {
 
@@ -37,6 +40,97 @@ internal class WebViewContextSnapshotTest {
         assertThat(snapshot.getValue("package")).isEqualTo(JsonNull)
         assertThat(snapshot.getValue("selected_package")).isEqualTo(JsonNull)
         assertThat(snapshot.getValue("inputs").jsonObject).isEmpty()
+    }
+
+    @Test
+    fun `serializes the whole payload in contract order`() {
+        val prepaid = prepaidPackage()
+
+        val snapshot = testContextSnapshot(
+            customVariables = mapOf("org" to CustomVariableValue.String("RevenueCat")),
+            offering = offeringOf(prepaid),
+            componentPackage = prepaid,
+            storefrontCountryCode = "ES",
+            workflowScreen = WorkflowScreenContext(
+                workflowId = "wf_123",
+                stepId = "step_paywall",
+                stepType = "screen",
+                screenType = listOf("paywall"),
+            ),
+        ).withFixedTimestamp()
+
+        assertThat(prettyJson.encodeToString(JsonObject.serializer(), snapshot)).isEqualTo(
+            """
+            {
+                "custom": {
+                    "org": "RevenueCat"
+                },
+                "offering": {
+                    "identifier": "promo",
+                    "display_name": "Promo offering"
+                },
+                "packages": [
+                    {
+                        "identifier": "prepaid",
+                        "products": [
+                            {
+                                "identifier": "prepaid_monthly",
+                                "store": {
+                                    "store_type": "play_store",
+                                    "country": "ES"
+                                },
+                                "display_name": "Prepaid Monthly",
+                                "is_subscription": true,
+                                "period": "P1M",
+                                "is_auto_renewing": false,
+                                "price": {
+                                    "amount": 2.99,
+                                    "currency": "USD"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "package": {
+                    "identifier": "prepaid",
+                    "products": [
+                        {
+                            "identifier": "prepaid_monthly",
+                            "store": {
+                                "store_type": "play_store",
+                                "country": "ES"
+                            },
+                            "display_name": "Prepaid Monthly",
+                            "is_subscription": true,
+                            "period": "P1M",
+                            "is_auto_renewing": false,
+                            "price": {
+                                "amount": 2.99,
+                                "currency": "USD"
+                            }
+                        }
+                    ]
+                },
+                "selected_package": null,
+                "inputs": {
+                },
+                "workflow": {
+                    "workflow_id": "wf_123",
+                    "step_id": "step_paywall",
+                    "step_type": "screen",
+                    "screen_type": [
+                        "paywall"
+                    ]
+                },
+                "device_meta": {
+                    "is_preview": false,
+                    "locale": "en-US",
+                    "dark_mode": false,
+                    "updated_at": 0
+                }
+            }
+            """.trimIndent(),
+        )
     }
 
     // --- custom ---
@@ -207,6 +301,44 @@ internal class WebViewContextSnapshotTest {
         assertThat(product.getValue("is_subscription").jsonPrimitive.boolean).isFalse()
         assertThat(product).doesNotContainKey("period")
         assertThat(product).doesNotContainKey("is_auto_renewing")
+    }
+
+    // --- workflow ---
+
+    @Test
+    fun `workflow is omitted on a standalone paywall`() {
+        assertThat(testContextSnapshot()).doesNotContainKey("workflow")
+    }
+
+    @Test
+    fun `workflow carries the step this state renders`() {
+        val workflow = testContextSnapshot(
+            workflowScreen = WorkflowScreenContext(
+                workflowId = "wf_123",
+                stepId = "step_paywall",
+                stepType = "screen",
+                screenType = listOf("paywall"),
+            ),
+        ).getValue("workflow").jsonObject
+
+        assertThat(Json.encodeToString(JsonObject.serializer(), workflow)).isEqualTo(
+            """{"workflow_id":"wf_123","step_id":"step_paywall","step_type":"screen","screen_type":["paywall"]}""",
+        )
+    }
+
+    @Test
+    fun `screen_type is an empty array for an untagged step`() {
+        // The wire type has no null; the untagged-vs-tagged-empty distinction is native-only.
+        val workflow = testContextSnapshot(
+            workflowScreen = WorkflowScreenContext(
+                workflowId = "wf_123",
+                stepId = "step_paywall",
+                stepType = "screen",
+                screenType = null,
+            ),
+        ).getValue("workflow").jsonObject
+
+        assertThat(workflow.getValue("screen_type").jsonArray).isEmpty()
     }
 
     // --- device_meta ---

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewSnapshotFixture.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewSnapshotFixture.kt
@@ -15,9 +15,12 @@ import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowScreenContext
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 
 /** A snapshot for tests that care about one section, or about the frames rather than the payload. */
 internal fun testContextSnapshot(
@@ -27,6 +30,7 @@ internal fun testContextSnapshot(
     selectedPackage: Package? = null,
     store: Store = Store.PLAY_STORE,
     storefrontCountryCode: String? = "US",
+    workflowScreen: WorkflowScreenContext? = null,
     locale: String = "en-US",
     darkMode: Boolean = false,
 ): JsonObject = webViewContextSnapshot(
@@ -37,6 +41,7 @@ internal fun testContextSnapshot(
         selectedPackage = selectedPackage,
         store = store,
         storefrontCountryCode = storefrontCountryCode,
+        workflowScreen = workflowScreen,
         locale = locale,
         darkMode = darkMode,
     ),
@@ -84,4 +89,20 @@ internal fun testWebViewStyle(rcPackage: Package? = null) = WebViewComponentStyl
     overrides = emptyList(),
     rcPackage = rcPackage,
     tabIndex = null,
+)
+
+internal fun offeringOf(vararg packages: Package): Offering = Offering(
+    identifier = "promo",
+    serverDescription = "Promo offering",
+    metadata = emptyMap(),
+    availablePackages = packages.toList(),
+)
+
+/** Pins the one value that moves, so a whole payload can be compared as a single string. */
+internal fun JsonObject.withFixedTimestamp(): JsonObject = JsonObject(
+    toMutableMap().apply {
+        val deviceMeta = getValue("device_meta").jsonObject.toMutableMap()
+        deviceMeta["updated_at"] = JsonPrimitive(0)
+        put("device_meta", JsonObject(deviceMeta))
+    },
 )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -582,6 +582,38 @@ class PaywallViewModelWorkflowTest {
     }
 
     @Test
+    fun `each step's state carries the identity of the step it renders`() {
+        val wfl = workflow.copy(
+            steps = mapOf(
+                "step-1" to step1.copy(metadata = screenTypeMetadata(WorkflowScreenType.PAYWALL)),
+                "step-2" to step2.copy(type = "survey"),
+            ),
+        )
+        val vm = createVm()
+        vm.startWorkflowPresentationFromResult(wfl, testOfferings, null, uiConfig)
+
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        vm.onTransitionComplete(vm.workflowState.value!!.pendingTransition!!.id)
+
+        assertThat(vm.workflowScreenOf("step-1")).isEqualTo(
+            WorkflowScreenContext(
+                workflowId = "wfl-test",
+                stepId = "step-1",
+                stepType = "screen",
+                screenType = listOf(WorkflowScreenType.PAYWALL),
+            ),
+        )
+        assertThat(vm.workflowScreenOf("step-2")).isEqualTo(
+            WorkflowScreenContext(
+                workflowId = "wfl-test",
+                stepId = "step-2",
+                stepType = "survey",
+                screenType = null,
+            ),
+        )
+    }
+
+    @Test
     fun `back navigation returns step state with the selection the user left on it`() {
         val (fetchResult2, offerings2) = makeTwoPackageWorkflow()
         val vm = createVm()
@@ -2308,6 +2340,9 @@ class PaywallViewModelWorkflowTest {
 
     private fun List<FeatureEvent>.paywallEventsOfType(type: PaywallEventType) =
         filterIsInstance<PaywallEvent>().filter { it.type == type }
+
+    private fun PaywallViewModelImpl.workflowScreenOf(stepId: String): WorkflowScreenContext? =
+        workflowState.value?.stepStates?.get(stepId)?.workflowScreen
 
     @Test
     fun `step tagged paywall reports impression and close`() = runTest {


### PR DESCRIPTION
- Adds the `workflow` section: `workflow_id`, `step_id`, `step_type` and `screen_type`, so a custom component inside a workflow can tell which step it is on.
- Extends the re-push to locale and dark mode changes.
- With this PR the contract on https://github.com/RevenueCat/docs/pull/1874 is finished

[untitled.webm](https://github.com/user-attachments/assets/27039e9b-0057-4bad-ba75-165fe482a571)


### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

PWENG-202. Workflow identity is the one part of the snapshot that was not reachable from a rendered component at all. Composables only receive a bare `currentStepId` through `WorkflowPaywallUiState`; the workflow id, step type and screen type stay private to the view model, so this is mostly plumbing.

### Description

- `WorkflowScreenContext` is built in `PaywallViewModel.computeStateForStep`, the one place holding both the `PublishedWorkflow` and the `WorkflowStep`, and passed to `PaywallState.Loaded.Components`. It is `null` for a standalone paywall.
- Each step already gets its own state instance from `workflowStepStateCache`, so a component in step N reads step N's identity rather than whichever step is on screen.
- The re-push key gains locale and dark mode.

**Not visible in the diff:** the two new re-push triggers behave differently underneath, and reading through `rememberUpdatedState(state)` covers both. A locale change mutates the existing state instance in place; a colour-scheme change clears `workflowStepStateCache` and rebuilds fresh instances.

**Worth noting separately:** `screen_type` is always an array, empty when the backend did not tag the step. Internally the untagged case is `null`, which matters for native paywall-event gating, but that distinction does not exist in the wire contract.

Locale is also the one input where a change may legitimately *not* push: `toLocaleId()` resolves to the first locale the paywall has a dictionary for, so switching to an unlocalized locale changes nothing the content would see. Both cases are covered.

**Regression gate:** `WebViewContextPushKeyTest`. The push key is extracted to a testable function specifically so it has one; an earlier version omitted the state instance, which meant custom variable changes never pushed at all.

**Rejected:**

- A new `CompositionLocal` for the workflow context: the `AGENTS.md` guardrail forbids adding them.
- Threading the extra parameters through the generic `ComponentView`: every component type would pay for a field one of them uses.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JSON and paywall-state plumbing for workflow WebViews; standalone paywalls omit `workflow` and behavior is covered by new unit tests.
> 
> **Overview**
> Workflow funnels now expose **which step** a custom WebView component is rendering on, completing the custom-component context contract (docs#1874).
> 
> **Workflow identity in paywall state and WebView context:** Introduces `WorkflowScreenContext` and threads it from `PaywallViewModel.computeStateForStep` into each cached `PaywallState.Loaded.Components` (null for standalone paywalls). The WebView handshake/push JSON gains an optional `workflow` object (`workflow_id`, `step_id`, `step_type`, `screen_type` as an array—empty when the step is untagged).
> 
> **Smarter context re-pushes:** `WebViewComponentView` uses a testable `webViewContextPushKey` so the bridge pushes again when paywall state is replaced, package selection changes, **resolved locale** changes, or **dark mode** changes—without treating unsupported device locales as a push when the rendered locale is unchanged.
> 
> Unit tests cover snapshot shape, push-key behavior, and per-step `workflowScreen` on the view model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f75ee9c33618c455f9366604b90cb576ce94b0b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->