### PR TITLE
ci: notify external PRs feed on PRs from outside the org

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -1,0 +1,13 @@
+name: External PR Notifications
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    secrets:
+      EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Adds a workflow that posts to an internal Slack feed when a PR is opened by someone outside the RevenueCat org.
- Uses `pull_request_target` so the job has the webhook secret on fork PRs; it never checks out or runs PR code and holds a `GITHUB_TOKEN` with no permissions.


### Checklist

- [x] `actionlint` clean
- [ ] Same caller in the other SDK repos once this one is verified

<details><summary>Agent description</summary>

### Motivation

The existing PR feed cannot filter by author, so external contributions get lost between bot and staff PRs. The shared workflow is RevenueCat/sdk-github-workflows#10.

### Description

`pull_request_target` runs the workflow definition from the base branch with base repo secrets, which is what fork PRs need for the webhook and also why the job must not touch PR content. The reusable workflow only reads event metadata (`author_association`, `user.type`, title, number, URL, login) and passes it to the shell via `env:`, escaping `&`, `<`, `>` before it reaches Slack so a title cannot inject a mention or a spoofed link.

`permissions: {}` is set here because this repo's default workflow token permission is `write`, and a reusable workflow cannot raise what the caller grants.

Author filter, verified against live PRs: fork authors are `NONE` or `CONTRIBUTOR`, org members and `RCGitBot` are `MEMBER`, dependabot is `CONTRIBUTOR` with `user.type` `Bot`. Outside collaborators (`COLLABORATOR`) are treated as external.

Not visible in the diff: this PR itself triggers nothing, since `pull_request_target` uses the workflow file on `main`. First real run is the next PR from a fork after merge.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds CI-only notification wiring with no application code changes; security posture relies on not running PR code and empty workflow permissions, matching the described design.
> 
> **Overview**
> Adds a GitHub Actions workflow that posts to an internal Slack feed when a **pull request is opened** by someone outside the RevenueCat org, so external contributions are easier to spot alongside bot and staff PRs.
> 
> The caller uses **`pull_request_target`** (opened only) so fork PRs can use the base repo’s **`EXTERNAL_PR_SLACK_WEBHOOK_URL`** secret without checking out PR code; **`permissions: {}`** keeps the workflow token from inheriting this repo’s default write scope. Implementation is delegated to the shared **`revenuecat/sdk-github-workflows`** reusable workflow at **v7** (pinned SHA).
> 
> The workflow file on **`main`** is what runs after merge; this PR does not exercise it until the next fork PR after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b9d643a00ff5255dd5e41d6b1bf6b4fd62695e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->