### PR TITLE
feat: add five discount paywall variables

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
@@ -149,6 +149,7 @@ private fun rememberProcessedText(
                 VariableProcessor.PackageContext(
                     discountRelativeToMostExpensivePerMonth = discount,
                     showZeroDecimalPlacePrices = !state.showPricesWithDecimals,
+                    mostExpensivePricePerMonthMicros = state.mostExpensivePricePerMonthMicros,
                 )
             }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PricingPhaseExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PricingPhaseExtensions.kt
@@ -138,3 +138,22 @@ internal fun PricingPhase.productOfferEndDate(locale: Locale, date: Date): Strin
 
 internal fun PricingPhase.canDisplay(unit: Period.Unit): Boolean =
     unit.ordinal <= billingPeriod.unit.ordinal
+
+/**
+ * This phase's price, but only when it can be compared like-for-like against the standard renewal
+ * price: same billing period, and not free. Returns null otherwise so the offer discount variables
+ * render empty rather than a misleading number — a 7-day trial on a monthly product would otherwise
+ * read as a full month's saving.
+ */
+internal fun PricingPhase.comparableOfferPriceMicros(rcPackage: Package?): Long? {
+    val basePeriod = rcPackage?.product?.period ?: return null
+
+    // Compare unit and value rather than the whole Period: its generated equals() also covers
+    // `iso8601`, so semantically identical periods built from different strings ("P3M" vs
+    // "P0Y3M0D") would compare unequal and silently blank a legitimate same-period offer.
+    if (billingPeriod.unit != basePeriod.unit || billingPeriod.value != basePeriod.value) {
+        return null
+    }
+
+    return price.amountMicros.takeIf { it > 0L }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
@@ -13,6 +13,7 @@ internal object VariableProcessor {
     internal data class PackageContext(
         val discountRelativeToMostExpensivePerMonth: Double?,
         val showZeroDecimalPlacePrices: Boolean = false,
+        val mostExpensivePricePerMonthMicros: Long? = null,
     )
 
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorV2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorV2.kt
@@ -2,12 +2,14 @@ package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
 import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationKey
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.components.countdown.CountdownTime
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableProcessor.PackageContext
+import com.revenuecat.purchases.ui.revenuecatui.extensions.localized
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import java.util.Currency
 import java.util.Date
@@ -53,6 +55,9 @@ internal object VariableProcessorV2 {
         PRODUCT_SECONDARY_OFFER_PERIOD("product.secondary_offer_period"),
         PRODUCT_SECONDARY_OFFER_PERIOD_ABBREVIATED("product.secondary_offer_period_abbreviated"),
         PRODUCT_RELATIVE_DISCOUNT("product.relative_discount"),
+        PRODUCT_ABSOLUTE_DISCOUNT("product.absolute_discount"),
+        PRODUCT_OFFER_RELATIVE_DISCOUNT("product.offer_relative_discount"),
+        PRODUCT_OFFER_ABSOLUTE_DISCOUNT("product.offer_absolute_discount"),
         PRODUCT_STORE_PRODUCT_NAME("product.store_product_name"),
 
         COUNT_DAYS_WITH_ZERO("count_days_with_zero"),
@@ -576,6 +581,28 @@ internal object VariableProcessorV2 {
             ) { rcPackage?.productPeriodAbbreviated(localizedVariableKeys) }
 
         Variable.PRODUCT_RELATIVE_DISCOUNT -> packageContext?.relativeDiscount(localizedVariableKeys)
+
+        Variable.PRODUCT_ABSOLUTE_DISCOUNT -> packageContext?.absoluteDiscount(rcPackage, currencyLocale)
+
+        Variable.PRODUCT_OFFER_RELATIVE_DISCOUNT ->
+            primaryDiscountPhase(subscriptionOption, rcPackage)
+                ?.comparableOfferPriceMicros(rcPackage)
+                ?.let { offerPriceMicros ->
+                    offerRelativeDiscount(rcPackage, offerPriceMicros, localizedVariableKeys)
+                }
+
+        Variable.PRODUCT_OFFER_ABSOLUTE_DISCOUNT ->
+            primaryDiscountPhase(subscriptionOption, rcPackage)
+                ?.comparableOfferPriceMicros(rcPackage)
+                ?.let { offerPriceMicros ->
+                    offerAbsoluteDiscount(
+                        rcPackage = rcPackage,
+                        offerPriceMicros = offerPriceMicros,
+                        locale = currencyLocale,
+                        showZeroDecimalPlacePrices = packageContext?.showZeroDecimalPlacePrices ?: false,
+                    )
+                }
+
         Variable.PRODUCT_STORE_PRODUCT_NAME -> rcPackage?.product?.name
 
         Variable.COUNT_DAYS_WITH_ZERO -> countdownTime?.let {
@@ -655,4 +682,55 @@ internal object VariableProcessorV2 {
             ?.let { discountPercentage ->
                 localizedVariableKeys.getStringOrLogError(VariableLocalizationKey.PERCENT)?.format(discountPercentage)
             }
+
+    /**
+     * The saving against the most expensive package, expressed over this package's own period.
+     *
+     * The anchor is picked by per-month price, exactly as [relativeDiscount] does, so the two variables
+     * always compare the same pair of packages. The amount is then normalized to the period being
+     * purchased: a ratio is period-invariant, but a currency amount is not, so quoting it per month would
+     * peg the number to an arbitrary unit rather than to what the customer actually buys.
+     */
+    private fun PackageContext.absoluteDiscount(rcPackage: Package?, locale: Locale): String? {
+        val product = rcPackage?.product ?: return null
+        val mostExpensiveMicros = mostExpensivePricePerMonthMicros ?: return null
+        val pricePerMonthMicros = product.pricePerMonth(locale)?.amountMicros ?: return null
+        // Non-subscriptions have no period to normalize the anchor to.
+        val periodInMonths = product.period?.valueInMonths ?: return null
+
+        if (mostExpensiveMicros <= pricePerMonthMicros) return null
+
+        val savingMicros = (mostExpensiveMicros * periodInMonths).toLong() - product.price.amountMicros
+        if (savingMicros <= 0L) return null
+
+        // `formatted` is unused: localized() derives the display string from amountMicros.
+        return Price("", savingMicros, product.price.currencyCode).localized(locale, showZeroDecimalPlacePrices)
+    }
+
+    private fun offerRelativeDiscount(
+        rcPackage: Package?,
+        offerPriceMicros: Long,
+        localizedVariableKeys: Map<VariableLocalizationKey, String>,
+    ): String? {
+        val standardMicros = rcPackage?.product?.price?.amountMicros ?: return null
+        if (standardMicros <= offerPriceMicros) return null
+
+        val percentage =
+            ((standardMicros - offerPriceMicros).toDouble() * PERCENT_SCALE / standardMicros).roundToInt()
+        return localizedVariableKeys.getStringOrLogError(VariableLocalizationKey.PERCENT)?.format(percentage)
+    }
+
+    private fun offerAbsoluteDiscount(
+        rcPackage: Package?,
+        offerPriceMicros: Long,
+        locale: Locale,
+        showZeroDecimalPlacePrices: Boolean,
+    ): String? {
+        val standardPrice = rcPackage?.product?.price ?: return null
+        val savingMicros = standardPrice.amountMicros - offerPriceMicros
+        if (savingMicros <= 0L) return null
+
+        // `formatted` is unused: localized() derives the display string from amountMicros.
+        return Price("", savingMicros, standardPrice.currencyCode).localized(locale, showZeroDecimalPlacePrices)
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorV2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorV2.kt
@@ -3,6 +3,8 @@ package com.revenuecat.purchases.ui.revenuecatui.data.processed
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.PricingPhase
+import com.revenuecat.purchases.models.RecurrenceMode
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
 import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationKey
@@ -58,6 +60,8 @@ internal object VariableProcessorV2 {
         PRODUCT_ABSOLUTE_DISCOUNT("product.absolute_discount"),
         PRODUCT_OFFER_RELATIVE_DISCOUNT("product.offer_relative_discount"),
         PRODUCT_OFFER_ABSOLUTE_DISCOUNT("product.offer_absolute_discount"),
+        PRODUCT_RELATIVE_DISCOUNT_WITH_OFFER("product.relative_discount_with_offer"),
+        PRODUCT_ABSOLUTE_DISCOUNT_WITH_OFFER("product.absolute_discount_with_offer"),
         PRODUCT_STORE_PRODUCT_NAME("product.store_product_name"),
 
         COUNT_DAYS_WITH_ZERO("count_days_with_zero"),
@@ -603,6 +607,12 @@ internal object VariableProcessorV2 {
                     )
                 }
 
+        Variable.PRODUCT_RELATIVE_DISCOUNT_WITH_OFFER ->
+            packageContext?.relativeDiscountWithOffer(rcPackage, subscriptionOption, localizedVariableKeys)
+
+        Variable.PRODUCT_ABSOLUTE_DISCOUNT_WITH_OFFER ->
+            packageContext?.absoluteDiscountWithOffer(rcPackage, subscriptionOption, currencyLocale)
+
         Variable.PRODUCT_STORE_PRODUCT_NAME -> rcPackage?.product?.name
 
         Variable.COUNT_DAYS_WITH_ZERO -> countdownTime?.let {
@@ -705,6 +715,96 @@ internal object VariableProcessorV2 {
 
         // `formatted` is unused: localized() derives the display string from amountMicros.
         return Price("", savingMicros, product.price.currencyCode).localized(locale, showZeroDecimalPlacePrices)
+    }
+
+    /**
+     * What the customer actually pays and over how long: the primary offer's, or the package's own
+     * when there is no usable offer. A free offer counts as no offer — "100% off" isn't the claim
+     * these variables make.
+     *
+     * [totalMicros] and [months] are null only when the phase repeats until cancellation, because there
+     * is then no term over which a total saving accrues. [ratePerMonthMicros] is still known in that
+     * case, so the relative variant keeps working.
+     */
+    private data class EffectiveTerm(
+        val ratePerMonthMicros: Double,
+        val totalMicros: Long?,
+        val months: Double?,
+    )
+
+    private fun effectiveTerm(rcPackage: Package?, subscriptionOption: SubscriptionOption?): EffectiveTerm? {
+        val product = rcPackage?.product ?: return null
+        val phase = primaryDiscountPhase(subscriptionOption, rcPackage)
+
+        if (phase != null && phase.price.amountMicros > 0L) {
+            val periodInMonths = phase.billingPeriod.valueInMonths
+            if (periodInMonths <= 0.0) return null
+            val cycles = phase.offerCycleCount()
+
+            return EffectiveTerm(
+                ratePerMonthMicros = phase.price.amountMicros / periodInMonths,
+                totalMicros = cycles?.let { phase.price.amountMicros * it },
+                months = cycles?.let { periodInMonths * it },
+            )
+        }
+
+        // Non-subscriptions have no period to normalize the anchor to.
+        val periodInMonths = product.period?.valueInMonths ?: return null
+        if (periodInMonths <= 0.0) return null
+
+        return EffectiveTerm(
+            ratePerMonthMicros = product.price.amountMicros / periodInMonths,
+            totalMicros = product.price.amountMicros,
+            months = periodInMonths,
+        )
+    }
+
+    /**
+     * How many times this phase is billed, or null when it repeats until cancellation.
+     *
+     * Deliberately keys off [RecurrenceMode] rather than `billingCycleCount` being null. Play's
+     * `getBillingCycleCount()` is a primitive int, so `toRevenueCatPricingPhase` passes through 0 —
+     * never null — for non-finite phases, despite what the property's doc comment says. Treating 0 as
+     * "no cycles" would multiply a single-payment offer's total out to zero and silently blank it.
+     */
+    private fun PricingPhase.offerCycleCount(): Int? = when (recurrenceMode) {
+        RecurrenceMode.INFINITE_RECURRING -> null
+        RecurrenceMode.NON_RECURRING -> 1
+        RecurrenceMode.FINITE_RECURRING,
+        RecurrenceMode.UNKNOWN,
+        -> billingCycleCount?.takeIf { it > 0 } ?: 1
+    }
+
+    private fun PackageContext.relativeDiscountWithOffer(
+        rcPackage: Package?,
+        subscriptionOption: SubscriptionOption?,
+        localizedVariableKeys: Map<VariableLocalizationKey, String>,
+    ): String? {
+        val anchorMicros = mostExpensivePricePerMonthMicros ?: return null
+        val term = effectiveTerm(rcPackage, subscriptionOption) ?: return null
+        if (term.ratePerMonthMicros >= anchorMicros) return null
+
+        val percentage = ((anchorMicros - term.ratePerMonthMicros) * PERCENT_SCALE / anchorMicros).roundToInt()
+        return localizedVariableKeys.getStringOrLogError(VariableLocalizationKey.PERCENT)?.format(percentage)
+    }
+
+    private fun PackageContext.absoluteDiscountWithOffer(
+        rcPackage: Package?,
+        subscriptionOption: SubscriptionOption?,
+        locale: Locale,
+    ): String? {
+        val anchorMicros = mostExpensivePricePerMonthMicros ?: return null
+        val currencyCode = rcPackage?.product?.price?.currencyCode ?: return null
+        val term = effectiveTerm(rcPackage, subscriptionOption) ?: return null
+        val totalMicros = term.totalMicros ?: return null
+        val months = term.months ?: return null
+
+        // Compare totals rather than scaling a monthly rate back up, so no rounding is amplified.
+        val savingMicros = (anchorMicros * months).toLong() - totalMicros
+        if (savingMicros <= 0L) return null
+
+        // `formatted` is unused: localized() derives the display string from amountMicros.
+        return Price("", savingMicros, currencyCode).localized(locale, showZeroDecimalPlacePrices)
     }
 
     private fun offerRelativeDiscount(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/DiscountVariableProcessingTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/DiscountVariableProcessingTests.kt
@@ -1,0 +1,267 @@
+package com.revenuecat.purchases.ui.revenuecatui.data.processed
+
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.PricingPhase
+import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.models.SubscriptionOption
+import com.revenuecat.purchases.models.TestStoreProduct
+import com.revenuecat.purchases.ui.revenuecatui.components.variableLocalizationKeysForEnUs
+import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableProcessor.PackageContext
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockResourceProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.Date
+import java.util.Locale
+
+class DiscountVariableProcessingTests {
+
+    private companion object {
+        private const val OFFERING_ID = "offering_identifier"
+
+        private fun usd(amountMicros: Long, formatted: String) =
+            Price(amountMicros = amountMicros, currencyCode = "USD", formatted = formatted)
+
+        private fun subscriptionPackage(
+            id: String,
+            packageType: PackageType,
+            price: Price,
+            period: Period?,
+        ) = Package(
+            identifier = id,
+            packageType = packageType,
+            product = TestStoreProduct(
+                id = "com.revenuecat.$id",
+                name = id,
+                title = "$id (App name)",
+                description = id,
+                price = price,
+                period = period,
+            ),
+            presentedOfferingContext = PresentedOfferingContext(offeringIdentifier = OFFERING_ID),
+        )
+
+        private val monthlyPackage = subscriptionPackage(
+            id = "monthly",
+            packageType = PackageType.MONTHLY,
+            price = usd(10_000_000, "$10.00"),
+            period = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+        )
+
+        private val annualPackage = subscriptionPackage(
+            id = "annual",
+            packageType = PackageType.ANNUAL,
+            price = usd(60_000_000, "$60.00"),
+            period = Period(value = 1, unit = Period.Unit.YEAR, iso8601 = "P1Y"),
+        )
+
+        private val quarterlyPackage = subscriptionPackage(
+            id = "quarterly",
+            packageType = PackageType.THREE_MONTH,
+            price = usd(27_000_000, "$27.00"),
+            period = Period(value = 3, unit = Period.Unit.MONTH, iso8601 = "P3M"),
+        )
+
+        private val lifetimePackage = subscriptionPackage(
+            id = "lifetime",
+            packageType = PackageType.LIFETIME,
+            price = usd(119_000_000, "$119.00"),
+            period = null,
+        )
+    }
+
+    // region product.absolute_discount
+
+    @Test
+    fun `absolute discount is expressed over the package's own period`() {
+        // A $10.00/mo anchor against a $60.00 annual package: the saving over the year
+        // being bought is ($10.00 x 12) - $60.00 = $60.00, not the $5.00 per-month gap.
+        val result = processTemplate(
+            template = "{{ product.absolute_discount }}",
+            rcPackage = annualPackage,
+            mostExpensivePricePerMonthMicros = 10_000_000,
+        )
+
+        assertThat(result).isEqualTo("$60.00")
+    }
+
+    @Test
+    fun `absolute discount is empty for the anchor package itself`() {
+        val result = processTemplate(
+            template = "{{ product.absolute_discount }}",
+            rcPackage = monthlyPackage,
+            mostExpensivePricePerMonthMicros = 10_000_000,
+        )
+
+        assertThat(result).isEqualTo("")
+    }
+
+    @Test
+    fun `absolute discount is empty without an anchor`() {
+        val result = processTemplate(
+            template = "{{ product.absolute_discount }}",
+            rcPackage = annualPackage,
+            mostExpensivePricePerMonthMicros = null,
+        )
+
+        assertThat(result).isEqualTo("")
+    }
+
+    @Test
+    fun `absolute discount is empty for a package with no period`() {
+        // Lifetime has no period to normalize the anchor onto.
+        val result = processTemplate(
+            template = "{{ product.absolute_discount }}",
+            rcPackage = lifetimePackage,
+            mostExpensivePricePerMonthMicros = 10_000_000,
+        )
+
+        assertThat(result).isEqualTo("")
+    }
+
+    // endregion
+
+    // region product.offer_relative_discount / product.offer_absolute_discount
+
+    @Test
+    fun `offer discounts compare the offer price to the standard price`() {
+        // $10.00/mo base with a $6.00/mo intro: saves $4.00, 40% off.
+        val option = offerOption(
+            offerPrice = usd(6_000_000, "$6.00"),
+            offerPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+        )
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.offer_relative_discount }}",
+                rcPackage = monthlyPackage,
+                subscriptionOption = option,
+            ),
+        ).isEqualTo("40%")
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.offer_absolute_discount }}",
+                rcPackage = monthlyPackage,
+                subscriptionOption = option,
+            ),
+        ).isEqualTo("$4.00")
+    }
+
+    @Test
+    fun `offer discounts are empty when the offer period differs from the base period`() {
+        // A 2-week offer on a monthly product doesn't cover the same span as the base price.
+        val option = offerOption(
+            offerPrice = usd(6_000_000, "$6.00"),
+            offerPeriod = Period(value = 2, unit = Period.Unit.WEEK, iso8601 = "P2W"),
+        )
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.offer_relative_discount }}",
+                rcPackage = monthlyPackage,
+                subscriptionOption = option,
+            ),
+        ).isEqualTo("")
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.offer_absolute_discount }}",
+                rcPackage = monthlyPackage,
+                subscriptionOption = option,
+            ),
+        ).isEqualTo("")
+    }
+
+    @Test
+    fun `offer discounts are empty for a free offer`() {
+        // A free month would otherwise read as "100%" off / a full month's saving.
+        val option = offerOption(
+            offerPrice = usd(0, "Free"),
+            offerPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+        )
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.offer_relative_discount }}",
+                rcPackage = monthlyPackage,
+                subscriptionOption = option,
+            ),
+        ).isEqualTo("")
+    }
+
+    @Test
+    fun `offer discounts ignore iso8601 formatting differences between equal periods`() {
+        // Period's generated equals() also covers `iso8601`, so comparing whole Periods
+        // would blank a legitimate offer whose duration string is spelled differently.
+        val option = offerOption(
+            offerPrice = usd(15_000_000, "$15.00"),
+            offerPeriod = Period(value = 3, unit = Period.Unit.MONTH, iso8601 = "P0Y3M0D"),
+        )
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.offer_relative_discount }}",
+                rcPackage = quarterlyPackage,
+                subscriptionOption = option,
+            ),
+        ).isEqualTo("44%")
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.offer_absolute_discount }}",
+                rcPackage = quarterlyPackage,
+                subscriptionOption = option,
+            ),
+        ).isEqualTo("$12.00")
+    }
+
+    // endregion
+
+    private fun offerOption(offerPrice: Price, offerPeriod: Period): SubscriptionOption {
+        val phase = mockk<PricingPhase> {
+            every { price } returns offerPrice
+            every { billingPeriod } returns offerPeriod
+            every { billingCycleCount } returns 3
+            every { recurrenceMode } returns RecurrenceMode.FINITE_RECURRING
+        }
+
+        return mockk {
+            every { freePhase } returns null
+            every { introPhase } returns phase
+        }
+    }
+
+    private fun processTemplate(
+        template: String,
+        rcPackage: Package,
+        subscriptionOption: SubscriptionOption? = null,
+        mostExpensivePricePerMonthMicros: Long? = null,
+    ): String {
+        return VariableProcessorV2.processVariables(
+            template = template,
+            localizedVariableKeys = variableLocalizationKeysForEnUs(),
+            variableConfig = UiConfig.VariableConfig(
+                variableCompatibilityMap = emptyMap(),
+                functionCompatibilityMap = emptyMap(),
+            ),
+            variableDataProvider = VariableDataProvider(MockResourceProvider()),
+            packageContext = PackageContext(
+                discountRelativeToMostExpensivePerMonth = null,
+                showZeroDecimalPlacePrices = false,
+                mostExpensivePricePerMonthMicros = mostExpensivePricePerMonthMicros,
+            ),
+            rcPackage = rcPackage,
+            subscriptionOption = subscriptionOption,
+            currencyLocale = Locale.US,
+            dateLocale = Locale.US,
+            date = Date(),
+        )
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/DiscountVariableProcessingTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/DiscountVariableProcessingTests.kt
@@ -224,12 +224,194 @@ class DiscountVariableProcessingTests {
 
     // endregion
 
-    private fun offerOption(offerPrice: Price, offerPeriod: Period): SubscriptionOption {
+    // region product.relative_discount_with_offer / product.absolute_discount_with_offer
+
+    @Test
+    fun `with_offer variables price the offer against the anchor`() {
+        // A $9.99/mo anchor vs. a $99.99/yr annual carrying a paid intro year at $52.99,
+        // i.e. $4.42/mo. The base-price comparison would report a much smaller number.
+        val annual = subscriptionPackage(
+            id = "annual",
+            packageType = PackageType.ANNUAL,
+            price = usd(99_990_000, "$99.99"),
+            period = Period(value = 1, unit = Period.Unit.YEAR, iso8601 = "P1Y"),
+        )
+        val option = offerOption(
+            offerPrice = usd(52_990_000, "$52.99"),
+            offerPeriod = Period(value = 1, unit = Period.Unit.YEAR, iso8601 = "P1Y"),
+            cycles = 1,
+        )
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.relative_discount_with_offer }}",
+                rcPackage = annual,
+                subscriptionOption = option,
+                mostExpensivePricePerMonthMicros = 9_990_000,
+            ),
+        ).isEqualTo("56%")
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.absolute_discount_with_offer }}",
+                rcPackage = annual,
+                subscriptionOption = option,
+                mostExpensivePricePerMonthMicros = 9_990_000,
+            ),
+        ).isEqualTo("$66.89")
+    }
+
+    @Test
+    fun `absolute_discount_with_offer spans every offer cycle`() {
+        // 3 cycles at $6.00/mo against a $10.00/mo anchor: $4.00 x 3 = $12.00.
+        val option = offerOption(
+            offerPrice = usd(6_000_000, "$6.00"),
+            offerPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+            cycles = 3,
+        )
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.absolute_discount_with_offer }}",
+                rcPackage = monthlyPackage,
+                subscriptionOption = option,
+                mostExpensivePricePerMonthMicros = 10_000_000,
+            ),
+        ).isEqualTo("$12.00")
+    }
+
+    @Test
+    fun `with_offer variables fall back to the base comparison without an offer`() {
+        assertThat(
+            processTemplate(
+                template = "{{ product.absolute_discount_with_offer }}",
+                rcPackage = annualPackage,
+                mostExpensivePricePerMonthMicros = 10_000_000,
+            ),
+        ).isEqualTo(
+            processTemplate(
+                template = "{{ product.absolute_discount }}",
+                rcPackage = annualPackage,
+                mostExpensivePricePerMonthMicros = 10_000_000,
+            ),
+        )
+    }
+
+    @Test
+    fun `a perpetual discount keeps the relative variant but empties the absolute one`() {
+        // Play sends billingCycleCount 0 (not null) for an infinite phase, so the recurrence
+        // mode is what tells us there is no term over which a total saving accrues. The
+        // monthly rate is still known, so the relative variant keeps working.
+        val option = offerOption(
+            offerPrice = usd(6_000_000, "$6.00"),
+            offerPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+            cycles = 0,
+            mode = RecurrenceMode.INFINITE_RECURRING,
+        )
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.relative_discount_with_offer }}",
+                rcPackage = monthlyPackage,
+                subscriptionOption = option,
+                mostExpensivePricePerMonthMicros = 10_000_000,
+            ),
+        ).isEqualTo("40%")
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.absolute_discount_with_offer }}",
+                rcPackage = monthlyPackage,
+                subscriptionOption = option,
+                mostExpensivePricePerMonthMicros = 10_000_000,
+            ),
+        ).isEqualTo("")
+    }
+
+    @Test
+    fun `a free offer is treated as no offer rather than 100 percent off`() {
+        val option = offerOption(
+            offerPrice = usd(0, "Free"),
+            offerPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+            cycles = 1,
+        )
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.relative_discount_with_offer }}",
+                rcPackage = annualPackage,
+                subscriptionOption = option,
+                mostExpensivePricePerMonthMicros = 10_000_000,
+            ),
+        ).isEqualTo(
+            processTemplate(
+                template = "{{ product.relative_discount_with_offer }}",
+                rcPackage = annualPackage,
+                mostExpensivePricePerMonthMicros = 10_000_000,
+            ),
+        )
+    }
+
+    @Test
+    fun `a single-payment offer is billed exactly once`() {
+        // Regression: Play's getBillingCycleCount() is a primitive int, so a NON_RECURRING
+        // phase arrives as 0 rather than null. Treating that as "no cycles" multiplied the
+        // offer total out to zero and silently blanked a fully determinable saving.
+        val annual = subscriptionPackage(
+            id = "annual_single_payment",
+            packageType = PackageType.ANNUAL,
+            price = usd(99_990_000, "$99.99"),
+            period = Period(value = 1, unit = Period.Unit.YEAR, iso8601 = "P1Y"),
+        )
+        val option = offerOption(
+            offerPrice = usd(52_990_000, "$52.99"),
+            offerPeriod = Period(value = 1, unit = Period.Unit.YEAR, iso8601 = "P1Y"),
+            cycles = 0,
+            mode = RecurrenceMode.NON_RECURRING,
+        )
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.absolute_discount_with_offer }}",
+                rcPackage = annual,
+                subscriptionOption = option,
+                mostExpensivePricePerMonthMicros = 9_990_000,
+            ),
+        ).isEqualTo("$66.89")
+    }
+
+    @Test
+    fun `with_offer variables are empty for a package with no period`() {
+        assertThat(
+            processTemplate(
+                template = "{{ product.absolute_discount_with_offer }}",
+                rcPackage = lifetimePackage,
+                mostExpensivePricePerMonthMicros = 10_000_000,
+            ),
+        ).isEqualTo("")
+
+        assertThat(
+            processTemplate(
+                template = "{{ product.relative_discount_with_offer }}",
+                rcPackage = lifetimePackage,
+                mostExpensivePricePerMonthMicros = 10_000_000,
+            ),
+        ).isEqualTo("")
+    }
+
+    // endregion
+
+    private fun offerOption(
+        offerPrice: Price,
+        offerPeriod: Period,
+        cycles: Int? = 3,
+        mode: RecurrenceMode = RecurrenceMode.FINITE_RECURRING,
+    ): SubscriptionOption {
         val phase = mockk<PricingPhase> {
             every { price } returns offerPrice
             every { billingPeriod } returns offerPeriod
-            every { billingCycleCount } returns 3
-            every { recurrenceMode } returns RecurrenceMode.FINITE_RECURRING
+            every { billingCycleCount } returns cycles
+            every { recurrenceMode } returns mode
         }
 
         return mockk {


### PR DESCRIPTION
> [!WARNING]
> **Draft: this has never been compiled or run.** There is no JDK or Android SDK on the machine it was written on, so `./gradlew` was never invoked — not the module build, not detekt/ktlint, not the tests. Everything below is reasoned from the source, not observed. Someone with a working Android toolchain should build and run it before this leaves draft.

Mirrors the iOS reference implementation ([purchases-ios#7546](https://github.com/RevenueCat/purchases-ios/pull/7546)) for five new Paywalls V2 variables. Part of [Paywall variables: discounts & secondary offer parity](https://app.notion.com/p/361cb1a108b08189a94def9fab1e8752) — Milestone 1 of 2.

Siblings: [purchases-js#1099](https://github.com/RevenueCat/purchases-js/pull/1099), [purchases-ui-js#376](https://github.com/RevenueCat/purchases-ui-js/pull/376), [revenuecat-app#11647](https://github.com/RevenueCat/revenuecat-app/pull/11647).

## Two comparison axes

| Variable | Compares | Example |
|---|---|---|
| `absolute_discount` | this package vs. the most expensive package | `$60.00` |
| `offer_relative_discount` / `offer_absolute_discount` | an offer vs. **its own package's** standard price | `40%` / `$4.00` |
| `relative_discount_with_offer` / `absolute_discount_with_offer` | this package **with its offer applied** vs. the most expensive package | `56%` / `$66.89` |

All five select the same anchor — most-expensive per-month base price — so they never disagree about which packages are being compared. `PackageContext` gains `mostExpensivePricePerMonthMicros`, defaulted to null so the two V1 construction sites in `PackageConfigurationFactory` compile untouched.

## `absolute_discount`

```
(mostExpensivePricePerMonthMicros × periodInMonths) − packagePrice
```

The anchor is *selected* by per-month price, exactly as `relative_discount` does. The saving is then expressed over **the purchased package's own period**, not per month: a ratio is period-invariant so the unit is arbitrary, but a currency amount changes with whatever unit you quote it in, so it's anchored to the term actually being bought.

## `offer_relative_discount` / `offer_absolute_discount`

The primary discount phase's price against the same package's standard renewal price, compared raw. Both render empty unless the phase's billing period matches the base period **and** the price is above zero.

`comparableOfferPriceMicros` compares the period's `unit` and `value` rather than the whole `Period`. `Period` is a `@Poko` class whose generated `equals()` also covers `iso8601`, so semantically identical periods spelled `"P3M"` and `"P0Y3M0D"` would compare unequal and silently blank a legitimate same-period offer. There's a test for exactly that.

## `relative_discount_with_offer` / `absolute_discount_with_offer`

The same cross-package comparison as `absolute_discount`, but priced off the offer the customer would actually get — the "56% off annual" badge on a paywall where annual carries a paid intro offer.

- The absolute variant spans the offer's **full duration** (billing period × cycles).
- When the phase repeats until cancellation there is no such term, so it renders empty — matching what `relative_discount` already does for a lifetime product. The relative variant still works, since a perpetual discount has a well-defined monthly rate.
- With no usable offer both collapse to the bare variables. A free offer counts as no offer rather than "100% off".

**The cycle count is resolved from `RecurrenceMode`, not from `billingCycleCount` being null.** Play's `getBillingCycleCount()` is a primitive `int`, so `toRevenueCatPricingPhase` passes through `0` — never null — for non-finite phases, despite what the property's doc comment claims. Treating `0` as "no cycles" multiplied a single-payment offer's total out to zero and silently blanked a fully determinable saving, which is exactly the "$52.99 once, then $99.99/yr" shape this feature targets. There's a regression test stubbing a real `NON_RECURRING` phase with `billingCycleCount = 0`.

## Notes

- No new localization strings — percentages reuse the existing `PERCENT` key, and amounts go through `Price.localized`, whose `getFormatted` already rounds down via `RoundingMode.DOWN`, so a saving is never overstated.
- `Price("", micros, currencyCode)` is constructed with an empty `formatted` because `localized()` derives the display string from `amountMicros`; noted in a comment so a future refactor doesn't silently regress it.
- `comparableOfferPriceMicros` takes the phase as a receiver so the secondary-offer variants only need `secondaryDiscountPhase` passed in.

**Known limitation:** the `offer_*` pair renders empty for products with a free trial *and* a discounted intro phase, since `primaryDiscountPhase` prefers `freePhase`. That needs `secondary_offer_*_discount`, which is Milestone 2.

## What needs verifying before this leaves draft

- [ ] `./gradlew :ui:revenuecatui:compileReleaseKotlin` — the Kotlin has never been through a compiler
- [ ] `./gradlew :ui:revenuecatui:testDebugUnitTest --tests "*DiscountVariableProcessingTests*"` — 15 tests, all unrun. The mockk `PricingPhase`/`SubscriptionOption` stubs are modelled on `OfferVariableProcessingTests`, but the stubbed member set may need adjusting.
- [ ] detekt and ktlint. No added line exceeds 120 chars, but nothing else was checked.
- [ ] The `$60.00` / `$66.89` / `$12.00` / `44%` / `56%` expectations were derived by hand from `Period.valueInMonths` and `Price.getFormatted`; confirm against real output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)