### PR TITLE
refactor(admob): deduplicate full-screen ad flow tests

### DIFF
--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AppOpenAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AppOpenAdFlowTest.kt
@@ -5,41 +5,36 @@ package com.revenuecat.purchases.admob.nextgen
 import android.app.Activity
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
-import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingAppOpenAdEventCallback
-import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
-import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
-import com.revenuecat.purchases.ads.events.types.AdLoadedData
-import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 class AppOpenAdFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
+    private val contract = FullScreenAdFlowContract<AppOpenAd, AppOpenAdEventCallback>(
+        adTracker = adTracker,
+        values = FullScreenAdTestValues(AdFormat.APP_OPEN, "app-open-unit", "load-placement"),
+        suspendingValues = FullScreenAdTestValues(
+            AdFormat.APP_OPEN,
+            "suspend-app-open-unit",
+            "suspend-load-placement",
+        ),
+    )
 
     @Before
     fun setUp() {
@@ -58,65 +53,40 @@ class AppOpenAdFlowTest {
 
     @Test
     fun `app open success installs tracking and supports placement and delegate updates`() {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "app-open-unit"
-        }
-        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-            every { adapterClassName } returns "test-network"
-            every { responseId } returns "response-id"
-        }
-        var installedCallback: AppOpenAdEventCallback? = null
-        val appOpenAd = mockk<AppOpenAd>(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo
-            every { adEventCallback } answers { installedCallback }
-            every { adEventCallback = any() } answers { installedCallback = firstArg() }
-        }
-        val activity = mockk<Activity>()
-        val loadCallback = RecordingAppOpenLoadCallback()
         val initialEventCallback = RecordingAppOpenAdEventCallback()
         val replacementEventCallback = RecordingAppOpenAdEventCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<AppOpenAd>>()
 
-        every { AppOpenAd.load(adRequest, capture(trackingLoadCallback)) } just runs
-
-        adTracker.loadAndTrackAppOpenAd(
-            adRequest = adRequest,
-            placement = "load-placement",
-            loadCallback = loadCallback,
-            adEventCallback = initialEventCallback,
+        contract.callbackSuccess(
+            createAd = { responseInfo, installedCallback ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback } answers { installedCallback.callback }
+                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
+                }
+            },
+            initialEventCallback = initialEventCallback,
+            replacementEventCallback = replacementEventCallback,
+            stubLoad = { adRequest, trackingLoadCallback ->
+                every { AppOpenAd.load(adRequest, any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrack = { adRequest, loadCallback, eventCallback ->
+                adTracker.loadAndTrackAppOpenAd(
+                    adRequest = adRequest,
+                    placement = "load-placement",
+                    loadCallback = loadCallback,
+                    adEventCallback = eventCallback,
+                )
+            },
+            asTrackingCallback = { it as? TrackingAppOpenAdEventCallback },
+            invokeDelegateCallback = { it.onAdDismissedFullScreenContent() },
+            assertInitialDelegateInvoked = { assertTrue(initialEventCallback.dismissed) },
+            setTrackingEventCallback = { ad, eventCallback -> ad.setTrackingAdEventCallback(eventCallback) },
+            assertReplacementDelegateInvoked = { assertTrue(replacementEventCallback.dismissed) },
+            show = { ad, activity, placement -> ad.show(activity, placement) },
+            verifyShow = { ad, activity -> verify(exactly = 1) { ad.show(activity) } },
         )
-        trackingLoadCallback.captured.onAdLoaded(appOpenAd)
-
-        assertSame(appOpenAd, loadCallback.loadedAd)
-
-        // Pins the format, ad unit and placement this entry point hands to the load tracker;
-        // the wrapper classes are covered separately, so only the wiring is asserted here.
-        val loadedData = slot<AdLoadedData>()
-        verify(exactly = 1) {
-            adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(
-            AdLoadedData(
-                networkName = "test-network",
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.APP_OPEN,
-                placement = "load-placement",
-                adUnitId = "app-open-unit",
-                impressionId = "response-id",
-            ),
-            loadedData.captured,
-        )
-        val trackingCallback = installedCallback as TrackingAppOpenAdEventCallback
-        trackingCallback.onAdDismissedFullScreenContent()
-        assertTrue(initialEventCallback.dismissed)
-
-        appOpenAd.setTrackingAdEventCallback(replacementEventCallback)
-        trackingCallback.onAdDismissedFullScreenContent()
-        assertTrue(replacementEventCallback.dismissed)
-
-        appOpenAd.show(activity, "show-placement")
-        assertEquals("show-placement", trackingCallback.placement)
-        verify(exactly = 1) { appOpenAd.show(activity) }
     }
 
     @Test
@@ -132,134 +102,87 @@ class AppOpenAdFlowTest {
             every { adEventCallback } returns trackingCallback
         }
 
-        appOpenAd.show(activity, placement = null)
-
-        assertNull(trackingCallback.placement)
-        verify(exactly = 1) { appOpenAd.show(activity) }
+        assertShowClearsPlacement(
+            trackingCallback = trackingCallback,
+            show = { appOpenAd.show(activity, placement = null) },
+            verifyShow = { verify(exactly = 1) { appOpenAd.show(activity) } },
+        )
     }
 
     @Test
     fun `app open failure is forwarded to load callback`() {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "app-open-unit"
-        }
-        val error = mockk<LoadAdError>(relaxed = true)
-        val loadCallback = RecordingAppOpenLoadCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<AppOpenAd>>()
-
-        every { AppOpenAd.load(adRequest, capture(trackingLoadCallback)) } just runs
-
-        adTracker.loadAndTrackAppOpenAd(
-            adRequest = adRequest,
-            placement = "load-placement",
-            loadCallback = loadCallback,
+        contract.callbackFailure(
+            stubLoad = { adRequest, trackingLoadCallback ->
+                every { AppOpenAd.load(adRequest, any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrack = { adRequest, loadCallback ->
+                adTracker.loadAndTrackAppOpenAd(
+                    adRequest = adRequest,
+                    placement = "load-placement",
+                    loadCallback = loadCallback,
+                )
+            },
         )
-        trackingLoadCallback.captured.onAdFailedToLoad(error)
-
-        assertSame(error, loadCallback.loadError)
-
-        val failedData = slot<AdFailedToLoadData>()
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(AdFormat.APP_OPEN, failedData.captured.adFormat)
-        assertEquals("app-open-unit", failedData.captured.adUnitId)
-        assertEquals("load-placement", failedData.captured.placement)
     }
 
     @Test
-    fun `suspending app open success tracks and installs callback before returning original result`() =
-        runBlocking {
-            val adRequest = mockk<AdRequest> {
-                every { adUnitId } returns "suspend-app-open-unit"
-            }
-            val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-                every { adapterClassName } returns "suspend-test-network"
-                every { responseId } returns "suspend-response-id"
-            }
-            var installedCallback: AppOpenAdEventCallback? = null
-            val appOpenAd = mockk<AppOpenAd>(relaxed = true) {
-                every { getResponseInfo() } returns responseInfo
-                every { adEventCallback } answers { installedCallback }
-                every { adEventCallback = any() } answers { installedCallback = firstArg() }
-            }
-            val eventCallback = RecordingAppOpenAdEventCallback()
-            val sdkResult = AdLoadResult.Success(appOpenAd)
+    fun `suspending app open success tracks and installs callback before returning original result`() = runBlocking {
+        val eventCallback = RecordingAppOpenAdEventCallback()
 
-            coEvery { AppOpenAd.load(adRequest) } returns sdkResult
-
-            val result = adTracker.loadAndTrackAppOpenAd(
-                adRequest = adRequest,
-                placement = "suspend-load-placement",
-                adEventCallback = eventCallback,
-            )
-
-            assertSame(sdkResult, result)
-            val trackingCallback = installedCallback as TrackingAppOpenAdEventCallback
-            trackingCallback.onAdDismissedFullScreenContent()
-            assertTrue(eventCallback.dismissed)
-
-            val loadedData = slot<AdLoadedData>()
-            verify(exactly = 1) {
-                adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER)
-            }
-            assertEquals(
-                AdLoadedData(
-                    networkName = "suspend-test-network",
-                    mediatorName = AdMediatorName.AD_MOB,
-                    adFormat = AdFormat.APP_OPEN,
+        contract.suspendingSuccess(
+            createAd = { responseInfo, installedCallback ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback } answers { installedCallback.callback }
+                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
+                }
+            },
+            eventCallback = eventCallback,
+            stubLoad = { adRequest, sdkResult -> coEvery { AppOpenAd.load(adRequest) } returns sdkResult },
+            loadAndTrack = { adRequest, delegate ->
+                adTracker.loadAndTrackAppOpenAd(
+                    adRequest = adRequest,
                     placement = "suspend-load-placement",
-                    adUnitId = "suspend-app-open-unit",
-                    impressionId = "suspend-response-id",
-                ),
-                loadedData.captured,
-            )
-        }
+                    adEventCallback = delegate,
+                )
+            },
+            asTrackingCallback = { it as? TrackingAppOpenAdEventCallback },
+            invokeDelegateCallback = { it.onAdDismissedFullScreenContent() },
+            assertDelegateInvoked = { assertTrue(eventCallback.dismissed) },
+        )
+    }
 
     @Test
     fun `suspending app open failure tracks error and returns original result`() = runBlocking {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "suspend-app-open-unit"
-        }
-        val error = mockk<LoadAdError> {
-            every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR
-        }
-        val sdkResult = AdLoadResult.Failure<AppOpenAd>(error)
-
-        coEvery { AppOpenAd.load(adRequest) } returns sdkResult
-
-        val result = adTracker.loadAndTrackAppOpenAd(
-            adRequest = adRequest,
-            placement = "suspend-load-placement",
-        )
-
-        assertSame(sdkResult, result)
-        val failedData = slot<AdFailedToLoadData>()
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(
-            AdFailedToLoadData(
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.APP_OPEN,
-                placement = "suspend-load-placement",
-                adUnitId = "suspend-app-open-unit",
-                mediatorErrorCode = LoadAdError.ErrorCode.NETWORK_ERROR.value,
-            ),
-            failedData.captured,
+        contract.suspendingFailure(
+            stubLoad = { adRequest, sdkResult -> coEvery { AppOpenAd.load(adRequest) } returns sdkResult },
+            loadAndTrack = { adRequest ->
+                adTracker.loadAndTrackAppOpenAd(
+                    adRequest = adRequest,
+                    placement = "suspend-load-placement",
+                )
+            },
         )
     }
 
     @Test
     fun `setting event callback directly falls back when tracking is not installed`() {
-        val appOpenAd = mockk<AppOpenAd>(relaxed = true) {
-            every { adEventCallback } returns null
-        }
         val eventCallback = RecordingAppOpenAdEventCallback()
 
-        appOpenAd.setTrackingAdEventCallback(eventCallback)
-
-        verify(exactly = 1) { appOpenAd.adEventCallback = eventCallback }
+        contract.eventCallbackFallback(
+            createAd = {
+                mockk(relaxed = true) {
+                    every { adEventCallback } returns null
+                }
+            },
+            eventCallback = eventCallback,
+            setTrackingEventCallback = { ad, callback -> ad.setTrackingAdEventCallback(callback) },
+            verifyEventCallbackInstalled = { ad, callback ->
+                verify(exactly = 1) { ad.adEventCallback = callback }
+            },
+        )
     }
 
     private class RecordingAppOpenAdEventCallback : AppOpenAdEventCallback {
@@ -267,19 +190,6 @@ class AppOpenAdFlowTest {
 
         override fun onAdDismissedFullScreenContent() {
             dismissed = true
-        }
-    }
-
-    private class RecordingAppOpenLoadCallback : AdLoadCallback<AppOpenAd> {
-        var loadedAd: AppOpenAd? = null
-        var loadError: LoadAdError? = null
-
-        override fun onAdLoaded(ad: AppOpenAd) {
-            loadedAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            loadError = adError
         }
     }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AppOpenAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AppOpenAdFlowTest.kt
@@ -5,19 +5,32 @@ package com.revenuecat.purchases.admob.nextgen
 import android.app.Activity
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingAppOpenAdEventCallback
 import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdLoadedData
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -26,14 +39,11 @@ class AppOpenAdFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
-    private val contract = FullScreenAdFlowContract<AppOpenAd, AppOpenAdEventCallback>(
-        adTracker = adTracker,
-        values = FullScreenAdTestValues(AdFormat.APP_OPEN, "app-open-unit", "load-placement"),
-        suspendingValues = FullScreenAdTestValues(
-            AdFormat.APP_OPEN,
-            "suspend-app-open-unit",
-            "suspend-load-placement",
-        ),
+    private val values = FullScreenAdTestValues(AdFormat.APP_OPEN, "app-open-unit", "load-placement")
+    private val suspendingValues = FullScreenAdTestValues(
+        AdFormat.APP_OPEN,
+        "suspend-app-open-unit",
+        "suspend-load-placement",
     )
 
     @Before
@@ -53,40 +63,49 @@ class AppOpenAdFlowTest {
 
     @Test
     fun `app open success installs tracking and supports placement and delegate updates`() {
+        val adRequest = mockk<AdRequest> {
+            every { adUnitId } returns values.adUnitId
+        }
+        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
+            every { adapterClassName } returns "test-network"
+            every { responseId } returns "response-id"
+        }
+        var installedCallback: AppOpenAdEventCallback? = null
+        val appOpenAd = mockk<AppOpenAd>(relaxed = true) {
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback } answers { installedCallback }
+            every { adEventCallback = any() } answers { installedCallback = firstArg() }
+        }
+        val activity = mockk<Activity>()
+        val loadCallback = FullScreenRecordingAdLoadCallback<AppOpenAd>()
         val initialEventCallback = RecordingAppOpenAdEventCallback()
         val replacementEventCallback = RecordingAppOpenAdEventCallback()
+        val trackingLoadCallback = slot<AdLoadCallback<AppOpenAd>>()
 
-        contract.callbackSuccess(
-            createAd = { responseInfo, installedCallback ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback } answers { installedCallback.callback }
-                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
-                }
-            },
-            initialEventCallback = initialEventCallback,
-            replacementEventCallback = replacementEventCallback,
-            stubLoad = { adRequest, trackingLoadCallback ->
-                every { AppOpenAd.load(adRequest, any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrack = { adRequest, loadCallback, eventCallback ->
-                adTracker.loadAndTrackAppOpenAd(
-                    adRequest = adRequest,
-                    placement = "load-placement",
-                    loadCallback = loadCallback,
-                    adEventCallback = eventCallback,
-                )
-            },
-            asTrackingCallback = { it as? TrackingAppOpenAdEventCallback },
-            invokeDelegateCallback = { it.onAdDismissedFullScreenContent() },
-            assertInitialDelegateInvoked = { assertTrue(initialEventCallback.dismissed) },
-            setTrackingEventCallback = { ad, eventCallback -> ad.setTrackingAdEventCallback(eventCallback) },
-            assertReplacementDelegateInvoked = { assertTrue(replacementEventCallback.dismissed) },
-            show = { ad, activity, placement -> ad.show(activity, placement) },
-            verifyShow = { ad, activity -> verify(exactly = 1) { ad.show(activity) } },
+        every { AppOpenAd.load(adRequest, capture(trackingLoadCallback)) } just runs
+
+        adTracker.loadAndTrackAppOpenAd(
+            adRequest = adRequest,
+            placement = values.placement,
+            loadCallback = loadCallback,
+            adEventCallback = initialEventCallback,
         )
+        trackingLoadCallback.captured.onAdLoaded(appOpenAd)
+
+        assertSame(appOpenAd, loadCallback.loadedAd)
+        adTracker.assertLoadedData(slot(), values, "test-network", "response-id")
+
+        val trackingCallback = requireNotNull(installedCallback as? TrackingAppOpenAdEventCallback)
+        trackingCallback.onAdDismissedFullScreenContent()
+        assertTrue(initialEventCallback.dismissed)
+
+        appOpenAd.setTrackingAdEventCallback(replacementEventCallback)
+        trackingCallback.onAdDismissedFullScreenContent()
+        assertTrue(replacementEventCallback.dismissed)
+
+        appOpenAd.show(activity, "show-placement")
+        assertEquals("show-placement", trackingCallback.placement)
+        verify(exactly = 1) { appOpenAd.show(activity) }
     }
 
     @Test
@@ -102,87 +121,103 @@ class AppOpenAdFlowTest {
             every { adEventCallback } returns trackingCallback
         }
 
-        assertShowClearsPlacement(
-            trackingCallback = trackingCallback,
-            show = { appOpenAd.show(activity, placement = null) },
-            verifyShow = { verify(exactly = 1) { appOpenAd.show(activity) } },
-        )
+        appOpenAd.show(activity, placement = null)
+
+        assertNull(trackingCallback.placement)
+        verify(exactly = 1) { appOpenAd.show(activity) }
     }
 
     @Test
     fun `app open failure is forwarded to load callback`() {
-        contract.callbackFailure(
-            stubLoad = { adRequest, trackingLoadCallback ->
-                every { AppOpenAd.load(adRequest, any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrack = { adRequest, loadCallback ->
-                adTracker.loadAndTrackAppOpenAd(
-                    adRequest = adRequest,
-                    placement = "load-placement",
-                    loadCallback = loadCallback,
-                )
-            },
+        val adRequest = mockk<AdRequest> {
+            every { adUnitId } returns values.adUnitId
+        }
+        val error = mockk<LoadAdError>(relaxed = true)
+        val loadCallback = FullScreenRecordingAdLoadCallback<AppOpenAd>()
+        val trackingLoadCallback = slot<AdLoadCallback<AppOpenAd>>()
+
+        every { AppOpenAd.load(adRequest, capture(trackingLoadCallback)) } just runs
+
+        adTracker.loadAndTrackAppOpenAd(
+            adRequest = adRequest,
+            placement = values.placement,
+            loadCallback = loadCallback,
         )
+        trackingLoadCallback.captured.onAdFailedToLoad(error)
+
+        assertSame(error, loadCallback.loadError)
+        adTracker.assertFailedData(slot(), values)
     }
 
     @Test
     fun `suspending app open success tracks and installs callback before returning original result`() = runBlocking {
+        val adRequest = mockk<AdRequest> {
+            every { adUnitId } returns suspendingValues.adUnitId
+        }
+        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
+            every { adapterClassName } returns "suspend-test-network"
+            every { responseId } returns "suspend-response-id"
+        }
+        var installedCallback: AppOpenAdEventCallback? = null
+        val appOpenAd = mockk<AppOpenAd>(relaxed = true) {
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback } answers { installedCallback }
+            every { adEventCallback = any() } answers { installedCallback = firstArg() }
+        }
         val eventCallback = RecordingAppOpenAdEventCallback()
+        val sdkResult = AdLoadResult.Success(appOpenAd)
 
-        contract.suspendingSuccess(
-            createAd = { responseInfo, installedCallback ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback } answers { installedCallback.callback }
-                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
-                }
-            },
-            eventCallback = eventCallback,
-            stubLoad = { adRequest, sdkResult -> coEvery { AppOpenAd.load(adRequest) } returns sdkResult },
-            loadAndTrack = { adRequest, delegate ->
-                adTracker.loadAndTrackAppOpenAd(
-                    adRequest = adRequest,
-                    placement = "suspend-load-placement",
-                    adEventCallback = delegate,
-                )
-            },
-            asTrackingCallback = { it as? TrackingAppOpenAdEventCallback },
-            invokeDelegateCallback = { it.onAdDismissedFullScreenContent() },
-            assertDelegateInvoked = { assertTrue(eventCallback.dismissed) },
+        coEvery { AppOpenAd.load(adRequest) } returns sdkResult
+
+        val result = adTracker.loadAndTrackAppOpenAd(
+            adRequest = adRequest,
+            placement = suspendingValues.placement,
+            adEventCallback = eventCallback,
+        )
+
+        assertSame(sdkResult, result)
+        val trackingCallback = requireNotNull(installedCallback as? TrackingAppOpenAdEventCallback)
+        trackingCallback.onAdDismissedFullScreenContent()
+        assertTrue(eventCallback.dismissed)
+        adTracker.assertLoadedData(
+            slot<AdLoadedData>(),
+            suspendingValues,
+            "suspend-test-network",
+            "suspend-response-id",
         )
     }
 
     @Test
     fun `suspending app open failure tracks error and returns original result`() = runBlocking {
-        contract.suspendingFailure(
-            stubLoad = { adRequest, sdkResult -> coEvery { AppOpenAd.load(adRequest) } returns sdkResult },
-            loadAndTrack = { adRequest ->
-                adTracker.loadAndTrackAppOpenAd(
-                    adRequest = adRequest,
-                    placement = "suspend-load-placement",
-                )
-            },
+        val adRequest = mockk<AdRequest> {
+            every { adUnitId } returns suspendingValues.adUnitId
+        }
+        val error = mockk<LoadAdError> {
+            every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR
+        }
+        val sdkResult = AdLoadResult.Failure<AppOpenAd>(error)
+
+        coEvery { AppOpenAd.load(adRequest) } returns sdkResult
+
+        val result = adTracker.loadAndTrackAppOpenAd(
+            adRequest = adRequest,
+            placement = suspendingValues.placement,
         )
+
+        assertSame(sdkResult, result)
+        adTracker.assertSuspendingFailedData(slot<AdFailedToLoadData>(), suspendingValues)
     }
 
     @Test
     fun `setting event callback directly falls back when tracking is not installed`() {
+        val appOpenAd = mockk<AppOpenAd>(relaxed = true) {
+            every { adEventCallback } returns null
+        }
         val eventCallback = RecordingAppOpenAdEventCallback()
 
-        contract.eventCallbackFallback(
-            createAd = {
-                mockk(relaxed = true) {
-                    every { adEventCallback } returns null
-                }
-            },
-            eventCallback = eventCallback,
-            setTrackingEventCallback = { ad, callback -> ad.setTrackingAdEventCallback(callback) },
-            verifyEventCallbackInstalled = { ad, callback ->
-                verify(exactly = 1) { ad.adEventCallback = callback }
-            },
-        )
+        appOpenAd.setTrackingAdEventCallback(eventCallback)
+
+        verify(exactly = 1) { appOpenAd.adEventCallback = eventCallback }
     }
 
     private class RecordingAppOpenAdEventCallback : AppOpenAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AppOpenAdResponseFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AppOpenAdResponseFlowTest.kt
@@ -4,6 +4,8 @@ package com.revenuecat.purchases.admob.nextgen
 
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingAppOpenAdEventCallback
@@ -22,13 +24,9 @@ class AppOpenAdResponseFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
-    private val contract = FullScreenAdResponseFlowContract<AppOpenAd, AppOpenAdEventCallback>(
+    private val contract = FullScreenAdResponseFlowContract(
         adTracker = adTracker,
-        values = FullScreenAdTestValues(
-            adFormat = AdFormat.APP_OPEN,
-            adUnitId = "supplied-app-open-unit",
-            placement = "response-app-open",
-        ),
+        adapter = AppOpenAdAdapter(),
     )
 
     @Before
@@ -51,53 +49,63 @@ class AppOpenAdResponseFlowTest {
         val eventCallback = RecordingAppOpenEventCallback()
 
         contract.responseSuccess(
-            createAd = { responseInfo, installedCallback, onCallbackInstalled ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback = any() } answers {
-                        installedCallback.callback = firstArg()
-                        onCallbackInstalled()
-                    }
-                }
-            },
             eventCallback = eventCallback,
-            stubLoadFromResponse = { trackingLoadCallback ->
-                every { AppOpenAd.loadFromAdResponse("opaque-response", any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrackFromResponse = { loadCallback, delegate ->
-                adTracker.loadAndTrackAppOpenAdFromResponse(
-                    adResponse = "opaque-response",
-                    adUnitId = "supplied-app-open-unit",
-                    placement = "response-app-open",
-                    loadCallback = loadCallback,
-                    adEventCallback = delegate,
-                )
-            },
-            asTrackingCallback = { it as? TrackingAppOpenAdEventCallback },
-            invokeDelegateCallback = { it.onAdDismissedFullScreenContent() },
             assertDelegateInvoked = { assertTrue(eventCallback.dismissed) },
         )
     }
 
     @Test
     fun `response failure uses supplied ad unit and placement before forwarding`() {
-        contract.responseFailure(
-            stubLoadFromResponse = { trackingLoadCallback ->
-                every { AppOpenAd.loadFromAdResponse("opaque-response", any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrackFromResponse = { loadCallback ->
-                adTracker.loadAndTrackAppOpenAdFromResponse(
-                    adResponse = "opaque-response",
-                    adUnitId = "supplied-app-open-unit",
-                    placement = "response-app-open",
-                    loadCallback = loadCallback,
-                )
-            },
+        contract.responseFailure()
+    }
+
+    private inner class AppOpenAdAdapter : FullScreenAdResponseFlowAdapter<AppOpenAd, AppOpenAdEventCallback> {
+        override val values = FullScreenAdTestValues(
+            adFormat = AdFormat.APP_OPEN,
+            adUnitId = "supplied-app-open-unit",
+            placement = "response-app-open",
         )
+
+        override fun createAd(
+            responseInfo: ResponseInfo,
+            installedCallback: CallbackHolder<AppOpenAdEventCallback>,
+            onCallbackInstalled: () -> Unit,
+        ): AppOpenAd = mockk(relaxed = true) {
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback = any() } answers {
+                installedCallback.callback = firstArg()
+                onCallbackInstalled()
+            }
+        }
+
+        override fun stubLoadFromResponse(
+            trackingLoadCallback: CallbackHolder<AdLoadCallback<AppOpenAd>>,
+        ) {
+            every { AppOpenAd.loadFromAdResponse("opaque-response", any()) } answers {
+                trackingLoadCallback.callback = secondArg()
+            }
+        }
+
+        override fun loadAndTrackFromResponse(
+            loadCallback: AdLoadCallback<AppOpenAd>,
+            eventCallback: AppOpenAdEventCallback?,
+        ) {
+            adTracker.loadAndTrackAppOpenAdFromResponse(
+                adResponse = "opaque-response",
+                adUnitId = values.adUnitId,
+                placement = values.placement,
+                loadCallback = loadCallback,
+                adEventCallback = eventCallback,
+            )
+        }
+
+        override fun asTrackingCallback(
+            callback: AppOpenAdEventCallback,
+        ): TrackingAppOpenAdEventCallback? = callback as? TrackingAppOpenAdEventCallback
+
+        override fun invokeDelegateCallback(callback: AppOpenAdEventCallback) {
+            callback.onAdDismissedFullScreenContent()
+        }
     }
 
     private class RecordingAppOpenEventCallback : AppOpenAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AppOpenAdResponseFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AppOpenAdResponseFlowTest.kt
@@ -4,36 +4,32 @@ package com.revenuecat.purchases.admob.nextgen
 
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingAppOpenAdEventCallback
-import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
-import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
-import com.revenuecat.purchases.ads.events.types.AdLoadedData
-import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.slot
 import io.mockk.unmockkObject
-import io.mockk.verify
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 class AppOpenAdResponseFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
+    private val contract = FullScreenAdResponseFlowContract<AppOpenAd, AppOpenAdEventCallback>(
+        adTracker = adTracker,
+        values = FullScreenAdTestValues(
+            adFormat = AdFormat.APP_OPEN,
+            adUnitId = "supplied-app-open-unit",
+            placement = "response-app-open",
+        ),
+    )
 
     @Before
     fun setUp() {
@@ -52,101 +48,56 @@ class AppOpenAdResponseFlowTest {
 
     @Test
     fun `response success tracks and installs event callback before forwarding`() {
-        val order = mutableListOf<String>()
-        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-            every { adapterClassName } returns "test-network"
-            every { responseId } returns "response-id"
-        }
-        val appOpenAd = mockk<AppOpenAd>(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo
-        }
-        val loadCallback = object : AdLoadCallback<AppOpenAd> {
-            override fun onAdLoaded(ad: AppOpenAd) {
-                order += "load-callback"
-                assertSame(appOpenAd, ad)
-            }
-        }
         val eventCallback = RecordingAppOpenEventCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<AppOpenAd>>()
-        val installedEventCallback = slot<AppOpenAdEventCallback>()
-        val loadedData = slot<AdLoadedData>()
 
-        every {
-            AppOpenAd.loadFromAdResponse("opaque-response", capture(trackingLoadCallback))
-        } just runs
-        every { adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER) } answers {
-            order += "tracked"
-        }
-        every { appOpenAd.adEventCallback = capture(installedEventCallback) } answers {
-            order += "event-callback"
-        }
-
-        adTracker.loadAndTrackAppOpenAdFromResponse(
-            adResponse = "opaque-response",
-            adUnitId = "supplied-app-open-unit",
-            placement = "response-app-open",
-            loadCallback = loadCallback,
-            adEventCallback = eventCallback,
+        contract.responseSuccess(
+            createAd = { responseInfo, installedCallback, onCallbackInstalled ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback = any() } answers {
+                        installedCallback.callback = firstArg()
+                        onCallbackInstalled()
+                    }
+                }
+            },
+            eventCallback = eventCallback,
+            stubLoadFromResponse = { trackingLoadCallback ->
+                every { AppOpenAd.loadFromAdResponse("opaque-response", any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrackFromResponse = { loadCallback, delegate ->
+                adTracker.loadAndTrackAppOpenAdFromResponse(
+                    adResponse = "opaque-response",
+                    adUnitId = "supplied-app-open-unit",
+                    placement = "response-app-open",
+                    loadCallback = loadCallback,
+                    adEventCallback = delegate,
+                )
+            },
+            asTrackingCallback = { it as? TrackingAppOpenAdEventCallback },
+            invokeDelegateCallback = { it.onAdDismissedFullScreenContent() },
+            assertDelegateInvoked = { assertTrue(eventCallback.dismissed) },
         )
-        trackingLoadCallback.captured.onAdLoaded(appOpenAd)
-
-        assertEquals(listOf("tracked", "event-callback", "load-callback"), order)
-        assertEquals(
-            AdLoadedData(
-                networkName = "test-network",
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.APP_OPEN,
-                placement = "response-app-open",
-                adUnitId = "supplied-app-open-unit",
-                impressionId = "response-id",
-            ),
-            loadedData.captured,
-        )
-        assertTrue(installedEventCallback.captured is TrackingAppOpenAdEventCallback)
-
-        installedEventCallback.captured.onAdDismissedFullScreenContent()
-        assertTrue(eventCallback.dismissed)
     }
 
     @Test
     fun `response failure uses supplied ad unit and placement before forwarding`() {
-        val order = mutableListOf<String>()
-        val error = LoadAdError(
-            LoadAdError.ErrorCode.INVALID_AD_RESPONSE,
-            "invalid response",
-            mockk(relaxed = true),
+        contract.responseFailure(
+            stubLoadFromResponse = { trackingLoadCallback ->
+                every { AppOpenAd.loadFromAdResponse("opaque-response", any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrackFromResponse = { loadCallback ->
+                adTracker.loadAndTrackAppOpenAdFromResponse(
+                    adResponse = "opaque-response",
+                    adUnitId = "supplied-app-open-unit",
+                    placement = "response-app-open",
+                    loadCallback = loadCallback,
+                )
+            },
         )
-        val loadCallback = object : AdLoadCallback<AppOpenAd> {
-            override fun onAdFailedToLoad(adError: LoadAdError) {
-                order += "load-callback"
-                assertSame(error, adError)
-            }
-        }
-        val trackingLoadCallback = slot<AdLoadCallback<AppOpenAd>>()
-        val failedData = slot<AdFailedToLoadData>()
-
-        every {
-            AppOpenAd.loadFromAdResponse("opaque-response", capture(trackingLoadCallback))
-        } just runs
-        every { adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER) } answers {
-            order += "tracked"
-        }
-
-        adTracker.loadAndTrackAppOpenAdFromResponse(
-            adResponse = "opaque-response",
-            adUnitId = "supplied-app-open-unit",
-            placement = "response-app-open",
-            loadCallback = loadCallback,
-        )
-        trackingLoadCallback.captured.onAdFailedToLoad(error)
-
-        assertEquals(listOf("tracked", "load-callback"), order)
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(AdFormat.APP_OPEN, failedData.captured.adFormat)
-        assertEquals("supplied-app-open-unit", failedData.captured.adUnitId)
-        assertEquals("response-app-open", failedData.captured.placement)
     }
 
     private class RecordingAppOpenEventCallback : AppOpenAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/FullScreenAdFlowTestContracts.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/FullScreenAdFlowTestContracts.kt
@@ -1,0 +1,340 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.admob.nextgen
+
+import android.app.Activity
+import com.google.android.libraries.ads.mobile.sdk.common.Ad
+import com.google.android.libraries.ads.mobile.sdk.common.AdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.admob.nextgen.tracking.TrackingAdEventCallback
+import com.revenuecat.purchases.ads.events.AdCaptureMethod
+import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdLoadedData
+import com.revenuecat.purchases.ads.events.types.AdMediatorName
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+
+internal data class FullScreenAdTestValues(
+    val adFormat: AdFormat,
+    val adUnitId: String,
+    val placement: String,
+)
+
+internal class CallbackHolder<CallbackT> {
+    var callback: CallbackT? = null
+
+    fun requireCallback(): CallbackT = requireNotNull(callback) { "Expected an ad event callback to be installed" }
+}
+
+internal class FullScreenRecordingAdLoadCallback<AdT> : AdLoadCallback<AdT> {
+    var loadedAd: AdT? = null
+    var loadError: LoadAdError? = null
+
+    override fun onAdLoaded(ad: AdT) {
+        loadedAd = ad
+    }
+
+    override fun onAdFailedToLoad(adError: LoadAdError) {
+        loadError = adError
+    }
+}
+
+internal class FullScreenAdResponseFlowContract<AdT, CallbackT : AdEventCallback>(
+    private val adTracker: AdTracker,
+    private val values: FullScreenAdTestValues,
+) {
+    @Suppress("LongParameterList")
+    fun responseSuccess(
+        createAd: (ResponseInfo, CallbackHolder<CallbackT>, () -> Unit) -> AdT,
+        eventCallback: CallbackT,
+        stubLoadFromResponse: (CallbackHolder<AdLoadCallback<AdT>>) -> Unit,
+        loadAndTrackFromResponse: (AdLoadCallback<AdT>, CallbackT) -> Unit,
+        asTrackingCallback: (CallbackT) -> TrackingAdEventCallback<CallbackT>?,
+        invokeDelegateCallback: (CallbackT) -> Unit,
+        assertDelegateInvoked: () -> Unit,
+    ) {
+        val order = mutableListOf<String>()
+        val responseInfo = responseInfo()
+        val installedCallback = CallbackHolder<CallbackT>()
+        val expectedAd = createAd(responseInfo, installedCallback) { order += "event-callback" }
+        val loadCallback = object : AdLoadCallback<AdT> {
+            override fun onAdLoaded(ad: AdT) {
+                order += "load-callback"
+                assertSame(expectedAd, ad)
+            }
+        }
+        val trackingLoadCallback = CallbackHolder<AdLoadCallback<AdT>>()
+        val loadedData = slot<AdLoadedData>()
+
+        stubLoadFromResponse(trackingLoadCallback)
+        every { adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER) } answers {
+            order += "tracked"
+        }
+
+        loadAndTrackFromResponse(loadCallback, eventCallback)
+        trackingLoadCallback.requireCallback().onAdLoaded(expectedAd)
+
+        assertEquals(listOf("tracked", "event-callback", "load-callback"), order)
+        adTracker.assertLoadedData(
+            loadedData = loadedData,
+            values = values,
+            networkName = "test-network",
+            impressionId = "response-id",
+        )
+
+        val callback = installedCallback.requireCallback()
+        requireNotNull(asTrackingCallback(callback)) { "Expected a format-specific tracking callback" }
+        invokeDelegateCallback(callback)
+        assertDelegateInvoked()
+    }
+
+    fun responseFailure(
+        stubLoadFromResponse: (CallbackHolder<AdLoadCallback<AdT>>) -> Unit,
+        loadAndTrackFromResponse: (AdLoadCallback<AdT>) -> Unit,
+    ) {
+        val order = mutableListOf<String>()
+        val error = LoadAdError(
+            LoadAdError.ErrorCode.INVALID_AD_RESPONSE,
+            "invalid response",
+            mockk(relaxed = true),
+        )
+        val loadCallback = object : AdLoadCallback<AdT> {
+            override fun onAdFailedToLoad(adError: LoadAdError) {
+                order += "load-callback"
+                assertSame(error, adError)
+            }
+        }
+        val trackingLoadCallback = CallbackHolder<AdLoadCallback<AdT>>()
+        val failedData = slot<AdFailedToLoadData>()
+
+        stubLoadFromResponse(trackingLoadCallback)
+        every { adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER) } answers {
+            order += "tracked"
+        }
+
+        loadAndTrackFromResponse(loadCallback)
+        trackingLoadCallback.requireCallback().onAdFailedToLoad(error)
+
+        assertEquals(listOf("tracked", "load-callback"), order)
+        adTracker.assertFailedData(failedData, values)
+    }
+
+    private fun responseInfo(): ResponseInfo = mockk(relaxed = true) {
+        every { adapterClassName } returns "test-network"
+        every { responseId } returns "response-id"
+    }
+}
+
+internal class FullScreenAdFlowContract<AdT : Ad, CallbackT : AdEventCallback>(
+    private val adTracker: AdTracker,
+    private val values: FullScreenAdTestValues,
+    private val suspendingValues: FullScreenAdTestValues,
+) {
+    @Suppress("LongParameterList")
+    fun callbackSuccess(
+        createAd: (ResponseInfo, CallbackHolder<CallbackT>) -> AdT,
+        initialEventCallback: CallbackT,
+        replacementEventCallback: CallbackT,
+        stubLoad: (AdRequest, CallbackHolder<AdLoadCallback<AdT>>) -> Unit,
+        loadAndTrack: (AdRequest, AdLoadCallback<AdT>, CallbackT) -> Unit,
+        asTrackingCallback: (CallbackT) -> TrackingAdEventCallback<CallbackT>?,
+        invokeDelegateCallback: (CallbackT) -> Unit,
+        assertInitialDelegateInvoked: () -> Unit,
+        setTrackingEventCallback: (AdT, CallbackT) -> Unit,
+        assertReplacementDelegateInvoked: () -> Unit,
+        show: (AdT, Activity, String) -> Unit,
+        verifyShow: (AdT, Activity) -> Unit,
+    ) {
+        val adRequest = adRequest(values.adUnitId)
+        val installedCallback = CallbackHolder<CallbackT>()
+        val ad = createAd(responseInfo("test-network", "response-id"), installedCallback)
+        val activity = mockk<Activity>()
+        val loadCallback = FullScreenRecordingAdLoadCallback<AdT>()
+        val trackingLoadCallback = CallbackHolder<AdLoadCallback<AdT>>()
+
+        stubLoad(adRequest, trackingLoadCallback)
+        loadAndTrack(adRequest, loadCallback, initialEventCallback)
+        trackingLoadCallback.requireCallback().onAdLoaded(ad)
+
+        assertSame(ad, loadCallback.loadedAd)
+        val loadedData = slot<AdLoadedData>()
+        adTracker.assertLoadedData(loadedData, values, "test-network", "response-id")
+
+        val callback = installedCallback.requireCallback()
+        val trackingCallback = requireNotNull(asTrackingCallback(callback)) {
+            "Expected a format-specific tracking callback"
+        }
+        invokeDelegateCallback(callback)
+        assertInitialDelegateInvoked()
+
+        setTrackingEventCallback(ad, replacementEventCallback)
+        invokeDelegateCallback(callback)
+        assertReplacementDelegateInvoked()
+
+        show(ad, activity, "show-placement")
+        assertEquals("show-placement", trackingCallback.placement)
+        verifyShow(ad, activity)
+    }
+
+    fun callbackFailure(
+        stubLoad: (AdRequest, CallbackHolder<AdLoadCallback<AdT>>) -> Unit,
+        loadAndTrack: (AdRequest, AdLoadCallback<AdT>) -> Unit,
+    ) {
+        val adRequest = adRequest(values.adUnitId)
+        val error = mockk<LoadAdError>(relaxed = true)
+        val loadCallback = FullScreenRecordingAdLoadCallback<AdT>()
+        val trackingLoadCallback = CallbackHolder<AdLoadCallback<AdT>>()
+
+        stubLoad(adRequest, trackingLoadCallback)
+        loadAndTrack(adRequest, loadCallback)
+        trackingLoadCallback.requireCallback().onAdFailedToLoad(error)
+
+        assertSame(error, loadCallback.loadError)
+        adTracker.assertFailedData(slot(), values)
+    }
+
+    @Suppress("LongParameterList")
+    suspend fun suspendingSuccess(
+        createAd: (ResponseInfo, CallbackHolder<CallbackT>) -> AdT,
+        eventCallback: CallbackT,
+        stubLoad: (AdRequest, AdLoadResult<AdT>) -> Unit,
+        loadAndTrack: suspend (AdRequest, CallbackT) -> AdLoadResult<AdT>,
+        asTrackingCallback: (CallbackT) -> TrackingAdEventCallback<CallbackT>?,
+        invokeDelegateCallback: (CallbackT) -> Unit,
+        assertDelegateInvoked: () -> Unit,
+    ) {
+        val adRequest = adRequest(suspendingValues.adUnitId)
+        val installedCallback = CallbackHolder<CallbackT>()
+        val ad = createAd(responseInfo("suspend-test-network", "suspend-response-id"), installedCallback)
+        val sdkResult = AdLoadResult.Success(ad)
+
+        stubLoad(adRequest, sdkResult)
+        val result = loadAndTrack(adRequest, eventCallback)
+
+        assertSame(sdkResult, result)
+        val callback = installedCallback.requireCallback()
+        requireNotNull(asTrackingCallback(callback)) { "Expected a format-specific tracking callback" }
+        invokeDelegateCallback(callback)
+        assertDelegateInvoked()
+
+        val loadedData = slot<AdLoadedData>()
+        adTracker.assertLoadedData(
+            loadedData,
+            suspendingValues,
+            networkName = "suspend-test-network",
+            impressionId = "suspend-response-id",
+        )
+    }
+
+    suspend fun suspendingFailure(
+        stubLoad: (AdRequest, AdLoadResult<AdT>) -> Unit,
+        loadAndTrack: suspend (AdRequest) -> AdLoadResult<AdT>,
+    ) {
+        val adRequest = adRequest(suspendingValues.adUnitId)
+        val error = mockk<LoadAdError> {
+            every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR
+        }
+        val sdkResult = AdLoadResult.Failure<AdT>(error)
+
+        stubLoad(adRequest, sdkResult)
+        val result = loadAndTrack(adRequest)
+
+        assertSame(sdkResult, result)
+        val failedData = slot<AdFailedToLoadData>()
+        verify(exactly = 1) {
+            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
+        }
+        assertEquals(
+            AdFailedToLoadData(
+                mediatorName = AdMediatorName.AD_MOB,
+                adFormat = suspendingValues.adFormat,
+                placement = suspendingValues.placement,
+                adUnitId = suspendingValues.adUnitId,
+                mediatorErrorCode = LoadAdError.ErrorCode.NETWORK_ERROR.value,
+            ),
+            failedData.captured,
+        )
+    }
+
+    fun eventCallbackFallback(
+        createAd: () -> AdT,
+        eventCallback: CallbackT,
+        setTrackingEventCallback: (AdT, CallbackT) -> Unit,
+        verifyEventCallbackInstalled: (AdT, CallbackT) -> Unit,
+    ) {
+        val ad = createAd()
+
+        setTrackingEventCallback(ad, eventCallback)
+
+        verifyEventCallbackInstalled(ad, eventCallback)
+    }
+
+    private fun adRequest(adUnitId: String): AdRequest = mockk {
+        every { this@mockk.adUnitId } returns adUnitId
+    }
+
+    private fun responseInfo(networkName: String, impressionId: String): ResponseInfo = mockk(relaxed = true) {
+        every { adapterClassName } returns networkName
+        every { responseId } returns impressionId
+    }
+}
+
+internal fun <CallbackT : AdEventCallback> assertShowClearsPlacement(
+    trackingCallback: TrackingAdEventCallback<CallbackT>,
+    show: () -> Unit,
+    verifyShow: () -> Unit,
+) {
+    assertEquals("load-placement", trackingCallback.placement)
+
+    show()
+
+    assertNull(trackingCallback.placement)
+    verifyShow()
+}
+
+internal fun AdTracker.assertLoadedData(
+    loadedData: CapturingSlot<AdLoadedData>,
+    values: FullScreenAdTestValues,
+    networkName: String,
+    impressionId: String,
+) {
+    verify(exactly = 1) {
+        trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER)
+    }
+    assertEquals(
+        AdLoadedData(
+            networkName = networkName,
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = values.adFormat,
+            placement = values.placement,
+            adUnitId = values.adUnitId,
+            impressionId = impressionId,
+        ),
+        loadedData.captured,
+    )
+}
+
+internal fun AdTracker.assertFailedData(
+    failedData: CapturingSlot<AdFailedToLoadData>,
+    values: FullScreenAdTestValues,
+) {
+    verify(exactly = 1) {
+        trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
+    }
+    assertEquals(values.adFormat, failedData.captured.adFormat)
+    assertEquals(values.adUnitId, failedData.captured.adUnitId)
+    assertEquals(values.placement, failedData.captured.placement)
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/FullScreenAdFlowTestContracts.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/FullScreenAdFlowTestContracts.kt
@@ -2,12 +2,8 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
-import android.app.Activity
-import com.google.android.libraries.ads.mobile.sdk.common.Ad
 import com.google.android.libraries.ads.mobile.sdk.common.AdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
-import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -24,7 +20,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 
 internal data class FullScreenAdTestValues(
@@ -36,7 +31,7 @@ internal data class FullScreenAdTestValues(
 internal class CallbackHolder<CallbackT> {
     var callback: CallbackT? = null
 
-    fun requireCallback(): CallbackT = requireNotNull(callback) { "Expected an ad event callback to be installed" }
+    fun requireCallback(): CallbackT = requireNotNull(callback) { "Expected an ad callback to be installed" }
 }
 
 internal class FullScreenRecordingAdLoadCallback<AdT> : AdLoadCallback<AdT> {
@@ -52,24 +47,39 @@ internal class FullScreenRecordingAdLoadCallback<AdT> : AdLoadCallback<AdT> {
     }
 }
 
+/** Format-specific, statically typed wiring exercised by the shared response-flow contract. */
+internal interface FullScreenAdResponseFlowAdapter<AdT, CallbackT : AdEventCallback> {
+    val values: FullScreenAdTestValues
+
+    fun createAd(
+        responseInfo: ResponseInfo,
+        installedCallback: CallbackHolder<CallbackT>,
+        onCallbackInstalled: () -> Unit,
+    ): AdT
+
+    fun stubLoadFromResponse(trackingLoadCallback: CallbackHolder<AdLoadCallback<AdT>>)
+
+    fun loadAndTrackFromResponse(
+        loadCallback: AdLoadCallback<AdT>,
+        eventCallback: CallbackT?,
+    )
+
+    fun asTrackingCallback(callback: CallbackT): TrackingAdEventCallback<CallbackT>?
+
+    fun invokeDelegateCallback(callback: CallbackT)
+}
+
 internal class FullScreenAdResponseFlowContract<AdT, CallbackT : AdEventCallback>(
     private val adTracker: AdTracker,
-    private val values: FullScreenAdTestValues,
+    private val adapter: FullScreenAdResponseFlowAdapter<AdT, CallbackT>,
 ) {
-    @Suppress("LongParameterList")
     fun responseSuccess(
-        createAd: (ResponseInfo, CallbackHolder<CallbackT>, () -> Unit) -> AdT,
         eventCallback: CallbackT,
-        stubLoadFromResponse: (CallbackHolder<AdLoadCallback<AdT>>) -> Unit,
-        loadAndTrackFromResponse: (AdLoadCallback<AdT>, CallbackT) -> Unit,
-        asTrackingCallback: (CallbackT) -> TrackingAdEventCallback<CallbackT>?,
-        invokeDelegateCallback: (CallbackT) -> Unit,
         assertDelegateInvoked: () -> Unit,
     ) {
         val order = mutableListOf<String>()
-        val responseInfo = responseInfo()
         val installedCallback = CallbackHolder<CallbackT>()
-        val expectedAd = createAd(responseInfo, installedCallback) { order += "event-callback" }
+        val expectedAd = adapter.createAd(responseInfo(), installedCallback) { order += "event-callback" }
         val loadCallback = object : AdLoadCallback<AdT> {
             override fun onAdLoaded(ad: AdT) {
                 order += "load-callback"
@@ -79,32 +89,29 @@ internal class FullScreenAdResponseFlowContract<AdT, CallbackT : AdEventCallback
         val trackingLoadCallback = CallbackHolder<AdLoadCallback<AdT>>()
         val loadedData = slot<AdLoadedData>()
 
-        stubLoadFromResponse(trackingLoadCallback)
+        adapter.stubLoadFromResponse(trackingLoadCallback)
         every { adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER) } answers {
             order += "tracked"
         }
 
-        loadAndTrackFromResponse(loadCallback, eventCallback)
+        adapter.loadAndTrackFromResponse(loadCallback, eventCallback)
         trackingLoadCallback.requireCallback().onAdLoaded(expectedAd)
 
         assertEquals(listOf("tracked", "event-callback", "load-callback"), order)
         adTracker.assertLoadedData(
             loadedData = loadedData,
-            values = values,
+            values = adapter.values,
             networkName = "test-network",
             impressionId = "response-id",
         )
 
         val callback = installedCallback.requireCallback()
-        requireNotNull(asTrackingCallback(callback)) { "Expected a format-specific tracking callback" }
-        invokeDelegateCallback(callback)
+        requireNotNull(adapter.asTrackingCallback(callback)) { "Expected a format-specific tracking callback" }
+        adapter.invokeDelegateCallback(callback)
         assertDelegateInvoked()
     }
 
-    fun responseFailure(
-        stubLoadFromResponse: (CallbackHolder<AdLoadCallback<AdT>>) -> Unit,
-        loadAndTrackFromResponse: (AdLoadCallback<AdT>) -> Unit,
-    ) {
+    fun responseFailure() {
         val order = mutableListOf<String>()
         val error = LoadAdError(
             LoadAdError.ErrorCode.INVALID_AD_RESPONSE,
@@ -120,189 +127,22 @@ internal class FullScreenAdResponseFlowContract<AdT, CallbackT : AdEventCallback
         val trackingLoadCallback = CallbackHolder<AdLoadCallback<AdT>>()
         val failedData = slot<AdFailedToLoadData>()
 
-        stubLoadFromResponse(trackingLoadCallback)
+        adapter.stubLoadFromResponse(trackingLoadCallback)
         every { adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER) } answers {
             order += "tracked"
         }
 
-        loadAndTrackFromResponse(loadCallback)
+        adapter.loadAndTrackFromResponse(loadCallback, eventCallback = null)
         trackingLoadCallback.requireCallback().onAdFailedToLoad(error)
 
         assertEquals(listOf("tracked", "load-callback"), order)
-        adTracker.assertFailedData(failedData, values)
+        adTracker.assertFailedData(failedData, adapter.values)
     }
 
     private fun responseInfo(): ResponseInfo = mockk(relaxed = true) {
         every { adapterClassName } returns "test-network"
         every { responseId } returns "response-id"
     }
-}
-
-internal class FullScreenAdFlowContract<AdT : Ad, CallbackT : AdEventCallback>(
-    private val adTracker: AdTracker,
-    private val values: FullScreenAdTestValues,
-    private val suspendingValues: FullScreenAdTestValues,
-) {
-    @Suppress("LongParameterList")
-    fun callbackSuccess(
-        createAd: (ResponseInfo, CallbackHolder<CallbackT>) -> AdT,
-        initialEventCallback: CallbackT,
-        replacementEventCallback: CallbackT,
-        stubLoad: (AdRequest, CallbackHolder<AdLoadCallback<AdT>>) -> Unit,
-        loadAndTrack: (AdRequest, AdLoadCallback<AdT>, CallbackT) -> Unit,
-        asTrackingCallback: (CallbackT) -> TrackingAdEventCallback<CallbackT>?,
-        invokeDelegateCallback: (CallbackT) -> Unit,
-        assertInitialDelegateInvoked: () -> Unit,
-        setTrackingEventCallback: (AdT, CallbackT) -> Unit,
-        assertReplacementDelegateInvoked: () -> Unit,
-        show: (AdT, Activity, String) -> Unit,
-        verifyShow: (AdT, Activity) -> Unit,
-    ) {
-        val adRequest = adRequest(values.adUnitId)
-        val installedCallback = CallbackHolder<CallbackT>()
-        val ad = createAd(responseInfo("test-network", "response-id"), installedCallback)
-        val activity = mockk<Activity>()
-        val loadCallback = FullScreenRecordingAdLoadCallback<AdT>()
-        val trackingLoadCallback = CallbackHolder<AdLoadCallback<AdT>>()
-
-        stubLoad(adRequest, trackingLoadCallback)
-        loadAndTrack(adRequest, loadCallback, initialEventCallback)
-        trackingLoadCallback.requireCallback().onAdLoaded(ad)
-
-        assertSame(ad, loadCallback.loadedAd)
-        val loadedData = slot<AdLoadedData>()
-        adTracker.assertLoadedData(loadedData, values, "test-network", "response-id")
-
-        val callback = installedCallback.requireCallback()
-        val trackingCallback = requireNotNull(asTrackingCallback(callback)) {
-            "Expected a format-specific tracking callback"
-        }
-        invokeDelegateCallback(callback)
-        assertInitialDelegateInvoked()
-
-        setTrackingEventCallback(ad, replacementEventCallback)
-        invokeDelegateCallback(callback)
-        assertReplacementDelegateInvoked()
-
-        show(ad, activity, "show-placement")
-        assertEquals("show-placement", trackingCallback.placement)
-        verifyShow(ad, activity)
-    }
-
-    fun callbackFailure(
-        stubLoad: (AdRequest, CallbackHolder<AdLoadCallback<AdT>>) -> Unit,
-        loadAndTrack: (AdRequest, AdLoadCallback<AdT>) -> Unit,
-    ) {
-        val adRequest = adRequest(values.adUnitId)
-        val error = mockk<LoadAdError>(relaxed = true)
-        val loadCallback = FullScreenRecordingAdLoadCallback<AdT>()
-        val trackingLoadCallback = CallbackHolder<AdLoadCallback<AdT>>()
-
-        stubLoad(adRequest, trackingLoadCallback)
-        loadAndTrack(adRequest, loadCallback)
-        trackingLoadCallback.requireCallback().onAdFailedToLoad(error)
-
-        assertSame(error, loadCallback.loadError)
-        adTracker.assertFailedData(slot(), values)
-    }
-
-    @Suppress("LongParameterList")
-    suspend fun suspendingSuccess(
-        createAd: (ResponseInfo, CallbackHolder<CallbackT>) -> AdT,
-        eventCallback: CallbackT,
-        stubLoad: (AdRequest, AdLoadResult<AdT>) -> Unit,
-        loadAndTrack: suspend (AdRequest, CallbackT) -> AdLoadResult<AdT>,
-        asTrackingCallback: (CallbackT) -> TrackingAdEventCallback<CallbackT>?,
-        invokeDelegateCallback: (CallbackT) -> Unit,
-        assertDelegateInvoked: () -> Unit,
-    ) {
-        val adRequest = adRequest(suspendingValues.adUnitId)
-        val installedCallback = CallbackHolder<CallbackT>()
-        val ad = createAd(responseInfo("suspend-test-network", "suspend-response-id"), installedCallback)
-        val sdkResult = AdLoadResult.Success(ad)
-
-        stubLoad(adRequest, sdkResult)
-        val result = loadAndTrack(adRequest, eventCallback)
-
-        assertSame(sdkResult, result)
-        val callback = installedCallback.requireCallback()
-        requireNotNull(asTrackingCallback(callback)) { "Expected a format-specific tracking callback" }
-        invokeDelegateCallback(callback)
-        assertDelegateInvoked()
-
-        val loadedData = slot<AdLoadedData>()
-        adTracker.assertLoadedData(
-            loadedData,
-            suspendingValues,
-            networkName = "suspend-test-network",
-            impressionId = "suspend-response-id",
-        )
-    }
-
-    suspend fun suspendingFailure(
-        stubLoad: (AdRequest, AdLoadResult<AdT>) -> Unit,
-        loadAndTrack: suspend (AdRequest) -> AdLoadResult<AdT>,
-    ) {
-        val adRequest = adRequest(suspendingValues.adUnitId)
-        val error = mockk<LoadAdError> {
-            every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR
-        }
-        val sdkResult = AdLoadResult.Failure<AdT>(error)
-
-        stubLoad(adRequest, sdkResult)
-        val result = loadAndTrack(adRequest)
-
-        assertSame(sdkResult, result)
-        val failedData = slot<AdFailedToLoadData>()
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(
-            AdFailedToLoadData(
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = suspendingValues.adFormat,
-                placement = suspendingValues.placement,
-                adUnitId = suspendingValues.adUnitId,
-                mediatorErrorCode = LoadAdError.ErrorCode.NETWORK_ERROR.value,
-            ),
-            failedData.captured,
-        )
-    }
-
-    fun eventCallbackFallback(
-        createAd: () -> AdT,
-        eventCallback: CallbackT,
-        setTrackingEventCallback: (AdT, CallbackT) -> Unit,
-        verifyEventCallbackInstalled: (AdT, CallbackT) -> Unit,
-    ) {
-        val ad = createAd()
-
-        setTrackingEventCallback(ad, eventCallback)
-
-        verifyEventCallbackInstalled(ad, eventCallback)
-    }
-
-    private fun adRequest(adUnitId: String): AdRequest = mockk {
-        every { this@mockk.adUnitId } returns adUnitId
-    }
-
-    private fun responseInfo(networkName: String, impressionId: String): ResponseInfo = mockk(relaxed = true) {
-        every { adapterClassName } returns networkName
-        every { responseId } returns impressionId
-    }
-}
-
-internal fun <CallbackT : AdEventCallback> assertShowClearsPlacement(
-    trackingCallback: TrackingAdEventCallback<CallbackT>,
-    show: () -> Unit,
-    verifyShow: () -> Unit,
-) {
-    assertEquals("load-placement", trackingCallback.placement)
-
-    show()
-
-    assertNull(trackingCallback.placement)
-    verifyShow()
 }
 
 internal fun AdTracker.assertLoadedData(
@@ -337,4 +177,23 @@ internal fun AdTracker.assertFailedData(
     assertEquals(values.adFormat, failedData.captured.adFormat)
     assertEquals(values.adUnitId, failedData.captured.adUnitId)
     assertEquals(values.placement, failedData.captured.placement)
+}
+
+internal fun AdTracker.assertSuspendingFailedData(
+    failedData: CapturingSlot<AdFailedToLoadData>,
+    values: FullScreenAdTestValues,
+) {
+    verify(exactly = 1) {
+        trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
+    }
+    assertEquals(
+        AdFailedToLoadData(
+            mediatorName = AdMediatorName.AD_MOB,
+            adFormat = values.adFormat,
+            placement = values.placement,
+            adUnitId = values.adUnitId,
+            mediatorErrorCode = LoadAdError.ErrorCode.NETWORK_ERROR.value,
+        ),
+        failedData.captured,
+    )
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdFlowTest.kt
@@ -3,43 +3,38 @@
 package com.revenuecat.purchases.admob.nextgen
 
 import android.app.Activity
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
-import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingInterstitialAdEventCallback
-import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
-import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
-import com.revenuecat.purchases.ads.events.types.AdLoadedData
-import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 class InterstitialAdFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
+    private val contract = FullScreenAdFlowContract<InterstitialAd, InterstitialAdEventCallback>(
+        adTracker = adTracker,
+        values = FullScreenAdTestValues(AdFormat.INTERSTITIAL, "interstitial-unit", "load-placement"),
+        suspendingValues = FullScreenAdTestValues(
+            AdFormat.INTERSTITIAL,
+            "suspend-interstitial-unit",
+            "suspend-load-placement",
+        ),
+    )
 
     @Before
     fun setUp() {
@@ -58,65 +53,40 @@ class InterstitialAdFlowTest {
 
     @Test
     fun `interstitial success installs tracking and supports placement and delegate updates`() {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "interstitial-unit"
-        }
-        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-            every { adapterClassName } returns "test-network"
-            every { responseId } returns "response-id"
-        }
-        var installedCallback: InterstitialAdEventCallback? = null
-        val interstitialAd = mockk<InterstitialAd>(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo
-            every { adEventCallback } answers { installedCallback }
-            every { adEventCallback = any() } answers { installedCallback = firstArg() }
-        }
-        val activity = mockk<Activity>()
-        val loadCallback = RecordingInterstitialLoadCallback()
         val initialEventCallback = RecordingInterstitialAdEventCallback()
         val replacementEventCallback = RecordingInterstitialAdEventCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<InterstitialAd>>()
 
-        every { InterstitialAd.load(adRequest, capture(trackingLoadCallback)) } just runs
-
-        adTracker.loadAndTrackInterstitialAd(
-            adRequest = adRequest,
-            placement = "load-placement",
-            loadCallback = loadCallback,
-            adEventCallback = initialEventCallback,
+        contract.callbackSuccess(
+            createAd = { responseInfo, installedCallback ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback } answers { installedCallback.callback }
+                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
+                }
+            },
+            initialEventCallback = initialEventCallback,
+            replacementEventCallback = replacementEventCallback,
+            stubLoad = { adRequest, trackingLoadCallback ->
+                every { InterstitialAd.load(adRequest, any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrack = { adRequest, loadCallback, eventCallback ->
+                adTracker.loadAndTrackInterstitialAd(
+                    adRequest = adRequest,
+                    placement = "load-placement",
+                    loadCallback = loadCallback,
+                    adEventCallback = eventCallback,
+                )
+            },
+            asTrackingCallback = { it as? TrackingInterstitialAdEventCallback },
+            invokeDelegateCallback = { it.onAppEvent("name", "data") },
+            assertInitialDelegateInvoked = { assertTrue(initialEventCallback.appEventCalled) },
+            setTrackingEventCallback = { ad, eventCallback -> ad.setTrackingAdEventCallback(eventCallback) },
+            assertReplacementDelegateInvoked = { assertTrue(replacementEventCallback.appEventCalled) },
+            show = { ad, activity, placement -> ad.show(activity, placement) },
+            verifyShow = { ad, activity -> verify(exactly = 1) { ad.show(activity) } },
         )
-        trackingLoadCallback.captured.onAdLoaded(interstitialAd)
-
-        assertSame(interstitialAd, loadCallback.loadedAd)
-
-        // Pins the format, ad unit and placement this entry point hands to the load tracker;
-        // the wrapper classes are covered separately, so only the wiring is asserted here.
-        val loadedData = slot<AdLoadedData>()
-        verify(exactly = 1) {
-            adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(
-            AdLoadedData(
-                networkName = "test-network",
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.INTERSTITIAL,
-                placement = "load-placement",
-                adUnitId = "interstitial-unit",
-                impressionId = "response-id",
-            ),
-            loadedData.captured,
-        )
-        val trackingCallback = installedCallback as TrackingInterstitialAdEventCallback
-        trackingCallback.onAppEvent("name", "data")
-        assertTrue(initialEventCallback.appEventCalled)
-
-        interstitialAd.setTrackingAdEventCallback(replacementEventCallback)
-        trackingCallback.onAppEvent("name", "data")
-        assertTrue(replacementEventCallback.appEventCalled)
-
-        interstitialAd.show(activity, "show-placement")
-        assertEquals("show-placement", trackingCallback.placement)
-        verify(exactly = 1) { interstitialAd.show(activity) }
     }
 
     @Test
@@ -132,134 +102,87 @@ class InterstitialAdFlowTest {
             every { adEventCallback } returns trackingCallback
         }
 
-        interstitialAd.show(activity, placement = null)
-
-        assertNull(trackingCallback.placement)
-        verify(exactly = 1) { interstitialAd.show(activity) }
+        assertShowClearsPlacement(
+            trackingCallback = trackingCallback,
+            show = { interstitialAd.show(activity, placement = null) },
+            verifyShow = { verify(exactly = 1) { interstitialAd.show(activity) } },
+        )
     }
 
     @Test
     fun `interstitial failure is forwarded to load callback`() {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "interstitial-unit"
-        }
-        val error = mockk<LoadAdError>(relaxed = true)
-        val loadCallback = RecordingInterstitialLoadCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<InterstitialAd>>()
-
-        every { InterstitialAd.load(adRequest, capture(trackingLoadCallback)) } just runs
-
-        adTracker.loadAndTrackInterstitialAd(
-            adRequest = adRequest,
-            placement = "load-placement",
-            loadCallback = loadCallback,
+        contract.callbackFailure(
+            stubLoad = { adRequest, trackingLoadCallback ->
+                every { InterstitialAd.load(adRequest, any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrack = { adRequest, loadCallback ->
+                adTracker.loadAndTrackInterstitialAd(
+                    adRequest = adRequest,
+                    placement = "load-placement",
+                    loadCallback = loadCallback,
+                )
+            },
         )
-        trackingLoadCallback.captured.onAdFailedToLoad(error)
-
-        assertSame(error, loadCallback.loadError)
-
-        val failedData = slot<AdFailedToLoadData>()
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(AdFormat.INTERSTITIAL, failedData.captured.adFormat)
-        assertEquals("interstitial-unit", failedData.captured.adUnitId)
-        assertEquals("load-placement", failedData.captured.placement)
     }
 
     @Test
-    fun `suspending interstitial success tracks and installs callback before returning original result`() =
-        runBlocking {
-            val adRequest = mockk<AdRequest> {
-                every { adUnitId } returns "suspend-interstitial-unit"
-            }
-            val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-                every { adapterClassName } returns "suspend-test-network"
-                every { responseId } returns "suspend-response-id"
-            }
-            var installedCallback: InterstitialAdEventCallback? = null
-            val interstitialAd = mockk<InterstitialAd>(relaxed = true) {
-                every { getResponseInfo() } returns responseInfo
-                every { adEventCallback } answers { installedCallback }
-                every { adEventCallback = any() } answers { installedCallback = firstArg() }
-            }
-            val eventCallback = RecordingInterstitialAdEventCallback()
-            val sdkResult = AdLoadResult.Success(interstitialAd)
+    fun `suspending interstitial success tracks and installs callback before returning original result`() = runBlocking {
+        val eventCallback = RecordingInterstitialAdEventCallback()
 
-            coEvery { InterstitialAd.load(adRequest) } returns sdkResult
-
-            val result = adTracker.loadAndTrackInterstitialAd(
-                adRequest = adRequest,
-                placement = "suspend-load-placement",
-                adEventCallback = eventCallback,
-            )
-
-            assertSame(sdkResult, result)
-            val trackingCallback = installedCallback as TrackingInterstitialAdEventCallback
-            trackingCallback.onAppEvent("name", "data")
-            assertTrue(eventCallback.appEventCalled)
-
-            val loadedData = slot<AdLoadedData>()
-            verify(exactly = 1) {
-                adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER)
-            }
-            assertEquals(
-                AdLoadedData(
-                    networkName = "suspend-test-network",
-                    mediatorName = AdMediatorName.AD_MOB,
-                    adFormat = AdFormat.INTERSTITIAL,
+        contract.suspendingSuccess(
+            createAd = { responseInfo, installedCallback ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback } answers { installedCallback.callback }
+                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
+                }
+            },
+            eventCallback = eventCallback,
+            stubLoad = { adRequest, sdkResult -> coEvery { InterstitialAd.load(adRequest) } returns sdkResult },
+            loadAndTrack = { adRequest, delegate ->
+                adTracker.loadAndTrackInterstitialAd(
+                    adRequest = adRequest,
                     placement = "suspend-load-placement",
-                    adUnitId = "suspend-interstitial-unit",
-                    impressionId = "suspend-response-id",
-                ),
-                loadedData.captured,
-            )
-        }
+                    adEventCallback = delegate,
+                )
+            },
+            asTrackingCallback = { it as? TrackingInterstitialAdEventCallback },
+            invokeDelegateCallback = { it.onAppEvent("name", "data") },
+            assertDelegateInvoked = { assertTrue(eventCallback.appEventCalled) },
+        )
+    }
 
     @Test
     fun `suspending interstitial failure tracks error and returns original result`() = runBlocking {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "suspend-interstitial-unit"
-        }
-        val error = mockk<LoadAdError> {
-            every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR
-        }
-        val sdkResult = AdLoadResult.Failure<InterstitialAd>(error)
-
-        coEvery { InterstitialAd.load(adRequest) } returns sdkResult
-
-        val result = adTracker.loadAndTrackInterstitialAd(
-            adRequest = adRequest,
-            placement = "suspend-load-placement",
-        )
-
-        assertSame(sdkResult, result)
-        val failedData = slot<AdFailedToLoadData>()
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(
-            AdFailedToLoadData(
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.INTERSTITIAL,
-                placement = "suspend-load-placement",
-                adUnitId = "suspend-interstitial-unit",
-                mediatorErrorCode = LoadAdError.ErrorCode.NETWORK_ERROR.value,
-            ),
-            failedData.captured,
+        contract.suspendingFailure(
+            stubLoad = { adRequest, sdkResult -> coEvery { InterstitialAd.load(adRequest) } returns sdkResult },
+            loadAndTrack = { adRequest ->
+                adTracker.loadAndTrackInterstitialAd(
+                    adRequest = adRequest,
+                    placement = "suspend-load-placement",
+                )
+            },
         )
     }
 
     @Test
     fun `setting event callback directly falls back when tracking is not installed`() {
-        val interstitialAd = mockk<InterstitialAd>(relaxed = true) {
-            every { adEventCallback } returns null
-        }
         val eventCallback = RecordingInterstitialAdEventCallback()
 
-        interstitialAd.setTrackingAdEventCallback(eventCallback)
-
-        verify(exactly = 1) { interstitialAd.adEventCallback = eventCallback }
+        contract.eventCallbackFallback(
+            createAd = {
+                mockk(relaxed = true) {
+                    every { adEventCallback } returns null
+                }
+            },
+            eventCallback = eventCallback,
+            setTrackingEventCallback = { ad, callback -> ad.setTrackingAdEventCallback(callback) },
+            verifyEventCallbackInstalled = { ad, callback ->
+                verify(exactly = 1) { ad.adEventCallback = callback }
+            },
+        )
     }
 
     private class RecordingInterstitialAdEventCallback : InterstitialAdEventCallback {
@@ -267,19 +190,6 @@ class InterstitialAdFlowTest {
 
         override fun onAppEvent(name: String, data: String?) {
             appEventCalled = true
-        }
-    }
-
-    private class RecordingInterstitialLoadCallback : AdLoadCallback<InterstitialAd> {
-        var loadedAd: InterstitialAd? = null
-        var loadError: LoadAdError? = null
-
-        override fun onAdLoaded(ad: InterstitialAd) {
-            loadedAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            loadError = adError
         }
     }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdFlowTest.kt
@@ -3,21 +3,34 @@
 package com.revenuecat.purchases.admob.nextgen
 
 import android.app.Activity
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingInterstitialAdEventCallback
 import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdLoadedData
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -26,14 +39,11 @@ class InterstitialAdFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
-    private val contract = FullScreenAdFlowContract<InterstitialAd, InterstitialAdEventCallback>(
-        adTracker = adTracker,
-        values = FullScreenAdTestValues(AdFormat.INTERSTITIAL, "interstitial-unit", "load-placement"),
-        suspendingValues = FullScreenAdTestValues(
-            AdFormat.INTERSTITIAL,
-            "suspend-interstitial-unit",
-            "suspend-load-placement",
-        ),
+    private val values = FullScreenAdTestValues(AdFormat.INTERSTITIAL, "interstitial-unit", "load-placement")
+    private val suspendingValues = FullScreenAdTestValues(
+        AdFormat.INTERSTITIAL,
+        "suspend-interstitial-unit",
+        "suspend-load-placement",
     )
 
     @Before
@@ -53,40 +63,47 @@ class InterstitialAdFlowTest {
 
     @Test
     fun `interstitial success installs tracking and supports placement and delegate updates`() {
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns values.adUnitId }
+        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
+            every { adapterClassName } returns "test-network"
+            every { responseId } returns "response-id"
+        }
+        var installedCallback: InterstitialAdEventCallback? = null
+        val interstitialAd = mockk<InterstitialAd>(relaxed = true) {
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback } answers { installedCallback }
+            every { adEventCallback = any() } answers { installedCallback = firstArg() }
+        }
+        val activity = mockk<Activity>()
+        val loadCallback = FullScreenRecordingAdLoadCallback<InterstitialAd>()
         val initialEventCallback = RecordingInterstitialAdEventCallback()
         val replacementEventCallback = RecordingInterstitialAdEventCallback()
+        val trackingLoadCallback = slot<AdLoadCallback<InterstitialAd>>()
 
-        contract.callbackSuccess(
-            createAd = { responseInfo, installedCallback ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback } answers { installedCallback.callback }
-                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
-                }
-            },
-            initialEventCallback = initialEventCallback,
-            replacementEventCallback = replacementEventCallback,
-            stubLoad = { adRequest, trackingLoadCallback ->
-                every { InterstitialAd.load(adRequest, any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrack = { adRequest, loadCallback, eventCallback ->
-                adTracker.loadAndTrackInterstitialAd(
-                    adRequest = adRequest,
-                    placement = "load-placement",
-                    loadCallback = loadCallback,
-                    adEventCallback = eventCallback,
-                )
-            },
-            asTrackingCallback = { it as? TrackingInterstitialAdEventCallback },
-            invokeDelegateCallback = { it.onAppEvent("name", "data") },
-            assertInitialDelegateInvoked = { assertTrue(initialEventCallback.appEventCalled) },
-            setTrackingEventCallback = { ad, eventCallback -> ad.setTrackingAdEventCallback(eventCallback) },
-            assertReplacementDelegateInvoked = { assertTrue(replacementEventCallback.appEventCalled) },
-            show = { ad, activity, placement -> ad.show(activity, placement) },
-            verifyShow = { ad, activity -> verify(exactly = 1) { ad.show(activity) } },
+        every { InterstitialAd.load(adRequest, capture(trackingLoadCallback)) } just runs
+
+        adTracker.loadAndTrackInterstitialAd(
+            adRequest = adRequest,
+            placement = values.placement,
+            loadCallback = loadCallback,
+            adEventCallback = initialEventCallback,
         )
+        trackingLoadCallback.captured.onAdLoaded(interstitialAd)
+
+        assertSame(interstitialAd, loadCallback.loadedAd)
+        adTracker.assertLoadedData(slot(), values, "test-network", "response-id")
+
+        val trackingCallback = requireNotNull(installedCallback as? TrackingInterstitialAdEventCallback)
+        trackingCallback.onAppEvent("name", "data")
+        assertTrue(initialEventCallback.appEventCalled)
+
+        interstitialAd.setTrackingAdEventCallback(replacementEventCallback)
+        trackingCallback.onAppEvent("name", "data")
+        assertTrue(replacementEventCallback.appEventCalled)
+
+        interstitialAd.show(activity, "show-placement")
+        assertEquals("show-placement", trackingCallback.placement)
+        verify(exactly = 1) { interstitialAd.show(activity) }
     }
 
     @Test
@@ -102,87 +119,93 @@ class InterstitialAdFlowTest {
             every { adEventCallback } returns trackingCallback
         }
 
-        assertShowClearsPlacement(
-            trackingCallback = trackingCallback,
-            show = { interstitialAd.show(activity, placement = null) },
-            verifyShow = { verify(exactly = 1) { interstitialAd.show(activity) } },
-        )
+        interstitialAd.show(activity, placement = null)
+
+        assertNull(trackingCallback.placement)
+        verify(exactly = 1) { interstitialAd.show(activity) }
     }
 
     @Test
     fun `interstitial failure is forwarded to load callback`() {
-        contract.callbackFailure(
-            stubLoad = { adRequest, trackingLoadCallback ->
-                every { InterstitialAd.load(adRequest, any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrack = { adRequest, loadCallback ->
-                adTracker.loadAndTrackInterstitialAd(
-                    adRequest = adRequest,
-                    placement = "load-placement",
-                    loadCallback = loadCallback,
-                )
-            },
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns values.adUnitId }
+        val error = mockk<LoadAdError>(relaxed = true)
+        val loadCallback = FullScreenRecordingAdLoadCallback<InterstitialAd>()
+        val trackingLoadCallback = slot<AdLoadCallback<InterstitialAd>>()
+
+        every { InterstitialAd.load(adRequest, capture(trackingLoadCallback)) } just runs
+        adTracker.loadAndTrackInterstitialAd(
+            adRequest = adRequest,
+            placement = values.placement,
+            loadCallback = loadCallback,
         )
+        trackingLoadCallback.captured.onAdFailedToLoad(error)
+
+        assertSame(error, loadCallback.loadError)
+        adTracker.assertFailedData(slot(), values)
     }
 
     @Test
     fun `suspending interstitial success tracks and installs callback before returning original result`() = runBlocking {
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns suspendingValues.adUnitId }
+        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
+            every { adapterClassName } returns "suspend-test-network"
+            every { responseId } returns "suspend-response-id"
+        }
+        var installedCallback: InterstitialAdEventCallback? = null
+        val interstitialAd = mockk<InterstitialAd>(relaxed = true) {
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback } answers { installedCallback }
+            every { adEventCallback = any() } answers { installedCallback = firstArg() }
+        }
         val eventCallback = RecordingInterstitialAdEventCallback()
+        val sdkResult = AdLoadResult.Success(interstitialAd)
 
-        contract.suspendingSuccess(
-            createAd = { responseInfo, installedCallback ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback } answers { installedCallback.callback }
-                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
-                }
-            },
-            eventCallback = eventCallback,
-            stubLoad = { adRequest, sdkResult -> coEvery { InterstitialAd.load(adRequest) } returns sdkResult },
-            loadAndTrack = { adRequest, delegate ->
-                adTracker.loadAndTrackInterstitialAd(
-                    adRequest = adRequest,
-                    placement = "suspend-load-placement",
-                    adEventCallback = delegate,
-                )
-            },
-            asTrackingCallback = { it as? TrackingInterstitialAdEventCallback },
-            invokeDelegateCallback = { it.onAppEvent("name", "data") },
-            assertDelegateInvoked = { assertTrue(eventCallback.appEventCalled) },
+        coEvery { InterstitialAd.load(adRequest) } returns sdkResult
+
+        val result = adTracker.loadAndTrackInterstitialAd(
+            adRequest = adRequest,
+            placement = suspendingValues.placement,
+            adEventCallback = eventCallback,
+        )
+
+        assertSame(sdkResult, result)
+        val trackingCallback = requireNotNull(installedCallback as? TrackingInterstitialAdEventCallback)
+        trackingCallback.onAppEvent("name", "data")
+        assertTrue(eventCallback.appEventCalled)
+        adTracker.assertLoadedData(
+            slot<AdLoadedData>(),
+            suspendingValues,
+            "suspend-test-network",
+            "suspend-response-id",
         )
     }
 
     @Test
     fun `suspending interstitial failure tracks error and returns original result`() = runBlocking {
-        contract.suspendingFailure(
-            stubLoad = { adRequest, sdkResult -> coEvery { InterstitialAd.load(adRequest) } returns sdkResult },
-            loadAndTrack = { adRequest ->
-                adTracker.loadAndTrackInterstitialAd(
-                    adRequest = adRequest,
-                    placement = "suspend-load-placement",
-                )
-            },
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns suspendingValues.adUnitId }
+        val error = mockk<LoadAdError> { every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR }
+        val sdkResult = AdLoadResult.Failure<InterstitialAd>(error)
+
+        coEvery { InterstitialAd.load(adRequest) } returns sdkResult
+        val result = adTracker.loadAndTrackInterstitialAd(
+            adRequest = adRequest,
+            placement = suspendingValues.placement,
         )
+
+        assertSame(sdkResult, result)
+        adTracker.assertSuspendingFailedData(slot<AdFailedToLoadData>(), suspendingValues)
     }
 
     @Test
     fun `setting event callback directly falls back when tracking is not installed`() {
+        val interstitialAd = mockk<InterstitialAd>(relaxed = true) {
+            every { adEventCallback } returns null
+        }
         val eventCallback = RecordingInterstitialAdEventCallback()
 
-        contract.eventCallbackFallback(
-            createAd = {
-                mockk(relaxed = true) {
-                    every { adEventCallback } returns null
-                }
-            },
-            eventCallback = eventCallback,
-            setTrackingEventCallback = { ad, callback -> ad.setTrackingAdEventCallback(callback) },
-            verifyEventCallbackInstalled = { ad, callback ->
-                verify(exactly = 1) { ad.adEventCallback = callback }
-            },
-        )
+        interstitialAd.setTrackingAdEventCallback(eventCallback)
+
+        verify(exactly = 1) { interstitialAd.adEventCallback = eventCallback }
     }
 
     private class RecordingInterstitialAdEventCallback : InterstitialAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdResponseFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdResponseFlowTest.kt
@@ -2,6 +2,8 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -22,13 +24,9 @@ class InterstitialAdResponseFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
-    private val contract = FullScreenAdResponseFlowContract<InterstitialAd, InterstitialAdEventCallback>(
+    private val contract = FullScreenAdResponseFlowContract(
         adTracker = adTracker,
-        values = FullScreenAdTestValues(
-            adFormat = AdFormat.INTERSTITIAL,
-            adUnitId = "supplied-interstitial-unit",
-            placement = "response-interstitial",
-        ),
+        adapter = InterstitialAdAdapter(),
     )
 
     @Before
@@ -51,53 +49,64 @@ class InterstitialAdResponseFlowTest {
         val eventCallback = RecordingInterstitialEventCallback()
 
         contract.responseSuccess(
-            createAd = { responseInfo, installedCallback, onCallbackInstalled ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback = any() } answers {
-                        installedCallback.callback = firstArg()
-                        onCallbackInstalled()
-                    }
-                }
-            },
             eventCallback = eventCallback,
-            stubLoadFromResponse = { trackingLoadCallback ->
-                every { InterstitialAd.loadFromAdResponse("opaque-response", any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrackFromResponse = { loadCallback, delegate ->
-                adTracker.loadAndTrackInterstitialAdFromResponse(
-                    adResponse = "opaque-response",
-                    adUnitId = "supplied-interstitial-unit",
-                    placement = "response-interstitial",
-                    loadCallback = loadCallback,
-                    adEventCallback = delegate,
-                )
-            },
-            asTrackingCallback = { it as? TrackingInterstitialAdEventCallback },
-            invokeDelegateCallback = { it.onAppEvent("name", "data") },
             assertDelegateInvoked = { assertTrue(eventCallback.appEventCalled) },
         )
     }
 
     @Test
     fun `response failure uses supplied ad unit and placement before forwarding`() {
-        contract.responseFailure(
-            stubLoadFromResponse = { trackingLoadCallback ->
-                every { InterstitialAd.loadFromAdResponse("opaque-response", any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrackFromResponse = { loadCallback ->
-                adTracker.loadAndTrackInterstitialAdFromResponse(
-                    adResponse = "opaque-response",
-                    adUnitId = "supplied-interstitial-unit",
-                    placement = "response-interstitial",
-                    loadCallback = loadCallback,
-                )
-            },
+        contract.responseFailure()
+    }
+
+    private inner class InterstitialAdAdapter :
+        FullScreenAdResponseFlowAdapter<InterstitialAd, InterstitialAdEventCallback> {
+        override val values = FullScreenAdTestValues(
+            adFormat = AdFormat.INTERSTITIAL,
+            adUnitId = "supplied-interstitial-unit",
+            placement = "response-interstitial",
         )
+
+        override fun createAd(
+            responseInfo: ResponseInfo,
+            installedCallback: CallbackHolder<InterstitialAdEventCallback>,
+            onCallbackInstalled: () -> Unit,
+        ): InterstitialAd = mockk(relaxed = true) {
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback = any() } answers {
+                installedCallback.callback = firstArg()
+                onCallbackInstalled()
+            }
+        }
+
+        override fun stubLoadFromResponse(
+            trackingLoadCallback: CallbackHolder<AdLoadCallback<InterstitialAd>>,
+        ) {
+            every { InterstitialAd.loadFromAdResponse("opaque-response", any()) } answers {
+                trackingLoadCallback.callback = secondArg()
+            }
+        }
+
+        override fun loadAndTrackFromResponse(
+            loadCallback: AdLoadCallback<InterstitialAd>,
+            eventCallback: InterstitialAdEventCallback?,
+        ) {
+            adTracker.loadAndTrackInterstitialAdFromResponse(
+                adResponse = "opaque-response",
+                adUnitId = values.adUnitId,
+                placement = values.placement,
+                loadCallback = loadCallback,
+                adEventCallback = eventCallback,
+            )
+        }
+
+        override fun asTrackingCallback(
+            callback: InterstitialAdEventCallback,
+        ): TrackingInterstitialAdEventCallback? = callback as? TrackingInterstitialAdEventCallback
+
+        override fun invokeDelegateCallback(callback: InterstitialAdEventCallback) {
+            callback.onAppEvent("name", "data")
+        }
     }
 
     private class RecordingInterstitialEventCallback : InterstitialAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdResponseFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/InterstitialAdResponseFlowTest.kt
@@ -2,38 +2,34 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingInterstitialAdEventCallback
-import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
-import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
-import com.revenuecat.purchases.ads.events.types.AdLoadedData
-import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.slot
 import io.mockk.unmockkObject
-import io.mockk.verify
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 class InterstitialAdResponseFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
+    private val contract = FullScreenAdResponseFlowContract<InterstitialAd, InterstitialAdEventCallback>(
+        adTracker = adTracker,
+        values = FullScreenAdTestValues(
+            adFormat = AdFormat.INTERSTITIAL,
+            adUnitId = "supplied-interstitial-unit",
+            placement = "response-interstitial",
+        ),
+    )
 
     @Before
     fun setUp() {
@@ -52,101 +48,56 @@ class InterstitialAdResponseFlowTest {
 
     @Test
     fun `response success tracks and installs event callback before forwarding`() {
-        val order = mutableListOf<String>()
-        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-            every { adapterClassName } returns "test-network"
-            every { responseId } returns "response-id"
-        }
-        val interstitialAd = mockk<InterstitialAd>(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo
-        }
-        val loadCallback = object : AdLoadCallback<InterstitialAd> {
-            override fun onAdLoaded(ad: InterstitialAd) {
-                order += "load-callback"
-                assertSame(interstitialAd, ad)
-            }
-        }
         val eventCallback = RecordingInterstitialEventCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<InterstitialAd>>()
-        val installedEventCallback = slot<InterstitialAdEventCallback>()
-        val loadedData = slot<AdLoadedData>()
 
-        every {
-            InterstitialAd.loadFromAdResponse("opaque-response", capture(trackingLoadCallback))
-        } just runs
-        every { adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER) } answers {
-            order += "tracked"
-        }
-        every { interstitialAd.adEventCallback = capture(installedEventCallback) } answers {
-            order += "event-callback"
-        }
-
-        adTracker.loadAndTrackInterstitialAdFromResponse(
-            adResponse = "opaque-response",
-            adUnitId = "supplied-interstitial-unit",
-            placement = "response-interstitial",
-            loadCallback = loadCallback,
-            adEventCallback = eventCallback,
+        contract.responseSuccess(
+            createAd = { responseInfo, installedCallback, onCallbackInstalled ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback = any() } answers {
+                        installedCallback.callback = firstArg()
+                        onCallbackInstalled()
+                    }
+                }
+            },
+            eventCallback = eventCallback,
+            stubLoadFromResponse = { trackingLoadCallback ->
+                every { InterstitialAd.loadFromAdResponse("opaque-response", any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrackFromResponse = { loadCallback, delegate ->
+                adTracker.loadAndTrackInterstitialAdFromResponse(
+                    adResponse = "opaque-response",
+                    adUnitId = "supplied-interstitial-unit",
+                    placement = "response-interstitial",
+                    loadCallback = loadCallback,
+                    adEventCallback = delegate,
+                )
+            },
+            asTrackingCallback = { it as? TrackingInterstitialAdEventCallback },
+            invokeDelegateCallback = { it.onAppEvent("name", "data") },
+            assertDelegateInvoked = { assertTrue(eventCallback.appEventCalled) },
         )
-        trackingLoadCallback.captured.onAdLoaded(interstitialAd)
-
-        assertEquals(listOf("tracked", "event-callback", "load-callback"), order)
-        assertEquals(
-            AdLoadedData(
-                networkName = "test-network",
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.INTERSTITIAL,
-                placement = "response-interstitial",
-                adUnitId = "supplied-interstitial-unit",
-                impressionId = "response-id",
-            ),
-            loadedData.captured,
-        )
-        assertTrue(installedEventCallback.captured is TrackingInterstitialAdEventCallback)
-
-        installedEventCallback.captured.onAppEvent("name", "data")
-        assertTrue(eventCallback.appEventCalled)
     }
 
     @Test
     fun `response failure uses supplied ad unit and placement before forwarding`() {
-        val order = mutableListOf<String>()
-        val error = LoadAdError(
-            LoadAdError.ErrorCode.INVALID_AD_RESPONSE,
-            "invalid response",
-            mockk(relaxed = true),
+        contract.responseFailure(
+            stubLoadFromResponse = { trackingLoadCallback ->
+                every { InterstitialAd.loadFromAdResponse("opaque-response", any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrackFromResponse = { loadCallback ->
+                adTracker.loadAndTrackInterstitialAdFromResponse(
+                    adResponse = "opaque-response",
+                    adUnitId = "supplied-interstitial-unit",
+                    placement = "response-interstitial",
+                    loadCallback = loadCallback,
+                )
+            },
         )
-        val loadCallback = object : AdLoadCallback<InterstitialAd> {
-            override fun onAdFailedToLoad(adError: LoadAdError) {
-                order += "load-callback"
-                assertSame(error, adError)
-            }
-        }
-        val trackingLoadCallback = slot<AdLoadCallback<InterstitialAd>>()
-        val failedData = slot<AdFailedToLoadData>()
-
-        every {
-            InterstitialAd.loadFromAdResponse("opaque-response", capture(trackingLoadCallback))
-        } just runs
-        every { adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER) } answers {
-            order += "tracked"
-        }
-
-        adTracker.loadAndTrackInterstitialAdFromResponse(
-            adResponse = "opaque-response",
-            adUnitId = "supplied-interstitial-unit",
-            placement = "response-interstitial",
-            loadCallback = loadCallback,
-        )
-        trackingLoadCallback.captured.onAdFailedToLoad(error)
-
-        assertEquals(listOf("tracked", "load-callback"), order)
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(AdFormat.INTERSTITIAL, failedData.captured.adFormat)
-        assertEquals("supplied-interstitial-unit", failedData.captured.adUnitId)
-        assertEquals("response-interstitial", failedData.captured.placement)
     }
 
     private class RecordingInterstitialEventCallback : InterstitialAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedAdFlowTest.kt
@@ -3,6 +3,11 @@
 package com.revenuecat.purchases.admob.nextgen
 
 import android.app.Activity
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.rewarded.OnUserEarnedRewardListener
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdEventCallback
@@ -10,15 +15,23 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedAdEventCallback
 import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdLoadedData
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -27,14 +40,11 @@ class RewardedAdFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
-    private val contract = FullScreenAdFlowContract<RewardedAd, RewardedAdEventCallback>(
-        adTracker = adTracker,
-        values = FullScreenAdTestValues(AdFormat.REWARDED, "rewarded-unit", "load-placement"),
-        suspendingValues = FullScreenAdTestValues(
-            AdFormat.REWARDED,
-            "suspend-rewarded-unit",
-            "suspend-load-placement",
-        ),
+    private val values = FullScreenAdTestValues(AdFormat.REWARDED, "rewarded-unit", "load-placement")
+    private val suspendingValues = FullScreenAdTestValues(
+        AdFormat.REWARDED,
+        "suspend-rewarded-unit",
+        "suspend-load-placement",
     )
 
     @Before
@@ -54,41 +64,47 @@ class RewardedAdFlowTest {
 
     @Test
     fun `rewarded success installs tracking and supports placement and delegate updates`() {
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns values.adUnitId }
+        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
+            every { adapterClassName } returns "test-network"
+            every { responseId } returns "response-id"
+        }
+        var installedCallback: RewardedAdEventCallback? = null
+        val rewardedAd = mockk<RewardedAd>(relaxed = true) {
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback } answers { installedCallback }
+            every { adEventCallback = any() } answers { installedCallback = firstArg() }
+        }
+        val activity = mockk<Activity>()
         val rewardListener = mockk<OnUserEarnedRewardListener>()
+        val loadCallback = FullScreenRecordingAdLoadCallback<RewardedAd>()
         val initialEventCallback = RecordingRewardedAdEventCallback()
         val replacementEventCallback = RecordingRewardedAdEventCallback()
+        val trackingLoadCallback = slot<AdLoadCallback<RewardedAd>>()
 
-        contract.callbackSuccess(
-            createAd = { responseInfo, installedCallback ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback } answers { installedCallback.callback }
-                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
-                }
-            },
-            initialEventCallback = initialEventCallback,
-            replacementEventCallback = replacementEventCallback,
-            stubLoad = { adRequest, trackingLoadCallback ->
-                every { RewardedAd.load(adRequest, any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrack = { adRequest, loadCallback, eventCallback ->
-                adTracker.loadAndTrackRewardedAd(
-                    adRequest = adRequest,
-                    placement = "load-placement",
-                    loadCallback = loadCallback,
-                    adEventCallback = eventCallback,
-                )
-            },
-            asTrackingCallback = { it as? TrackingRewardedAdEventCallback },
-            invokeDelegateCallback = { it.onAdMetadataChanged() },
-            assertInitialDelegateInvoked = { assertTrue(initialEventCallback.metadataChangedCalled) },
-            setTrackingEventCallback = { ad, eventCallback -> ad.setTrackingAdEventCallback(eventCallback) },
-            assertReplacementDelegateInvoked = { assertTrue(replacementEventCallback.metadataChangedCalled) },
-            show = { ad, activity, placement -> ad.show(activity, placement, rewardListener) },
-            verifyShow = { ad, activity -> verify(exactly = 1) { ad.show(activity, rewardListener) } },
+        every { RewardedAd.load(adRequest, capture(trackingLoadCallback)) } just runs
+        adTracker.loadAndTrackRewardedAd(
+            adRequest = adRequest,
+            placement = values.placement,
+            loadCallback = loadCallback,
+            adEventCallback = initialEventCallback,
         )
+        trackingLoadCallback.captured.onAdLoaded(rewardedAd)
+
+        assertSame(rewardedAd, loadCallback.loadedAd)
+        adTracker.assertLoadedData(slot(), values, "test-network", "response-id")
+
+        val trackingCallback = requireNotNull(installedCallback as? TrackingRewardedAdEventCallback)
+        trackingCallback.onAdMetadataChanged()
+        assertTrue(initialEventCallback.metadataChangedCalled)
+
+        rewardedAd.setTrackingAdEventCallback(replacementEventCallback)
+        trackingCallback.onAdMetadataChanged()
+        assertTrue(replacementEventCallback.metadataChangedCalled)
+
+        rewardedAd.show(activity, "show-placement", rewardListener)
+        assertEquals("show-placement", trackingCallback.placement)
+        verify(exactly = 1) { rewardedAd.show(activity, rewardListener) }
     }
 
     @Test
@@ -105,93 +121,92 @@ class RewardedAdFlowTest {
         val activity = mockk<Activity>()
         val rewardListener = mockk<OnUserEarnedRewardListener>()
 
-        assertShowClearsPlacement(
-            trackingCallback = trackingCallback,
-            show = {
-                rewardedAd.show(
-                    activity = activity,
-                    placement = null,
-                    onUserEarnedRewardListener = rewardListener,
-                )
-            },
-            verifyShow = { verify(exactly = 1) { rewardedAd.show(activity, rewardListener) } },
-        )
+        rewardedAd.show(activity, placement = null, onUserEarnedRewardListener = rewardListener)
+
+        assertNull(trackingCallback.placement)
+        verify(exactly = 1) { rewardedAd.show(activity, rewardListener) }
     }
 
     @Test
     fun `rewarded failure is forwarded to load callback`() {
-        contract.callbackFailure(
-            stubLoad = { adRequest, trackingLoadCallback ->
-                every { RewardedAd.load(adRequest, any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrack = { adRequest, loadCallback ->
-                adTracker.loadAndTrackRewardedAd(
-                    adRequest = adRequest,
-                    placement = "load-placement",
-                    loadCallback = loadCallback,
-                )
-            },
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns values.adUnitId }
+        val error = mockk<LoadAdError>(relaxed = true)
+        val loadCallback = FullScreenRecordingAdLoadCallback<RewardedAd>()
+        val trackingLoadCallback = slot<AdLoadCallback<RewardedAd>>()
+
+        every { RewardedAd.load(adRequest, capture(trackingLoadCallback)) } just runs
+        adTracker.loadAndTrackRewardedAd(
+            adRequest = adRequest,
+            placement = values.placement,
+            loadCallback = loadCallback,
         )
+        trackingLoadCallback.captured.onAdFailedToLoad(error)
+
+        assertSame(error, loadCallback.loadError)
+        adTracker.assertFailedData(slot(), values)
     }
 
     @Test
     fun `suspending rewarded success tracks and installs callback before returning original result`() = runBlocking {
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns suspendingValues.adUnitId }
+        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
+            every { adapterClassName } returns "suspend-test-network"
+            every { responseId } returns "suspend-response-id"
+        }
+        var installedCallback: RewardedAdEventCallback? = null
+        val rewardedAd = mockk<RewardedAd>(relaxed = true) {
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback } answers { installedCallback }
+            every { adEventCallback = any() } answers { installedCallback = firstArg() }
+        }
         val eventCallback = RecordingRewardedAdEventCallback()
+        val sdkResult = AdLoadResult.Success(rewardedAd)
 
-        contract.suspendingSuccess(
-            createAd = { responseInfo, installedCallback ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback } answers { installedCallback.callback }
-                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
-                }
-            },
-            eventCallback = eventCallback,
-            stubLoad = { adRequest, sdkResult -> coEvery { RewardedAd.load(adRequest) } returns sdkResult },
-            loadAndTrack = { adRequest, delegate ->
-                adTracker.loadAndTrackRewardedAd(
-                    adRequest = adRequest,
-                    placement = "suspend-load-placement",
-                    adEventCallback = delegate,
-                )
-            },
-            asTrackingCallback = { it as? TrackingRewardedAdEventCallback },
-            invokeDelegateCallback = { it.onAdMetadataChanged() },
-            assertDelegateInvoked = { assertTrue(eventCallback.metadataChangedCalled) },
+        coEvery { RewardedAd.load(adRequest) } returns sdkResult
+        val result = adTracker.loadAndTrackRewardedAd(
+            adRequest = adRequest,
+            placement = suspendingValues.placement,
+            adEventCallback = eventCallback,
+        )
+
+        assertSame(sdkResult, result)
+        val trackingCallback = requireNotNull(installedCallback as? TrackingRewardedAdEventCallback)
+        trackingCallback.onAdMetadataChanged()
+        assertTrue(eventCallback.metadataChangedCalled)
+        adTracker.assertLoadedData(
+            slot<AdLoadedData>(),
+            suspendingValues,
+            "suspend-test-network",
+            "suspend-response-id",
         )
     }
 
     @Test
     fun `suspending rewarded failure tracks error and returns original result`() = runBlocking {
-        contract.suspendingFailure(
-            stubLoad = { adRequest, sdkResult -> coEvery { RewardedAd.load(adRequest) } returns sdkResult },
-            loadAndTrack = { adRequest ->
-                adTracker.loadAndTrackRewardedAd(
-                    adRequest = adRequest,
-                    placement = "suspend-load-placement",
-                )
-            },
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns suspendingValues.adUnitId }
+        val error = mockk<LoadAdError> { every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR }
+        val sdkResult = AdLoadResult.Failure<RewardedAd>(error)
+
+        coEvery { RewardedAd.load(adRequest) } returns sdkResult
+        val result = adTracker.loadAndTrackRewardedAd(
+            adRequest = adRequest,
+            placement = suspendingValues.placement,
         )
+
+        assertSame(sdkResult, result)
+        adTracker.assertSuspendingFailedData(slot<AdFailedToLoadData>(), suspendingValues)
     }
 
     @Test
     fun `setting event callback directly falls back when tracking is not installed`() {
+        val rewardedAd = mockk<RewardedAd>(relaxed = true) {
+            every { adEventCallback } returns null
+        }
         val eventCallback = RecordingRewardedAdEventCallback()
 
-        contract.eventCallbackFallback(
-            createAd = {
-                mockk(relaxed = true) {
-                    every { adEventCallback } returns null
-                }
-            },
-            eventCallback = eventCallback,
-            setTrackingEventCallback = { ad, callback -> ad.setTrackingAdEventCallback(callback) },
-            verifyEventCallbackInstalled = { ad, callback ->
-                verify(exactly = 1) { ad.adEventCallback = callback }
-            },
-        )
+        rewardedAd.setTrackingAdEventCallback(eventCallback)
+
+        verify(exactly = 1) { rewardedAd.adEventCallback = eventCallback }
     }
 
     private class RecordingRewardedAdEventCallback : RewardedAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedAdFlowTest.kt
@@ -3,44 +3,39 @@
 package com.revenuecat.purchases.admob.nextgen
 
 import android.app.Activity
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
-import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.rewarded.OnUserEarnedRewardListener
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedAdEventCallback
-import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
-import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
-import com.revenuecat.purchases.ads.events.types.AdLoadedData
-import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 class RewardedAdFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
+    private val contract = FullScreenAdFlowContract<RewardedAd, RewardedAdEventCallback>(
+        adTracker = adTracker,
+        values = FullScreenAdTestValues(AdFormat.REWARDED, "rewarded-unit", "load-placement"),
+        suspendingValues = FullScreenAdTestValues(
+            AdFormat.REWARDED,
+            "suspend-rewarded-unit",
+            "suspend-load-placement",
+        ),
+    )
 
     @Before
     fun setUp() {
@@ -59,66 +54,41 @@ class RewardedAdFlowTest {
 
     @Test
     fun `rewarded success installs tracking and supports placement and delegate updates`() {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "rewarded-unit"
-        }
-        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-            every { adapterClassName } returns "test-network"
-            every { responseId } returns "response-id"
-        }
-        var installedCallback: RewardedAdEventCallback? = null
-        val rewardedAd = mockk<RewardedAd>(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo
-            every { adEventCallback } answers { installedCallback }
-            every { adEventCallback = any() } answers { installedCallback = firstArg() }
-        }
-        val activity = mockk<Activity>()
         val rewardListener = mockk<OnUserEarnedRewardListener>()
-        val loadCallback = RecordingRewardedLoadCallback()
         val initialEventCallback = RecordingRewardedAdEventCallback()
         val replacementEventCallback = RecordingRewardedAdEventCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<RewardedAd>>()
 
-        every { RewardedAd.load(adRequest, capture(trackingLoadCallback)) } just runs
-
-        adTracker.loadAndTrackRewardedAd(
-            adRequest = adRequest,
-            placement = "load-placement",
-            loadCallback = loadCallback,
-            adEventCallback = initialEventCallback,
+        contract.callbackSuccess(
+            createAd = { responseInfo, installedCallback ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback } answers { installedCallback.callback }
+                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
+                }
+            },
+            initialEventCallback = initialEventCallback,
+            replacementEventCallback = replacementEventCallback,
+            stubLoad = { adRequest, trackingLoadCallback ->
+                every { RewardedAd.load(adRequest, any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrack = { adRequest, loadCallback, eventCallback ->
+                adTracker.loadAndTrackRewardedAd(
+                    adRequest = adRequest,
+                    placement = "load-placement",
+                    loadCallback = loadCallback,
+                    adEventCallback = eventCallback,
+                )
+            },
+            asTrackingCallback = { it as? TrackingRewardedAdEventCallback },
+            invokeDelegateCallback = { it.onAdMetadataChanged() },
+            assertInitialDelegateInvoked = { assertTrue(initialEventCallback.metadataChangedCalled) },
+            setTrackingEventCallback = { ad, eventCallback -> ad.setTrackingAdEventCallback(eventCallback) },
+            assertReplacementDelegateInvoked = { assertTrue(replacementEventCallback.metadataChangedCalled) },
+            show = { ad, activity, placement -> ad.show(activity, placement, rewardListener) },
+            verifyShow = { ad, activity -> verify(exactly = 1) { ad.show(activity, rewardListener) } },
         )
-        trackingLoadCallback.captured.onAdLoaded(rewardedAd)
-
-        assertSame(rewardedAd, loadCallback.loadedAd)
-
-        // Pins the format, ad unit and placement this entry point hands to the load tracker;
-        // the wrapper classes are covered separately, so only the wiring is asserted here.
-        val loadedData = slot<AdLoadedData>()
-        verify(exactly = 1) {
-            adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(
-            AdLoadedData(
-                networkName = "test-network",
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.REWARDED,
-                placement = "load-placement",
-                adUnitId = "rewarded-unit",
-                impressionId = "response-id",
-            ),
-            loadedData.captured,
-        )
-        val trackingCallback = installedCallback as TrackingRewardedAdEventCallback
-        trackingCallback.onAdMetadataChanged()
-        assertTrue(initialEventCallback.metadataChangedCalled)
-
-        rewardedAd.setTrackingAdEventCallback(replacementEventCallback)
-        trackingCallback.onAdMetadataChanged()
-        assertTrue(replacementEventCallback.metadataChangedCalled)
-
-        rewardedAd.show(activity, "show-placement", rewardListener)
-        assertEquals("show-placement", trackingCallback.placement)
-        verify(exactly = 1) { rewardedAd.show(activity, rewardListener) }
     }
 
     @Test
@@ -135,138 +105,93 @@ class RewardedAdFlowTest {
         val activity = mockk<Activity>()
         val rewardListener = mockk<OnUserEarnedRewardListener>()
 
-        rewardedAd.show(
-            activity = activity,
-            placement = null,
-            onUserEarnedRewardListener = rewardListener,
+        assertShowClearsPlacement(
+            trackingCallback = trackingCallback,
+            show = {
+                rewardedAd.show(
+                    activity = activity,
+                    placement = null,
+                    onUserEarnedRewardListener = rewardListener,
+                )
+            },
+            verifyShow = { verify(exactly = 1) { rewardedAd.show(activity, rewardListener) } },
         )
-
-        assertNull(trackingCallback.placement)
-        verify(exactly = 1) { rewardedAd.show(activity, rewardListener) }
     }
 
     @Test
     fun `rewarded failure is forwarded to load callback`() {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "rewarded-unit"
-        }
-        val error = mockk<LoadAdError>(relaxed = true)
-        val loadCallback = RecordingRewardedLoadCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<RewardedAd>>()
-
-        every { RewardedAd.load(adRequest, capture(trackingLoadCallback)) } just runs
-
-        adTracker.loadAndTrackRewardedAd(
-            adRequest = adRequest,
-            placement = "load-placement",
-            loadCallback = loadCallback,
+        contract.callbackFailure(
+            stubLoad = { adRequest, trackingLoadCallback ->
+                every { RewardedAd.load(adRequest, any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrack = { adRequest, loadCallback ->
+                adTracker.loadAndTrackRewardedAd(
+                    adRequest = adRequest,
+                    placement = "load-placement",
+                    loadCallback = loadCallback,
+                )
+            },
         )
-        trackingLoadCallback.captured.onAdFailedToLoad(error)
-
-        assertSame(error, loadCallback.loadError)
-
-        val failedData = slot<AdFailedToLoadData>()
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(AdFormat.REWARDED, failedData.captured.adFormat)
-        assertEquals("rewarded-unit", failedData.captured.adUnitId)
-        assertEquals("load-placement", failedData.captured.placement)
     }
 
     @Test
-    fun `suspending rewarded success tracks and installs callback before returning original result`() =
-        runBlocking {
-            val adRequest = mockk<AdRequest> {
-                every { adUnitId } returns "suspend-rewarded-unit"
-            }
-            val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-                every { adapterClassName } returns "suspend-test-network"
-                every { responseId } returns "suspend-response-id"
-            }
-            var installedCallback: RewardedAdEventCallback? = null
-            val rewardedAd = mockk<RewardedAd>(relaxed = true) {
-                every { getResponseInfo() } returns responseInfo
-                every { adEventCallback } answers { installedCallback }
-                every { adEventCallback = any() } answers { installedCallback = firstArg() }
-            }
-            val eventCallback = RecordingRewardedAdEventCallback()
-            val sdkResult = AdLoadResult.Success(rewardedAd)
+    fun `suspending rewarded success tracks and installs callback before returning original result`() = runBlocking {
+        val eventCallback = RecordingRewardedAdEventCallback()
 
-            coEvery { RewardedAd.load(adRequest) } returns sdkResult
-
-            val result = adTracker.loadAndTrackRewardedAd(
-                adRequest = adRequest,
-                placement = "suspend-load-placement",
-                adEventCallback = eventCallback,
-            )
-
-            assertSame(sdkResult, result)
-            val trackingCallback = installedCallback as TrackingRewardedAdEventCallback
-            trackingCallback.onAdMetadataChanged()
-            assertTrue(eventCallback.metadataChangedCalled)
-
-            val loadedData = slot<AdLoadedData>()
-            verify(exactly = 1) {
-                adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER)
-            }
-            assertEquals(
-                AdLoadedData(
-                    networkName = "suspend-test-network",
-                    mediatorName = AdMediatorName.AD_MOB,
-                    adFormat = AdFormat.REWARDED,
+        contract.suspendingSuccess(
+            createAd = { responseInfo, installedCallback ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback } answers { installedCallback.callback }
+                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
+                }
+            },
+            eventCallback = eventCallback,
+            stubLoad = { adRequest, sdkResult -> coEvery { RewardedAd.load(adRequest) } returns sdkResult },
+            loadAndTrack = { adRequest, delegate ->
+                adTracker.loadAndTrackRewardedAd(
+                    adRequest = adRequest,
                     placement = "suspend-load-placement",
-                    adUnitId = "suspend-rewarded-unit",
-                    impressionId = "suspend-response-id",
-                ),
-                loadedData.captured,
-            )
-        }
+                    adEventCallback = delegate,
+                )
+            },
+            asTrackingCallback = { it as? TrackingRewardedAdEventCallback },
+            invokeDelegateCallback = { it.onAdMetadataChanged() },
+            assertDelegateInvoked = { assertTrue(eventCallback.metadataChangedCalled) },
+        )
+    }
 
     @Test
     fun `suspending rewarded failure tracks error and returns original result`() = runBlocking {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "suspend-rewarded-unit"
-        }
-        val error = mockk<LoadAdError> {
-            every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR
-        }
-        val sdkResult = AdLoadResult.Failure<RewardedAd>(error)
-
-        coEvery { RewardedAd.load(adRequest) } returns sdkResult
-
-        val result = adTracker.loadAndTrackRewardedAd(
-            adRequest = adRequest,
-            placement = "suspend-load-placement",
-        )
-
-        assertSame(sdkResult, result)
-        val failedData = slot<AdFailedToLoadData>()
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(
-            AdFailedToLoadData(
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.REWARDED,
-                placement = "suspend-load-placement",
-                adUnitId = "suspend-rewarded-unit",
-                mediatorErrorCode = LoadAdError.ErrorCode.NETWORK_ERROR.value,
-            ),
-            failedData.captured,
+        contract.suspendingFailure(
+            stubLoad = { adRequest, sdkResult -> coEvery { RewardedAd.load(adRequest) } returns sdkResult },
+            loadAndTrack = { adRequest ->
+                adTracker.loadAndTrackRewardedAd(
+                    adRequest = adRequest,
+                    placement = "suspend-load-placement",
+                )
+            },
         )
     }
 
     @Test
     fun `setting event callback directly falls back when tracking is not installed`() {
-        val rewardedAd = mockk<RewardedAd>(relaxed = true) {
-            every { adEventCallback } returns null
-        }
         val eventCallback = RecordingRewardedAdEventCallback()
 
-        rewardedAd.setTrackingAdEventCallback(eventCallback)
-
-        verify(exactly = 1) { rewardedAd.adEventCallback = eventCallback }
+        contract.eventCallbackFallback(
+            createAd = {
+                mockk(relaxed = true) {
+                    every { adEventCallback } returns null
+                }
+            },
+            eventCallback = eventCallback,
+            setTrackingEventCallback = { ad, callback -> ad.setTrackingAdEventCallback(callback) },
+            verifyEventCallbackInstalled = { ad, callback ->
+                verify(exactly = 1) { ad.adEventCallback = callback }
+            },
+        )
     }
 
     private class RecordingRewardedAdEventCallback : RewardedAdEventCallback {
@@ -274,19 +199,6 @@ class RewardedAdFlowTest {
 
         override fun onAdMetadataChanged() {
             metadataChangedCalled = true
-        }
-    }
-
-    private class RecordingRewardedLoadCallback : AdLoadCallback<RewardedAd> {
-        var loadedAd: RewardedAd? = null
-        var loadError: LoadAdError? = null
-
-        override fun onAdLoaded(ad: RewardedAd) {
-            loadedAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            loadError = adError
         }
     }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedAdResponseFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedAdResponseFlowTest.kt
@@ -2,6 +2,8 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -22,13 +24,9 @@ class RewardedAdResponseFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
-    private val contract = FullScreenAdResponseFlowContract<RewardedAd, RewardedAdEventCallback>(
+    private val contract = FullScreenAdResponseFlowContract(
         adTracker = adTracker,
-        values = FullScreenAdTestValues(
-            adFormat = AdFormat.REWARDED,
-            adUnitId = "supplied-rewarded-unit",
-            placement = "response-rewarded",
-        ),
+        adapter = RewardedAdAdapter(),
     )
 
     @Before
@@ -51,53 +49,63 @@ class RewardedAdResponseFlowTest {
         val eventCallback = RecordingRewardedEventCallback()
 
         contract.responseSuccess(
-            createAd = { responseInfo, installedCallback, onCallbackInstalled ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback = any() } answers {
-                        installedCallback.callback = firstArg()
-                        onCallbackInstalled()
-                    }
-                }
-            },
             eventCallback = eventCallback,
-            stubLoadFromResponse = { trackingLoadCallback ->
-                every { RewardedAd.loadFromAdResponse("opaque-response", any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrackFromResponse = { loadCallback, delegate ->
-                adTracker.loadAndTrackRewardedAdFromResponse(
-                    adResponse = "opaque-response",
-                    adUnitId = "supplied-rewarded-unit",
-                    placement = "response-rewarded",
-                    loadCallback = loadCallback,
-                    adEventCallback = delegate,
-                )
-            },
-            asTrackingCallback = { it as? TrackingRewardedAdEventCallback },
-            invokeDelegateCallback = { it.onAdMetadataChanged() },
             assertDelegateInvoked = { assertTrue(eventCallback.metadataChangedCalled) },
         )
     }
 
     @Test
     fun `response failure uses supplied ad unit and placement before forwarding`() {
-        contract.responseFailure(
-            stubLoadFromResponse = { trackingLoadCallback ->
-                every { RewardedAd.loadFromAdResponse("opaque-response", any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrackFromResponse = { loadCallback ->
-                adTracker.loadAndTrackRewardedAdFromResponse(
-                    adResponse = "opaque-response",
-                    adUnitId = "supplied-rewarded-unit",
-                    placement = "response-rewarded",
-                    loadCallback = loadCallback,
-                )
-            },
+        contract.responseFailure()
+    }
+
+    private inner class RewardedAdAdapter : FullScreenAdResponseFlowAdapter<RewardedAd, RewardedAdEventCallback> {
+        override val values = FullScreenAdTestValues(
+            adFormat = AdFormat.REWARDED,
+            adUnitId = "supplied-rewarded-unit",
+            placement = "response-rewarded",
         )
+
+        override fun createAd(
+            responseInfo: ResponseInfo,
+            installedCallback: CallbackHolder<RewardedAdEventCallback>,
+            onCallbackInstalled: () -> Unit,
+        ): RewardedAd = mockk(relaxed = true) {
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback = any() } answers {
+                installedCallback.callback = firstArg()
+                onCallbackInstalled()
+            }
+        }
+
+        override fun stubLoadFromResponse(
+            trackingLoadCallback: CallbackHolder<AdLoadCallback<RewardedAd>>,
+        ) {
+            every { RewardedAd.loadFromAdResponse("opaque-response", any()) } answers {
+                trackingLoadCallback.callback = secondArg()
+            }
+        }
+
+        override fun loadAndTrackFromResponse(
+            loadCallback: AdLoadCallback<RewardedAd>,
+            eventCallback: RewardedAdEventCallback?,
+        ) {
+            adTracker.loadAndTrackRewardedAdFromResponse(
+                adResponse = "opaque-response",
+                adUnitId = values.adUnitId,
+                placement = values.placement,
+                loadCallback = loadCallback,
+                adEventCallback = eventCallback,
+            )
+        }
+
+        override fun asTrackingCallback(
+            callback: RewardedAdEventCallback,
+        ): TrackingRewardedAdEventCallback? = callback as? TrackingRewardedAdEventCallback
+
+        override fun invokeDelegateCallback(callback: RewardedAdEventCallback) {
+            callback.onAdMetadataChanged()
+        }
     }
 
     private class RecordingRewardedEventCallback : RewardedAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedAdResponseFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedAdResponseFlowTest.kt
@@ -2,38 +2,34 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedAdEventCallback
-import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
-import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
-import com.revenuecat.purchases.ads.events.types.AdLoadedData
-import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.slot
 import io.mockk.unmockkObject
-import io.mockk.verify
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 class RewardedAdResponseFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
+    private val contract = FullScreenAdResponseFlowContract<RewardedAd, RewardedAdEventCallback>(
+        adTracker = adTracker,
+        values = FullScreenAdTestValues(
+            adFormat = AdFormat.REWARDED,
+            adUnitId = "supplied-rewarded-unit",
+            placement = "response-rewarded",
+        ),
+    )
 
     @Before
     fun setUp() {
@@ -52,101 +48,56 @@ class RewardedAdResponseFlowTest {
 
     @Test
     fun `response success tracks and installs event callback before forwarding`() {
-        val order = mutableListOf<String>()
-        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-            every { adapterClassName } returns "test-network"
-            every { responseId } returns "response-id"
-        }
-        val rewardedAd = mockk<RewardedAd>(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo
-        }
-        val loadCallback = object : AdLoadCallback<RewardedAd> {
-            override fun onAdLoaded(ad: RewardedAd) {
-                order += "load-callback"
-                assertSame(rewardedAd, ad)
-            }
-        }
         val eventCallback = RecordingRewardedEventCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<RewardedAd>>()
-        val installedEventCallback = slot<RewardedAdEventCallback>()
-        val loadedData = slot<AdLoadedData>()
 
-        every {
-            RewardedAd.loadFromAdResponse("opaque-response", capture(trackingLoadCallback))
-        } just runs
-        every { adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER) } answers {
-            order += "tracked"
-        }
-        every { rewardedAd.adEventCallback = capture(installedEventCallback) } answers {
-            order += "event-callback"
-        }
-
-        adTracker.loadAndTrackRewardedAdFromResponse(
-            adResponse = "opaque-response",
-            adUnitId = "supplied-rewarded-unit",
-            placement = "response-rewarded",
-            loadCallback = loadCallback,
-            adEventCallback = eventCallback,
+        contract.responseSuccess(
+            createAd = { responseInfo, installedCallback, onCallbackInstalled ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback = any() } answers {
+                        installedCallback.callback = firstArg()
+                        onCallbackInstalled()
+                    }
+                }
+            },
+            eventCallback = eventCallback,
+            stubLoadFromResponse = { trackingLoadCallback ->
+                every { RewardedAd.loadFromAdResponse("opaque-response", any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrackFromResponse = { loadCallback, delegate ->
+                adTracker.loadAndTrackRewardedAdFromResponse(
+                    adResponse = "opaque-response",
+                    adUnitId = "supplied-rewarded-unit",
+                    placement = "response-rewarded",
+                    loadCallback = loadCallback,
+                    adEventCallback = delegate,
+                )
+            },
+            asTrackingCallback = { it as? TrackingRewardedAdEventCallback },
+            invokeDelegateCallback = { it.onAdMetadataChanged() },
+            assertDelegateInvoked = { assertTrue(eventCallback.metadataChangedCalled) },
         )
-        trackingLoadCallback.captured.onAdLoaded(rewardedAd)
-
-        assertEquals(listOf("tracked", "event-callback", "load-callback"), order)
-        assertEquals(
-            AdLoadedData(
-                networkName = "test-network",
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.REWARDED,
-                placement = "response-rewarded",
-                adUnitId = "supplied-rewarded-unit",
-                impressionId = "response-id",
-            ),
-            loadedData.captured,
-        )
-        assertTrue(installedEventCallback.captured is TrackingRewardedAdEventCallback)
-
-        installedEventCallback.captured.onAdMetadataChanged()
-        assertTrue(eventCallback.metadataChangedCalled)
     }
 
     @Test
     fun `response failure uses supplied ad unit and placement before forwarding`() {
-        val order = mutableListOf<String>()
-        val error = LoadAdError(
-            LoadAdError.ErrorCode.INVALID_AD_RESPONSE,
-            "invalid response",
-            mockk(relaxed = true),
+        contract.responseFailure(
+            stubLoadFromResponse = { trackingLoadCallback ->
+                every { RewardedAd.loadFromAdResponse("opaque-response", any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrackFromResponse = { loadCallback ->
+                adTracker.loadAndTrackRewardedAdFromResponse(
+                    adResponse = "opaque-response",
+                    adUnitId = "supplied-rewarded-unit",
+                    placement = "response-rewarded",
+                    loadCallback = loadCallback,
+                )
+            },
         )
-        val loadCallback = object : AdLoadCallback<RewardedAd> {
-            override fun onAdFailedToLoad(adError: LoadAdError) {
-                order += "load-callback"
-                assertSame(error, adError)
-            }
-        }
-        val trackingLoadCallback = slot<AdLoadCallback<RewardedAd>>()
-        val failedData = slot<AdFailedToLoadData>()
-
-        every {
-            RewardedAd.loadFromAdResponse("opaque-response", capture(trackingLoadCallback))
-        } just runs
-        every { adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER) } answers {
-            order += "tracked"
-        }
-
-        adTracker.loadAndTrackRewardedAdFromResponse(
-            adResponse = "opaque-response",
-            adUnitId = "supplied-rewarded-unit",
-            placement = "response-rewarded",
-            loadCallback = loadCallback,
-        )
-        trackingLoadCallback.captured.onAdFailedToLoad(error)
-
-        assertEquals(listOf("tracked", "load-callback"), order)
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(AdFormat.REWARDED, failedData.captured.adFormat)
-        assertEquals("supplied-rewarded-unit", failedData.captured.adUnitId)
-        assertEquals("response-rewarded", failedData.captured.placement)
     }
 
     private class RecordingRewardedEventCallback : RewardedAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedInterstitialAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedInterstitialAdFlowTest.kt
@@ -4,36 +4,23 @@ package com.revenuecat.purchases.admob.nextgen
 
 import android.app.Activity
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.rewarded.OnUserEarnedRewardListener
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedInterstitialAdEventCallback
-import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
-import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
-import com.revenuecat.purchases.ads.events.types.AdLoadedData
-import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -42,6 +29,19 @@ class RewardedInterstitialAdFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
+    private val contract = FullScreenAdFlowContract<RewardedInterstitialAd, RewardedInterstitialAdEventCallback>(
+        adTracker = adTracker,
+        values = FullScreenAdTestValues(
+            AdFormat.REWARDED_INTERSTITIAL,
+            "rewarded-interstitial-unit",
+            "load-placement",
+        ),
+        suspendingValues = FullScreenAdTestValues(
+            AdFormat.REWARDED_INTERSTITIAL,
+            "suspend-rewarded-interstitial-unit",
+            "suspend-load-placement",
+        ),
+    )
 
     @Before
     fun setUp() {
@@ -60,222 +60,155 @@ class RewardedInterstitialAdFlowTest {
 
     @Test
     fun `rewarded interstitial success installs tracking and supports placement and delegate updates`() {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "rewarded-interstitial-unit"
-        }
-        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-            every { adapterClassName } returns "test-network"
-            every { responseId } returns "response-id"
-        }
-        var installedCallback: RewardedInterstitialAdEventCallback? = null
-        val rewardedInterstitialAd = mockk<RewardedInterstitialAd>(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo
-            every { adEventCallback } answers { installedCallback }
-            every { adEventCallback = any() } answers { installedCallback = firstArg() }
-        }
-        val activity = mockk<Activity>()
         val rewardListener = mockk<OnUserEarnedRewardListener>()
-        val loadCallback = RecordingRewardedInterstitialLoadCallback()
         val initialEventCallback = RecordingRewardedInterstitialAdEventCallback()
         val replacementEventCallback = RecordingRewardedInterstitialAdEventCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<RewardedInterstitialAd>>()
 
-        every { RewardedInterstitialAd.load(adRequest, capture(trackingLoadCallback)) } just runs
-
-        adTracker.loadAndTrackRewardedInterstitialAd(
-            adRequest = adRequest,
-            placement = "load-placement",
-            loadCallback = loadCallback,
-            adEventCallback = initialEventCallback,
+        contract.callbackSuccess(
+            createAd = { responseInfo, installedCallback ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback } answers { installedCallback.callback }
+                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
+                }
+            },
+            initialEventCallback = initialEventCallback,
+            replacementEventCallback = replacementEventCallback,
+            stubLoad = { adRequest, trackingLoadCallback ->
+                every { RewardedInterstitialAd.load(adRequest, any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrack = { adRequest, loadCallback, eventCallback ->
+                adTracker.loadAndTrackRewardedInterstitialAd(
+                    adRequest = adRequest,
+                    placement = "load-placement",
+                    loadCallback = loadCallback,
+                    adEventCallback = eventCallback,
+                )
+            },
+            asTrackingCallback = { it as? TrackingRewardedInterstitialAdEventCallback },
+            invokeDelegateCallback = { it.onAdMetadataChanged() },
+            assertInitialDelegateInvoked = { assertTrue(initialEventCallback.metadataChangedCalled) },
+            setTrackingEventCallback = { ad, eventCallback -> ad.setTrackingAdEventCallback(eventCallback) },
+            assertReplacementDelegateInvoked = { assertTrue(replacementEventCallback.metadataChangedCalled) },
+            show = { ad, activity, placement -> ad.show(activity, placement, rewardListener) },
+            verifyShow = { ad, activity -> verify(exactly = 1) { ad.show(activity, rewardListener) } },
         )
-        trackingLoadCallback.captured.onAdLoaded(rewardedInterstitialAd)
-
-        assertSame(rewardedInterstitialAd, loadCallback.loadedAd)
-
-        // Pins the format, ad unit and placement this entry point hands to the load tracker;
-        // the wrapper classes are covered separately, so only the wiring is asserted here.
-        val loadedData = slot<AdLoadedData>()
-        verify(exactly = 1) {
-            adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(
-            AdLoadedData(
-                networkName = "test-network",
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.REWARDED_INTERSTITIAL,
-                placement = "load-placement",
-                adUnitId = "rewarded-interstitial-unit",
-                impressionId = "response-id",
-            ),
-            loadedData.captured,
-        )
-        val trackingCallback = installedCallback as TrackingRewardedInterstitialAdEventCallback
-        trackingCallback.onAdMetadataChanged()
-        assertTrue(initialEventCallback.metadataChangedCalled)
-
-        rewardedInterstitialAd.setTrackingAdEventCallback(replacementEventCallback)
-        trackingCallback.onAdMetadataChanged()
-        assertTrue(replacementEventCallback.metadataChangedCalled)
-
-        rewardedInterstitialAd.show(activity, "show-placement", rewardListener)
-        assertEquals("show-placement", trackingCallback.placement)
-        verify(exactly = 1) { rewardedInterstitialAd.show(activity, rewardListener) }
     }
 
     @Test
     fun `show with null placement clears the load-time placement`() {
+        val installedCallback = CallbackHolder<RewardedInterstitialAdEventCallback>()
+        val rewardedInterstitialAd = mockk<RewardedInterstitialAd>(relaxed = true) {
+            every { adEventCallback } answers { installedCallback.callback }
+            every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
+        }
         val adRequest = mockk<AdRequest> {
             every { adUnitId } returns "rewarded-interstitial-unit"
         }
-        var installedCallback: RewardedInterstitialAdEventCallback? = null
-        val rewardedInterstitialAd = mockk<RewardedInterstitialAd>(relaxed = true) {
-            every { adEventCallback } answers { installedCallback }
-            every { adEventCallback = any() } answers { installedCallback = firstArg() }
+        val trackingLoadCallback = CallbackHolder<AdLoadCallback<RewardedInterstitialAd>>()
+        every { RewardedInterstitialAd.load(adRequest, any()) } answers {
+            trackingLoadCallback.callback = secondArg()
         }
-        val activity = mockk<Activity>()
-        val rewardListener = mockk<OnUserEarnedRewardListener>()
-        val trackingLoadCallback = slot<AdLoadCallback<RewardedInterstitialAd>>()
-
-        every { RewardedInterstitialAd.load(adRequest, capture(trackingLoadCallback)) } just runs
-
         adTracker.loadAndTrackRewardedInterstitialAd(
             adRequest = adRequest,
             placement = "load-placement",
-            loadCallback = RecordingRewardedInterstitialLoadCallback(),
+            loadCallback = FullScreenRecordingAdLoadCallback(),
         )
-        trackingLoadCallback.captured.onAdLoaded(rewardedInterstitialAd)
+        trackingLoadCallback.requireCallback().onAdLoaded(rewardedInterstitialAd)
 
-        val trackingCallback = installedCallback as TrackingRewardedInterstitialAdEventCallback
-        assertEquals("load-placement", trackingCallback.placement)
-
-        rewardedInterstitialAd.show(activity, placement = null, rewardListener)
-
-        assertNull(trackingCallback.placement)
-        verify(exactly = 1) { rewardedInterstitialAd.show(activity, rewardListener) }
+        val trackingCallback = requireNotNull(
+            installedCallback.requireCallback() as? TrackingRewardedInterstitialAdEventCallback,
+        )
+        val activity = mockk<Activity>()
+        val rewardListener = mockk<OnUserEarnedRewardListener>()
+        assertShowClearsPlacement(
+            trackingCallback = trackingCallback,
+            show = { rewardedInterstitialAd.show(activity, placement = null, rewardListener) },
+            verifyShow = { verify(exactly = 1) { rewardedInterstitialAd.show(activity, rewardListener) } },
+        )
     }
 
     @Test
     fun `rewarded interstitial failure is forwarded to load callback`() {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "rewarded-interstitial-unit"
-        }
-        val error = mockk<LoadAdError>(relaxed = true)
-        val loadCallback = RecordingRewardedInterstitialLoadCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<RewardedInterstitialAd>>()
-
-        every { RewardedInterstitialAd.load(adRequest, capture(trackingLoadCallback)) } just runs
-
-        adTracker.loadAndTrackRewardedInterstitialAd(
-            adRequest = adRequest,
-            placement = "load-placement",
-            loadCallback = loadCallback,
+        contract.callbackFailure(
+            stubLoad = { adRequest, trackingLoadCallback ->
+                every { RewardedInterstitialAd.load(adRequest, any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrack = { adRequest, loadCallback ->
+                adTracker.loadAndTrackRewardedInterstitialAd(
+                    adRequest = adRequest,
+                    placement = "load-placement",
+                    loadCallback = loadCallback,
+                )
+            },
         )
-        trackingLoadCallback.captured.onAdFailedToLoad(error)
-
-        assertSame(error, loadCallback.loadError)
-
-        val failedData = slot<AdFailedToLoadData>()
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(AdFormat.REWARDED_INTERSTITIAL, failedData.captured.adFormat)
-        assertEquals("rewarded-interstitial-unit", failedData.captured.adUnitId)
-        assertEquals("load-placement", failedData.captured.placement)
     }
 
     @Test
     fun `suspending rewarded interstitial success tracks and installs callback before returning original result`() =
         runBlocking {
-            val adRequest = mockk<AdRequest> {
-                every { adUnitId } returns "suspend-rewarded-interstitial-unit"
-            }
-            val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-                every { adapterClassName } returns "suspend-test-network"
-                every { responseId } returns "suspend-response-id"
-            }
-            var installedCallback: RewardedInterstitialAdEventCallback? = null
-            val rewardedInterstitialAd = mockk<RewardedInterstitialAd>(relaxed = true) {
-                every { getResponseInfo() } returns responseInfo
-                every { adEventCallback } answers { installedCallback }
-                every { adEventCallback = any() } answers { installedCallback = firstArg() }
-            }
             val eventCallback = RecordingRewardedInterstitialAdEventCallback()
-            val sdkResult = AdLoadResult.Success(rewardedInterstitialAd)
 
-            coEvery { RewardedInterstitialAd.load(adRequest) } returns sdkResult
-
-            val result = adTracker.loadAndTrackRewardedInterstitialAd(
-                adRequest = adRequest,
-                placement = "suspend-load-placement",
-                adEventCallback = eventCallback,
-            )
-
-            assertSame(sdkResult, result)
-            val trackingCallback = installedCallback as TrackingRewardedInterstitialAdEventCallback
-            trackingCallback.onAdMetadataChanged()
-            assertTrue(eventCallback.metadataChangedCalled)
-
-            val loadedData = slot<AdLoadedData>()
-            verify(exactly = 1) {
-                adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER)
-            }
-            assertEquals(
-                AdLoadedData(
-                    networkName = "suspend-test-network",
-                    mediatorName = AdMediatorName.AD_MOB,
-                    adFormat = AdFormat.REWARDED_INTERSTITIAL,
-                    placement = "suspend-load-placement",
-                    adUnitId = "suspend-rewarded-interstitial-unit",
-                    impressionId = "suspend-response-id",
-                ),
-                loadedData.captured,
+            contract.suspendingSuccess(
+                createAd = { responseInfo, installedCallback ->
+                    mockk(relaxed = true) {
+                        every { getResponseInfo() } returns responseInfo
+                        every { adEventCallback } answers { installedCallback.callback }
+                        every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
+                    }
+                },
+                eventCallback = eventCallback,
+                stubLoad = { adRequest, sdkResult ->
+                    coEvery { RewardedInterstitialAd.load(adRequest) } returns sdkResult
+                },
+                loadAndTrack = { adRequest, delegate ->
+                    adTracker.loadAndTrackRewardedInterstitialAd(
+                        adRequest = adRequest,
+                        placement = "suspend-load-placement",
+                        adEventCallback = delegate,
+                    )
+                },
+                asTrackingCallback = { it as? TrackingRewardedInterstitialAdEventCallback },
+                invokeDelegateCallback = { it.onAdMetadataChanged() },
+                assertDelegateInvoked = { assertTrue(eventCallback.metadataChangedCalled) },
             )
         }
 
     @Test
     fun `suspending rewarded interstitial failure tracks error and returns original result`() = runBlocking {
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "suspend-rewarded-interstitial-unit"
-        }
-        val error = mockk<LoadAdError> {
-            every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR
-        }
-        val sdkResult = AdLoadResult.Failure<RewardedInterstitialAd>(error)
-
-        coEvery { RewardedInterstitialAd.load(adRequest) } returns sdkResult
-
-        val result = adTracker.loadAndTrackRewardedInterstitialAd(
-            adRequest = adRequest,
-            placement = "suspend-load-placement",
-        )
-
-        assertSame(sdkResult, result)
-        val failedData = slot<AdFailedToLoadData>()
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(
-            AdFailedToLoadData(
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.REWARDED_INTERSTITIAL,
-                placement = "suspend-load-placement",
-                adUnitId = "suspend-rewarded-interstitial-unit",
-                mediatorErrorCode = LoadAdError.ErrorCode.NETWORK_ERROR.value,
-            ),
-            failedData.captured,
+        contract.suspendingFailure(
+            stubLoad = { adRequest, sdkResult ->
+                coEvery { RewardedInterstitialAd.load(adRequest) } returns sdkResult
+            },
+            loadAndTrack = { adRequest ->
+                adTracker.loadAndTrackRewardedInterstitialAd(
+                    adRequest = adRequest,
+                    placement = "suspend-load-placement",
+                )
+            },
         )
     }
 
     @Test
     fun `setting event callback directly falls back when tracking is not installed`() {
-        val rewardedInterstitialAd = mockk<RewardedInterstitialAd>(relaxed = true) {
-            every { adEventCallback } returns null
-        }
         val eventCallback = RecordingRewardedInterstitialAdEventCallback()
 
-        rewardedInterstitialAd.setTrackingAdEventCallback(eventCallback)
-
-        verify(exactly = 1) { rewardedInterstitialAd.adEventCallback = eventCallback }
+        contract.eventCallbackFallback(
+            createAd = {
+                mockk(relaxed = true) {
+                    every { adEventCallback } returns null
+                }
+            },
+            eventCallback = eventCallback,
+            setTrackingEventCallback = { ad, callback -> ad.setTrackingAdEventCallback(callback) },
+            verifyEventCallbackInstalled = { ad, callback ->
+                verify(exactly = 1) { ad.adEventCallback = callback }
+            },
+        )
     }
 
     private class RecordingRewardedInterstitialAdEventCallback : RewardedInterstitialAdEventCallback {
@@ -283,19 +216,6 @@ class RewardedInterstitialAdFlowTest {
 
         override fun onAdMetadataChanged() {
             metadataChangedCalled = true
-        }
-    }
-
-    private class RecordingRewardedInterstitialLoadCallback : AdLoadCallback<RewardedInterstitialAd> {
-        var loadedAd: RewardedInterstitialAd? = null
-        var loadError: LoadAdError? = null
-
-        override fun onAdLoaded(ad: RewardedInterstitialAd) {
-            loadedAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            loadError = adError
         }
     }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedInterstitialAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedInterstitialAdFlowTest.kt
@@ -4,7 +4,10 @@ package com.revenuecat.purchases.admob.nextgen
 
 import android.app.Activity
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.rewarded.OnUserEarnedRewardListener
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAdEventCallback
@@ -12,15 +15,23 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedInterstitialAdEventCallback
 import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
+import com.revenuecat.purchases.ads.events.types.AdLoadedData
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -29,18 +40,15 @@ class RewardedInterstitialAdFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
-    private val contract = FullScreenAdFlowContract<RewardedInterstitialAd, RewardedInterstitialAdEventCallback>(
-        adTracker = adTracker,
-        values = FullScreenAdTestValues(
-            AdFormat.REWARDED_INTERSTITIAL,
-            "rewarded-interstitial-unit",
-            "load-placement",
-        ),
-        suspendingValues = FullScreenAdTestValues(
-            AdFormat.REWARDED_INTERSTITIAL,
-            "suspend-rewarded-interstitial-unit",
-            "suspend-load-placement",
-        ),
+    private val values = FullScreenAdTestValues(
+        AdFormat.REWARDED_INTERSTITIAL,
+        "rewarded-interstitial-unit",
+        "load-placement",
+    )
+    private val suspendingValues = FullScreenAdTestValues(
+        AdFormat.REWARDED_INTERSTITIAL,
+        "suspend-rewarded-interstitial-unit",
+        "suspend-load-placement",
     )
 
     @Before
@@ -60,155 +68,165 @@ class RewardedInterstitialAdFlowTest {
 
     @Test
     fun `rewarded interstitial success installs tracking and supports placement and delegate updates`() {
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns values.adUnitId }
+        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
+            every { adapterClassName } returns "test-network"
+            every { responseId } returns "response-id"
+        }
+        var installedCallback: RewardedInterstitialAdEventCallback? = null
+        val rewardedInterstitialAd = mockk<RewardedInterstitialAd>(relaxed = true) {
+            every { getResponseInfo() } returns responseInfo
+            every { adEventCallback } answers { installedCallback }
+            every { adEventCallback = any() } answers { installedCallback = firstArg() }
+        }
+        val activity = mockk<Activity>()
         val rewardListener = mockk<OnUserEarnedRewardListener>()
+        val loadCallback = FullScreenRecordingAdLoadCallback<RewardedInterstitialAd>()
         val initialEventCallback = RecordingRewardedInterstitialAdEventCallback()
         val replacementEventCallback = RecordingRewardedInterstitialAdEventCallback()
+        val trackingLoadCallback = slot<AdLoadCallback<RewardedInterstitialAd>>()
 
-        contract.callbackSuccess(
-            createAd = { responseInfo, installedCallback ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback } answers { installedCallback.callback }
-                    every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
-                }
-            },
-            initialEventCallback = initialEventCallback,
-            replacementEventCallback = replacementEventCallback,
-            stubLoad = { adRequest, trackingLoadCallback ->
-                every { RewardedInterstitialAd.load(adRequest, any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrack = { adRequest, loadCallback, eventCallback ->
-                adTracker.loadAndTrackRewardedInterstitialAd(
-                    adRequest = adRequest,
-                    placement = "load-placement",
-                    loadCallback = loadCallback,
-                    adEventCallback = eventCallback,
-                )
-            },
-            asTrackingCallback = { it as? TrackingRewardedInterstitialAdEventCallback },
-            invokeDelegateCallback = { it.onAdMetadataChanged() },
-            assertInitialDelegateInvoked = { assertTrue(initialEventCallback.metadataChangedCalled) },
-            setTrackingEventCallback = { ad, eventCallback -> ad.setTrackingAdEventCallback(eventCallback) },
-            assertReplacementDelegateInvoked = { assertTrue(replacementEventCallback.metadataChangedCalled) },
-            show = { ad, activity, placement -> ad.show(activity, placement, rewardListener) },
-            verifyShow = { ad, activity -> verify(exactly = 1) { ad.show(activity, rewardListener) } },
+        every { RewardedInterstitialAd.load(adRequest, capture(trackingLoadCallback)) } just runs
+        adTracker.loadAndTrackRewardedInterstitialAd(
+            adRequest = adRequest,
+            placement = values.placement,
+            loadCallback = loadCallback,
+            adEventCallback = initialEventCallback,
         )
+        trackingLoadCallback.captured.onAdLoaded(rewardedInterstitialAd)
+
+        assertSame(rewardedInterstitialAd, loadCallback.loadedAd)
+        adTracker.assertLoadedData(slot(), values, "test-network", "response-id")
+
+        val trackingCallback = requireNotNull(
+            installedCallback as? TrackingRewardedInterstitialAdEventCallback,
+        )
+        trackingCallback.onAdMetadataChanged()
+        assertTrue(initialEventCallback.metadataChangedCalled)
+
+        rewardedInterstitialAd.setTrackingAdEventCallback(replacementEventCallback)
+        trackingCallback.onAdMetadataChanged()
+        assertTrue(replacementEventCallback.metadataChangedCalled)
+
+        rewardedInterstitialAd.show(activity, "show-placement", rewardListener)
+        assertEquals("show-placement", trackingCallback.placement)
+        verify(exactly = 1) { rewardedInterstitialAd.show(activity, rewardListener) }
     }
 
     @Test
     fun `show with null placement clears the load-time placement`() {
-        val installedCallback = CallbackHolder<RewardedInterstitialAdEventCallback>()
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns values.adUnitId }
+        var installedCallback: RewardedInterstitialAdEventCallback? = null
         val rewardedInterstitialAd = mockk<RewardedInterstitialAd>(relaxed = true) {
-            every { adEventCallback } answers { installedCallback.callback }
-            every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
+            every { adEventCallback } answers { installedCallback }
+            every { adEventCallback = any() } answers { installedCallback = firstArg() }
         }
-        val adRequest = mockk<AdRequest> {
-            every { adUnitId } returns "rewarded-interstitial-unit"
-        }
-        val trackingLoadCallback = CallbackHolder<AdLoadCallback<RewardedInterstitialAd>>()
-        every { RewardedInterstitialAd.load(adRequest, any()) } answers {
-            trackingLoadCallback.callback = secondArg()
-        }
-        adTracker.loadAndTrackRewardedInterstitialAd(
-            adRequest = adRequest,
-            placement = "load-placement",
-            loadCallback = FullScreenRecordingAdLoadCallback(),
-        )
-        trackingLoadCallback.requireCallback().onAdLoaded(rewardedInterstitialAd)
-
-        val trackingCallback = requireNotNull(
-            installedCallback.requireCallback() as? TrackingRewardedInterstitialAdEventCallback,
-        )
         val activity = mockk<Activity>()
         val rewardListener = mockk<OnUserEarnedRewardListener>()
-        assertShowClearsPlacement(
-            trackingCallback = trackingCallback,
-            show = { rewardedInterstitialAd.show(activity, placement = null, rewardListener) },
-            verifyShow = { verify(exactly = 1) { rewardedInterstitialAd.show(activity, rewardListener) } },
+        val trackingLoadCallback = slot<AdLoadCallback<RewardedInterstitialAd>>()
+
+        every { RewardedInterstitialAd.load(adRequest, capture(trackingLoadCallback)) } just runs
+        adTracker.loadAndTrackRewardedInterstitialAd(
+            adRequest = adRequest,
+            placement = values.placement,
+            loadCallback = FullScreenRecordingAdLoadCallback(),
         )
+        trackingLoadCallback.captured.onAdLoaded(rewardedInterstitialAd)
+
+        val trackingCallback = requireNotNull(
+            installedCallback as? TrackingRewardedInterstitialAdEventCallback,
+        )
+        assertEquals("load-placement", trackingCallback.placement)
+
+        rewardedInterstitialAd.show(activity, placement = null, rewardListener)
+
+        assertNull(trackingCallback.placement)
+        verify(exactly = 1) { rewardedInterstitialAd.show(activity, rewardListener) }
     }
 
     @Test
     fun `rewarded interstitial failure is forwarded to load callback`() {
-        contract.callbackFailure(
-            stubLoad = { adRequest, trackingLoadCallback ->
-                every { RewardedInterstitialAd.load(adRequest, any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrack = { adRequest, loadCallback ->
-                adTracker.loadAndTrackRewardedInterstitialAd(
-                    adRequest = adRequest,
-                    placement = "load-placement",
-                    loadCallback = loadCallback,
-                )
-            },
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns values.adUnitId }
+        val error = mockk<LoadAdError>(relaxed = true)
+        val loadCallback = FullScreenRecordingAdLoadCallback<RewardedInterstitialAd>()
+        val trackingLoadCallback = slot<AdLoadCallback<RewardedInterstitialAd>>()
+
+        every { RewardedInterstitialAd.load(adRequest, capture(trackingLoadCallback)) } just runs
+        adTracker.loadAndTrackRewardedInterstitialAd(
+            adRequest = adRequest,
+            placement = values.placement,
+            loadCallback = loadCallback,
         )
+        trackingLoadCallback.captured.onAdFailedToLoad(error)
+
+        assertSame(error, loadCallback.loadError)
+        adTracker.assertFailedData(slot(), values)
     }
 
     @Test
     fun `suspending rewarded interstitial success tracks and installs callback before returning original result`() =
         runBlocking {
+            val adRequest = mockk<AdRequest> { every { adUnitId } returns suspendingValues.adUnitId }
+            val responseInfo = mockk<ResponseInfo>(relaxed = true) {
+                every { adapterClassName } returns "suspend-test-network"
+                every { responseId } returns "suspend-response-id"
+            }
+            var installedCallback: RewardedInterstitialAdEventCallback? = null
+            val rewardedInterstitialAd = mockk<RewardedInterstitialAd>(relaxed = true) {
+                every { getResponseInfo() } returns responseInfo
+                every { adEventCallback } answers { installedCallback }
+                every { adEventCallback = any() } answers { installedCallback = firstArg() }
+            }
             val eventCallback = RecordingRewardedInterstitialAdEventCallback()
+            val sdkResult = AdLoadResult.Success(rewardedInterstitialAd)
 
-            contract.suspendingSuccess(
-                createAd = { responseInfo, installedCallback ->
-                    mockk(relaxed = true) {
-                        every { getResponseInfo() } returns responseInfo
-                        every { adEventCallback } answers { installedCallback.callback }
-                        every { adEventCallback = any() } answers { installedCallback.callback = firstArg() }
-                    }
-                },
-                eventCallback = eventCallback,
-                stubLoad = { adRequest, sdkResult ->
-                    coEvery { RewardedInterstitialAd.load(adRequest) } returns sdkResult
-                },
-                loadAndTrack = { adRequest, delegate ->
-                    adTracker.loadAndTrackRewardedInterstitialAd(
-                        adRequest = adRequest,
-                        placement = "suspend-load-placement",
-                        adEventCallback = delegate,
-                    )
-                },
-                asTrackingCallback = { it as? TrackingRewardedInterstitialAdEventCallback },
-                invokeDelegateCallback = { it.onAdMetadataChanged() },
-                assertDelegateInvoked = { assertTrue(eventCallback.metadataChangedCalled) },
+            coEvery { RewardedInterstitialAd.load(adRequest) } returns sdkResult
+            val result = adTracker.loadAndTrackRewardedInterstitialAd(
+                adRequest = adRequest,
+                placement = suspendingValues.placement,
+                adEventCallback = eventCallback,
+            )
+
+            assertSame(sdkResult, result)
+            val trackingCallback = requireNotNull(
+                installedCallback as? TrackingRewardedInterstitialAdEventCallback,
+            )
+            trackingCallback.onAdMetadataChanged()
+            assertTrue(eventCallback.metadataChangedCalled)
+            adTracker.assertLoadedData(
+                slot<AdLoadedData>(),
+                suspendingValues,
+                "suspend-test-network",
+                "suspend-response-id",
             )
         }
 
     @Test
     fun `suspending rewarded interstitial failure tracks error and returns original result`() = runBlocking {
-        contract.suspendingFailure(
-            stubLoad = { adRequest, sdkResult ->
-                coEvery { RewardedInterstitialAd.load(adRequest) } returns sdkResult
-            },
-            loadAndTrack = { adRequest ->
-                adTracker.loadAndTrackRewardedInterstitialAd(
-                    adRequest = adRequest,
-                    placement = "suspend-load-placement",
-                )
-            },
+        val adRequest = mockk<AdRequest> { every { adUnitId } returns suspendingValues.adUnitId }
+        val error = mockk<LoadAdError> { every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR }
+        val sdkResult = AdLoadResult.Failure<RewardedInterstitialAd>(error)
+
+        coEvery { RewardedInterstitialAd.load(adRequest) } returns sdkResult
+        val result = adTracker.loadAndTrackRewardedInterstitialAd(
+            adRequest = adRequest,
+            placement = suspendingValues.placement,
         )
+
+        assertSame(sdkResult, result)
+        adTracker.assertSuspendingFailedData(slot<AdFailedToLoadData>(), suspendingValues)
     }
 
     @Test
     fun `setting event callback directly falls back when tracking is not installed`() {
+        val rewardedInterstitialAd = mockk<RewardedInterstitialAd>(relaxed = true) {
+            every { adEventCallback } returns null
+        }
         val eventCallback = RecordingRewardedInterstitialAdEventCallback()
 
-        contract.eventCallbackFallback(
-            createAd = {
-                mockk(relaxed = true) {
-                    every { adEventCallback } returns null
-                }
-            },
-            eventCallback = eventCallback,
-            setTrackingEventCallback = { ad, callback -> ad.setTrackingAdEventCallback(callback) },
-            verifyEventCallbackInstalled = { ad, callback ->
-                verify(exactly = 1) { ad.adEventCallback = callback }
-            },
-        )
+        rewardedInterstitialAd.setTrackingAdEventCallback(eventCallback)
+
+        verify(exactly = 1) { rewardedInterstitialAd.adEventCallback = eventCallback }
     }
 
     private class RecordingRewardedInterstitialAdEventCallback : RewardedInterstitialAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedInterstitialAdResponseFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedInterstitialAdResponseFlowTest.kt
@@ -2,6 +2,8 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -22,15 +24,10 @@ class RewardedInterstitialAdResponseFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
-    private val contract =
-        FullScreenAdResponseFlowContract<RewardedInterstitialAd, RewardedInterstitialAdEventCallback>(
-            adTracker = adTracker,
-            values = FullScreenAdTestValues(
-                adFormat = AdFormat.REWARDED_INTERSTITIAL,
-                adUnitId = "supplied-rewarded-interstitial-unit",
-                placement = "response-rewarded-interstitial",
-            ),
-        )
+    private val contract = FullScreenAdResponseFlowContract(
+        adTracker = adTracker,
+        adapter = RewardedInterstitialAdAdapter(),
+    )
 
     @Before
     fun setUp() {
@@ -52,53 +49,65 @@ class RewardedInterstitialAdResponseFlowTest {
         val eventCallback = RecordingRewardedInterstitialEventCallback()
 
         contract.responseSuccess(
-            createAd = { responseInfo, installedCallback, onCallbackInstalled ->
-                mockk(relaxed = true) {
-                    every { getResponseInfo() } returns responseInfo
-                    every { adEventCallback = any() } answers {
-                        installedCallback.callback = firstArg()
-                        onCallbackInstalled()
-                    }
-                }
-            },
             eventCallback = eventCallback,
-            stubLoadFromResponse = { trackingLoadCallback ->
-                every { RewardedInterstitialAd.loadFromAdResponse("opaque-response", any()) } answers {
-                    trackingLoadCallback.callback = secondArg()
-                }
-            },
-            loadAndTrackFromResponse = { loadCallback, delegate ->
-                adTracker.loadAndTrackRewardedInterstitialAdFromResponse(
-                    adResponse = "opaque-response",
-                    adUnitId = "supplied-rewarded-interstitial-unit",
-                    placement = "response-rewarded-interstitial",
-                    loadCallback = loadCallback,
-                    adEventCallback = delegate,
-                )
-            },
-            asTrackingCallback = { it as? TrackingRewardedInterstitialAdEventCallback },
-            invokeDelegateCallback = { it.onAdMetadataChanged() },
             assertDelegateInvoked = { assertTrue(eventCallback.metadataChangedCalled) },
         )
     }
 
     @Test
     fun `response failure uses supplied ad unit and placement before forwarding`() {
-        contract.responseFailure(
-            stubLoadFromResponse = { trackingLoadCallback ->
+        contract.responseFailure()
+    }
+
+    private inner class RewardedInterstitialAdAdapter :
+        FullScreenAdResponseFlowAdapter<RewardedInterstitialAd, RewardedInterstitialAdEventCallback> {
+            override val values = FullScreenAdTestValues(
+                adFormat = AdFormat.REWARDED_INTERSTITIAL,
+                adUnitId = "supplied-rewarded-interstitial-unit",
+                placement = "response-rewarded-interstitial",
+            )
+
+            override fun createAd(
+                responseInfo: ResponseInfo,
+                installedCallback: CallbackHolder<RewardedInterstitialAdEventCallback>,
+                onCallbackInstalled: () -> Unit,
+            ): RewardedInterstitialAd = mockk(relaxed = true) {
+                every { getResponseInfo() } returns responseInfo
+                every { adEventCallback = any() } answers {
+                    installedCallback.callback = firstArg()
+                    onCallbackInstalled()
+                }
+            }
+
+            override fun stubLoadFromResponse(
+                trackingLoadCallback: CallbackHolder<AdLoadCallback<RewardedInterstitialAd>>,
+            ) {
                 every { RewardedInterstitialAd.loadFromAdResponse("opaque-response", any()) } answers {
                     trackingLoadCallback.callback = secondArg()
                 }
-            },
-            loadAndTrackFromResponse = { loadCallback ->
+            }
+
+            override fun loadAndTrackFromResponse(
+                loadCallback: AdLoadCallback<RewardedInterstitialAd>,
+                eventCallback: RewardedInterstitialAdEventCallback?,
+            ) {
                 adTracker.loadAndTrackRewardedInterstitialAdFromResponse(
                     adResponse = "opaque-response",
-                    adUnitId = "supplied-rewarded-interstitial-unit",
-                    placement = "response-rewarded-interstitial",
+                    adUnitId = values.adUnitId,
+                    placement = values.placement,
                     loadCallback = loadCallback,
+                    adEventCallback = eventCallback,
                 )
-            },
-        )
+            }
+
+            override fun asTrackingCallback(
+                callback: RewardedInterstitialAdEventCallback,
+            ): TrackingRewardedInterstitialAdEventCallback? =
+                callback as? TrackingRewardedInterstitialAdEventCallback
+
+            override fun invokeDelegateCallback(callback: RewardedInterstitialAdEventCallback) {
+                callback.onAdMetadataChanged()
+            }
     }
 
     private class RecordingRewardedInterstitialEventCallback : RewardedInterstitialAdEventCallback {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedInterstitialAdResponseFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/RewardedInterstitialAdResponseFlowTest.kt
@@ -2,38 +2,35 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingRewardedInterstitialAdEventCallback
-import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
-import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
-import com.revenuecat.purchases.ads.events.types.AdLoadedData
-import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.slot
 import io.mockk.unmockkObject
-import io.mockk.verify
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+
 class RewardedInterstitialAdResponseFlowTest {
 
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
+    private val contract =
+        FullScreenAdResponseFlowContract<RewardedInterstitialAd, RewardedInterstitialAdEventCallback>(
+            adTracker = adTracker,
+            values = FullScreenAdTestValues(
+                adFormat = AdFormat.REWARDED_INTERSTITIAL,
+                adUnitId = "supplied-rewarded-interstitial-unit",
+                placement = "response-rewarded-interstitial",
+            ),
+        )
 
     @Before
     fun setUp() {
@@ -52,101 +49,56 @@ class RewardedInterstitialAdResponseFlowTest {
 
     @Test
     fun `response success tracks and installs event callback before forwarding`() {
-        val order = mutableListOf<String>()
-        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-            every { adapterClassName } returns "test-network"
-            every { responseId } returns "response-id"
-        }
-        val rewardedInterstitialAd = mockk<RewardedInterstitialAd>(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo
-        }
-        val loadCallback = object : AdLoadCallback<RewardedInterstitialAd> {
-            override fun onAdLoaded(ad: RewardedInterstitialAd) {
-                order += "load-callback"
-                assertSame(rewardedInterstitialAd, ad)
-            }
-        }
         val eventCallback = RecordingRewardedInterstitialEventCallback()
-        val trackingLoadCallback = slot<AdLoadCallback<RewardedInterstitialAd>>()
-        val installedEventCallback = slot<RewardedInterstitialAdEventCallback>()
-        val loadedData = slot<AdLoadedData>()
 
-        every {
-            RewardedInterstitialAd.loadFromAdResponse("opaque-response", capture(trackingLoadCallback))
-        } just runs
-        every { adTracker.trackAdLoaded(capture(loadedData), AdCaptureMethod.ADAPTER) } answers {
-            order += "tracked"
-        }
-        every { rewardedInterstitialAd.adEventCallback = capture(installedEventCallback) } answers {
-            order += "event-callback"
-        }
-
-        adTracker.loadAndTrackRewardedInterstitialAdFromResponse(
-            adResponse = "opaque-response",
-            adUnitId = "supplied-rewarded-interstitial-unit",
-            placement = "response-rewarded-interstitial",
-            loadCallback = loadCallback,
-            adEventCallback = eventCallback,
+        contract.responseSuccess(
+            createAd = { responseInfo, installedCallback, onCallbackInstalled ->
+                mockk(relaxed = true) {
+                    every { getResponseInfo() } returns responseInfo
+                    every { adEventCallback = any() } answers {
+                        installedCallback.callback = firstArg()
+                        onCallbackInstalled()
+                    }
+                }
+            },
+            eventCallback = eventCallback,
+            stubLoadFromResponse = { trackingLoadCallback ->
+                every { RewardedInterstitialAd.loadFromAdResponse("opaque-response", any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrackFromResponse = { loadCallback, delegate ->
+                adTracker.loadAndTrackRewardedInterstitialAdFromResponse(
+                    adResponse = "opaque-response",
+                    adUnitId = "supplied-rewarded-interstitial-unit",
+                    placement = "response-rewarded-interstitial",
+                    loadCallback = loadCallback,
+                    adEventCallback = delegate,
+                )
+            },
+            asTrackingCallback = { it as? TrackingRewardedInterstitialAdEventCallback },
+            invokeDelegateCallback = { it.onAdMetadataChanged() },
+            assertDelegateInvoked = { assertTrue(eventCallback.metadataChangedCalled) },
         )
-        trackingLoadCallback.captured.onAdLoaded(rewardedInterstitialAd)
-
-        assertEquals(listOf("tracked", "event-callback", "load-callback"), order)
-        assertEquals(
-            AdLoadedData(
-                networkName = "test-network",
-                mediatorName = AdMediatorName.AD_MOB,
-                adFormat = AdFormat.REWARDED_INTERSTITIAL,
-                placement = "response-rewarded-interstitial",
-                adUnitId = "supplied-rewarded-interstitial-unit",
-                impressionId = "response-id",
-            ),
-            loadedData.captured,
-        )
-        assertTrue(installedEventCallback.captured is TrackingRewardedInterstitialAdEventCallback)
-
-        installedEventCallback.captured.onAdMetadataChanged()
-        assertTrue(eventCallback.metadataChangedCalled)
     }
 
     @Test
     fun `response failure uses supplied ad unit and placement before forwarding`() {
-        val order = mutableListOf<String>()
-        val error = LoadAdError(
-            LoadAdError.ErrorCode.INVALID_AD_RESPONSE,
-            "invalid response",
-            mockk(relaxed = true),
+        contract.responseFailure(
+            stubLoadFromResponse = { trackingLoadCallback ->
+                every { RewardedInterstitialAd.loadFromAdResponse("opaque-response", any()) } answers {
+                    trackingLoadCallback.callback = secondArg()
+                }
+            },
+            loadAndTrackFromResponse = { loadCallback ->
+                adTracker.loadAndTrackRewardedInterstitialAdFromResponse(
+                    adResponse = "opaque-response",
+                    adUnitId = "supplied-rewarded-interstitial-unit",
+                    placement = "response-rewarded-interstitial",
+                    loadCallback = loadCallback,
+                )
+            },
         )
-        val loadCallback = object : AdLoadCallback<RewardedInterstitialAd> {
-            override fun onAdFailedToLoad(adError: LoadAdError) {
-                order += "load-callback"
-                assertSame(error, adError)
-            }
-        }
-        val trackingLoadCallback = slot<AdLoadCallback<RewardedInterstitialAd>>()
-        val failedData = slot<AdFailedToLoadData>()
-
-        every {
-            RewardedInterstitialAd.loadFromAdResponse("opaque-response", capture(trackingLoadCallback))
-        } just runs
-        every { adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER) } answers {
-            order += "tracked"
-        }
-
-        adTracker.loadAndTrackRewardedInterstitialAdFromResponse(
-            adResponse = "opaque-response",
-            adUnitId = "supplied-rewarded-interstitial-unit",
-            placement = "response-rewarded-interstitial",
-            loadCallback = loadCallback,
-        )
-        trackingLoadCallback.captured.onAdFailedToLoad(error)
-
-        assertEquals(listOf("tracked", "load-callback"), order)
-        verify(exactly = 1) {
-            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
-        }
-        assertEquals(AdFormat.REWARDED_INTERSTITIAL, failedData.captured.adFormat)
-        assertEquals("supplied-rewarded-interstitial-unit", failedData.captured.adUnitId)
-        assertEquals("response-rewarded-interstitial", failedData.captured.placement)
     }
 
     private class RecordingRewardedInterstitialEventCallback : RewardedInterstitialAdEventCallback {


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
The full-screen AdMob response-flow tests repeat the same load, tracking, callback, and failure contracts across four ad formats. One more level of indirection but I think the consolidation makes sense and saves some repeated work.

<details>
<summary>More context</summary>

This introduces a focused response-flow contract driven by small, named, statically typed per-format adapters; the direct-flow tests remain explicit and share only compact result assertions and recording callbacks.
Each concrete test still invokes its real Google companion loader, callback property, tracking extension, show signature, and unique delegate callback, preserving compiler coverage without reflection, `Any` dispatch, unchecked casts, or broad lint suppressions.
No production code or unrelated fixtures are changed.
Tested with `./gradlew :feature:admob-next-gen:testDefaultsDebugUnitTest --rerun-tasks`, `./gradlew detektAll --rerun-tasks`, and `git diff --check`.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to unit tests; runtime AdMob integration and event tracking code are untouched.
> 
> **Overview**
> **Test-only refactor** in `feature/admob-next-gen`: no production or tracking behavior changes.
> 
> Adds **`FullScreenAdFlowTestContracts.kt`** with shared helpers—`FullScreenAdTestValues`, a generic **`FullScreenRecordingAdLoadCallback`**, **`AdTracker`** assertion extensions (`assertLoadedData`, `assertFailedData`, `assertSuspendingFailedData`), and a **`FullScreenAdResponseFlowContract`** driven by per-format **`FullScreenAdResponseFlowAdapter`** implementations.
> 
> **Direct-load tests** (app open, interstitial, rewarded, rewarded interstitial) drop duplicated load-callback classes and repeated `trackAdLoaded` / `trackAdFailedToLoad` blocks in favor of the shared values and assertions; format-specific scenarios (show/placement, suspending load, delegate wiring) stay in each file.
> 
> **Response-flow tests** for the same four formats shrink to thin wrappers that call `contract.responseSuccess()` / `contract.responseFailure()` while each file’s inner adapter still wires the real `loadFromAdResponse` entry point, tracking extension, and format-specific delegate callback—preserving the same ordering and payload checks as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b566fe1e519ecbd9c808d272c62293a4fdf3e049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->