### PR TITLE
Add the customer's purchases and entitlements as rule evaluation properties

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -30,6 +30,7 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.EventsManager
 import com.revenuecat.purchases.common.isDeviceProtectedStorageCompat
+import com.revenuecat.purchases.common.localrules.CustomerInfoDimensionProvider
 import com.revenuecat.purchases.common.localrules.DeviceDimensionProvider
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesEngineLoggerBridge
@@ -53,6 +54,8 @@ import com.revenuecat.purchases.common.remoteconfig.RemoteConfigBlobStore
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopicStore
+import com.revenuecat.purchases.common.safeResume
+import com.revenuecat.purchases.common.safeResumeWithException
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
@@ -83,6 +86,7 @@ import com.revenuecat.purchases.utils.UrlConnectionFactory
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import com.revenuecat.purchases.utils.prewarmTargetOfferingIds
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencyManager
+import kotlinx.coroutines.suspendCancellableCoroutine
 import java.net.URL
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -394,6 +398,12 @@ internal class PurchasesFactory(
                             identityManager.currentAppUserID,
                         )
                     },
+                    CustomerInfoDimensionProvider(
+                        currentAppUserId = { identityManager.currentAppUserID },
+                        customerInfo = { appUserID ->
+                            Purchases.sharedInstance.purchasesOrchestrator.awaitCustomerInfo(appUserID)
+                        },
+                    ),
                 ),
             )
 
@@ -681,3 +691,20 @@ internal class PurchasesFactory(
         ): Boolean = diagnosticsEnabled && !uiPreviewMode
     }
 }
+
+/**
+ * The cache when it is warm, the initial fetch otherwise. Goes through the orchestrator because
+ * `Purchases.awaitCustomerInfo` only exists in the `defaults` source set, while this is compiled for both flavors.
+ */
+private suspend fun PurchasesOrchestrator.awaitCustomerInfo(appUserID: String): CustomerInfo =
+    suspendCancellableCoroutine { continuation ->
+        getCustomerInfo(
+            appUserID = appUserID,
+            fetchPolicy = CacheFetchPolicy.default(),
+            trackDiagnostics = false,
+            callback = receiveCustomerInfoCallback(
+                onSuccess = { continuation.safeResume(it) },
+                onError = { continuation.safeResumeWithException(PurchasesException(it)) },
+            ),
+        )
+    }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -980,8 +980,25 @@ internal class PurchasesOrchestrator(
         trackDiagnostics: Boolean,
         callback: ReceiveCustomerInfoCallback,
     ) {
+        getCustomerInfo(identityManager.currentAppUserID, fetchPolicy, trackDiagnostics, callback)
+    }
+
+    /**
+     * For a caller that has already read the app user ID: the cache lookup and the backend request both use the
+     * given ID instead of re-reading the current one.
+     *
+     * Not a guarantee that the answer describes that customer. On a cold cache the pending-purchase sync runs
+     * first and reads the current app user for itself, so a caller that needs the guarantee checks the ID again
+     * once the answer is in.
+     */
+    fun getCustomerInfo(
+        appUserID: String,
+        fetchPolicy: CacheFetchPolicy,
+        trackDiagnostics: Boolean,
+        callback: ReceiveCustomerInfoCallback,
+    ) {
         customerInfoHelper.retrieveCustomerInfo(
-            identityManager.currentAppUserID,
+            appUserID,
             fetchPolicy,
             state.appInBackground,
             allowSharingPlayStoreAccount,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -1,0 +1,290 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.EntitlementInfo
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.OwnershipType
+import com.revenuecat.purchases.PeriodType
+import com.revenuecat.purchases.SubscriptionInfo
+import com.revenuecat.purchases.common.Constants
+import com.revenuecat.purchases.common.warnLog
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.Transaction
+import kotlinx.coroutines.CancellationException
+import java.util.Date
+
+internal class CustomerInfoDimensionProvider(
+    private val currentAppUserId: () -> String,
+    private val customerInfo: suspend (appUserId: String) -> CustomerInfo,
+) : RulesDimensionProvider {
+
+    override val name: String = "customer_info"
+
+    /**
+     * The app user ID is reported without waiting for the customer info, so a rule targeting only the ID does not
+     * depend on the network: it is known as soon as the SDK is configured.
+     *
+     * Read once per evaluation, so the ID reported and the customer info fetched cannot describe two different
+     * customers within this provider's values.
+     */
+    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+        // Nobody to ask about: the SDK has no cached user, so there is no request to make on their behalf.
+        val appUserId = currentAppUserId().ifEmpty { return emptyMap() }
+        return customerInfoDimensions(appUserId, date) +
+            buildMap { putString(KEY_APP_USER_ID, appUserId) }
+    }
+
+    /**
+     * A customer info that cannot be read contributes no dimensions rather than failing the snapshot, which would
+     * take an otherwise resolvable checkpoint down with it. Cancellation is not a failure and propagates.
+     *
+     * The records are built inside the same guard, because a [CustomerInfo] parses its purchases out of its raw
+     * payload on first access rather than at construction, so a malformed payload surfaces here.
+     */
+    private suspend fun customerInfoDimensions(
+        appUserId: String,
+        date: Date,
+    ): Map<String, RulesDimensionValue> = try {
+        customerInfo(appUserId).dimensions(date)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        warnLog { "The customer info is unavailable, so customer dimensions can't be evaluated: $e" }
+        emptyMap()
+    }
+
+    private fun CustomerInfo.dimensions(date: Date): Map<String, RulesDimensionValue> = buildMap {
+        putString(KEY_ORIGINAL_APP_USER_ID, originalAppUserId)
+        putDate(KEY_FIRST_SEEN_AT, firstSeen)
+        putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
+        putObjectList(KEY_PURCHASES, purchaseRecords(date))
+        putObjectList(KEY_ENTITLEMENTS, entitlementRecords())
+    }
+
+    /**
+     * Newest first, so `purchases.0` is the customer's most recent purchase of any kind and a rule about it needs
+     * no iteration at all. Subscriptions are ordered by product before the merge, so purchases that share a date
+     * still come out in a defined order.
+     */
+    private fun CustomerInfo.purchaseRecords(date: Date): List<Map<String, RulesDimensionValue>> {
+        val subscriptions = subscriptionsByProductIdentifier.values
+            .sortedBy { subscription -> subscription.productIdentifier }
+            .map { subscription -> subscription.record(date) }
+        // Already sorted by purchase date by `CustomerInfo`.
+        val transactions = nonSubscriptionTransactions.map { transaction -> transaction.record() }
+        return (subscriptions + transactions).sortedByDescending { record -> record.dateOrNull(KEY_PURCHASED_AT) }
+    }
+
+    private fun CustomerInfo.entitlementRecords(): List<Map<String, RulesDimensionValue>> =
+        entitlements.all.values
+            .sortedBy { entitlement -> entitlement.identifier }
+            .map { entitlement -> entitlement.record() }
+
+    private fun SubscriptionInfo.record(date: Date): Map<String, RulesDimensionValue> = buildMap {
+        putString(KEY_KIND, KIND_SUBSCRIPTION)
+        putString(KEY_PRODUCT_IDENTIFIER, productIdentifier)
+        putString(KEY_PRODUCT_PLAN_IDENTIFIER, productPlanIdentifier)
+        putString(
+            KEY_PURCHASED_PRODUCT_IDENTIFIER,
+            purchasedProductIdentifier(productIdentifier, productPlanIdentifier),
+        )
+        putString(KEY_STORE_TRANSACTION_ID, storeTransactionId)
+        putString(KEY_DISPLAY_NAME, displayName)
+        putString(KEY_STORE, store.stringValue)
+        putString(KEY_OWNERSHIP_TYPE, ownershipType.dimensionValue)
+        putString(KEY_PERIOD_TYPE, periodType.dimensionValue)
+        putString(KEY_STATUS, status(date))
+        putPrice(price)
+        putDate(KEY_PURCHASED_AT, purchaseDate)
+        putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
+        putDate(KEY_EXPIRES_AT, expiresDate)
+        putDate(KEY_UNSUBSCRIBE_DETECTED_AT, unsubscribeDetectedAt)
+        putDate(KEY_BILLING_ISSUE_DETECTED_AT, billingIssuesDetectedAt)
+        putDate(KEY_GRACE_PERIOD_EXPIRES_AT, gracePeriodExpiresDate)
+        putDate(KEY_REFUNDED_AT, refundedAt)
+        putDate(KEY_AUTO_RESUME_AT, autoResumeDate)
+        putBool(KEY_IS_SANDBOX, isSandbox)
+        putBool(KEY_IS_ACTIVE, isActive)
+        putBool(KEY_WILL_RENEW, willRenew)
+        // The store keeps serving a subscription while a billing issue is being retried, and `is_active` does not
+        // cover that, so `{"or": [is_active, is_in_grace_period]}` is the still-being-served test.
+        putBool(KEY_IS_IN_GRACE_PERIOD, isInGracePeriod(date))
+        putBool(KEY_IS_REFUNDED, refundedAt != null)
+        // A resume date is only ever set while a Google subscription is paused, so having one *is* being paused.
+        putBool(KEY_IS_PAUSED, autoResumeDate != null)
+    }
+
+    private fun Transaction.record(): Map<String, RulesDimensionValue> = buildMap {
+        putString(KEY_KIND, KIND_NON_SUBSCRIPTION)
+        putString(KEY_PRODUCT_IDENTIFIER, productIdentifier)
+        // A one-time purchase has no base plan, so the two forms of the identifier are the same one.
+        putString(KEY_PURCHASED_PRODUCT_IDENTIFIER, productIdentifier)
+        putString(KEY_TRANSACTION_IDENTIFIER, transactionIdentifier)
+        putString(KEY_STORE_TRANSACTION_ID, storeTransactionId)
+        putString(KEY_DISPLAY_NAME, displayName)
+        putString(KEY_STORE, store.stringValue)
+        putPrice(price)
+        putDate(KEY_PURCHASED_AT, purchaseDate)
+        putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
+        putBool(KEY_IS_SANDBOX, isSandbox)
+    }
+
+    private fun EntitlementInfo.record(): Map<String, RulesDimensionValue> = buildMap {
+        putString(KEY_IDENTIFIER, identifier)
+        putString(KEY_PRODUCT_IDENTIFIER, productIdentifier)
+        putString(KEY_PRODUCT_PLAN_IDENTIFIER, productPlanIdentifier)
+        putString(
+            KEY_PURCHASED_PRODUCT_IDENTIFIER,
+            purchasedProductIdentifier(productIdentifier, productPlanIdentifier),
+        )
+        putString(KEY_STORE, store.stringValue)
+        putString(KEY_OWNERSHIP_TYPE, ownershipType.dimensionValue)
+        putString(KEY_PERIOD_TYPE, periodType.dimensionValue)
+        putDate(KEY_LATEST_PURCHASED_AT, latestPurchaseDate)
+        putDate(KEY_ORIGINAL_PURCHASED_AT, originalPurchaseDate)
+        putDate(KEY_EXPIRES_AT, expirationDate)
+        putDate(KEY_UNSUBSCRIBE_DETECTED_AT, unsubscribeDetectedAt)
+        putDate(KEY_BILLING_ISSUE_DETECTED_AT, billingIssueDetectedAt)
+        putBool(KEY_IS_SANDBOX, isSandbox)
+        putBool(KEY_IS_ACTIVE, isActive)
+        putBool(KEY_WILL_RENEW, willRenew)
+    }
+
+    internal companion object {
+        const val KEY_APP_USER_ID = "app_user_id"
+        const val KEY_ENTITLEMENTS = "entitlements"
+        const val KEY_FIRST_SEEN_AT = "first_seen_at"
+        const val KEY_ORIGINAL_APP_USER_ID = "original_app_user_id"
+        const val KEY_PURCHASES = "purchases"
+
+        const val KEY_AUTO_RESUME_AT = "auto_resume_at"
+        const val KEY_BILLING_ISSUE_DETECTED_AT = "billing_issue_detected_at"
+        const val KEY_DISPLAY_NAME = "display_name"
+        const val KEY_EXPIRES_AT = "expires_at"
+        const val KEY_GRACE_PERIOD_EXPIRES_AT = "grace_period_expires_at"
+        const val KEY_IDENTIFIER = "identifier"
+        const val KEY_IS_ACTIVE = "is_active"
+        const val KEY_IS_IN_GRACE_PERIOD = "is_in_grace_period"
+        const val KEY_IS_PAUSED = "is_paused"
+        const val KEY_IS_REFUNDED = "is_refunded"
+        const val KEY_IS_SANDBOX = "is_sandbox"
+        const val KEY_KIND = "kind"
+        const val KEY_LATEST_PURCHASED_AT = "latest_purchased_at"
+        const val KEY_ORIGINAL_PURCHASED_AT = "original_purchased_at"
+        const val KEY_OWNERSHIP_TYPE = "ownership_type"
+        const val KEY_PERIOD_TYPE = "period_type"
+        const val KEY_PRICE_AMOUNT_MICROS = "price_amount_micros"
+        const val KEY_PRICE_CURRENCY = "price_currency"
+        const val KEY_PRODUCT_IDENTIFIER = "product_identifier"
+        const val KEY_PRODUCT_PLAN_IDENTIFIER = "product_plan_identifier"
+        const val KEY_PURCHASED_AT = "purchased_at"
+        const val KEY_PURCHASED_PRODUCT_IDENTIFIER = "purchased_product_identifier"
+        const val KEY_REFUNDED_AT = "refunded_at"
+        const val KEY_STATUS = "status"
+        const val KEY_STORE = "store"
+        const val KEY_STORE_TRANSACTION_ID = "store_transaction_id"
+        const val KEY_TRANSACTION_IDENTIFIER = "transaction_identifier"
+        const val KEY_UNSUBSCRIBE_DETECTED_AT = "unsubscribe_detected_at"
+        const val KEY_WILL_RENEW = "will_renew"
+
+        const val KIND_NON_SUBSCRIPTION = "non_subscription"
+        const val KIND_SUBSCRIPTION = "subscription"
+
+        const val STATUS_ACTIVE = "active"
+        const val STATUS_EXPIRED = "expired"
+        const val STATUS_IN_GRACE_PERIOD = "in_grace_period"
+        const val STATUS_PAUSED = "paused"
+        const val STATUS_TRIALING = "trialing"
+
+        /**
+         * The base plan is part of what was bought on Google, and it is the form the dashboard lists a
+         * subscription under, so it is spelled out as its own value rather than left for a predicate to
+         * concatenate. Built the same way [CustomerInfo.allPurchasedProductIds] builds its keys.
+         */
+        private fun purchasedProductIdentifier(productIdentifier: String, productPlanIdentifier: String?): String =
+            productPlanIdentifier
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { plan -> "$productIdentifier${Constants.SUBS_ID_BASE_PLAN_ID_SEPARATOR}$plan" }
+                ?: productIdentifier
+
+        /**
+         * Not a value to compare against: an unknown ownership type is the absence of one.
+         */
+        private val OwnershipType.dimensionValue: String?
+            get() = when (this) {
+                OwnershipType.PURCHASED -> "PURCHASED"
+                OwnershipType.FAMILY_SHARED -> "FAMILY_SHARED"
+                OwnershipType.UNKNOWN -> null
+            }
+
+        /**
+         * Where the customer is in this subscription's lifecycle, as one value instead of a combination every
+         * predicate has to assemble for itself.
+         *
+         * Read most specific first: a paused subscription is paused whatever its dates say, a billing issue the
+         * store is still serving through outranks the trial or the renewal it interrupted, and anything not
+         * currently granting access has expired.
+         *
+         * `in_billing_retry` and `incomplete` belong to the same vocabulary but are never reported here. Once a
+         * grace period is over, whether the store is still retrying is something it tells the backend and not this
+         * device, which only sees that access lapsed; a predicate that needs the distinction reads
+         * [KEY_BILLING_ISSUE_DETECTED_AT] itself.
+         */
+        private fun SubscriptionInfo.status(date: Date): String = when {
+            autoResumeDate != null -> STATUS_PAUSED
+            isInGracePeriod(date) -> STATUS_IN_GRACE_PERIOD
+            isActive && periodType == PeriodType.TRIAL -> STATUS_TRIALING
+            isActive -> STATUS_ACTIVE
+            else -> STATUS_EXPIRED
+        }
+
+        /**
+         * The store keeps serving a subscription while a billing issue is being retried. Shared by
+         * [KEY_IS_IN_GRACE_PERIOD] and [KEY_STATUS] so the two always agree.
+         */
+        private fun SubscriptionInfo.isInGracePeriod(date: Date): Boolean =
+            gracePeriodExpiresDate?.after(date) == true
+
+        private val PeriodType.dimensionValue: String
+            get() = when (this) {
+                PeriodType.NORMAL -> "normal"
+                PeriodType.INTRO -> "intro"
+                PeriodType.TRIAL -> "trial"
+                PeriodType.PREPAID -> "prepaid"
+            }
+
+        private fun Map<String, RulesDimensionValue>.dateOrNull(key: String): Date? =
+            (this[key] as? RulesDimensionValue.DateValue)?.value
+
+        private fun MutableMap<String, RulesDimensionValue>.putBool(key: String, value: Boolean) {
+            put(key, RulesDimensionValue.BoolValue(value))
+        }
+
+        private fun MutableMap<String, RulesDimensionValue>.putString(key: String, value: String?) {
+            if (!value.isNullOrEmpty()) put(key, RulesDimensionValue.StringValue(value))
+        }
+
+        private fun MutableMap<String, RulesDimensionValue>.putDate(key: String, value: Date?) {
+            if (value != null) put(key, RulesDimensionValue.DateValue(value))
+        }
+
+        private fun MutableMap<String, RulesDimensionValue>.putObjectList(
+            key: String,
+            value: List<Map<String, RulesDimensionValue>>,
+        ) {
+            put(key, RulesDimensionValue.ObjectListValue(value))
+        }
+
+        /**
+         * The formatted price is deliberately left out: it is rendered in the device's locale, so it is not
+         * something a predicate authored once can compare against.
+         */
+        private fun MutableMap<String, RulesDimensionValue>.putPrice(price: Price?) {
+            if (price == null) return
+            put(KEY_PRICE_AMOUNT_MICROS, RulesDimensionValue.IntValue(price.amountMicros))
+            putString(KEY_PRICE_CURRENCY, price.currencyCode)
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
@@ -24,7 +24,7 @@ internal class DeviceDimensionProvider(
     private val localeProvider: LocaleProvider,
 ) : RulesDimensionProvider {
 
-    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.Device
+    override val name: String = "device"
 
     private val fixedDimensions: Map<String, RulesDimensionValue> = mapOf(
         KEY_APP_VERSION to RulesDimensionValue.StringValue(appConfig.versionName),
@@ -56,11 +56,11 @@ internal class DeviceDimensionProvider(
             .replace(oldChar = '-', newChar = '_')
 
     internal companion object {
-        const val KEY_APP_VERSION = "appVersion"
+        const val KEY_APP_VERSION = "app_version"
         const val KEY_LOCALE = "locale"
         const val KEY_PLATFORM = "platform"
-        const val KEY_PLATFORM_VERSION = "platformVersion"
-        const val KEY_SDK_VERSION = "sdkVersion"
+        const val KEY_PLATFORM_VERSION = "platform_version"
+        const val KEY_SDK_VERSION = "sdk_version"
 
         /**
          * A dimension the device could not tell us about is omitted rather than reported as an empty string: a

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/DeviceDimensionProvider.kt
@@ -29,7 +29,9 @@ internal class DeviceDimensionProvider(
     private val fixedDimensions: Map<String, RulesDimensionValue> = mapOf(
         KEY_APP_VERSION to RulesDimensionValue.StringValue(appConfig.versionName),
         KEY_PLATFORM to RulesDimensionValue.StringValue(appConfig.store.platformName),
-        KEY_PLATFORM_VERSION to RulesDimensionValue.IntValue(Build.VERSION.SDK_INT.toLong()),
+        // A string rather than a number so one predicate can treat the platform version the same on every
+        // platform: iOS reports versions like "26.1", which only a string can carry.
+        KEY_PLATFORM_VERSION to RulesDimensionValue.StringValue(Build.VERSION.SDK_INT.toString()),
         KEY_SDK_VERSION to RulesDimensionValue.StringValue(Config.frameworkVersion),
     )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -6,40 +6,23 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import java.util.Date
 
 /**
- * The SDK-owned roots a predicate can read. Closed on purpose, like `RemoteConfigTopic`: these names are part of
- * the contract predicates are authored against, so a provider must not be able to invent one.
- *
- * Each entry becomes a real nested object in the evaluated scope, because the engine's `var` operator walks
- * nested objects by strict dot-path and has no flat-key fallback — `device.appVersion` resolves *through*
- * `device`, it is never a literal key.
- */
-internal enum class RulesDimensionNamespace(val key: String) {
-    /** Predicate results pre-evaluated by the backend, supplied per evaluation; see [LocalRulesEvaluator.match]. */
-    Backend("backend"),
-
-    /** Values supplied by the caller for one evaluation; see [LocalRulesEvaluator.match]. */
-    Custom("custom"),
-    Device("device"),
-    Store("store"),
-
-    /** What the app has told the SDK about the customer; see `Purchases.setAttributes`. */
-    SubscriberAttributes("subscriberAttributes"),
-}
-
-/**
- * Supplies one subtree of on-device dimensions.
+ * Supplies part of the root scope of on-device dimensions.
  *
  * Implementations may observe or persist state internally, but values are pulled only when an evaluation asks for
  * a new snapshot, since eligibility reflects the customer's state at the moment the rule is evaluated.
  */
 internal interface RulesDimensionProvider {
 
-    /** The root this provider's values are nested under, and the name it is reported under in diagnostics. */
-    val namespace: RulesDimensionNamespace
+    /** The name this provider is reported under in diagnostics. It is not part of the evaluated scope. */
+    val name: String
 
     /**
-     * The complete current set of values relative to [namespace], keyed in camelCase (`appVersion`);
-     * [RulesDimensionResolver] adds the namespace.
+     * The complete current set of values, keyed by root-level snake_case names (`app_version`);
+     * [RulesDimensionResolver] merges every provider into a single root scope.
+     *
+     * The root names are part of the contract predicates are authored against, so a provider must not claim one
+     * that is not its own: the resolver fails the whole snapshot when two sources supply the same name, or when a
+     * provider supplies one of the roots the resolver itself owns (`evaluated_at`, `custom`, `backend`).
      *
      * A value that is unavailable is omitted rather than guessed: a predicate that reads an absent key fails as
      * an unresolved variable, rather than being answered from a value we invented. A name no predicate could

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -130,7 +130,9 @@ private fun MutableMap<String, Value>.addNestedDimensions(
 /**
  * Drops the names no predicate could ever read, at any depth; see [String.isReachableDimensionName]. Names inside
  * [RulesDimensionValue.ObjectValue] and [RulesDimensionValue.ObjectListValue] records are one `var` path segment
- * each, so the same rule applies to them, one entry at a time.
+ * each, so the same rule applies to them, one entry at a time. An object left with nothing readable is dropped
+ * along with its names, for the same reason [addNestedDimensions] contributes no root for an empty source: an
+ * empty object is truthy in JSON Logic, so keeping it would make `{"var": "profile"}` read as present.
  *
  * Dropped rather than failing the snapshot, unlike this resolver's other two rejections: custom variables are
  * named by the app, so a single value the SDK cannot expose must not stop every checkpoint from resolving. Same
@@ -143,29 +145,33 @@ private fun Map<String, RulesDimensionValue>.filterReachable(
     val path = root?.let { "$it$DIMENSION_PATH_SEPARATOR$name" } ?: name
     if (!name.isReachableDimensionName) {
         warnLog {
-            "Ignoring dimension '$path': a dimension name can't be empty or contain '$DIMENSION_PATH_SEPARATOR'."
+            "Ignoring dimension '$path': a dimension name can't be blank or contain '$DIMENSION_PATH_SEPARATOR'."
         }
         null
     } else {
-        name to value.filterReachable(path)
+        value.filterReachable(path)?.let { reachable -> name to reachable }
     }
 }.toMap()
 
-private fun RulesDimensionValue.filterReachable(path: String): RulesDimensionValue = when (this) {
-    is RulesDimensionValue.ObjectValue -> RulesDimensionValue.ObjectValue(value.filterReachable(root = path))
+private fun RulesDimensionValue.filterReachable(path: String): RulesDimensionValue? = when (this) {
+    is RulesDimensionValue.ObjectValue -> value.filterReachable(root = path)
+        .takeIf { it.isNotEmpty() }
+        ?.let { RulesDimensionValue.ObjectValue(it) }
     is RulesDimensionValue.ObjectListValue -> RulesDimensionValue.ObjectListValue(
-        value.mapIndexed { index, record -> record.filterReachable(root = "$path$DIMENSION_PATH_SEPARATOR$index") },
+        value.mapIndexedNotNull { index, record ->
+            record.filterReachable(root = "$path$DIMENSION_PATH_SEPARATOR$index").takeIf { it.isNotEmpty() }
+        },
     )
     else -> this
 }
 
 /**
  * Whether a predicate could read this name. The engine's `var` walks a strict dot-path, so a name containing a
- * `.` would be read as a path through a nested object that does not exist, and an empty one is not a name a
+ * `.` would be read as a path through a nested object that does not exist, and a blank one is not a name a
  * predicate can be written against.
  */
 internal val String.isReachableDimensionName: Boolean
-    get() = isNotEmpty() && !contains(DIMENSION_PATH_SEPARATOR)
+    get() = isNotBlank() && !contains(DIMENSION_PATH_SEPARATOR)
 
 internal const val DIMENSION_PATH_SEPARATOR = '.'
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -21,23 +21,23 @@ internal data class RulesDimensionSnapshot(
 internal sealed class RulesDimensionResolutionException(message: String) : Exception(message) {
 
     internal data class ProviderFailed(
-        val namespace: RulesDimensionNamespace,
+        val providerName: String,
         val reason: String,
-    ) : RulesDimensionResolutionException("dimension provider '${namespace.key}' failed: $reason")
+    ) : RulesDimensionResolutionException("dimension provider '$providerName' failed: $reason")
 
     internal data class ConflictingDimension(
         val path: String,
-    ) : RulesDimensionResolutionException("two dimension providers supplied '$path'")
+    ) : RulesDimensionResolutionException("two dimension sources supplied '$path'")
 }
 
 /**
- * Builds the scope local rule evaluation runs against by collecting every provider once and nesting its values
- * under the provider's namespace.
+ * Builds the scope local rule evaluation runs against by collecting every provider once and merging its values
+ * into a single root scope. Every snapshot also carries the evaluation instant as `evaluated_at`.
  *
  * All providers see the same reference instant, so every dimension in one snapshot is consistent with the others.
  *
  * Both failure modes are configuration bugs rather than runtime conditions — a provider that cannot produce its
- * values, and two providers claiming the same path — so they fail the whole snapshot instead of silently
+ * values, and two sources claiming the same root name — so they fail the whole snapshot instead of silently
  * degrading a rule to a non-match, which would be indistinguishable from a customer who genuinely does not match.
  * Cancellation is neither, and propagates.
  */
@@ -47,9 +47,10 @@ internal class RulesDimensionResolver(
 ) {
 
     /**
-     * [customVariables] are the caller's own values for this one evaluation, exposed under
-     * [RulesDimensionNamespace.Custom]. [backendValues] are the backend's pre-evaluated values for this one
-     * evaluation, exposed under [RulesDimensionNamespace.Backend].
+     * [customVariables] are the caller's own values for this one evaluation, exposed under `custom`.
+     * [backendValues] are the backend's pre-evaluated values for this one evaluation, exposed under `backend`.
+     * Both roots are reserved whether or not this evaluation supplies values for them, so a provider colliding
+     * with one is deterministic rather than dependent on call arguments.
      */
     @Suppress("ReturnCount")
     suspend fun snapshot(
@@ -57,7 +58,8 @@ internal class RulesDimensionResolver(
         backendValues: Map<String, RulesDimensionValue> = emptyMap(),
     ): Result<RulesDimensionSnapshot> {
         val date = dateProvider.now
-        val values = mutableMapOf<String, MutableMap<String, Value>>()
+        // Seeded before any provider runs, so a provider claiming this root is an ordinary collision.
+        val values = mutableMapOf<String, Value>(KEY_EVALUATED_AT to Value.IntValue(date.time))
 
         for (provider in providers) {
             val dimensions = try {
@@ -67,75 +69,79 @@ internal class RulesDimensionResolver(
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
                 return Result.failure(
                     RulesDimensionResolutionException.ProviderFailed(
-                        namespace = provider.namespace,
+                        providerName = provider.name,
                         reason = error.message ?: error.toString(),
                     ),
                 )
             }
-            values.addDimensions(provider.namespace, dimensions)?.let { conflict ->
+            values.addRootDimensions(dimensions)?.let { conflict ->
                 return Result.failure(conflict)
             }
         }
 
-        values.addDimensions(RulesDimensionNamespace.Custom, customVariables)?.let { conflict ->
+        values.addNestedDimensions(KEY_CUSTOM, customVariables)?.let { conflict ->
             return Result.failure(conflict)
         }
 
-        values.addDimensions(RulesDimensionNamespace.Backend, backendValues)?.let { conflict ->
+        values.addNestedDimensions(KEY_BACKEND, backendValues)?.let { conflict ->
             return Result.failure(conflict)
         }
 
         return Result.success(
             RulesDimensionSnapshot(
-                values = values.mapValues { (_, dimensions) -> Value.ObjectValue(dimensions) },
+                values = values,
                 evaluationDate = date,
             ),
         )
     }
 }
 
-/** Nests [dimensions] under [namespace], or returns the conflict that stops the whole snapshot. */
-@Suppress("ReturnCount")
-private fun MutableMap<String, MutableMap<String, Value>>.addDimensions(
-    namespace: RulesDimensionNamespace,
+/** Merges [dimensions] into the root scope, or returns the conflict that stops the whole snapshot. */
+private fun MutableMap<String, Value>.addRootDimensions(
     dimensions: Map<String, RulesDimensionValue>,
 ): RulesDimensionResolutionException.ConflictingDimension? {
-    // Filtered before the check below, so a source whose every name was unreachable still contributes no namespace.
-    val reachable = dimensions.filterReachable(namespace)
-    // A source with nothing to say contributes no namespace at all: an empty object is truthy in JSON Logic, so
-    // `{"var": "store"}` would read as present for a customer whose store never answered.
-    if (reachable.isEmpty()) return null
-    val target = getOrPut(namespace.key) { mutableMapOf() }
-    for ((name, value) in reachable) {
-        if (target.containsKey(name)) {
-            return RulesDimensionResolutionException.ConflictingDimension("${namespace.key}.$name")
+    for ((name, value) in dimensions.filterReachable(root = null)) {
+        if (containsKey(name) || name == KEY_CUSTOM || name == KEY_BACKEND) {
+            return RulesDimensionResolutionException.ConflictingDimension(name)
         }
-        target[name] = value.asRulesEngineValue
+        this[name] = value.asRulesEngineValue
     }
     return null
 }
 
+/** Nests [dimensions] under [root], or returns the conflict that stops the whole snapshot. */
+@Suppress("ReturnCount")
+private fun MutableMap<String, Value>.addNestedDimensions(
+    root: String,
+    dimensions: Map<String, RulesDimensionValue>,
+): RulesDimensionResolutionException.ConflictingDimension? {
+    // Filtered before the check below, so a source whose every name was unreachable still contributes no root.
+    val reachable = dimensions.filterReachable(root)
+    // A source with nothing to say contributes no root at all: an empty object is truthy in JSON Logic, so
+    // `{"var": "custom"}` would read as present for an evaluation that supplied no custom values.
+    if (reachable.isEmpty()) return null
+    if (containsKey(root)) {
+        return RulesDimensionResolutionException.ConflictingDimension(root)
+    }
+    this[root] = Value.ObjectValue(reachable.mapValues { (_, value) -> value.asRulesEngineValue })
+    return null
+}
+
 /**
- * Drops the names no predicate could ever read, at any depth. The engine's `var` walks a strict dot-path, so a
- * name containing a `.` would be read as a path through a nested object that does not exist, and an empty one is
- * not a name a predicate can be written against. Names inside [RulesDimensionValue.ObjectValue] and
- * [RulesDimensionValue.ObjectListValue] records are one `var` path segment each, so the same rule applies to
- * them, one entry at a time.
+ * Drops the names no predicate could ever read, at any depth; see [String.isReachableDimensionName]. Names inside
+ * [RulesDimensionValue.ObjectValue] and [RulesDimensionValue.ObjectListValue] records are one `var` path segment
+ * each, so the same rule applies to them, one entry at a time.
  *
- * Dropped rather than failing the snapshot, unlike this resolver's other two rejections: a namespace like
- * [RulesDimensionNamespace.SubscriberAttributes] is named by the app, so a single attribute the SDK cannot expose
- * must not stop every checkpoint from resolving. Same treatment `CustomVariableKeyValidator` gives the other
- * developer-named namespace.
+ * Dropped rather than failing the snapshot, unlike this resolver's other two rejections: custom variables are
+ * named by the app, so a single value the SDK cannot expose must not stop every checkpoint from resolving. Same
+ * treatment `CustomVariableKeyValidator` gives them at registration time, and
+ * [SubscriberAttributesDimensionProvider] gives the other developer-named source.
  */
 private fun Map<String, RulesDimensionValue>.filterReachable(
-    namespace: RulesDimensionNamespace,
-): Map<String, RulesDimensionValue> = filterReachable(parentPath = namespace.key)
-
-private fun Map<String, RulesDimensionValue>.filterReachable(
-    parentPath: String,
+    root: String?,
 ): Map<String, RulesDimensionValue> = mapNotNull { (name, value) ->
-    val path = "$parentPath$DIMENSION_PATH_SEPARATOR$name"
-    if (name.isEmpty() || name.contains(DIMENSION_PATH_SEPARATOR)) {
+    val path = root?.let { "$it$DIMENSION_PATH_SEPARATOR$name" } ?: name
+    if (!name.isReachableDimensionName) {
         warnLog {
             "Ignoring dimension '$path': a dimension name can't be empty or contain '$DIMENSION_PATH_SEPARATOR'."
         }
@@ -146,14 +152,26 @@ private fun Map<String, RulesDimensionValue>.filterReachable(
 }.toMap()
 
 private fun RulesDimensionValue.filterReachable(path: String): RulesDimensionValue = when (this) {
-    is RulesDimensionValue.ObjectValue -> RulesDimensionValue.ObjectValue(value.filterReachable(path))
+    is RulesDimensionValue.ObjectValue -> RulesDimensionValue.ObjectValue(value.filterReachable(root = path))
     is RulesDimensionValue.ObjectListValue -> RulesDimensionValue.ObjectListValue(
-        value.mapIndexed { index, record -> record.filterReachable("$path$DIMENSION_PATH_SEPARATOR$index") },
+        value.mapIndexed { index, record -> record.filterReachable(root = "$path$DIMENSION_PATH_SEPARATOR$index") },
     )
     else -> this
 }
 
-private const val DIMENSION_PATH_SEPARATOR = '.'
+/**
+ * Whether a predicate could read this name. The engine's `var` walks a strict dot-path, so a name containing a
+ * `.` would be read as a path through a nested object that does not exist, and an empty one is not a name a
+ * predicate can be written against.
+ */
+internal val String.isReachableDimensionName: Boolean
+    get() = isNotEmpty() && !contains(DIMENSION_PATH_SEPARATOR)
+
+internal const val DIMENSION_PATH_SEPARATOR = '.'
+
+private const val KEY_EVALUATED_AT = "evaluated_at"
+private const val KEY_CUSTOM = "custom"
+private const val KEY_BACKEND = "backend"
 
 private val RulesDimensionValue.asRulesEngineValue: Value
     get() = when (this) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValue.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValue.kt
@@ -48,7 +48,7 @@ public sealed class RulesDimensionValue {
      * A named group of values, for a dimension that is one thing described several ways — a subscriber attribute
      * and when it was set.
      *
-     * Reaches the engine as a nested object, which `var` walks by dot-path: `subscriberAttributes.goal.value`
+     * Reaches the engine as a nested object, which `var` walks by dot-path: `subscriber_attributes.goal.value`
      * resolves *through* `goal`. Unlike a record inside [ObjectListValue], a predicate reading one of these still
      * sees the whole scope around it, because no iteration operator is involved.
      *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/StoreDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/StoreDimensionProvider.kt
@@ -13,8 +13,8 @@ import java.util.MissingResourceException
 /**
  * Store dimensions: what the customer's storefront says about where they buy.
  *
- * `country` is an ISO 3166-1 **alpha-3** code such as `USA`, which is the format StoreKit hands the iOS SDK, so one
- * predicate can target a country on either platform. Android's stores report alpha-2 (`US`), so it is converted
+ * `storefront` is an ISO 3166-1 **alpha-3** code such as `USA`, which is the format StoreKit hands the iOS SDK, so
+ * one predicate can target a country on either platform. Android's stores report alpha-2 (`US`), so it is converted
  * here, and a code with no alpha-3 equivalent is omitted rather than guessed — the Amazon Appstore reports a
  * marketplace rather than a country, and values like `UK` are not ISO regions.
  */
@@ -22,7 +22,7 @@ internal class StoreDimensionProvider(
     private val storefrontCountryCode: suspend () -> String?,
 ) : RulesDimensionProvider {
 
-    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.Store
+    override val name: String = "store"
 
     /**
      * Fetched rather than snapshotted: the storefront is not known until the store has been asked, and it can
@@ -50,7 +50,7 @@ internal class StoreDimensionProvider(
             warnLog { "Ignoring store country '$countryCode': it has no ISO 3166-1 alpha-3 equivalent." }
             return emptyMap()
         }
-        return mapOf(KEY_COUNTRY to RulesDimensionValue.StringValue(alpha3CountryCode))
+        return mapOf(KEY_STOREFRONT to RulesDimensionValue.StringValue(alpha3CountryCode))
     }
 
     private fun String.asAlpha3CountryCodeOrNull(): String? =
@@ -63,6 +63,6 @@ internal class StoreDimensionProvider(
         }
 
     internal companion object {
-        const val KEY_COUNTRY = "country"
+        const val KEY_STOREFRONT = "storefront"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
@@ -11,7 +11,7 @@ internal class SubscriberAttributesDimensionProvider(
     private val storedAttributes: () -> Map<String, SubscriberAttribute>,
 ) : RulesDimensionProvider {
 
-    override val namespace: RulesDimensionNamespace = RulesDimensionNamespace.SubscriberAttributes
+    override val name: String = KEY_SUBSCRIBER_ATTRIBUTES
 
     /**
      * Read per evaluation rather than snapshotted: an app can set an attribute at any time, and an audience keyed
@@ -21,6 +21,7 @@ internal class SubscriberAttributesDimensionProvider(
      * of whatever is on disk, so a payload an older version wrote differently surfaces here, and that should not
      * take an otherwise resolvable checkpoint down with it.
      */
+    @Suppress("ReturnCount")
     override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
         val attributes = try {
             storedAttributes()
@@ -28,27 +29,39 @@ internal class SubscriberAttributesDimensionProvider(
             warnLog { "The subscriber attributes are unavailable, so they can't be evaluated: $e" }
             return emptyMap()
         }
-        return attributes.values.mapNotNull { attribute -> attribute.dimension(date) }.toMap()
+        val records = attributes.values.mapNotNull { attribute -> attribute.record() }.toMap()
+        // Absent rather than empty when there is nothing to say: an empty object is truthy in JSON Logic, so
+        // `{"var": "subscriber_attributes"}` would read as present for a customer who has no attributes.
+        if (records.isEmpty()) return emptyMap()
+        return mapOf(KEY_SUBSCRIBER_ATTRIBUTES to RulesDimensionValue.ObjectValue(records))
     }
 
-    private fun SubscriberAttribute.dimension(date: Date): Pair<String, RulesDimensionValue>? {
+    @Suppress("ReturnCount")
+    private fun SubscriberAttribute.record(): Pair<String, RulesDimensionValue>? {
         // A deleted attribute is kept as a tombstone with no value until it has been posted, and an empty value is
         // the SDK's other spelling of a deletion, so both mean the customer no longer has the attribute.
         val value = value?.takeIf { it.isNotEmpty() } ?: return null
-        // A name the engine could not resolve is dropped by RulesDimensionResolver, which applies the same rule to
-        // every source.
+        // RulesDimensionResolver applies the same reachability rule at every depth, but this provider must filter
+        // before it counts: a customer whose only attributes are unreadable has to contribute no root at all,
+        // and by the time the resolver drops the names, the root object would already exist (empty, and truthy).
+        if (!key.backendKey.isReachableDimensionName) {
+            warnLog {
+                "Ignoring dimension '$KEY_SUBSCRIBER_ATTRIBUTES$DIMENSION_PATH_SEPARATOR${key.backendKey}': " +
+                    "a dimension name can't be empty or contain '$DIMENSION_PATH_SEPARATOR'."
+            }
+            return null
+        }
         return key.backendKey to RulesDimensionValue.ObjectValue(
             mapOf(
                 KEY_VALUE to RulesDimensionValue.StringValue(value),
                 KEY_UPDATED_AT to RulesDimensionValue.DateValue(setTime),
-                KEY_EVALUATED_AT to RulesDimensionValue.DateValue(date),
             ),
         )
     }
 
     internal companion object {
-        const val KEY_EVALUATED_AT = "evaluatedAt"
-        const val KEY_UPDATED_AT = "updatedAt"
+        const val KEY_SUBSCRIBER_ATTRIBUTES = "subscriber_attributes"
+        const val KEY_UPDATED_AT = "updated_at"
         const val KEY_VALUE = "value"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProvider.kt
@@ -47,7 +47,7 @@ internal class SubscriberAttributesDimensionProvider(
         if (!key.backendKey.isReachableDimensionName) {
             warnLog {
                 "Ignoring dimension '$KEY_SUBSCRIBER_ATTRIBUTES$DIMENSION_PATH_SEPARATOR${key.backendKey}': " +
-                    "a dimension name can't be empty or contain '$DIMENSION_PATH_SEPARATOR'."
+                    "a dimension name can't be blank or contain '$DIMENSION_PATH_SEPARATOR'."
             }
             return null
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -2207,6 +2207,51 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
+    fun `getCustomerInfo for a given app user ID asks about exactly that user`() {
+        val callback = mockk<ReceiveCustomerInfoCallback>(relaxed = true)
+
+        purchases.purchasesOrchestrator.getCustomerInfo(
+            appUserID = "other_user",
+            fetchPolicy = CacheFetchPolicy.FETCH_CURRENT,
+            trackDiagnostics = true,
+            callback = callback,
+        )
+
+        verify(exactly = 1) {
+            mockCustomerInfoHelper.retrieveCustomerInfo(
+                "other_user",
+                CacheFetchPolicy.FETCH_CURRENT,
+                appInBackground = false,
+                allowSharingPlayStoreAccount = false,
+                trackDiagnostics = true,
+                callback = callback,
+            )
+        }
+    }
+
+    @Test
+    fun `getCustomerInfo without an explicit app user ID asks about the current user`() {
+        val callback = mockk<ReceiveCustomerInfoCallback>(relaxed = true)
+
+        purchases.purchasesOrchestrator.getCustomerInfo(
+            fetchPolicy = CacheFetchPolicy.FETCH_CURRENT,
+            trackDiagnostics = false,
+            callback = callback,
+        )
+
+        verify(exactly = 1) {
+            mockCustomerInfoHelper.retrieveCustomerInfo(
+                appUserId,
+                CacheFetchPolicy.FETCH_CURRENT,
+                appInBackground = false,
+                allowSharingPlayStoreAccount = false,
+                trackDiagnostics = false,
+                callback = callback,
+            )
+        }
+    }
+
+    @Test
     fun `fetch customer info on foregrounded if it's stale`() {
         mockCacheStale(customerInfoStale = true)
         mockSynchronizeSubscriberAttributesForAllUsers()

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -19,7 +19,6 @@ import com.revenuecat.purchases.common.checkpoints.CheckpointRule
 import com.revenuecat.purchases.common.checkpoints.CheckpointRulesResolution
 import com.revenuecat.purchases.common.checkpoints.CheckpointsConfigProvider
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
-import com.revenuecat.purchases.common.localrules.RulesDimensionNamespace
 import com.revenuecat.purchases.common.localrules.RulesDimensionProvider
 import com.revenuecat.purchases.common.localrules.RulesDimensionValue
 import com.revenuecat.purchases.common.remoteconfig.ConfigTopic
@@ -672,7 +671,7 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     private object FailingDimensionProvider : RulesDimensionProvider {
-        override val namespace = RulesDimensionNamespace.Device
+        override val name = "device"
         override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
             throw IllegalStateException("no dimensions")
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -1,0 +1,586 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.CustomerInfoFactory
+import com.revenuecat.purchases.rules.RulesEngine
+import com.revenuecat.purchases.rules.Value
+import com.revenuecat.purchases.utils.Iso8601Utils
+import com.revenuecat.purchases.utils.Responses
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class CustomerInfoDimensionProviderTest {
+
+    private val date = Date(1_700_000_000_000)
+
+    @Test
+    fun `provides the customer's identity and lifecycle dimensions`() = runTest {
+        val dimensions = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date)
+
+        assertThat(dimensions.filterValues { it !is RulesDimensionValue.ObjectListValue }).isEqualTo(
+            mapOf(
+                "app_user_id" to string(APP_USER_ID),
+                "original_app_user_id" to string("original_user"),
+                "first_seen_at" to date("2022-01-01T00:00:00Z"),
+                "original_purchased_at" to date("2021-01-01T00:00:00Z"),
+            ),
+        )
+    }
+
+    @Test
+    fun `describes every purchase of either kind, newest first`() = runTest {
+        val purchases = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+
+        assertThat(purchases.map { it["kind"] to it["purchased_product_identifier"] }).containsExactly(
+            string("subscription") to string("premium:monthly"),
+            string("non_subscription") to string("coins"),
+            string("subscription") to string("legacy:annual"),
+        )
+    }
+
+    @Test
+    fun `describes a subscription with everything the SDK knows about it`() = runTest {
+        val purchases = provider(customerInfo(FULLY_POPULATED_RESPONSE)).dimensions(date).purchases()
+
+        assertThat(purchases.single()).isEqualTo(
+            mapOf(
+                "kind" to string("subscription"),
+                "product_identifier" to string("premium"),
+                "product_plan_identifier" to string("monthly"),
+                "purchased_product_identifier" to string("premium:monthly"),
+                "store_transaction_id" to string("GPA.0000-0000-0000-00000"),
+                "display_name" to string("Premium Monthly"),
+                "store" to string("play_store"),
+                "ownership_type" to string("PURCHASED"),
+                "period_type" to string("trial"),
+                "status" to string("paused"),
+                "price_amount_micros" to RulesDimensionValue.IntValue(4_990_000),
+                "price_currency" to string("USD"),
+                "purchased_at" to date("2024-05-01T00:00:00Z"),
+                "original_purchased_at" to date("2021-01-01T00:00:00Z"),
+                "expires_at" to date("2100-01-01T00:00:00Z"),
+                "unsubscribe_detected_at" to date("2024-05-03T00:00:00Z"),
+                "billing_issue_detected_at" to date("2024-05-04T00:00:00Z"),
+                "grace_period_expires_at" to date("2024-05-10T00:00:00Z"),
+                "refunded_at" to date("2024-05-05T00:00:00Z"),
+                "auto_resume_at" to date("2024-06-01T00:00:00Z"),
+                "is_sandbox" to bool(true),
+                "is_active" to bool(true),
+                "will_renew" to bool(false),
+                "is_in_grace_period" to bool(true),
+                "is_refunded" to bool(true),
+                "is_paused" to bool(true),
+            ),
+        )
+    }
+
+    @Test
+    fun `describes a one-time purchase without the fields only a subscription has`() = runTest {
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+            .single { it["kind"] == string("non_subscription") }
+
+        assertThat(purchase).isEqualTo(
+            mapOf(
+                "kind" to string("non_subscription"),
+                "product_identifier" to string("coins"),
+                "purchased_product_identifier" to string("coins"),
+                "transaction_identifier" to string("abc123"),
+                "store" to string("play_store"),
+                "purchased_at" to date("2023-03-03T00:00:00Z"),
+                "original_purchased_at" to date("2023-03-03T00:00:00Z"),
+                "is_sandbox" to bool(true),
+            ),
+        )
+    }
+
+    @Test
+    fun `describes every entitlement, ordered by identifier`() = runTest {
+        val entitlements = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).entitlements()
+
+        assertThat(entitlements.map { it["identifier"] })
+            .containsExactly(string("extra"), string("old"), string("premium"))
+        assertThat(entitlements.single { it["identifier"] == string("old") }).isEqualTo(
+            mapOf(
+                "identifier" to string("old"),
+                "product_identifier" to string("legacy"),
+                "product_plan_identifier" to string("annual"),
+                "purchased_product_identifier" to string("legacy:annual"),
+                "store" to string("amazon"),
+                "ownership_type" to string("FAMILY_SHARED"),
+                "period_type" to string("normal"),
+                "latest_purchased_at" to date("2022-06-01T00:00:00Z"),
+                "original_purchased_at" to date("2022-06-01T00:00:00Z"),
+                "expires_at" to date("2023-06-01T00:00:00Z"),
+                "is_sandbox" to bool(true),
+                "is_active" to bool(false),
+                "will_renew" to bool(true),
+            ),
+        )
+    }
+
+    @Test
+    fun `reports where the customer is in each subscription's lifecycle`() = runTest {
+        val cases = listOf(
+            Triple("a paid subscription", "active", statusResponse(expiresDate = FUTURE)),
+            Triple("a free trial", "trialing", statusResponse(expiresDate = FUTURE, periodType = "trial")),
+            // Still being served while the billing issue is retried, which outranks the trial it interrupted.
+            Triple(
+                "a trial in a grace period",
+                "in_grace_period",
+                statusResponse(
+                    expiresDate = FUTURE,
+                    periodType = "trial",
+                    billingIssuesDetectedAt = PAST,
+                    gracePeriodExpiresDate = FUTURE,
+                ),
+            ),
+            // Paused whatever the dates say.
+            Triple("a paused subscription", "paused", statusResponse(expiresDate = FUTURE, autoResumeDate = FUTURE)),
+            Triple("a lapsed subscription", "expired", statusResponse(expiresDate = PAST)),
+            // The device cannot tell a store still retrying from one that gave up long ago, so this does not claim
+            // `in_billing_retry`; `billing_issue_detected_at` is on the record for a predicate that needs it.
+            Triple(
+                "a subscription that lapsed after a billing issue",
+                "expired",
+                statusResponse(expiresDate = PAST, billingIssuesDetectedAt = PAST),
+            ),
+        )
+
+        for ((label, expected, response) in cases) {
+            val purchase = provider(customerInfo(response)).dimensions(date).purchases().single()
+
+            assertThat(purchase["status"]).describedAs(label).isEqualTo(string(expected))
+        }
+    }
+
+    @Test
+    fun `a lifetime subscription is active`() = runTest {
+        val purchase = provider(customerInfo(LIFETIME_RESPONSE)).dimensions(date).purchases().single()
+
+        assertThat(purchase["status"]).isEqualTo(string("active"))
+    }
+
+    @Test
+    fun `the grace period status and the grace period flag always agree`() = runTest {
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+            .single { it["purchased_product_identifier"] == string("legacy:annual") }
+
+        assertThat(purchase["is_in_grace_period"]).isEqualTo(bool(true))
+        assertThat(purchase["status"]).isEqualTo(string("in_grace_period"))
+    }
+
+    @Test
+    fun `a one-time purchase has no status, since only a subscription has a lifecycle`() = runTest {
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+            .single { it["kind"] == string("non_subscription") }
+
+        assertThat(purchase).doesNotContainKey("status")
+    }
+
+    @Test
+    fun `a customer who has never bought anything reports empty collections rather than none`() = runTest {
+        val dimensions = provider(customerInfo(Responses.validEmptyPurchaserResponse)).dimensions(date)
+
+        // An empty array is what makes `none` a definite yes and `some` a definite no; an absent key would leave
+        // both unknown.
+        assertThat(dimensions["purchases"]).isEqualTo(RulesDimensionValue.ObjectListValue(emptyList()))
+        assertThat(dimensions["entitlements"]).isEqualTo(RulesDimensionValue.ObjectListValue(emptyList()))
+    }
+
+    @Test
+    fun `a lifetime purchase reports no expiry and stays active`() = runTest {
+        val purchase = provider(customerInfo(LIFETIME_RESPONSE)).dimensions(date).purchases().single()
+
+        assertThat(purchase).doesNotContainKey("expires_at")
+        assertThat(purchase["is_active"]).isEqualTo(bool(true))
+        // Nothing to renew.
+        assertThat(purchase["will_renew"]).isEqualTo(bool(false))
+    }
+
+    @Test
+    fun `an unknown ownership type is reported as no ownership type at all`() = runTest {
+        val purchase = provider(customerInfo(PROMO_RESPONSE)).dimensions(date).purchases().single()
+
+        assertThat(purchase).doesNotContainKey("ownership_type")
+        assertThat(purchase["store"]).isEqualTo(string("promotional"))
+    }
+
+    @Test
+    fun `a subscription being served through a grace period says so`() = runTest {
+        val purchase = provider(customerInfo(SUBSCRIBED_RESPONSE)).dimensions(date).purchases()
+            .single { it["purchased_product_identifier"] == string("legacy:annual") }
+
+        // Expired in 2023, but the store keeps serving it until 2100.
+        assertThat(purchase["is_active"]).isEqualTo(bool(false))
+        assertThat(purchase["is_in_grace_period"]).isEqualTo(bool(true))
+    }
+
+    @Test
+    fun `a customer info that cannot be read leaves the identity dimensions usable`() = runTest {
+        // Not just PurchasesException: the read goes through the configured instance, which an app can tear down
+        // mid-evaluation, and it can fall back to the network.
+        val failures = listOf(
+            PurchasesException(PurchasesError(PurchasesErrorCode.NetworkError, "Nope.")),
+            UninitializedPropertyAccessException("There is no singleton instance."),
+            IllegalStateException("Something else entirely."),
+        )
+
+        for (failure in failures) {
+            val snapshot = resolver(provider { throw failure }).snapshot()
+
+            assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
+            // The app user ID is known without asking the backend, so a rule on it survives the failure.
+            val values = snapshot.getOrThrow().values
+            assertThat(values["app_user_id"]).describedAs("%s", failure)
+                .isEqualTo(Value.StringValue(APP_USER_ID))
+            assertThat(values).describedAs("%s", failure).doesNotContainKey("purchases")
+        }
+    }
+
+    @Test
+    fun `the customer info is requested for the app user the dimensions report`() = runTest {
+        var requestedAppUserId: String? = null
+        val provider = provider { appUserId ->
+            requestedAppUserId = appUserId
+            customerInfo(SUBSCRIBED_RESPONSE)
+        }
+
+        val dimensions = provider.dimensions(date)
+
+        // Both come from the same read of the current ID, so they cannot describe two different customers.
+        assertThat(requestedAppUserId).isEqualTo(APP_USER_ID)
+        assertThat(dimensions["app_user_id"]).isEqualTo(string(APP_USER_ID))
+        assertThat(dimensions.purchases()).isNotEmpty()
+    }
+
+    @Test
+    fun `a customer the SDK has no ID for is not asked about`() = runTest {
+        var asked = false
+        val provider = CustomerInfoDimensionProvider(
+            currentAppUserId = { "" },
+            customerInfo = {
+                asked = true
+                customerInfo(SUBSCRIBED_RESPONSE)
+            },
+        )
+
+        val dimensions = provider.dimensions(date)
+
+        assertThat(asked).isFalse()
+        assertThat(dimensions).isEmpty()
+    }
+
+    @Test
+    fun `cancellation while reading the customer info propagates`() = runTest {
+        val cancelling = provider { throw CancellationException("cancelled") }
+
+        val thrown = try {
+            cancelling.dimensions(date)
+            null
+        } catch (e: CancellationException) {
+            e
+        }
+
+        assertThat(thrown).hasMessage("cancelled")
+    }
+
+    @Test
+    fun `the customer info is read on every evaluation`() = runTest {
+        var response = Responses.validEmptyPurchaserResponse
+        val provider = provider { customerInfo(response) }
+
+        assertThat(provider.dimensions(date).purchases()).isEmpty()
+
+        response = SUBSCRIBED_RESPONSE
+
+        assertThat(provider.dimensions(date).purchases()).hasSize(3)
+    }
+
+    @Test
+    fun `the records are searchable by a predicate`() = runTest {
+        val values = resolver(provider(customerInfo(SUBSCRIBED_RESPONSE))).snapshot().getOrThrow().values
+
+        val matching = listOf(
+            """{"==": [{"var": "app_user_id"}, "$APP_USER_ID"]}""",
+            """{"some": [{"var": "entitlements"},
+                 {"and": [{"==": [{"var": "identifier"}, "premium"]}, {"var": "is_active"}]}]}""",
+            """{"some": [{"var": "purchases"},
+                 {"==": [{"var": "purchased_product_identifier"}, "legacy:annual"]}]}""",
+            // The latest purchase of any kind, with no iteration at all.
+            """{"==": [{"var": "purchases.0.product_identifier"}, "premium"]}""",
+            // Ends more than a day from the evaluation instant. Read by index, since the root instant is not
+            // in scope inside an iteration operator.
+            """{">": [{"-": [{"var": "purchases.0.expires_at"}, {"var": "evaluated_at"}]}, 86400000]}""",
+            // A one-time purchase omits `is_refunded`, and negation cannot match on an omitted variable, so a
+            // predicate across both kinds spells out the default.
+            """{"none": [{"var": "purchases"}, {"var": ["is_refunded", false]}]}""",
+        )
+        val notMatching = listOf(
+            """{"some": [{"var": "entitlements"},
+                 {"and": [{"==": [{"var": "identifier"}, "old"]}, {"var": "is_active"}]}]}""",
+            """{"some": [{"var": "purchases"}, {"==": [{"var": ["period_type", ""]}, "trial"]}]}""",
+            """{"some": [{"var": "purchases"},
+                 {"==": [{"var": "purchased_product_identifier"}, "legacy"]}]}""",
+        )
+
+        for (predicate in matching) {
+            assertThat(RulesEngine.evaluate(predicate, values).getOrThrow()).describedAs(predicate).isTrue()
+        }
+        for (predicate in notMatching) {
+            assertThat(RulesEngine.evaluate(predicate, values).getOrThrow()).describedAs(predicate).isFalse()
+        }
+    }
+
+    private fun provider(customerInfo: CustomerInfo) = provider { customerInfo }
+
+    private fun provider(customerInfo: suspend (appUserId: String) -> CustomerInfo) = CustomerInfoDimensionProvider(
+        currentAppUserId = { APP_USER_ID },
+        customerInfo = customerInfo,
+    )
+
+    private fun resolver(customerInfoProvider: RulesDimensionProvider) = RulesDimensionResolver(
+        providers = listOf(deviceProvider(), customerInfoProvider),
+    )
+
+    private fun deviceProvider() = object : RulesDimensionProvider {
+        override val name = "device"
+        override suspend fun dimensions(date: Date) = mapOf("platform" to string("android"))
+    }
+
+    private fun customerInfo(response: String): CustomerInfo =
+        CustomerInfoFactory.buildCustomerInfo(JSONObject(response), null, VerificationResult.NOT_REQUESTED)
+
+    private fun Map<String, RulesDimensionValue>.purchases() = objectList("purchases")
+    private fun Map<String, RulesDimensionValue>.entitlements() = objectList("entitlements")
+
+    private fun Map<String, RulesDimensionValue>.objectList(key: String) =
+        (this[key] as RulesDimensionValue.ObjectListValue).value
+
+    private fun string(value: String) = RulesDimensionValue.StringValue(value)
+    private fun bool(value: Boolean) = RulesDimensionValue.BoolValue(value)
+    private fun date(iso8601: String) = RulesDimensionValue.DateValue(Iso8601Utils.parse(iso8601))
+
+    private companion object {
+
+        const val APP_USER_ID = "current_user"
+
+        /**
+         * A Google subscription bought most recently, an Amazon one that expired but is in a grace period, and a
+         * one-time purchase in between. Two entitlements are unlocked by the latest subscription and one by the
+         * older one.
+         */
+        val SUBSCRIBED_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "premium": {
+                  ${subscription(
+                store = "play_store",
+                purchaseDate = "2024-01-15T10:00:00Z",
+                originalPurchaseDate = "2021-01-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = "PURCHASED",
+            )}
+                },
+                "legacy": {
+                  ${subscription(
+                store = "amazon",
+                purchaseDate = "2022-06-01T00:00:00Z",
+                originalPurchaseDate = "2022-06-01T00:00:00Z",
+                expiresDate = "2023-06-01T00:00:00Z",
+                ownershipType = "FAMILY_SHARED",
+                productPlanIdentifier = "annual",
+                gracePeriodExpiresDate = "2100-01-01T00:00:00Z",
+            )}
+                }
+            """,
+            nonSubscriptions = """
+                "coins": [
+                  {
+                    "id": "abc123",
+                    "is_sandbox": true,
+                    "original_purchase_date": "2023-03-03T00:00:00Z",
+                    "purchase_date": "2023-03-03T00:00:00Z",
+                    "store": "play_store"
+                  }
+                ]
+            """,
+            entitlements = """
+                "premium": {
+                  "expires_date": "2100-01-01T00:00:00Z",
+                  "product_identifier": "premium",
+                  "product_plan_identifier": "monthly",
+                  "purchase_date": "2024-01-15T10:00:00Z"
+                },
+                "extra": {
+                  "expires_date": "2100-01-01T00:00:00Z",
+                  "product_identifier": "premium",
+                  "product_plan_identifier": "monthly",
+                  "purchase_date": "2024-01-15T10:00:00Z"
+                },
+                "old": {
+                  "expires_date": "2023-06-01T00:00:00Z",
+                  "product_identifier": "legacy",
+                  "product_plan_identifier": "annual",
+                  "purchase_date": "2022-06-01T00:00:00Z"
+                }
+            """,
+        )
+
+        /** Every field the backend can send on a subscription, so a record can be asserted whole. */
+        val FULLY_POPULATED_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "premium": {
+                  ${subscription(
+                store = "play_store",
+                purchaseDate = "2024-05-01T00:00:00Z",
+                originalPurchaseDate = "2021-01-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = "PURCHASED",
+                periodType = "trial",
+                unsubscribeDetectedAt = "2024-05-03T00:00:00Z",
+                billingIssuesDetectedAt = "2024-05-04T00:00:00Z",
+                gracePeriodExpiresDate = "2024-05-10T00:00:00Z",
+                refundedAt = "2024-05-05T00:00:00Z",
+                autoResumeDate = "2024-06-01T00:00:00Z",
+                displayName = "Premium Monthly",
+                price = """{"amount": 4.99, "currency": "USD"}""",
+            )}
+                }
+            """,
+        )
+
+        val LIFETIME_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "lifetime": {
+                  ${subscription(
+                store = "play_store",
+                purchaseDate = "2024-05-01T00:00:00Z",
+                originalPurchaseDate = "2024-05-01T00:00:00Z",
+                expiresDate = null,
+                ownershipType = "PURCHASED",
+            )}
+                }
+            """,
+        )
+
+        val PROMO_RESPONSE = subscriberResponse(
+            subscriptions = """
+                "rc_promo_pro_monthly": {
+                  ${subscription(
+                store = "promotional",
+                purchaseDate = "2024-05-01T00:00:00Z",
+                originalPurchaseDate = "2024-05-01T00:00:00Z",
+                expiresDate = "2100-01-01T00:00:00Z",
+                ownershipType = null,
+            )}
+                }
+            """,
+        )
+
+        const val FUTURE = "2100-01-01T00:00:00Z"
+
+        // Before the evaluation date, so a grace period ending here has already ended.
+        const val PAST = "2023-01-01T00:00:00Z"
+
+        /** One subscription, naming only the fields a status is derived from. */
+        private fun statusResponse(
+            expiresDate: String?,
+            periodType: String = "normal",
+            billingIssuesDetectedAt: String? = null,
+            gracePeriodExpiresDate: String? = null,
+            autoResumeDate: String? = null,
+        ) = subscriberResponse(
+            subscriptions = """
+                "premium": {
+                  ${subscription(
+            store = "play_store",
+            purchaseDate = "2024-05-01T00:00:00Z",
+            originalPurchaseDate = "2024-05-01T00:00:00Z",
+            expiresDate = expiresDate,
+            ownershipType = "PURCHASED",
+            periodType = periodType,
+            billingIssuesDetectedAt = billingIssuesDetectedAt,
+            gracePeriodExpiresDate = gracePeriodExpiresDate,
+            autoResumeDate = autoResumeDate,
+        )}
+                }
+            """,
+        )
+
+        @Suppress("LongParameterList")
+        private fun subscription(
+            store: String,
+            purchaseDate: String,
+            originalPurchaseDate: String,
+            expiresDate: String?,
+            ownershipType: String?,
+            productPlanIdentifier: String? = "monthly",
+            periodType: String = "normal",
+            unsubscribeDetectedAt: String? = null,
+            billingIssuesDetectedAt: String? = null,
+            gracePeriodExpiresDate: String? = null,
+            refundedAt: String? = null,
+            autoResumeDate: String? = null,
+            displayName: String? = null,
+            price: String = "null",
+        ) = """
+            "store": "$store",
+            "product_plan_identifier": ${productPlanIdentifier.asJsonString()},
+            "purchase_date": "$purchaseDate",
+            "original_purchase_date": "$originalPurchaseDate",
+            "expires_date": ${expiresDate.asJsonString()},
+            "period_type": "$periodType",
+            "is_sandbox": true,
+            "unsubscribe_detected_at": ${unsubscribeDetectedAt.asJsonString()},
+            "billing_issues_detected_at": ${billingIssuesDetectedAt.asJsonString()},
+            "grace_period_expires_date": ${gracePeriodExpiresDate.asJsonString()},
+            "auto_resume_date": ${autoResumeDate.asJsonString()},
+            "refunded_at": ${refundedAt.asJsonString()},
+            "display_name": ${displayName.asJsonString()},
+            "price": $price,
+            "store_transaction_id": "GPA.0000-0000-0000-00000"${ownershipType.asOwnershipTypeEntry()}
+        """
+
+        private fun subscriberResponse(
+            subscriptions: String = "",
+            nonSubscriptions: String = "",
+            entitlements: String = "",
+        ) = """
+            {
+              "request_date": "2024-06-01T00:00:00Z",
+              "subscriber": {
+                "original_app_user_id": "original_user",
+                "original_application_version": "1.0",
+                "first_seen": "2022-01-01T00:00:00Z",
+                "original_purchase_date": "2021-01-01T00:00:00Z",
+                "management_url": null,
+                "subscriptions": { $subscriptions },
+                "non_subscriptions": { $nonSubscriptions },
+                "entitlements": { $entitlements }
+              }
+            }
+        """
+
+        private fun String?.asJsonString() = this?.let { "\"$it\"" } ?: "null"
+
+        // The backend omits the key rather than sending null, and so must the fixture: the response model
+        // defaults it instead of accepting null.
+        private fun String?.asOwnershipTypeEntry() = this?.let { ",\n\"ownership_type\": \"$it\"" }.orEmpty()
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
@@ -35,11 +35,11 @@ class DeviceDimensionProviderTest {
 
         assertThat(dimensions).isEqualTo(
             mapOf(
-                "appVersion" to RulesDimensionValue.StringValue("1.2.3"),
+                "app_version" to RulesDimensionValue.StringValue("1.2.3"),
                 "locale" to RulesDimensionValue.StringValue("en_us"),
                 "platform" to RulesDimensionValue.StringValue("android"),
-                "platformVersion" to RulesDimensionValue.IntValue(34),
-                "sdkVersion" to RulesDimensionValue.StringValue(Config.frameworkVersion),
+                "platform_version" to RulesDimensionValue.IntValue(34),
+                "sdk_version" to RulesDimensionValue.StringValue(Config.frameworkVersion),
             ),
         )
     }
@@ -85,7 +85,7 @@ class DeviceDimensionProviderTest {
 
         val dimensions = provider(languageTag = "", versionName = "").dimensions(date)
 
-        assertThat(dimensions).containsOnlyKeys("platform", "platformVersion", "sdkVersion")
+        assertThat(dimensions).containsOnlyKeys("platform", "platform_version", "sdk_version")
     }
 
     private fun provider(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/DeviceDimensionProviderTest.kt
@@ -38,7 +38,7 @@ class DeviceDimensionProviderTest {
                 "app_version" to RulesDimensionValue.StringValue("1.2.3"),
                 "locale" to RulesDimensionValue.StringValue("en_us"),
                 "platform" to RulesDimensionValue.StringValue("android"),
-                "platform_version" to RulesDimensionValue.IntValue(34),
+                "platform_version" to RulesDimensionValue.StringValue("34"),
                 "sdk_version" to RulesDimensionValue.StringValue(Config.frameworkVersion),
             ),
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -12,13 +12,13 @@ import java.util.Date
 
 class LocalRulesEvaluatorTest {
 
-    private val matchingPredicate = """{"==": [{"var": "device.platform"}, "android"]}"""
-    private val nonMatchingPredicate = """{"==": [{"var": "device.platform"}, "amazon"]}"""
+    private val matchingPredicate = """{"==": [{"var": "platform"}, "android"]}"""
+    private val nonMatchingPredicate = """{"==": [{"var": "platform"}, "amazon"]}"""
     private val malformedPredicate = "{not json"
 
     private var snapshotsTaken = 0
     private val deviceProvider = object : RulesDimensionProvider {
-        override val namespace = RulesDimensionNamespace.Device
+        override val name = "device"
         override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
             snapshotsTaken++
             return mapOf("platform" to RulesDimensionValue.StringValue("android"))
@@ -59,13 +59,13 @@ class LocalRulesEvaluatorTest {
         // unanswerable. Reporting that is what lets the caller tell it apart
         // from a rule that was evaluated and did not match.
         val result = evaluator().match(
-            listOf(TestRule("only", """{"==": [{"var": "device.unknown_dimension"}, true]}""")),
+            listOf(TestRule("only", """{"==": [{"var": "unknown_dimension"}, true]}""")),
         )
 
         val error = result.exceptionOrNull() as LocalRulesEvaluationException.PredicateEvaluation
         assertThat(error.ruleIndex).isZero()
         assertThat(error.error)
-            .isEqualTo(RulesEngine.EvaluationException.UnresolvedVariable("device.unknown_dimension"))
+            .isEqualTo(RulesEngine.EvaluationException.UnresolvedVariable("unknown_dimension"))
     }
 
     @Test
@@ -98,7 +98,7 @@ class LocalRulesEvaluatorTest {
     @Test
     fun `a failed dimension snapshot fails the evaluation`() = runTest {
         val failing = object : RulesDimensionProvider {
-            override val namespace = RulesDimensionNamespace.Device
+            override val name = "device"
             override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
                 throw IllegalStateException("nope")
         }
@@ -108,7 +108,7 @@ class LocalRulesEvaluatorTest {
 
         val error = result.exceptionOrNull() as LocalRulesEvaluationException.DimensionResolution
         assertThat(error.reason)
-            .isEqualTo(RulesDimensionResolutionException.ProviderFailed(RulesDimensionNamespace.Device, "nope"))
+            .isEqualTo(RulesDimensionResolutionException.ProviderFailed("device", "nope"))
     }
 
     @Test
@@ -163,7 +163,7 @@ class LocalRulesEvaluatorTest {
             TestRule(
                 "only",
                 """{"and": [
-                    {"==": [{"var": "device.platform"}, "android"]},
+                    {"==": [{"var": "platform"}, "android"]},
                     {"==": [{"var": "custom.source"}, "settings"]}
                 ]}""",
             ),
@@ -197,7 +197,7 @@ class LocalRulesEvaluatorTest {
             TestRule(
                 "only",
                 """{"and": [
-                    {"==": [{"var": "device.platform"}, "android"]},
+                    {"==": [{"var": "platform"}, "android"]},
                     {"==": [{"var": "custom.source"}, "settings"]},
                     {"var": ["backend.hash", false]}
                 ]}""",

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -22,49 +22,45 @@ import java.util.Date
 class RulesDimensionResolverTest {
 
     private val evaluationDate = Date(1_700_000_000_000)
+    private val evaluatedAt = "evaluated_at" to Value.IntValue(1_700_000_000_000)
 
     @Test
-    fun `dimensions are nested under their provider's namespace`() = runTest {
+    fun `dimensions are merged into the root scope`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "appVersion" to string("1.2.3")),
+            provider("app_version" to string("1.2.3")),
         )
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).isEqualTo(
-            mapOf("device" to Value.ObjectValue(mapOf("appVersion" to Value.StringValue("1.2.3")))),
-        )
+        assertThat(values).isEqualTo(mapOf(evaluatedAt, "app_version" to Value.StringValue("1.2.3")))
     }
 
     @Test
-    fun `nested dimensions are reachable by dot-path from a predicate`() = runTest {
+    fun `dimensions are reachable by name from a predicate`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
+            provider("platform" to string("android")),
         )
         val values = resolver.snapshot().getOrThrow().values
 
-        val matches = RulesEngine.evaluate("""{"==": [{"var": "device.platform"}, "android"]}""", values)
+        val matches = RulesEngine.evaluate("""{"==": [{"var": "platform"}, "android"]}""", values)
 
         assertThat(matches.getOrThrow()).isTrue()
     }
 
     @Test
-    fun `providers sharing a namespace are merged`() = runTest {
+    fun `providers are merged`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
-            provider(RulesDimensionNamespace.Device, "locale" to string("en-US")),
+            provider("platform" to string("android")),
+            provider("locale" to string("en-US")),
         )
 
         val values = resolver.snapshot().getOrThrow().values
 
         assertThat(values).isEqualTo(
             mapOf(
-                "device" to Value.ObjectValue(
-                    mapOf(
-                        "platform" to Value.StringValue("android"),
-                        "locale" to Value.StringValue("en-US"),
-                    ),
-                ),
+                evaluatedAt,
+                "platform" to Value.StringValue("android"),
+                "locale" to Value.StringValue("en-US"),
             ),
         )
     }
@@ -72,21 +68,21 @@ class RulesDimensionResolverTest {
     @Test
     fun `two providers supplying the same dimension fail the snapshot`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
-            provider(RulesDimensionNamespace.Device, "platform" to string("amazon")),
+            provider("platform" to string("android")),
+            provider("platform" to string("amazon")),
         )
 
         val error = resolver.snapshot().exceptionOrNull()
 
-        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("device.platform"))
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("platform"))
     }
 
     @Test
-    fun `a provider that throws fails the snapshot with its namespace`() = runTest {
+    fun `a provider that throws fails the snapshot with its name`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Store, "country" to string("USA")),
+            provider("storefront" to string("USA")),
             object : RulesDimensionProvider {
-                override val namespace = RulesDimensionNamespace.Device
+                override val name = "device"
                 override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
                     throw IllegalStateException("nope")
             },
@@ -95,14 +91,14 @@ class RulesDimensionResolverTest {
         val error = resolver.snapshot().exceptionOrNull()
 
         assertThat(error)
-            .isEqualTo(RulesDimensionResolutionException.ProviderFailed(RulesDimensionNamespace.Device, "nope"))
+            .isEqualTo(RulesDimensionResolutionException.ProviderFailed("device", "nope"))
     }
 
     @Test
     fun `cancellation propagates instead of failing the snapshot`() = runTest {
         val resolver = resolver(
             object : RulesDimensionProvider {
-                override val namespace = RulesDimensionNamespace.Device
+                override val name = "device"
                 override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> =
                     throw CancellationException("cancelled")
             },
@@ -123,7 +119,7 @@ class RulesDimensionResolverTest {
         val dates = mutableListOf<Date>()
         val recordingProvider = {
             object : RulesDimensionProvider {
-                override val namespace = RulesDimensionNamespace.Device
+                override val name = "device"
                 override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
                     dates += date
                     return emptyMap()
@@ -139,10 +135,39 @@ class RulesDimensionResolverTest {
     }
 
     @Test
+    fun `every snapshot carries the evaluation instant`() = runTest {
+        val values = resolver().snapshot().getOrThrow().values
+
+        assertThat(values).isEqualTo(mapOf(evaluatedAt))
+    }
+
+    @Test
+    fun `the evaluation instant is ordered by a predicate`() = runTest {
+        val values = resolver().snapshot().getOrThrow().values
+
+        assertThat(
+            RulesEngine.evaluate("""{">": [{"var": "evaluated_at"}, 1699999999999]}""", values).getOrThrow(),
+        ).isTrue()
+        assertThat(
+            RulesEngine.evaluate("""{">": [{"var": "evaluated_at"}, 1700000000001]}""", values).getOrThrow(),
+        ).isFalse()
+    }
+
+    @Test
+    fun `a provider supplying the evaluation instant fails the snapshot`() = runTest {
+        val resolver = resolver(
+            provider("evaluated_at" to RulesDimensionValue.DateValue(evaluationDate)),
+        )
+
+        val error = resolver.snapshot().exceptionOrNull()
+
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("evaluated_at"))
+    }
+
+    @Test
     fun `each dimension value maps to its engine counterpart`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.Device,
                 "text" to RulesDimensionValue.StringValue("value"),
                 "flag" to RulesDimensionValue.BoolValue(true),
                 "count" to RulesDimensionValue.IntValue(3),
@@ -159,19 +184,18 @@ class RulesDimensionResolverTest {
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values["device"]).isEqualTo(
-            Value.ObjectValue(
-                mapOf(
-                    "text" to Value.StringValue("value"),
-                    "flag" to Value.BoolValue(true),
-                    "count" to Value.IntValue(3),
-                    "ratio" to Value.FloatValue(1.5),
-                    "date" to Value.IntValue(1_700_000_000_000),
-                    "records" to Value.ArrayValue(
-                        listOf(Value.ObjectValue(mapOf("id" to Value.StringValue("one")))),
-                    ),
-                    "record" to Value.ObjectValue(mapOf("id" to Value.StringValue("one"))),
+        assertThat(values).isEqualTo(
+            mapOf(
+                evaluatedAt,
+                "text" to Value.StringValue("value"),
+                "flag" to Value.BoolValue(true),
+                "count" to Value.IntValue(3),
+                "ratio" to Value.FloatValue(1.5),
+                "date" to Value.IntValue(1_700_000_000_000),
+                "records" to Value.ArrayValue(
+                    listOf(Value.ObjectValue(mapOf("id" to Value.StringValue("one")))),
                 ),
+                "record" to Value.ObjectValue(mapOf("id" to Value.StringValue("one"))),
             ),
         )
     }
@@ -180,17 +204,16 @@ class RulesDimensionResolverTest {
     fun `a date dimension is ordered by a predicate`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.Device,
-                "expiresAt" to RulesDimensionValue.DateValue(Date(1_700_000_000_000)),
+                "expires_at" to RulesDimensionValue.DateValue(Date(1_700_000_000_000)),
             ),
         )
         val values = resolver.snapshot().getOrThrow().values
 
         assertThat(
-            RulesEngine.evaluate("""{">": [{"var": "device.expiresAt"}, 1699999999999]}""", values).getOrThrow(),
+            RulesEngine.evaluate("""{">": [{"var": "expires_at"}, 1699999999999]}""", values).getOrThrow(),
         ).isTrue()
         assertThat(
-            RulesEngine.evaluate("""{">": [{"var": "device.expiresAt"}, 1700000000001]}""", values).getOrThrow(),
+            RulesEngine.evaluate("""{">": [{"var": "expires_at"}, 1700000000001]}""", values).getOrThrow(),
         ).isFalse()
     }
 
@@ -198,16 +221,15 @@ class RulesDimensionResolverTest {
     fun `an object list dimension is walked one record at a time by a predicate`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.Device,
                 "purchases" to RulesDimensionValue.ObjectListValue(
                     listOf(
                         mapOf(
-                            "productId" to RulesDimensionValue.StringValue("plus"),
-                            "isActive" to RulesDimensionValue.BoolValue(false),
+                            "product_id" to RulesDimensionValue.StringValue("plus"),
+                            "is_active" to RulesDimensionValue.BoolValue(false),
                         ),
                         mapOf(
-                            "productId" to RulesDimensionValue.StringValue("pro"),
-                            "isActive" to RulesDimensionValue.BoolValue(true),
+                            "product_id" to RulesDimensionValue.StringValue("pro"),
+                            "is_active" to RulesDimensionValue.BoolValue(true),
                         ),
                     ),
                 ),
@@ -215,17 +237,17 @@ class RulesDimensionResolverTest {
         )
         val values = resolver.snapshot().getOrThrow().values
 
-        val active = """{"some": [{"var": "device.purchases"},
-            {"and": [{"==": [{"var": "productId"}, "pro"]}, {"var": "isActive"}]}]}"""
+        val active = """{"some": [{"var": "purchases"},
+            {"and": [{"==": [{"var": "product_id"}, "pro"]}, {"var": "is_active"}]}]}"""
         assertThat(RulesEngine.evaluate(active, values).getOrThrow()).isTrue()
 
         // A record is searched on its own values, so the same product with the other record's state does not match.
-        val inactive = """{"some": [{"var": "device.purchases"},
-            {"and": [{"==": [{"var": "productId"}, "plus"]}, {"var": "isActive"}]}]}"""
+        val inactive = """{"some": [{"var": "purchases"},
+            {"and": [{"==": [{"var": "product_id"}, "plus"]}, {"var": "is_active"}]}]}"""
         assertThat(RulesEngine.evaluate(inactive, values).getOrThrow()).isFalse()
 
         // A record is reachable by index too.
-        val byIndex = """{"==": [{"var": "device.purchases.1.productId"}, "pro"]}"""
+        val byIndex = """{"==": [{"var": "purchases.1.product_id"}, "pro"]}"""
         assertThat(RulesEngine.evaluate(byIndex, values).getOrThrow()).isTrue()
     }
 
@@ -233,48 +255,46 @@ class RulesDimensionResolverTest {
     fun `an empty object list is an empty array rather than an absent dimension`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.Device,
                 "purchases" to RulesDimensionValue.ObjectListValue(emptyList()),
             ),
         )
         val values = resolver.snapshot().getOrThrow().values
 
         // "Has bought nothing" has to be a definite answer, which only a present, empty array gives.
-        assertThat(values["device"]).isEqualTo(Value.ObjectValue(mapOf("purchases" to Value.ArrayValue(emptyList()))))
+        assertThat(values["purchases"]).isEqualTo(Value.ArrayValue(emptyList()))
         assertThat(
-            RulesEngine.evaluate("""{"none": [{"var": "device.purchases"}, {"var": "isActive"}]}""", values)
+            RulesEngine.evaluate("""{"none": [{"var": "purchases"}, {"var": "is_active"}]}""", values)
                 .getOrThrow(),
         ).isTrue()
     }
 
     @Test
-    fun `an object dimension is read through by name rather than searched`() = runTest {
+    fun `an object dimension is read through by dot-path rather than searched`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.Device,
                 "goal" to RulesDimensionValue.ObjectValue(
                     mapOf(
                         "value" to RulesDimensionValue.StringValue("lose_weight"),
-                        "updatedAt" to RulesDimensionValue.DateValue(Date(1_700_000_000_000)),
+                        "updated_at" to RulesDimensionValue.DateValue(Date(1_700_000_000_000)),
                     ),
                 ),
             ),
         )
         val values = resolver.snapshot().getOrThrow().values
 
-        val byName = """{"==": [{"var": "device.goal.value"}, "lose_weight"]}"""
+        val byName = """{"==": [{"var": "goal.value"}, "lose_weight"]}"""
         assertThat(RulesEngine.evaluate(byName, values).getOrThrow()).isTrue()
 
         // Unlike a record inside an object list, a predicate reading one of these still sees the scope around it,
         // because no iteration operator is involved.
-        val alongsideTheRestOfTheScope = """{"and": [{"==": [{"var": "device.goal.value"}, "lose_weight"]},
-            {">": [{"var": "device.goal.updatedAt"}, 1699999999999]}]}"""
+        val alongsideTheRestOfTheScope = """{"and": [{"==": [{"var": "goal.value"}, "lose_weight"]},
+            {">": [{"var": "goal.updated_at"}, 1699999999999]}]}"""
         assertThat(RulesEngine.evaluate(alongsideTheRestOfTheScope, values).getOrThrow()).isTrue()
     }
 
     @Test
-    fun `custom variables are nested under the custom namespace`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+    fun `custom variables are nested under the custom root`() = runTest {
+        val resolver = resolver(provider("platform" to string("android")))
 
         val values = resolver.snapshot(mapOf("source" to string("settings"))).getOrThrow().values
 
@@ -283,13 +303,13 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `no custom variables leaves the namespace absent rather than empty`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+    fun `no custom variables leaves the root absent rather than empty`() = runTest {
+        val resolver = resolver(provider("platform" to string("android")))
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).containsOnlyKeys("device")
-        // An empty object would be truthy, so an absent namespace is what makes this a non-match.
+        assertThat(values).containsOnlyKeys("evaluated_at", "platform")
+        // An empty object would be truthy, so an absent root is what makes this a non-match.
         // The default keeps the read legal, because an unresolved name is an error.
         assertThat(
             RulesEngine.evaluate("""{"!!": [{"var": ["custom", false]}]}""", values).getOrThrow(),
@@ -297,8 +317,20 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `backend values are nested under the backend namespace`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+    fun `a custom variable no predicate could read is dropped rather than exposed`() = runTest {
+        val resolver = resolver()
+
+        val values = resolver
+            .snapshot(mapOf("user.tier" to string("gold"), "tier" to string("gold")))
+            .getOrThrow()
+            .values
+
+        assertThat(values["custom"]).isEqualTo(Value.ObjectValue(mapOf("tier" to Value.StringValue("gold"))))
+    }
+
+    @Test
+    fun `backend values are nested under the backend root`() = runTest {
+        val resolver = resolver(provider("platform" to string("android")))
 
         val values = resolver
             .snapshot(backendValues = mapOf("349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to RulesDimensionValue.BoolValue(true)))
@@ -313,12 +345,12 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `no backend values leaves the namespace absent rather than empty`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Device, "platform" to string("android")))
+    fun `no backend values leaves the root absent rather than empty`() = runTest {
+        val resolver = resolver(provider("platform" to string("android")))
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).containsOnlyKeys("device")
+        assertThat(values).containsOnlyKeys("evaluated_at", "platform")
         // An absent hash reads as the rule's default, which is what keeps unknown hashes forward-compatible.
         assertThat(
             RulesEngine.evaluate("""{"var": ["backend.unknown_hash", false]}""", values).getOrThrow(),
@@ -326,46 +358,44 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `a backend value colliding with a provider fails the snapshot`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Backend, "hash" to RulesDimensionValue.BoolValue(false)))
-
-        val error = resolver
-            .snapshot(backendValues = mapOf("hash" to RulesDimensionValue.BoolValue(true)))
-            .exceptionOrNull()
-
-        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("backend.hash"))
-    }
-
-    @Test
-    fun `a custom variable colliding with a provider fails the snapshot`() = runTest {
-        val resolver = resolver(provider(RulesDimensionNamespace.Custom, "source" to string("provided")))
-
-        val error = resolver.snapshot(mapOf("source" to string("call"))).exceptionOrNull()
-
-        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("custom.source"))
-    }
-
-    @Test
-    fun `a provider with nothing to contribute leaves its namespace absent`() = runTest {
+    fun `a provider claiming the backend root fails the snapshot`() = runTest {
         val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
-            provider(RulesDimensionNamespace.Store),
+            provider("backend" to RulesDimensionValue.ObjectValue(emptyMap())),
+        )
+
+        // Reserved whether or not this evaluation supplies backend values, so the collision is deterministic.
+        val error = resolver.snapshot().exceptionOrNull()
+
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("backend"))
+    }
+
+    @Test
+    fun `a provider claiming the custom root fails the snapshot`() = runTest {
+        val resolver = resolver(
+            provider("custom" to RulesDimensionValue.ObjectValue(emptyMap())),
+        )
+
+        val error = resolver.snapshot().exceptionOrNull()
+
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("custom"))
+    }
+
+    @Test
+    fun `a provider with nothing to contribute adds nothing to the scope`() = runTest {
+        val resolver = resolver(
+            provider("platform" to string("android")),
+            provider(),
         )
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).containsOnlyKeys("device")
-        // An empty object would be truthy, which is what makes the absence matter.
-        assertThat(
-            RulesEngine.evaluate("""{"!!": [{"var": ["store", false]}]}""", values).getOrThrow(),
-        ).isFalse()
+        assertThat(values).containsOnlyKeys("evaluated_at", "platform")
     }
 
     @Test
     fun `a name no predicate could read is dropped rather than exposed`() = runTest {
         val resolver = resolver(
             provider(
-                RulesDimensionNamespace.SubscriberAttributes,
                 // A '.' would be walked as a path through a "user" object that does not exist, and "" is not a
                 // name a predicate can be written against.
                 "user.tier" to string("gold"),
@@ -376,8 +406,7 @@ class RulesDimensionResolverTest {
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values["subscriberAttributes"])
-            .isEqualTo(Value.ObjectValue(mapOf("tier" to Value.StringValue("gold"))))
+        assertThat(values).containsOnlyKeys("evaluated_at", "tier")
     }
 
     @Test
@@ -444,24 +473,8 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `a provider whose every name is unreachable leaves its namespace absent`() = runTest {
-        val resolver = resolver(
-            provider(RulesDimensionNamespace.Device, "platform" to string("android")),
-            provider(RulesDimensionNamespace.SubscriberAttributes, "user.tier" to string("gold")),
-        )
-
-        val values = resolver.snapshot().getOrThrow().values
-
-        // Filtering the names inside the namespace would leave an empty object behind, which is truthy.
-        assertThat(values).containsOnlyKeys("device")
-        assertThat(
-            RulesEngine.evaluate("""{"!!": [{"var": ["subscriberAttributes", false]}]}""", values).getOrThrow(),
-        ).isFalse()
-    }
-
-    @Test
-    fun `no providers yields an empty scope`() = runTest {
-        assertThat(resolver().snapshot().getOrThrow().values).isEmpty()
+    fun `no providers yields a scope with only the evaluation instant`() = runTest {
+        assertThat(resolver().snapshot().getOrThrow().values).isEqualTo(mapOf(evaluatedAt))
     }
 
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
@@ -474,10 +487,10 @@ class RulesDimensionResolverTest {
     private fun string(value: String) = RulesDimensionValue.StringValue(value)
 
     private fun provider(
-        dimensionNamespace: RulesDimensionNamespace,
         vararg values: Pair<String, RulesDimensionValue>,
+        providerName: String = "test",
     ) = object : RulesDimensionProvider {
-        override val namespace = dimensionNamespace
+        override val name = providerName
         override suspend fun dimensions(date: Date) = values.toMap()
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -360,7 +360,7 @@ class RulesDimensionResolverTest {
     @Test
     fun `a provider claiming the backend root fails the snapshot`() = runTest {
         val resolver = resolver(
-            provider("backend" to RulesDimensionValue.ObjectValue(emptyMap())),
+            provider("backend" to RulesDimensionValue.ObjectValue(mapOf("source" to string("x")))),
         )
 
         // Reserved whether or not this evaluation supplies backend values, so the collision is deterministic.
@@ -372,7 +372,7 @@ class RulesDimensionResolverTest {
     @Test
     fun `a provider claiming the custom root fails the snapshot`() = runTest {
         val resolver = resolver(
-            provider("custom" to RulesDimensionValue.ObjectValue(emptyMap())),
+            provider("custom" to RulesDimensionValue.ObjectValue(mapOf("source" to string("x")))),
         )
 
         val error = resolver.snapshot().exceptionOrNull()
@@ -396,10 +396,11 @@ class RulesDimensionResolverTest {
     fun `a name no predicate could read is dropped rather than exposed`() = runTest {
         val resolver = resolver(
             provider(
-                // A '.' would be walked as a path through a "user" object that does not exist, and "" is not a
-                // name a predicate can be written against.
+                // A '.' would be walked as a path through a "user" object that does not exist, and a blank name is
+                // not one a predicate can be written against.
                 "user.tier" to string("gold"),
                 "" to string("anything"),
+                " " to string("anything"),
                 "tier" to string("gold"),
             ),
         )
@@ -419,6 +420,7 @@ class RulesDimensionResolverTest {
                     mapOf(
                         "user.tier" to string("gold"),
                         "" to string("anything"),
+                        " " to string("anything"),
                         "tier" to string("gold"),
                         "nested" to RulesDimensionValue.ObjectValue(
                             mapOf("also.bad" to string("dropped"), "kept" to string("yes")),
@@ -469,6 +471,55 @@ class RulesDimensionResolverTest {
                     ),
                 ),
             ),
+        )
+    }
+
+    @Test
+    fun `an object dimension with nothing readable is absent rather than empty`() = runTest {
+        // An empty object is truthy in JSON Logic, so keeping one would make `{"var": "profile"}` read as present.
+        // Same whether the object was supplied empty or every name inside it was unreachable, at any depth.
+        val resolver = resolver(
+            provider(
+                "empty" to RulesDimensionValue.ObjectValue(emptyMap()),
+                "profile" to RulesDimensionValue.ObjectValue(mapOf("user.tier" to string("gold"))),
+                "goal" to RulesDimensionValue.ObjectValue(
+                    mapOf(
+                        "value" to string("lose_weight"),
+                        "emptied" to RulesDimensionValue.ObjectValue(mapOf("also.bad" to string("dropped"))),
+                    ),
+                ),
+            ),
+        )
+
+        val values = resolver
+            .snapshot(mapOf("settings" to RulesDimensionValue.ObjectValue(emptyMap())))
+            .getOrThrow()
+            .values
+
+        assertThat(values).containsOnlyKeys("evaluated_at", "goal")
+        assertThat(values["goal"]).isEqualTo(Value.ObjectValue(mapOf("value" to Value.StringValue("lose_weight"))))
+        assertThat(
+            RulesEngine.evaluate("""{"!!": [{"var": ["profile", false]}]}""", values).getOrThrow(),
+        ).isFalse()
+    }
+
+    @Test
+    fun `an object list record with nothing readable is dropped from the array`() = runTest {
+        val resolver = resolver(
+            provider(
+                "results" to RulesDimensionValue.ObjectListValue(
+                    listOf(
+                        mapOf("user.tier" to string("gold")),
+                        mapOf("id" to string("b")),
+                    ),
+                ),
+            ),
+        )
+
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values["results"]).isEqualTo(
+            Value.ArrayValue(listOf(Value.ObjectValue(mapOf("id" to Value.StringValue("b"))))),
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -1,0 +1,359 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.AppConfig
+import com.revenuecat.purchases.common.Config
+import com.revenuecat.purchases.common.CustomerInfoFactory
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.LocaleProvider
+import com.revenuecat.purchases.rules.RulesEngine
+import com.revenuecat.purchases.rules.Value
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
+import com.revenuecat.purchases.utils.Iso8601Utils
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Date
+import org.robolectric.annotation.Config as RobolectricConfig
+
+/**
+ * The complete scope a predicate is evaluated against, spelled out.
+ *
+ * Every other test in this package covers one source in isolation. This one wires all of them together the way
+ * [com.revenuecat.purchases.PurchasesFactory] does and writes down the whole result, so the answer to "what can a
+ * rule actually read?" is one file rather than a survey of every provider — for whoever authors a predicate, and
+ * for the platform that has to expose the same scope under the same names.
+ *
+ * The customer is deliberately not a realistic one: they are refunded *and* renewing, in a trial *and* paused, so
+ * that every key appears once. A customer who really is any of those things has the absent keys left out.
+ *
+ * Dates are epoch milliseconds, which is the only form the engine has. The ISO instants they were built from are
+ * in [SUBSCRIBER_RESPONSE] below; the evaluation instant is 2024-06-15T12:00:00Z.
+ *
+ * When this fails after an intended change, the assertion message contains the new scope verbatim.
+ *
+ * It does not verify that [com.revenuecat.purchases.PurchasesFactory] wires exactly these providers, since that
+ * would mean configuring an SDK instance: a provider added there and not here goes unnoticed by this test.
+ */
+@RunWith(AndroidJUnit4::class)
+@RobolectricConfig(manifest = RobolectricConfig.NONE, sdk = [34])
+class RulesDimensionScopeTest {
+
+    private val evaluationDate = Iso8601Utils.parse("2024-06-15T12:00:00Z")
+
+    @Test
+    fun `the whole evaluation scope`() = runTest {
+        val scope = resolver().snapshot(CUSTOM_VARIABLES, BACKEND_VALUES).getOrThrow().values
+
+        assertThat(scope.render()).isEqualTo(
+            """
+            {
+              "app_user_id": "current_user",
+              "app_version": "1.2.3",
+              "backend": {
+                "349OzehoTyCAdiZblj9w0J0yD-Uow8X3": true
+              },
+              "custom": {
+                "plan": "gold",
+                "seats": 3,
+                "trialEligible": true
+              },
+              "entitlements": [
+                {
+                  "billing_issue_detected_at": 1714780800000,
+                  "expires_at": 4102444800000,
+                  "identifier": "extra",
+                  "is_active": true,
+                  "is_sandbox": true,
+                  "latest_purchased_at": 1714521600000,
+                  "original_purchased_at": 1609459200000,
+                  "ownership_type": "PURCHASED",
+                  "period_type": "trial",
+                  "product_identifier": "premium",
+                  "product_plan_identifier": "monthly",
+                  "purchased_product_identifier": "premium:monthly",
+                  "store": "play_store",
+                  "unsubscribe_detected_at": 1714694400000,
+                  "will_renew": false
+                },
+                {
+                  "billing_issue_detected_at": 1714780800000,
+                  "expires_at": 4102444800000,
+                  "identifier": "premium",
+                  "is_active": true,
+                  "is_sandbox": true,
+                  "latest_purchased_at": 1714521600000,
+                  "original_purchased_at": 1609459200000,
+                  "ownership_type": "PURCHASED",
+                  "period_type": "trial",
+                  "product_identifier": "premium",
+                  "product_plan_identifier": "monthly",
+                  "purchased_product_identifier": "premium:monthly",
+                  "store": "play_store",
+                  "unsubscribe_detected_at": 1714694400000,
+                  "will_renew": false
+                }
+              ],
+              "evaluated_at": 1718452800000,
+              "first_seen_at": 1640995200000,
+              "locale": "en_us",
+              "original_app_user_id": "original_user",
+              "original_purchased_at": 1609459200000,
+              "platform": "android",
+              "platform_version": "34",
+              "purchases": [
+                {
+                  "auto_resume_at": 1717200000000,
+                  "billing_issue_detected_at": 1714780800000,
+                  "display_name": "Premium Monthly",
+                  "expires_at": 4102444800000,
+                  "grace_period_expires_at": 1715299200000,
+                  "is_active": true,
+                  "is_in_grace_period": false,
+                  "is_paused": true,
+                  "is_refunded": true,
+                  "is_sandbox": true,
+                  "kind": "subscription",
+                  "original_purchased_at": 1609459200000,
+                  "ownership_type": "PURCHASED",
+                  "period_type": "trial",
+                  "price_amount_micros": 4990000,
+                  "price_currency": "USD",
+                  "product_identifier": "premium",
+                  "product_plan_identifier": "monthly",
+                  "purchased_at": 1714521600000,
+                  "purchased_product_identifier": "premium:monthly",
+                  "refunded_at": 1714867200000,
+                  "status": "paused",
+                  "store": "play_store",
+                  "store_transaction_id": "GPA.0000-0000-0000-00000",
+                  "unsubscribe_detected_at": 1714694400000,
+                  "will_renew": false
+                },
+                {
+                  "display_name": "100 Coins",
+                  "is_sandbox": false,
+                  "kind": "non_subscription",
+                  "original_purchased_at": 1677801600000,
+                  "price_amount_micros": 1990000,
+                  "price_currency": "EUR",
+                  "product_identifier": "coins",
+                  "purchased_at": 1677801600000,
+                  "purchased_product_identifier": "coins",
+                  "store": "amazon",
+                  "store_transaction_id": "amzn.1234",
+                  "transaction_identifier": "abc123"
+                }
+              ],
+              "sdk_version": "${Config.frameworkVersion}",
+              "storefront": "USA",
+              "subscriber_attributes": {
+                "${'$'}email": {
+                  "updated_at": 1714521600000,
+                  "value": "jane@example.com"
+                },
+                "goal": {
+                  "updated_at": 1718366400000,
+                  "value": "lose_weight"
+                },
+                "seats": {
+                  "updated_at": 1714780800000,
+                  "value": "3"
+                }
+              }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `every root of the scope is readable by a predicate`() = runTest {
+        val scope = resolver().snapshot(CUSTOM_VARIABLES, BACKEND_VALUES).getOrThrow().values
+
+        val predicates = listOf(
+            """{"==": [{"var": "platform"}, "android"]}""",
+            """{"==": [{"var": "storefront"}, "USA"]}""",
+            """{"==": [{"var": "custom.plan"}, "gold"]}""",
+            """{"var": ["backend.349OzehoTyCAdiZblj9w0J0yD-Uow8X3", false]}""",
+            """{"==": [{"var": "app_user_id"}, "current_user"]}""",
+            """{"some": [{"var": "purchases"}, {"==": [{"var": "period_type"}, "trial"]}]}""",
+            """{"some": [{"var": "entitlements"}, {"var": "is_active"}]}""",
+            """{"==": [{"var": "subscriber_attributes.${'$'}email.value"}, "jane@example.com"]}""",
+            """{"<": [{"-": [{"var": "evaluated_at"},
+                {"var": "subscriber_attributes.goal.updated_at"}]}, 604800000]}""",
+            // The root instant is not in scope inside an iteration operator, so a purchase compared against it is
+            // read by index.
+            """{">": [{"var": "purchases.0.expires_at"}, {"var": "evaluated_at"}]}""",
+        )
+
+        for (predicate in predicates) {
+            assertThat(RulesEngine.evaluate(predicate, scope).getOrThrow()).describedAs(predicate).isTrue()
+        }
+    }
+
+    private fun resolver(): RulesDimensionResolver {
+        val appConfig = mockk<AppConfig>().also {
+            every { it.store } returns Store.PLAY_STORE
+            every { it.languageTag } returns "en-US"
+            every { it.versionName } returns "1.2.3"
+        }
+        val localeProvider = object : LocaleProvider {
+            override val currentLocalesLanguageTags: String get() = "en-US"
+        }
+        // Verified on purpose, and deliberately absent from the scope below: entitlement verification is not
+        // something a rule is evaluated against.
+        val customerInfo = CustomerInfoFactory.buildCustomerInfo(
+            JSONObject(SUBSCRIBER_RESPONSE),
+            null,
+            VerificationResult.VERIFIED,
+        )
+        return RulesDimensionResolver(
+            providers = listOf(
+                DeviceDimensionProvider(appConfig, localeProvider),
+                StoreDimensionProvider { "US" },
+                CustomerInfoDimensionProvider(
+                    currentAppUserId = { APP_USER_ID },
+                    customerInfo = { customerInfo },
+                ),
+                SubscriberAttributesDimensionProvider { SUBSCRIBER_ATTRIBUTES },
+            ),
+            dateProvider = object : DateProvider {
+                override val now: Date get() = evaluationDate
+            },
+        )
+    }
+
+    /**
+     * Renders the scope the way the engine holds it, with object keys sorted so the shape is readable and stable.
+     * Array order is left alone: it is part of the contract, since `purchases.0` is the most recent purchase.
+     */
+    private fun Map<String, Value>.render(): String = Value.ObjectValue(this).render(indent = "")
+
+    private fun Value.render(indent: String): String = when (this) {
+        is Value.ObjectValue -> entries.entries
+            .sortedBy { (key, _) -> key }
+            .joinToString(separator = ",\n", prefix = "{\n", postfix = "\n$indent}") { (key, value) ->
+                """$indent  "$key": ${value.render("$indent  ")}"""
+            }
+            .takeIf { entries.isNotEmpty() } ?: "{}"
+        is Value.ArrayValue -> items
+            .joinToString(separator = ",\n", prefix = "[\n", postfix = "\n$indent]") { item ->
+                "$indent  ${item.render("$indent  ")}"
+            }
+            .takeIf { items.isNotEmpty() } ?: "[]"
+        is Value.StringValue -> "\"$value\""
+        is Value.BoolValue -> value.toString()
+        is Value.IntValue -> value.toString()
+        is Value.FloatValue -> value.toString()
+        Value.Null -> "null"
+        Value.Undefined -> "undefined"
+    }
+
+    private companion object {
+
+        const val APP_USER_ID = "current_user"
+
+        /**
+         * A reserved name, custom ones, a value that looks like a number but stays the string it was set as, and
+         * two the scope leaves out: a deleted attribute, and a name a dot-path could not reach.
+         */
+        val SUBSCRIBER_ATTRIBUTES = listOf(
+            subscriberAttribute("\$email", "jane@example.com", setAt = "2024-05-01T00:00:00Z"),
+            subscriberAttribute("goal", "lose_weight", setAt = "2024-06-14T12:00:00Z"),
+            subscriberAttribute("seats", "3", setAt = "2024-05-04T00:00:00Z"),
+            subscriberAttribute("tier", null, setAt = "2024-05-04T00:00:00Z"),
+            subscriberAttribute("user.tier", "gold", setAt = "2024-05-04T00:00:00Z"),
+        ).associateBy { attribute -> attribute.key.backendKey }
+
+        private fun subscriberAttribute(key: String, value: String?, setAt: String) = SubscriberAttribute(
+            key = key,
+            value = value,
+            setTime = Iso8601Utils.parse(setAt),
+            isSynced = true,
+        )
+
+        val CUSTOM_VARIABLES = mapOf(
+            "plan" to RulesDimensionValue.StringValue("gold"),
+            "seats" to RulesDimensionValue.IntValue(3),
+            "trialEligible" to RulesDimensionValue.BoolValue(true),
+        )
+
+        val BACKEND_VALUES = mapOf(
+            "349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to RulesDimensionValue.BoolValue(true),
+        )
+
+        /**
+         * One Google subscription with every field the backend can send, one Amazon one-time purchase, and two
+         * entitlements unlocked by the subscription.
+         */
+        val SUBSCRIBER_RESPONSE = """
+            {
+              "request_date": "2024-06-01T00:00:00Z",
+              "subscriber": {
+                "original_app_user_id": "original_user",
+                "first_seen": "2022-01-01T00:00:00Z",
+                "original_purchase_date": "2021-01-01T00:00:00Z",
+                "management_url": "https://play.google.com/store/account/subscriptions",
+                "subscriptions": {
+                  "premium": {
+                    "store": "play_store",
+                    "product_plan_identifier": "monthly",
+                    "purchase_date": "2024-05-01T00:00:00Z",
+                    "original_purchase_date": "2021-01-01T00:00:00Z",
+                    "expires_date": "2100-01-01T00:00:00Z",
+                    "period_type": "trial",
+                    "ownership_type": "PURCHASED",
+                    "is_sandbox": true,
+                    "unsubscribe_detected_at": "2024-05-03T00:00:00Z",
+                    "billing_issues_detected_at": "2024-05-04T00:00:00Z",
+                    "grace_period_expires_date": "2024-05-10T00:00:00Z",
+                    "refunded_at": "2024-05-05T00:00:00Z",
+                    "auto_resume_date": "2024-06-01T00:00:00Z",
+                    "display_name": "Premium Monthly",
+                    "price": { "amount": 4.99, "currency": "USD" },
+                    "store_transaction_id": "GPA.0000-0000-0000-00000"
+                  }
+                },
+                "non_subscriptions": {
+                  "coins": [
+                    {
+                      "id": "abc123",
+                      "is_sandbox": false,
+                      "original_purchase_date": "2023-03-03T00:00:00Z",
+                      "purchase_date": "2023-03-03T00:00:00Z",
+                      "store": "amazon",
+                      "display_name": "100 Coins",
+                      "price": { "amount": 1.99, "currency": "EUR" },
+                      "store_transaction_id": "amzn.1234"
+                    }
+                  ]
+                },
+                "entitlements": {
+                  "premium": {
+                    "expires_date": "2100-01-01T00:00:00Z",
+                    "product_identifier": "premium",
+                    "product_plan_identifier": "monthly",
+                    "purchase_date": "2024-05-01T00:00:00Z"
+                  },
+                  "extra": {
+                    "expires_date": "2100-01-01T00:00:00Z",
+                    "product_identifier": "premium",
+                    "product_plan_identifier": "monthly",
+                    "purchase_date": "2024-05-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+        """
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
@@ -24,11 +24,11 @@ class StoreDimensionProviderTest {
     private val date = Date(1_700_000_000_000)
 
     @Test
-    fun `the store country is exposed as a three-letter code`() = runTest {
+    fun `the storefront is exposed as a three-letter code`() = runTest {
         assertThat(provider("US").dimensions(date))
-            .isEqualTo(mapOf("country" to RulesDimensionValue.StringValue("USA")))
+            .isEqualTo(mapOf("storefront" to RulesDimensionValue.StringValue("USA")))
         assertThat(provider("ES").dimensions(date))
-            .isEqualTo(mapOf("country" to RulesDimensionValue.StringValue("ESP")))
+            .isEqualTo(mapOf("storefront" to RulesDimensionValue.StringValue("ESP")))
     }
 
     @Test
@@ -55,7 +55,7 @@ class StoreDimensionProviderTest {
         for (failure in failures) {
             val snapshot = RulesDimensionResolver(
                 providers = listOf(
-                    provider(RulesDimensionNamespace.Device, "platform" to "android"),
+                    deviceProvider("platform" to "android"),
                     StoreDimensionProvider { throw failure },
                 ),
             ).snapshot()
@@ -63,7 +63,7 @@ class StoreDimensionProviderTest {
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
             assertThat(snapshot.getOrThrow().values)
                 .describedAs("%s", failure)
-                .containsOnlyKeys("device")
+                .containsOnlyKeys("evaluated_at", "platform")
         }
     }
 
@@ -82,33 +82,32 @@ class StoreDimensionProviderTest {
     }
 
     @Test
-    fun `the store country is fetched on every evaluation`() = runTest {
+    fun `the storefront is fetched on every evaluation`() = runTest {
         var countryCode: String? = "US"
         val provider = StoreDimensionProvider { countryCode }
 
-        assertThat(provider.dimensions(date)["country"]).isEqualTo(RulesDimensionValue.StringValue("USA"))
+        assertThat(provider.dimensions(date)["storefront"]).isEqualTo(RulesDimensionValue.StringValue("USA"))
 
         countryCode = "ES"
 
-        assertThat(provider.dimensions(date)["country"]).isEqualTo(RulesDimensionValue.StringValue("ESP"))
+        assertThat(provider.dimensions(date)["storefront"]).isEqualTo(RulesDimensionValue.StringValue("ESP"))
     }
 
     @Test
-    fun `the store country is reachable by dot-path from a predicate`() = runTest {
+    fun `the storefront is reachable by name from a predicate`() = runTest {
         val values = RulesDimensionResolver(providers = listOf(provider("US"))).snapshot().getOrThrow().values
 
-        val matches = RulesEngine.evaluate("""{"==": [{"var": "store.country"}, "USA"]}""", values)
+        val matches = RulesEngine.evaluate("""{"==": [{"var": "storefront"}, "USA"]}""", values)
 
         assertThat(matches.getOrThrow()).isTrue()
     }
 
     private fun provider(countryCode: String?) = StoreDimensionProvider { countryCode }
 
-    private fun provider(
-        dimensionNamespace: RulesDimensionNamespace,
+    private fun deviceProvider(
         vararg values: Pair<String, String>,
     ) = object : RulesDimensionProvider {
-        override val namespace = dimensionNamespace
+        override val name = "device"
         override suspend fun dimensions(date: Date) =
             values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
@@ -9,7 +9,6 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
-import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_EVALUATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_UPDATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_VALUE
 import com.revenuecat.purchases.rules.RulesEngine
@@ -89,14 +88,13 @@ class SubscriberAttributesDimensionIntegrationTest {
 
         val goal = values.recordFor("goal")
         assertThat(goal[KEY_VALUE]).isEqualTo(Value.StringValue("lose_weight"))
-        assertThat(goal[KEY_EVALUATED_AT]).isEqualTo(Value.IntValue(evaluationDate.time))
         // Set by this device just now, so it survived the round-trip through JSON with the value.
         assertThat((goal[KEY_UPDATED_AT] as Value.IntValue).value).isBetween(before.time, Date().time)
 
         assertThat(
             RulesEngine.evaluate(
-                """{"and": [{"==": [{"var": "subscriberAttributes.goal.value"}, "lose_weight"]},
-                    {"==": [{"var": "subscriberAttributes.seats.value"}, 3]}]}""",
+                """{"and": [{"==": [{"var": "subscriber_attributes.goal.value"}, "lose_weight"]},
+                    {"==": [{"var": "subscriber_attributes.seats.value"}, 3]}]}""",
                 values,
             ).getOrThrow(),
         ).isTrue()
@@ -111,7 +109,7 @@ class SubscriberAttributesDimensionIntegrationTest {
 
         assertThat(
             RulesEngine.evaluate(
-                """{"==": [{"var": "subscriberAttributes.${'$'}email.value"}, "jane@example.com"]}""",
+                """{"==": [{"var": "subscriber_attributes.${'$'}email.value"}, "jane@example.com"]}""",
                 values,
             ).getOrThrow(),
         ).isTrue()
@@ -132,13 +130,13 @@ class SubscriberAttributesDimensionIntegrationTest {
     }
 
     @Test
-    fun `a customer the app has said nothing about contributes no namespace`() = runTest {
+    fun `a customer the app has said nothing about contributes no root`() = runTest {
         attributes.setAttributes(mapOf("goal" to "lose_weight"), "user_a")
         cache.cacheAppUserID("user_b")
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat(values).doesNotContainKey("subscriberAttributes")
+        assertThat(values).doesNotContainKey("subscriber_attributes")
     }
 
     @Test
@@ -149,7 +147,7 @@ class SubscriberAttributesDimensionIntegrationTest {
         attributes.setAttributes(mapOf("goal" to null), "user_a")
 
         val values = resolver.snapshot().getOrThrow().values
-        assertThat((values["subscriberAttributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
+        assertThat((values["subscriber_attributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
         // The deletion is still on disk waiting to be posted; it is the scope that leaves it out, not the cache.
         assertThat(attributesCache.getAllStoredSubscriberAttributes("user_a")).containsKey("goal")
     }
@@ -161,9 +159,9 @@ class SubscriberAttributesDimensionIntegrationTest {
 
         val values = resolver.snapshot().getOrThrow().values
 
-        assertThat((values["subscriberAttributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
+        assertThat((values["subscriber_attributes"] as Value.ObjectValue).entries).containsOnlyKeys("tier")
     }
 
     private fun Map<String, Value>.recordFor(name: String): Map<String, Value> =
-        ((this["subscriberAttributes"] as Value.ObjectValue).entries[name] as Value.ObjectValue).entries
+        ((this["subscriber_attributes"] as Value.ObjectValue).entries[name] as Value.ObjectValue).entries
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -98,12 +98,13 @@ class SubscriberAttributesDimensionProviderTest {
 
     @Test
     fun `an attribute named so no predicate could read it is left out`() = runTest {
-        // A '.' would be walked as a path through a "user" object that does not exist, and "" is not a name a
-        // predicate can be written against. Attribute names sit inside this provider's root dimension, where the
+        // A '.' would be walked as a path through a "user" object that does not exist, and a blank name is not one
+        // a predicate can be written against. Attribute names sit inside this provider's root dimension, where the
         // resolver's own filtering cannot see them.
         val records = provider(
             attribute("user.tier", "gold"),
             attribute("", "anything"),
+            attribute(" ", "anything"),
             attribute("tier", "gold"),
         ).records(evaluationDate)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -5,7 +5,7 @@ package com.revenuecat.purchases.common.localrules
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
-import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_EVALUATED_AT
+import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_SUBSCRIBER_ATTRIBUTES
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_UPDATED_AT
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider.Companion.KEY_VALUE
 import com.revenuecat.purchases.rules.RulesEngine
@@ -30,27 +30,30 @@ class SubscriberAttributesDimensionProviderTest {
 
     @Test
     fun `every stored attribute is exposed under the name the app set it with`() = runTest {
-        val dimensions = provider(
+        val records = provider(
             attribute("\$email", "jane@example.com"),
             attribute("goal", "lose_weight"),
-        ).dimensions(evaluationDate)
+        ).records(evaluationDate)
 
         // Reserved names keep their '$': it is what the app set, what the dashboard shows, and what keeps a custom
         // "email" from colliding with the reserved one. Only '.' means anything to the engine.
-        assertThat(dimensions).containsOnlyKeys("\$email", "goal")
+        assertThat(records).containsOnlyKeys("\$email", "goal")
     }
 
     @Test
-    fun `an attribute is a record of its value, when it was set, and when it was read`() = runTest {
+    fun `the attributes are one root dimension wrapping a record per attribute`() = runTest {
         val dimensions = provider(attribute("goal", "lose_weight")).dimensions(evaluationDate)
 
         assertThat(dimensions).isEqualTo(
             mapOf(
-                "goal" to RulesDimensionValue.ObjectValue(
+                KEY_SUBSCRIBER_ATTRIBUTES to RulesDimensionValue.ObjectValue(
                     mapOf(
-                        KEY_VALUE to RulesDimensionValue.StringValue("lose_weight"),
-                        KEY_UPDATED_AT to RulesDimensionValue.DateValue(setDate),
-                        KEY_EVALUATED_AT to RulesDimensionValue.DateValue(evaluationDate),
+                        "goal" to RulesDimensionValue.ObjectValue(
+                            mapOf(
+                                KEY_VALUE to RulesDimensionValue.StringValue("lose_weight"),
+                                KEY_UPDATED_AT to RulesDimensionValue.DateValue(setDate),
+                            ),
+                        ),
                     ),
                 ),
             ),
@@ -59,47 +62,63 @@ class SubscriberAttributesDimensionProviderTest {
 
     @Test
     fun `a value stays the string the app set, whatever it looks like`() = runTest {
-        val dimensions = provider(
+        val records = provider(
             attribute("seats", "3"),
             attribute("betaOptIn", "true"),
             attribute("sku", "0123"),
-        ).dimensions(evaluationDate)
+        ).records(evaluationDate)
 
-        assertThat(dimensions.valueOf("seats")).isEqualTo(RulesDimensionValue.StringValue("3"))
-        assertThat(dimensions.valueOf("betaOptIn")).isEqualTo(RulesDimensionValue.StringValue("true"))
+        assertThat(records.valueOf("seats")).isEqualTo(RulesDimensionValue.StringValue("3"))
+        assertThat(records.valueOf("betaOptIn")).isEqualTo(RulesDimensionValue.StringValue("true"))
         // A product code the SDK guessed at would silently stop being the string it was set as.
-        assertThat(dimensions.valueOf("sku")).isEqualTo(RulesDimensionValue.StringValue("0123"))
+        assertThat(records.valueOf("sku")).isEqualTo(RulesDimensionValue.StringValue("0123"))
     }
 
     @Test
     fun `a deleted attribute is left out whether or not it has been posted yet`() = runTest {
         // A deletion is stored as a tombstone with no value, and stays in the cache for the current customer even
         // after the backend has been told about it.
-        val dimensions = provider(
+        val records = provider(
             attribute("pending", null, isSynced = false),
             attribute("posted", null, isSynced = true),
             attribute("goal", "lose_weight"),
-        ).dimensions(evaluationDate)
+        ).records(evaluationDate)
 
-        assertThat(dimensions).containsOnlyKeys("goal")
+        assertThat(records).containsOnlyKeys("goal")
     }
 
     @Test
     fun `an attribute set to an empty value is left out`() = runTest {
         // The SDK's other spelling of a deletion, and an empty string would compare equal to an absent value
         // anyway.
-        val dimensions = provider(attribute("goal", ""), attribute("tier", "gold")).dimensions(evaluationDate)
+        val records = provider(attribute("goal", ""), attribute("tier", "gold")).records(evaluationDate)
 
-        assertThat(dimensions).containsOnlyKeys("tier")
+        assertThat(records).containsOnlyKeys("tier")
     }
 
     @Test
-    fun `a customer with no attributes contributes no namespace at all`() = runTest {
-        val values = resolver(provider()).snapshot().getOrThrow().values
+    fun `an attribute named so no predicate could read it is left out`() = runTest {
+        // A '.' would be walked as a path through a "user" object that does not exist, and "" is not a name a
+        // predicate can be written against. Attribute names sit inside this provider's root dimension, where the
+        // resolver's own filtering cannot see them.
+        val records = provider(
+            attribute("user.tier", "gold"),
+            attribute("", "anything"),
+            attribute("tier", "gold"),
+        ).records(evaluationDate)
 
-        // An empty object is truthy in JSON Logic, so `{"var": "subscriberAttributes"}` would read as present for a
-        // customer the app has never said anything about.
-        assertThat(values).doesNotContainKey("subscriberAttributes")
+        assertThat(records).containsOnlyKeys("tier")
+    }
+
+    @Test
+    fun `a customer with no readable attributes contributes no root at all`() = runTest {
+        // An empty object is truthy in JSON Logic, so `{"var": "subscriber_attributes"}` would read as present for
+        // a customer the app has never said anything about.
+        assertThat(provider().dimensions(evaluationDate)).isEmpty()
+        assertThat(provider(attribute("user.tier", "gold")).dimensions(evaluationDate)).isEmpty()
+
+        val values = resolver(provider()).snapshot().getOrThrow().values
+        assertThat(values).doesNotContainKey(KEY_SUBSCRIBER_ATTRIBUTES)
     }
 
     @Test
@@ -117,7 +136,9 @@ class SubscriberAttributesDimensionProviderTest {
             ).snapshot()
 
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
-            assertThat(snapshot.getOrThrow().values).describedAs("%s", failure).containsOnlyKeys("device")
+            assertThat(snapshot.getOrThrow().values)
+                .describedAs("%s", failure)
+                .containsOnlyKeys("evaluated_at", "platform")
         }
     }
 
@@ -126,12 +147,12 @@ class SubscriberAttributesDimensionProviderTest {
         var attributes = mapOf("goal" to attribute("goal", "lose_weight"))
         val provider = SubscriberAttributesDimensionProvider { attributes }
 
-        assertThat(provider.dimensions(evaluationDate).valueOf("goal"))
+        assertThat(provider.records(evaluationDate).valueOf("goal"))
             .isEqualTo(RulesDimensionValue.StringValue("lose_weight"))
 
         attributes = mapOf("goal" to attribute("goal", "gain_muscle"))
 
-        assertThat(provider.dimensions(evaluationDate).valueOf("goal"))
+        assertThat(provider.records(evaluationDate).valueOf("goal"))
             .isEqualTo(RulesDimensionValue.StringValue("gain_muscle"))
     }
 
@@ -147,23 +168,23 @@ class SubscriberAttributesDimensionProviderTest {
         ).snapshot().getOrThrow().values
 
         val matching = listOf(
-            """{"==": [{"var": "subscriberAttributes.${'$'}email.value"}, "jane@example.com"]}""",
+            """{"==": [{"var": "subscriber_attributes.${'$'}email.value"}, "jane@example.com"]}""",
             // The loose operators coerce, so a value the app set as a string is still comparable to a number.
-            """{"==": [{"var": "subscriberAttributes.seats.value"}, 3]}""",
-            """{">": [{"var": "subscriberAttributes.seats.value"}, 2]}""",
-            // Each record carries the evaluation instant, so "set in the last 7 days" needs nothing else in scope.
-            """{"<": [{"-": [{"var": "subscriberAttributes.tier.evaluatedAt"},
-                {"var": "subscriberAttributes.tier.updatedAt"}]}, 604800000]}""",
+            """{"==": [{"var": "subscriber_attributes.seats.value"}, 3]}""",
+            """{">": [{"var": "subscriber_attributes.seats.value"}, 2]}""",
+            // The scope carries the evaluation instant at its root, so "set in the last 7 days" needs nothing else.
+            """{"<": [{"-": [{"var": "evaluated_at"},
+                {"var": "subscriber_attributes.tier.updated_at"}]}, 604800000]}""",
         )
         val notMatching = listOf(
-            """{"==": [{"var": "subscriberAttributes.goal.value"}, "gain_muscle"]}""",
+            """{"==": [{"var": "subscriber_attributes.goal.value"}, "gain_muscle"]}""",
             // An attribute the app never set on this device, and one the SDK does not expose. Both
             // need a default, since reading a name that resolves to nothing is an error.
-            """{"!!": {"var": ["subscriberAttributes.favoriteColor.value", false]}}""",
-            """{"!!": {"var": ["subscriberAttributes.goal.isSynced", false]}}""",
+            """{"!!": {"var": ["subscriber_attributes.favoriteColor.value", false]}}""",
+            """{"!!": {"var": ["subscriber_attributes.goal.isSynced", false]}}""",
             // The same window, for an attribute set six weeks ago.
-            """{"<": [{"-": [{"var": "subscriberAttributes.goal.evaluatedAt"},
-                {"var": "subscriberAttributes.goal.updatedAt"}]}, 604800000]}""",
+            """{"<": [{"-": [{"var": "evaluated_at"},
+                {"var": "subscriber_attributes.goal.updated_at"}]}, 604800000]}""",
         )
 
         for (predicate in matching) {
@@ -193,10 +214,13 @@ class SubscriberAttributesDimensionProviderTest {
     )
 
     private fun deviceProvider(vararg values: Pair<String, String>) = object : RulesDimensionProvider {
-        override val namespace = RulesDimensionNamespace.Device
+        override val name = "device"
         override suspend fun dimensions(date: Date) =
             values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }
     }
+
+    private suspend fun SubscriberAttributesDimensionProvider.records(date: Date): Map<String, RulesDimensionValue> =
+        (dimensions(date)[KEY_SUBSCRIBER_ATTRIBUTES] as? RulesDimensionValue.ObjectValue)?.value.orEmpty()
 
     private fun Map<String, RulesDimensionValue>.valueOf(name: String): RulesDimensionValue? =
         (this[name] as? RulesDimensionValue.ObjectValue)?.value?.get(KEY_VALUE)


### PR DESCRIPTION
### Description
Adds customer-info properties to the rule evaluation properties

- `purchases`: subscriptions and one-time purchases merged newest first (`purchases.0` is the most recent of either kind), discriminated by `kind`. Subscriptions carry a derived `status` (`paused` | `in_grace_period` | `trialing` | `active` | `expired`) so a predicate doesn't have to assemble the lifecycle for itself.
- `entitlements`: ordered by identifier.
- Other at the root: `app_user_id`, `original_app_user_id`, `first_seen_at`, `original_purchased_at`.

```json
{
  "app_user_id": "current_user",
  "original_app_user_id": "original_user",
  "first_seen_at": 1640995200000,
  "original_purchased_at": 1609459200000,
  "purchases": [
    {
      "auto_resume_at": 1717200000000,
      "billing_issue_detected_at": 1714780800000,
      "display_name": "Premium Monthly",
      "expires_at": 4102444800000,
      "grace_period_expires_at": 1715299200000,
      "is_active": true,
      "is_in_grace_period": false,
      "is_paused": true,
      "is_refunded": true,
      "is_sandbox": true,
      "kind": "subscription",
      "original_purchased_at": 1609459200000,
      "ownership_type": "PURCHASED",
      "period_type": "trial",
      "price_amount_micros": 4990000,
      "price_currency": "USD",
      "product_identifier": "premium",
      "product_plan_identifier": "monthly",
      "purchased_at": 1714521600000,
      "purchased_product_identifier": "premium:monthly",
      "refunded_at": 1714867200000,
      "status": "paused",
      "store": "play_store",
      "store_transaction_id": "GPA.0000-0000-0000-00000",
      "unsubscribe_detected_at": 1714694400000,
      "will_renew": false
    },
    {
      "display_name": "100 Coins",
      "is_sandbox": false,
      "kind": "non_subscription",
      "original_purchased_at": 1677801600000,
      "price_amount_micros": 1990000,
      "price_currency": "EUR",
      "product_identifier": "coins",
      "purchased_at": 1677801600000,
      "purchased_product_identifier": "coins",
      "store": "amazon",
      "store_transaction_id": "amzn.1234",
      "transaction_identifier": "abc123"
    }
  ],
  "entitlements": [
    {
      "billing_issue_detected_at": 1714780800000,
      "expires_at": 4102444800000,
      "identifier": "extra",
      "is_active": true,
      "is_sandbox": true,
      "latest_purchased_at": 1714521600000,
      "original_purchased_at": 1609459200000,
      "ownership_type": "PURCHASED",
      "period_type": "trial",
      "product_identifier": "premium",
      "product_plan_identifier": "monthly",
      "purchased_product_identifier": "premium:monthly",
      "store": "play_store",
      "unsubscribe_detected_at": 1714694400000,
      "will_renew": false
    }
  ]
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkpoint/rule outcomes now depend on async customer-info reads and new subscription status semantics; failures degrade to partial dimensions rather than failing the snapshot, which could change targeting edge cases.
> 
> **Overview**
> **Adds customer-info dimensions to local rules / checkpoint evaluation**, so predicates can target subscription state, purchase history, and entitlements without assembling lifecycle logic by hand.
> 
> A new **`CustomerInfoDimensionProvider`** maps `CustomerInfo` into the merged rule scope: root fields (`app_user_id`, `original_app_user_id`, `first_seen_at`, `original_purchased_at`), a **`purchases`** list (subscriptions and one-time purchases merged **newest first**, with `kind` and subscription **`status`**), and **`entitlements`** sorted by identifier. Customer-info fetch failures omit purchase/entitlement keys but keep `app_user_id` so ID-only rules still work; cancellation still propagates.
> 
> **Wiring:** `PurchasesFactory` registers the provider on `LocalRulesEvaluator` and loads customer info via a new **`PurchasesOrchestrator.getCustomerInfo(appUserID, …)`** overload plus a private suspend **`awaitCustomerInfo`** bridge (default cache policy, both product flavors).
> 
> **Tests** cover dimension shaping, orchestrator ID forwarding, end-to-end scope (`RulesDimensionScopeTest`), and predicate examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1b59ac3b6ea50c4ce7a63874d8078b1bc61290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->