### PR TITLE
feat: support offers for Google Play one-time products

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.models.GooglePurchasingData
 import com.revenuecat.purchases.models.GoogleReplacementMode
+import com.revenuecat.purchases.models.OneTimePurchaseOfferDetails
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreReplacementMode
@@ -85,6 +86,17 @@ public class PurchaseParams(public val builder: Builder) {
                 activity,
                 subscriptionOption.purchasingData,
                 subscriptionOption.presentedOfferingContext,
+                product = null,
+            )
+
+        public constructor(
+            activity: Activity,
+            oneTimePurchaseOfferDetails: OneTimePurchaseOfferDetails,
+        ) :
+            this(
+                activity,
+                oneTimePurchaseOfferDetails.purchasingData,
+                oneTimePurchaseOfferDetails.presentedOfferingContext,
                 product = null,
             )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -972,6 +972,8 @@ internal class BillingWrapper(
     ): Result<BillingFlowParams, PurchasesError> {
         val productDetailsParamsList = BillingFlowParams.ProductDetailsParams.newBuilder().apply {
             setProductDetails(purchaseInfo.productDetails)
+            val offerToken = purchaseInfo.selectedOfferToken
+            offerToken?.let { setOfferToken(it) }
         }.build()
 
         try {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.models.GoogleDiscountDisplayInfo
 import com.revenuecat.purchases.models.GoogleOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.OneTimePurchaseOfferDetailsList
@@ -90,13 +91,28 @@ internal fun ProductDetails.OneTimePurchaseOfferDetails.toGoogleOneTimePurchaseO
         amountMicros = this.priceAmountMicros,
         currencyCode = this.priceCurrencyCode,
     )
+    val discountDisplayInfo = this.discountDisplayInfo?.let { googleDiscount ->
+        val percentage = googleDiscount.percentageDiscount
+        val discountAmountPrice = googleDiscount.discountAmount?.let { amount ->
+            Price(
+                formatted = amount.formattedDiscountAmount,
+                amountMicros = amount.discountAmountMicros,
+                currencyCode = amount.discountAmountCurrencyCode,
+            )
+        }
+        GoogleDiscountDisplayInfo(
+            percentageDiscount = percentage,
+            discountAmount = discountAmountPrice,
+        )
+    }
+
     return GoogleOneTimePurchaseOfferDetails(
         productId = productId,
         price = price,
         offerId = this.offerId,
         offerToken = this.offerToken,
         offerTags = this.offerTags,
-        discountDisplayInfo = this.discountDisplayInfo,
+        discountDisplayInfo = discountDisplayInfo,
         productDetails = productDetails,
         presentedOfferingContext = null,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -32,7 +32,9 @@ internal fun ProductDetails.toStoreProduct(
             OneTimePurchaseOfferDetailsList(
                 this.oneTimePurchaseOfferDetailsList?.map {
                     it.toGoogleOneTimePurchaseOfferDetails(productId, this)
-                } ?: emptyList()
+                } ?: listOfNotNull(
+                    this.oneTimePurchaseOfferDetails?.toGoogleOneTimePurchaseOfferDetails(productId, this)
+                )
             )
         } else {
             null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -27,10 +27,6 @@ internal fun ProductDetails.toStoreProduct(
         null
     }
 
-    val basePlan = subscriptionOptions?.basePlan
-    val basePlanPrice = basePlan?.fullPricePhase?.price
-    val price = createOneTimeProductPrice() ?: basePlanPrice ?: return null
-
     val oneTimePurchaseOfferDetailsList =
         if (productType.toRevenueCatProductType() == ProductType.INAPP) {
             OneTimePurchaseOfferDetailsList(
@@ -42,15 +38,24 @@ internal fun ProductDetails.toStoreProduct(
             null
         }
 
+    val basePlanSubscription = subscriptionOptions?.basePlan
+    val basePlanOneTimeOffer = oneTimePurchaseOfferDetailsList?.basePlan
+
+    val basePlanPrice = basePlanSubscription?.fullPricePhase?.price
+        ?: basePlanOneTimeOffer?.price
+        ?: createOneTimeProductPrice()
+        ?: return null
+
+
     return GoogleStoreProduct(
         productId = productId,
-        basePlanId = basePlan?.id,
+        basePlanId = basePlanSubscription?.id,
         type = productType.toRevenueCatProductType(),
-        price = price,
+        price = basePlanPrice,
         name = name,
         title = title,
         description = description,
-        period = basePlan?.billingPeriod,
+        period = basePlanSubscription?.billingPeriod,
         subscriptionOptions = subscriptionOptions,
         defaultOption = subscriptionOptions?.defaultOffer,
         productDetails = this,
@@ -89,6 +94,7 @@ internal fun ProductDetails.OneTimePurchaseOfferDetails.toGoogleOneTimePurchaseO
         offerId = this.offerId,
         offerToken = this.offerToken,
         offerTags = this.offerTags,
+        discountDisplayInfo = this.discountDisplayInfo,
         productDetails = productDetails,
         presentedOfferingContext = null,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -5,7 +5,9 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.models.GoogleOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.models.GoogleStoreProduct
+import com.revenuecat.purchases.models.OneTimePurchaseOfferDetailsList
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.SubscriptionOptions
@@ -29,6 +31,17 @@ internal fun ProductDetails.toStoreProduct(
     val basePlanPrice = basePlan?.fullPricePhase?.price
     val price = createOneTimeProductPrice() ?: basePlanPrice ?: return null
 
+    val oneTimePurchaseOfferDetailsList =
+        if (productType.toRevenueCatProductType() == ProductType.INAPP) {
+            OneTimePurchaseOfferDetailsList(
+                this.oneTimePurchaseOfferDetailsList?.map {
+                    it.toGoogleOneTimePurchaseOfferDetails(productId, this)
+                } ?: emptyList()
+            )
+        } else {
+            null
+        }
+
     return GoogleStoreProduct(
         productId = productId,
         basePlanId = basePlan?.id,
@@ -42,6 +55,8 @@ internal fun ProductDetails.toStoreProduct(
         defaultOption = subscriptionOptions?.defaultOffer,
         productDetails = this,
         presentedOfferingContext = null,
+        oneTimePurchaseOfferDetailsList = oneTimePurchaseOfferDetailsList,
+        defaultOneTimeOffer = oneTimePurchaseOfferDetailsList?.defaultOffer
     )
 }
 
@@ -57,6 +72,26 @@ private fun ProductDetails.createOneTimeProductPrice(): Price? {
     } else {
         null
     }
+}
+
+internal fun ProductDetails.OneTimePurchaseOfferDetails.toGoogleOneTimePurchaseOfferDetails(
+    productId: String,
+    productDetails: ProductDetails,
+): GoogleOneTimePurchaseOfferDetails {
+    val price = Price(
+        formatted = this.formattedPrice,
+        amountMicros = this.priceAmountMicros,
+        currencyCode = this.priceCurrencyCode,
+    )
+    return GoogleOneTimePurchaseOfferDetails(
+        productId = productId,
+        price = price,
+        offerId = this.offerId,
+        offerToken = this.offerToken,
+        offerTags = this.offerTags,
+        productDetails = productDetails,
+        presentedOfferingContext = null,
+    )
 }
 
 @OptIn(InternalRevenueCatAPI::class)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/DiscountDisplayInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/DiscountDisplayInfo.kt
@@ -1,0 +1,17 @@
+package com.revenuecat.purchases.models
+
+/**
+ * Represents discount display information for a one-time purchase offer.
+ */
+public interface DiscountDisplayInfo {
+    /**
+     * Percentage discount offered by this one-time purchase offer, or null if unavailable.
+     */
+    public val percentageDiscount: Int?
+
+    /**
+     * Discount amount details for this one-time purchase offer, or null if unavailable.
+     */
+    public val discountAmount: Price?
+}
+

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleDiscountDisplayInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleDiscountDisplayInfo.kt
@@ -1,0 +1,12 @@
+package com.revenuecat.purchases.models
+
+import dev.drewhamilton.poko.Poko
+
+/**
+ * Google-specific discount display information for a one-time purchase offer.
+ */
+@Poko
+public class GoogleDiscountDisplayInfo(
+    override val percentageDiscount: Int? = null,
+    override val discountAmount: Price? = null,
+) : DiscountDisplayInfo

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleOneTimePurchaseOfferDetails.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleOneTimePurchaseOfferDetails.kt
@@ -35,6 +35,11 @@ public class GoogleOneTimePurchaseOfferDetails @JvmOverloads constructor(
     override val offerTags: List<String>?,
 
     /**
+     * Discount display info for this offer, or null if base plan/no discount.
+     */
+    override val discountDisplayInfo: ProductDetails.OneTimePurchaseOfferDetails.DiscountDisplayInfo? = null,
+
+    /**
      * The `ProductDetails` object from BillingClient this offer was created from.
      */
     public val productDetails: ProductDetails,
@@ -54,6 +59,7 @@ public class GoogleOneTimePurchaseOfferDetails @JvmOverloads constructor(
         offerDetails.offerId,
         offerDetails.offerToken,
         offerDetails.offerTags,
+        offerDetails.discountDisplayInfo,
         offerDetails.productDetails,
         presentedOfferingContext,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleOneTimePurchaseOfferDetails.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleOneTimePurchaseOfferDetails.kt
@@ -1,0 +1,67 @@
+package com.revenuecat.purchases.models
+
+import com.android.billingclient.api.ProductDetails
+import com.revenuecat.purchases.PresentedOfferingContext
+import dev.drewhamilton.poko.Poko
+
+/**
+ * Defines Google-specific offer details for a one-time (INAPP) product.
+ */
+@Poko
+public class GoogleOneTimePurchaseOfferDetails @JvmOverloads constructor(
+    /**
+     * Product ID of the one-time product.
+     */
+    override val productId: String,
+
+    /**
+     * Price information for this offer.
+     */
+    override val price: Price,
+
+    /**
+     * Offer ID set in Play Console, or null if none.
+     */
+    override val offerId: String?,
+
+    /**
+     * The offer token used to purchase this offer.
+     */
+    override val offerToken: String?,
+
+    /**
+     * List of tags associated with this offer.
+     */
+    override val offerTags: List<String>?,
+
+    /**
+     * The `ProductDetails` object from BillingClient this offer was created from.
+     */
+    public val productDetails: ProductDetails,
+
+    /**
+     * The context from which this offer details was obtained.
+     */
+    override val presentedOfferingContext: PresentedOfferingContext? = null,
+) : OneTimePurchaseOfferDetails {
+
+    internal constructor(
+        offerDetails: GoogleOneTimePurchaseOfferDetails,
+        presentedOfferingContext: PresentedOfferingContext?,
+    ) : this(
+        offerDetails.productId,
+        offerDetails.price,
+        offerDetails.offerId,
+        offerDetails.offerToken,
+        offerDetails.offerTags,
+        offerDetails.productDetails,
+        presentedOfferingContext,
+    )
+
+    override val purchasingData: PurchasingData
+        get() = GooglePurchasingData.InAppProduct(
+            productId = productId,
+            productDetails = productDetails,
+            selectedOfferToken = offerToken,
+        )
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleOneTimePurchaseOfferDetails.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleOneTimePurchaseOfferDetails.kt
@@ -37,7 +37,7 @@ public class GoogleOneTimePurchaseOfferDetails @JvmOverloads constructor(
     /**
      * Discount display info for this offer, or null if base plan/no discount.
      */
-    override val discountDisplayInfo: ProductDetails.OneTimePurchaseOfferDetails.DiscountDisplayInfo? = null,
+    override val discountDisplayInfo: DiscountDisplayInfo? = null,
 
     /**
      * The `ProductDetails` object from BillingClient this offer was created from.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GooglePurchasingData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GooglePurchasingData.kt
@@ -7,9 +7,10 @@ import dev.drewhamilton.poko.Poko
 
 public sealed class GooglePurchasingData : PurchasingData {
     @Poko
-    public class InAppProduct(
+    public class InAppProduct @JvmOverloads constructor(
         public override val productId: String,
         public val productDetails: ProductDetails,
+        public val selectedOfferToken: String? = null,
     ) : GooglePurchasingData()
 
     @Poko

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleStoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleStoreProduct.kt
@@ -111,6 +111,19 @@ constructor(
      * Null if not using RevenueCat offerings system, or if fetched directly via `Purchases.getProducts`
      */
     override val presentedOfferingContext: PresentedOfferingContext? = null,
+
+    /**
+     * Contains all [OneTimePurchaseOfferDetails]. Null for subscriptions or if no offer details exist.
+     */
+    override val oneTimePurchaseOfferDetailsList: OneTimePurchaseOfferDetailsList?,
+
+    /**
+     * The default [OneTimePurchaseOfferDetails] that will be used when purchasing an INAPP product without specifying
+     * a different option. Evaluates the cheapest offer excluding "rc-ignore-offer" and "rc-customer-center" tags.
+     * Null for SUBS products or if no offer details exist.
+     */
+    override val defaultOneTimeOffer: OneTimePurchaseOfferDetails?
+
 ) : StoreProduct {
 
     internal constructor(
@@ -126,6 +139,8 @@ constructor(
         defaultOption: SubscriptionOption?,
         productDetails: ProductDetails,
         presentedOfferingContext: PresentedOfferingContext? = null,
+        oneTimePurchaseOfferDetailsList: OneTimePurchaseOfferDetailsList?,
+        defaultOneTimeOffer: OneTimePurchaseOfferDetails?
     ) : this(
         productId,
         basePlanId,
@@ -140,6 +155,8 @@ constructor(
         productDetails,
         presentedOfferingContext?.offeringIdentifier,
         presentedOfferingContext,
+        oneTimePurchaseOfferDetailsList,
+        defaultOneTimeOffer,
     )
 
     @Deprecated(
@@ -174,6 +191,8 @@ constructor(
         defaultOption,
         productDetails,
         presentedOfferingIdentifier?.let { PresentedOfferingContext(it) },
+        null,
+        null,
     )
 
     private constructor(
@@ -181,6 +200,8 @@ constructor(
         defaultOption: SubscriptionOption?,
         subscriptionOptionsWithOfferingId: SubscriptionOptions?,
         presentedOfferingContext: PresentedOfferingContext?,
+        oneTimePurchaseOfferDetailsList: OneTimePurchaseOfferDetailsList?,
+        defaultOneTimeOffer: OneTimePurchaseOfferDetails?
     ) :
         this(
             otherProduct.productId,
@@ -195,6 +216,8 @@ constructor(
             defaultOption,
             otherProduct.productDetails,
             presentedOfferingContext,
+            oneTimePurchaseOfferDetailsList,
+            defaultOneTimeOffer,
         )
 
     /**
@@ -213,6 +236,8 @@ constructor(
     override val purchasingData: PurchasingData
         get() = if (type == ProductType.SUBS && defaultOption != null) {
             defaultOption.purchasingData
+        } else if (type == ProductType.INAPP && defaultOneTimeOffer != null) {
+            defaultOneTimeOffer.purchasingData
         } else {
             GooglePurchasingData.InAppProduct(
                 id,
@@ -267,11 +292,23 @@ constructor(
             )
         }
 
+        val oneTimeOfferDetailsWithContext = oneTimePurchaseOfferDetailsList?.mapNotNull {
+            (it as? GoogleOneTimePurchaseOfferDetails)?.let { googleOffer ->
+                GoogleOneTimePurchaseOfferDetails(googleOffer, presentedOfferingContext)
+            }
+        }
+
+        val defaultOneTimeOfferWithContext = (defaultOneTimeOffer as? GoogleOneTimePurchaseOfferDetails)?.let {
+            GoogleOneTimePurchaseOfferDetails(it, presentedOfferingContext)
+        }
+
         return GoogleStoreProduct(
             this,
             defaultOptionWithOfferingId,
             subscriptionOptionsWithContext?.let { SubscriptionOptions(it) },
             presentedOfferingContext,
+            oneTimeOfferDetailsWithContext?.let { OneTimePurchaseOfferDetailsList(it) },
+            defaultOneTimeOfferWithContext,
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleStoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleStoreProduct.kt
@@ -115,14 +115,14 @@ constructor(
     /**
      * Contains all [OneTimePurchaseOfferDetails]. Null for subscriptions or if no offer details exist.
      */
-    override val oneTimePurchaseOfferDetailsList: OneTimePurchaseOfferDetailsList?,
+    override val oneTimePurchaseOfferDetailsList: OneTimePurchaseOfferDetailsList? = null,
 
     /**
      * The default [OneTimePurchaseOfferDetails] that will be used when purchasing an INAPP product without specifying
      * a different option. Evaluates the cheapest offer excluding "rc-ignore-offer" and "rc-customer-center" tags.
      * Null for SUBS products or if no offer details exist.
      */
-    override val defaultOneTimeOffer: OneTimePurchaseOfferDetails?
+    override val defaultOneTimeOffer: OneTimePurchaseOfferDetails? = null
 
 ) : StoreProduct {
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/OneTimePurchaseOfferDetails.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/OneTimePurchaseOfferDetails.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.models
 
-import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.PresentedOfferingContext
 
 /**
@@ -35,7 +34,7 @@ public interface OneTimePurchaseOfferDetails {
     /**
      * Discount display info for the one-time purchase offer, null if base plan / no discount.
      */
-    public val discountDisplayInfo: ProductDetails.OneTimePurchaseOfferDetails.DiscountDisplayInfo?
+    public val discountDisplayInfo: DiscountDisplayInfo?
 
     /**
      * Contains only data that is required to make the purchase.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/OneTimePurchaseOfferDetails.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/OneTimePurchaseOfferDetails.kt
@@ -1,0 +1,43 @@
+package com.revenuecat.purchases.models
+
+import com.revenuecat.purchases.PresentedOfferingContext
+
+/**
+ * Represents an offer/discount details for a one-time (INAPP) product.
+ */
+public interface OneTimePurchaseOfferDetails {
+    /**
+     * Product ID of the one-time product.
+     */
+    public val productId: String
+
+    /**
+     * Price details for the one-time purchase offer.
+     */
+    public val price: Price
+
+    /**
+     * Offer ID set in the Play Console if this offer has an ID, null otherwise.
+     */
+    public val offerId: String?
+
+    /**
+     * The offer token required to purchase this one-time offer via Google Play Billing.
+     */
+    public val offerToken: String?
+
+    /**
+     * Tags defined on the one-time purchase offer.
+     */
+    public val offerTags: List<String>?
+
+    /**
+     * Contains only data that is required to make the purchase.
+     */
+    public val purchasingData: PurchasingData
+
+    /**
+     * The context from which this one-time purchase offer was obtained.
+     */
+    public val presentedOfferingContext: PresentedOfferingContext?
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/OneTimePurchaseOfferDetails.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/OneTimePurchaseOfferDetails.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.models
 
+import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.PresentedOfferingContext
 
 /**
@@ -30,6 +31,11 @@ public interface OneTimePurchaseOfferDetails {
      * Tags defined on the one-time purchase offer.
      */
     public val offerTags: List<String>?
+
+    /**
+     * Discount display info for the one-time purchase offer, null if base plan / no discount.
+     */
+    public val discountDisplayInfo: ProductDetails.OneTimePurchaseOfferDetails.DiscountDisplayInfo?
 
     /**
      * Contains only data that is required to make the purchase.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/OneTimePurchaseOfferDetailsList.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/OneTimePurchaseOfferDetailsList.kt
@@ -26,6 +26,12 @@ public class OneTimePurchaseOfferDetailsList(
         }
 
     /**
+     * The base plan [OneTimePurchaseOfferDetails] (the offer detail with null [discountDisplayInfo]).
+     */
+    public val basePlan: OneTimePurchaseOfferDetails?
+        get() = this.firstOrNull { it.discountDisplayInfo == null }
+
+    /**
      * Finds all [OneTimePurchaseOfferDetails] with a specific tag.
      */
     public fun withTag(tag: String): List<OneTimePurchaseOfferDetails> {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/OneTimePurchaseOfferDetailsList.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/OneTimePurchaseOfferDetailsList.kt
@@ -1,0 +1,49 @@
+package com.revenuecat.purchases.models
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.SharedConstants
+
+public class OneTimePurchaseOfferDetailsList(
+    private val oneTimePurchaseOfferDetailsList: List<OneTimePurchaseOfferDetails>,
+) : List<OneTimePurchaseOfferDetails> by oneTimePurchaseOfferDetailsList {
+
+    private companion object {
+        const val RC_IGNORE_OFFER_TAG = "rc-ignore-offer"
+    }
+
+    /**
+     * The default [OneTimePurchaseOfferDetails]:
+     *   - Filters out offers with "rc-ignore-offer" and "rc-customer-center" tag
+     *   - Uses [OneTimePurchaseOfferDetails] with cheapest price (`amountMicros`)
+     */
+    @OptIn(InternalRevenueCatAPI::class)
+    public val defaultOffer: OneTimePurchaseOfferDetails?
+        get() {
+            return this
+                .filter { !(it.offerTags?.contains(RC_IGNORE_OFFER_TAG) ?: false) }
+                .filter { !(it.offerTags?.contains(SharedConstants.RC_CUSTOMER_CENTER_TAG) ?: false) }
+                .minByOrNull { it.price.amountMicros }
+        }
+
+    /**
+     * Finds all [OneTimePurchaseOfferDetails] with a specific tag.
+     */
+    public fun withTag(tag: String): List<OneTimePurchaseOfferDetails> {
+        return this.filter { it.offerTags?.contains(tag) ?: false }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        (other as? OneTimePurchaseOfferDetailsList)?.let {
+            return listOf(this.oneTimePurchaseOfferDetailsList) == listOf(other.oneTimePurchaseOfferDetailsList)
+        } ?: run {
+            return false
+        }
+    }
+
+    override fun hashCode(): Int {
+        return listOf(this.oneTimePurchaseOfferDetailsList).hashCode()
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
@@ -85,6 +85,20 @@ public interface StoreProduct {
     public val defaultOption: SubscriptionOption?
 
     /**
+     * Contains all [OneTimePurchaseOfferDetails]. Null for subscriptions or if no offer details exist.
+     */
+    public val oneTimePurchaseOfferDetailsList: List<OneTimePurchaseOfferDetails>?
+        get() = null
+
+    /**
+     * The default [OneTimePurchaseOfferDetails] that will be used when purchasing an INAPP product without specifying
+     * a different option. Evaluates the cheapest offer excluding "rc-ignore-offer" and "rc-customer-center" tags.
+     * Null for SUBS products or if no offer details exist.
+     */
+    public val defaultOneTimeOffer: OneTimePurchaseOfferDetails?
+        get() = null
+
+    /**
      * Contains only data that is required to make the purchase.
      */
     public val purchasingData: PurchasingData

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
@@ -6,9 +6,11 @@
 package com.revenuecat.purchases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.models.GoogleOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.models.GooglePurchasingData
 import com.revenuecat.purchases.models.GoogleReplacementMode
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
+import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreReplacementMode
@@ -115,6 +117,28 @@ class PurchaseParamsTest {
 
         val expectedPurchasingData = basePlanSubscriptionOption.purchasingData
         assertThat(purchasePackageParams.purchasingData).isEqualTo(expectedPurchasingData)
+    }
+
+    @Test
+    fun `Initializing with OneTimePurchaseOfferDetails sets proper presentedOfferingIdentifier and purchasingData`() {
+        val presentedOfferingContext = PresentedOfferingContext(STUB_OFFERING_IDENTIFIER)
+        val offerDetails = GoogleOneTimePurchaseOfferDetails(
+            productId = "product-id",
+            price = Price(formatted = "$4.99", amountMicros = 4990000, currencyCode = "USD"),
+            offerId = "offer-id",
+            offerToken = "mock-token",
+            offerTags = emptyList(),
+            productDetails = mockk(),
+            presentedOfferingContext = presentedOfferingContext
+        )
+
+        val purchaseParams = PurchaseParams.Builder(
+            mockk(),
+            offerDetails
+        ).build()
+
+        assertThat(purchaseParams.presentedOfferingContext?.offeringIdentifier).isEqualTo(STUB_OFFERING_IDENTIFIER)
+        assertThat(purchaseParams.purchasingData).isEqualTo(offerDetails.purchasingData)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -569,7 +569,7 @@ class AmazonBillingTest {
     }
 
     @Test
-    fun `If purchase state is "purchased", purchase is fulfilled and cached`() {
+    fun `If purchase state is 'purchased', purchase is fulfilled and cached`() {
         setup()
         val dummyReceipt = dummyReceipt()
 

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -888,6 +888,11 @@ class BillingWrapperTest {
             ProductDetailsParams.newBuilder()
         } returns mockProductDetailsBuilder
 
+        val tokenSlot = slot<String>()
+        every {
+            mockProductDetailsBuilder.setOfferToken(capture(tokenSlot))
+        } returns mockProductDetailsBuilder
+
         val productDetailsSlot = slot<ProductDetails>()
         every {
             mockProductDetailsBuilder.setProductDetails(capture(productDetailsSlot))
@@ -918,10 +923,64 @@ class BillingWrapperTest {
             null,
         )
 
-        verify(exactly = 0) {
-            mockProductDetailsBuilder.setOfferToken(any())
+        assertThat(tokenSlot.isCaptured).isTrue
+        assertThat(tokenSlot.captured).isEqualTo("mockOfferToken")
+        assertThat(productDetailsSlot.isCaptured).isTrue
+        assertThat(productDetailsSlot.captured).isEqualTo(productDetails)
+    }
+
+    @Test
+    fun `properly sets ProductDetailsParams offerToken for inapp product with offerToken`() {
+        mockkStatic(BillingFlowParams::class)
+        mockkStatic(ProductDetailsParams::class)
+
+        val mockProductDetailsBuilder = mockk<ProductDetailsParams.Builder>(relaxed = true)
+        every {
+            ProductDetailsParams.newBuilder()
+        } returns mockProductDetailsBuilder
+
+        val tokenSlot = slot<String>()
+        every {
+            mockProductDetailsBuilder.setOfferToken(capture(tokenSlot))
+        } returns mockProductDetailsBuilder
+
+        val productDetailsSlot = slot<ProductDetails>()
+        every {
+            mockProductDetailsBuilder.setProductDetails(capture(productDetailsSlot))
+        } returns mockProductDetailsBuilder
+
+        val productId = "product_a"
+        val offerToken = "mock_inapp_offer_token"
+
+        val productDetails = mockProductDetails(
+            productId = productId,
+            type = inAppGoogleProductType,
+            oneTimePurchaseOfferDetails = mockOneTimePurchaseOfferDetails(offerTokenProvided = offerToken),
+            subscriptionOfferDetails = null
+        )
+        val purchasingData = GooglePurchasingData.InAppProduct(
+            productId = productId,
+            productDetails = productDetails,
+            selectedOfferToken = offerToken
+        )
+
+        every {
+            mockClient.launchBillingFlow(eq(mockActivity), any())
+        } answers {
+            billingClientOKResult
         }
 
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
+        wrapper.makePurchaseAsync(
+            mockActivity,
+            appUserId,
+            purchasingData,
+            null,
+            null,
+        )
+
+        assertThat(tokenSlot.isCaptured).isTrue
+        assertThat(tokenSlot.captured).isEqualTo(offerToken)
         assertThat(productDetailsSlot.isCaptured).isTrue
         assertThat(productDetailsSlot.captured).isEqualTo(productDetails)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/GoogleOneTimePurchaseOfferDetailsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/GoogleOneTimePurchaseOfferDetailsTest.kt
@@ -1,0 +1,126 @@
+package com.revenuecat.purchases.google
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.models.GoogleOneTimePurchaseOfferDetails
+import com.revenuecat.purchases.models.GooglePurchasingData
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.utils.mockProductDetails
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GoogleOneTimePurchaseOfferDetailsTest {
+
+    private val productId = "product-id"
+    private val offerId = "offer-id"
+    private val offerToken = "mock-offer-token"
+    private val price = Price(
+        formatted = "$4.99",
+        amountMicros = 4990000,
+        currencyCode = "USD"
+    )
+
+    @Test
+    fun `GoogleOneTimePurchaseOfferDetails stores properties correctly`() {
+        val productDetails = mockProductDetails()
+        val presentedOfferingContext = PresentedOfferingContext("offering_a")
+
+        val offerDetails = GoogleOneTimePurchaseOfferDetails(
+            productId = productId,
+            price = price,
+            offerId = offerId,
+            offerToken = offerToken,
+            offerTags = listOf("tag1", "tag2"),
+            productDetails = productDetails,
+            presentedOfferingContext = presentedOfferingContext
+        )
+
+        assertThat(offerDetails.productId).isEqualTo(productId)
+        assertThat(offerDetails.price).isEqualTo(price)
+        assertThat(offerDetails.offerId).isEqualTo(offerId)
+        assertThat(offerDetails.offerToken).isEqualTo(offerToken)
+        assertThat(offerDetails.offerTags).containsExactly("tag1", "tag2")
+        assertThat(offerDetails.productDetails).isEqualTo(productDetails)
+        assertThat(offerDetails.presentedOfferingContext).isEqualTo(presentedOfferingContext)
+        assertThat(offerDetails.presentedOfferingContext?.offeringIdentifier).isEqualTo("offering_a")
+    }
+
+    @Test
+    fun `GoogleOneTimePurchaseOfferDetails purchasingData returns GooglePurchasingData InAppProduct with selectedOfferToken`() {
+        val productDetails = mockProductDetails()
+        val offerDetails = GoogleOneTimePurchaseOfferDetails(
+            productId = productId,
+            price = price,
+            offerId = offerId,
+            offerToken = offerToken,
+            offerTags = emptyList(),
+            productDetails = productDetails,
+            presentedOfferingContext = null
+        )
+
+        val purchasingData = offerDetails.purchasingData
+        assertThat(purchasingData).isInstanceOf(GooglePurchasingData.InAppProduct::class.java)
+        val inAppPurchasingData = purchasingData as GooglePurchasingData.InAppProduct
+        assertThat(inAppPurchasingData.productId).isEqualTo(productId)
+        assertThat(inAppPurchasingData.productDetails).isEqualTo(productDetails)
+        assertThat(inAppPurchasingData.selectedOfferToken).isEqualTo(offerToken)
+    }
+
+    @Test
+    fun `GoogleOneTimePurchaseOfferDetails internal copy constructor updates presentedOfferingContext`() {
+        val productDetails = mockProductDetails()
+        val initialContext = PresentedOfferingContext("offering_a")
+        val newContext = PresentedOfferingContext("offering_b")
+
+        val original = GoogleOneTimePurchaseOfferDetails(
+            productId = productId,
+            price = price,
+            offerId = offerId,
+            offerToken = offerToken,
+            offerTags = listOf("tag1"),
+            productDetails = productDetails,
+            presentedOfferingContext = initialContext
+        )
+
+        val copy = GoogleOneTimePurchaseOfferDetails(original, newContext)
+
+        assertThat(copy.productId).isEqualTo(productId)
+        assertThat(copy.price).isEqualTo(price)
+        assertThat(copy.offerId).isEqualTo(offerId)
+        assertThat(copy.offerToken).isEqualTo(offerToken)
+        assertThat(copy.offerTags).containsExactly("tag1")
+        assertThat(copy.productDetails).isEqualTo(productDetails)
+        assertThat(copy.presentedOfferingContext).isEqualTo(newContext)
+        assertThat(copy.presentedOfferingContext?.offeringIdentifier).isEqualTo("offering_b")
+    }
+
+    @Test
+    fun `Two GoogleOneTimePurchaseOfferDetails with same properties are equal and have same hashCode`() {
+        val productDetails = mockProductDetails()
+
+        val offer1 = GoogleOneTimePurchaseOfferDetails(
+            productId = productId,
+            price = price,
+            offerId = offerId,
+            offerToken = offerToken,
+            offerTags = listOf("tag1"),
+            productDetails = productDetails,
+            presentedOfferingContext = null
+        )
+
+        val offer2 = GoogleOneTimePurchaseOfferDetails(
+            productId = productId,
+            price = price,
+            offerId = offerId,
+            offerToken = offerToken,
+            offerTags = listOf("tag1"),
+            productDetails = productDetails,
+            presentedOfferingContext = null
+        )
+
+        assertThat(offer1).isEqualTo(offer2)
+        assertThat(offer1.hashCode()).isEqualTo(offer2.hashCode())
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/google/OneTimePurchaseOfferDetailsListTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/OneTimePurchaseOfferDetailsListTest.kt
@@ -1,10 +1,12 @@
 package com.revenuecat.purchases.google
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.models.GoogleOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.models.OneTimePurchaseOfferDetailsList
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.utils.mockProductDetails
+import io.mockk.mockk
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -87,6 +89,35 @@ class OneTimePurchaseOfferDetailsListTest {
         assertThat(list.withTag("tagA")).containsExactly(offerWithTagA, offerWithBoth)
         assertThat(list.withTag("tagB")).containsExactly(offerWithTagB, offerWithBoth)
         assertThat(list.withTag("nonexistent")).isEmpty()
+    }
+
+    @Test
+    fun `basePlan returns offer detail with null discountDisplayInfo`() {
+        val discountInfo = mockk<ProductDetails.OneTimePurchaseOfferDetails.DiscountDisplayInfo>()
+        val discountedOffer = GoogleOneTimePurchaseOfferDetails(
+            productId = productId,
+            price = Price(formatted = "$2.99", amountMicros = 2990000, currencyCode = "USD"),
+            offerId = "discounted",
+            offerToken = "token-discounted",
+            offerTags = emptyList(),
+            discountDisplayInfo = discountInfo,
+            productDetails = mockProductDetails(),
+            presentedOfferingContext = null
+        )
+        val basePlanOffer = GoogleOneTimePurchaseOfferDetails(
+            productId = productId,
+            price = Price(formatted = "$4.99", amountMicros = 4990000, currencyCode = "USD"),
+            offerId = null,
+            offerToken = "token-base",
+            offerTags = emptyList(),
+            discountDisplayInfo = null,
+            productDetails = mockProductDetails(),
+            presentedOfferingContext = null
+        )
+
+        val list = OneTimePurchaseOfferDetailsList(listOf(discountedOffer, basePlanOffer))
+
+        assertThat(list.basePlan).isEqualTo(basePlanOffer)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/google/OneTimePurchaseOfferDetailsListTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/OneTimePurchaseOfferDetailsListTest.kt
@@ -1,0 +1,103 @@
+package com.revenuecat.purchases.google
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.models.GoogleOneTimePurchaseOfferDetails
+import com.revenuecat.purchases.models.OneTimePurchaseOfferDetailsList
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.utils.mockProductDetails
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OneTimePurchaseOfferDetailsListTest {
+
+    private val productId = "product-id"
+
+    private fun createOffer(
+        offerId: String,
+        amountMicros: Long,
+        tags: List<String> = emptyList()
+    ) = GoogleOneTimePurchaseOfferDetails(
+        productId = productId,
+        price = Price(formatted = "$$amountMicros", amountMicros = amountMicros, currencyCode = "USD"),
+        offerId = offerId,
+        offerToken = "token-$offerId",
+        offerTags = tags,
+        productDetails = mockProductDetails(),
+        presentedOfferingContext = null
+    )
+
+    @Test
+    fun `defaultOffer selects cheapest offer`() {
+        val expensiveOffer = createOffer("expensive", 9990000)
+        val cheapestOffer = createOffer("cheapest", 1990000)
+        val midOffer = createOffer("mid", 4990000)
+
+        val list = OneTimePurchaseOfferDetailsList(listOf(expensiveOffer, cheapestOffer, midOffer))
+
+        assertThat(list.defaultOffer).isEqualTo(cheapestOffer)
+    }
+
+    @Test
+    fun `defaultOffer filters out rc-ignore-offer tag`() {
+        val cheapIgnoredOffer = createOffer("cheap-ignored", 1990000, listOf("rc-ignore-offer"))
+        val validOffer = createOffer("valid", 4990000)
+
+        val list = OneTimePurchaseOfferDetailsList(listOf(cheapIgnoredOffer, validOffer))
+
+        assertThat(list.defaultOffer).isEqualTo(validOffer)
+    }
+
+    @Test
+    fun `defaultOffer filters out rc-customer-center tag`() {
+        val cheapCustomerCenterOffer = createOffer("cheap-cc", 1990000, listOf("rc-customer-center"))
+        val validOffer = createOffer("valid", 4990000)
+
+        val list = OneTimePurchaseOfferDetailsList(listOf(cheapCustomerCenterOffer, validOffer))
+
+        assertThat(list.defaultOffer).isEqualTo(validOffer)
+    }
+
+    @Test
+    fun `defaultOffer returns null when all offers are ignored`() {
+        val ignoredOffer1 = createOffer("ignored-1", 1990000, listOf("rc-ignore-offer"))
+        val ignoredOffer2 = createOffer("ignored-2", 4990000, listOf("rc-customer-center"))
+
+        val list = OneTimePurchaseOfferDetailsList(listOf(ignoredOffer1, ignoredOffer2))
+
+        assertThat(list.defaultOffer).isNull()
+    }
+
+    @Test
+    fun `defaultOffer returns null for empty list`() {
+        val list = OneTimePurchaseOfferDetailsList(emptyList())
+
+        assertThat(list.defaultOffer).isNull()
+    }
+
+    @Test
+    fun `withTag filters offers correctly`() {
+        val offerWithTagA = createOffer("offer-a", 1990000, listOf("promo", "tagA"))
+        val offerWithTagB = createOffer("offer-b", 4990000, listOf("tagB"))
+        val offerWithBoth = createOffer("offer-c", 9990000, listOf("tagA", "tagB"))
+
+        val list = OneTimePurchaseOfferDetailsList(listOf(offerWithTagA, offerWithTagB, offerWithBoth))
+
+        assertThat(list.withTag("tagA")).containsExactly(offerWithTagA, offerWithBoth)
+        assertThat(list.withTag("tagB")).containsExactly(offerWithTagB, offerWithBoth)
+        assertThat(list.withTag("nonexistent")).isEmpty()
+    }
+
+    @Test
+    fun `equals and hashCode work as expected`() {
+        val offer1 = createOffer("offer-1", 1990000)
+        val offer2 = createOffer("offer-2", 4990000)
+
+        val list1 = OneTimePurchaseOfferDetailsList(listOf(offer1, offer2))
+        val list2 = OneTimePurchaseOfferDetailsList(listOf(offer1, offer2))
+
+        assertThat(list1).isEqualTo(list2)
+        assertThat(list1.hashCode()).isEqualTo(list2.hashCode())
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/google/OneTimePurchaseOfferDetailsListTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/OneTimePurchaseOfferDetailsListTest.kt
@@ -1,12 +1,11 @@
 package com.revenuecat.purchases.google
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.billingclient.api.ProductDetails
+import com.revenuecat.purchases.models.GoogleDiscountDisplayInfo
 import com.revenuecat.purchases.models.GoogleOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.models.OneTimePurchaseOfferDetailsList
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.utils.mockProductDetails
-import io.mockk.mockk
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -93,7 +92,7 @@ class OneTimePurchaseOfferDetailsListTest {
 
     @Test
     fun `basePlan returns offer detail with null discountDisplayInfo`() {
-        val discountInfo = mockk<ProductDetails.OneTimePurchaseOfferDetails.DiscountDisplayInfo>()
+        val discountInfo = GoogleDiscountDisplayInfo(percentageDiscount = 20)
         val discountedOffer = GoogleOneTimePurchaseOfferDetails(
             productId = productId,
             price = Price(formatted = "$2.99", amountMicros = 2990000, currencyCode = "USD"),

--- a/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductConversionsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductConversionsTest.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.utils.mockOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.utils.mockPricingPhase
 import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.mockSubscriptionOfferDetails
+import io.mockk.every
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -56,6 +57,25 @@ class StoreProductConversionsTest {
         assertThat(googleStoreProduct?.oneTimePurchaseOfferDetailsList).isNotNull
         assertThat(googleStoreProduct?.defaultOneTimeOffer).isNotNull
         assertThat(googleStoreProduct?.defaultOneTimeOffer?.offerToken).isEqualTo("mock-offer-token")
+    }
+
+    @Test
+    fun `INAPP ProductDetails with null singular oneTimePurchaseOfferDetails but valid oneTimePurchaseOfferDetailsList maps to StoreProduct`() {
+        val offerDetails = mockOneTimePurchaseOfferDetails(price = 4.99, offerTokenProvided = "list-token")
+        val productDetail1 = mockProductDetails(
+            productId = "iap_1",
+            type = BillingClient.ProductType.INAPP,
+            oneTimePurchaseOfferDetails = null,
+            subscriptionOfferDetails = null
+        ).apply {
+            every { oneTimePurchaseOfferDetailsList } returns listOf(offerDetails)
+        }
+
+        val storeProducts = listOf(productDetail1).toStoreProducts()
+        assertThat(storeProducts.size).isEqualTo(1)
+        val storeProduct = storeProducts.first()
+        assertThat(storeProduct.price.amountMicros).isEqualTo(4990000)
+        assertThat(storeProduct.googleProduct?.defaultOneTimeOffer?.offerToken).isEqualTo("list-token")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductConversionsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductConversionsTest.kt
@@ -40,6 +40,25 @@ class StoreProductConversionsTest {
     }
 
     @Test
+    fun `list of INAPP ProductDetails with oneTimePurchaseOfferDetails maps defaultOneTimeOffer and oneTimePurchaseOfferDetailsList`() {
+        val offerDetails = mockOneTimePurchaseOfferDetails(offerTokenProvided = "mock-offer-token")
+        val productDetail1 = mockProductDetails(
+            productId = "iap_1",
+            type = BillingClient.ProductType.INAPP,
+            oneTimePurchaseOfferDetails = offerDetails,
+            subscriptionOfferDetails = null
+        )
+
+        val storeProducts = listOf(productDetail1).toStoreProducts()
+        assertThat(storeProducts.size).isEqualTo(1)
+        val googleStoreProduct = storeProducts.first().googleProduct
+        assertThat(googleStoreProduct).isNotNull
+        assertThat(googleStoreProduct?.oneTimePurchaseOfferDetailsList).isNotNull
+        assertThat(googleStoreProduct?.defaultOneTimeOffer).isNotNull
+        assertThat(googleStoreProduct?.defaultOneTimeOffer?.offerToken).isEqualTo("mock-offer-token")
+    }
+
+    @Test
     fun `list of SUBS ProductDetails maps to StoreProducts`() {
         val productDetail1 = mockProductDetails(productId = "sub_1", type = BillingClient.ProductType.SUBS)
         val productDetails = listOf(productDetail1)

--- a/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -1,9 +1,12 @@
 package com.revenuecat.purchases.google
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.models.GoogleOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
+import com.revenuecat.purchases.models.OneTimePurchaseOfferDetailsList
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
@@ -412,5 +415,81 @@ class StoreProductTest {
             productDetails = productDetails,
             presentedOfferingIdentifier = "originalOfferingId"
         )
+    }
+
+    @Test
+    fun `GoogleStoreProduct INAPP with defaultOneTimeOffer uses defaultOneTimeOffer purchasingData`() {
+        val productDetails = mockProductDetails()
+        val price = Price(formatted = "$1.00", amountMicros = 1_000_000, currencyCode = "USD")
+        val offerDetails = GoogleOneTimePurchaseOfferDetails(
+            productId = "product_id",
+            price = price,
+            offerId = "offer_id",
+            offerToken = "offer_token",
+            offerTags = emptyList(),
+            productDetails = productDetails,
+            presentedOfferingContext = null
+        )
+
+        val storeProduct = GoogleStoreProduct(
+            productId = "product_id",
+            basePlanId = null,
+            type = ProductType.INAPP,
+            price = price,
+            name = "TITLE",
+            title = "TITLE (App name)",
+            description = "DESCRIPTION",
+            period = null,
+            subscriptionOptions = null,
+            defaultOption = null,
+            productDetails = productDetails,
+            presentedOfferingContext = null,
+            oneTimePurchaseOfferDetailsList = OneTimePurchaseOfferDetailsList(listOf(offerDetails)),
+            defaultOneTimeOffer = offerDetails
+        )
+
+        assertThat(storeProduct.defaultOneTimeOffer).isEqualTo(offerDetails)
+        assertThat(storeProduct.purchasingData).isEqualTo(offerDetails.purchasingData)
+    }
+
+    @Test
+    fun `copyWithOfferingId applies offeringId to defaultOneTimeOffer and oneTimePurchaseOfferDetailsList`() {
+        val productDetails = mockProductDetails()
+        val price = Price(formatted = "$1.00", amountMicros = 1_000_000, currencyCode = "USD")
+        val offerDetails = GoogleOneTimePurchaseOfferDetails(
+            productId = "product_id",
+            price = price,
+            offerId = "offer_id",
+            offerToken = "offer_token",
+            offerTags = emptyList(),
+            productDetails = productDetails,
+            presentedOfferingContext = null
+        )
+
+        val storeProduct = GoogleStoreProduct(
+            productId = "product_id",
+            basePlanId = null,
+            type = ProductType.INAPP,
+            price = price,
+            name = "TITLE",
+            title = "TITLE (App name)",
+            description = "DESCRIPTION",
+            period = null,
+            subscriptionOptions = null,
+            defaultOption = null,
+            productDetails = productDetails,
+            presentedOfferingContext = PresentedOfferingContext("originalOfferingId"),
+            oneTimePurchaseOfferDetailsList = OneTimePurchaseOfferDetailsList(listOf(offerDetails)),
+            defaultOneTimeOffer = offerDetails
+        )
+
+        val expectedOfferingId = "expectedOfferingId"
+        val copiedProduct = storeProduct.copyWithOfferingId(expectedOfferingId) as GoogleStoreProduct
+
+        assertThat(copiedProduct.presentedOfferingContext?.offeringIdentifier).isEqualTo(expectedOfferingId)
+        assertThat(copiedProduct.defaultOneTimeOffer?.presentedOfferingContext?.offeringIdentifier).isEqualTo(expectedOfferingId)
+        copiedProduct.oneTimePurchaseOfferDetailsList?.forEach {
+            assertThat(it.presentedOfferingContext?.offeringIdentifier).isEqualTo(expectedOfferingId)
+        }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubs.kt
@@ -41,6 +41,7 @@ fun mockProductDetails(
     every { getDescription() } returns description
     every { getTitle() } returns title
     every { getOneTimePurchaseOfferDetails() } returns oneTimePurchaseOfferDetails
+    every { oneTimePurchaseOfferDetailsList } returns oneTimePurchaseOfferDetails?.let { listOf(it) }
     every { getSubscriptionOfferDetails() } returns subscriptionOfferDetails
     every { zza() } returns "mock-package-name" // This seems to return the packageName property from the response json
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubsBcDependent.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubsBcDependent.kt
@@ -13,6 +13,7 @@ fun mockOneTimePurchaseOfferDetails(
     offerTokenProvided: String = "mockOfferToken",
     offerIdProvided: String? = null,
     offerTagsProvided: List<String>? = emptyList(),
+    discountDisplayInfoProvided: OneTimePurchaseOfferDetails.DiscountDisplayInfo? = null,
 ): OneTimePurchaseOfferDetails = mockk<OneTimePurchaseOfferDetails>().apply {
     every { formattedPrice } returns "${'$'}$price"
     every { priceAmountMicros } returns price.times(1_000_000).toLong()
@@ -20,4 +21,5 @@ fun mockOneTimePurchaseOfferDetails(
     every { offerToken } returns offerTokenProvided
     every { offerId } returns offerIdProvided
     every { offerTags } returns offerTagsProvided
+    every { discountDisplayInfo } returns discountDisplayInfoProvided
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubsBcDependent.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubsBcDependent.kt
@@ -11,9 +11,13 @@ fun mockOneTimePurchaseOfferDetails(
     price: Double = 4.99,
     priceCurrencyCodeValue: String = "USD",
     offerTokenProvided: String = "mockOfferToken",
+    offerIdProvided: String? = null,
+    offerTagsProvided: List<String>? = emptyList(),
 ): OneTimePurchaseOfferDetails = mockk<OneTimePurchaseOfferDetails>().apply {
     every { formattedPrice } returns "${'$'}$price"
     every { priceAmountMicros } returns price.times(1_000_000).toLong()
     every { priceCurrencyCode } returns priceCurrencyCodeValue
     every { offerToken } returns offerTokenProvided
+    every { offerId } returns offerIdProvided
+    every { offerTags } returns offerTagsProvided
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Google Play Billing supports offers and discounts for one-time (INAPP) products. This PR introduces support for retrieving, selecting, and purchasing one-time product offers in `purchases-android`, following the established architecture of subscription options (`SubscriptionOptions` / `SubscriptionOption`).

Developers can now either allow the SDK to automatically purchase the cheapest default offer or explicitly specify a target `OneTimePurchaseOfferDetails` when initiating a purchase via `PurchaseParams.Builder`.

Resolves #4136

### Description
- **One-Time Offer Modeling (`OneTimePurchaseOfferDetails`)**: Created the `OneTimePurchaseOfferDetails` interface and `GoogleOneTimePurchaseOfferDetails` class to model one-time offer metadata (price, offer ID, offer token, offer tags, product details, and presented offering context).
- **`OneTimePurchaseOfferDetailsList` & Default Offer Selection**: Introduced `OneTimePurchaseOfferDetailsList` (mirroring `SubscriptionOptions`). Automatically computes `defaultOffer` by picking the cheapest offer (`price.amountMicros`) while filtering out offers tagged with `"rc-ignore-offer"` and `"rc-customer-center"`.
- **`StoreProduct` Integration**: Exposed `oneTimePurchaseOfferDetailsList` and `defaultOneTimeOffer` on `StoreProduct` and `GoogleStoreProduct` with `null` default values for backward compatibility. `GoogleStoreProduct` delegates purchasing data to `defaultOneTimeOffer.purchasingData` for in-app products when an offer exists.
- **Explicit Offer Selection via `PurchaseParams`**: Added `PurchaseParams.Builder(activity, OneTimePurchaseOfferDetails)` constructor overload, allowing developers to target a specific one-time purchase offer.
- **Billing Flow Integration**: Updated `GooglePurchasingData.InAppProduct` to carry `selectedOfferToken` and updated `BillingWrapper` to set `offerToken` on `ProductDetailsParams` when launching the Google Play Billing flow.
- **Unit Tests**: Added comprehensive unit test coverage in `GoogleOneTimePurchaseOfferDetailsTest`, `OneTimePurchaseOfferDetailsListTest`, `StoreProductTest`, `PurchaseParamsTest`, `BillingWrapperTest`, and `StoreProductConversionsTest`.

#### How Has This Been Tested?
Executed `:purchases:testDefaultsDebugUnitTest` in Android Studio verifying property mapping, default offer price comparison, tag filtering, explicit offer purchasing data delegation, and billing flow parameters setup..

### Follow-up work

This implementation is Android-specific. Follow-up work will be required
for hybrid SDKs and Flutter:

- `purchases-flutter`
- `purchases-hybrid-common`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Google Play purchase parameter construction and default INAPP purchasing when offers exist, which can affect which price/token is charged even though APIs remain backward compatible.
> 
> **Overview**
> Adds **one-time (INAPP) offer** support on Android, modeled like subscription options: new `OneTimePurchaseOfferDetails` / `GoogleOneTimePurchaseOfferDetails`, `OneTimePurchaseOfferDetailsList` (cheapest `defaultOffer`, tag filtering, `basePlan`), and discount display types.
> 
> **Store products** now expose `oneTimePurchaseOfferDetailsList` and `defaultOneTimeOffer`; INAPP `ProductDetails` conversion reads both singular and list billing offer APIs. **`GoogleStoreProduct.purchasingData`** uses the default one-time offer (including offer token) when present.
> 
> Developers can target a specific offer via **`PurchaseParams.Builder(activity, OneTimePurchaseOfferDetails)`**. **`BillingWrapper`** passes `selectedOfferToken` into `ProductDetailsParams` for the billing flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906c7c42a26e8c8fa9b9d53245bdab4fbdcd8202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->