### PR TITLE
Cache the backend's subscriber dimensions and evaluate rules against them

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -36,6 +36,7 @@ import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesEngineLoggerBridge
 import com.revenuecat.purchases.common.localrules.StoreDimensionProvider
 import com.revenuecat.purchases.common.localrules.SubscriberAttributesDimensionProvider
+import com.revenuecat.purchases.common.localrules.SubscriberDimensionsProvider
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.networking.APISourceFailover
 import com.revenuecat.purchases.common.networking.DeviceConnectivityChecker
@@ -404,6 +405,9 @@ internal class PurchasesFactory(
                             Purchases.sharedInstance.purchasesOrchestrator.awaitCustomerInfo(appUserID)
                         },
                     ),
+                    SubscriberDimensionsProvider {
+                        cache.getCachedSubscriberDimensionsJson(identityManager.currentAppUserID)
+                    },
                 ),
             )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
@@ -79,7 +79,8 @@ internal class AudiencesConfigProvider(
             val result = element.asRulesDimensionValue()
             if (result == null) {
                 // Rules read these with a default (`{"var": ["backend.<hash>", false]}`), so a value shape this
-                // SDK version cannot represent degrades to the rule's default instead of failing the item.
+                // SDK version cannot represent degrades to the rule's default instead of failing the item. An
+                // explicit null is not such a shape: it reaches the rule as null, which is falsy.
                 warnLog { "Ignoring backend predicate result '$hash': its value can't be read by a rule." }
                 null
             } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
@@ -6,21 +6,14 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.localrules.RulesDimensionValue
+import com.revenuecat.purchases.common.localrules.asRulesDimensionValue
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.readConsistent
 import com.revenuecat.purchases.common.warnLog
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.longOrNull
 
 /**
  * The audiences topic as of one read: the audience dictionary from the static `default` blob together with the
@@ -99,27 +92,4 @@ internal class AudiencesConfigProvider(
         const val ITEM_DEFAULT = "default"
         const val ITEM_BACKEND_PREDICATE_RESULTS = "backend_predicate_results"
     }
-}
-
-/**
- * `null` for a value no rule could read: an explicit JSON `null` (no value to compare) or an array of anything
- * but objects ([RulesDimensionValue.ObjectListValue] is the only collection a dimension can be). An entry an
- * object holds that can't be read is dropped from it, mirroring how absent record values behave.
- */
-private fun JsonElement.asRulesDimensionValue(): RulesDimensionValue? = when (this) {
-    is JsonNull -> null
-    is JsonPrimitive -> when {
-        isString -> RulesDimensionValue.StringValue(content)
-        else -> booleanOrNull?.let { RulesDimensionValue.BoolValue(it) }
-            ?: longOrNull?.let { RulesDimensionValue.IntValue(it) }
-            ?: doubleOrNull?.let { RulesDimensionValue.DoubleValue(it) }
-    }
-    is JsonObject -> RulesDimensionValue.ObjectValue(
-        mapNotNull { (name, element) -> element.asRulesDimensionValue()?.let { name to it } }.toMap(),
-    )
-    is JsonArray -> map { element -> (element as? JsonObject)?.asRulesDimensionValue() }
-        .takeIf { records -> records.all { it is RulesDimensionValue.ObjectValue } }
-        ?.let { records ->
-            RulesDimensionValue.ObjectListValue(records.map { (it as RulesDimensionValue.ObjectValue).value })
-        }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
+import com.revenuecat.purchases.common.responses.CustomerInfoResponseJsonKeys
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.interfaces.StorefrontProvider
@@ -132,6 +133,10 @@ public open class DeviceCache(
         "$apiKeyPrefix.virtualCurrenciesLastUpdated"
     }
 
+    private val subscriberDimensionsCacheBaseKey: String by lazy {
+        "$apiKeyPrefix.subscriberDimensions"
+    }
+
     private val offeringsResponseCacheKey: String by lazy { "$apiKeyPrefix.offeringsResponse" }
 
     internal fun startEditing(): SharedPreferences.Editor {
@@ -167,6 +172,7 @@ public open class DeviceCache(
             .clearCustomerInfoCacheTimestamp(appUserID)
             .clearVirtualCurrenciesCacheTimestamp(appUserID)
             .clearVirtualCurrenciesCache(appUserID)
+            .clearSubscriberDimensionsCache(appUserID)
             .apply()
     }
 
@@ -241,6 +247,15 @@ public open class DeviceCache(
 
     @Synchronized
     internal fun cacheCustomerInfo(appUserID: String, info: CustomerInfo) {
+        // The dimensions sibling of `subscriber` is cached on its own because not every response carries it:
+        // the last value received stays authoritative until a response replaces it. Absent or empty keeps the
+        // previous value, and a cache-loaded info never writes so a stale copy inside the blob below can't
+        // resurrect an older value.
+        if (!info.loadedFromCache) {
+            info.rawData.optJSONObject(CustomerInfoResponseJsonKeys.DIMENSIONS)
+                ?.takeIf { it.length() > 0 }
+                ?.let { cacheSubscriberDimensions(appUserID, it.toString()) }
+        }
         val jsonObject = info.rawData.also {
             it.put(CUSTOMER_INFO_SCHEMA_VERSION_KEY, CUSTOMER_INFO_SCHEMA_VERSION)
             it.put(CUSTOMER_INFO_VERIFICATION_RESULT_KEY, info.entitlements.verification.name)
@@ -419,6 +434,36 @@ public open class DeviceCache(
         }
         getLegacyCachedAppUserID()?.let {
             remove(virtualCurrenciesCacheKey(it))
+        }
+        return this
+    }
+    // endregion
+
+    // region subscriber dimensions
+
+    @VisibleForTesting
+    internal fun subscriberDimensionsCacheKey(appUserID: String) = "$subscriberDimensionsCacheBaseKey.$appUserID"
+
+    @Synchronized
+    internal fun cacheSubscriberDimensions(appUserID: String, dimensionsJson: String) {
+        preferences.edit()
+            .putString(subscriberDimensionsCacheKey(appUserID), dimensionsJson)
+            .apply()
+    }
+
+    @Synchronized
+    internal fun getCachedSubscriberDimensionsJson(appUserID: String): String? {
+        return preferences.getString(subscriberDimensionsCacheKey(appUserID), null)
+    }
+
+    private fun SharedPreferences.Editor.clearSubscriberDimensionsCache(appUserID: String): SharedPreferences.Editor {
+        remove(subscriberDimensionsCacheKey(appUserID))
+
+        getCachedAppUserID()?.let {
+            remove(subscriberDimensionsCacheKey(it))
+        }
+        getLegacyCachedAppUserID()?.let {
+            remove(subscriberDimensionsCacheKey(it))
         }
         return this
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -25,7 +25,8 @@ internal interface RulesDimensionProvider {
      * provider supplies one of the roots the resolver itself owns (`evaluated_at`, `custom`, `backend`).
      *
      * A value that is unavailable is omitted rather than guessed: a predicate that reads an absent key fails as
-     * an unresolved variable, rather than being answered from a value we invented. A name no predicate could
+     * an unresolved variable, rather than being answered from a value we invented. Only a source whose values are
+     * its own to state, such as the backend, supplies [RulesDimensionValue.NullValue]. A name no predicate could
      * read is dropped by [RulesDimensionResolver], which applies that rule to every provider. Throwing is
      * reserved for a systemic failure to produce this provider's values.
      *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -186,6 +186,7 @@ private val RulesDimensionValue.asRulesEngineValue: Value
         is RulesDimensionValue.IntValue -> Value.IntValue(value)
         is RulesDimensionValue.DoubleValue -> Value.FloatValue(value)
         is RulesDimensionValue.DateValue -> Value.IntValue(value.time)
+        is RulesDimensionValue.NullValue -> Value.Null
         is RulesDimensionValue.ObjectListValue -> Value.ArrayValue(
             value.map { record -> Value.ObjectValue(record.mapValues { (_, item) -> item.asRulesEngineValue }) },
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValue.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValue.kt
@@ -31,6 +31,15 @@ public sealed class RulesDimensionValue {
     public data class DateValue(val value: Date) : RulesDimensionValue()
 
     /**
+     * An explicit null a source states for a name it does have, as opposed to leaving the name out.
+     *
+     * Reaches the engine as JSON `null`: `var` resolves it instead of failing as an unresolved variable, `missing`
+     * still reports it, and it is falsy. For a source whose values are its own to state — the backend's — rather
+     * than one the SDK observes, where an unavailable value is omitted.
+     */
+    public object NullValue : RulesDimensionValue()
+
+    /**
      * A collection of records, for a dimension the customer has any number of rather than one of — their
      * purchases, their entitlements.
      *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValueJson.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValueJson.kt
@@ -13,12 +13,13 @@ import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.longOrNull
 
 /**
- * `null` for a value no rule could read: an explicit JSON `null` (no value to compare) or an array of anything
- * but objects ([RulesDimensionValue.ObjectListValue] is the only collection a dimension can be). An entry an
- * object holds that can't be read is dropped from it, mirroring how absent record values behave.
+ * `null` for a value no rule could read: an array of anything but objects ([RulesDimensionValue.ObjectListValue]
+ * is the only collection a dimension can be). An entry an object holds that can't be read is dropped from it,
+ * mirroring how absent record values behave. An explicit JSON `null` is a value the source stated, and is kept
+ * as [RulesDimensionValue.NullValue].
  */
 internal fun JsonElement.asRulesDimensionValue(): RulesDimensionValue? = when (this) {
-    is JsonNull -> null
+    is JsonNull -> RulesDimensionValue.NullValue
     is JsonPrimitive -> when {
         isString -> RulesDimensionValue.StringValue(content)
         else -> booleanOrNull?.let { RulesDimensionValue.BoolValue(it) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValueJson.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionValueJson.kt
@@ -1,0 +1,36 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.longOrNull
+
+/**
+ * `null` for a value no rule could read: an explicit JSON `null` (no value to compare) or an array of anything
+ * but objects ([RulesDimensionValue.ObjectListValue] is the only collection a dimension can be). An entry an
+ * object holds that can't be read is dropped from it, mirroring how absent record values behave.
+ */
+internal fun JsonElement.asRulesDimensionValue(): RulesDimensionValue? = when (this) {
+    is JsonNull -> null
+    is JsonPrimitive -> when {
+        isString -> RulesDimensionValue.StringValue(content)
+        else -> booleanOrNull?.let { RulesDimensionValue.BoolValue(it) }
+            ?: longOrNull?.let { RulesDimensionValue.IntValue(it) }
+            ?: doubleOrNull?.let { RulesDimensionValue.DoubleValue(it) }
+    }
+    is JsonObject -> RulesDimensionValue.ObjectValue(
+        mapNotNull { (name, element) -> element.asRulesDimensionValue()?.let { name to it } }.toMap(),
+    )
+    is JsonArray -> map { element -> (element as? JsonObject)?.asRulesDimensionValue() }
+        .takeIf { records -> records.all { it is RulesDimensionValue.ObjectValue } }
+        ?.let { records ->
+            RulesDimensionValue.ObjectListValue(records.map { (it as RulesDimensionValue.ObjectValue).value })
+        }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProvider.kt
@@ -1,0 +1,55 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.common.warnLog
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonObject
+import java.util.Date
+
+/**
+ * The dimensions the backend last delivered alongside the subscriber, cached because not every response carries
+ * them, exposed as root-level names. Distinct from the reserved nested `backend` root, which holds the backend's
+ * pre-evaluated predicate results for one evaluation.
+ *
+ * The names are the backend's to choose, and the root-name contract applies to it like any other source: one
+ * that collides with an SDK-provided dimension fails the snapshot. A value no rule could read is dropped here,
+ * and a cache that cannot be read at all contributes nothing.
+ */
+internal class SubscriberDimensionsProvider(
+    private val cachedDimensionsJson: () -> String?,
+) : RulesDimensionProvider {
+
+    override val name: String = "subscriber_dimensions"
+
+    @Suppress("ReturnCount")
+    override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+        val dimensionsJson = try {
+            cachedDimensionsJson()
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            warnLog { "The subscriber dimensions are unavailable, so they can't be evaluated: $e" }
+            return emptyMap()
+        } ?: return emptyMap()
+        val entries = try {
+            JsonTools.json.parseToJsonElement(dimensionsJson) as? JsonObject
+        } catch (e: SerializationException) {
+            warnLog { "The cached subscriber dimensions can't be parsed, so they can't be evaluated: $e" }
+            return emptyMap()
+        }
+        if (entries == null) {
+            warnLog { "The cached subscriber dimensions are not a JSON object, so they can't be evaluated." }
+            return emptyMap()
+        }
+        return entries.mapNotNull { (name, element) ->
+            val value = element.asRulesDimensionValue()
+            if (value == null) {
+                warnLog { "Ignoring dimension '$name': its value can't be read by a rule." }
+                null
+            } else {
+                name to value
+            }
+        }.toMap()
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProvider.kt
@@ -15,8 +15,9 @@ import java.util.Date
  * pre-evaluated predicate results for one evaluation.
  *
  * The names are the backend's to choose, and the root-name contract applies to it like any other source: one
- * that collides with an SDK-provided dimension fails the snapshot. A value no rule could read is dropped here,
- * and a cache that cannot be read at all contributes nothing.
+ * that collides with an SDK-provided dimension fails the snapshot. An explicit null is kept as null, since the
+ * backend stated it; a value no rule could read is dropped here, and a cache that cannot be read at all
+ * contributes nothing.
  */
 internal class SubscriberDimensionsProvider(
     private val cachedDimensionsJson: () -> String?,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/CustomerInfoResponseJsonKeys.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/CustomerInfoResponseJsonKeys.kt
@@ -4,6 +4,7 @@ internal object CustomerInfoResponseJsonKeys {
     const val REQUEST_DATE = "request_date"
     const val REQUEST_DATE_MS = "request_date_ms"
     const val SUBSCRIBER = "subscriber"
+    const val DIMENSIONS = "dimensions"
     const val ORIGINAL_APP_USER_ID = "original_app_user_id"
     const val ORIGINAL_APPLICATION_VERSION = "original_application_version"
     const val ENTITLEMENTS = "entitlements"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -461,6 +461,8 @@ class DeviceCacheTest {
         verify { mockEditor.remove(cache.virtualCurrenciesCacheKey("legacyAppUserID")) }
         verify { mockEditor.remove(cache.virtualCurrenciesLastUpdatedCacheKey("appUserID")) }
         verify { mockEditor.remove(cache.virtualCurrenciesLastUpdatedCacheKey("legacyAppUserID")) }
+        verify { mockEditor.remove(cache.subscriberDimensionsCacheKey("appUserID")) }
+        verify { mockEditor.remove(cache.subscriberDimensionsCacheKey("legacyAppUserID")) }
     }
 
     @Test
@@ -902,6 +904,89 @@ class DeviceCacheTest {
         assertThat(vcs).`as`("cached VirtualCurrencies is null when JSONException is thrown").isNull()
     }
     // endregion virtualCurrencies
+
+    // region subscriber dimensions
+
+    @Test
+    fun `given no cached subscriber dimensions, null is returned`() {
+        mockString(cache.subscriberDimensionsCacheKey(appUserID), null)
+        assertThat(cache.getCachedSubscriberDimensionsJson(appUserID)).isNull()
+        verify {
+            mockPrefs.getString(cache.subscriberDimensionsCacheKey(appUserID), isNull())
+        }
+    }
+
+    @Test
+    fun `cached subscriber dimensions are returned as stored`() {
+        mockString(cache.subscriberDimensionsCacheKey(appUserID), """{"plan":"annual"}""")
+        assertThat(cache.getCachedSubscriberDimensionsJson(appUserID)).isEqualTo("""{"plan":"annual"}""")
+    }
+
+    @Test
+    fun `subscriber dimensions are cached under the user's key`() {
+        cache.cacheSubscriberDimensions(appUserID, """{"plan":"annual"}""")
+        verifyAll {
+            mockEditor.putString(cache.subscriberDimensionsCacheKey(appUserID), """{"plan":"annual"}""")
+            mockEditor.apply()
+        }
+    }
+
+    @Test
+    fun `caching a customer info with dimensions caches them separately`() {
+        val response = JSONObject(Responses.validFullPurchaserResponse)
+            .put("dimensions", JSONObject("""{"plan":"annual"}"""))
+        val dimensionsSlot = slot<String>()
+        every {
+            mockEditor.putString(cache.subscriberDimensionsCacheKey(appUserID), capture(dimensionsSlot))
+        } returns mockEditor
+
+        cache.cacheCustomerInfo(appUserID, createCustomerInfo(response))
+
+        assertThat(JSONObject(dimensionsSlot.captured).getString("plan")).isEqualTo("annual")
+    }
+
+    @Test
+    fun `caching a customer info without dimensions keeps the previous value`() {
+        cache.cacheCustomerInfo(appUserID, createCustomerInfo(Responses.validFullPurchaserResponse))
+
+        verify(exactly = 0) {
+            mockEditor.putString(cache.subscriberDimensionsCacheKey(appUserID), any())
+        }
+    }
+
+    @Test
+    fun `caching a customer info with empty dimensions keeps the previous value`() {
+        val response = JSONObject(Responses.validFullPurchaserResponse)
+            .put("dimensions", JSONObject())
+
+        cache.cacheCustomerInfo(appUserID, createCustomerInfo(response))
+
+        verify(exactly = 0) {
+            mockEditor.putString(cache.subscriberDimensionsCacheKey(appUserID), any())
+        }
+    }
+
+    @Test
+    fun `caching a cache-loaded customer info never writes the subscriber dimensions`() {
+        // A cache-loaded blob can still hold the dimensions of the response that produced it; re-caching it
+        // must not resurrect them over a value received since.
+        val response = JSONObject(Responses.validFullPurchaserResponse)
+            .put("dimensions", JSONObject("""{"plan":"annual"}"""))
+        val info = CustomerInfoFactory.buildCustomerInfo(
+            response,
+            null,
+            VerificationResult.NOT_REQUESTED,
+            loadedFromCache = true,
+        )
+
+        cache.cacheCustomerInfo(appUserID, info)
+
+        verify(exactly = 0) {
+            mockEditor.putString(cache.subscriberDimensionsCacheKey(appUserID), any())
+        }
+    }
+
+    // endregion subscriber dimensions
 
     // region auto-renewing status
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
@@ -185,8 +185,12 @@ internal class AudiencesConfigProviderTest {
 
         assertThat(provider.getSnapshot()?.backendPredicateResults).isEqualTo(
             mapOf(
+                "null-result" to RulesDimensionValue.NullValue,
                 "null-in-object" to RulesDimensionValue.ObjectValue(
-                    mapOf("kept" to RulesDimensionValue.BoolValue(true)),
+                    mapOf(
+                        "value" to RulesDimensionValue.NullValue,
+                        "kept" to RulesDimensionValue.BoolValue(true),
+                    ),
                 ),
                 "kept" to RulesDimensionValue.BoolValue(true),
             ),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -173,11 +173,20 @@ class RulesDimensionResolverTest {
                 "count" to RulesDimensionValue.IntValue(3),
                 "ratio" to RulesDimensionValue.DoubleValue(1.5),
                 "date" to RulesDimensionValue.DateValue(evaluationDate),
+                "nothing" to RulesDimensionValue.NullValue,
                 "records" to RulesDimensionValue.ObjectListValue(
-                    listOf(mapOf("id" to RulesDimensionValue.StringValue("one"))),
+                    listOf(
+                        mapOf(
+                            "id" to RulesDimensionValue.StringValue("one"),
+                            "nothing" to RulesDimensionValue.NullValue,
+                        ),
+                    ),
                 ),
                 "record" to RulesDimensionValue.ObjectValue(
-                    mapOf("id" to RulesDimensionValue.StringValue("one")),
+                    mapOf(
+                        "id" to RulesDimensionValue.StringValue("one"),
+                        "nothing" to RulesDimensionValue.NullValue,
+                    ),
                 ),
             ),
         )
@@ -192,10 +201,13 @@ class RulesDimensionResolverTest {
                 "count" to Value.IntValue(3),
                 "ratio" to Value.FloatValue(1.5),
                 "date" to Value.IntValue(1_700_000_000_000),
+                "nothing" to Value.Null,
                 "records" to Value.ArrayValue(
-                    listOf(Value.ObjectValue(mapOf("id" to Value.StringValue("one")))),
+                    listOf(
+                        Value.ObjectValue(mapOf("id" to Value.StringValue("one"), "nothing" to Value.Null)),
+                    ),
                 ),
-                "record" to Value.ObjectValue(mapOf("id" to Value.StringValue("one"))),
+                "record" to Value.ObjectValue(mapOf("id" to Value.StringValue("one"), "nothing" to Value.Null)),
             ),
         )
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -58,6 +58,7 @@ class RulesDimensionScopeTest {
         assertThat(scope.render()).isEqualTo(
             """
             {
+              "acquisition_channel": "paid_search",
               "app_user_id": "current_user",
               "app_version": "1.2.3",
               "backend": {
@@ -111,6 +112,7 @@ class RulesDimensionScopeTest {
               "original_purchased_at": 1609459200000,
               "platform": "android",
               "platform_version": "34",
+              "predicted_ltv_band": 3,
               "purchases": [
                 {
                   "auto_resume_at": 1717200000000,
@@ -186,6 +188,7 @@ class RulesDimensionScopeTest {
             """{"==": [{"var": "custom.plan"}, "gold"]}""",
             """{"var": ["backend.349OzehoTyCAdiZblj9w0J0yD-Uow8X3", false]}""",
             """{"==": [{"var": "app_user_id"}, "current_user"]}""",
+            """{"==": [{"var": "acquisition_channel"}, "paid_search"]}""",
             """{"some": [{"var": "purchases"}, {"==": [{"var": "period_type"}, "trial"]}]}""",
             """{"some": [{"var": "entitlements"}, {"var": "is_active"}]}""",
             """{"==": [{"var": "subscriber_attributes.${'$'}email.value"}, "jane@example.com"]}""",
@@ -226,6 +229,7 @@ class RulesDimensionScopeTest {
                     customerInfo = { customerInfo },
                 ),
                 SubscriberAttributesDimensionProvider { SUBSCRIBER_ATTRIBUTES },
+                SubscriberDimensionsProvider { SUBSCRIBER_DIMENSIONS },
             ),
             dateProvider = object : DateProvider {
                 override val now: Date get() = evaluationDate
@@ -291,6 +295,14 @@ class RulesDimensionScopeTest {
         val BACKEND_VALUES = mapOf(
             "349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to RulesDimensionValue.BoolValue(true),
         )
+
+        /** The dimensions the backend last sent alongside the subscriber, root-level under their own names. */
+        val SUBSCRIBER_DIMENSIONS = """
+            {
+              "acquisition_channel": "paid_search",
+              "predicted_ltv_band": 3
+            }
+        """
 
         /**
          * One Google subscription with every field the backend can send, one Amazon one-time purchase, and two

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProviderTest.kt
@@ -58,10 +58,29 @@ class SubscriberDimensionsProviderTest {
     }
 
     @Test
+    fun `an explicit null is kept as null, at the root and inside an object`() = runTest {
+        // The backend stated the name and chose null for it, which a rule can compare against.
+        val dimensions = provider("""{"gone": null, "profile": {"tier": null, "age": 42}}""")
+            .dimensions(evaluationDate)
+
+        assertThat(dimensions).isEqualTo(
+            mapOf(
+                "gone" to RulesDimensionValue.NullValue,
+                "profile" to RulesDimensionValue.ObjectValue(
+                    mapOf(
+                        "tier" to RulesDimensionValue.NullValue,
+                        "age" to RulesDimensionValue.IntValue(42),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `a value no rule could read is dropped without dropping the others`() = runTest {
-        // An explicit null carries no value to compare, and an object list is the only collection a dimension
-        // can be — same treatment the backend predicate results get.
-        val dimensions = provider("""{"gone": null, "codes": [1, 2], "plan": "annual"}""")
+        // An object list is the only collection a dimension can be — same treatment the backend predicate
+        // results get.
+        val dimensions = provider("""{"codes": [1, 2], "mixed": [{"id": "a"}, null], "plan": "annual"}""")
             .dimensions(evaluationDate)
 
         assertThat(dimensions).containsOnlyKeys("plan")
@@ -121,17 +140,21 @@ class SubscriberDimensionsProviderTest {
     @Test
     fun `the dimensions are readable by a predicate`() = runTest {
         val values = resolver(
-            provider("""{"plan": "annual", "seats": 3, "profile": {"tier": "gold"}}"""),
+            provider("""{"plan": "annual", "seats": 3, "profile": {"tier": "gold"}, "gone": null}"""),
         ).snapshot().getOrThrow().values
 
         val matching = listOf(
             """{"==": [{"var": "plan"}, "annual"]}""",
             """{">": [{"var": "seats"}, 2]}""",
             """{"==": [{"var": "profile.tier"}, "gold"]}""",
+            // A null the backend stated is present: `var` resolves it rather than failing or using the default.
+            """{"==": [{"var": "gone"}, null]}""",
+            """{"==": [{"var": ["gone", "fallback"]}, null]}""",
         )
         val notMatching = listOf(
             """{"==": [{"var": "plan"}, "monthly"]}""",
             """{"!!": {"var": ["never_sent", false]}}""",
+            """{"!!": {"var": "gone"}}""",
         )
 
         for (predicate in matching) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProviderTest.kt
@@ -1,0 +1,159 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
+
+package com.revenuecat.purchases.common.localrules
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.rules.RulesEngine
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class SubscriberDimensionsProviderTest {
+
+    private val evaluationDate = Date(1_718_452_800_000)
+
+    @Test
+    fun `every value shape a rule can read is kept`() = runTest {
+        val dimensions = provider(
+            """
+            {
+                "plan": "annual",
+                "beta": true,
+                "seats": 3,
+                "score": 0.75,
+                "profile": {"tier": "gold", "age": 42},
+                "teams": [{"id": "a"}, {"id": "b"}]
+            }
+            """.trimIndent(),
+        ).dimensions(evaluationDate)
+
+        assertThat(dimensions).isEqualTo(
+            mapOf(
+                "plan" to RulesDimensionValue.StringValue("annual"),
+                "beta" to RulesDimensionValue.BoolValue(true),
+                "seats" to RulesDimensionValue.IntValue(3),
+                "score" to RulesDimensionValue.DoubleValue(0.75),
+                "profile" to RulesDimensionValue.ObjectValue(
+                    mapOf(
+                        "tier" to RulesDimensionValue.StringValue("gold"),
+                        "age" to RulesDimensionValue.IntValue(42),
+                    ),
+                ),
+                "teams" to RulesDimensionValue.ObjectListValue(
+                    listOf(
+                        mapOf("id" to RulesDimensionValue.StringValue("a")),
+                        mapOf("id" to RulesDimensionValue.StringValue("b")),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `a value no rule could read is dropped without dropping the others`() = runTest {
+        // An explicit null carries no value to compare, and an object list is the only collection a dimension
+        // can be — same treatment the backend predicate results get.
+        val dimensions = provider("""{"gone": null, "codes": [1, 2], "plan": "annual"}""")
+            .dimensions(evaluationDate)
+
+        assertThat(dimensions).containsOnlyKeys("plan")
+    }
+
+    @Test
+    fun `a cache that is not a JSON object contributes nothing`() = runTest {
+        val unreadable = listOf("not json at all", """["an", "array"]""", "\"a string\"", "42")
+
+        for (json in unreadable) {
+            assertThat(provider(json).dimensions(evaluationDate)).describedAs(json).isEmpty()
+        }
+    }
+
+    @Test
+    fun `a customer with no cached dimensions contributes nothing`() = runTest {
+        assertThat(provider(null).dimensions(evaluationDate)).isEmpty()
+    }
+
+    @Test
+    fun `a cache that cannot be read leaves the other dimensions usable`() = runTest {
+        val snapshot = resolver(
+            deviceProvider("platform" to "android"),
+            SubscriberDimensionsProvider { throw IllegalStateException("no cache") },
+        ).snapshot()
+
+        assertThat(snapshot.isSuccess).isTrue()
+        assertThat(snapshot.getOrThrow().values).containsOnlyKeys("evaluated_at", "platform")
+    }
+
+    @Test
+    fun `the cache is read on every evaluation`() = runTest {
+        var json: String? = """{"plan": "annual"}"""
+        val provider = SubscriberDimensionsProvider { json }
+
+        assertThat(provider.dimensions(evaluationDate))
+            .containsEntry("plan", RulesDimensionValue.StringValue("annual"))
+
+        json = """{"plan": "monthly"}"""
+
+        assertThat(provider.dimensions(evaluationDate))
+            .containsEntry("plan", RulesDimensionValue.StringValue("monthly"))
+    }
+
+    @Test
+    fun `a dimension colliding with an SDK-provided one fails the snapshot`() = runTest {
+        // Same treatment as any other source: the root names are one contract, and the backend's side of it is
+        // to not claim a name the SDK already exposes.
+        val error = resolver(
+            deviceProvider("platform" to "android"),
+            provider("""{"platform": "spoofed", "plan": "annual"}"""),
+        ).snapshot().exceptionOrNull()
+
+        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("platform"))
+    }
+
+    @Test
+    fun `the dimensions are readable by a predicate`() = runTest {
+        val values = resolver(
+            provider("""{"plan": "annual", "seats": 3, "profile": {"tier": "gold"}}"""),
+        ).snapshot().getOrThrow().values
+
+        val matching = listOf(
+            """{"==": [{"var": "plan"}, "annual"]}""",
+            """{">": [{"var": "seats"}, 2]}""",
+            """{"==": [{"var": "profile.tier"}, "gold"]}""",
+        )
+        val notMatching = listOf(
+            """{"==": [{"var": "plan"}, "monthly"]}""",
+            """{"!!": {"var": ["never_sent", false]}}""",
+        )
+
+        for (predicate in matching) {
+            assertThat(RulesEngine.evaluate(predicate, values).getOrThrow()).describedAs(predicate).isTrue()
+        }
+        for (predicate in notMatching) {
+            assertThat(RulesEngine.evaluate(predicate, values).getOrThrow()).describedAs(predicate).isFalse()
+        }
+    }
+
+    private fun provider(json: String?) = SubscriberDimensionsProvider { json }
+
+    private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
+        providers = providers.toList(),
+        dateProvider = object : DateProvider {
+            override val now: Date = evaluationDate
+        },
+    )
+
+    private fun deviceProvider(vararg values: Pair<String, String>) = object : RulesDimensionProvider {
+        override val name = "device"
+        override suspend fun dimensions(date: Date) =
+            values.associate { (key, value) -> key to RulesDimensionValue.StringValue(value) }
+    }
+}


### PR DESCRIPTION
### Description

`subscriber` responses now may come with a new `dimensions` property including information used for rule evaluation. This PR reads those and cached them separately (reasoning is that these values might not be provided by fortress or other situations, and we would like to keep the latest valid value)

This PR also propagates this new field's properties into the rules engine as root properties. If there are any conflicts in names with one of the other SDK properties, the rule evaluation will fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local rule evaluation scope and persistent cache behavior for customer info; wrong sticky-cache or null handling could change audience outcomes, though conflicts fail closed and tests cover cache edge cases.
> 
> **Overview**
> Adds support for the optional **`dimensions`** object on customer info responses so audience/checkpoint rules can read backend-supplied fields as **root-level** variables (separate from the reserved `backend.*` predicate hashes).
> 
> **Caching:** `DeviceCache` persists dimensions in their own per-user key when fresh network customer info includes a non-empty `dimensions` object; missing/empty payloads and re-caching cache-loaded customer info do **not** overwrite the last stored value. User cache clears remove this entry too.
> 
> **Rules engine:** New `SubscriberDimensionsProvider` parses the cached JSON into `RulesDimensionValue`s and is registered in `LocalRulesEvaluator`. Name collisions with other SDK dimensions still fail the whole snapshot.
> 
> **Null semantics:** Introduces `RulesDimensionValue.NullValue` and shared `JsonElement.asRulesDimensionValue()` so explicit JSON `null` is preserved for rules (falsy, `var` resolves) rather than treated as unreadable; backend predicate metadata parsing uses the same helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f97bcbaaaffb06d1ff67c698b921cec17e12146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->