### PR TITLE
Fail rule resolution when the customer changes mid-snapshot

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -409,6 +409,7 @@ internal class PurchasesFactory(
                         cache.getCachedSubscriberDimensionsJson(identityManager.currentAppUserID)
                     },
                 ),
+                currentAppUserId = { identityManager.currentAppUserID },
             )
 
             val customerInfoUpdateHandler = CustomerInfoUpdateHandler(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -187,7 +187,10 @@ internal class PurchasesOrchestrator(
     internal val audiencesConfigProvider: AudiencesConfigProvider,
     val adTracker: AdTracker = AdTracker(adEventsManager),
     private val currentActivityTracker: CurrentActivityTracker = CurrentActivityTracker(),
-    private val localRulesEvaluator: LocalRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+    private val localRulesEvaluator: LocalRulesEvaluator = LocalRulesEvaluator(
+        providers = emptyList(),
+        currentAppUserId = { identityManager.currentAppUserID },
+    ),
     @OptIn(InternalRevenueCatAPI::class)
     private val checkpointWorkflowResolver: CheckpointWorkflowResolver = CheckpointWorkflowResolverImpl(
         workflowManager = workflowManager,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -26,8 +26,10 @@ internal class CustomerInfoDimensionProvider(
      * The app user ID is reported without waiting for the customer info, so a rule targeting only the ID does not
      * depend on the network: it is known as soon as the SDK is configured.
      *
-     * Read once per evaluation, so the ID reported and the customer info fetched cannot describe two different
-     * customers within this provider's values.
+     * Read once per evaluation. Reading it here does not by itself guarantee the fetched customer info describes
+     * the same customer: an identity change can land while the fetch is in flight, and on a cold cache the
+     * pending-purchase sync reads the current user for itself. [RulesDimensionResolver] closes that gap by
+     * re-reading the current ID after every provider has run and failing the snapshot on a change.
      */
     override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
         // Nobody to ask about: the SDK has no cached user, so there is no request to make on their behalf.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -28,10 +28,11 @@ internal sealed class LocalRulesEvaluationException(message: String) : Exception
  */
 internal class LocalRulesEvaluator(
     providers: List<RulesDimensionProvider>,
+    currentAppUserId: () -> String,
     dateProvider: DateProvider = DefaultDateProvider(),
 ) {
 
-    private val dimensionResolver = RulesDimensionResolver(providers, dateProvider)
+    private val dimensionResolver = RulesDimensionResolver(providers, currentAppUserId, dateProvider)
 
     /**
      * The first rule that matches, or `null` when none does.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -29,8 +29,8 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
         val path: String,
     ) : RulesDimensionResolutionException("two dimension sources supplied '$path'")
 
-    internal class CustomerChanged :
-        RulesDimensionResolutionException("the customer changed while dimensions were being collected")
+    internal class AppUserChanged :
+        RulesDimensionResolutionException("the app user changed while dimensions were being collected")
 }
 
 /**
@@ -92,7 +92,7 @@ internal class RulesDimensionResolver(
 
         // Checked once, at the end: a change at any point during collection is still a change here.
         if (currentAppUserId() != appUserId) {
-            return Result.failure(RulesDimensionResolutionException.CustomerChanged())
+            return Result.failure(RulesDimensionResolutionException.AppUserChanged())
         }
 
         return Result.success(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -28,6 +28,9 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
     internal data class ConflictingDimension(
         val path: String,
     ) : RulesDimensionResolutionException("two dimension sources supplied '$path'")
+
+    internal class CustomerChanged :
+        RulesDimensionResolutionException("the customer changed while dimensions were being collected")
 }
 
 /**
@@ -36,13 +39,18 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
  *
  * All providers see the same reference instant, so every dimension in one snapshot is consistent with the others.
  *
- * Both failure modes are configuration bugs rather than runtime conditions — a provider that cannot produce its
- * values, and two sources claiming the same root name — so they fail the whole snapshot instead of silently
+ * Two of the failure modes are configuration bugs rather than runtime conditions — a provider that cannot produce
+ * its values, and two sources claiming the same root name — so they fail the whole snapshot instead of silently
  * degrading a rule to a non-match, which would be indistinguishable from a customer who genuinely does not match.
- * Cancellation is neither, and propagates.
+ * The third is a runtime condition: providers suspend, so an identity change can land mid-collection and leave a
+ * snapshot describing two customers at once, or one whose values were emptied under it. That snapshot must not be
+ * evaluated either, so [currentAppUserId] is read before the first provider and verified after the last. An
+ * identity change also advances the remote config generation, so a caller guarding on it retries against the new
+ * customer rather than reporting this failure. Cancellation is none of these, and propagates.
  */
 internal class RulesDimensionResolver(
     private val providers: List<RulesDimensionProvider>,
+    private val currentAppUserId: () -> String,
     private val dateProvider: DateProvider = DefaultDateProvider(),
 ) {
 
@@ -55,6 +63,7 @@ internal class RulesDimensionResolver(
     suspend fun snapshot(
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
     ): Result<RulesDimensionSnapshot> {
+        val appUserId = currentAppUserId()
         val date = dateProvider.now
         // Seeded before any provider runs, so a provider claiming this root is an ordinary collision.
         val values = mutableMapOf<String, Value>(KEY_EVALUATED_AT to Value.IntValue(date.time))
@@ -79,6 +88,11 @@ internal class RulesDimensionResolver(
 
         values.addNestedDimensions(KEY_CUSTOM, customVariables)?.let { conflict ->
             return Result.failure(conflict)
+        }
+
+        // Checked once, at the end: a change at any point during collection is still a change here.
+        if (currentAppUserId() != appUserId) {
+            return Result.failure(RulesDimensionResolutionException.CustomerChanged())
         }
 
         return Result.success(

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -98,7 +98,7 @@ class CheckpointWorkflowResolverImplTest {
             uiConfigProvider = mockUiConfigProvider,
             checkpointsConfigProvider = mockCheckpointsConfigProvider,
             audiencesConfigProvider = mockAudiencesConfigProvider,
-            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList(), currentAppUserId = { "user" }),
             getOfferings = {
                 offeringsFetched++
                 offeringsFetchError?.let { throw PurchasesException(it) }
@@ -386,7 +386,7 @@ class CheckpointWorkflowResolverImplTest {
                 uiConfigProvider = mockUiConfigProvider,
                 checkpointsConfigProvider = mockCheckpointsConfigProvider,
                 audiencesConfigProvider = mockAudiencesConfigProvider,
-                localRulesEvaluator = LocalRulesEvaluator(providers = listOf(FailingDimensionProvider)),
+                localRulesEvaluator = LocalRulesEvaluator(providers = listOf(FailingDimensionProvider), currentAppUserId = { "user" }),
                 getOfferings = { mockOfferings },
             )
 
@@ -596,7 +596,7 @@ class CheckpointWorkflowResolverImplTest {
             uiConfigProvider = mockUiConfigProvider,
             checkpointsConfigProvider = mockCheckpointsConfigProvider,
             audiencesConfigProvider = mockAudiencesConfigProvider,
-            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList(), currentAppUserId = { "user" }),
             getOfferings = { throw CancellationException("cancelled") },
         )
 
@@ -680,7 +680,7 @@ class CheckpointWorkflowResolverImplTest {
         uiConfigProvider = mockUiConfigProvider,
         checkpointsConfigProvider = CheckpointsConfigProvider(manager),
         audiencesConfigProvider = AudiencesConfigProvider(manager),
-        localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+        localRulesEvaluator = LocalRulesEvaluator(providers = emptyList(), currentAppUserId = { "user" }),
         getOfferings = { mockOfferings },
     )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -271,6 +271,41 @@ class CustomerInfoDimensionProviderTest {
     }
 
     @Test
+    fun `a customer change while the customer info is being fetched fails the snapshot`() = runTest {
+        var currentUser = APP_USER_ID
+        val provider = CustomerInfoDimensionProvider(
+            currentAppUserId = { currentUser },
+            customerInfo = {
+                // A logIn completing while the fetch is in flight: the answer describes the previous customer.
+                currentUser = "another_user"
+                customerInfo(SUBSCRIBED_RESPONSE)
+            },
+        )
+
+        val error = resolver(provider, currentAppUserId = { currentUser }).snapshot().exceptionOrNull()
+
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+    }
+
+    @Test
+    fun `a customer info read broken by a customer change fails the snapshot instead of degrading it`() = runTest {
+        var currentUser = APP_USER_ID
+        val provider = CustomerInfoDimensionProvider(
+            currentAppUserId = { currentUser },
+            customerInfo = {
+                // A logOut wiping the caches mid-fetch: the read fails *because* the customer changed, so the
+                // snapshot must not quietly carry on with only the identity dimensions.
+                currentUser = "another_user"
+                throw PurchasesException(PurchasesError(PurchasesErrorCode.NetworkError, "Caches were cleared."))
+            },
+        )
+
+        val error = resolver(provider, currentAppUserId = { currentUser }).snapshot().exceptionOrNull()
+
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+    }
+
+    @Test
     fun `a customer the SDK has no ID for is not asked about`() = runTest {
         var asked = false
         val provider = CustomerInfoDimensionProvider(
@@ -355,8 +390,12 @@ class CustomerInfoDimensionProviderTest {
         customerInfo = customerInfo,
     )
 
-    private fun resolver(customerInfoProvider: RulesDimensionProvider) = RulesDimensionResolver(
+    private fun resolver(
+        customerInfoProvider: RulesDimensionProvider,
+        currentAppUserId: () -> String = { APP_USER_ID },
+    ) = RulesDimensionResolver(
         providers = listOf(deviceProvider(), customerInfoProvider),
+        currentAppUserId = currentAppUserId,
     )
 
     private fun deviceProvider() = object : RulesDimensionProvider {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -271,7 +271,7 @@ class CustomerInfoDimensionProviderTest {
     }
 
     @Test
-    fun `a customer change while the customer info is being fetched fails the snapshot`() = runTest {
+    fun `an app user change while the customer info is being fetched fails the snapshot`() = runTest {
         var currentUser = APP_USER_ID
         val provider = CustomerInfoDimensionProvider(
             currentAppUserId = { currentUser },
@@ -284,16 +284,16 @@ class CustomerInfoDimensionProviderTest {
 
         val error = resolver(provider, currentAppUserId = { currentUser }).snapshot().exceptionOrNull()
 
-        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.AppUserChanged::class.java)
     }
 
     @Test
-    fun `a customer info read broken by a customer change fails the snapshot instead of degrading it`() = runTest {
+    fun `a customer info read broken by an app user change fails the snapshot instead of degrading it`() = runTest {
         var currentUser = APP_USER_ID
         val provider = CustomerInfoDimensionProvider(
             currentAppUserId = { currentUser },
             customerInfo = {
-                // A logOut wiping the caches mid-fetch: the read fails *because* the customer changed, so the
+                // A logOut wiping the caches mid-fetch: the read fails *because* the app user changed, so the
                 // snapshot must not quietly carry on with only the identity dimensions.
                 currentUser = "another_user"
                 throw PurchasesException(PurchasesError(PurchasesErrorCode.NetworkError, "Caches were cleared."))
@@ -302,7 +302,7 @@ class CustomerInfoDimensionProviderTest {
 
         val error = resolver(provider, currentAppUserId = { currentUser }).snapshot().exceptionOrNull()
 
-        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.AppUserChanged::class.java)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -103,12 +103,30 @@ class LocalRulesEvaluatorTest {
                 throw IllegalStateException("nope")
         }
 
-        val result = LocalRulesEvaluator(providers = listOf(failing))
+        val result = LocalRulesEvaluator(providers = listOf(failing), currentAppUserId = { "user" })
             .match(listOf(TestRule("only", matchingPredicate)))
 
         val error = result.exceptionOrNull() as LocalRulesEvaluationException.DimensionResolution
         assertThat(error.reason)
             .isEqualTo(RulesDimensionResolutionException.ProviderFailed("device", "nope"))
+    }
+
+    @Test
+    fun `a customer change during the snapshot fails the evaluation`() = runTest {
+        var currentUser = "userA"
+        val flipping = object : RulesDimensionProvider {
+            override val name = "identity_flipper"
+            override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+                currentUser = "userB"
+                return emptyMap()
+            }
+        }
+
+        val result = LocalRulesEvaluator(providers = listOf(flipping), currentAppUserId = { currentUser })
+            .match(listOf(TestRule("only", matchingPredicate)))
+
+        val error = result.exceptionOrNull() as LocalRulesEvaluationException.DimensionResolution
+        assertThat(error.reason).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
     }
 
     @Test
@@ -184,7 +202,7 @@ class LocalRulesEvaluatorTest {
         assertThat(snapshotsTaken).isEqualTo(1)
     }
 
-    private fun evaluator() = LocalRulesEvaluator(providers = listOf(deviceProvider))
+    private fun evaluator() = LocalRulesEvaluator(providers = listOf(deviceProvider), currentAppUserId = { "user" })
 
     private data class TestRule(
         val name: String,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -112,7 +112,7 @@ class LocalRulesEvaluatorTest {
     }
 
     @Test
-    fun `a customer change during the snapshot fails the evaluation`() = runTest {
+    fun `an app user change during the snapshot fails the evaluation`() = runTest {
         var currentUser = "userA"
         val flipping = object : RulesDimensionProvider {
             override val name = "identity_flipper"
@@ -126,7 +126,7 @@ class LocalRulesEvaluatorTest {
             .match(listOf(TestRule("only", matchingPredicate)))
 
         val error = result.exceptionOrNull() as LocalRulesEvaluationException.DimensionResolution
-        assertThat(error.reason).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+        assertThat(error.reason).isInstanceOf(RulesDimensionResolutionException.AppUserChanged::class.java)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -95,6 +95,51 @@ class RulesDimensionResolverTest {
     }
 
     @Test
+    fun `a customer change while dimensions are collected fails the snapshot`() = runTest {
+        var currentUser = "userA"
+        val resolver = resolver(
+            provider("platform" to string("android")),
+            object : RulesDimensionProvider {
+                override val name = "identity_flipper"
+                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+                    currentUser = "userB"
+                    return emptyMap()
+                }
+            },
+            currentAppUserId = { currentUser },
+        )
+
+        val error = resolver.snapshot().exceptionOrNull()
+
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+        assertThat(error).hasMessage("the customer changed while dimensions were being collected")
+    }
+
+    @Test
+    fun `a customer that changed back by the end of collection does not fail the snapshot`() = runTest {
+        var currentUser = "userA"
+        val resolver = resolver(
+            object : RulesDimensionProvider {
+                override val name = "identity_flipper"
+                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+                    currentUser = "userB"
+                    return emptyMap()
+                }
+            },
+            object : RulesDimensionProvider {
+                override val name = "identity_flipper_back"
+                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+                    currentUser = "userA"
+                    return emptyMap()
+                }
+            },
+            currentAppUserId = { currentUser },
+        )
+
+        assertThat(resolver.snapshot().isSuccess).isTrue()
+    }
+
+    @Test
     fun `cancellation propagates instead of failing the snapshot`() = runTest {
         val resolver = resolver(
             object : RulesDimensionProvider {
@@ -495,8 +540,12 @@ class RulesDimensionResolverTest {
         assertThat(resolver().snapshot().getOrThrow().values).isEqualTo(mapOf(evaluatedAt))
     }
 
-    private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
+    private fun resolver(
+        vararg providers: RulesDimensionProvider,
+        currentAppUserId: () -> String = { "user" },
+    ) = RulesDimensionResolver(
         providers = providers.toList(),
+        currentAppUserId = currentAppUserId,
         dateProvider = object : DateProvider {
             override val now: Date = evaluationDate
         },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -95,7 +95,7 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `a customer change while dimensions are collected fails the snapshot`() = runTest {
+    fun `an app user change while dimensions are collected fails the snapshot`() = runTest {
         var currentUser = "userA"
         val resolver = resolver(
             provider("platform" to string("android")),
@@ -111,12 +111,12 @@ class RulesDimensionResolverTest {
 
         val error = resolver.snapshot().exceptionOrNull()
 
-        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
-        assertThat(error).hasMessage("the customer changed while dimensions were being collected")
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.AppUserChanged::class.java)
+        assertThat(error).hasMessage("the app user changed while dimensions were being collected")
     }
 
     @Test
-    fun `a customer that changed back by the end of collection does not fail the snapshot`() = runTest {
+    fun `an app user that changed back by the end of collection does not fail the snapshot`() = runTest {
         var currentUser = "userA"
         val resolver = resolver(
             object : RulesDimensionProvider {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -227,6 +227,7 @@ class RulesDimensionScopeTest {
                 SubscriberAttributesDimensionProvider { SUBSCRIBER_ATTRIBUTES },
                 SubscriberDimensionsProvider { SUBSCRIBER_DIMENSIONS },
             ),
+            currentAppUserId = { APP_USER_ID },
             dateProvider = object : DateProvider {
                 override val now: Date get() = evaluationDate
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
@@ -58,6 +58,7 @@ class StoreDimensionProviderTest {
                     deviceProvider("platform" to "android"),
                     StoreDimensionProvider { throw failure },
                 ),
+                currentAppUserId = { "user" },
             ).snapshot()
 
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
@@ -95,7 +96,8 @@ class StoreDimensionProviderTest {
 
     @Test
     fun `the storefront is reachable by name from a predicate`() = runTest {
-        val values = RulesDimensionResolver(providers = listOf(provider("US"))).snapshot().getOrThrow().values
+        val values = RulesDimensionResolver(providers = listOf(provider("US")), currentAppUserId = { "user" })
+            .snapshot().getOrThrow().values
 
         val matches = RulesEngine.evaluate("""{"==": [{"var": "storefront"}, "USA"]}""", values)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
@@ -72,6 +72,7 @@ class SubscriberAttributesDimensionIntegrationTest {
                     attributesCache.getAllStoredSubscriberAttributes(cache.getCachedAppUserID() ?: "")
                 },
             ),
+            currentAppUserId = { cache.getCachedAppUserID() ?: "" },
             dateProvider = object : DateProvider {
                 override val now: Date get() = evaluationDate
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -209,6 +209,7 @@ class SubscriberAttributesDimensionProviderTest {
 
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
         providers = providers.toList(),
+        currentAppUserId = { "user" },
         dateProvider = object : DateProvider {
             override val now: Date = evaluationDate
         },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProviderTest.kt
@@ -169,6 +169,7 @@ class SubscriberDimensionsProviderTest {
 
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
         providers = providers.toList(),
+        currentAppUserId = { "user" },
         dateProvider = object : DateProvider {
             override val now: Date = evaluationDate
         },


### PR DESCRIPTION
### Description
This PR protects against changes in the user id while the rules are evaluated. In case a change is detected, the evaluation is failed with an error 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes audience/checkpoint matching during identity transitions; failures are intentional but can surface as configuration-unavailable until a retry on the new user.
> 
> **Overview**
> Local rule evaluation (checkpoints, audiences) now **refuses to use a dimension snapshot** if the app user ID changes while providers are still collecting data—e.g. during `logIn`/`logOut` while `CustomerInfo` is loading.
> 
> `RulesDimensionResolver` records `currentAppUserId` at the start of `snapshot()` and compares again after all providers finish; a mismatch returns **`RulesDimensionResolutionException.AppUserChanged`**, which bubbles through `LocalRulesEvaluator` as a dimension-resolution failure instead of evaluating rules against a mixed or stale customer view. `LocalRulesEvaluator` and production wiring in **`PurchasesFactory`** / **`PurchasesOrchestrator`** pass `{ identityManager.currentAppUserID }`; **`CustomerInfoDimensionProvider`** docs now describe this guard rather than claiming a single read ties ID to fetched info.
> 
> Tests cover mid-fetch identity flips, revert-before-end success, and evaluator integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ccd2a542c41932dfe10d95b4f50eb3227031d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->