### PR TITLE
Reshape rule evaluation properties

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
@@ -24,7 +24,7 @@ internal class DeviceDimensionProvider(
     private val localeProvider: LocaleProvider,
 ) : RulesDimensionProvider {
 
-    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.Device
+    override val name: String = "device"
 
     private val fixedDimensions: Map<String, RulesDimensionValue> = mapOf(
         KEY_APP_VERSION to RulesDimensionValue.StringValue(appConfig.versionName),
@@ -56,11 +56,11 @@ internal class DeviceDimensionProvider(
             .replace(oldChar = '-', newChar = '_')
 
     internal companion object {
-        const val KEY_APP_VERSION = "appVersion"
+        const val KEY_APP_VERSION = "app_version"
         const val KEY_LOCALE = "locale"
         const val KEY_PLATFORM = "platform"
-        const val KEY_PLATFORM_VERSION = "platformVersion"
-        const val KEY_SDK_VERSION = "sdkVersion"
+        const val KEY_PLATFORM_VERSION = "platform_version"
+        const val KEY_SDK_VERSION = "sdk_version"
 
         /**
          * A dimension the device could not tell us about is omitted rather than reported as an empty string: a

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
@@ -29,7 +29,9 @@ internal class DeviceDimensionProvider(
     private val fixedDimensions: Map<String, RulesDimensionValue> = mapOf(
         KEY_APP_VERSION to RulesDimensionValue.StringValue(appConfig.versionName),
         KEY_PLATFORM to RulesDimensionValue.StringValue(appConfig.store.platformName),
-        KEY_PLATFORM_VERSION to RulesDimensionValue.IntValue(Build.VERSION.SDK_INT.toLong()),
+        // A string rather than a number so one predicate can treat the platform version the same on every
+        // platform: iOS reports versions like "26.1", which only a string can carry.
+        KEY_PLATFORM_VERSION to RulesDimensionValue.StringValue(Build.VERSION.SDK_INT.toString()),
         KEY_SDK_VERSION to RulesDimensionValue.StringValue(Config.frameworkVersion),
     )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -6,40 +6,23 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import java.util.Date
 
 /**
- * The SDK-owned roots a predicate can read. Closed on purpose, like `RemoteConfigTopic`: these names are part of
- * the contract predicates are authored against, so a provider must not be able to invent one.
- *
- * Each entry becomes a real nested object in the evaluated scope, because the engine's `var` operator walks
- * nested objects by strict dot-path and has no flat-key fallback — `device.appVersion` resolves *through*
- * `device`, it is never a literal key.
- */
-internal enum class RulesDimensionNamespace(val key: String) {
-    /** Predicate results pre-evaluated by the backend, supplied per evaluation; see [LocalRulesEvaluator.match]. */
-    Backend("backend"),
-
-    /** Values supplied by the caller for one evaluation; see [LocalRulesEvaluator.match]. */
-    Custom("custom"),
-    Device("device"),
-    Store("store"),
-
-    /** What the app has told the SDK about the customer; see `Purchases.setAttributes`. */
-    SubscriberAttributes("subscriberAttributes"),
-}
-
-/**
- * Supplies one subtree of on-device dimensions.
+ * Supplies part of the root scope of on-device dimensions.
  *
  * Implementations may observe or persist state internally, but values are pulled only when an evaluation asks for
  * a new snapshot, since eligibility reflects the customer's state at the moment the rule is evaluated.
  */
 internal interface RulesDimensionProvider {
 
-    /** The root this provider's values are nested under, and the name it is reported under in diagnostics. */
-    val namespace: RulesDimensionNamespace
+    /** The name this provider is reported under in diagnostics. It is not part of the evaluated scope. */
+    val name: String
 
     /**
-     * The complete current set of values relative to [namespace], keyed in camelCase (`appVersion`);
-     * [RulesDimensionResolver] adds the namespace.
+     * The complete current set of values, keyed by root-level snake_case names (`app_version`);
+     * [RulesDimensionResolver] merges every provider into a single root scope.
+     *
+     * The root names are part of the contract predicates are authored against, so a provider must not claim one
+     * that is not its own: the resolver fails the whole snapshot when two sources supply the same name, or when a
+     * provider supplies one of the roots the resolver itself owns (`evaluated_at`, `custom`, `backend`).
      *
      * A value that is unavailable is omitted rather than guessed: a predicate that reads an absent key fails as
      * an unresolved variable, rather than being answered from a value we invented. A name no predicate could

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -130,7 +130,9 @@ private fun MutableMap<String, Value>.addNestedDimensions(
 /**
  * Drops the names no predicate could ever read, at any depth; see [String.isReachableDimensionName]. Names inside
  * [RulesDimensionValue.ObjectValue] and [RulesDimensionValue.ObjectListValue] records are one `var` path segment
- * each, so the same rule applies to them, one entry at a time.
+ * each, so the same rule applies to them, one entry at a time. An object left with nothing readable is dropped
+ * along with its names, for the same reason [addNestedDimensions] contributes no root for an empty source: an
+ * empty object is truthy in JSON Logic, so keeping it would make `{"var": "profile"}` read as present.
  *
  * Dropped rather than failing the snapshot, unlike this resolver's other two rejections: custom variables are
  * named by the app, so a single value the SDK cannot expose must not stop every checkpoint from resolving. Same
@@ -143,29 +145,33 @@ private fun Map<String, RulesDimensionValue>.filterReachable(
     val path = root?.let { "$it$DIMENSION_PATH_SEPARATOR$name" } ?: name
     if (!name.isReachableDimensionName) {
         warnLog {
-            "Ignoring dimension '$path': a dimension name can't be empty or contain '$DIMENSION_PATH_SEPARATOR'."
+            "Ignoring dimension '$path': a dimension name can't be blank or contain '$DIMENSION_PATH_SEPARATOR'."
         }
         null
     } else {
-        name to value.filterReachable(path)
+        value.filterReachable(path)?.let { reachable -> name to reachable }
     }
 }.toMap()
 
-private fun RulesDimensionValue.filterReachable(path: String): RulesDimensionValue = when (this) {
-    is RulesDimensionValue.ObjectValue -> RulesDimensionValue.ObjectValue(value.filterReachable(root = path))
+private fun RulesDimensionValue.filterReachable(path: String): RulesDimensionValue? = when (this) {
+    is RulesDimensionValue.ObjectValue -> value.filterReachable(root = path)
+        .takeIf { it.isNotEmpty() }
+        ?.let { RulesDimensionValue.ObjectValue(it) }
     is RulesDimensionValue.ObjectListValue -> RulesDimensionValue.ObjectListValue(
-        value.mapIndexed { index, record -> record.filterReachable(root = "$path$DIMENSION_PATH_SEPARATOR$index") },
+        value.mapIndexedNotNull { index, record ->
+            record.filterReachable(root = "$path$DIMENSION_PATH_SEPARATOR$index").takeIf { it.isNotEmpty() }
+        },
     )
     else -> this
 }
 
 /**
  * Whether a predicate could read this name. The engine's `var` walks a strict dot-path, so a name containing a
- * `.` would be read as a path through a nested object that does not exist, and an empty one is not a name a
+ * `.` would be read as a path through a nested object that does not exist, and a blank one is not a name a
  * predicate can be written against.
  */
 internal val String.isReachableDimensionName: Boolean
-    get() = isNotEmpty() && !contains(DIMENSION_PATH_SEPARATOR)
+    get() = isNotBlank() && !contains(DIMENSION_PATH_SEPARATOR)
 
 internal const val DIMENSION_PATH_SEPARATOR = '.'
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -21,23 +21,23 @@ internal data class RulesDimensionSnapshot(
 internal sealed class RulesDimensionResolutionException(message: String) : Exception(message) {
 
     internal data class ProviderFailed(
-        val namespace: RulesDimensionNamespace,
+        val providerName: String,
         val reason: String,
-    ) : RulesDimensionResolutionException("dimension provider '${namespace.key}' failed: $reason")
+    ) : RulesDimensionResolutionException("dimension provider '$providerName' failed: $reason")
 
     internal data class ConflictingDimension(
         val path: String,
-    ) : RulesDimensionResolutionException("two dimension providers supplied '$path'")
+    ) : RulesDimensionResolutionException("two dimension sources supplied '$path'")
 }
 
 /**
- * Builds the scope local rule evaluation runs against by collecting every provider once and nesting its values
- * under the provider's namespace.
+ * Builds the scope local rule evaluation runs against by collecting every provider once and merging its values
+ * into a single root scope. Every snapshot also carries the evaluation instant as `evaluated_at`.
  *
  * All providers see the same reference instant, so every dimension in one snapshot is consistent with the others.
  *
  * Both failure modes are configuration bugs rather than runtime conditions — a provider that cannot produce its
- * values, and two providers claiming the same path — so they fail the whole snapshot instead of silently
+ * values, and two sources claiming the same root name — so they fail the whole snapshot instead of silently
  * degrading a rule to a non-match, which would be indistinguishable from a customer who genuinely does not match.
  * Cancellation is neither, and propagates.
  */
@@ -47,9 +47,10 @@ internal class RulesDimensionResolver(
 ) {
 
     /**
-     * [customVariables] are the caller's own values for this one evaluation, exposed under
-     * [RulesDimensionNamespace.Custom]. [backendValues] are the backend's pre-evaluated values for this one
-     * evaluation, exposed under [RulesDimensionNamespace.Backend].
+     * [customVariables] are the caller's own values for this one evaluation, exposed under `custom`.
+     * [backendValues] are the backend's pre-evaluated values for this one evaluation, exposed under `backend`.
+     * Both roots are reserved whether or not this evaluation supplies values for them, so a provider colliding
+     * with one is deterministic rather than dependent on call arguments.
      */
     @Suppress("ReturnCount")
     suspend fun snapshot(
@@ -57,7 +58,8 @@ internal class RulesDimensionResolver(
         backendValues: Map<String, RulesDimensionValue> = emptyMap(),
     ): Result<RulesDimensionSnapshot> {
         val date = dateProvider.now
-        val values = mutableMapOf<String, MutableMap<String, Value>>()
+        // Seeded before any provider runs, so a provider claiming this root is an ordinary collision.
+        val values = mutableMapOf<String, Value>(KEY_EVALUATED_AT to Value.IntValue(date.time))
 
         for (provider in providers) {
             val dimensions = try {
@@ -67,75 +69,79 @@ internal class RulesDimensionResolver(
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
                 return Result.failure(
                     RulesDimensionResolutionException.ProviderFailed(
-                        namespace = provider.namespace,
+                        providerName = provider.name,
                         reason = error.message ?: error.toString(),
                     ),
                 )
             }
-            values.addDimensions(provider.namespace, dimensions)?.let { conflict ->
+            values.addRootDimensions(dimensions)?.let { conflict ->
                 return Result.failure(conflict)
             }
         }
 
-        values.addDimensions(RulesDimensionNamespace.Custom, customVariables)?.let { conflict ->
+        values.addNestedDimensions(KEY_CUSTOM, customVariables)?.let { conflict ->
             return Result.failure(conflict)
         }
 
-        values.addDimensions(RulesDimensionNamespace.Backend, backendValues)?.let { conflict ->
+        values.addNestedDimensions(KEY_BACKEND, backendValues)?.let { conflict ->
             return Result.failure(conflict)
         }
 
         return Result.success(
             RulesDimensionSnapshot(
-                values = values.mapValues { (_, dimensions) -> Value.ObjectValue(dimensions) },
+                values = values,
                 evaluationDate = date,
             ),
         )
     }
 }
 
-/** Nests [dimensions] under [namespace], or returns the conflict that stops the whole snapshot. */
-@Suppress("ReturnCount")
-private fun MutableMap<String, MutableMap<String, Value>>.addDimensions(
-    namespace: RulesDimensionNamespace,
+/** Merges [dimensions] into the root scope, or returns the conflict that stops the whole snapshot. */
+private fun MutableMap<String, Value>.addRootDimensions(
     dimensions: Map<String, RulesDimensionValue>,
 ): RulesDimensionResolutionException.ConflictingDimension? {
-    // Filtered before the check below, so a source whose every name was unreachable still contributes no namespace.
-    val reachable = dimensions.filterReachable(namespace)
-    // A source with nothing to say contributes no namespace at all: an empty object is truthy in JSON Logic, so
-    // `{"var": "store"}` would read as present for a customer whose store never answered.
-    if (reachable.isEmpty()) return null
-    val target = getOrPut(namespace.key) { mutableMapOf() }
-    for ((name, value) in reachable) {
-        if (target.containsKey(name)) {
-            return RulesDimensionResolutionException.ConflictingDimension("${namespace.key}.$name")
+    for ((name, value) in dimensions.filterReachable(root = null)) {
+        if (containsKey(name) || name == KEY_CUSTOM || name == KEY_BACKEND) {
+            return RulesDimensionResolutionException.ConflictingDimension(name)
         }
-        target[name] = value.asRulesEngineValue
+        this[name] = value.asRulesEngineValue
     }
     return null
 }
 
+/** Nests [dimensions] under [root], or returns the conflict that stops the whole snapshot. */
+@Suppress("ReturnCount")
+private fun MutableMap<String, Value>.addNestedDimensions(
+    root: String,
+    dimensions: Map<String, RulesDimensionValue>,
+): RulesDimensionResolutionException.ConflictingDimension? {
+    // Filtered before the check below, so a source whose every name was unreachable still contributes no root.
+    val reachable = dimensions.filterReachable(root)
+    // A source with nothing to say contributes no root at all: an empty object is truthy in JSON Logic, so
+    // `{"var": "custom"}` would read as present for an evaluation that supplied no custom values.
+    if (reachable.isEmpty()) return null
+    if (containsKey(root)) {
+        return RulesDimensionResolutionException.ConflictingDimension(root)
+    }
+    this[root] = Value.ObjectValue(reachable.mapValues { (_, value) -> value.asRulesEngineValue })
+    return null
+}
+
 /**
- * Drops the names no predicate could ever read, at any depth. The engine's `var` walks a strict dot-path, so a
- * name containing a `.` would be read as a path through a nested object that does not exist, and an empty one is
- * not a name a predicate can be written against. Names inside [RulesDimensionValue.ObjectValue] and
- * [RulesDimensionValue.ObjectListValue] records are one `var` path segment each, so the same rule applies to
- * them, one entry at a time.
+ * Drops the names no predicate could ever read, at any depth; see [String.isReachableDimensionName]. Names inside
+ * [RulesDimensionValue.ObjectValue] and [RulesDimensionValue.ObjectListValue] records are one `var` path segment
+ * each, so the same rule applies to them, one entry at a time.
  *
- * Dropped rather than failing the snapshot, unlike this resolver's other two rejections: a namespace like
- * [RulesDimensionNamespace.SubscriberAttributes] is named by the app, so a single attribute the SDK cannot expose
- * must not stop every checkpoint from resolving. Same treatment `CustomVariableKeyValidator` gives the other
- * developer-named namespace.
+ * Dropped rather than failing the snapshot, unlike this resolver's other two rejections: custom variables are
+ * named by the app, so a single value the SDK cannot expose must not stop every checkpoint from resolving. Same
+ * treatment `CustomVariableKeyValidator` gives them at registration time, and
+ * [SubscriberAttributesDimensionProvider] gives the other developer-named source.
  */
 private fun Map<String, RulesDimensionValue>.filterReachable(
-    namespace: RulesDimensionNamespace,
-): Map<String, RulesDimensionValue> = filterReachable(parentPath = namespace.key)
-
-private fun Map<String, RulesDimensionValue>.filterReachable(
-    parentPath: String,
+    root: String?,
 ): Map<String, RulesDimensionValue> = mapNotNull { (name, value) ->
-    val path = "$parentPath$DIMENSION_PATH_SEPARATOR$name"
-    if (name.isEmpty() || name.contains(DIMENSION_PATH_SEPARATOR)) {
+    val path = root?.let { "$it$DIMENSION_PATH_SEPARATOR$name" } ?: name
+    if (!name.isReachableDimensionName) {
         warnLog {
             "Ignoring dimension '$path': a dimension name can't be empty or contain '$DIMENSION_PATH_SEPARATOR'."
         }
@@ -146,14 +152,26 @@ private fun Map<String, RulesDimensionValue>.filterReachable(
 }.toMap()
 
 private fun RulesDimensionValue.filterReachable(path: String): RulesDimensionValue = when (this) {
-    is RulesDimensionValue.ObjectValue -> RulesDimensionValue.ObjectValue(value.filterReachable(path))
+    is RulesDimensionValue.ObjectValue -> RulesDimensionValue.ObjectValue(value.filterReachable(root = path))
     is RulesDimensionValue.ObjectListValue -> RulesDimensionValue.ObjectListValue(
-        value.mapIndexed { index, record -> record.filterReachable("$path$DIMENSION_PATH_SEPARATOR$index") },
+        value.mapIndexed { index, record -> record.filterReachable(root = "$path$DIMENSION_PATH_SEPARATOR$index") },
     )
     else -> this
 }
 
-private const val DIMENSION_PATH_SEPARATOR = '.'
+/**
+ * Whether a predicate could read this name. The engine's `var` walks a strict dot-path, so a name containing a
+ * `.` would be read as a path through a nested object that does not exist, and an empty one is not a name a
+ * predicate can be written against.
+ */
+internal val String.isReachableDimensionName: Boolean
+    get() = isNotEmpty() && !contains(DIMENSION_PATH_SEPARATOR)
+
+internal const val DIMENSION_PATH_SEPARATOR = '.'
+
+private const val KEY_EVALUATED_AT = "evaluated_at"
+private const val KEY_CUSTOM = "custom"
+private const val KEY_BACKEND = "backend"
 
 private val RulesDimensionValue.asRulesEngineValue: Value
     get() = when (this) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValue.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValue.kt
@@ -48,7 +48,7 @@ public sealed class RulesDimensionValue {
      * A named group of values, for a dimension that is one thing described several ways — a subscriber attribute
      * and when it was set.
      *
-     * Reaches the engine as a nested object, which `var` walks by dot-path: `subscriberAttributes.goal.value`
+     * Reaches the engine as a nested object, which `var` walks by dot-path: `subscriber_attributes.goal.value`
      * resolves *through* `goal`. Unlike a record inside [ObjectListValue], a predicate reading one of these still
      * sees the whole scope around it, because no iteration operator is involved.
      *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/StoreDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/StoreDimensionProvider.kt
@@ -13,8 +13,8 @@ import java.util.MissingResourceException
 /**
  * Store dimensions: what the customer's storefront says about where they buy.
  *
- * `country` is an ISO 3166-1 **alpha-3** code such as `USA`, which is the format StoreKit hands the iOS SDK, so one
- * predicate can target a country on either platform. Android's stores report alpha-2 (`US`), so it is converted
+ * `storefront` is an ISO 3166-1 **alpha-3** code such as `USA`, which is the format StoreKit hands the iOS SDK, so
+ * one predicate can target a country on either platform. Android's stores report alpha-2 (`US`), so it is converted
  * here, and a code with no alpha-3 equivalent is omitted rather than guessed — the Amazon Appstore reports a
  * marketplace rather than a country, and values like `UK` are not ISO regions.
  */
@@ -22,7 +22,7 @@ internal class StoreDimensionProvider(
     private val storefrontCountryCode: suspend () -> String?,
 ) : RulesDimensionProvider {
 
-    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.Store
+    override val name: String = "store"
 
     /**
      * Fetched rather than snapshotted: the storefront is not known until the store has been asked, and it can
@@ -50,7 +50,7 @@ internal class StoreDimensionProvider(
             warnLog { "Ignoring store country '$countryCode': it has no ISO 3166-1 alpha-3 equivalent." }
             return emptyMap()
         }
-        return mapOf(KEY_COUNTRY to RulesDimensionValue.StringValue(alpha3CountryCode))
+        return mapOf(KEY_STOREFRONT to RulesDimensionValue.StringValue(alpha3CountryCode))
     }
 
     private fun String.asAlpha3CountryCodeOrNull(): String? =
@@ -63,6 +63,6 @@ internal class StoreDimensionProvider(
         }
 
     internal companion object {
-        const val KEY_COUNTRY = "country"
+        const val KEY_STOREFRONT = "storefront"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
@@ -11,7 +11,7 @@ internal class SubscriberAttributesDimensionProvider(
     private val storedAttributes: () -> Map<String, SubscriberAttribute>,
 ) : RulesDimensionProvider {
 
-    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.SubscriberAttributes
+    override val name: String = KEY_SUBSCRIBER_ATTRIBUTES
 
     /**
      * Read per evaluation rather than snapshotted: an app can set an attribute at any time, and an audience keyed
@@ -21,6 +21,7 @@ internal class SubscriberAttributesDimensionProvider(
      * of whatever is on disk, so a payload an older version wrote differently surfaces here, and that should not
      * take an otherwise resolvable checkpoint down with it.
      */
+    @Suppress("ReturnCount")
     override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
         val attributes = try {
             storedAttributes()
@@ -28,27 +29,39 @@ internal class SubscriberAttributesDimensionProvider(
             warnLog { "The subscriber attributes are unavailable, so they can't be evaluated: $e" }
             return emptyMap()
         }
-        return attributes.values.mapNotNull { attribute -> attribute.dimension(date) }.toMap()
+        val records = attributes.values.mapNotNull { attribute -> attribute.record() }.toMap()
+        // Absent rather than empty when there is nothing to say: an empty object is truthy in JSON Logic, so
+        // `{"var": "subscriber_attributes"}` would read as present for a customer who has no attributes.
+        if (records.isEmpty()) return emptyMap()
+        return mapOf(KEY_SUBSCRIBER_ATTRIBUTES to RulesDimensionValue.ObjectValue(records))
     }
 
-    private fun SubscriberAttribute.dimension(date: Date): Pair<String, RulesDimensionValue>? {
+    @Suppress("ReturnCount")
+    private fun SubscriberAttribute.record(): Pair<String, RulesDimensionValue>? {
         // A deleted attribute is kept as a tombstone with no value until it has been posted, and an empty value is
         // the SDK's other spelling of a deletion, so both mean the customer no longer has the attribute.
         val value = value?.takeIf { it.isNotEmpty() } ?: return null
-        // A name the engine could not resolve is dropped by RulesDimensionResolver, which applies the same rule to
-        // every source.
+        // RulesDimensionResolver applies the same reachability rule at every depth, but this provider must filter
+        // before it counts: a customer whose only attributes are unreadable has to contribute no root at all,
+        // and by the time the resolver drops the names, the root object would already exist (empty, and truthy).
+        if (!key.backendKey.isReachableDimensionName) {
+            warnLog {
+                "Ignoring dimension '$KEY_SUBSCRIBER_ATTRIBUTES$DIMENSION_PATH_SEPARATOR${key.backendKey}': " +
+                    "a dimension name can't be empty or contain '$DIMENSION_PATH_SEPARATOR'."
+            }
+            return null
+        }
         return key.backendKey to RulesDimensionValue.ObjectValue(
             mapOf(
                 KEY_VALUE to RulesDimensionValue.StringValue(value),
                 KEY_UPDATED_AT to RulesDimensionValue.DateValue(setTime),
-                KEY_EVALUATED_AT to RulesDimensionValue.DateValue(date),
             ),
         )
     }
 
     internal companion object {
-        const val KEY_EVALUATED_AT = "evaluatedAt"
-        const val KEY_UPDATED_AT = "updatedAt"
+        const val KEY_SUBSCRIBER_ATTRIBUTES = "subscriber_attributes"
+        const val KEY_UPDATED_AT = "updated_at"
         const val KEY_VALUE = "value"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
@@ -47,7 +47,7 @@ internal class SubscriberAttributesDimensionProvider(
         if (!key.backendKey.isReachableDimensionName) {
             warnLog {
                 "Ignoring dimension '$KEY_SUBSCRIBER_ATTRIBUTES$DIMENSION_PATH_SEPARATOR${key.backendKey}': " +
-                    "a dimension name can't be empty or contain '$DIMENSION_PATH_SEPARATOR'."
+                    "a dimension name can't be blank or contain '$DIMENSION_PATH_SEPARATOR'."
             }
             return null
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -19,7 +19,6 @@ import com.revenuecat.purchases.common.checkpoints.CheckpointRule
 import com.revenuecat.purchases.common.checkpoints.CheckpointRulesResolution
 import com.revenuecat.purchases.common.checkpoints.CheckpointsConfigProvider
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
-import com.revenuecat.purchases.common.localrules.RulesDimensionNamespace
 import com.revenuecat.purchases.common.localrules.RulesDimensionProvider
 import com.revenuecat.purchases.common.localrules.RulesDimensionValue
 import com.revenuecat.purchases.common.remoteconfig.ConfigTopic
@@ -672,7 +671,7 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     private object FailingDimensionProvider : RulesDimensionProvider {
-        override val namespace = RulesDimensionNamespace.Device
+        override val name = "device"
         override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
             throw IllegalStateException("no dimensions")
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
@@ -35,11 +35,11 @@ class DeviceDimensionProviderTest {
 
         assertThat(dimensions).isEqualTo(
             mapOf(
-                "appVersion" to RulesDimensionValue.StringValue("1.2.3"),
+                "app_version" to RulesDimensionValue.StringValue("1.2.3"),
                 "locale" to RulesDimensionValue.StringValue("en_us"),
                 "platform" to RulesDimensionValue.StringValue("android"),
-                "platformVersion" to RulesDimensionValue.IntValue(34),
-                "sdkVersion" to RulesDimensionValue.StringValue(Config.frameworkVersion),
+                "platform_version" to RulesDimensionValue.IntValue(34),
+                "sdk_version" to RulesDimensionValue.StringValue(Config.frameworkVersion),
             ),
         )
     }
@@ -85,7 +85,7 @@ class DeviceDimensionProviderTest {
 
         val dimensions = provider(languageTag = "", versionName = "").dimensions(date)
 
-        assertThat(dimensions).containsOnlyKeys("platform", "platformVersion", "sdkVersion")
+        assertThat(dimensions).containsOnlyKeys("platform", "platform_version", "sdk_version")
     }
 
     private fun provider(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
@@ -38,7 +38,7 @@ class DeviceDimensionProviderTest {
                 "app_version" to RulesDimensionValue.StringValue("1.2.3"),
                 "locale" to RulesDimensionValue.StringValue("en_us"),
                 "platform" to RulesDimensionValue.StringValue("android"),
-                "platform_version" to RulesDimensionValue.IntValue(34),
+                "platform_version" to RulesDimensionValue.StringValue("34"),
                 "sdk_version" to RulesDimensionValue.StringValue(Config.frameworkVersion),
             ),
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -12,13 +12,13 @@ import java.util.Date
 
 class LocalRulesEvaluatorTest {
 
-    private val matchingPredicate = """{"==": [{"var": "device.platform"}, "android"]}"""
-    private val nonMatchingPredicate = """{"==": [{"var": "device.platform"}, "amazon"]}"""
+    private val matchingPredicate = """{"==": [{"var": "platform"}, "android"]}"""
+    private val nonMatchingPredicate = """{"==": [{"var": "platform"}, "amazon"]}"""
     private val malformedPredicate = "{not json"
 
     private var snapshotsTaken = 0
     private val deviceProvider = object : RulesDimensionProvider {
-        override val namespace = RulesDimensionNamespace.Device
+        override val name = "device"
         override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
             snapshotsTaken++
             return mapOf("platform" to RulesDimensionValue.StringValue("android"))
@@ -59,13 +59,13 @@ class LocalRulesEvaluatorTest {
         // unanswerable. Reporting that is what lets the caller tell it apart
         // from a rule that was evaluated and did not match.
         val result = evaluator().match(
-            listOf(TestRule("only", """{"==": [{"var": "device.unknown_dimension"}, true]}""")),
+            listOf(TestRule("only", """{"==": [{"var": "unknown_dimension"}, true]}""")),
         )
 
         val error = result.exceptionOrNull() as LocalRulesEvaluationException.PredicateEvaluation
         assertThat(error.ruleIndex).isZero()
         assertThat(error.error)
-            .isEqualTo(RulesEngine.EvaluationException.UnresolvedVariable("device.unknown_dimension"))
+            .isEqualTo(RulesEngine.EvaluationException.UnresolvedVariable("unknown_dimension"))
     }
 
     @Test
@@ -98,7 +98,7 @@ class LocalRulesEvaluatorTest {
     @Test
     fun `a failed dimension snapshot fails the evaluation`() = runTest {
         val failing = object : RulesDimensionProvider {
-            override val namespace = RulesDimensionNamespace.Device
+            override val name = "device"
             override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
                 throw IllegalStateException("nope")
         }
@@ -108,7 +108,7 @@ class LocalRulesEvaluatorTest {
 
         val error = result.exceptionOrNull() as LocalRulesEvaluationException.DimensionResolution
         assertThat(error.reason)
-            .isEqualTo(RulesDimensionResolutionException.ProviderFailed(RulesDimensionNamespace.Device, "nope"))
+            .isEqualTo(RulesDimensionResolutionException.ProviderFailed("device", "nope"))
     }
 
     @Test
@@ -163,7 +163,7 @@ class LocalRulesEvaluatorTest {
             TestRule(
                 "only",
                 """{"and": [
-                    {"==": [{"var": "device.platform"}, "android"]},
+                    {"==": [{"var": "platform"}, "android"]},
                     {"==": [{"var": "custom.source"}, "settings"]}
                 ]}""",
             ),
@@ -197,7 +197,7 @@ class LocalRulesEvaluatorTest {
             TestRule(
                 "only",
                 """{"and": [
-                    {"==": [{"var": "device.platform"}, "android"]},
+                    {"==": [{"var": "platform"}, "android"]},
                     {"==": [{"var": "custom.source"}, "settings"]},
                     {"var": ["backend.hash", false]}
                 ]}""",

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -22,49 +22,45 @@ import java.util.Date
 class RulesDimensionResolverTest {
 
     private val evaluationDate = Date(1_700_000_000_000)
+    private val evaluatedAt = "evaluated_at" to Value.IntValue(1_700_000_000_000)
 
     @Test
-    fun `dimensions are nested under their provider's namespace`() = runTest {
+    fun `dimensions are merged into the root scope`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "appVersion" to string("1.2.3")),
+            provider("app_version" to string("1.2.3")),
         )
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).isEqualTo(
-            mapOf("device" to Value.ObjectValue(mapOf("appVersion" to Value.StringValue("1.2.3")))),
-        )
+        assertThat(values).isEqualTo(mapOf(evaluatedAt, "app_version" to Value.StringValue("1.2.3")))
     }
 
     @Test
-    fun `nested dimensions are reachable by dot-path from a predicate`() = runTest {
+    fun `dimensions are reachable by name from a predicate`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
+            provider("platform" to string("android")),
         )
         val values = resolver.snapshot().getOrThrow().values
 
-        val matches = RulesEngine.evaluate("""{"==": [{"var": "device.platform"}, "android"]}""", values)
+        val matches = RulesEngine.evaluate("""{"==": [{"var": "platform"}, "android"]}""", values)
 
         assertThat(matches.getOrThrow()).isTrue()
     }
 
     @Test
-    fun `providers sharing a namespace are merged`() = runTest {
+    fun `providers are merged`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
-            provider(RulesDimensionNamespace.Device, "locale" to string("en-US")),
+            provider("platform" to string("android")),
+            provider("locale" to string("en-US")),
         )
 
         val values = resolver.snapshot().getOrThrow().values
 
         assertThat(values).isEqualTo(
             mapOf(
-                "device" to Value.ObjectValue(
-                    mapOf(
-                        "platform" to Value.StringValue("android"),
-                        "locale" to Value.StringValue("en-US"),
-                    ),
-                ),
+                evaluatedAt,
+                "platform" to Value.StringValue("android"),
+                "locale" to Value.StringValue("en-US"),
             ),
         )
     }
@@ -72,21 +68,21 @@ class RulesDimensionResolverTest {
     @Test
     fun `two providers supplying the same dimension fail the snapshot`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
-            provider(RulesDimensionNamespace.Device, "platform" to string("amazon")),
+            provider("platform" to string("android")),
+            provider("platform" to string("amazon")),
         )
 
         val error = resolver.snapshot().exceptionOrNull()
 
-        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("device.platform"))
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("platform"))
     }
 
     @Test
-    fun `a provider that throws fails the snapshot with its namespace`() = runTest {
+    fun `a provider that throws fails the snapshot with its name`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Store, "country" to string("USA")),
+            provider("storefront" to string("USA")),
             object : RulesDimensionProvider {
-                override val namespace = RulesDimensionNamespace.Device
+                override val name = "device"
                 override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
                     throw IllegalStateException("nope")
             },
@@ -95,14 +91,14 @@ class RulesDimensionResolverTest {
         val error = resolver.snapshot().exceptionOrNull()
 
         assertThat(error)
-            .isEqualTo(RulesDimensionResolutionException.ProviderFailed(RulesDimensionNamespace.Device, "nope"))
+            .isEqualTo(RulesDimensionResolutionException.ProviderFailed("device", "nope"))
     }
 
     @Test
     fun `cancellation propagates instead of failing the snapshot`() = runTest {
         val resolver = resolver(
             object : RulesDimensionProvider {
-                override val namespace = RulesDimensionNamespace.Device
+                override val name = "device"
                 override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
                     throw CancellationException("cancelled")
             },
@@ -123,7 +119,7 @@ class RulesDimensionResolverTest {
         val dates = mutableListOf<Date>()
         val recordingProvider = {
             object : RulesDimensionProvider {
-                override val namespace = RulesDimensionNamespace.Device
+                override val name = "device"
                 override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
                     dates += date
                     return emptyMap()
@@ -139,10 +135,39 @@ class RulesDimensionResolverTest {
     }
 
     @Test
+    fun `every snapshot carries the evaluation instant`() = runTest {
+        val values = resolver().snapshot().getOrThrow().values
+
+        assertThat(values).isEqualTo(mapOf(evaluatedAt))
+    }
+
+    @Test
+    fun `the evaluation instant is ordered by a predicate`() = runTest {
+        val values = resolver().snapshot().getOrThrow().values
+
+        assertThat(
+            RulesEngine.evaluate("""{">": [{"var": "evaluated_at"}, 1699999999999]}""", values).getOrThrow(),
+        ).isTrue()
+        assertThat(
+            RulesEngine.evaluate("""{">": [{"var": "evaluated_at"}, 1700000000001]}""", values).getOrThrow(),
+        ).isFalse()
+    }
+
+    @Test
+    fun `a provider supplying the evaluation instant fails the snapshot`() = runTest {
+        val resolver = resolver(
+            provider("evaluated_at" to RulesDimensionValue.DateValue(evaluationDate)),
+        )
+
+        val error = resolver.snapshot().exceptionOrNull()
+
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("evaluated_at"))
+    }
+
+    @Test
     fun `each dimension value maps to its engine counterpart`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.Device,
                 "text" to RulesDimensionValue.StringValue("value"),
                 "flag" to RulesDimensionValue.BoolValue(true),
                 "count" to RulesDimensionValue.IntValue(3),
@@ -159,19 +184,18 @@ class RulesDimensionResolverTest {
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values["device"]).isEqualTo(
-            Value.ObjectValue(
-                mapOf(
-                    "text" to Value.StringValue("value"),
-                    "flag" to Value.BoolValue(true),
-                    "count" to Value.IntValue(3),
-                    "ratio" to Value.FloatValue(1.5),
-                    "date" to Value.IntValue(1_700_000_000_000),
-                    "records" to Value.ArrayValue(
-                        listOf(Value.ObjectValue(mapOf("id" to Value.StringValue("one")))),
-                    ),
-                    "record" to Value.ObjectValue(mapOf("id" to Value.StringValue("one"))),
+        assertThat(values).isEqualTo(
+            mapOf(
+                evaluatedAt,
+                "text" to Value.StringValue("value"),
+                "flag" to Value.BoolValue(true),
+                "count" to Value.IntValue(3),
+                "ratio" to Value.FloatValue(1.5),
+                "date" to Value.IntValue(1_700_000_000_000),
+                "records" to Value.ArrayValue(
+                    listOf(Value.ObjectValue(mapOf("id" to Value.StringValue("one")))),
                 ),
+                "record" to Value.ObjectValue(mapOf("id" to Value.StringValue("one"))),
             ),
         )
     }
@@ -180,17 +204,16 @@ class RulesDimensionResolverTest {
     fun `a date dimension is ordered by a predicate`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.Device,
-                "expiresAt" to RulesDimensionValue.DateValue(Date(1_700_000_000_000)),
+                "expires_at" to RulesDimensionValue.DateValue(Date(1_700_000_000_000)),
             ),
         )
         val values = resolver.snapshot().getOrThrow().values
 
         assertThat(
-            RulesEngine.evaluate("""{">": [{"var": "device.expiresAt"}, 1699999999999]}""", values).getOrThrow(),
+            RulesEngine.evaluate("""{">": [{"var": "expires_at"}, 1699999999999]}""", values).getOrThrow(),
         ).isTrue()
         assertThat(
-            RulesEngine.evaluate("""{">": [{"var": "device.expiresAt"}, 1700000000001]}""", values).getOrThrow(),
+            RulesEngine.evaluate("""{">": [{"var": "expires_at"}, 1700000000001]}""", values).getOrThrow(),
         ).isFalse()
     }
 
@@ -198,16 +221,15 @@ class RulesDimensionResolverTest {
     fun `an object list dimension is walked one record at a time by a predicate`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.Device,
                 "purchases" to RulesDimensionValue.ObjectListValue(
                     listOf(
                         mapOf(
-                            "productId" to RulesDimensionValue.StringValue("plus"),
-                            "isActive" to RulesDimensionValue.BoolValue(false),
+                            "product_id" to RulesDimensionValue.StringValue("plus"),
+                            "is_active" to RulesDimensionValue.BoolValue(false),
                         ),
                         mapOf(
-                            "productId" to RulesDimensionValue.StringValue("pro"),
-                            "isActive" to RulesDimensionValue.BoolValue(true),
+                            "product_id" to RulesDimensionValue.StringValue("pro"),
+                            "is_active" to RulesDimensionValue.BoolValue(true),
                         ),
                     ),
                 ),
@@ -215,17 +237,17 @@ class RulesDimensionResolverTest {
         )
         val values = resolver.snapshot().getOrThrow().values
 
-        val active = """{"some": [{"var": "device.purchases"},
-            {"and": [{"==": [{"var": "productId"}, "pro"]}, {"var": "isActive"}]}]}"""
+        val active = """{"some": [{"var": "purchases"},
+            {"and": [{"==": [{"var": "product_id"}, "pro"]}, {"var": "is_active"}]}]}"""
         assertThat(RulesEngine.evaluate(active, values).getOrThrow()).isTrue()
 
         // A record is searched on its own values, so the same product with the other record's state does not match.
-        val inactive = """{"some": [{"var": "device.purchases"},
-            {"and": [{"==": [{"var": "productId"}, "plus"]}, {"var": "isActive"}]}]}"""
+        val inactive = """{"some": [{"var": "purchases"},
+            {"and": [{"==": [{"var": "product_id"}, "plus"]}, {"var": "is_active"}]}]}"""
         assertThat(RulesEngine.evaluate(inactive, values).getOrThrow()).isFalse()
 
         // A record is reachable by index too.
-        val byIndex = """{"==": [{"var": "device.purchases.1.productId"}, "pro"]}"""
+        val byIndex = """{"==": [{"var": "purchases.1.product_id"}, "pro"]}"""
         assertThat(RulesEngine.evaluate(byIndex, values).getOrThrow()).isTrue()
     }
 
@@ -233,48 +255,46 @@ class RulesDimensionResolverTest {
     fun `an empty object list is an empty array rather than an absent dimension`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.Device,
                 "purchases" to RulesDimensionValue.ObjectListValue(emptyList()),
             ),
         )
         val values = resolver.snapshot().getOrThrow().values
 
         // "Has bought nothing" has to be a definite answer, which only a present, empty array gives.
-        assertThat(values["device"]).isEqualTo(Value.ObjectValue(mapOf("purchases" to Value.ArrayValue(emptyList()))))
+        assertThat(values["purchases"]).isEqualTo(Value.ArrayValue(emptyList()))
         assertThat(
-            RulesEngine.evaluate("""{"none": [{"var": "device.purchases"}, {"var": "isActive"}]}""", values)
+            RulesEngine.evaluate("""{"none": [{"var": "purchases"}, {"var": "is_active"}]}""", values)
                 .getOrThrow(),
         ).isTrue()
     }
 
     @Test
-    fun `an object dimension is read through by name rather than searched`() = runTest {
+    fun `an object dimension is read through by dot-path rather than searched`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.Device,
                 "goal" to RulesDimensionValue.ObjectValue(
                     mapOf(
                         "value" to RulesDimensionValue.StringValue("lose_weight"),
-                        "updatedAt" to RulesDimensionValue.DateValue(Date(1_700_000_000_000)),
+                        "updated_at" to RulesDimensionValue.DateValue(Date(1_700_000_000_000)),
                     ),
                 ),
             ),
         )
         val values = resolver.snapshot().getOrThrow().values
 
-        val byName = """{"==": [{"var": "device.goal.value"}, "lose_weight"]}"""
+        val byName = """{"==": [{"var": "goal.value"}, "lose_weight"]}"""
         assertThat(RulesEngine.evaluate(byName, values).getOrThrow()).isTrue()
 
         // Unlike a record inside an object list, a predicate reading one of these still sees the scope around it,
         // because no iteration operator is involved.
-        val alongsideTheRestOfTheScope = """{"and": [{"==": [{"var": "device.goal.value"}, "lose_weight"]},
-            {">": [{"var": "device.goal.updatedAt"}, 1699999999999]}]}"""
+        val alongsideTheRestOfTheScope = """{"and": [{"==": [{"var": "goal.value"}, "lose_weight"]},
+            {">": [{"var": "goal.updated_at"}, 1699999999999]}]}"""
         assertThat(RulesEngine.evaluate(alongsideTheRestOfTheScope, values).getOrThrow()).isTrue()
     }
 
     @Test
-    fun `custom variables are nested under the custom namespace`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+    fun `custom variables are nested under the custom root`() = runTest {
+        val resolver = resolver(provider("platform" to string("android")))
 
         val values = resolver.snapshot(mapOf("source" to string("settings"))).getOrThrow().values
 
@@ -283,13 +303,13 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `no custom variables leaves the namespace absent rather than empty`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+    fun `no custom variables leaves the root absent rather than empty`() = runTest {
+        val resolver = resolver(provider("platform" to string("android")))
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).containsOnlyKeys("device")
-        // An empty object would be truthy, so an absent namespace is what makes this a non-match.
+        assertThat(values).containsOnlyKeys("evaluated_at", "platform")
+        // An empty object would be truthy, so an absent root is what makes this a non-match.
         // The default keeps the read legal, because an unresolved name is an error.
         assertThat(
             RulesEngine.evaluate("""{"!!": [{"var": ["custom", false]}]}""", values).getOrThrow(),
@@ -297,8 +317,20 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `backend values are nested under the backend namespace`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+    fun `a custom variable no predicate could read is dropped rather than exposed`() = runTest {
+        val resolver = resolver()
+
+        val values = resolver
+            .snapshot(mapOf("user.tier" to string("gold"), "tier" to string("gold")))
+            .getOrThrow()
+            .values
+
+        assertThat(values["custom"]).isEqualTo(Value.ObjectValue(mapOf("tier" to Value.StringValue("gold"))))
+    }
+
+    @Test
+    fun `backend values are nested under the backend root`() = runTest {
+        val resolver = resolver(provider("platform" to string("android")))
 
         val values = resolver
             .snapshot(backendValues = mapOf("349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to RulesDimensionValue.BoolValue(true)))
@@ -313,12 +345,12 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `no backend values leaves the namespace absent rather than empty`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+    fun `no backend values leaves the root absent rather than empty`() = runTest {
+        val resolver = resolver(provider("platform" to string("android")))
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).containsOnlyKeys("device")
+        assertThat(values).containsOnlyKeys("evaluated_at", "platform")
         // An absent hash reads as the rule's default, which is what keeps unknown hashes forward-compatible.
         assertThat(
             RulesEngine.evaluate("""{"var": ["backend.unknown_hash", false]}""", values).getOrThrow(),
@@ -326,46 +358,44 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `a backend value colliding with a provider fails the snapshot`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Backend, "hash" to RulesDimensionValue.BoolValue(false)))
-
-        val error = resolver
-            .snapshot(backendValues = mapOf("hash" to RulesDimensionValue.BoolValue(true)))
-            .exceptionOrNull()
-
-        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("backend.hash"))
-    }
-
-    @Test
-    fun `a custom variable colliding with a provider fails the snapshot`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Custom, "source" to string("provided")))
-
-        val error = resolver.snapshot(mapOf("source" to string("call"))).exceptionOrNull()
-
-        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("custom.source"))
-    }
-
-    @Test
-    fun `a provider with nothing to contribute leaves its namespace absent`() = runTest {
+    fun `a provider claiming the backend root fails the snapshot`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
-            provider(RulesDimensionNamespace.Store),
+            provider("backend" to RulesDimensionValue.ObjectValue(emptyMap())),
+        )
+
+        // Reserved whether or not this evaluation supplies backend values, so the collision is deterministic.
+        val error = resolver.snapshot().exceptionOrNull()
+
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("backend"))
+    }
+
+    @Test
+    fun `a provider claiming the custom root fails the snapshot`() = runTest {
+        val resolver = resolver(
+            provider("custom" to RulesDimensionValue.ObjectValue(emptyMap())),
+        )
+
+        val error = resolver.snapshot().exceptionOrNull()
+
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("custom"))
+    }
+
+    @Test
+    fun `a provider with nothing to contribute adds nothing to the scope`() = runTest {
+        val resolver = resolver(
+            provider("platform" to string("android")),
+            provider(),
         )
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).containsOnlyKeys("device")
-        // An empty object would be truthy, which is what makes the absence matter.
-        assertThat(
-            RulesEngine.evaluate("""{"!!": [{"var": ["store", false]}]}""", values).getOrThrow(),
-        ).isFalse()
+        assertThat(values).containsOnlyKeys("evaluated_at", "platform")
     }
 
     @Test
     fun `a name no predicate could read is dropped rather than exposed`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.SubscriberAttributes,
                 // A '.' would be walked as a path through a "user" object that does not exist, and "" is not a
                 // name a predicate can be written against.
                 "user.tier" to string("gold"),
@@ -376,8 +406,7 @@ class RulesDimensionResolverTest {
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values["subscriberAttributes"])
-            .isEqualTo(Value.ObjectValue(mapOf("tier" to Value.StringValue("gold"))))
+        assertThat(values).containsOnlyKeys("evaluated_at", "tier")
     }
 
     @Test
@@ -444,24 +473,8 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `a provider whose every name is unreachable leaves its namespace absent`() = runTest {
-        val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
-            provider(RulesDimensionNamespace.SubscriberAttributes, "user.tier" to string("gold")),
-        )
-
-        val values = resolver.snapshot().getOrThrow().values
-
-        // Filtering the names inside the namespace would leave an empty object behind, which is truthy.
-        assertThat(values).containsOnlyKeys("device")
-        assertThat(
-            RulesEngine.evaluate("""{"!!": [{"var": ["subscriberAttributes", false]}]}""", values).getOrThrow(),
-        ).isFalse()
-    }
-
-    @Test
-    fun `no providers yields an empty scope`() = runTest {
-        assertThat(resolver().snapshot().getOrThrow().values).isEmpty()
+    fun `no providers yields a scope with only the evaluation instant`() = runTest {
+        assertThat(resolver().snapshot().getOrThrow().values).isEqualTo(mapOf(evaluatedAt))
     }
 
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
@@ -474,10 +487,10 @@ class RulesDimensionResolverTest {
     private fun string(value: String) = RulesDimensionValue.StringValue(value)
 
     private fun provider(
-        dimensionNamespace: RulesDimensionNamespace,
         vararg values: Pair<String, RulesDimensionValue>,
+        providerName: String = "test",
     ) = object : RulesDimensionProvider {
-        override val namespace = dimensionNamespace
+        override val name = providerName
         override suspend fun dimensions(date: Date) = values.toMap()
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -360,7 +360,7 @@ class RulesDimensionResolverTest {
     @Test
     fun `a provider claiming the backend root fails the snapshot`() = runTest {
         val resolver = resolver(
-            provider("backend" to RulesDimensionValue.ObjectValue(emptyMap())),
+            provider("backend" to RulesDimensionValue.ObjectValue(mapOf("source" to string("x")))),
         )
 
         // Reserved whether or not this evaluation supplies backend values, so the collision is deterministic.
@@ -372,7 +372,7 @@ class RulesDimensionResolverTest {
     @Test
     fun `a provider claiming the custom root fails the snapshot`() = runTest {
         val resolver = resolver(
-            provider("custom" to RulesDimensionValue.ObjectValue(emptyMap())),
+            provider("custom" to RulesDimensionValue.ObjectValue(mapOf("source" to string("x")))),
         )
 
         val error = resolver.snapshot().exceptionOrNull()
@@ -396,10 +396,11 @@ class RulesDimensionResolverTest {
     fun `a name no predicate could read is dropped rather than exposed`() = runTest {
         val resolver = resolver(
             provider(
-                // A '.' would be walked as a path through a "user" object that does not exist, and "" is not a
-                // name a predicate can be written against.
+                // A '.' would be walked as a path through a "user" object that does not exist, and a blank name is
+                // not one a predicate can be written against.
                 "user.tier" to string("gold"),
                 "" to string("anything"),
+                " " to string("anything"),
                 "tier" to string("gold"),
             ),
         )
@@ -419,6 +420,7 @@ class RulesDimensionResolverTest {
                     mapOf(
                         "user.tier" to string("gold"),
                         "" to string("anything"),
+                        " " to string("anything"),
                         "tier" to string("gold"),
                         "nested" to RulesDimensionValue.ObjectValue(
                             mapOf("also.bad" to string("dropped"), "kept" to string("yes")),
@@ -469,6 +471,55 @@ class RulesDimensionResolverTest {
                     ),
                 ),
             ),
+        )
+    }
+
+    @Test
+    fun `an object dimension with nothing readable is absent rather than empty`() = runTest {
+        // An empty object is truthy in JSON Logic, so keeping one would make `{"var": "profile"}` read as present.
+        // Same whether the object was supplied empty or every name inside it was unreachable, at any depth.
+        val resolver = resolver(
+            provider(
+                "empty" to RulesDimensionValue.ObjectValue(emptyMap()),
+                "profile" to RulesDimensionValue.ObjectValue(mapOf("user.tier" to string("gold"))),
+                "goal" to RulesDimensionValue.ObjectValue(
+                    mapOf(
+                        "value" to string("lose_weight"),
+                        "emptied" to RulesDimensionValue.ObjectValue(mapOf("also.bad" to string("dropped"))),
+                    ),
+                ),
+            ),
+        )
+
+        val values = resolver
+            .snapshot(mapOf("settings" to RulesDimensionValue.ObjectValue(emptyMap())))
+            .getOrThrow()
+            .values
+
+        assertThat(values).containsOnlyKeys("evaluated_at", "goal")
+        assertThat(values["goal"]).isEqualTo(Value.ObjectValue(mapOf("value" to Value.StringValue("lose_weight"))))
+        assertThat(
+            RulesEngine.evaluate("""{"!!": [{"var": ["profile", false]}]}""", values).getOrThrow(),
+        ).isFalse()
+    }
+
+    @Test
+    fun `an object list record with nothing readable is dropped from the array`() = runTest {
+        val resolver = resolver(
+            provider(
+                "results" to RulesDimensionValue.ObjectListValue(
+                    listOf(
+                        mapOf("user.tier" to string("gold")),
+                        mapOf("id" to string("b")),
+                    ),
+                ),
+            ),
+        )
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values["results"]).isEqualTo(
+            Value.ArrayValue(listOf(Value.ObjectValue(mapOf("id" to Value.StringValue("b"))))),
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
@@ -24,11 +24,11 @@ class StoreDimensionProviderTest {
     private val date = Date(1_700_000_000_000)
 
     @Test
-    fun `the store country is exposed as a three-letter code`() = runTest {
+    fun `the storefront is exposed as a three-letter code`() = runTest {
         assertThat(provider("US").dimensions(date))
-            .isEqualTo(mapOf("country" to RulesDimensionValue.StringValue("USA")))
+            .isEqualTo(mapOf("storefront" to RulesDimensionValue.StringValue("USA")))
         assertThat(provider("ES").dimensions(date))
-            .isEqualTo(mapOf("country" to RulesDimensionValue.StringValue("ESP")))
+            .isEqualTo(mapOf("storefront" to RulesDimensionValue.StringValue("ESP")))
     }
 
     @Test
@@ -55,7 +55,7 @@ class StoreDimensionProviderTest {
         for (failure in failures) {
             val snapshot = RulesDimensionResolver(
                 providers = listOf(
-                    provider(RulesDimensionNamespace.Device, "platform" to "android"),
+                    deviceProvider("platform" to "android"),
                     StoreDimensionProvider { throw failure },
                 ),
             ).snapshot()
@@ -63,7 +63,7 @@ class StoreDimensionProviderTest {
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
             assertThat(snapshot.getOrThrow().values)
                 .describedAs("%s", failure)
-                .containsOnlyKeys("device")
+                .containsOnlyKeys("evaluated_at", "platform")
         }
     }
 
@@ -82,33 +82,32 @@ class StoreDimensionProviderTest {
     }
 
     @Test
-    fun `the store country is fetched on every evaluation`() = runTest {
+    fun `the storefront is fetched on every evaluation`() = runTest {
         var countryCode: String? = "US"
         val provider = StoreDimensionProvider { countryCode }
 
-        assertThat(provider.dimensions(date)["country"]).isEqualTo(RulesDimensionValue.StringValue("USA"))
+        assertThat(provider.dimensions(date)["storefront"]).isEqualTo(RulesDimensionValue.StringValue("USA"))
 
         countryCode = "ES"
 
-        assertThat(provider.dimensions(date)["country"]).isEqualTo(RulesDimensionValue.StringValue("ESP"))
+        assertThat(provider.dimensions(date)["storefront"]).isEqualTo(RulesDimensionValue.StringValue("ESP"))
     }
 
     @Test
-    fun `the store country is reachable by dot-path from a predicate`() = runTest {
+    fun `the storefront is reachable by name from a predicate`() = runTest {
         val values = RulesDimensionResolver(providers = listOf(provider("US"))).snapshot().getOrThrow().values
 
-        val matches = RulesEngine.evaluate("""{"==": [{"var": "store.country"}, "USA"]}""", values)
+        val matches = RulesEngine.evaluate("""{"==": [{"var": "storefront"}, "USA"]}""", values)
 
         assertThat(matches.getOrThrow()).isTrue()
     }
 
     private fun provider(countryCode: String?) = StoreDimensionProvider { countryCode }
 
-    private fun provider(
-        dimensionNamespace: RulesDimensionNamespace,
+    private fun deviceProvider(
         vararg values: Pair<String, String>,
     ) = object : RulesDimensionProvider {
-        override val namespace = dimensionNamespace
+        override val name = "device"
         override suspend fun dimensions(date: Date) =
             values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
@@ -9,7 +9,6 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
-import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_EVALUATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_UPDATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_VALUE
 import com.revenuecat.purchases.rules.RulesEngine
@@ -89,14 +88,13 @@ class SubscriberAttributesDimensionIntegrationTest {
 
         val goal = values.recordFor("goal")
         assertThat(goal[KEY_VALUE]).isEqualTo(Value.StringValue("lose_weight"))
-        assertThat(goal[KEY_EVALUATED_AT]).isEqualTo(Value.IntValue(evaluationDate.time))
         // Set by this device just now, so it survived the round-trip through JSON with the value.
         assertThat((goal[KEY_UPDATED_AT] as Value.IntValue).value).isBetween(before.time, Date().time)
 
         assertThat(
             RulesEngine.evaluate(
-                """{"and": [{"==": [{"var": "subscriberAttributes.goal.value"}, "lose_weight"]},
-                    {"==": [{"var": "subscriberAttributes.seats.value"}, 3]}]}""",
+                """{"and": [{"==": [{"var": "subscriber_attributes.goal.value"}, "lose_weight"]},
+                    {"==": [{"var": "subscriber_attributes.seats.value"}, 3]}]}""",
                 values,
             ).getOrThrow(),
         ).isTrue()
@@ -111,7 +109,7 @@ class SubscriberAttributesDimensionIntegrationTest {
 
         assertThat(
             RulesEngine.evaluate(
-                """{"==": [{"var": "subscriberAttributes.${'$'}email.value"}, "jane@example.com"]}""",
+                """{"==": [{"var": "subscriber_attributes.${'$'}email.value"}, "jane@example.com"]}""",
                 values,
             ).getOrThrow(),
         ).isTrue()
@@ -132,13 +130,13 @@ class SubscriberAttributesDimensionIntegrationTest {
     }
 
     @Test
-    fun `a customer the app has said nothing about contributes no namespace`() = runTest {
+    fun `a customer the app has said nothing about contributes no root`() = runTest {
         attributes.setAttributes(mapOf("goal" to "lose_weight"), "user_a")
         cache.cacheAppUserID("user_b")
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).doesNotContainKey("subscriberAttributes")
+        assertThat(values).doesNotContainKey("subscriber_attributes")
     }
 
     @Test
@@ -149,7 +147,7 @@ class SubscriberAttributesDimensionIntegrationTest {
         attributes.setAttributes(mapOf("goal" to null), "user_a")
 
         val values = resolver.snapshot().getOrThrow().values
-        assertThat((values["subscriberAttributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
+        assertThat((values["subscriber_attributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
         // The deletion is still on disk waiting to be posted; it is the scope that leaves it out, not the cache.
         assertThat(attributesCache.getAllStoredSubscriberAttributes("user_a")).containsKey("goal")
     }
@@ -161,9 +159,9 @@ class SubscriberAttributesDimensionIntegrationTest {
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat((values["subscriberAttributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
+        assertThat((values["subscriber_attributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
     }
 
     private fun Map<String, Value>.recordFor(name: String): Map<String, Value> =
-        ((this["subscriberAttributes"] as Value.ObjectValue).entries[name] as Value.ObjectValue).entries
+        ((this["subscriber_attributes"] as Value.ObjectValue).entries[name] as Value.ObjectValue).entries
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -98,12 +98,13 @@ class SubscriberAttributesDimensionProviderTest {
 
     @Test
     fun `an attribute named so no predicate could read it is left out`() = runTest {
-        // A '.' would be walked as a path through a "user" object that does not exist, and "" is not a name a
-        // predicate can be written against. Attribute names sit inside this provider's root dimension, where the
+        // A '.' would be walked as a path through a "user" object that does not exist, and a blank name is not one
+        // a predicate can be written against. Attribute names sit inside this provider's root dimension, where the
         // resolver's own filtering cannot see them.
         val records = provider(
             attribute("user.tier", "gold"),
             attribute("", "anything"),
+            attribute(" ", "anything"),
             attribute("tier", "gold"),
         ).records(evaluationDate)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -5,7 +5,7 @@ package com.revenuecat.purchases.common.localrules
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
-import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_EVALUATED_AT
+import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_SUBSCRIBER_ATTRIBUTES
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_UPDATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_VALUE
 import com.revenuecat.purchases.rules.RulesEngine
@@ -30,27 +30,30 @@ class SubscriberAttributesDimensionProviderTest {
 
     @Test
     fun `every stored attribute is exposed under the name the app set it with`() = runTest {
-        val dimensions = provider(
+        val records = provider(
             attribute("\$email", "jane@example.com"),
             attribute("goal", "lose_weight"),
-        ).dimensions(evaluationDate)
+        ).records(evaluationDate)
 
         // Reserved names keep their '$': it is what the app set, what the dashboard shows, and what keeps a custom
         // "email" from colliding with the reserved one. Only '.' means anything to the engine.
-        assertThat(dimensions).containsOnlyKeys("\$email", "goal")
+        assertThat(records).containsOnlyKeys("\$email", "goal")
     }
 
     @Test
-    fun `an attribute is a record of its value, when it was set, and when it was read`() = runTest {
+    fun `the attributes are one root dimension wrapping a record per attribute`() = runTest {
         val dimensions = provider(attribute("goal", "lose_weight")).dimensions(evaluationDate)
 
         assertThat(dimensions).isEqualTo(
             mapOf(
-                "goal" to RulesDimensionValue.ObjectValue(
+                KEY_SUBSCRIBER_ATTRIBUTES to RulesDimensionValue.ObjectValue(
                     mapOf(
-                        KEY_VALUE to RulesDimensionValue.StringValue("lose_weight"),
-                        KEY_UPDATED_AT to RulesDimensionValue.DateValue(setDate),
-                        KEY_EVALUATED_AT to RulesDimensionValue.DateValue(evaluationDate),
+                        "goal" to RulesDimensionValue.ObjectValue(
+                            mapOf(
+                                KEY_VALUE to RulesDimensionValue.StringValue("lose_weight"),
+                                KEY_UPDATED_AT to RulesDimensionValue.DateValue(setDate),
+                            ),
+                        ),
                     ),
                 ),
             ),
@@ -59,47 +62,63 @@ class SubscriberAttributesDimensionProviderTest {
 
     @Test
     fun `a value stays the string the app set, whatever it looks like`() = runTest {
-        val dimensions = provider(
+        val records = provider(
             attribute("seats", "3"),
             attribute("betaOptIn", "true"),
             attribute("sku", "0123"),
-        ).dimensions(evaluationDate)
+        ).records(evaluationDate)
 
-        assertThat(dimensions.valueOf("seats")).isEqualTo(RulesDimensionValue.StringValue("3"))
-        assertThat(dimensions.valueOf("betaOptIn")).isEqualTo(RulesDimensionValue.StringValue("true"))
+        assertThat(records.valueOf("seats")).isEqualTo(RulesDimensionValue.StringValue("3"))
+        assertThat(records.valueOf("betaOptIn")).isEqualTo(RulesDimensionValue.StringValue("true"))
         // A product code the SDK guessed at would silently stop being the string it was set as.
-        assertThat(dimensions.valueOf("sku")).isEqualTo(RulesDimensionValue.StringValue("0123"))
+        assertThat(records.valueOf("sku")).isEqualTo(RulesDimensionValue.StringValue("0123"))
     }
 
     @Test
     fun `a deleted attribute is left out whether or not it has been posted yet`() = runTest {
         // A deletion is stored as a tombstone with no value, and stays in the cache for the current customer even
         // after the backend has been told about it.
-        val dimensions = provider(
+        val records = provider(
             attribute("pending", null, isSynced = false),
             attribute("posted", null, isSynced = true),
             attribute("goal", "lose_weight"),
-        ).dimensions(evaluationDate)
+        ).records(evaluationDate)
 
-        assertThat(dimensions).containsOnlyKeys("goal")
+        assertThat(records).containsOnlyKeys("goal")
     }
 
     @Test
     fun `an attribute set to an empty value is left out`() = runTest {
         // The SDK's other spelling of a deletion, and an empty string would compare equal to an absent value
         // anyway.
-        val dimensions = provider(attribute("goal", ""), attribute("tier", "gold")).dimensions(evaluationDate)
+        val records = provider(attribute("goal", ""), attribute("tier", "gold")).records(evaluationDate)
 
-        assertThat(dimensions).containsOnlyKeys("tier")
+        assertThat(records).containsOnlyKeys("tier")
     }
 
     @Test
-    fun `a customer with no attributes contributes no namespace at all`() = runTest {
-        val values = resolver(provider()).snapshot().getOrThrow().values
+    fun `an attribute named so no predicate could read it is left out`() = runTest {
+        // A '.' would be walked as a path through a "user" object that does not exist, and "" is not a name a
+        // predicate can be written against. Attribute names sit inside this provider's root dimension, where the
+        // resolver's own filtering cannot see them.
+        val records = provider(
+            attribute("user.tier", "gold"),
+            attribute("", "anything"),
+            attribute("tier", "gold"),
+        ).records(evaluationDate)
 
-        // An empty object is truthy in JSON Logic, so `{"var": "subscriberAttributes"}` would read as present for a
-        // customer the app has never said anything about.
-        assertThat(values).doesNotContainKey("subscriberAttributes")
+        assertThat(records).containsOnlyKeys("tier")
+    }
+
+    @Test
+    fun `a customer with no readable attributes contributes no root at all`() = runTest {
+        // An empty object is truthy in JSON Logic, so `{"var": "subscriber_attributes"}` would read as present for
+        // a customer the app has never said anything about.
+        assertThat(provider().dimensions(evaluationDate)).isEmpty()
+        assertThat(provider(attribute("user.tier", "gold")).dimensions(evaluationDate)).isEmpty()
+
+        val values = resolver(provider()).snapshot().getOrThrow().values
+        assertThat(values).doesNotContainKey(KEY_SUBSCRIBER_ATTRIBUTES)
     }
 
     @Test
@@ -117,7 +136,9 @@ class SubscriberAttributesDimensionProviderTest {
             ).snapshot()
 
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
-            assertThat(snapshot.getOrThrow().values).describedAs("%s", failure).containsOnlyKeys("device")
+            assertThat(snapshot.getOrThrow().values)
+                .describedAs("%s", failure)
+                .containsOnlyKeys("evaluated_at", "platform")
         }
     }
 
@@ -126,12 +147,12 @@ class SubscriberAttributesDimensionProviderTest {
         var attributes = mapOf("goal" to attribute("goal", "lose_weight"))
         val provider = SubscriberAttributesDimensionProvider { attributes }
 
-        assertThat(provider.dimensions(evaluationDate).valueOf("goal"))
+        assertThat(provider.records(evaluationDate).valueOf("goal"))
             .isEqualTo(RulesDimensionValue.StringValue("lose_weight"))
 
         attributes = mapOf("goal" to attribute("goal", "gain_muscle"))
 
-        assertThat(provider.dimensions(evaluationDate).valueOf("goal"))
+        assertThat(provider.records(evaluationDate).valueOf("goal"))
             .isEqualTo(RulesDimensionValue.StringValue("gain_muscle"))
     }
 
@@ -147,23 +168,23 @@ class SubscriberAttributesDimensionProviderTest {
         ).snapshot().getOrThrow().values
 
         val matching = listOf(
-            """{"==": [{"var": "subscriberAttributes.${'$'}email.value"}, "jane@example.com"]}""",
+            """{"==": [{"var": "subscriber_attributes.${'$'}email.value"}, "jane@example.com"]}""",
             // The loose operators coerce, so a value the app set as a string is still comparable to a number.
-            """{"==": [{"var": "subscriberAttributes.seats.value"}, 3]}""",
-            """{">": [{"var": "subscriberAttributes.seats.value"}, 2]}""",
-            // Each record carries the evaluation instant, so "set in the last 7 days" needs nothing else in scope.
-            """{"<": [{"-": [{"var": "subscriberAttributes.tier.evaluatedAt"},
-                {"var": "subscriberAttributes.tier.updatedAt"}]}, 604800000]}""",
+            """{"==": [{"var": "subscriber_attributes.seats.value"}, 3]}""",
+            """{">": [{"var": "subscriber_attributes.seats.value"}, 2]}""",
+            // The scope carries the evaluation instant at its root, so "set in the last 7 days" needs nothing else.
+            """{"<": [{"-": [{"var": "evaluated_at"},
+                {"var": "subscriber_attributes.tier.updated_at"}]}, 604800000]}""",
         )
         val notMatching = listOf(
-            """{"==": [{"var": "subscriberAttributes.goal.value"}, "gain_muscle"]}""",
+            """{"==": [{"var": "subscriber_attributes.goal.value"}, "gain_muscle"]}""",
             // An attribute the app never set on this device, and one the SDK does not expose. Both
             // need a default, since reading a name that resolves to nothing is an error.
-            """{"!!": {"var": ["subscriberAttributes.favoriteColor.value", false]}}""",
-            """{"!!": {"var": ["subscriberAttributes.goal.isSynced", false]}}""",
+            """{"!!": {"var": ["subscriber_attributes.favoriteColor.value", false]}}""",
+            """{"!!": {"var": ["subscriber_attributes.goal.isSynced", false]}}""",
             // The same window, for an attribute set six weeks ago.
-            """{"<": [{"-": [{"var": "subscriberAttributes.goal.evaluatedAt"},
-                {"var": "subscriberAttributes.goal.updatedAt"}]}, 604800000]}""",
+            """{"<": [{"-": [{"var": "evaluated_at"},
+                {"var": "subscriber_attributes.goal.updated_at"}]}, 604800000]}""",
         )
 
         for (predicate in matching) {
@@ -193,10 +214,13 @@ class SubscriberAttributesDimensionProviderTest {
     )
 
     private fun deviceProvider(vararg values: Pair<String, String>) = object : RulesDimensionProvider {
-        override val namespace = RulesDimensionNamespace.Device
+        override val name = "device"
         override suspend fun dimensions(date: Date) =
             values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }
     }
+
+    private suspend fun SubscriberAttributesDimensionProvider.records(date: Date): Map<String, RulesDimensionValue> =
+        (dimensions(date)[KEY_SUBSCRIBER_ATTRIBUTES] as? RulesDimensionValue.ObjectValue)?.value.orEmpty()
 
     private fun Map<String, RulesDimensionValue>.valueOf(name: String): RulesDimensionValue? =
         (this[name] as? RulesDimensionValue.ObjectValue)?.value?.get(KEY_VALUE)


### PR DESCRIPTION
### Description

Reshapes the properties injected into the local rules engine to look like:

```json
{
  "evaluated_at": 1700000000000,
  "platform": "android",
  "platform_version": "34",
  "app_version": "1.2.3",
  "sdk_version": "9.x.y",
  "locale": "en_us",
  "storefront": "USA",
  "subscriber_attributes": { "<key>": { "value": "...", "updated_at": 1700000000000 } },
  "custom": { "...": "..." },
  "backend": { "<hash>": false }
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to audience/checkpoint predicate variable paths and types (`platform` vs `device.platform`, `platform_version` string); misconfigured dashboards could stop matching until predicates are updated.
> 
> **Overview**
> **Reshapes the JSON Logic evaluation scope** from nested namespaces (`device.*`, `store.*`, `subscriberAttributes.*`) to a **single flat root** with snake_case keys, aligned cross-platform with the shape in the PR description.
> 
> `RulesDimensionResolver` now merges provider maps at the root, always seeds **`evaluated_at`** (epoch ms), and keeps **`custom`** / **`backend`** as nested objects only. `RulesDimensionNamespace` is removed; providers expose a diagnostic **`name`** and supply root-level keys. Collisions on reserved or duplicate names still fail the whole snapshot.
> 
> **Provider/key changes:** device keys become `app_version`, `platform_version`, `sdk_version`; **`platform_version` is a string** (not int) for iOS-style versions. Store **`country`** → root **`storefront`**. Subscriber attributes are one **`subscriber_attributes`** object (per-key `value` / `updated_at` only—no per-attribute `evaluatedAt`; time windows use root `evaluated_at`).
> 
> **Resolver hygiene:** blank or dot-containing names are dropped; empty nested objects and unreadable object-list records are omitted so JSON Logic does not treat empty objects as present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9cb6224c6a4e69f1f98dc7c05aaeea892a25773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->