### PR TITLE
build: move sdksizetesting to AGP 9

### DIFF
--- a/test-apps/sdksizetesting/app/build.gradle.kts
+++ b/test-apps/sdksizetesting/app/build.gradle.kts
@@ -1,6 +1,7 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.emerge)
 }
@@ -33,9 +34,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
     }
     buildFeatures {
         compose = true
@@ -73,6 +71,12 @@ emerge {
             repoName.set("purchases-android")
             repoOwner.set("RevenueCat")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }
 

--- a/test-apps/sdksizetesting/build.gradle.kts
+++ b/test-apps/sdksizetesting/build.gradle.kts
@@ -1,6 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
 }

--- a/test-apps/sdksizetesting/gradle/libs.versions.toml
+++ b/test-apps/sdksizetesting/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.2"
+agp = "9.2.1"
 kotlin = "2.2.21"
 coreKtx = "1.17.0"
 junit = "4.13.2"
@@ -31,6 +31,5 @@ revenuecat-ui = { group = "com.revenuecat.purchases", name = "purchases-ui", ver
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 emerge = { id = "com.emergetools.android", version.ref = "emergeGradlePlugin" }

--- a/test-apps/sdksizetesting/gradle/wrapper/gradle-wrapper.properties
+++ b/test-apps/sdksizetesting/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Moves `sdksizetesting` to the new AGP version. Targets `11.0-dev` integration branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit afd111decd547556cf518d86af6fb35dee6dfde3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->