### PR TITLE
Read the reshaped audiences topic: static default blob + backend predicate results

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -44,6 +44,7 @@ import kotlinx.serialization.json.JsonPrimitive
  * [SIMULATED_ERROR_CHECKPOINT_ID] is the one piece of PoC scaffolding left: it is the only way for the tester
  * apps to exercise the throw path, since nothing in the config-driven path throws.
  */
+@Suppress("TooManyFunctions")
 internal class CheckpointWorkflowResolverImpl(
     private val workflowManager: WorkflowManager,
     private val uiConfigProvider: UiConfigProvider,
@@ -87,14 +88,7 @@ internal class CheckpointWorkflowResolverImpl(
             CheckpointRulesResolution.Unavailable ->
                 return configurationUnavailable("The rules for checkpoint '$identifier' could not be read.")
         }
-        val matchResult = localRulesEvaluator.match(
-            rules = rulesResolution.checkpoint.rules,
-            customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
-        ) { rule ->
-            audiencesConfigProvider.getAudience(rule.audienceId)
-                ?.let { audience -> Result.success(audience.rules) }
-                ?: Result.failure(AudienceUnavailableException(rule.audienceId))
-        }
+        val matchResult = matchRule(audiencesConfigProvider, rulesResolution.checkpoint.rules, customVariables)
         // An audience the SDK failed to evaluate is not the same answer as an audience the customer is outside of,
         // so it can't report NO_MATCH.
         val rule = matchResult.getOrElse { error ->
@@ -114,6 +108,32 @@ internal class CheckpointWorkflowResolverImpl(
         } ?: return configurationUnavailable("UI config is unavailable for checkpoint '$identifier'.")
         val result = resolveRule(identifier, workflowManager, rule, uiConfig)
         return result.takeIf { checkpointsConfigProvider.isCurrent(rulesResolution) }
+    }
+
+    /**
+     * The whole audiences topic is read once as a snapshot, so every rule is matched against audiences and
+     * backend predicate results from the same committed config, and matching itself never re-reads config.
+     */
+    @Suppress("ReturnCount")
+    private suspend fun matchRule(
+        audiencesConfigProvider: AudiencesConfigProvider,
+        rules: List<CheckpointRule>,
+        customVariables: Map<String, RulesDimensionValue>,
+    ): Result<CheckpointRule?> {
+        if (rules.isEmpty()) return Result.success(null)
+        val snapshot = audiencesConfigProvider.getSnapshot()
+            ?: return Result.failure(AudiencesUnavailableException())
+        return localRulesEvaluator.match(
+            rules = rules,
+            customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
+            backendValues = snapshot.backendPredicateResults.mapValues { (_, result) ->
+                RulesDimensionValue.BoolValue(result)
+            },
+        ) { rule ->
+            snapshot.audiences[rule.audienceId]
+                ?.let { audience -> Result.success(audience.rules) }
+                ?: Result.failure(AudienceUnavailableException(rule.audienceId))
+        }
     }
 
     @Suppress("ReturnCount")
@@ -225,6 +245,9 @@ internal class CheckpointWorkflowResolverImpl(
 
     private class AudienceUnavailableException(identifier: String) :
         Exception("audience '$identifier' could not be read")
+
+    private class AudiencesUnavailableException :
+        Exception("the audiences configuration could not be read")
 
     private companion object {
         const val SIMULATED_ERROR_CHECKPOINT_ID = "error_checkpoint"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -89,6 +89,10 @@ internal class CheckpointWorkflowResolverImpl(
                 return configurationUnavailable("The rules for checkpoint '$identifier' could not be read.")
         }
         val matchResult = matchRule(audiencesConfigProvider, rulesResolution.checkpoint.rules, customVariables)
+        // Checked before the result is unwrapped: a match that failed against a generation that moved mid-read
+        // (audiences read from a later commit than the rules) is stale rather than authoritative, and deserves
+        // the retry as much as a stale success does.
+        if (!checkpointsConfigProvider.isCurrent(rulesResolution)) return null
         // An audience the SDK failed to evaluate is not the same answer as an audience the customer is outside of,
         // so it can't report NO_MATCH.
         val rule = matchResult.getOrElse { error ->
@@ -96,7 +100,6 @@ internal class CheckpointWorkflowResolverImpl(
                 "The audiences for checkpoint '$identifier' could not be evaluated: ${error.message}",
             )
         }
-        if (!checkpointsConfigProvider.isCurrent(rulesResolution)) return null
         if (rule == null) return noMatch(identifier)
         val uiConfig = try {
             uiConfigProvider.getUiConfig()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -126,9 +126,7 @@ internal class CheckpointWorkflowResolverImpl(
         return localRulesEvaluator.match(
             rules = rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
-            backendValues = snapshot.backendPredicateResults.mapValues { (_, result) ->
-                RulesDimensionValue.BoolValue(result)
-            },
+            backendValues = snapshot.backendPredicateResults,
         ) { rule ->
             snapshot.audiences[rule.audienceId]
                 ?.let { audience -> Result.success(audience.rules) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
@@ -1,16 +1,26 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
 package com.revenuecat.purchases.common.audiences
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.localrules.RulesDimensionValue
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.readConsistent
 import com.revenuecat.purchases.common.warnLog
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.longOrNull
 
 /**
  * The audiences topic as of one read: the audience dictionary from the static `default` blob together with the
@@ -20,7 +30,7 @@ import kotlinx.serialization.json.jsonObject
  */
 internal data class AudiencesSnapshot(
     val audiences: Map<String, Audience>,
-    val backendPredicateResults: Map<String, Boolean>,
+    val backendPredicateResults: Map<String, RulesDimensionValue>,
 )
 
 internal class AudiencesConfigProvider(
@@ -67,17 +77,17 @@ internal class AudiencesConfigProvider(
         }.toMap()
     }
 
-    private suspend fun backendPredicateResults(): Map<String, Boolean> {
+    private suspend fun backendPredicateResults(): Map<String, RulesDimensionValue> {
         val metadata = manager.topic(RemoteConfigTopic.Audiences)
             ?.get(ITEM_BACKEND_PREDICATE_RESULTS)
             ?.metadata
             ?: return emptyMap()
         return metadata.mapNotNull { (hash, element) ->
-            val result = (element as? JsonPrimitive)?.takeUnless { it.isString }?.booleanOrNull
+            val result = element.asRulesDimensionValue()
             if (result == null) {
                 // Rules read these with a default (`{"var": ["backend.<hash>", false]}`), so a value shape this
-                // SDK version does not understand degrades to the rule's default instead of failing the item.
-                warnLog { "Ignoring backend predicate result '$hash': its value is not a boolean." }
+                // SDK version cannot represent degrades to the rule's default instead of failing the item.
+                warnLog { "Ignoring backend predicate result '$hash': its value can't be read by a rule." }
                 null
             } else {
                 hash to result
@@ -89,4 +99,27 @@ internal class AudiencesConfigProvider(
         const val ITEM_DEFAULT = "default"
         const val ITEM_BACKEND_PREDICATE_RESULTS = "backend_predicate_results"
     }
+}
+
+/**
+ * `null` for a value no rule could read: an explicit JSON `null` (no value to compare) or an array of anything
+ * but objects ([RulesDimensionValue.ObjectListValue] is the only collection a dimension can be). An entry an
+ * object holds that can't be read is dropped from it, mirroring how absent record values behave.
+ */
+private fun JsonElement.asRulesDimensionValue(): RulesDimensionValue? = when (this) {
+    is JsonNull -> null
+    is JsonPrimitive -> when {
+        isString -> RulesDimensionValue.StringValue(content)
+        else -> booleanOrNull?.let { RulesDimensionValue.BoolValue(it) }
+            ?: longOrNull?.let { RulesDimensionValue.IntValue(it) }
+            ?: doubleOrNull?.let { RulesDimensionValue.DoubleValue(it) }
+    }
+    is JsonObject -> RulesDimensionValue.ObjectValue(
+        mapNotNull { (name, element) -> element.asRulesDimensionValue()?.let { name to it } }.toMap(),
+    )
+    is JsonArray -> map { element -> (element as? JsonObject)?.asRulesDimensionValue() }
+        .takeIf { records -> records.all { it is RulesDimensionValue.ObjectValue } }
+        ?.let { records ->
+            RulesDimensionValue.ObjectListValue(records.map { (it as RulesDimensionValue.ObjectValue).value })
+        }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
@@ -5,23 +5,88 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.readConsistent
+import com.revenuecat.purchases.common.warnLog
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * The audiences topic as of one read: the audience dictionary from the static `default` blob together with the
+ * `backend_predicate_results` the backend committed alongside it. Rules in [audiences] read
+ * [backendPredicateResults] under `backend.*`, so consumers must evaluate the two together rather than
+ * re-reading either on its own.
+ */
+internal data class AudiencesSnapshot(
+    val audiences: Map<String, Audience>,
+    val backendPredicateResults: Map<String, Boolean>,
+)
 
 internal class AudiencesConfigProvider(
     private val manager: RemoteConfigManager,
 ) {
-    suspend fun getAudience(identifier: String): Audience? =
-        manager.readConsistent(what = { "audience '$identifier'" }) { _ ->
-            val metadata = manager.topic(RemoteConfigTopic.Audiences)
-                ?.get(identifier)
-                ?.metadata
+    /**
+     * The current audiences topic, or `null` when the topic, its `default` item, or that item's blob is
+     * unavailable. Both parts are read under one config generation: [readConsistent] re-reads them once if a
+     * commit races the read, and gives up with `null` if that read is superseded too.
+     */
+    suspend fun getSnapshot(): AudiencesSnapshot? =
+        manager.readConsistent(what = { "the audiences topic" }) { _ ->
+            val audiences = manager.blobData(RemoteConfigTopic.Audiences, ITEM_DEFAULT, ::parseAudiences)
                 ?: return@readConsistent null
+            AudiencesSnapshot(
+                audiences = audiences,
+                backendPredicateResults = backendPredicateResults(),
+            )
+        }
+
+    /**
+     * An audience that does not parse is dropped rather than failing the whole blob, so one audience on a shape
+     * this SDK version does not understand cannot make every other audience unreadable. A rule that references
+     * the dropped audience still fails to resolve, which is the honest answer for that rule alone.
+     */
+    @Suppress("ReturnCount")
+    private fun parseAudiences(bytes: ByteArray): Map<String, Audience>? {
+        val entries = try {
+            JsonTools.json.parseToJsonElement(bytes.decodeToString()).jsonObject
+        } catch (e: SerializationException) {
+            errorLog(e) { "Failed to parse the audiences blob as JSON." }
+            return null
+        } catch (e: IllegalArgumentException) {
+            errorLog(e) { "The audiences blob is not a JSON object." }
+            return null
+        }
+        return entries.mapNotNull { (identifier, element) ->
             try {
-                JsonTools.json.decodeFromJsonElement<Audience>(metadata)
+                identifier to JsonTools.json.decodeFromJsonElement<Audience>(element)
             } catch (e: SerializationException) {
-                errorLog(e) { "Failed to parse remote config metadata for audience '$identifier' as JSON." }
+                errorLog(e) { "Ignoring audience '$identifier' in the audiences blob: it could not be parsed." }
                 null
             }
-        }
+        }.toMap()
+    }
+
+    private suspend fun backendPredicateResults(): Map<String, Boolean> {
+        val metadata = manager.topic(RemoteConfigTopic.Audiences)
+            ?.get(ITEM_BACKEND_PREDICATE_RESULTS)
+            ?.metadata
+            ?: return emptyMap()
+        return metadata.mapNotNull { (hash, element) ->
+            val result = (element as? JsonPrimitive)?.takeUnless { it.isString }?.booleanOrNull
+            if (result == null) {
+                // Rules read these with a default (`{"var": ["backend.<hash>", false]}`), so a value shape this
+                // SDK version does not understand degrades to the rule's default instead of failing the item.
+                warnLog { "Ignoring backend predicate result '$hash': its value is not a boolean." }
+                null
+            } else {
+                hash to result
+            }
+        }.toMap()
+    }
+
+    private companion object {
+        const val ITEM_DEFAULT = "default"
+        const val ITEM_BACKEND_PREDICATE_RESULTS = "backend_predicate_results"
+    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -43,21 +43,26 @@ internal class LocalRulesEvaluator(
      *
      * When a predicate must be resolved before it can be evaluated, a resolution failure fails the call immediately.
      * [customVariables] are the caller's own values for this evaluation, readable under `custom.*`.
+     * [backendValues] are the backend's pre-evaluated predicate results for this evaluation, readable under
+     * `backend.*`; the caller supplies them alongside the rules they were committed with, so both reflect the
+     * same remote config state.
      */
     suspend fun <Rule : LocalRule> match(
         rules: List<Rule>,
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
-    ): Result<Rule?> = match(rules, customVariables) { rule -> Result.success(rule.predicate) }
+        backendValues: Map<String, RulesDimensionValue> = emptyMap(),
+    ): Result<Rule?> = match(rules, customVariables, backendValues) { rule -> Result.success(rule.predicate) }
 
     @Suppress("ReturnCount")
     suspend fun <Rule> match(
         rules: List<Rule>,
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
+        backendValues: Map<String, RulesDimensionValue> = emptyMap(),
         predicateFor: suspend (Rule) -> Result<String>,
     ): Result<Rule?> {
         if (rules.isEmpty()) return Result.success(null)
 
-        val snapshot = dimensionResolver.snapshot(customVariables).fold(
+        val snapshot = dimensionResolver.snapshot(customVariables, backendValues).fold(
             onSuccess = { snapshot -> snapshot },
             onFailure = { error ->
                 return Result.failure(LocalRulesEvaluationException.DimensionResolution(error))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -14,6 +14,9 @@ import java.util.Date
  * `device`, it is never a literal key.
  */
 internal enum class RulesDimensionNamespace(val key: String) {
+    /** Predicate results pre-evaluated by the backend, supplied per evaluation; see [LocalRulesEvaluator.match]. */
+    Backend("backend"),
+
     /** Values supplied by the caller for one evaluation; see [LocalRulesEvaluator.match]. */
     Custom("custom"),
     Device("device"),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -48,11 +48,13 @@ internal class RulesDimensionResolver(
 
     /**
      * [customVariables] are the caller's own values for this one evaluation, exposed under
-     * [RulesDimensionNamespace.Custom].
+     * [RulesDimensionNamespace.Custom]. [backendValues] are the backend's pre-evaluated values for this one
+     * evaluation, exposed under [RulesDimensionNamespace.Backend].
      */
     @Suppress("ReturnCount")
     suspend fun snapshot(
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
+        backendValues: Map<String, RulesDimensionValue> = emptyMap(),
     ): Result<RulesDimensionSnapshot> {
         val date = dateProvider.now
         val values = mutableMapOf<String, MutableMap<String, Value>>()
@@ -76,6 +78,10 @@ internal class RulesDimensionResolver(
         }
 
         values.addDimensions(RulesDimensionNamespace.Custom, customVariables)?.let { conflict ->
+            return Result.failure(conflict)
+        }
+
+        values.addDimensions(RulesDimensionNamespace.Backend, backendValues)?.let { conflict ->
             return Result.failure(conflict)
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -116,9 +116,11 @@ private fun MutableMap<String, MutableMap<String, Value>>.addDimensions(
 }
 
 /**
- * Drops the names no predicate could ever read. The engine's `var` walks a strict dot-path, so a name containing a
- * `.` would be read as a path through a nested object that does not exist, and an empty one is not a name a
- * predicate can be written against.
+ * Drops the names no predicate could ever read, at any depth. The engine's `var` walks a strict dot-path, so a
+ * name containing a `.` would be read as a path through a nested object that does not exist, and an empty one is
+ * not a name a predicate can be written against. Names inside [RulesDimensionValue.ObjectValue] and
+ * [RulesDimensionValue.ObjectListValue] records are one `var` path segment each, so the same rule applies to
+ * them, one entry at a time.
  *
  * Dropped rather than failing the snapshot, unlike this resolver's other two rejections: a namespace like
  * [RulesDimensionNamespace.SubscriberAttributes] is named by the app, so a single attribute the SDK cannot expose
@@ -127,15 +129,28 @@ private fun MutableMap<String, MutableMap<String, Value>>.addDimensions(
  */
 private fun Map<String, RulesDimensionValue>.filterReachable(
     namespace: RulesDimensionNamespace,
-): Map<String, RulesDimensionValue> = filterKeys { name ->
-    (name.isNotEmpty() && !name.contains(DIMENSION_PATH_SEPARATOR)).also { reachable ->
-        if (!reachable) {
-            warnLog {
-                "Ignoring dimension '${namespace.key}.$name': a dimension name can't be empty or contain " +
-                    "'$DIMENSION_PATH_SEPARATOR'."
-            }
+): Map<String, RulesDimensionValue> = filterReachable(parentPath = namespace.key)
+
+private fun Map<String, RulesDimensionValue>.filterReachable(
+    parentPath: String,
+): Map<String, RulesDimensionValue> = mapNotNull { (name, value) ->
+    val path = "$parentPath$DIMENSION_PATH_SEPARATOR$name"
+    if (name.isEmpty() || name.contains(DIMENSION_PATH_SEPARATOR)) {
+        warnLog {
+            "Ignoring dimension '$path': a dimension name can't be empty or contain '$DIMENSION_PATH_SEPARATOR'."
         }
+        null
+    } else {
+        name to value.filterReachable(path)
     }
+}.toMap()
+
+private fun RulesDimensionValue.filterReachable(path: String): RulesDimensionValue = when (this) {
+    is RulesDimensionValue.ObjectValue -> RulesDimensionValue.ObjectValue(value.filterReachable(path))
+    is RulesDimensionValue.ObjectListValue -> RulesDimensionValue.ObjectListValue(
+        value.mapIndexed { index, record -> record.filterReachable("$path$DIMENSION_PATH_SEPARATOR$index") },
+    )
+    else -> this
 }
 
 private const val DIMENSION_PATH_SEPARATOR = '.'

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -435,7 +435,7 @@ class CheckpointWorkflowResolverImplTest {
                     {"==": [{"var": "custom.country"}, "PL"]}
                 ]}""",
             ),
-            backendPredicateResults = mapOf(BACKEND_PREDICATE_HASH to true),
+            backendPredicateResults = mapOf(BACKEND_PREDICATE_HASH to RulesDimensionValue.BoolValue(true)),
         )
 
         assertThat(resolve()).isInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
@@ -445,10 +445,20 @@ class CheckpointWorkflowResolverImplTest {
     fun `a false backend predicate result resolves NoAction with NO_MATCH`() = runTest {
         configureAudiences(
             Audience("aud_wf1234", """{"var": ["backend.$BACKEND_PREDICATE_HASH", false]}"""),
-            backendPredicateResults = mapOf(BACKEND_PREDICATE_HASH to false),
+            backendPredicateResults = mapOf(BACKEND_PREDICATE_HASH to RulesDimensionValue.BoolValue(false)),
         )
 
         assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
+    }
+
+    @Test
+    fun `a non-boolean backend predicate result is compared like any other dimension`() = runTest {
+        configureAudiences(
+            Audience("aud_wf1234", """{"==": [{"var": ["backend.$BACKEND_PREDICATE_HASH", ""]}, "variant_b"]}"""),
+            backendPredicateResults = mapOf(BACKEND_PREDICATE_HASH to RulesDimensionValue.StringValue("variant_b")),
+        )
+
+        assertThat(resolve()).isInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
     }
 
     @Test
@@ -637,7 +647,7 @@ class CheckpointWorkflowResolverImplTest {
 
     private fun configureAudiences(
         vararg audiences: Audience,
-        backendPredicateResults: Map<String, Boolean> = emptyMap(),
+        backendPredicateResults: Map<String, RulesDimensionValue> = emptyMap(),
     ) {
         coEvery { mockAudiencesConfigProvider.getSnapshot() } returns AudiencesSnapshot(
             audiences = audiences.associateBy { it.id },

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -236,6 +236,46 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
+    fun `config changing during a failed audiences read is retried`() = runTest {
+        // A snapshot that could not be read while the generation moved is stale, not authoritative: the commit
+        // that moved the generation is the likely reason the read failed, so the retry gets a consistent view.
+        var generation = 0
+        var snapshotReads = 0
+        configureRulesReadAt { generation }
+        coEvery { mockAudiencesConfigProvider.getSnapshot() } answers {
+            if (snapshotReads++ == 0) {
+                generation++
+                null
+            } else {
+                AudiencesSnapshot(
+                    audiences = mapOf("aud_wf1234" to alwaysMatching("aud_wf1234")),
+                    backendPredicateResults = emptyMap(),
+                )
+            }
+        }
+
+        assertThat(resolve()).isInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
+    }
+
+    @Test
+    fun `config changing during every failed audiences read is configuration unavailable after one retry`() =
+        runTest {
+            var generation = 0
+            var snapshotReads = 0
+            configureRulesReadAt { generation }
+            coEvery { mockAudiencesConfigProvider.getSnapshot() } answers {
+                snapshotReads++
+                generation++
+                null
+            }
+
+            assertThat(noActionReason(resolve()))
+                .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+            // Two resolution attempts, no more: a burst of commits can't keep resolution spinning.
+            assertThat(snapshotReads).isEqualTo(2)
+        }
+
+    @Test
     fun `config changing once while resolving the workflow is retried`() = runTest {
         var generation = 0
         var workflowFetches = 0

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.audiences.Audience
 import com.revenuecat.purchases.common.audiences.AudiencesConfigProvider
+import com.revenuecat.purchases.common.audiences.AudiencesSnapshot
 import com.revenuecat.purchases.common.checkpoints.CheckpointResponse
 import com.revenuecat.purchases.common.checkpoints.CheckpointRule
 import com.revenuecat.purchases.common.checkpoints.CheckpointRulesResolution
@@ -59,6 +60,10 @@ class CheckpointWorkflowResolverImplTest {
 
     private val checkpointId = "test_checkpoint"
 
+    private companion object {
+        const val BACKEND_PREDICATE_HASH = "349OzehoTyCAdiZblj9w0J0yD-Uow8X3"
+    }
+
     private lateinit var mockWorkflowManager: WorkflowManager
     private lateinit var mockUiConfigProvider: UiConfigProvider
     private lateinit var mockCheckpointsConfigProvider: CheckpointsConfigProvider
@@ -89,10 +94,13 @@ class CheckpointWorkflowResolverImplTest {
         every { mockWorkflowManager.prewarmWorkflowAssets(any(), any()) } just Runs
         coEvery { mockUiConfigProvider.getUiConfig() } returns mockUiConfig
         every { mockOfferings.all } returns mapOf("default" to mockOffering)
-        coEvery { mockAudiencesConfigProvider.getAudience(any()) } answers {
-            val audienceId = firstArg<String>()
-            Audience(id = audienceId, rules = "true")
-        }
+        configureAudiences(
+            alwaysMatching("aud_wf1234"),
+            alwaysMatching("aud_wf5678"),
+            alwaysMatching("aud_wf-ui"),
+            alwaysMatching("aud_wf-offering"),
+            alwaysMatching("aud_wf-invalid"),
+        )
         every { mockCheckpointsConfigProvider.isCurrent(any()) } returns true
         configureRules(rule("wf1234"))
         resolver = CheckpointWorkflowResolverImpl(
@@ -135,7 +143,7 @@ class CheckpointWorkflowResolverImplTest {
 
         assertThat(noActionReason(resolve()))
             .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
-        coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience(any()) }
+        coVerify(exactly = 0) { mockAudiencesConfigProvider.getSnapshot() }
     }
 
     @Test
@@ -144,6 +152,8 @@ class CheckpointWorkflowResolverImplTest {
 
         assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
         assertThat(offeringsFetched).isZero()
+        // With no rules to match, there is nothing to read the audiences for.
+        coVerify(exactly = 0) { mockAudiencesConfigProvider.getSnapshot() }
     }
 
     @Test
@@ -186,10 +196,10 @@ class CheckpointWorkflowResolverImplTest {
     @Test
     fun `the first matching audience determines the workflow`() = runTest {
         configureRules(rule("wf5678"), rule("wf1234"))
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf5678") } returns
-            Audience("aud_wf5678", "false")
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
-            Audience("aud_wf1234", "true")
+        configureAudiences(
+            Audience("aud_wf5678", "false"),
+            Audience("aud_wf1234", "true"),
+        )
 
         val resolution = resolve() as CheckpointResolution.MatchedWorkflow
 
@@ -197,31 +207,32 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
-    fun `config changing once during audience evaluation is retried`() = runTest {
+    fun `config changing once during the audiences read is retried`() = runTest {
         val generation = AtomicInteger(1)
-        val audienceReads = AtomicInteger(0)
+        val snapshotReads = AtomicInteger(0)
         resolver = resolverBackedBy(
-            stalenessManager(generation) { if (audienceReads.getAndIncrement() == 0) generation.incrementAndGet() },
+            stalenessManager(generation) { if (snapshotReads.getAndIncrement() == 0) generation.incrementAndGet() },
         )
 
         assertThat(resolve()).isInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
     }
 
     @Test
-    fun `config changing on every audience evaluation is configuration unavailable after one retry`() = runTest {
+    fun `config changing on every audiences read is configuration unavailable after one retry`() = runTest {
         val generation = AtomicInteger(1)
-        val audienceReads = AtomicInteger(0)
+        val snapshotReads = AtomicInteger(0)
         resolver = resolverBackedBy(
             stalenessManager(generation) {
-                audienceReads.incrementAndGet()
+                snapshotReads.incrementAndGet()
                 generation.incrementAndGet()
             },
         )
 
         assertThat(noActionReason(resolve()))
             .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
-        // Two resolution attempts, no more: a burst of commits can't keep resolution spinning.
-        assertThat(audienceReads.get()).isEqualTo(2)
+        // Two resolution attempts, each reading the snapshot twice (its own consistent re-read), and no more: a
+        // burst of commits can't keep resolution spinning.
+        assertThat(snapshotReads.get()).isEqualTo(4)
     }
 
     @Test
@@ -253,29 +264,39 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
-    fun `audiences after the first match are not loaded`() = runTest {
+    fun `rules after the first match do not need their audience`() = runTest {
         configureRules(rule("wf1234"), rule("wf5678"))
+        // aud_wf5678 is absent from the snapshot, so consulting it would fail the resolution.
+        configureAudiences(alwaysMatching("aud_wf1234"))
 
         val resolution = resolve() as CheckpointResolution.MatchedWorkflow
 
         assertThat(resolution.workflow).isEqualTo(mockWorkflow)
-        coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience("aud_wf5678") }
+        coVerify(exactly = 1) { mockAudiencesConfigProvider.getSnapshot() }
+    }
+
+    @Test
+    fun `an unavailable audiences snapshot is configuration unavailable`() = runTest {
+        coEvery { mockAudiencesConfigProvider.getSnapshot() } returns null
+
+        assertThat(noActionReason(resolve()))
+            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        coVerify(exactly = 0) { mockWorkflowManager.getWorkflowBody(any()) }
     }
 
     @Test
     fun `a missing audience before a match is configuration unavailable`() = runTest {
         configureRules(rule("missing"), rule("wf1234"))
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_missing") } returns null
+        configureAudiences(alwaysMatching("aud_wf1234"))
 
         assertThat(noActionReason(resolve()))
             .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
-        coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudience("aud_wf1234") }
+        coVerify(exactly = 0) { mockWorkflowManager.getWorkflowBody(any()) }
     }
 
     @Test
     fun `false audiences resolve to no match`() = runTest {
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
-            Audience("aud_wf1234", "false")
+        configureAudiences(Audience("aud_wf1234", "false"))
 
         assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
         assertThat(offeringsFetched).isZero()
@@ -284,10 +305,10 @@ class CheckpointWorkflowResolverImplTest {
     @Test
     fun `a malformed audience before a match does not prevent a later matching workflow`() = runTest {
         configureRules(rule("wf5678"), rule("wf1234"))
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf5678") } returns
-            Audience("aud_wf5678", "{not json")
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
-            Audience("aud_wf1234", "true")
+        configureAudiences(
+            Audience("aud_wf5678", "{not json"),
+            Audience("aud_wf1234", "true"),
+        )
 
         val resolution = resolve() as CheckpointResolution.MatchedWorkflow
 
@@ -366,8 +387,7 @@ class CheckpointWorkflowResolverImplTest {
 
     @Test
     fun `a custom variable the audience requires resolves the workflow`() = runTest {
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
-            Audience("aud_wf1234", """{"==": [{"var": "custom.source"}, "settings"]}""")
+        configureAudiences(Audience("aud_wf1234", """{"==": [{"var": "custom.source"}, "settings"]}"""))
 
         val resolution = resolver.resolve(checkpointId, mapOf("source" to RulesDimensionValue.StringValue("settings")))
 
@@ -376,8 +396,7 @@ class CheckpointWorkflowResolverImplTest {
 
     @Test
     fun `a custom variable the audience does not accept resolves NoAction with NO_MATCH`() = runTest {
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
-            Audience("aud_wf1234", """{"==": [{"var": "custom.source"}, "settings"]}""")
+        configureAudiences(Audience("aud_wf1234", """{"==": [{"var": "custom.source"}, "settings"]}"""))
 
         assertThat(noActionReason(resolver.resolve(checkpointId, mapOf("source" to RulesDimensionValue.StringValue("onboarding")))))
             .isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
@@ -387,8 +406,7 @@ class CheckpointWorkflowResolverImplTest {
     fun `a custom variable the audience requires but the app omitted is not a NO_MATCH`() = runTest {
         // The audience asks about a variable the call never supplied, so the SDK cannot place this
         // customer inside or outside it. Saying NO_MATCH would claim an answer it does not have.
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
-            Audience("aud_wf1234", """{"==": [{"var": "custom.source"}, "settings"]}""")
+        configureAudiences(Audience("aud_wf1234", """{"==": [{"var": "custom.source"}, "settings"]}"""))
 
         assertThat(noActionReason(resolver.resolve(checkpointId, emptyMap())))
             .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
@@ -398,13 +416,55 @@ class CheckpointWorkflowResolverImplTest {
     fun `negating an audience on an omitted variable does not manufacture a match`() = runTest {
         // Negation is where an unanswerable comparison does the most damage: a false inner result
         // becomes a match, admitting exactly the customers the audience was written to exclude.
-        coEvery { mockAudiencesConfigProvider.getAudience("aud_wf1234") } returns
-            Audience("aud_wf1234", """{"!": [{"==": [{"var": "custom.source"}, "settings"]}]}""")
+        configureAudiences(Audience("aud_wf1234", """{"!": [{"==": [{"var": "custom.source"}, "settings"]}]}"""))
 
         val resolution = resolver.resolve(checkpointId, emptyMap())
 
         assertThat(resolution).isNotInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
         assertThat(noActionReason(resolution))
+            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+    }
+
+    @Test
+    fun `a backend predicate result the audience reads resolves the workflow`() = runTest {
+        configureAudiences(
+            Audience(
+                "aud_wf1234",
+                """{"or": [
+                    {"var": ["backend.$BACKEND_PREDICATE_HASH", false]},
+                    {"==": [{"var": "custom.country"}, "PL"]}
+                ]}""",
+            ),
+            backendPredicateResults = mapOf(BACKEND_PREDICATE_HASH to true),
+        )
+
+        assertThat(resolve()).isInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
+    }
+
+    @Test
+    fun `a false backend predicate result resolves NoAction with NO_MATCH`() = runTest {
+        configureAudiences(
+            Audience("aud_wf1234", """{"var": ["backend.$BACKEND_PREDICATE_HASH", false]}"""),
+            backendPredicateResults = mapOf(BACKEND_PREDICATE_HASH to false),
+        )
+
+        assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
+    }
+
+    @Test
+    fun `a backend predicate result absent from the snapshot falls back to the rule's default`() = runTest {
+        // A hash this SDK never received (a newer backend, a value shape it skipped) reads as the default the
+        // rule was authored with, the same forward-compatibility path as any other unknown dimension.
+        configureAudiences(Audience("aud_wf1234", """{"var": ["backend.$BACKEND_PREDICATE_HASH", false]}"""))
+
+        assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
+    }
+
+    @Test
+    fun `a backend predicate read without a default is not a NO_MATCH when the hash is absent`() = runTest {
+        configureAudiences(Audience("aud_wf1234", """{"var": "backend.$BACKEND_PREDICATE_HASH"}"""))
+
+        assertThat(noActionReason(resolve()))
             .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
     }
 
@@ -573,6 +633,18 @@ class CheckpointWorkflowResolverImplTest {
         workflowId = workflowId,
     )
 
+    private fun alwaysMatching(audienceId: String) = Audience(id = audienceId, rules = "true")
+
+    private fun configureAudiences(
+        vararg audiences: Audience,
+        backendPredicateResults: Map<String, Boolean> = emptyMap(),
+    ) {
+        coEvery { mockAudiencesConfigProvider.getSnapshot() } returns AudiencesSnapshot(
+            audiences = audiences.associateBy { it.id },
+            backendPredicateResults = backendPredicateResults,
+        )
+    }
+
     private fun configureRules(vararg rules: CheckpointRule) {
         configureResolution(
             CheckpointRulesResolution.Found(
@@ -602,8 +674,8 @@ class CheckpointWorkflowResolverImplTest {
         }
     }
 
-    /** A manager serving one checkpoint and one always-matching audience, running [onAudienceRead] on each read. */
-    private fun stalenessManager(generation: AtomicInteger, onAudienceRead: () -> Unit): RemoteConfigManager =
+    /** A manager serving one checkpoint and one always-matching audience, running [onSnapshotRead] on each read. */
+    private fun stalenessManager(generation: AtomicInteger, onSnapshotRead: () -> Unit): RemoteConfigManager =
         mockk<RemoteConfigManager>().also { manager ->
             every { manager.configGeneration } answers { generation.get() }
             coEvery {
@@ -613,18 +685,23 @@ class CheckpointWorkflowResolverImplTest {
                     any<(ByteArray) -> CheckpointResponse?>(),
                 )
             } returns CheckpointResponse(rules = listOf(rule("wf1234")))
-            coEvery { manager.topic(RemoteConfigTopic.Audiences) } answers {
-                onAudienceRead()
-                ConfigTopic(
-                    mapOf(
-                        "aud_wf1234" to RemoteConfiguration.ConfigItem(
-                            metadata = JsonTools.json.parseToJsonElement(
-                                """{"id":"aud_wf1234","rules":{"==":[1,1]}}""",
-                            ).jsonObject,
-                        ),
-                    ),
+            coEvery {
+                manager.blobData(
+                    RemoteConfigTopic.Audiences,
+                    "default",
+                    any<(ByteArray) -> Map<String, Audience>?>(),
                 )
+            } answers {
+                onSnapshotRead()
+                mapOf("aud_wf1234" to Audience(id = "aud_wf1234", rules = """{"==":[1,1]}"""))
             }
+            coEvery { manager.topic(RemoteConfigTopic.Audiences) } returns ConfigTopic(
+                mapOf(
+                    "backend_predicate_results" to RemoteConfiguration.ConfigItem(
+                        metadata = JsonTools.json.parseToJsonElement("""{"hash": true}""").jsonObject,
+                    ),
+                ),
+            )
         }
 
     private fun resolverBackedBy(manager: RemoteConfigManager) = CheckpointWorkflowResolverImpl(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.common.audiences
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.common.currentLogHandler
+import com.revenuecat.purchases.common.localrules.RulesDimensionValue
 import com.revenuecat.purchases.common.remoteconfig.ConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
@@ -113,7 +114,7 @@ internal class AudiencesConfigProviderTest {
     }
 
     @Test
-    fun `boolean backend predicate results are read from the topic item`() = runTest {
+    fun `backend predicate results are read from the topic item`() = runTest {
         returnDefaultBlob("{}")
         returnTopicItems(
             "backend_predicate_results" to """
@@ -126,28 +127,70 @@ internal class AudiencesConfigProviderTest {
 
         assertThat(provider.getSnapshot()?.backendPredicateResults).isEqualTo(
             mapOf(
-                "349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to false,
-                "PROg2cJoAVWa3sWx-6djaRxQQbDPpWwW" to true,
+                "349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to RulesDimensionValue.BoolValue(false),
+                "PROg2cJoAVWa3sWx-6djaRxQQbDPpWwW" to RulesDimensionValue.BoolValue(true),
             ),
         )
     }
 
     @Test
-    fun `a non-boolean backend predicate result is dropped without dropping the others`() = runTest {
+    fun `every backend predicate result shape a rule can read is kept`() = runTest {
         returnDefaultBlob("{}")
         returnTopicItems(
             "backend_predicate_results" to """
             {
-              "string-boolean": "true",
-              "number": 1,
+              "string": "variant_b",
+              "int": 3,
+              "double": 1.5,
+              "object": { "value": true, "count": 2 },
+              "records": [{ "id": "one" }, { "id": "two" }]
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(provider.getSnapshot()?.backendPredicateResults).isEqualTo(
+            mapOf(
+                "string" to RulesDimensionValue.StringValue("variant_b"),
+                "int" to RulesDimensionValue.IntValue(3),
+                "double" to RulesDimensionValue.DoubleValue(1.5),
+                "object" to RulesDimensionValue.ObjectValue(
+                    mapOf(
+                        "value" to RulesDimensionValue.BoolValue(true),
+                        "count" to RulesDimensionValue.IntValue(2),
+                    ),
+                ),
+                "records" to RulesDimensionValue.ObjectListValue(
+                    listOf(
+                        mapOf("id" to RulesDimensionValue.StringValue("one")),
+                        mapOf("id" to RulesDimensionValue.StringValue("two")),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `a backend predicate result no rule could read is dropped without dropping the others`() = runTest {
+        returnDefaultBlob("{}")
+        returnTopicItems(
+            "backend_predicate_results" to """
+            {
               "null-result": null,
-              "object": { "value": true },
+              "scalar-array": [1, 2, 3],
+              "null-in-object": { "value": null, "kept": true },
               "kept": true
             }
             """.trimIndent(),
         )
 
-        assertThat(provider.getSnapshot()?.backendPredicateResults).isEqualTo(mapOf("kept" to true))
+        assertThat(provider.getSnapshot()?.backendPredicateResults).isEqualTo(
+            mapOf(
+                "null-in-object" to RulesDimensionValue.ObjectValue(
+                    mapOf("kept" to RulesDimensionValue.BoolValue(true)),
+                ),
+                "kept" to RulesDimensionValue.BoolValue(true),
+            ),
+        )
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
@@ -34,6 +34,7 @@ internal class AudiencesConfigProviderTest {
             override fun e(tag: String, msg: String, throwable: Throwable?) {}
         }
         every { manager.configGeneration } returns 0
+        returnTopicItems()
     }
 
     @After
@@ -47,76 +48,172 @@ internal class AudiencesConfigProviderTest {
     }
 
     @Test
-    fun `getAudience decodes a typed audience and ignores unknown fields`() = runTest {
-        returnMetadata(
-            "aud_123" to """
+    fun `the snapshot decodes typed audiences and ignores unknown fields`() = runTest {
+        returnDefaultBlob(
+            """
             {
-              "id": "aud_123",
-              "created_via": "dashboard",
-              "rules": { "and": [{ "var": "country" }, true] }
+              "aud_123": {
+                "id": "aud_123",
+                "created_via": "dashboard",
+                "rules": { "and": [{ "var": "country" }, true] }
+              },
+              "aud_456": {
+                "id": "aud_456",
+                "rules": { "==": [1, 1] }
+              }
             }
             """.trimIndent(),
         )
 
-        assertThat(provider.getAudience("aud_123")).isEqualTo(
-            Audience(
-                id = "aud_123",
-                rules = """{"and":[{"var":"country"},true]}""",
+        assertThat(provider.getSnapshot()?.audiences).isEqualTo(
+            mapOf(
+                "aud_123" to Audience(id = "aud_123", rules = """{"and":[{"var":"country"},true]}"""),
+                "aud_456" to Audience(id = "aud_456", rules = """{"==":[1,1]}"""),
             ),
         )
     }
 
     @Test
-    fun `getAudience returns null for missing or invalid metadata`() = runTest {
-        returnMetadata(
-            "missing-id" to """{"rules":{"==":[1,1]}}""",
-            "array-rules" to """{"id":"array-rules","rules":[1,2,3]}""",
-        )
+    fun `a missing default blob makes the snapshot unavailable without reading backend results`() = runTest {
+        returnNoDefaultBlob()
 
-        assertThat(provider.getAudience("missing-id")).isNull()
-        assertThat(provider.getAudience("array-rules")).isNull()
-        assertThat(provider.getAudience("unknown")).isNull()
+        assertThat(provider.getSnapshot()).isNull()
+        coVerify(exactly = 0) { manager.topic(RemoteConfigTopic.Audiences) }
     }
 
     @Test
-    fun `a malformed audience does not prevent reading another audience`() = runTest {
-        returnMetadata(
-            "invalid" to """{"id":"invalid","rules":[]}""",
-            "valid" to """{"id":"valid","rules":{"==":[1,1]}}""",
+    fun `a blob that is not a JSON object makes the snapshot unavailable`() = runTest {
+        returnDefaultBlob("""[{"id":"aud_123"}]""")
+
+        assertThat(provider.getSnapshot()).isNull()
+    }
+
+    @Test
+    fun `a malformed blob makes the snapshot unavailable`() = runTest {
+        returnDefaultBlob("{not json")
+
+        assertThat(provider.getSnapshot()).isNull()
+    }
+
+    @Test
+    fun `a malformed audience is dropped without dropping the others`() = runTest {
+        returnDefaultBlob(
+            """
+            {
+              "missing-id": { "rules": { "==": [1, 1] } },
+              "array-rules": { "id": "array-rules", "rules": [1, 2, 3] },
+              "valid": { "id": "valid", "rules": { "==": [1, 1] } }
+            }
+            """.trimIndent(),
         )
 
-        assertThat(provider.getAudience("invalid")).isNull()
-        assertThat(provider.getAudience("valid")).isEqualTo(
-            Audience(id = "valid", rules = """{"==":[1,1]}"""),
+        assertThat(provider.getSnapshot()?.audiences).isEqualTo(
+            mapOf("valid" to Audience(id = "valid", rules = """{"==":[1,1]}""")),
         )
     }
 
     @Test
-    fun `getAudience reads again when the config generation changes during the read`() = runTest {
+    fun `boolean backend predicate results are read from the topic item`() = runTest {
+        returnDefaultBlob("{}")
+        returnTopicItems(
+            "backend_predicate_results" to """
+            {
+              "349OzehoTyCAdiZblj9w0J0yD-Uow8X3": false,
+              "PROg2cJoAVWa3sWx-6djaRxQQbDPpWwW": true
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(provider.getSnapshot()?.backendPredicateResults).isEqualTo(
+            mapOf(
+                "349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to false,
+                "PROg2cJoAVWa3sWx-6djaRxQQbDPpWwW" to true,
+            ),
+        )
+    }
+
+    @Test
+    fun `a non-boolean backend predicate result is dropped without dropping the others`() = runTest {
+        returnDefaultBlob("{}")
+        returnTopicItems(
+            "backend_predicate_results" to """
+            {
+              "string-boolean": "true",
+              "number": 1,
+              "null-result": null,
+              "object": { "value": true },
+              "kept": true
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(provider.getSnapshot()?.backendPredicateResults).isEqualTo(mapOf("kept" to true))
+    }
+
+    @Test
+    fun `no backend predicate results item leaves the results empty rather than unavailable`() = runTest {
+        returnDefaultBlob("""{"aud_123":{"id":"aud_123","rules":{"==":[1,1]}}}""")
+        returnTopicItems("unrelated_item" to """{"some":"metadata"}""")
+
+        val snapshot = provider.getSnapshot()
+
+        assertThat(snapshot?.audiences).containsOnlyKeys("aud_123")
+        assertThat(snapshot?.backendPredicateResults).isEmpty()
+    }
+
+    @Test
+    fun `a topic that disappears mid-read leaves the results empty rather than unavailable`() = runTest {
+        returnDefaultBlob("{}")
+        coEvery { manager.topic(RemoteConfigTopic.Audiences) } returns null
+
+        assertThat(provider.getSnapshot()?.backendPredicateResults).isEmpty()
+    }
+
+    @Test
+    fun `getSnapshot reads again when the config generation changes during the read`() = runTest {
         every { manager.configGeneration } returnsMany listOf(0, 1)
-        returnMetadata("aud_123" to """{"id":"aud_123","rules":{"==":[1,1]}}""")
+        returnDefaultBlob("""{"aud_123":{"id":"aud_123","rules":{"==":[1,1]}}}""")
 
-        assertThat(provider.getAudience("aud_123")).isEqualTo(
-            Audience(id = "aud_123", rules = """{"==":[1,1]}"""),
+        assertThat(provider.getSnapshot()?.audiences).isEqualTo(
+            mapOf("aud_123" to Audience(id = "aud_123", rules = """{"==":[1,1]}""")),
         )
-        coVerify(exactly = 2) { manager.topic(RemoteConfigTopic.Audiences) }
+        coVerify(exactly = 2) {
+            manager.blobData(RemoteConfigTopic.Audiences, "default", any<(ByteArray) -> Map<String, Audience>?>())
+        }
     }
 
     @Test
-    fun `getAudience returns null when the config changes during both reads`() = runTest {
+    fun `getSnapshot returns null when the config changes during both reads`() = runTest {
         every { manager.configGeneration } returnsMany listOf(0, 1, 1, 2)
-        returnMetadata("aud_123" to """{"id":"aud_123","rules":{"==":[1,1]}}""")
+        returnDefaultBlob("""{"aud_123":{"id":"aud_123","rules":{"==":[1,1]}}}""")
 
-        assertThat(provider.getAudience("aud_123")).isNull()
-        coVerify(exactly = 2) { manager.topic(RemoteConfigTopic.Audiences) }
+        assertThat(provider.getSnapshot()).isNull()
+        coVerify(exactly = 2) {
+            manager.blobData(RemoteConfigTopic.Audiences, "default", any<(ByteArray) -> Map<String, Audience>?>())
+        }
     }
 
-    private fun returnMetadata(vararg audiences: Pair<String, String>) {
-        val items = audiences.associate { (identifier, json) ->
-            identifier to RemoteConfiguration.ConfigItem(
-                metadata = JsonTools.json.parseToJsonElement(json).jsonObject,
-            )
+    private fun returnDefaultBlob(json: String) {
+        coEvery {
+            manager.blobData(RemoteConfigTopic.Audiences, "default", any<(ByteArray) -> Map<String, Audience>?>())
+        } answers {
+            thirdArg<(ByteArray) -> Map<String, Audience>?>()(json.toByteArray())
         }
-        coEvery { manager.topic(RemoteConfigTopic.Audiences) } returns ConfigTopic(items)
+    }
+
+    private fun returnNoDefaultBlob() {
+        coEvery {
+            manager.blobData(RemoteConfigTopic.Audiences, "default", any<(ByteArray) -> Map<String, Audience>?>())
+        } returns null
+    }
+
+    private fun returnTopicItems(vararg items: Pair<String, String>) {
+        coEvery { manager.topic(RemoteConfigTopic.Audiences) } returns ConfigTopic(
+            items.associate { (key, json) ->
+                key to RemoteConfiguration.ConfigItem(
+                    metadata = JsonTools.json.parseToJsonElement(json).jsonObject,
+                )
+            },
+        )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -176,6 +176,44 @@ class LocalRulesEvaluatorTest {
     }
 
     @Test
+    fun `a predicate reading a backend value matches`() = runTest {
+        val rules = listOf(TestRule("only", """{"var": ["backend.hash", false]}"""))
+
+        assertThat(
+            evaluator().match(rules, backendValues = mapOf("hash" to RulesDimensionValue.BoolValue(true)))
+                .getOrThrow()?.name,
+        ).isEqualTo("only")
+        assertThat(
+            evaluator().match(rules, backendValues = mapOf("hash" to RulesDimensionValue.BoolValue(false)))
+                .getOrThrow(),
+        ).isNull()
+        // A backend value this SDK never received reads as the default the rule was authored with.
+        assertThat(evaluator().match(rules).getOrThrow()).isNull()
+    }
+
+    @Test
+    fun `backend values, custom variables, and ambient dimensions are visible in the same call`() = runTest {
+        val rules = listOf(
+            TestRule(
+                "only",
+                """{"and": [
+                    {"==": [{"var": "device.platform"}, "android"]},
+                    {"==": [{"var": "custom.source"}, "settings"]},
+                    {"var": ["backend.hash", false]}
+                ]}""",
+            ),
+        )
+
+        val matched = evaluator().match(
+            rules,
+            customVariables = mapOf("source" to RulesDimensionValue.StringValue("settings")),
+            backendValues = mapOf("hash" to RulesDimensionValue.BoolValue(true)),
+        )
+
+        assertThat(matched.getOrThrow()?.name).isEqualTo("only")
+    }
+
+    @Test
     fun `dimensions are collected once per call regardless of rule count`() = runTest {
         evaluator().match(listOf("first", "second", "third")) { rule ->
             Result.success(if (rule == "third") matchingPredicate else nonMatchingPredicate)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -297,6 +297,46 @@ class RulesDimensionResolverTest {
     }
 
     @Test
+    fun `backend values are nested under the backend namespace`() = runTest {
+        val resolver = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+
+        val values = resolver
+            .snapshot(backendValues = mapOf("349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to RulesDimensionValue.BoolValue(true)))
+            .getOrThrow()
+            .values
+
+        val matches = RulesEngine.evaluate(
+            """{"var": ["backend.349OzehoTyCAdiZblj9w0J0yD-Uow8X3", false]}""",
+            values,
+        )
+        assertThat(matches.getOrThrow()).isTrue()
+    }
+
+    @Test
+    fun `no backend values leaves the namespace absent rather than empty`() = runTest {
+        val resolver = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values).containsOnlyKeys("device")
+        // An absent hash reads as the rule's default, which is what keeps unknown hashes forward-compatible.
+        assertThat(
+            RulesEngine.evaluate("""{"var": ["backend.unknown_hash", false]}""", values).getOrThrow(),
+        ).isFalse()
+    }
+
+    @Test
+    fun `a backend value colliding with a provider fails the snapshot`() = runTest {
+        val resolver = resolver(provider(RulesDimensionNamespace.Backend, "hash" to RulesDimensionValue.BoolValue(false)))
+
+        val error = resolver
+            .snapshot(backendValues = mapOf("hash" to RulesDimensionValue.BoolValue(true)))
+            .exceptionOrNull()
+
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("backend.hash"))
+    }
+
+    @Test
     fun `a custom variable colliding with a provider fails the snapshot`() = runTest {
         val resolver = resolver(provider(RulesDimensionNamespace.Custom, "source" to string("provided")))
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -381,6 +381,69 @@ class RulesDimensionResolverTest {
     }
 
     @Test
+    fun `a nested name no predicate could read is dropped rather than exposed`() = runTest {
+        // Object values carry names too — one `var` path segment each — and the backend's pre-evaluated results
+        // are the source that can nest arbitrarily, so the same reachability rule applies at every depth.
+        val values = resolver().snapshot(
+            backendValues = mapOf(
+                "profile" to RulesDimensionValue.ObjectValue(
+                    mapOf(
+                        "user.tier" to string("gold"),
+                        "" to string("anything"),
+                        "tier" to string("gold"),
+                        "nested" to RulesDimensionValue.ObjectValue(
+                            mapOf("also.bad" to string("dropped"), "kept" to string("yes")),
+                        ),
+                    ),
+                ),
+            ),
+        ).getOrThrow().values
+
+        assertThat(values["backend"]).isEqualTo(
+            Value.ObjectValue(
+                mapOf(
+                    "profile" to Value.ObjectValue(
+                        mapOf(
+                            "tier" to Value.StringValue("gold"),
+                            "nested" to Value.ObjectValue(mapOf("kept" to Value.StringValue("yes"))),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        assertThat(
+            RulesEngine.evaluate("""{"==": [{"var": "backend.profile.tier"}, "gold"]}""", values).getOrThrow(),
+        ).isTrue()
+    }
+
+    @Test
+    fun `a name inside an object list record no predicate could read is dropped rather than exposed`() = runTest {
+        val values = resolver().snapshot(
+            backendValues = mapOf(
+                "results" to RulesDimensionValue.ObjectListValue(
+                    listOf(
+                        mapOf("user.tier" to string("gold"), "id" to string("a")),
+                        mapOf("id" to string("b")),
+                    ),
+                ),
+            ),
+        ).getOrThrow().values
+
+        assertThat(values["backend"]).isEqualTo(
+            Value.ObjectValue(
+                mapOf(
+                    "results" to Value.ArrayValue(
+                        listOf(
+                            Value.ObjectValue(mapOf("id" to Value.StringValue("a"))),
+                            Value.ObjectValue(mapOf("id" to Value.StringValue("b"))),
+                        ),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `a provider whose every name is unreachable leaves its namespace absent`() = runTest {
         val resolver = resolver(
             provider(RulesDimensionNamespace.Device, "platform" to string("android")),


### PR DESCRIPTION
### Description

The `audiences` remote-config topic is being reshaped from one item per audience (inline `{id, rules}` metadata) to exactly one items:

- **`default`**: `{blob_ref, prefetch: true}` — a static blob holding the whole audience dictionary (`{<audienceId>: {id, rules}}`), inlined in the response or fetched through the blob sources like other static blobs.

This PR changes the audience topic reading to parse this new format + passes the backend_predicate_results to the rules engine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how checkpoint audiences are loaded and how eligibility predicates resolve, including a new remote-config contract; behavior is heavily tested but mis-parsed config or staleness edge cases could affect which workflow a customer sees.
> 
> **Overview**
> The audiences remote-config topic is consumed in its new shape: a **`default`** static blob holding the full audience dictionary plus inline **`backend_predicate_results`** (hash → pre-evaluated values). **`AudiencesConfigProvider`** replaces per-id **`getAudience`** with **`getSnapshot()`**, which loads both parts under one consistent generation; malformed audiences or unreadable predicate values are dropped without failing the whole snapshot.
> 
> **Checkpoint resolution** loads audiences once per match via **`matchRule`**, feeds **`backendPredicateResults`** into **`LocalRulesEvaluator`**, and treats a failed audience read as stale (retry) by checking config currency before unwrapping the match result.
> 
> The rules engine gains a **`backend.*`** dimension namespace: **`LocalRulesEvaluator`** and **`RulesDimensionResolver`** accept **`backendValues`**, with nested reachability filtering extended to object and object-list predicate results so audience rules can use `{"var": ["backend.<hash>", default]}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9390e1c71e59730105293100060072a472739f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->