### PR TITLE
refactor(admob): deduplicate next-gen sample preloader UI

### DIFF
--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/BannerScreen.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/BannerScreen.kt
@@ -137,18 +137,17 @@ internal fun BannerScreen(activity: Activity, onBack: () -> Unit) {
                         ),
                     ),
                     onToggle = {
-                        if (preloadState.started) {
-                            preloadState.updateAfterStop(BannerAdPreloader.destroy(BANNER_PRELOAD_ID))
-                        } else {
-                            preloadState.updateAfterStart(
+                        preloadState.toggle(
+                            start = {
                                 BannerAdPreloader.startAndTrack(
                                     BANNER_PRELOAD_ID,
                                     PreloadConfiguration(bannerRequest(), preloadState.bufferSize),
                                     placement = "banner_preload",
                                     preloadCallback = preloadState.preloadCallback(scope),
-                                ),
-                            )
-                        }
+                                )
+                            },
+                            stop = { BannerAdPreloader.destroy(BANNER_PRELOAD_ID) },
+                        )
                     },
                 )
             }

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/FullScreenScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/FullScreenScreens.kt
@@ -221,13 +221,12 @@ private fun <AdT : Ad, EventCallbackT> FullScreenAdScreen(
                     ),
                 ),
                 onToggle = {
-                    if (preloadState.started) {
-                        preloadState.updateAfterStop(stopPreloader())
-                    } else {
-                        preloadState.updateAfterStart(
-                            startPreloader(preloadState.bufferSize, preloadState.preloadCallback(scope)),
-                        )
-                    }
+                    preloadState.toggle(
+                        start = {
+                            startPreloader(preloadState.bufferSize, preloadState.preloadCallback(scope))
+                        },
+                        stop = stopPreloader,
+                    )
                 },
             )
         }

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/NativeScreen.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/NativeScreen.kt
@@ -8,7 +8,6 @@ import android.widget.TextView
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -125,8 +124,9 @@ internal fun NativeScreen(onBack: () -> Unit) {
                 NativeAdCountSetting(
                     batchSize = batchSize,
                     maximum = MAX_NATIVE_BATCH_SIZE,
-                    onDecrease = { batchSize = (batchSize - 1).coerceAtLeast(MIN_NATIVE_BATCH_SIZE) },
-                    onIncrease = { batchSize = (batchSize + 1).coerceAtMost(MAX_NATIVE_BATCH_SIZE) },
+                    onValueChange = {
+                        batchSize = it.coerceAtLeast(MIN_NATIVE_BATCH_SIZE).coerceAtMost(MAX_NATIVE_BATCH_SIZE)
+                    },
                 )
             }
         }
@@ -164,13 +164,10 @@ internal fun NativeScreen(onBack: () -> Unit) {
                     NativeAdCountSetting(
                         batchSize = preloadedAdCount,
                         maximum = preloadState.adsAvailable,
-                        onDecrease = {
-                            preferredPreloadedAdCount =
-                                (preloadedAdCount - 1).coerceAtLeast(MIN_NATIVE_BATCH_SIZE)
-                        },
-                        onIncrease = {
-                            preferredPreloadedAdCount =
-                                (preloadedAdCount + 1).coerceAtMost(preloadState.adsAvailable)
+                        onValueChange = {
+                            preferredPreloadedAdCount = it
+                                .coerceAtLeast(MIN_NATIVE_BATCH_SIZE)
+                                .coerceAtMost(preloadState.adsAvailable)
                         },
                     )
                 },
@@ -192,18 +189,17 @@ internal fun NativeScreen(onBack: () -> Unit) {
                     ),
                 ),
                 onToggle = {
-                    if (preloadState.started) {
-                        preloadState.updateAfterStop(NativeAdPreloader.destroy(NATIVE_PRELOAD_ID))
-                    } else {
-                        preloadState.updateAfterStart(
+                    preloadState.toggle(
+                        start = {
                             NativeAdPreloader.startAndTrack(
                                 NATIVE_PRELOAD_ID,
                                 PreloadConfiguration(nativeRequest(adVariant), preloadState.bufferSize),
                                 placement = adVariant.placement("preload"),
                                 preloadCallback = preloadState.preloadCallback(scope),
-                            ),
-                        )
-                    }
+                            )
+                        },
+                        stop = { NativeAdPreloader.destroy(NATIVE_PRELOAD_ID) },
+                    )
                 },
             )
         }
@@ -219,29 +215,14 @@ internal fun NativeScreen(onBack: () -> Unit) {
 private fun NativeAdCountSetting(
     batchSize: Int,
     maximum: Int,
-    onDecrease: () -> Unit,
-    onIncrease: () -> Unit,
+    onValueChange: (Int) -> Unit,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text("Number of ads", modifier = Modifier.weight(1f))
-        OutlinedButton(
-            onClick = onDecrease,
-            enabled = batchSize > MIN_NATIVE_BATCH_SIZE,
-        ) {
-            Text("−")
-        }
-        Text(batchSize.toString())
-        OutlinedButton(
-            onClick = onIncrease,
-            enabled = batchSize < maximum,
-        ) {
-            Text("+")
-        }
-    }
+    NumericCountSetting(
+        label = { Text("Number of ads") },
+        value = batchSize,
+        valueRange = MIN_NATIVE_BATCH_SIZE..maximum,
+        onValueChange = onValueChange,
+    )
 }
 
 private data class HandledNativeResult(val ads: List<NativeAd>, val status: String)

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/PreloaderUi.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/PreloaderUi.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.sample.admob.nextgen.ui
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -63,12 +64,8 @@ internal class PreloaderUiState(
         }
     }
 
-    fun decreaseBufferSize() {
-        if (!started && bufferSize > MIN_BUFFER_SIZE) bufferSize--
-    }
-
-    fun increaseBufferSize() {
-        if (!started && bufferSize < MAX_SAMPLE_BUFFER_SIZE) bufferSize++
+    fun updateBufferSize(newBufferSize: Int) {
+        if (!started) bufferSize = newBufferSize.coerceIn(MIN_BUFFER_SIZE, MAX_SAMPLE_BUFFER_SIZE)
     }
 
     fun preloadCallback(scope: CoroutineScope): PreloadCallback = preloadStatusCallback(
@@ -82,6 +79,14 @@ internal class PreloaderUiState(
             refresh()
         },
     )
+
+    fun toggle(start: () -> Boolean, stop: () -> Boolean) {
+        if (started) {
+            updateAfterStop(stop())
+        } else {
+            updateAfterStart(start())
+        }
+    }
 
     fun updateAfterStart(startResult: Boolean) {
         refresh()
@@ -200,29 +205,47 @@ private fun PreloaderHeader(state: PreloaderUiState, onToggle: () -> Unit) {
 @Composable
 private fun BufferSizeSetting(state: PreloaderUiState) {
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
+        NumericCountSetting(
+            label = {
+                Text(
+                    text = "Buffer capacity",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            value = state.bufferSize,
+            valueRange = MIN_BUFFER_SIZE..MAX_SAMPLE_BUFFER_SIZE,
+            enabled = !state.started,
+            onValueChange = state::updateBufferSize,
+        )
+    }
+}
+
+@Composable
+internal fun NumericCountSetting(
+    label: @Composable () -> Unit,
+    value: Int,
+    valueRange: IntRange,
+    enabled: Boolean = true,
+    onValueChange: (Int) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(modifier = Modifier.weight(1f)) { label() }
+        OutlinedButton(
+            onClick = { onValueChange(value - 1) },
+            enabled = enabled && value > valueRange.first,
         ) {
-            Text(
-                text = "Buffer capacity",
-                modifier = Modifier.weight(1f),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            OutlinedButton(
-                onClick = state::decreaseBufferSize,
-                enabled = !state.started && state.bufferSize > MIN_BUFFER_SIZE,
-            ) {
-                Text("−")
-            }
-            Text(state.bufferSize.toString())
-            OutlinedButton(
-                onClick = state::increaseBufferSize,
-                enabled = !state.started && state.bufferSize < MAX_SAMPLE_BUFFER_SIZE,
-            ) {
-                Text("+")
-            }
+            Text("−")
+        }
+        Text(value.toString())
+        OutlinedButton(
+            onClick = { onValueChange(value + 1) },
+            enabled = enabled && value < valueRange.last,
+        ) {
+            Text("+")
         }
     }
 }

--- a/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
+++ b/examples/admob-next-gen-sample/src/main/java/com/revenuecat/sample/admob/nextgen/ui/RewardedScreens.kt
@@ -247,13 +247,12 @@ private fun <AdT : Ad> RewardedAdScreen(
                     ),
                 ),
                 onToggle = {
-                    if (preloadState.started) {
-                        preloadState.updateAfterStop(stopPreloader())
-                    } else {
-                        preloadState.updateAfterStart(
-                            startPreloader(preloadState.bufferSize, preloadState.preloadCallback(scope)),
-                        )
-                    }
+                    preloadState.toggle(
+                        start = {
+                            startPreloader(preloadState.bufferSize, preloadState.preloadCallback(scope))
+                        },
+                        stop = stopPreloader,
+                    )
                 },
             )
         }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] Unit tests are not applicable to this sample-only refactor
- [ ] If applicable, create follow-up issues for purchases-ios and hybrids

### Motivation
Small refactor. Remove repeated preloader controls from the next-generation AdMob sample while keeping SDK-specific request construction at each screen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-only UI refactor; no production SDK or ad-tracking behavior changes.
> 
> **Overview**
> Deduplicates repeated preloader controls in the AdMob next-gen **sample app** without changing SDK wiring—each screen still owns its own `startAndTrack` / `destroy` calls.
> 
> **`PreloaderUiState`** gains `toggle(start, stop)` so banner, fullscreen, native, and rewarded screens no longer copy the same `if (started) updateAfterStop … else updateAfterStart …` block. Buffer sizing moves from separate increment/decrement helpers to `updateBufferSize` with in-range coercion.
> 
> **`NumericCountSetting`** is a shared +/- row composable used for buffer capacity and native ad count (replacing duplicate `OutlinedButton` UIs and `onDecrease` / `onIncrease` callbacks with a single `onValueChange`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34fb6a228ffba2528ee65f2ef978e275d32c577b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->