### PR TITLE
feat(paywalls): Add onInteraction to PaywallListener

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallListenerAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallListenerAPI.java
@@ -6,8 +6,13 @@ import com.revenuecat.purchases.CustomerInfo;
 import com.revenuecat.purchases.Package;
 import com.revenuecat.purchases.PurchasesError;
 import com.revenuecat.purchases.models.StoreTransaction;
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent;
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener;
 import com.revenuecat.purchases.ui.revenuecatui.utils.Resumable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings({"unused", "FieldCanBeLocal"})
 final class PaywallListenerAPI {
@@ -45,7 +50,57 @@ final class PaywallListenerAPI {
 
             @Override
             public void onUrlOpened(@NonNull String url) {}
+
+            @Override
+            public void onInteraction(@NonNull PaywallInteractionEvent event) {
+                Map<String, Object> rawProperties = event.getRawProperties();
+                String string = event.getProperty(PaywallInteractionEvent.Keys.COMPONENT_TYPE);
+                Integer integer = event.getProperty(PaywallInteractionEvent.Keys.ORIGIN_INDEX);
+                Long longValue = event.getProperty(PaywallInteractionEvent.Keys.TIMESTAMP);
+                Boolean bool = event.getProperty(PaywallInteractionEvent.Keys.DARK_MODE);
+                String name = PaywallInteractionEvent.Keys.COMPONENT_TYPE.getName();
+            }
         };
+
+        List<PaywallInteractionEvent.Key<?>> keys = Arrays.asList(
+                PaywallInteractionEvent.Keys.TIMESTAMP,
+                PaywallInteractionEvent.Keys.SESSION_ID,
+                PaywallInteractionEvent.Keys.OFFERING_ID,
+                PaywallInteractionEvent.Keys.PAYWALL_ID,
+                PaywallInteractionEvent.Keys.PAYWALL_REVISION,
+                PaywallInteractionEvent.Keys.DISPLAY_MODE,
+                PaywallInteractionEvent.Keys.DARK_MODE,
+                PaywallInteractionEvent.Keys.LOCALE,
+                PaywallInteractionEvent.Keys.COMPONENT_TYPE,
+                PaywallInteractionEvent.Keys.COMPONENT_VALUE,
+                PaywallInteractionEvent.Keys.COMPONENT_NAME,
+                PaywallInteractionEvent.Keys.COMPONENT_URL,
+                PaywallInteractionEvent.Keys.ORIGIN_INDEX,
+                PaywallInteractionEvent.Keys.DESTINATION_INDEX,
+                PaywallInteractionEvent.Keys.ORIGIN_CONTEXT_NAME,
+                PaywallInteractionEvent.Keys.DESTINATION_CONTEXT_NAME,
+                PaywallInteractionEvent.Keys.DEFAULT_INDEX,
+                PaywallInteractionEvent.Keys.ORIGIN_PACKAGE_ID,
+                PaywallInteractionEvent.Keys.DESTINATION_PACKAGE_ID,
+                PaywallInteractionEvent.Keys.DEFAULT_PACKAGE_ID,
+                PaywallInteractionEvent.Keys.CURRENT_PACKAGE_ID,
+                PaywallInteractionEvent.Keys.RESULTING_PACKAGE_ID,
+                PaywallInteractionEvent.Keys.ORIGIN_PRODUCT_ID,
+                PaywallInteractionEvent.Keys.DESTINATION_PRODUCT_ID,
+                PaywallInteractionEvent.Keys.DEFAULT_PRODUCT_ID,
+                PaywallInteractionEvent.Keys.CURRENT_PRODUCT_ID,
+                PaywallInteractionEvent.Keys.RESULTING_PRODUCT_ID
+        );
+        List<String> componentTypes = Arrays.asList(
+                PaywallInteractionEvent.ComponentTypes.TAB,
+                PaywallInteractionEvent.ComponentTypes.SWITCH,
+                PaywallInteractionEvent.ComponentTypes.CAROUSEL,
+                PaywallInteractionEvent.ComponentTypes.BUTTON,
+                PaywallInteractionEvent.ComponentTypes.TEXT,
+                PaywallInteractionEvent.ComponentTypes.PACKAGE,
+                PaywallInteractionEvent.ComponentTypes.PACKAGE_SELECTION_SHEET,
+                PaywallInteractionEvent.ComponentTypes.PURCHASE_BUTTON
+        );
 
         // Only compiles with -Xjvm-default=all-compatibility; guards against method additions
         // becoming source-breaking for Java implementors.

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallListenerAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallListenerAPI.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.utils.Resumable
 
@@ -32,6 +33,55 @@ private class PaywallListenerAPI {
             override fun onWebCheckoutOpened() {}
 
             override fun onUrlOpened(url: String) {}
+
+            override fun onInteraction(event: PaywallInteractionEvent) {
+                val rawProperties: Map<String, Any> = event.rawProperties
+                val string: String? = event.getProperty(PaywallInteractionEvent.Keys.COMPONENT_TYPE)
+                val int: Int? = event.getProperty(PaywallInteractionEvent.Keys.ORIGIN_INDEX)
+                val long: Long? = event.getProperty(PaywallInteractionEvent.Keys.TIMESTAMP)
+                val boolean: Boolean? = event.getProperty(PaywallInteractionEvent.Keys.DARK_MODE)
+                val name: String = PaywallInteractionEvent.Keys.COMPONENT_TYPE.name
+            }
         }
+
+        val keys: List<PaywallInteractionEvent.Key<*>> = listOf(
+            PaywallInteractionEvent.Keys.TIMESTAMP,
+            PaywallInteractionEvent.Keys.SESSION_ID,
+            PaywallInteractionEvent.Keys.OFFERING_ID,
+            PaywallInteractionEvent.Keys.PAYWALL_ID,
+            PaywallInteractionEvent.Keys.PAYWALL_REVISION,
+            PaywallInteractionEvent.Keys.DISPLAY_MODE,
+            PaywallInteractionEvent.Keys.DARK_MODE,
+            PaywallInteractionEvent.Keys.LOCALE,
+            PaywallInteractionEvent.Keys.COMPONENT_TYPE,
+            PaywallInteractionEvent.Keys.COMPONENT_VALUE,
+            PaywallInteractionEvent.Keys.COMPONENT_NAME,
+            PaywallInteractionEvent.Keys.COMPONENT_URL,
+            PaywallInteractionEvent.Keys.ORIGIN_INDEX,
+            PaywallInteractionEvent.Keys.DESTINATION_INDEX,
+            PaywallInteractionEvent.Keys.ORIGIN_CONTEXT_NAME,
+            PaywallInteractionEvent.Keys.DESTINATION_CONTEXT_NAME,
+            PaywallInteractionEvent.Keys.DEFAULT_INDEX,
+            PaywallInteractionEvent.Keys.ORIGIN_PACKAGE_ID,
+            PaywallInteractionEvent.Keys.DESTINATION_PACKAGE_ID,
+            PaywallInteractionEvent.Keys.DEFAULT_PACKAGE_ID,
+            PaywallInteractionEvent.Keys.CURRENT_PACKAGE_ID,
+            PaywallInteractionEvent.Keys.RESULTING_PACKAGE_ID,
+            PaywallInteractionEvent.Keys.ORIGIN_PRODUCT_ID,
+            PaywallInteractionEvent.Keys.DESTINATION_PRODUCT_ID,
+            PaywallInteractionEvent.Keys.DEFAULT_PRODUCT_ID,
+            PaywallInteractionEvent.Keys.CURRENT_PRODUCT_ID,
+            PaywallInteractionEvent.Keys.RESULTING_PRODUCT_ID,
+        )
+        val componentTypes: List<String> = listOf(
+            PaywallInteractionEvent.ComponentTypes.TAB,
+            PaywallInteractionEvent.ComponentTypes.SWITCH,
+            PaywallInteractionEvent.ComponentTypes.CAROUSEL,
+            PaywallInteractionEvent.ComponentTypes.BUTTON,
+            PaywallInteractionEvent.ComponentTypes.TEXT,
+            PaywallInteractionEvent.ComponentTypes.PACKAGE,
+            PaywallInteractionEvent.ComponentTypes.PACKAGE_SELECTION_SHEET,
+            PaywallInteractionEvent.ComponentTypes.PURCHASE_BUTTON,
+        )
     }
 }

--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -73,11 +73,101 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method @KotlinOnly @Deprecated @androidx.compose.runtime.Composable public static void PaywallFooter(com.revenuecat.purchases.ui.revenuecatui.PaywallOptions options, optional boolean condensed, optional kotlin.jvm.functions.Function1<androidx.compose.foundation.layout.PaddingValues,kotlin.Unit>? mainContent);
   }
 
+  public final class PaywallInteractionEvent {
+    method public <T> T? getProperty(com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<T> key);
+    method @InaccessibleFromKotlin public java.util.Map<java.lang.String,java.lang.Object> getRawProperties();
+    property public java.util.Map<java.lang.String,java.lang.Object> rawProperties;
+  }
+
+  public static final class PaywallInteractionEvent.ComponentTypes {
+    property public static String BUTTON;
+    property public static String CAROUSEL;
+    property public static String PACKAGE;
+    property public static String PACKAGE_SELECTION_SHEET;
+    property public static String PURCHASE_BUTTON;
+    property public static String SWITCH;
+    property public static String TAB;
+    property public static String TEXT;
+    field public static final String BUTTON = "button";
+    field public static final String CAROUSEL = "carousel";
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.ComponentTypes INSTANCE;
+    field public static final String PACKAGE = "package";
+    field public static final String PACKAGE_SELECTION_SHEET = "package_selection_sheet";
+    field public static final String PURCHASE_BUTTON = "purchase_button";
+    field public static final String SWITCH = "switch";
+    field public static final String TAB = "tab";
+    field public static final String TEXT = "text";
+  }
+
+  public static final class PaywallInteractionEvent.Key<T> {
+    method @InaccessibleFromKotlin public String getName();
+    property public String name;
+  }
+
+  public static final class PaywallInteractionEvent.Keys {
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> COMPONENT_NAME;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> COMPONENT_TYPE;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> COMPONENT_URL;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> COMPONENT_VALUE;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> CURRENT_PACKAGE_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> CURRENT_PRODUCT_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Boolean> DARK_MODE;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Integer> DEFAULT_INDEX;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DEFAULT_PACKAGE_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DEFAULT_PRODUCT_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DESTINATION_CONTEXT_NAME;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Integer> DESTINATION_INDEX;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DESTINATION_PACKAGE_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DESTINATION_PRODUCT_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DISPLAY_MODE;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> LOCALE;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> OFFERING_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> ORIGIN_CONTEXT_NAME;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Integer> ORIGIN_INDEX;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> ORIGIN_PACKAGE_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> ORIGIN_PRODUCT_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> PAYWALL_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Integer> PAYWALL_REVISION;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> RESULTING_PACKAGE_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> RESULTING_PRODUCT_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> SESSION_ID;
+    property public com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Long> TIMESTAMP;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> COMPONENT_NAME;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> COMPONENT_TYPE;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> COMPONENT_URL;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> COMPONENT_VALUE;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> CURRENT_PACKAGE_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> CURRENT_PRODUCT_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Boolean> DARK_MODE;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Integer> DEFAULT_INDEX;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DEFAULT_PACKAGE_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DEFAULT_PRODUCT_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DESTINATION_CONTEXT_NAME;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Integer> DESTINATION_INDEX;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DESTINATION_PACKAGE_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DESTINATION_PRODUCT_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> DISPLAY_MODE;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Keys INSTANCE;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> LOCALE;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> OFFERING_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> ORIGIN_CONTEXT_NAME;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Integer> ORIGIN_INDEX;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> ORIGIN_PACKAGE_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> ORIGIN_PRODUCT_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> PAYWALL_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Integer> PAYWALL_REVISION;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> RESULTING_PACKAGE_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> RESULTING_PRODUCT_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.String> SESSION_ID;
+    field public static final com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Key<java.lang.Long> TIMESTAMP;
+  }
+
   public final class PaywallKt {
     method @KotlinOnly @androidx.compose.runtime.Composable public static void Paywall(com.revenuecat.purchases.ui.revenuecatui.PaywallOptions options);
   }
 
   public interface PaywallListener {
+    method public default void onInteraction(com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent event);
     method public default void onPurchaseCancelled();
     method public default void onPurchaseCompleted(com.revenuecat.purchases.CustomerInfo customerInfo, com.revenuecat.purchases.models.StoreTransaction storeTransaction);
     method public default void onPurchaseError(com.revenuecat.purchases.PurchasesError error);

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallInteractionEvent.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallInteractionEvent.kt
@@ -1,0 +1,102 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+/**
+ * A paywall control interaction, as passed to [PaywallListener.onInteraction].
+ */
+public class PaywallInteractionEvent internal constructor(
+    /** The interaction as snake_case keys ([Key.name]) for analytics SDKs; keys that do not apply are absent. */
+    public val rawProperties: Map<String, Any>,
+) {
+
+    /** The value for [key], or null when it does not apply to this interaction. */
+    public fun <T : Any> getProperty(key: Key<T>): T? =
+        rawProperties[key.name]?.takeIf(key.type::isInstance)?.let(key.type::cast)
+
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is PaywallInteractionEvent && other.rawProperties == rawProperties)
+
+    override fun hashCode(): Int = rawProperties.hashCode()
+
+    override fun toString(): String = "PaywallInteractionEvent($rawProperties)"
+
+    public class Key<T : Any> internal constructor(
+        public val name: String,
+        internal val type: Class<T>,
+    )
+
+    public object Keys {
+        /** Milliseconds since the epoch. */
+        @JvmField public val TIMESTAMP: Key<Long> = longKey("timestamp")
+
+        @JvmField public val SESSION_ID: Key<String> = stringKey("session_id")
+
+        @JvmField public val OFFERING_ID: Key<String> = stringKey("offering_id")
+
+        @JvmField public val PAYWALL_ID: Key<String> = stringKey("paywall_id")
+
+        @JvmField public val PAYWALL_REVISION: Key<Int> = intKey("paywall_revision")
+
+        @JvmField public val DISPLAY_MODE: Key<String> = stringKey("display_mode")
+
+        @JvmField public val DARK_MODE: Key<Boolean> = booleanKey("dark_mode")
+
+        @JvmField public val LOCALE: Key<String> = stringKey("locale")
+
+        @JvmField public val COMPONENT_TYPE: Key<String> = stringKey("component_type")
+
+        @JvmField public val COMPONENT_VALUE: Key<String> = stringKey("component_value")
+
+        @JvmField public val COMPONENT_NAME: Key<String> = stringKey("component_name")
+
+        @JvmField public val COMPONENT_URL: Key<String> = stringKey("component_url")
+
+        @JvmField public val ORIGIN_INDEX: Key<Int> = intKey("origin_index")
+
+        @JvmField public val DESTINATION_INDEX: Key<Int> = intKey("destination_index")
+
+        @JvmField public val ORIGIN_CONTEXT_NAME: Key<String> = stringKey("origin_context_name")
+
+        @JvmField public val DESTINATION_CONTEXT_NAME: Key<String> = stringKey("destination_context_name")
+
+        @JvmField public val DEFAULT_INDEX: Key<Int> = intKey("default_index")
+
+        @JvmField public val ORIGIN_PACKAGE_ID: Key<String> = stringKey("origin_package_id")
+
+        @JvmField public val DESTINATION_PACKAGE_ID: Key<String> = stringKey("destination_package_id")
+
+        @JvmField public val DEFAULT_PACKAGE_ID: Key<String> = stringKey("default_package_id")
+
+        @JvmField public val CURRENT_PACKAGE_ID: Key<String> = stringKey("current_package_id")
+
+        @JvmField public val RESULTING_PACKAGE_ID: Key<String> = stringKey("resulting_package_id")
+
+        @JvmField public val ORIGIN_PRODUCT_ID: Key<String> = stringKey("origin_product_id")
+
+        @JvmField public val DESTINATION_PRODUCT_ID: Key<String> = stringKey("destination_product_id")
+
+        @JvmField public val DEFAULT_PRODUCT_ID: Key<String> = stringKey("default_product_id")
+
+        @JvmField public val CURRENT_PRODUCT_ID: Key<String> = stringKey("current_product_id")
+
+        @JvmField public val RESULTING_PRODUCT_ID: Key<String> = stringKey("resulting_product_id")
+
+        private fun stringKey(name: String) = Key(name, String::class.java)
+        private fun intKey(name: String) = Key(name, Int::class.javaObjectType)
+        private fun longKey(name: String) = Key(name, Long::class.javaObjectType)
+        private fun booleanKey(name: String) = Key(name, Boolean::class.javaObjectType)
+    }
+
+    /**
+     * Known values of [Keys.COMPONENT_TYPE].
+     */
+    public object ComponentTypes {
+        public const val TAB: String = "tab"
+        public const val SWITCH: String = "switch"
+        public const val CAROUSEL: String = "carousel"
+        public const val BUTTON: String = "button"
+        public const val TEXT: String = "text"
+        public const val PACKAGE: String = "package"
+        public const val PACKAGE_SELECTION_SHEET: String = "package_selection_sheet"
+        public const val PURCHASE_BUTTON: String = "purchase_button"
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
@@ -56,4 +56,13 @@ public interface PaywallListener {
      * @param url The URL that was opened.
      */
     public fun onUrlOpened(url: String) {}
+
+    /**
+     * Called when the user interacts with a paywall control.
+     *
+     * Exceptions thrown here are logged and do not affect the paywall.
+     *
+     * @param event The [PaywallInteractionEvent] containing the event data.
+     */
+    public fun onInteraction(event: PaywallInteractionEvent) {}
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -32,6 +32,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.OfferingSelection
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
@@ -193,6 +194,10 @@ internal class PaywallActivity : ComponentActivity() {
 
             override fun onUrlOpened(url: String) {
                 userListener?.onUrlOpened(url)
+            }
+
+            override fun onInteraction(event: PaywallInteractionEvent) {
+                userListener?.onInteraction(event)
             }
         }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -63,6 +63,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallProductIdentifier
 import com.revenuecat.purchases.ui.revenuecatui.helpers.resolveWebCheckoutUrlForInteraction
 import com.revenuecat.purchases.ui.revenuecatui.helpers.safeResume
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toInteractionEvent
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toLegacyPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedPaywall
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
@@ -552,6 +553,11 @@ internal class PaywallViewModelImpl(
             componentInteraction = data,
         )
         purchases.track(event)
+        listener?.let { listener ->
+            val interactionEvent = event.toInteractionEvent()
+            runCatching { listener.onInteraction(interactionEvent) }
+                .onFailure { Logger.e("PaywallListener.onInteraction threw", it) }
+        }
     }
 
     override suspend fun handleRestorePurchases() = runExclusiveAction { performRestore() }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallInteractionEventMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallInteractionEventMapper.kt
@@ -1,0 +1,60 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.helpers
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.events.PaywallComponentType
+import com.revenuecat.purchases.paywalls.events.PaywallEvent
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.ComponentTypes
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Keys
+
+internal fun PaywallEvent.toInteractionEvent(): PaywallInteractionEvent {
+    val interaction = requireNotNull(componentInteraction) { "Not a component interaction event: $type" }
+    val rawProperties = buildMap {
+        put(Keys.TIMESTAMP.name, creationData.date.time)
+        put(Keys.SESSION_ID.name, data.sessionIdentifier.toString())
+        put(Keys.OFFERING_ID.name, data.presentedOfferingContext.offeringIdentifier)
+        putIfNotNull(Keys.PAYWALL_ID.name, data.paywallIdentifier)
+        put(Keys.PAYWALL_REVISION.name, data.paywallRevision)
+        put(Keys.DISPLAY_MODE.name, data.displayMode)
+        put(Keys.DARK_MODE.name, data.darkMode)
+        put(Keys.LOCALE.name, data.localeIdentifier)
+
+        put(Keys.COMPONENT_TYPE.name, interaction.componentType.toInteractionEventValue())
+        put(Keys.COMPONENT_VALUE.name, interaction.componentValue)
+        putIfNotNull(Keys.COMPONENT_NAME.name, interaction.componentName)
+        putIfNotNull(Keys.COMPONENT_URL.name, interaction.componentUrl)
+        putIfNotNull(Keys.ORIGIN_INDEX.name, interaction.originIndex)
+        putIfNotNull(Keys.DESTINATION_INDEX.name, interaction.destinationIndex)
+        putIfNotNull(Keys.ORIGIN_CONTEXT_NAME.name, interaction.originContextName)
+        putIfNotNull(Keys.DESTINATION_CONTEXT_NAME.name, interaction.destinationContextName)
+        putIfNotNull(Keys.DEFAULT_INDEX.name, interaction.defaultIndex)
+        putIfNotNull(Keys.ORIGIN_PACKAGE_ID.name, interaction.originPackageIdentifier)
+        putIfNotNull(Keys.DESTINATION_PACKAGE_ID.name, interaction.destinationPackageIdentifier)
+        putIfNotNull(Keys.DEFAULT_PACKAGE_ID.name, interaction.defaultPackageIdentifier)
+        putIfNotNull(Keys.CURRENT_PACKAGE_ID.name, interaction.currentPackageIdentifier)
+        putIfNotNull(Keys.RESULTING_PACKAGE_ID.name, interaction.resultingPackageIdentifier)
+        putIfNotNull(Keys.ORIGIN_PRODUCT_ID.name, interaction.originProductIdentifier)
+        putIfNotNull(Keys.DESTINATION_PRODUCT_ID.name, interaction.destinationProductIdentifier)
+        putIfNotNull(Keys.DEFAULT_PRODUCT_ID.name, interaction.defaultProductIdentifier)
+        putIfNotNull(Keys.CURRENT_PRODUCT_ID.name, interaction.currentProductIdentifier)
+        putIfNotNull(Keys.RESULTING_PRODUCT_ID.name, interaction.resultingProductIdentifier)
+    }
+    return PaywallInteractionEvent(rawProperties)
+}
+
+internal fun PaywallComponentType.toInteractionEventValue(): String = when (this) {
+    PaywallComponentType.TAB -> ComponentTypes.TAB
+    PaywallComponentType.SWITCH -> ComponentTypes.SWITCH
+    PaywallComponentType.CAROUSEL -> ComponentTypes.CAROUSEL
+    PaywallComponentType.BUTTON -> ComponentTypes.BUTTON
+    PaywallComponentType.TEXT -> ComponentTypes.TEXT
+    PaywallComponentType.PACKAGE -> ComponentTypes.PACKAGE
+    PaywallComponentType.PACKAGE_SELECTION_SHEET -> ComponentTypes.PACKAGE_SELECTION_SHEET
+    PaywallComponentType.PURCHASE_BUTTON -> ComponentTypes.PURCHASE_BUTTON
+}
+
+private fun MutableMap<String, Any>.putIfNotNull(key: String, value: Any?) {
+    if (value != null) put(key, value)
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/OriginalTemplatePaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/OriginalTemplatePaywallFooterView.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.OfferingSelection
 import com.revenuecat.purchases.ui.revenuecatui.OriginalTemplatePaywallFooter
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.R
@@ -54,6 +55,7 @@ public open class PaywallFooterView(
  * View that wraps the [OriginalTemplatePaywallFooter] Composable to display the Paywall Footer
  * through XML layouts and the View system.
  */
+@Suppress("TooManyFunctions")
 public open class OriginalTemplatePaywallFooterView : FrameLayout {
 
     public constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
@@ -113,6 +115,7 @@ public open class OriginalTemplatePaywallFooterView : FrameLayout {
         override fun onRestoreError(error: PurchasesError) { listener?.onRestoreError(error) }
         override fun onWebCheckoutOpened() { listener?.onWebCheckoutOpened() }
         override fun onUrlOpened(url: String) { listener?.onUrlOpened(url) }
+        override fun onInteraction(event: PaywallInteractionEvent) { listener?.onInteraction(event) }
     }
 
     private var paywallOptions: PaywallOptions

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.OfferingSelection
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.PaywallPurchaseLogic
@@ -110,6 +111,7 @@ public class PaywallView : CompatComposeView {
         override fun onRestoreError(error: PurchasesError) { listener?.onRestoreError(error) }
         override fun onWebCheckoutOpened() { listener?.onWebCheckoutOpened() }
         override fun onUrlOpened(url: String) { listener?.onUrlOpened(url) }
+        override fun onInteraction(event: PaywallInteractionEvent) { listener?.onInteraction(event) }
     }
 
     private var paywallOptions: PaywallOptions

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -39,6 +39,7 @@ import com.revenuecat.purchases.paywalls.components.common.StateUpdate
 import com.revenuecat.purchases.paywalls.components.common.StateUpdateValue
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowResolution
 import com.revenuecat.purchases.common.workflows.WorkflowScreen
@@ -50,6 +51,7 @@ import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
 import com.revenuecat.purchases.ui.revenuecatui.OfferingSelection
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -67,6 +69,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData.copy
 import com.revenuecat.purchases.ui.revenuecatui.extensions.copy
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallLegacyComponentInteraction
 import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallPurchaseButtonAction
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toInteractionEvent
 import com.revenuecat.purchases.ui.revenuecatui.helpers.resolvedWebCheckoutInteractionUrl
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ResolvedOffer
 import com.revenuecat.purchases.ui.revenuecatui.helpers.UiConfig
@@ -255,6 +258,7 @@ class PaywallViewModelTest {
         every { listener.onRestoreCompleted(any()) } just runs
         every { listener.onRestoreError(any()) } just runs
         every { listener.onPurchaseCancelled() } just runs
+        every { listener.onInteraction(any()) } just runs
     }
 
     @After
@@ -1573,6 +1577,56 @@ class PaywallViewModelTest {
                 },
             )
         }
+    }
+
+    @Test
+    fun `trackComponentInteraction notifies listener with snake case map`() {
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        val events = mutableListOf<PaywallInteractionEvent>()
+        every { listener.onInteraction(capture(events)) } just runs
+
+        model.trackComponentInteraction(
+            componentType = PaywallComponentType.BUTTON,
+            componentName = PaywallLegacyComponentInteraction.RESTORE_BUTTON_NAME,
+            componentValue = PaywallLegacyComponentInteraction.Value.RESTORE_PURCHASES,
+        )
+
+        val trackedEvents = mutableListOf<FeatureEvent>()
+        verify { purchases.track(capture(trackedEvents)) }
+        val trackedInteraction = trackedEvents.filterIsInstance<PaywallEvent>()
+            .single { it.type == PaywallEventType.COMPONENT_INTERACTION }
+        assertThat(events).containsExactly(trackedInteraction.toInteractionEvent())
+    }
+
+    @Test
+    fun `trackComponentInteraction still tracks when listener throws`() {
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        every { listener.onInteraction(any()) } throws IllegalStateException("developer bug")
+
+        model.trackComponentInteraction(
+            componentType = PaywallComponentType.BUTTON,
+            componentName = PaywallLegacyComponentInteraction.RESTORE_BUTTON_NAME,
+            componentValue = PaywallLegacyComponentInteraction.Value.RESTORE_PURCHASES,
+        )
+
+        verify(exactly = 1) { listener.onInteraction(any()) }
+        verifyEventTracked(PaywallEventType.COMPONENT_INTERACTION, 1)
+    }
+
+    @Test
+    fun `trackComponentInteraction does not notify listener before impression`() {
+        val model = create()
+
+        model.trackComponentInteraction(
+            componentType = PaywallComponentType.BUTTON,
+            componentName = PaywallLegacyComponentInteraction.RESTORE_BUTTON_NAME,
+            componentValue = PaywallLegacyComponentInteraction.Value.RESTORE_PURCHASES,
+        )
+
+        verify(exactly = 0) { listener.onInteraction(any()) }
+        verify(exactly = 0) { purchases.track(any()) }
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallInteractionEventMapperTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallInteractionEventMapperTest.kt
@@ -1,0 +1,149 @@
+@file:OptIn(InternalRevenueCatAPI::class, ExperimentalSerializationApi::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.helpers
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.paywalls.events.PaywallComponentInteractionData
+import com.revenuecat.purchases.paywalls.events.PaywallComponentType
+import com.revenuecat.purchases.paywalls.events.PaywallEvent
+import com.revenuecat.purchases.paywalls.events.PaywallEventType
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.ComponentTypes
+import com.revenuecat.purchases.ui.revenuecatui.PaywallInteractionEvent.Keys
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.serializer
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
+import org.junit.Test
+import java.util.Date
+import java.util.UUID
+
+internal class PaywallInteractionEventMapperTest {
+
+    private val eventId = UUID.randomUUID()
+    private val sessionId = UUID.randomUUID()
+    private val date = Date(1_700_000_000_000L)
+
+    private fun event(
+        interaction: PaywallComponentInteractionData,
+        paywallIdentifier: String? = "pw_123",
+    ) = PaywallEvent(
+        creationData = PaywallEvent.CreationData(id = eventId, date = date),
+        data = PaywallEvent.Data(
+            paywallIdentifier = paywallIdentifier,
+            presentedOfferingContext = PresentedOfferingContext(offeringIdentifier = "default"),
+            paywallRevision = 7,
+            sessionIdentifier = sessionId,
+            displayMode = "full_screen",
+            localeIdentifier = "en_US",
+            darkMode = true,
+        ),
+        type = PaywallEventType.COMPONENT_INTERACTION,
+        componentInteraction = interaction,
+    )
+
+    @Test
+    fun `fully populated interaction maps every documented key`() {
+        val interaction = PaywallComponentInteractionData(
+            componentType = PaywallComponentType.CAROUSEL,
+            componentName = "hero",
+            componentValue = "page_change",
+            componentUrl = "https://example.com",
+            originIndex = 0,
+            destinationIndex = 1,
+            originContextName = "first",
+            destinationContextName = "second",
+            defaultIndex = 0,
+            originPackageIdentifier = "monthly",
+            destinationPackageIdentifier = "annual",
+            defaultPackageIdentifier = "monthly",
+            originProductIdentifier = "com.app.monthly",
+            destinationProductIdentifier = "com.app.annual",
+            defaultProductIdentifier = "com.app.monthly",
+            currentPackageIdentifier = "monthly",
+            resultingPackageIdentifier = "annual",
+            currentProductIdentifier = "com.app.monthly",
+            resultingProductIdentifier = "com.app.annual",
+        )
+
+        val map = event(interaction).toInteractionEvent().rawProperties
+
+        assertThat(map).containsOnly(
+            entry(Keys.TIMESTAMP.name, date.time),
+            entry(Keys.SESSION_ID.name, sessionId.toString()),
+            entry(Keys.OFFERING_ID.name, "default"),
+            entry(Keys.PAYWALL_ID.name, "pw_123"),
+            entry(Keys.PAYWALL_REVISION.name, 7),
+            entry(Keys.DISPLAY_MODE.name, "full_screen"),
+            entry(Keys.DARK_MODE.name, true),
+            entry(Keys.LOCALE.name, "en_US"),
+            entry(Keys.COMPONENT_TYPE.name, ComponentTypes.CAROUSEL),
+            entry(Keys.COMPONENT_VALUE.name, "page_change"),
+            entry(Keys.COMPONENT_NAME.name, "hero"),
+            entry(Keys.COMPONENT_URL.name, "https://example.com"),
+            entry(Keys.ORIGIN_INDEX.name, 0),
+            entry(Keys.DESTINATION_INDEX.name, 1),
+            entry(Keys.ORIGIN_CONTEXT_NAME.name, "first"),
+            entry(Keys.DESTINATION_CONTEXT_NAME.name, "second"),
+            entry(Keys.DEFAULT_INDEX.name, 0),
+            entry(Keys.ORIGIN_PACKAGE_ID.name, "monthly"),
+            entry(Keys.DESTINATION_PACKAGE_ID.name, "annual"),
+            entry(Keys.DEFAULT_PACKAGE_ID.name, "monthly"),
+            entry(Keys.CURRENT_PACKAGE_ID.name, "monthly"),
+            entry(Keys.RESULTING_PACKAGE_ID.name, "annual"),
+            entry(Keys.ORIGIN_PRODUCT_ID.name, "com.app.monthly"),
+            entry(Keys.DESTINATION_PRODUCT_ID.name, "com.app.annual"),
+            entry(Keys.DEFAULT_PRODUCT_ID.name, "com.app.monthly"),
+            entry(Keys.CURRENT_PRODUCT_ID.name, "com.app.monthly"),
+            entry(Keys.RESULTING_PRODUCT_ID.name, "com.app.annual"),
+        )
+    }
+
+    @Test
+    fun `minimal interaction omits absent keys`() {
+        val interaction = PaywallComponentInteractionData(
+            componentType = PaywallComponentType.BUTTON,
+            componentValue = "restore_purchases",
+        )
+
+        val map = event(interaction, paywallIdentifier = null).toInteractionEvent().rawProperties
+
+        assertThat(map.keys).containsExactlyInAnyOrder(
+            Keys.TIMESTAMP.name,
+            Keys.SESSION_ID.name,
+            Keys.OFFERING_ID.name,
+            Keys.PAYWALL_REVISION.name,
+            Keys.DISPLAY_MODE.name,
+            Keys.DARK_MODE.name,
+            Keys.LOCALE.name,
+            Keys.COMPONENT_TYPE.name,
+            Keys.COMPONENT_VALUE.name,
+        )
+    }
+
+    @Test
+    fun `typed keys read values and return null for absent keys`() {
+        val interaction = PaywallComponentInteractionData(
+            componentType = PaywallComponentType.TAB,
+            componentValue = "annual",
+            originIndex = 2,
+        )
+
+        val event = event(interaction).toInteractionEvent()
+
+        assertThat(event.getProperty(Keys.COMPONENT_TYPE)).isEqualTo(ComponentTypes.TAB)
+        assertThat(event.getProperty(Keys.ORIGIN_INDEX)).isEqualTo(2)
+        assertThat(event.getProperty(Keys.TIMESTAMP)).isEqualTo(date.time)
+        assertThat(event.getProperty(Keys.DARK_MODE)).isTrue()
+        assertThat(event.getProperty(Keys.COMPONENT_NAME)).isNull()
+        assertThat(event.getProperty(Keys.DESTINATION_INDEX)).isNull()
+    }
+
+    @Test
+    fun `component type values match the wire serial names`() {
+        val descriptor = serializer<PaywallComponentType>().descriptor
+        PaywallComponentType.values().forEach { type ->
+            assertThat(type.toInteractionEventValue()).isEqualTo(descriptor.getElementName(type.ordinal))
+        }
+    }
+}


### PR DESCRIPTION
- Adds `PaywallListener.onInteraction(event: PaywallInteractionEvent)`, called right after the SDK tracks a `paywall_component_interacted` event, on every presentation API that takes a listener: the composables, `PaywallActivityLauncher`, `PaywallView` and `OriginalTemplatePaywallFooterView`.
- `PaywallInteractionEvent` wraps the documented snake_case map: `rawProperties` for forwarding to an analytics SDK, and `event.getProperty(Keys.PAYWALL_REVISION)` for typed reads (`Key<Int>`, `Key<String>`, `Key<Long>`, `Key<Boolean>`), so no casts in app code. Keys that do not apply are absent and read as null.
- `ComponentTypes` also holds the known `component_type` values as plain strings for comparison
- Exceptions thrown by the listener are logged and do not affect tracking or the paywall.
- Same contract on iOS (RevenueCat/purchases-ios#7583) and web (RevenueCat/purchases-js#1109). PHC and the hybrids follow.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

Paywalls already track `paywall_component_interacted` internally but apps had no way to receive it, so forwarding paywall interactions to their own analytics required webhooks or a server-side integration. Part of [SDK-4455](https://linear.app/revenuecat/issue/SDK-4455) under [SDK-4453](https://linear.app/revenuecat/issue/SDK-4453); design in [Delivering UI Events to Developers](https://app.notion.com/p/revenuecat/Delivering-UI-Events-to-Developers-390cb1a108b081b599d4ee5078c4e516).

### Description

- Hook is in `PaywallViewModelImpl.trackComponentInteraction`, the single point every interaction call site (components, legacy templates, footer, default paywall) already funnels through. It inherits the existing gate: no callback before impression or after close, exactly when the event is tracked.
- The map is built in `revenuecatui` from the public `PaywallEvent` and `PaywallComponentInteractionData` types. `BackendEvent` and `toBackendComponentFields()` are `internal` to `purchases`, so they cannot be reused; the `ComponentTypes` values are checked against the enum's `@SerialName`s by a test.
- `Key<T>` carries a `Class<T>`, so `getProperty` checks `isInstance` and never throws; Java reads `event.getProperty(Keys.TIMESTAMP)` as `Long` and sees the keys directly through `@JvmField`. No `kotlin-reflect`.
- `PaywallInteractionEvent` is a final class with an internal constructor and `Key` cannot be constructed outside the SDK, so adding keys or values later is not a breaking change.
- Not visible in the diff: `PaywallActivity`, `PaywallView` and `OriginalTemplatePaywallFooterView` each wrap the app listener in their own `PaywallListener`, so the new method had to be forwarded in all three or it would be silently dropped, as happened to `onUrlOpened` before #3859.

### Regression gates

- `PaywallViewModelTest.trackComponentInteraction notifies listener with snake case map`: fails without the hook.
- `PaywallViewModelTest.trackComponentInteraction still tracks when listener throws`.
- `PaywallInteractionEventMapperTest`: full and minimal key sets, typed reads through `Key`, and `ComponentTypes` vs `@SerialName`.

</details>
