### PR TITLE
fix: Apply the video source to the view when the appearance changes

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoView.kt
@@ -392,6 +392,13 @@ private fun Video(
         mutableStateOf<TextureVideoView?>(null)
     }
 
+    // The uri the view was last given. The factory runs once, so a source change while the paywall
+    // is on screen (a light/dark switch, for instance) has to be applied to the existing view or it
+    // keeps playing the previous asset.
+    val appliedUri = remember {
+        mutableStateOf<String?>(null)
+    }
+
     // To guarantee autoplay starts on view creation
     // The code in the factory is not as reliable for view creation but better
     // for rotation
@@ -430,6 +437,8 @@ private fun Video(
                     autoPlay
                 }
 
+                // Recorded before the shadowing below, so the guard in `update` compares like for like.
+                appliedUri.value = videoUri
                 val videoUri = videoUri.toUri()
 
                 TextureVideoView(
@@ -458,6 +467,12 @@ private fun Video(
             update = { view ->
                 videoView.value = view
                 view.setOnReadyCallback(onReady)
+                // Guarded: update runs on every recomposition, and setVideoURI re-prepares the
+                // player, so applying it unconditionally would restart playback constantly.
+                if (appliedUri.value != videoUri) {
+                    appliedUri.value = videoUri
+                    view.setVideoURI(videoUri.toUri())
+                }
             },
             onRelease = { view ->
                 // Capture playback state BEFORE releasing

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoView.kt
@@ -392,9 +392,7 @@ private fun Video(
         mutableStateOf<TextureVideoView?>(null)
     }
 
-    // The uri the view was last given. The factory runs once, so a source change while the paywall
-    // is on screen (a light/dark switch, for instance) has to be applied to the existing view or it
-    // keeps playing the previous asset.
+    // The uri the view was last given. The factory only applies it on creation.
     val appliedUri = remember {
         mutableStateOf<String?>(null)
     }
@@ -437,7 +435,7 @@ private fun Video(
                     autoPlay
                 }
 
-                // Recorded before the shadowing below, so the guard in `update` compares like for like.
+                // Set before the shadowing below, so the guard compares the same string.
                 appliedUri.value = videoUri
                 val videoUri = videoUri.toUri()
 
@@ -467,8 +465,8 @@ private fun Video(
             update = { view ->
                 videoView.value = view
                 view.setOnReadyCallback(onReady)
-                // Guarded: update runs on every recomposition, and setVideoURI re-prepares the
-                // player, so applying it unconditionally would restart playback constantly.
+                // update runs on every recomposition and setVideoURI re-prepares the player, so
+                // applying it unconditionally would restart playback constantly.
                 if (appliedUri.value != videoUri) {
                     appliedUri.value = videoUri
                     view.setVideoURI(videoUri.toUri())


### PR DESCRIPTION
Switching light / dark while a paywall is on screen left the video showing the previous appearance's asset, while every other component updated. iOS equivalent: #7569, [PW-1351](https://linear.app/revenuecat/issue/PW-1351/fix-video-component-appearance-switching-on-screen).

Verified on an emulator against distinct light and dark assets, alongside a control run with the fix removed where the video never changes. This was only visible when the screen hosting the paywall survives the theme change. Android usually rebuilds it, which loads the correct asset anyway.

Video after fix:
https://github.com/user-attachments/assets/0efc7d09-3026-459f-8bb0-2bee0c513cb2



<details>
<summary>AI session context</summary>

## Metadata

- Branch: `facu/fix-video-theme-toggle-android`, off `origin/main` `e57f48b15`
- Human owner: @facumenzella
- Agents: Claude Opus 5 (Claude Code)
- Generated: 2026-09-02

## Goal

Port the iOS video appearance fix (#7569) to Android.

## Key Implementation Decisions

- Apply the new uri to the existing view rather than keying it for recreation. `setVideoURI` already resets `prepared` and `firstFrameRendered`, mirroring iOS's `FileImageLoader.updateURL`.
- Guard on the last applied uri, or `update` would restart playback on every recomposition.

## Corrections Made During The Session

- An earlier read concluded Android was unaffected, based on the state layer resolving correctly. Wrong: the resolved uri never reached the player.
- The first reproduction showed nothing, because the theme flip recreated the Activity and dismissed the paywall.

## Validation

- `./gradlew detektAll :ui:revenuecatui:testDefaultsDebugUnitTest --tests '*video*'`: BUILD SUCCESSFUL, re-run after the final edit.
- Manual: Pixel 9a, Android 16, `adb shell cmd uimode night yes|no`, in a temporary local sample. Recording plus a control run with the fix removed.
- CI: not run at the time of writing.

## Validation Gaps

- Reproduced in a temporary local sample with `configChanges="uiMode"` added to the tester. Emulator only. No automated test for the view wiring.

## Review Focus

- Should a swapped asset preserve playback position, or start fresh? Today the saved-state map is keyed per uri, so it starts fresh.
- The guard keys on the uri string. iOS widened to the whole resolved asset because light and dark can share a url but differ in checksum; `rememberSaveable` and `LaunchedEffect` here still key on `videoUrls.url` alone, so that gap remains.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Compose/AndroidView wiring in the revenue UI video component; guarded URI updates limit blast radius beyond theme or asset URL changes.
> 
> **Overview**
> Fixes paywall videos staying on the light/dark asset after an in-place theme switch when the hosting screen is not recreated.
> 
> The `AndroidView` factory only sets the source once, so a changed `videoUri` from appearance resolution never reached the player. **`appliedUri`** tracks the last string applied to the view; the **`update`** block calls **`setVideoURI`** only when that string differs, so theme-driven asset swaps reload without re-keying the view.
> 
> The guard avoids calling **`setVideoURI`** on every recomposition, which would re-prepare the player and restart playback. The factory seeds **`appliedUri`** before the local **`toUri()`** shadowing so the guard compares the same string form as **`update`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a34c9e338f3406f62f13c904b8af5fcb735e1e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->