### PR TITLE
ci: publish snapshots from 11.0-dev too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -999,7 +999,10 @@ workflows:
       and:
         - not:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: [ "main", << pipeline.git.branch >> ]
+        # TODO: drop the 11.0-dev clause before merging 11.0-dev into main.
+        - or:
+            - equal: [ "main", << pipeline.git.branch >> ]
+            - equal: [ "11.0-dev", << pipeline.git.branch >> ]
         - equal: [ "default", << pipeline.parameters.action >> ]
     jobs:
       - deploy-snapshot:


### PR DESCRIPTION
Temporary while 11.0-dev is WIP, so we can test it out in PHC and hybrids. we'll remove it before merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only branch filter change for snapshot publishing; no application or release logic changes, and the extra branch is explicitly temporary.
> 
> **Overview**
> **Temporarily** extends the `snapshot-deploy-sample-app-tests` CircleCI workflow so it runs on **`11.0-dev`** as well as **`main`**, not only on `main`.
> 
> That workflow still deploys Maven snapshots (`deploy-snapshot`) and then builds sample apps that depend on those artifacts. The branch gate is now an `or` on `main` / `11.0-dev`, with a **TODO** to remove the `11.0-dev` branch before merging that line into `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41cdc500df28cae0663ca18f267102eef308a0a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->