### PR TITLE
Expose a new `DangerousSettings#disableTestStoreCheck`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/DangerousSettingsAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/DangerousSettingsAPI.kt
@@ -6,5 +6,6 @@ import com.revenuecat.purchases.DangerousSettings
 private class DangerousSettingsAPI {
     fun check(dangerousSettings: DangerousSettings) {
         val autoSync: Boolean = dangerousSettings.autoSyncPurchases
+        dangerousSettings.forceAllowTestStoreInReleaseBuilds()
     }
 }

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -89,6 +89,7 @@ package com.revenuecat.purchases {
 
   @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize public final class DangerousSettings implements android.os.Parcelable {
     ctor public DangerousSettings(optional boolean autoSyncPurchases);
+    method public void forceAllowTestStoreInReleaseBuilds();
     method @InaccessibleFromKotlin public boolean getAutoSyncPurchases();
     property public boolean autoSyncPurchases;
     field public static final com.revenuecat.purchases.DangerousSettings.Companion Companion;

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -75,6 +75,7 @@ package com.revenuecat.purchases {
 
   @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize public final class DangerousSettings implements android.os.Parcelable {
     ctor public DangerousSettings(optional boolean autoSyncPurchases);
+    method public void forceAllowTestStoreInReleaseBuilds();
     method @InaccessibleFromKotlin public boolean getAutoSyncPurchases();
     property public boolean autoSyncPurchases;
     field public static final com.revenuecat.purchases.DangerousSettings.Companion Companion;

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
@@ -30,7 +30,7 @@ public class DangerousSettings internal constructor(
      */
     internal val usesRemoteConfigAPISources: Boolean = false,
 
-    internal val allowTestStoreInReleaseBuild: Boolean = false,
+    internal var allowTestStoreInReleaseBuild: Boolean = false,
 ) : Parcelable {
     public constructor(autoSyncPurchases: Boolean = true) : this(
         autoSyncPurchases = autoSyncPurchases,
@@ -40,6 +40,14 @@ public class DangerousSettings internal constructor(
         usesRemoteConfigAPISources = false,
         allowTestStoreInReleaseBuild = false,
     )
+
+    /**
+     * Forces the SDK to allow using a Test Store API key in release builds.
+     * Avoid calling this except when necessary, to make sure no builds with Test Store are uploaded to the stores.
+     */
+    public fun forceAllowTestStoreInReleaseBuilds() {
+        allowTestStoreInReleaseBuild = true
+    }
 
     public companion object {
         /**
@@ -54,18 +62,6 @@ public class DangerousSettings internal constructor(
             customEntitlementComputation = false,
             uiPreviewMode = true,
             applyObfuscatedAccountIdToSubscriptionChanges = false,
-        )
-
-        /**
-         * Creates a [DangerousSettings] that allows configuring the SDK with a Test Store API key
-         * in a release (non-debuggable) build, bypassing the safety check that otherwise blocks it.
-         *
-         * For RevenueCat-internal end-to-end testing only. Do not use in production apps.
-         */
-        @InternalRevenueCatAPI
-        @JvmStatic
-        public fun forTestStoreInReleaseBuild(): DangerousSettings = DangerousSettings(
-            allowTestStoreInReleaseBuild = true,
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -610,15 +610,13 @@ internal class PurchasesFactory(
             require(apiKey.isNotBlank()) { "API key must be set. Get this from the RevenueCat web app" }
 
             val apiKeyValidationResult = apiKeyValidator.validateAndLog(apiKey, store)
-
-            // Test Store keys are only meant for development. uiPreviewMode and
-            // allowTestStoreInReleaseBuild are internal opt-ins that intentionally bypass this guard.
-            val isTestStoreKeyInReleaseBuild = !isDebugBuild() &&
-                apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE
             val testStoreReleaseBuildAllowed = dangerousSettings.uiPreviewMode ||
                 dangerousSettings.allowTestStoreInReleaseBuild
 
-            if (isTestStoreKeyInReleaseBuild && !testStoreReleaseBuildAllowed) {
+            if (!testStoreReleaseBuildAllowed &&
+                apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE &&
+                !isDebugBuild()
+            ) {
                 val redactedApiKey = apiKeyValidator.redactApiKey(apiKey)
                 errorLog(
                     error = PurchasesError(

--- a/purchases/src/test/java/com/revenuecat/purchases/DangerousSettingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/DangerousSettingsTest.kt
@@ -26,6 +26,19 @@ class DangerousSettingsTest {
     }
 
     @Test
+    fun `allowTestStoreInReleaseBuild is false by default`() {
+        val dangerousSettings = DangerousSettings()
+        assertThat(dangerousSettings.allowTestStoreInReleaseBuild).isFalse
+    }
+
+    @Test
+    fun `forceAllowTestStoreInReleaseBuilds allows Test Store in release builds`() {
+        val dangerousSettings = DangerousSettings()
+        dangerousSettings.forceAllowTestStoreInReleaseBuilds()
+        assertThat(dangerousSettings.allowTestStoreInReleaseBuild).isTrue
+    }
+
+    @Test
     fun `default uiPreviewMode is false`() {
         val dangerousSettings = DangerousSettings()
         assertThat(dangerousSettings.uiPreviewMode).isFalse
@@ -49,6 +62,7 @@ class DangerousSettingsTest {
         val dangerousSettings = DangerousSettings.forPreviewMode()
         assertThat(dangerousSettings.uiPreviewMode).isTrue
         assertThat(dangerousSettings.autoSyncPurchases).isFalse
+        assertThat(dangerousSettings.allowTestStoreInReleaseBuild).isFalse
         assertThat(dangerousSettings.customEntitlementComputation).isFalse
         assertThat(dangerousSettings.applyObfuscatedAccountIdToSubscriptionChanges).isFalse
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -170,12 +170,15 @@ class PurchasesFactoryTest {
         verify(exactly = 0) { applicationMock.startActivity(any()) }
     }
 
-    @OptIn(InternalRevenueCatAPI::class)
     @Test
-    fun `configuring SDK with simulated store api key in release mode and allowTestStoreInReleaseBuild does not show error activity`() {
+    fun `forcing Test Store in release builds skips the check`() {
         // Arrange
+        var isDebugBuildCalled = false
         purchasesFactory = PurchasesFactory(
-            isDebugBuild = { false },
+            isDebugBuild = {
+                isDebugBuildCalled = true
+                false
+            },
             apiKeyValidator = apiKeyValidatorMock,
         )
         val applicationContextMock = mockk<Application>()
@@ -190,14 +193,18 @@ class PurchasesFactoryTest {
         } returns APIKeyValidator.ValidationResult.SIMULATED_STORE
 
         // Act
+        val dangerousSettings = DangerousSettings().apply {
+            forceAllowTestStoreInReleaseBuilds()
+        }
         purchasesFactory.validateConfiguration(
             createConfiguration(
-                dangerousSettings = DangerousSettings.forTestStoreInReleaseBuild(),
+                dangerousSettings = dangerousSettings,
             ),
         )
 
         // Assert
         verify(exactly = 0) { applicationMock.startActivity(any()) }
+        assertThat(isDebugBuildCalled).isFalse
     }
 
     @Test

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/E2ETestsApplication.kt
@@ -4,12 +4,10 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import com.revenuecat.purchases.DangerousSettings
-import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 
-@OptIn(InternalRevenueCatAPI::class)
 class E2ETestsApplication : Application() {
 
     override fun onCreate() {
@@ -52,7 +50,9 @@ class E2ETestsApplication : Application() {
         // This app runs as a minified release build in the Maestro e2e CI jobs (to exercise
         // the SDK's consumer R8 rules), but uses Test Store API keys. Opt in to allow that
         // combination, which the SDK otherwise blocks in non-debuggable builds.
-        private val testStoreInReleaseBuildSettings = DangerousSettings.forTestStoreInReleaseBuild()
+        private val testStoreInReleaseBuildSettings = DangerousSettings().apply {
+            forceAllowTestStoreInReleaseBuilds()
+        }
     }
 }
 


### PR DESCRIPTION
The SDK currently checks displays a dialog when the provided API key is a Test Store key and the host `Application` has `FLAG_DEBUGGABLE` set to true. While this works in general, it's a bit to restrictive when testing in release builds that are still not considered as "store builds". For instance, when having an internal-only nightly build that is not targeting the store but still built in release.

The approach taken consists on not impacting the current API as much as possible. It keeps the default behavior but introduces a new `DangerousSettings#disableTestStoreCheck` clients might use to inform the SDK to perform the check or not.

For performance reasons, the check is performed first when doing the check in `PurchasesFactory`. This is based on the assumption `isDebugBuild()` is side effect free which seems to be the case in the current source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a public bypass for a release-build safety check against Test Store API keys; misuse could ship test keys to production, though default behavior is unchanged and the API is explicitly documented as dangerous.
> 
> **Overview**
> Adds a **public** opt-in on `DangerousSettings` so release (non-debuggable) builds can use a Test Store API key without tripping the SDK’s configuration guard—intended for internal nightlies, minified e2e, and similar non-store builds.
> 
> **`forceAllowTestStoreInReleaseBuilds()`** sets the internal `allowTestStoreInReleaseBuild` flag (now a `var`). The previous **`DangerousSettings.forTestStoreInReleaseBuild()`** internal factory is removed; callers use `DangerousSettings().apply { forceAllowTestStoreInReleaseBuilds() }` instead (including the Maestro e2e app).
> 
> In **`PurchasesFactory.validateConfiguration`**, the release + simulated-store check is reordered so when the opt-in (or UI preview mode) is already enabled, **`isDebugBuild()` is not invoked**—same behavior when the guard runs, with a small fast path for opted-in configs.
> 
> Public API stubs and unit tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26cd5ca4671105ad5e9a505dd79c0cfdf75f4ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->