### PR TITLE
Centralize remote-config staleness handling in shared primitives

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
@@ -11,12 +11,6 @@ import kotlinx.serialization.json.decodeFromJsonElement
 internal class AudiencesConfigProvider(
     private val manager: RemoteConfigManager,
 ) {
-    /**
-     * Reads [identifier]'s audience from the `audiences` topic's inline item metadata, or `null` when the item
-     * is unknown or malformed. Guarded by [readConsistent]: the read may suspend across a self-primed
-     * `/v1/config` sync, and an audience read against a generation that moved underneath may belong to the
-     * previous user.
-     */
     suspend fun getAudience(identifier: String): Audience? =
         manager.readConsistent(what = { "audience '$identifier'" }) { _ ->
             val metadata = manager.topic(RemoteConfigTopic.Audiences)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
@@ -4,22 +4,30 @@ import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import com.revenuecat.purchases.common.remoteconfig.readConsistent
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.decodeFromJsonElement
 
 internal class AudiencesConfigProvider(
     private val manager: RemoteConfigManager,
 ) {
-    suspend fun getAudience(identifier: String): Audience? {
-        val metadata = manager.topic(RemoteConfigTopic.Audiences)
-            ?.get(identifier)
-            ?.metadata
-            ?: return null
-        return try {
-            JsonTools.json.decodeFromJsonElement<Audience>(metadata)
-        } catch (e: SerializationException) {
-            errorLog(e) { "Failed to parse remote config metadata for audience '$identifier' as JSON." }
-            null
+    /**
+     * Reads [identifier]'s audience from the `audiences` topic's inline item metadata, or `null` when the item
+     * is unknown or malformed. Guarded by [readConsistent]: the read may suspend across a self-primed
+     * `/v1/config` sync, and an audience read against a generation that moved underneath may belong to the
+     * previous user.
+     */
+    suspend fun getAudience(identifier: String): Audience? =
+        manager.readConsistent(what = { "audience '$identifier'" }) { _ ->
+            val metadata = manager.topic(RemoteConfigTopic.Audiences)
+                ?.get(identifier)
+                ?.metadata
+                ?: return@readConsistent null
+            try {
+                JsonTools.json.decodeFromJsonElement<Audience>(metadata)
+            } catch (e: SerializationException) {
+                errorLog(e) { "Failed to parse remote config metadata for audience '$identifier' as JSON." }
+                null
+            }
         }
-    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/checkpoints/CheckpointsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/checkpoints/CheckpointsConfigProvider.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.common.checkpoints
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import com.revenuecat.purchases.common.remoteconfig.readConsistent
 import com.revenuecat.purchases.common.verboseLog
 
 /**
@@ -19,26 +20,13 @@ internal class CheckpointsConfigProvider(
      * apart from one whose rules could not be read. See [CheckpointRulesResolution].
      *
      * The read suspends across disk IO and possibly a self-primed `/v1/config` sync, so the committed state can
-     * change under it: an identity change wipes the cache (the rules just read may belong to the previous user)
-     * and an ordinary commit can publish fresher rules. Either advances [RemoteConfigManager.configGeneration],
-     * and since there is no in-memory cache to fall back on the answer is to read once more against the new
-     * state rather than to discard. Only once, so a burst of commits can't spin here.
+     * change under it; [readConsistent] re-reads once against the new state. Since there is no in-memory cache
+     * to fall back on, a read superseded twice is [CheckpointRulesResolution.Unavailable].
      */
-    suspend fun resolveCheckpoint(identifier: String): CheckpointRulesResolution {
-        attemptRead(identifier)?.let { return it }
-        verboseLog { "Remote config changed while resolving checkpoint '$identifier'; reading it again." }
-        return attemptRead(identifier) ?: CheckpointRulesResolution.Unavailable
-    }
-
-    /**
-     * One read, or `null` if the committed state moved under it and the answer can no longer be trusted.
-     * [resolveCheckpoint] retries such a read exactly once, so it never reads more than twice.
-     */
-    private suspend fun attemptRead(identifier: String): CheckpointRulesResolution? {
-        val generation = manager.configGeneration
-        val resolution = readCheckpoint(identifier, generation)
-        return resolution.takeIf { manager.configGeneration == generation }
-    }
+    suspend fun resolveCheckpoint(identifier: String): CheckpointRulesResolution =
+        manager.readConsistent(what = { "checkpoint '$identifier'" }) { generation ->
+            readCheckpoint(identifier, generation)
+        } ?: CheckpointRulesResolution.Unavailable
 
     fun isCurrent(resolution: CheckpointRulesResolution.Found): Boolean =
         manager.configGeneration == resolution.configGeneration

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigConsistentRead.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigConsistentRead.kt
@@ -9,14 +9,6 @@ import com.revenuecat.purchases.common.verboseLog
  * belong to the previous user) and an ordinary commit can publish fresher data. Either advances the generation,
  * so a superseded read is re-run exactly once against the new state; only once, so a burst of commits can't
  * spin here.
- *
- * A **consistent** attempt returning `null` is the answer (the item isn't there), not staleness, and does not
- * retry. `null` is returned when both attempts were superseded — and also for that consistent-`null` answer; a
- * caller that must tell those apart should return a non-null result object from [block] (see the topic
- * providers). [block] receives the snapshot generation, so a caller can tag what it resolves with the
- * generation it belongs to.
- *
- * [what] labels the read in the retry log.
  */
 internal suspend fun <T : Any> RemoteConfigManager.readConsistent(
     what: () -> String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigConsistentRead.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigConsistentRead.kt
@@ -1,0 +1,31 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import com.revenuecat.purchases.common.verboseLog
+
+/**
+ * Runs [block] against a snapshot of [RemoteConfigManager.configGeneration] and trusts its result only if the
+ * generation is unchanged when it returns. A read that suspends across disk IO or a self-primed `/v1/config`
+ * sync can have the committed state change under it: an identity change wipes the cache (what was just read may
+ * belong to the previous user) and an ordinary commit can publish fresher data. Either advances the generation,
+ * so a superseded read is re-run exactly once against the new state; only once, so a burst of commits can't
+ * spin here.
+ *
+ * A **consistent** attempt returning `null` is the answer (the item isn't there), not staleness, and does not
+ * retry. `null` is returned when both attempts were superseded — and also for that consistent-`null` answer; a
+ * caller that must tell those apart should return a non-null result object from [block] (see the topic
+ * providers). [block] receives the snapshot generation, so a caller can tag what it resolves with the
+ * generation it belongs to.
+ *
+ * [what] labels the read in the retry log.
+ */
+internal suspend fun <T : Any> RemoteConfigManager.readConsistent(
+    what: () -> String,
+    block: suspend (generation: Int) -> T?,
+): T? {
+    var generation = configGeneration
+    val first = block(generation)
+    if (configGeneration == generation) return first
+    verboseLog { "Remote config changed while reading ${what()}; reading it again." }
+    generation = configGeneration
+    return block(generation).takeIf { configGeneration == generation }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigProvider.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.common.remoteconfig.GenerationGuardedCache
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigCommitListener
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import com.revenuecat.purchases.common.remoteconfig.readConsistent
 import com.revenuecat.purchases.common.verboseLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,7 +34,9 @@ import kotlinx.coroutines.launch
  * synchronously (the suspend fn never suspends, so it resumes on the caller's thread with no dispatch) and only
  * a miss touches the config layer. The in-memory copy is re-warmed on every config commit and dropped on
  * identity change / disable (via [RemoteConfigCommitListener]); a [RemoteConfigManager.configGeneration] guard
- * makes sure a slower disk warm never clobbers a fresher network commit (store-if-newer).
+ * makes sure a slower disk warm never clobbers a fresher network commit (store-if-newer). Cold reads are
+ * guarded by [readConsistent], so a read superseded mid-resolve re-resolves against the new state instead of
+ * serving it.
  */
 @OptIn(InternalRevenueCatAPI::class)
 @Suppress("TooManyFunctions")
@@ -61,21 +64,21 @@ internal class UiConfigProvider(
      */
     suspend fun resolveUiConfig(): UiConfigResolution {
         cache.cached?.let { return UiConfigResolution.Found(it) }
-
-        val generation = manager.configGeneration
-        val resolved = resolve()
-        if (resolved != null) cache.store(generation, resolved)
-
-        // What the cache accepted is what can be served, never `resolved` itself: store-if-newer drops a value
-        // whose generation was overtaken mid-resolve, and that value may belong to the previous user.
-        val served = cache.cached
-        return when {
-            served != null -> UiConfigResolution.Found(served)
-            // Resolved fine, but the generation guard dropped it — not a failure, and it must not be classified
-            // from the committed state (an identity change has already wiped it). The next read re-resolves.
-            resolved != null -> UiConfigResolution.Superseded
-            else -> classifyUnresolved()
+        val resolution = manager.readConsistent(what = { "ui_config" }) { generation ->
+            when (val resolved = resolve()) {
+                null -> classifyUnresolved()
+                else -> {
+                    // Publish only while the read still looks consistent: a superseded value may belong to the
+                    // previous user and must not land in the memory-first cache (the retry re-resolves, and the
+                    // commit that superseded it re-warms the cache on its own).
+                    if (manager.configGeneration == generation) cache.store(generation, resolved)
+                    UiConfigResolution.Found(resolved)
+                }
+            }
         }
+        // Superseded on both attempts: nothing trustworthy to serve or classify (an identity change has
+        // already wiped the committed state the read saw). The next read re-resolves.
+        return resolution ?: UiConfigResolution.Superseded
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigResolution.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/uiconfig/UiConfigResolution.kt
@@ -12,9 +12,9 @@ import com.revenuecat.purchases.UiConfig
  * - [Found]: the [UiConfig] is resolved and in memory.
  * - [NotConfigured]: the topic is absent, or carries none of the ui_config parts. A project with no paywalls
  *   configured legitimately has no `ui_config` at all, so there is nothing to resolve — not a failure.
- * - [Superseded]: a [UiConfig] **was** resolved, but a newer config commit or an identity change advanced the
- *   config generation while it was in flight, so it was dropped instead of served (store-if-newer). The next
- *   read re-resolves against the fresher config.
+ * - [Superseded]: the read was superseded twice in a row — a config commit or an identity change advanced the
+ *   config generation while each attempt was in flight — so nothing trustworthy could be served. The next read
+ *   re-resolves against the fresher config.
  * - [Unavailable]: the topic carries ui_config parts but they could not be resolved into one [UiConfig] (an
  *   unresolvable blob, or a merged object that doesn't decode). The only outcome worth reporting as an error.
  */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsConfigProvider.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.common.remoteconfig.GenerationGuardedCache
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigCommitListener
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
+import com.revenuecat.purchases.common.remoteconfig.readConsistent
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.common.warnLog
 import kotlinx.coroutines.CoroutineScope
@@ -93,38 +94,37 @@ internal class WorkflowsConfigProvider(
             return cached.offeringToWorkflowId[offeringId]?.let { WorkflowResolution.Found(it) }
                 ?: WorkflowResolution.NoWorkflow
         }
-        val generation = manager.configGeneration
-        val topic = manager.topic(RemoteConfigTopic.Workflows)
-        verboseLog { "workflows topic ${if (topic == null) "is absent" else "has ${topic.size} item(s)"}" }
-        // A null topic means it could not be read (a failed or not-yet-run sync). The caller should fall back to
-        // the offering's default paywall; this is not the same as a genuinely workflowless offering.
-        return if (topic == null) {
-            verboseLog { "Workflows topic unavailable resolving offering '$offeringId'" }
-            WorkflowResolution.Unavailable
-        } else {
-            val matches = topic.entries
-                .filter { (_, item) -> item.metadata.stringOrNull(KEY_OFFERING_IDENTIFIER) == offeringId }
-            if (matches.size > 1) {
-                warnLog { "Duplicate offering_identifier '$offeringId' in workflows topic: ${matches.map { it.key }}" }
-            }
-            // Last entry wins on duplicates.
-            val workflowId = matches.lastOrNull()?.key
-            verboseLog {
-                if (workflowId != null) {
-                    "Resolved offering '$offeringId' to workflow '$workflowId'"
-                } else {
-                    "No workflow found for offering '$offeringId'"
-                }
-            }
-            // If an identity-change invalidation advanced the generation while the topic was read, the resolved
-            // id may belong to the previous user; prefer whatever the (now newer) cache holds instead.
-            val resolvedId = if (cache.isCurrent(generation)) {
-                workflowId
+        // Superseded on both attempts: an id resolved against a generation that moved may belong to the previous
+        // user, and there is nothing trustworthy to serve. Callers treat Unavailable as "fall back to the
+        // offering's default paywall".
+        return manager.readConsistent(what = { "the workflow for offering '$offeringId'" }) { _ ->
+            val topic = manager.topic(RemoteConfigTopic.Workflows)
+            verboseLog { "workflows topic ${if (topic == null) "is absent" else "has ${topic.size} item(s)"}" }
+            // A null topic means it could not be read (a failed or not-yet-run sync). The caller should fall
+            // back to the offering's default paywall; this is not the same as a genuinely workflowless offering.
+            if (topic == null) {
+                verboseLog { "Workflows topic unavailable resolving offering '$offeringId'" }
+                WorkflowResolution.Unavailable
             } else {
-                cache.cached?.offeringToWorkflowId?.get(offeringId)
+                val matches = topic.entries
+                    .filter { (_, item) -> item.metadata.stringOrNull(KEY_OFFERING_IDENTIFIER) == offeringId }
+                if (matches.size > 1) {
+                    warnLog {
+                        "Duplicate offering_identifier '$offeringId' in workflows topic: ${matches.map { it.key }}"
+                    }
+                }
+                // Last entry wins on duplicates.
+                val workflowId = matches.lastOrNull()?.key
+                verboseLog {
+                    if (workflowId != null) {
+                        "Resolved offering '$offeringId' to workflow '$workflowId'"
+                    } else {
+                        "No workflow found for offering '$offeringId'"
+                    }
+                }
+                workflowId?.let { WorkflowResolution.Found(it) } ?: WorkflowResolution.NoWorkflow
             }
-            resolvedId?.let { WorkflowResolution.Found(it) } ?: WorkflowResolution.NoWorkflow
-        }
+        } ?: WorkflowResolution.Unavailable
     }
 
     /** The resolved workflow id for [offeringId], or `null` when none is mapped or the topic is unavailable. */
@@ -152,14 +152,10 @@ internal class WorkflowsConfigProvider(
      */
     suspend fun getWorkflow(workflowId: String): PublishedWorkflow? {
         cache.cached?.workflows?.get(workflowId)?.let { return it.value }
-        val generation = manager.configGeneration
-        val workflow = resolveWorkflowBody(workflowId)
-        // If an identity-change invalidation advanced the generation while the body was resolved, it may belong
-        // to the previous user; prefer whatever the (now newer) cache holds instead of serving it.
-        return when {
-            workflow == null -> null
-            cache.isCurrent(generation) -> workflow
-            else -> cache.cached?.workflows?.get(workflowId)?.value
+        // A body resolved against a generation that moved may belong to the previous user; readConsistent
+        // re-resolves it once against the new state instead of serving it.
+        return manager.readConsistent(what = { "workflow '$workflowId'" }) { _ ->
+            resolveWorkflowBody(workflowId)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
@@ -8,6 +8,8 @@ import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.jsonObject
@@ -31,6 +33,7 @@ internal class AudiencesConfigProviderTest {
             override fun w(tag: String, msg: String) {}
             override fun e(tag: String, msg: String, throwable: Throwable?) {}
         }
+        every { manager.configGeneration } returns 0
     }
 
     @After
@@ -86,6 +89,26 @@ internal class AudiencesConfigProviderTest {
         assertThat(provider.getAudience("valid")).isEqualTo(
             Audience(id = "valid", rules = """{"==":[1,1]}"""),
         )
+    }
+
+    @Test
+    fun `getAudience reads again when the config generation changes during the read`() = runTest {
+        every { manager.configGeneration } returnsMany listOf(0, 1)
+        returnMetadata("aud_123" to """{"id":"aud_123","rules":{"==":[1,1]}}""")
+
+        assertThat(provider.getAudience("aud_123")).isEqualTo(
+            Audience(id = "aud_123", rules = """{"==":[1,1]}"""),
+        )
+        coVerify(exactly = 2) { manager.topic(RemoteConfigTopic.Audiences) }
+    }
+
+    @Test
+    fun `getAudience returns null when the config changes during both reads`() = runTest {
+        every { manager.configGeneration } returnsMany listOf(0, 1, 1, 2)
+        returnMetadata("aud_123" to """{"id":"aud_123","rules":{"==":[1,1]}}""")
+
+        assertThat(provider.getAudience("aud_123")).isNull()
+        coVerify(exactly = 2) { manager.topic(RemoteConfigTopic.Audiences) }
     }
 
     private fun returnMetadata(vararg audiences: Pair<String, String>) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigConsistentReadTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigConsistentReadTest.kt
@@ -1,0 +1,72 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class RemoteConfigConsistentReadTest {
+    private val manager = mockk<RemoteConfigManager>()
+
+    @Test
+    fun `returns the first result without a retry when the generation is stable`() = runTest {
+        every { manager.configGeneration } returns 0
+        val generations = mutableListOf<Int>()
+
+        val result = manager.readConsistent(what = { "a value" }) { generation ->
+            generations += generation
+            "value"
+        }
+
+        assertThat(result).isEqualTo("value")
+        assertThat(generations).containsExactly(0)
+    }
+
+    @Test
+    fun `a consistent null result is the answer and does not retry`() = runTest {
+        every { manager.configGeneration } returns 0
+        var reads = 0
+
+        val result = manager.readConsistent<String>(what = { "a value" }) { reads++; null }
+
+        assertThat(result).isNull()
+        assertThat(reads).isEqualTo(1)
+    }
+
+    @Test
+    fun `retries once against the new generation when the read is superseded`() = runTest {
+        every { manager.configGeneration } returnsMany listOf(0, 1)
+        val generations = mutableListOf<Int>()
+
+        val result = manager.readConsistent(what = { "a value" }) { generation ->
+            generations += generation
+            "value at $generation"
+        }
+
+        assertThat(result).isEqualTo("value at 1")
+        assertThat(generations).containsExactly(0, 1)
+    }
+
+    @Test
+    fun `retries a superseded read even when it returned null`() = runTest {
+        every { manager.configGeneration } returnsMany listOf(0, 1)
+        var reads = 0
+
+        val result = manager.readConsistent(what = { "a value" }) { if (reads++ == 0) null else "retried" }
+
+        assertThat(result).isEqualTo("retried")
+        assertThat(reads).isEqualTo(2)
+    }
+
+    @Test
+    fun `returns null after exactly two attempts when both are superseded`() = runTest {
+        every { manager.configGeneration } returnsMany listOf(0, 1, 1, 2)
+        var reads = 0
+
+        val result = manager.readConsistent(what = { "a value" }) { reads++; "value" }
+
+        assertThat(result).isNull()
+        assertThat(reads).isEqualTo(2)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/uiconfig/UiConfigProviderTest.kt
@@ -296,20 +296,32 @@ internal class UiConfigProviderTest {
     }
 
     @Test
-    fun `resolveUiConfig returns Superseded when a newer invalidation lands mid-resolve`() = runTest {
-        // The value resolved fine but belongs to a superseded generation, so it is dropped rather than served.
-        // That is not a resolution failure, and must not be classified from the (already wiped) committed state.
-        every { manager.configGeneration } returns 0
-        val merged = minimalUiConfigJson()
-        coEvery {
+    fun `resolveUiConfig re-resolves once and serves the fresh value when the config changes mid-read`() = runTest {
+        // A commit advanced the generation while the first resolve was in flight; its value can't be trusted, so
+        // the read re-resolves once against the new state and serves (and caches) that result.
+        every { manager.configGeneration } returnsMany listOf(0, 1)
+        stubMergedRead(minimalUiConfigJson())
+
+        assertThat(provider.resolveUiConfig()).isInstanceOf(UiConfigResolution.Found::class.java)
+        assertThat(provider.isWarm()).isTrue
+        coVerify(exactly = 2) {
             manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
-        } answers {
-            provider.onConfigInvalidated(generation = 5)
-            thirdArg<(JsonObject) -> UiConfig?>().invoke(merged)
         }
+    }
+
+    @Test
+    fun `resolveUiConfig returns Superseded when the config changes during both reads`() = runTest {
+        // Values resolved fine but each belongs to a superseded generation, so they are dropped rather than
+        // served. That is not a resolution failure, and must not be classified from the committed state (an
+        // identity change may have already wiped it).
+        every { manager.configGeneration } returnsMany listOf(0, 1, 1, 1, 2, 2)
+        stubMergedRead(minimalUiConfigJson())
 
         assertThat(provider.resolveUiConfig()).isEqualTo(UiConfigResolution.Superseded)
         assertThat(provider.isWarm()).isFalse
+        coVerify(exactly = 2) {
+            manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())
+        }
         coVerify(exactly = 0) { manager.committedTopicOrNull(any()) }
     }
 
@@ -434,9 +446,10 @@ internal class UiConfigProviderTest {
     @Test
     fun `getUiConfig does not serve a value resolved before a concurrent newer invalidation`() = runTest {
         // Cold read snapshots generation 0, then an identity-change invalidation at a newer generation lands
-        // while the merge is in flight. The just-resolved value belongs to the previous user, so it must not be
-        // returned to the in-flight caller, nor repopulate the cache.
-        every { manager.configGeneration } returns 0
+        // while the merge is in flight (and the config keeps moving during the retry). The values resolved
+        // mid-change may belong to the previous user, so they must not be returned to the in-flight caller,
+        // nor repopulate the cache.
+        every { manager.configGeneration } returnsMany listOf(0, 5, 5, 5, 6, 6)
         val merged = minimalUiConfigJson()
         coEvery {
             manager.mergeItemsBlobData(RemoteConfigTopic.UiConfig, any(), any<(JsonObject) -> UiConfig?>())

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsConfigProviderTest.kt
@@ -258,10 +258,23 @@ internal class WorkflowsConfigProviderTest {
     }
 
     @Test
+    fun `getWorkflow re-resolves once and serves the fresh body when the config changes during the read`() =
+        runTest {
+            every { manager.configGeneration } returnsMany listOf(0, 1)
+            stubWorkflowBody(WF_CURRENT)
+
+            assertThat(provider.getWorkflow(WF_CURRENT)).isNotNull
+            coVerify(exactly = 2) {
+                manager.blobData(RemoteConfigTopic.Workflows, WF_CURRENT, any<(ByteArray) -> ByteArray?>())
+            }
+        }
+
+    @Test
     fun `getWorkflow does not serve a body resolved before a concurrent newer invalidation`() = runTest {
         // Cold read snapshots generation 0, then an identity-change invalidation at a newer generation lands
-        // while the body is being resolved. That body may belong to the previous user, so it must not be served.
-        every { manager.configGeneration } returns 0
+        // while the body is being resolved (and the config keeps moving during the retry). Those bodies may
+        // belong to the previous user, so they must not be served.
+        every { manager.configGeneration } returnsMany listOf(0, 5, 5, 6)
         val body = workflowJson(WF_CURRENT).toByteArray()
         coEvery {
             manager.blobData(RemoteConfigTopic.Workflows, WF_CURRENT, any<(ByteArray) -> ByteArray?>())
@@ -284,8 +297,19 @@ internal class WorkflowsConfigProviderTest {
     }
 
     @Test
+    fun `workflowIdForOfferingId re-resolves once when the config changes during the read`() = runTest {
+        every { manager.configGeneration } returnsMany listOf(0, 1)
+        coEvery { manager.topic(RemoteConfigTopic.Workflows) } returns topicWith(
+            WF_CURRENT to configItem(prefetch = false, offeringId = CURRENT_OFFERING),
+        )
+
+        assertThat(provider.workflowIdForOfferingId(CURRENT_OFFERING)).isEqualTo(WF_CURRENT)
+        coVerify(exactly = 2) { manager.topic(RemoteConfigTopic.Workflows) }
+    }
+
+    @Test
     fun `workflowIdForOfferingId does not serve an id resolved before a concurrent newer invalidation`() = runTest {
-        every { manager.configGeneration } returns 0
+        every { manager.configGeneration } returnsMany listOf(0, 5, 5, 6)
         coEvery { manager.topic(RemoteConfigTopic.Workflows) } answers {
             provider.onConfigInvalidated(generation = 5)
             topicWith(WF_CURRENT to configItem(prefetch = false, offeringId = CURRENT_OFFERING))


### PR DESCRIPTION
### Description

Until now, each config provider handled the generation guards to make sure that different reads were not cached incorrectly on their own, which meant this logic was duplicated in a lot of places, and was also easy to miss with new providers. This PR adds a basic function to extract the main logic outside of the config providers themselves and  adds a single retry mechanism to all of them. 

Additionally, it also adds handling of this to the audiences config provider

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall/UI config, workflow routing, and checkpoint rules at identity-switch boundaries; behavior is intentionally stricter about not serving stale cross-user data, with a single bounded retry.
> 
> **Overview**
> Introduces **`RemoteConfigManager.readConsistent`**, a shared helper that runs a suspend read against a snapshot of `configGeneration`, retries **once** if a commit or identity change advances the generation mid-read, and returns `null` if both attempts are superseded.
> 
> **Audiences**, **checkpoints**, **UI config**, and **workflows** providers now route cold/suspending reads through this helper instead of duplicating per-provider retry and generation checks. Checkpoint resolution drops its private `attemptRead`; workflow offering/body resolution no longer falls back to stale cache when the generation moves; UI config resolution **re-resolves and can serve** after a single mid-read invalidation, and only returns **`Superseded`** when both attempts are untrustworthy. **`UiConfigResolution.Superseded`** is documented to match that behavior.
> 
> Unit tests cover the helper and provider retry/supersede paths (including audiences, which previously lacked generation guarding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21483000e0ede397916ebd6c920e473c56fb8c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->