### PR TITLE
Surface attribute sync errors when fetching offerings

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -27,6 +27,7 @@ import com.revenuecat.purchases.checkpoints.CheckpointWorkflowResolver
 import com.revenuecat.purchases.checkpoints.CheckpointWorkflowResolverImpl
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendErrorCode
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.Config
 import com.revenuecat.purchases.common.Constants
@@ -39,6 +40,7 @@ import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.ReplaceProductInfo
+import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.audiences.AudiencesConfigProvider
 import com.revenuecat.purchases.common.between
 import com.revenuecat.purchases.common.caching.DeviceCache
@@ -126,6 +128,7 @@ import java.util.Collections
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -497,17 +500,40 @@ internal class PurchasesOrchestrator(
             return
         }
 
+        val firstBlockingError = AtomicReference<PurchasesError?>()
+
+        /**
+         * Whether an attribute sync error should prevent offerings from being fetched.
+         */
+        val shouldBlockOfferingsFetch = { error: PurchasesError, attributeErrors: List<SubscriberAttributeError> ->
+            error.code != PurchasesErrorCode.InvalidSubscriberAttributesError ||
+                attributeErrors.isEmpty() ||
+                attributeErrors.any {
+                    it.backendErrorCode != BackendErrorCode.BackendInvalidSubscriberAttributes.value ||
+                        !it.keyName.startsWith("$")
+                }
+        }
+
         subscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
             appUserID,
             Delay.jitterOnlyIfInBackground(state.appInBackground),
-        ) {
-            remoteConfigManager.refreshRemoteConfig(
-                state.appInBackground,
-                appUserID,
-                RemoteConfigFetchContext.Read,
-            )
-            getOfferings(receiveOfferingsCallback, fetchCurrent = true)
-        }
+            syncedAttribute = { error, attributeErrors ->
+                // Reserved-only 7263 errors are non-blocking because those attributes cannot always be updated.
+                if (error != null && shouldBlockOfferingsFetch(error, attributeErrors)) {
+                    firstBlockingError.compareAndSet(null, error)
+                }
+            },
+            completion = {
+                firstBlockingError.get()?.let(callback::onError) ?: run {
+                    remoteConfigManager.refreshRemoteConfig(
+                        state.appInBackground,
+                        appUserID,
+                        RemoteConfigFetchContext.Read,
+                    )
+                    getOfferings(receiveOfferingsCallback, fetchCurrent = true)
+                }
+            },
+        )
     }
 
     fun syncPurchases(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
@@ -131,4 +131,5 @@ private fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
 internal data class SubscriberAttributeError(
     val keyName: String,
     val message: String,
+    val backendErrorCode: Int? = null,
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.subscriberattributes
 
 import android.app.Application
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.SubscriberAttributeError
@@ -63,6 +64,15 @@ internal class SubscriberAttributesManager(
         delay: Delay,
         completion: (() -> Unit)? = null,
     ) {
+        synchronizeSubscriberAttributesForAllUsers(currentAppUserID, delay, null, completion)
+    }
+
+    fun synchronizeSubscriberAttributesForAllUsers(
+        currentAppUserID: AppUserID,
+        delay: Delay,
+        syncedAttribute: ((PurchasesError?, List<SubscriberAttributeError>) -> Unit)?,
+        completion: (() -> Unit)?,
+    ) {
         obtainingDeviceIdentifiersObservable.waitUntilIdle {
             // We are filtering out blank user IDs to skip requests for attributes that might have been stored
             // as blank user IDs on older versions of the SDK.
@@ -87,6 +97,7 @@ internal class SubscriberAttributesManager(
                     delay,
                     {
                         markAsSynced(syncingAppUserID, unsyncedAttributesForUser, emptyList())
+                        syncedAttribute?.invoke(null, emptyList())
                         log(LogIntent.RC_SUCCESS) {
                             AttributionStrings.ATTRIBUTES_SYNC_SUCCESS.format(syncingAppUserID)
                         }
@@ -102,6 +113,7 @@ internal class SubscriberAttributesManager(
                         if (didBackendGetAttributes) {
                             markAsSynced(syncingAppUserID, unsyncedAttributesForUser, attributeErrors)
                         }
+                        syncedAttribute?.invoke(error, attributeErrors)
                         log(LogIntent.RC_ERROR) {
                             AttributionStrings.ATTRIBUTES_SYNC_ERROR.format(syncingAppUserID, error)
                         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/subscriberattributes/backendHelpers.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/subscriberattributes/backendHelpers.kt
@@ -18,8 +18,13 @@ internal fun Map<String, SubscriberAttribute>.toBackendMap(): Map<String, Map<St
 internal fun JSONObject?.getAttributeErrors(): List<SubscriberAttributeError> {
     if (this == null) return emptyList()
 
-    val attributeErrorsJSONObject =
-        this.optJSONObject(ATTRIBUTES_ERROR_RESPONSE_KEY) ?: this
+    val attributeErrorsResponse = this.optJSONObject(ATTRIBUTES_ERROR_RESPONSE_KEY)
+    val attributeErrorsJSONObject = attributeErrorsResponse ?: this
+    val backendErrorCode = if (attributeErrorsResponse == null) {
+        attributeErrorsJSONObject.optInt("code").takeIf { it > 0 }
+    } else {
+        null
+    }
 
     return attributeErrorsJSONObject.optJSONArray(ATTRIBUTE_ERRORS_KEY)
         ?.let { jsonArray ->
@@ -30,6 +35,7 @@ internal fun JSONObject?.getAttributeErrors(): List<SubscriberAttributeError> {
                     SubscriberAttributeError(
                         it.getString("key_name"),
                         it.getString("message"),
+                        backendErrorCode,
                     )
                 }
                 .toList()

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -337,6 +337,9 @@ internal open class BasePurchasesTest {
         every {
             mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserId, any(), any())
         } just Runs
+        every {
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserId, any(), any(), any())
+        } just Runs
     }
     // endregion
 

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -468,6 +468,7 @@ internal open class BasePurchasesTest {
         apiKeyValidationResult: APIKeyValidator.ValidationResult = APIKeyValidator.ValidationResult.VALID,
         enableSimulatedStore: Boolean = false,
         store: Store = Store.PLAY_STORE,
+        subscriberAttributesManager: SubscriberAttributesManager = mockSubscriberAttributesManager,
     ) {
         appConfig = AppConfig(
             context = mockContext,
@@ -492,7 +493,7 @@ internal open class BasePurchasesTest {
             mockBillingAbstract,
             mockCache,
             identityManager = mockIdentityManager,
-            subscriberAttributesManager = mockSubscriberAttributesManager,
+            subscriberAttributesManager = subscriberAttributesManager,
             appConfig = appConfig,
             customerInfoHelper = mockCustomerInfoHelper,
             customerInfoUpdateHandler = mockCustomerInfoUpdateHandler,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -9,8 +9,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
+import com.revenuecat.purchases.common.BackendErrorCode
 import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.ReplaceProductInfo
+import com.revenuecat.purchases.common.SubscriberAttributeError
+import com.revenuecat.purchases.common.subscriberattributes.DeviceIdentifiersFetcher
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigCommitListener
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigFetchContext
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
@@ -30,6 +34,10 @@ import com.revenuecat.purchases.models.StoreReplacementMode
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.SubscriptionOptions
 import com.revenuecat.purchases.strings.PurchaseStrings
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
+import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
 import com.revenuecat.purchases.utils.STUB_OFFERING_IDENTIFIER
 import com.revenuecat.purchases.utils.createMockOneTimeProductDetails
 import com.revenuecat.purchases.utils.createMockProductDetailsFreeTrial
@@ -2951,7 +2959,12 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     @Test
     fun `syncAttributesAndOfferingsIfNeeded refreshes remote config`() {
         every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserId, any(), captureLambda())
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
+                appUserId,
+                any(),
+                any(),
+                captureLambda(),
+            )
         } answers { lambda<() -> Unit>().captured.invoke() }
         every {
             mockOfferingsManager.getOfferings(appUserId, false, any(), any(), fetchCurrent = true)
@@ -2970,9 +2983,170 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
+    fun `syncAttributesAndOfferingsIfNeeded returns attribute sync error without fetching offerings`() {
+        val expectedError = PurchasesError(PurchasesErrorCode.NetworkError)
+        assertAttributeSyncErrorBlocksOfferings(expectedError)
+    }
+
+    @Test
+    fun `syncAttributesAndOfferingsIfNeeded fetches offerings for reserved attribute 7263 error`() {
+        val expectedError = PurchasesError(PurchasesErrorCode.InvalidSubscriberAttributesError)
+        buildPurchasesWithAttributeSyncError(
+            expectedError,
+            listOf(
+                SubscriberAttributeError(
+                    "\$idfv",
+                    "IDFV cannot be modified.",
+                    BackendErrorCode.BackendInvalidSubscriberAttributes.value,
+                ),
+            ),
+        )
+        every {
+            mockOfferingsManager.getOfferings(appUserId, false, any(), any(), fetchCurrent = true)
+        } just Runs
+
+        purchases.purchasesOrchestrator.syncAttributesAndOfferingsIfNeeded(
+            object : SyncAttributesAndOfferingsCallback {
+                override fun onSuccess(offerings: Offerings) {}
+                override fun onError(error: PurchasesError) = fail("Expected offerings to be fetched")
+            },
+        )
+
+        verify(exactly = 1) {
+            mockOfferingsManager.getOfferings(appUserId, false, any(), any(), fetchCurrent = true)
+        }
+    }
+
+    @Test
+    fun `syncAttributesAndOfferingsIfNeeded returns custom attribute 7263 error`() {
+        val expectedError = PurchasesError(PurchasesErrorCode.InvalidSubscriberAttributesError)
+        assertAttributeSyncErrorBlocksOfferings(
+            expectedError,
+            listOf(
+                SubscriberAttributeError(
+                    "favorite_color",
+                    "Value is too long.",
+                    BackendErrorCode.BackendInvalidSubscriberAttributes.value,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `syncAttributesAndOfferingsIfNeeded returns mixed attribute 7263 error`() {
+        val expectedError = PurchasesError(PurchasesErrorCode.InvalidSubscriberAttributesError)
+        assertAttributeSyncErrorBlocksOfferings(
+            expectedError,
+            listOf(
+                SubscriberAttributeError(
+                    "\$idfv",
+                    "IDFV cannot be modified.",
+                    BackendErrorCode.BackendInvalidSubscriberAttributes.value,
+                ),
+                SubscriberAttributeError(
+                    "favorite_color",
+                    "Value is too long.",
+                    BackendErrorCode.BackendInvalidSubscriberAttributes.value,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `syncAttributesAndOfferingsIfNeeded returns 7263 error without attribute details`() {
+        val expectedError = PurchasesError(PurchasesErrorCode.InvalidSubscriberAttributesError)
+        assertAttributeSyncErrorBlocksOfferings(expectedError)
+    }
+
+    @Test
+    fun `syncAttributesAndOfferingsIfNeeded returns reserved attribute 7264 error`() {
+        val expectedError = PurchasesError(PurchasesErrorCode.InvalidSubscriberAttributesError)
+        assertAttributeSyncErrorBlocksOfferings(
+            expectedError,
+            listOf(
+                SubscriberAttributeError(
+                    "\$idfv",
+                    "IDFV cannot be modified.",
+                    BackendErrorCode.BackendInvalidSubscriberAttributesBody.value,
+                ),
+            ),
+        )
+    }
+
+    private fun assertAttributeSyncErrorBlocksOfferings(
+        expectedError: PurchasesError,
+        attributeErrors: List<SubscriberAttributeError> = emptyList(),
+    ) {
+        buildPurchasesWithAttributeSyncError(expectedError, attributeErrors)
+        every {
+            mockOfferingsManager.getOfferings(appUserId, false, any(), any(), fetchCurrent = true)
+        } just Runs
+
+        var receivedError: PurchasesError? = null
+        purchases.purchasesOrchestrator.syncAttributesAndOfferingsIfNeeded(
+            object : SyncAttributesAndOfferingsCallback {
+                override fun onSuccess(offerings: Offerings) = fail("Expected attribute sync to fail")
+
+                override fun onError(error: PurchasesError) {
+                    receivedError = error
+                }
+            },
+        )
+
+        assertThat(receivedError).isEqualTo(expectedError)
+        verify(exactly = 0) {
+            mockOfferingsManager.getOfferings(appUserId, false, any(), any(), fetchCurrent = true)
+        }
+    }
+
+    private fun buildPurchasesWithAttributeSyncError(
+        error: PurchasesError,
+        attributeErrors: List<SubscriberAttributeError> = emptyList(),
+    ) {
+        val subscriberAttribute = SubscriberAttribute("key", "value", isSynced = false)
+        val subscriberAttributesCache = mockk<SubscriberAttributesCache>()
+        val subscriberAttributesPoster = mockk<SubscriberAttributesPoster>()
+
+        every {
+            subscriberAttributesCache.getUnsyncedSubscriberAttributes()
+        } returns mapOf(appUserId to mapOf("key" to subscriberAttribute))
+        every {
+            subscriberAttributesPoster.postSubscriberAttributes(
+                any(),
+                appUserId,
+                any(),
+                any(),
+                captureLambda(),
+            )
+        } answers {
+            lambda<(PurchasesError, Boolean, List<SubscriberAttributeError>) -> Unit>().captured.invoke(
+                error,
+                false,
+                attributeErrors,
+            )
+        }
+
+        val subscriberAttributesManager = SubscriberAttributesManager(
+            subscriberAttributesCache,
+            subscriberAttributesPoster,
+            mockk<DeviceIdentifiersFetcher>(),
+            automaticDeviceIdentifierCollectionEnabled = true,
+        )
+        buildPurchases(
+            anonymous = false,
+            subscriberAttributesManager = subscriberAttributesManager,
+        )
+    }
+
+    @Test
     fun `syncAttributesAndOfferingsIfNeeded does not refresh remote config when rate limited`() {
         every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserId, any(), captureLambda())
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
+                appUserId,
+                any(),
+                any(),
+                captureLambda(),
+            )
         } answers { lambda<() -> Unit>().captured.invoke() }
         every {
             mockOfferingsManager.getOfferings(appUserId, false, any(), any(), any())

--- a/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -243,6 +243,7 @@ class SubscriberAttributesPosterTests {
         assertThat(receivedAttributeErrors!!.size).isEqualTo(1)
         assertThat(receivedAttributeErrors!![0].keyName).isEqualTo("email")
         assertThat(receivedAttributeErrors!![0].message).isEqualTo("Value is not a valid email address.")
+        assertThat(receivedAttributeErrors!![0].backendErrorCode).isEqualTo(7263)
     }
 
     @Test

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesCoroutinesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesCoroutinesTest.kt
@@ -287,7 +287,12 @@ internal class PurchasesCoroutinesTest : BasePurchasesTest() {
     @Test
     fun `sync attributes and offerings if needed - Success`() = runTest {
         every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any(), any(), captureLambda())
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
+                any(),
+                any(),
+                any(),
+                captureLambda(),
+            )
         } answers {
             lambda<() -> Unit>().captured.invoke()
         }
@@ -311,6 +316,7 @@ internal class PurchasesCoroutinesTest : BasePurchasesTest() {
             mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
                 currentAppUserID = any(),
                 delay = any(),
+                syncedAttribute = any(),
                 completion = captureLambda(),
             )
         }
@@ -332,7 +338,12 @@ internal class PurchasesCoroutinesTest : BasePurchasesTest() {
     @Test
     fun `sync attributes and offerings if needed - SyncingAttributesRateLimitReached`() = runTest {
         every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any(), any(), captureLambda())
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
+                any(),
+                any(),
+                any(),
+                captureLambda(),
+            )
         } answers {
             lambda<() -> Unit>().captured.invoke()
         }
@@ -355,6 +366,7 @@ internal class PurchasesCoroutinesTest : BasePurchasesTest() {
             mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
                 currentAppUserID = any(),
                 delay = any(),
+                syncedAttribute = any(),
                 completion = any(),
             )
         }
@@ -495,7 +507,12 @@ internal class PurchasesCoroutinesTest : BasePurchasesTest() {
         } just Runs
 
         every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any(), any(), captureLambda())
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
+                any(),
+                any(),
+                any(),
+                captureLambda(),
+            )
         } answers {
             lambda<() -> Unit>().captured.invoke()
         }
@@ -524,7 +541,12 @@ internal class PurchasesCoroutinesTest : BasePurchasesTest() {
         } just Runs
 
         every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any(), any(), captureLambda())
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
+                any(),
+                any(),
+                any(),
+                captureLambda(),
+            )
         } answers {
             lambda<() -> Unit>().captured.invoke()
         }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -835,7 +835,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         purchases.purchasesOrchestrator.state =
             purchases.purchasesOrchestrator.state.copy(appInBackground = false)
         every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any(), any(), any())
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any(), any(), any(), any())
         } just Runs
 
         purchases.syncAttributesAndOfferingsIfNeededWith({ fail("Expected to succeed") }, {})
@@ -844,6 +844,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
                 currentAppUserID = any(),
                 delay = Delay.NONE,
+                syncedAttribute = any(),
                 completion = any(),
             )
         }
@@ -854,7 +855,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         purchases.purchasesOrchestrator.state =
             purchases.purchasesOrchestrator.state.copy(appInBackground = true)
         every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any(), any(), any())
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any(), any(), any(), any())
         } just Runs
 
         purchases.syncAttributesAndOfferingsIfNeededWith({ fail("Expected to succeed") }, {})
@@ -863,6 +864,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
                 currentAppUserID = any(),
                 delay = Delay.DEFAULT,
+                syncedAttribute = any(),
                 completion = any(),
             )
         }
@@ -871,7 +873,12 @@ internal class PurchasesTest : BasePurchasesTest() {
     @Test
     fun `syncing attributes and offerings calls success callback when process completes successfully`() {
         every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any(), any(), captureLambda())
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
+                any(),
+                any(),
+                any(),
+                captureLambda(),
+            )
         } answers {
             lambda<() -> Unit>().captured.invoke()
         }
@@ -899,7 +906,12 @@ internal class PurchasesTest : BasePurchasesTest() {
     @Test
     fun `syncing attributes and offerings calls error callback when called twice within 60 seconds`() {
         every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(any(), any(), captureLambda())
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
+                any(),
+                any(),
+                any(),
+                captureLambda(),
+            )
         } answers {
             lambda<() -> Unit>().captured.invoke()
         }
@@ -922,6 +934,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(
                 currentAppUserID = any(),
                 delay = any(),
+                syncedAttribute = any(),
                 completion = any(),
             )
         }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -479,13 +479,15 @@ class SubscriberAttributesPurchasesTests {
             subscriberAttributesManagerMock.setAppstackAttributionParams(appUserId, data, any())
         } just Runs
         every {
-            subscriberAttributesManagerMock.synchronizeSubscriberAttributesForAllUsers(appUserId, any(), any())
+            subscriberAttributesManagerMock.synchronizeSubscriberAttributesForAllUsers(appUserId, any(), any(), any())
         } just Runs
 
         underTest.setAppstackAttributionParams(data, mockk(relaxed = true))
 
         verify { subscriberAttributesManagerMock.setAppstackAttributionParams(appUserId, data, any()) }
-        verify { subscriberAttributesManagerMock.synchronizeSubscriberAttributesForAllUsers(appUserId, any(), any()) }
+        verify {
+            subscriberAttributesManagerMock.synchronizeSubscriberAttributesForAllUsers(appUserId, any(), any(), any())
+        }
     }
 
     // endregion


### PR DESCRIPTION
## Description
Currently `syncAttributesAndOfferingsIfNeeded()` does not actually return an error if attribute syncing fails. Which is unexpected if you're trying to sync attributes that are expected to influence the offerings returned. 

This PR fixes this by returning the error returned from syncing attributes, before attempting to refresh the offerings. Ensuring that the error is surfaced correctly.

## Changes
We will now treat any error received during attribute syncing as fatal, thus returning and not continuing with fetching offerings, with one exception.

(Some) reserved attributes can only be set once, and any subsequent sync of an updated value will result in an error. Therefore we will treat these as non fatal, so if a sync results in errors only from reserved attributes, we'll still consider it a success and continue. This of course does not apply if any other errors are also encountered.

iOS counterpart: RevenueCat/purchases-ios#7539

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public-facing behavior of sync-then-offerings flows: callers may now see errors that were previously swallowed, though reserved-attribute 7263-only cases remain non-fatal by design.
> 
> **Overview**
> **`syncAttributesAndOfferingsIfNeeded`** now fails the callback when subscriber attribute sync hits a blocking error, instead of always continuing to refresh offerings.
> 
> Attribute sync reports per-request outcomes through a new optional **`syncedAttribute`** hook on **`SubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers`**. The orchestrator records the first blocking error and, after all syncs finish, either invokes **`onError`** and skips offerings, or proceeds with remote config refresh and **`getOfferings`** as before.
> 
> Blocking is skipped only for **`InvalidSubscriberAttributesError`** (backend **7263**) when every reported attribute error is on a reserved key (name starts with **`$`**) and carries that code. Custom attributes, mixed errors, missing attribute details, other error codes (e.g. **7264**), and non-attribute failures still block offerings fetch.
> 
> **`SubscriberAttributeError`** gains optional **`backendErrorCode`**, populated when parsing attribute error JSON in **`getAttributeErrors`** so the reserved-only exception can be applied reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 672ece840ce7df0792a3ecb45c90ba1a1bf65820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->