### PR TITLE
Remove backend predicate results from audience evaluation

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -114,8 +114,8 @@ internal class CheckpointWorkflowResolverImpl(
     }
 
     /**
-     * The whole audiences topic is read once as a snapshot, so every rule is matched against audiences and
-     * backend predicate results from the same committed config, and matching itself never re-reads config.
+     * The whole audience dictionary is read once, so every rule is matched against audiences from the same
+     * committed config, and matching itself never re-reads config.
      */
     @Suppress("ReturnCount")
     private suspend fun matchRule(
@@ -124,14 +124,13 @@ internal class CheckpointWorkflowResolverImpl(
         customVariables: Map<String, RulesDimensionValue>,
     ): Result<CheckpointRule?> {
         if (rules.isEmpty()) return Result.success(null)
-        val snapshot = audiencesConfigProvider.getSnapshot()
+        val audiences = audiencesConfigProvider.getAudiences()
             ?: return Result.failure(AudiencesUnavailableException())
         return localRulesEvaluator.match(
             rules = rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
-            backendValues = snapshot.backendPredicateResults,
         ) { rule ->
-            snapshot.audiences[rule.audienceId]
+            audiences[rule.audienceId]
                 ?.let { audience -> Result.success(audience.rules) }
                 ?: Result.failure(AudienceUnavailableException(rule.audienceId))
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/audiences/AudiencesConfigProvider.kt
@@ -5,43 +5,24 @@ package com.revenuecat.purchases.common.audiences
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.common.errorLog
-import com.revenuecat.purchases.common.localrules.RulesDimensionValue
-import com.revenuecat.purchases.common.localrules.asRulesDimensionValue
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.readConsistent
-import com.revenuecat.purchases.common.warnLog
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
-
-/**
- * The audiences topic as of one read: the audience dictionary from the static `default` blob together with the
- * `backend_predicate_results` the backend committed alongside it. Rules in [audiences] read
- * [backendPredicateResults] under `backend.*`, so consumers must evaluate the two together rather than
- * re-reading either on its own.
- */
-internal data class AudiencesSnapshot(
-    val audiences: Map<String, Audience>,
-    val backendPredicateResults: Map<String, RulesDimensionValue>,
-)
 
 internal class AudiencesConfigProvider(
     private val manager: RemoteConfigManager,
 ) {
     /**
-     * The current audiences topic, or `null` when the topic, its `default` item, or that item's blob is
-     * unavailable. Both parts are read under one config generation: [readConsistent] re-reads them once if a
-     * commit races the read, and gives up with `null` if that read is superseded too.
+     * The audience dictionary from the topic's static `default` blob, or `null` when the topic, that item, or its
+     * blob is unavailable. Read under one config generation: [readConsistent] re-reads once if a commit races the
+     * read, and gives up with `null` if that read is superseded too.
      */
-    suspend fun getSnapshot(): AudiencesSnapshot? =
+    suspend fun getAudiences(): Map<String, Audience>? =
         manager.readConsistent(what = { "the audiences topic" }) { _ ->
-            val audiences = manager.blobData(RemoteConfigTopic.Audiences, ITEM_DEFAULT, ::parseAudiences)
-                ?: return@readConsistent null
-            AudiencesSnapshot(
-                audiences = audiences,
-                backendPredicateResults = backendPredicateResults(),
-            )
+            manager.blobData(RemoteConfigTopic.Audiences, ITEM_DEFAULT, ::parseAudiences)
         }
 
     /**
@@ -70,27 +51,7 @@ internal class AudiencesConfigProvider(
         }.toMap()
     }
 
-    private suspend fun backendPredicateResults(): Map<String, RulesDimensionValue> {
-        val metadata = manager.topic(RemoteConfigTopic.Audiences)
-            ?.get(ITEM_BACKEND_PREDICATE_RESULTS)
-            ?.metadata
-            ?: return emptyMap()
-        return metadata.mapNotNull { (hash, element) ->
-            val result = element.asRulesDimensionValue()
-            if (result == null) {
-                // Rules read these with a default (`{"var": ["backend.<hash>", false]}`), so a value shape this
-                // SDK version cannot represent degrades to the rule's default instead of failing the item. An
-                // explicit null is not such a shape: it reaches the rule as null, which is falsy.
-                warnLog { "Ignoring backend predicate result '$hash': its value can't be read by a rule." }
-                null
-            } else {
-                hash to result
-            }
-        }.toMap()
-    }
-
     private companion object {
         const val ITEM_DEFAULT = "default"
-        const val ITEM_BACKEND_PREDICATE_RESULTS = "backend_predicate_results"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -43,26 +43,21 @@ internal class LocalRulesEvaluator(
      *
      * When a predicate must be resolved before it can be evaluated, a resolution failure fails the call immediately.
      * [customVariables] are the caller's own values for this evaluation, readable under `custom.*`.
-     * [backendValues] are the backend's pre-evaluated predicate results for this evaluation, readable under
-     * `backend.*`; the caller supplies them alongside the rules they were committed with, so both reflect the
-     * same remote config state.
      */
     suspend fun <Rule : LocalRule> match(
         rules: List<Rule>,
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
-        backendValues: Map<String, RulesDimensionValue> = emptyMap(),
-    ): Result<Rule?> = match(rules, customVariables, backendValues) { rule -> Result.success(rule.predicate) }
+    ): Result<Rule?> = match(rules, customVariables) { rule -> Result.success(rule.predicate) }
 
     @Suppress("ReturnCount")
     suspend fun <Rule> match(
         rules: List<Rule>,
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
-        backendValues: Map<String, RulesDimensionValue> = emptyMap(),
         predicateFor: suspend (Rule) -> Result<String>,
     ): Result<Rule?> {
         if (rules.isEmpty()) return Result.success(null)
 
-        val snapshot = dimensionResolver.snapshot(customVariables, backendValues).fold(
+        val snapshot = dimensionResolver.snapshot(customVariables).fold(
             onSuccess = { snapshot -> snapshot },
             onFailure = { error ->
                 return Result.failure(LocalRulesEvaluationException.DimensionResolution(error))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionProvider.kt
@@ -22,7 +22,7 @@ internal interface RulesDimensionProvider {
      *
      * The root names are part of the contract predicates are authored against, so a provider must not claim one
      * that is not its own: the resolver fails the whole snapshot when two sources supply the same name, or when a
-     * provider supplies one of the roots the resolver itself owns (`evaluated_at`, `custom`, `backend`).
+     * provider supplies one of the roots the resolver itself owns (`evaluated_at`, `custom`).
      *
      * A value that is unavailable is omitted rather than guessed: a predicate that reads an absent key fails as
      * an unresolved variable, rather than being answered from a value we invented. Only a source whose values are

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -47,15 +47,13 @@ internal class RulesDimensionResolver(
 ) {
 
     /**
-     * [customVariables] are the caller's own values for this one evaluation, exposed under `custom`.
-     * [backendValues] are the backend's pre-evaluated values for this one evaluation, exposed under `backend`.
-     * Both roots are reserved whether or not this evaluation supplies values for them, so a provider colliding
-     * with one is deterministic rather than dependent on call arguments.
+     * [customVariables] are the caller's own values for this one evaluation, exposed under `custom`. That root
+     * is reserved whether or not this evaluation supplies values for it, so a provider colliding with it is
+     * deterministic rather than dependent on call arguments.
      */
     @Suppress("ReturnCount")
     suspend fun snapshot(
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
-        backendValues: Map<String, RulesDimensionValue> = emptyMap(),
     ): Result<RulesDimensionSnapshot> {
         val date = dateProvider.now
         // Seeded before any provider runs, so a provider claiming this root is an ordinary collision.
@@ -83,10 +81,6 @@ internal class RulesDimensionResolver(
             return Result.failure(conflict)
         }
 
-        values.addNestedDimensions(KEY_BACKEND, backendValues)?.let { conflict ->
-            return Result.failure(conflict)
-        }
-
         return Result.success(
             RulesDimensionSnapshot(
                 values = values,
@@ -101,7 +95,7 @@ private fun MutableMap<String, Value>.addRootDimensions(
     dimensions: Map<String, RulesDimensionValue>,
 ): RulesDimensionResolutionException.ConflictingDimension? {
     for ((name, value) in dimensions.filterReachable(root = null)) {
-        if (containsKey(name) || name == KEY_CUSTOM || name == KEY_BACKEND) {
+        if (containsKey(name) || name == KEY_CUSTOM) {
             return RulesDimensionResolutionException.ConflictingDimension(name)
         }
         this[name] = value.asRulesEngineValue
@@ -177,7 +171,6 @@ internal const val DIMENSION_PATH_SEPARATOR = '.'
 
 private const val KEY_EVALUATED_AT = "evaluated_at"
 private const val KEY_CUSTOM = "custom"
-private const val KEY_BACKEND = "backend"
 
 private val RulesDimensionValue.asRulesEngineValue: Value
     get() = when (this) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProvider.kt
@@ -11,8 +11,7 @@ import java.util.Date
 
 /**
  * The dimensions the backend last delivered alongside the subscriber, cached because not every response carries
- * them, exposed as root-level names. Distinct from the reserved nested `backend` root, which holds the backend's
- * pre-evaluated predicate results for one evaluation.
+ * them, exposed as root-level names.
  *
  * The names are the backend's to choose, and the root-name contract applies to it like any other source: one
  * that collides with an SDK-provided dimension fails the snapshot. An explicit null is kept as null, since the

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -4,7 +4,6 @@ package com.revenuecat.purchases.checkpoints
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.PurchasesError
@@ -13,7 +12,6 @@ import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.audiences.Audience
 import com.revenuecat.purchases.common.audiences.AudiencesConfigProvider
-import com.revenuecat.purchases.common.audiences.AudiencesSnapshot
 import com.revenuecat.purchases.common.checkpoints.CheckpointResponse
 import com.revenuecat.purchases.common.checkpoints.CheckpointRule
 import com.revenuecat.purchases.common.checkpoints.CheckpointRulesResolution
@@ -21,10 +19,8 @@ import com.revenuecat.purchases.common.checkpoints.CheckpointsConfigProvider
 import com.revenuecat.purchases.common.localrules.LocalRulesEvaluator
 import com.revenuecat.purchases.common.localrules.RulesDimensionProvider
 import com.revenuecat.purchases.common.localrules.RulesDimensionValue
-import com.revenuecat.purchases.common.remoteconfig.ConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
-import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import com.revenuecat.purchases.common.uiconfig.UiConfigProvider
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowManager
@@ -44,7 +40,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.jsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -58,10 +53,6 @@ import java.util.concurrent.atomic.AtomicInteger
 class CheckpointWorkflowResolverImplTest {
 
     private val checkpointId = "test_checkpoint"
-
-    private companion object {
-        const val BACKEND_PREDICATE_HASH = "349OzehoTyCAdiZblj9w0J0yD-Uow8X3"
-    }
 
     private lateinit var mockWorkflowManager: WorkflowManager
     private lateinit var mockUiConfigProvider: UiConfigProvider
@@ -142,7 +133,7 @@ class CheckpointWorkflowResolverImplTest {
 
         assertThat(noActionReason(resolve()))
             .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
-        coVerify(exactly = 0) { mockAudiencesConfigProvider.getSnapshot() }
+        coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudiences() }
     }
 
     @Test
@@ -152,7 +143,7 @@ class CheckpointWorkflowResolverImplTest {
         assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
         assertThat(offeringsFetched).isZero()
         // With no rules to match, there is nothing to read the audiences for.
-        coVerify(exactly = 0) { mockAudiencesConfigProvider.getSnapshot() }
+        coVerify(exactly = 0) { mockAudiencesConfigProvider.getAudiences() }
     }
 
     @Test
@@ -241,15 +232,12 @@ class CheckpointWorkflowResolverImplTest {
         var generation = 0
         var snapshotReads = 0
         configureRulesReadAt { generation }
-        coEvery { mockAudiencesConfigProvider.getSnapshot() } answers {
+        coEvery { mockAudiencesConfigProvider.getAudiences() } answers {
             if (snapshotReads++ == 0) {
                 generation++
                 null
             } else {
-                AudiencesSnapshot(
-                    audiences = mapOf("aud_wf1234" to alwaysMatching("aud_wf1234")),
-                    backendPredicateResults = emptyMap(),
-                )
+                mapOf("aud_wf1234" to alwaysMatching("aud_wf1234"))
             }
         }
 
@@ -262,7 +250,7 @@ class CheckpointWorkflowResolverImplTest {
             var generation = 0
             var snapshotReads = 0
             configureRulesReadAt { generation }
-            coEvery { mockAudiencesConfigProvider.getSnapshot() } answers {
+            coEvery { mockAudiencesConfigProvider.getAudiences() } answers {
                 snapshotReads++
                 generation++
                 null
@@ -305,18 +293,18 @@ class CheckpointWorkflowResolverImplTest {
     @Test
     fun `rules after the first match do not need their audience`() = runTest {
         configureRules(rule("wf1234"), rule("wf5678"))
-        // aud_wf5678 is absent from the snapshot, so consulting it would fail the resolution.
+        // aud_wf5678 is absent from the audiences, so consulting it would fail the resolution.
         configureAudiences(alwaysMatching("aud_wf1234"))
 
         val resolution = resolve() as CheckpointResolution.MatchedWorkflow
 
         assertThat(resolution.workflow).isEqualTo(mockWorkflow)
-        coVerify(exactly = 1) { mockAudiencesConfigProvider.getSnapshot() }
+        coVerify(exactly = 1) { mockAudiencesConfigProvider.getAudiences() }
     }
 
     @Test
-    fun `an unavailable audiences snapshot is configuration unavailable`() = runTest {
-        coEvery { mockAudiencesConfigProvider.getSnapshot() } returns null
+    fun `unavailable audiences are configuration unavailable`() = runTest {
+        coEvery { mockAudiencesConfigProvider.getAudiences() } returns null
 
         assertThat(noActionReason(resolve()))
             .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
@@ -461,59 +449,6 @@ class CheckpointWorkflowResolverImplTest {
 
         assertThat(resolution).isNotInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
         assertThat(noActionReason(resolution))
-            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
-    }
-
-    @Test
-    fun `a backend predicate result the audience reads resolves the workflow`() = runTest {
-        configureAudiences(
-            Audience(
-                "aud_wf1234",
-                """{"or": [
-                    {"var": ["backend.$BACKEND_PREDICATE_HASH", false]},
-                    {"==": [{"var": "custom.country"}, "PL"]}
-                ]}""",
-            ),
-            backendPredicateResults = mapOf(BACKEND_PREDICATE_HASH to RulesDimensionValue.BoolValue(true)),
-        )
-
-        assertThat(resolve()).isInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
-    }
-
-    @Test
-    fun `a false backend predicate result resolves NoAction with NO_MATCH`() = runTest {
-        configureAudiences(
-            Audience("aud_wf1234", """{"var": ["backend.$BACKEND_PREDICATE_HASH", false]}"""),
-            backendPredicateResults = mapOf(BACKEND_PREDICATE_HASH to RulesDimensionValue.BoolValue(false)),
-        )
-
-        assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
-    }
-
-    @Test
-    fun `a non-boolean backend predicate result is compared like any other dimension`() = runTest {
-        configureAudiences(
-            Audience("aud_wf1234", """{"==": [{"var": ["backend.$BACKEND_PREDICATE_HASH", ""]}, "variant_b"]}"""),
-            backendPredicateResults = mapOf(BACKEND_PREDICATE_HASH to RulesDimensionValue.StringValue("variant_b")),
-        )
-
-        assertThat(resolve()).isInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
-    }
-
-    @Test
-    fun `a backend predicate result absent from the snapshot falls back to the rule's default`() = runTest {
-        // A hash this SDK never received (a newer backend, a value shape it skipped) reads as the default the
-        // rule was authored with, the same forward-compatibility path as any other unknown dimension.
-        configureAudiences(Audience("aud_wf1234", """{"var": ["backend.$BACKEND_PREDICATE_HASH", false]}"""))
-
-        assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
-    }
-
-    @Test
-    fun `a backend predicate read without a default is not a NO_MATCH when the hash is absent`() = runTest {
-        configureAudiences(Audience("aud_wf1234", """{"var": "backend.$BACKEND_PREDICATE_HASH"}"""))
-
-        assertThat(noActionReason(resolve()))
             .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
     }
 
@@ -684,14 +619,8 @@ class CheckpointWorkflowResolverImplTest {
 
     private fun alwaysMatching(audienceId: String) = Audience(id = audienceId, rules = "true")
 
-    private fun configureAudiences(
-        vararg audiences: Audience,
-        backendPredicateResults: Map<String, RulesDimensionValue> = emptyMap(),
-    ) {
-        coEvery { mockAudiencesConfigProvider.getSnapshot() } returns AudiencesSnapshot(
-            audiences = audiences.associateBy { it.id },
-            backendPredicateResults = backendPredicateResults,
-        )
+    private fun configureAudiences(vararg audiences: Audience) {
+        coEvery { mockAudiencesConfigProvider.getAudiences() } returns audiences.associateBy { it.id }
     }
 
     private fun configureRules(vararg rules: CheckpointRule) {
@@ -744,13 +673,6 @@ class CheckpointWorkflowResolverImplTest {
                 onSnapshotRead()
                 mapOf("aud_wf1234" to Audience(id = "aud_wf1234", rules = """{"==":[1,1]}"""))
             }
-            coEvery { manager.topic(RemoteConfigTopic.Audiences) } returns ConfigTopic(
-                mapOf(
-                    "backend_predicate_results" to RemoteConfiguration.ConfigItem(
-                        metadata = JsonTools.json.parseToJsonElement("""{"hash": true}""").jsonObject,
-                    ),
-                ),
-            )
         }
 
     private fun resolverBackedBy(manager: RemoteConfigManager) = CheckpointWorkflowResolverImpl(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/audiences/AudiencesConfigProviderTest.kt
@@ -1,19 +1,14 @@
 package com.revenuecat.purchases.common.audiences
 
-import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.common.currentLogHandler
-import com.revenuecat.purchases.common.localrules.RulesDimensionValue
-import com.revenuecat.purchases.common.remoteconfig.ConfigTopic
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigTopic
-import com.revenuecat.purchases.common.remoteconfig.RemoteConfiguration
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.jsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -35,7 +30,6 @@ internal class AudiencesConfigProviderTest {
             override fun e(tag: String, msg: String, throwable: Throwable?) {}
         }
         every { manager.configGeneration } returns 0
-        returnTopicItems()
     }
 
     @After
@@ -49,7 +43,7 @@ internal class AudiencesConfigProviderTest {
     }
 
     @Test
-    fun `the snapshot decodes typed audiences and ignores unknown fields`() = runTest {
+    fun `the default blob decodes typed audiences and ignores unknown fields`() = runTest {
         returnDefaultBlob(
             """
             {
@@ -66,7 +60,7 @@ internal class AudiencesConfigProviderTest {
             """.trimIndent(),
         )
 
-        assertThat(provider.getSnapshot()?.audiences).isEqualTo(
+        assertThat(provider.getAudiences()).isEqualTo(
             mapOf(
                 "aud_123" to Audience(id = "aud_123", rules = """{"and":[{"var":"country"},true]}"""),
                 "aud_456" to Audience(id = "aud_456", rules = """{"==":[1,1]}"""),
@@ -75,25 +69,24 @@ internal class AudiencesConfigProviderTest {
     }
 
     @Test
-    fun `a missing default blob makes the snapshot unavailable without reading backend results`() = runTest {
+    fun `a missing default blob makes the audiences unavailable`() = runTest {
         returnNoDefaultBlob()
 
-        assertThat(provider.getSnapshot()).isNull()
-        coVerify(exactly = 0) { manager.topic(RemoteConfigTopic.Audiences) }
+        assertThat(provider.getAudiences()).isNull()
     }
 
     @Test
-    fun `a blob that is not a JSON object makes the snapshot unavailable`() = runTest {
+    fun `a blob that is not a JSON object makes the audiences unavailable`() = runTest {
         returnDefaultBlob("""[{"id":"aud_123"}]""")
 
-        assertThat(provider.getSnapshot()).isNull()
+        assertThat(provider.getAudiences()).isNull()
     }
 
     @Test
-    fun `a malformed blob makes the snapshot unavailable`() = runTest {
+    fun `a malformed blob makes the audiences unavailable`() = runTest {
         returnDefaultBlob("{not json")
 
-        assertThat(provider.getSnapshot()).isNull()
+        assertThat(provider.getAudiences()).isNull()
     }
 
     @Test
@@ -108,120 +101,17 @@ internal class AudiencesConfigProviderTest {
             """.trimIndent(),
         )
 
-        assertThat(provider.getSnapshot()?.audiences).isEqualTo(
+        assertThat(provider.getAudiences()).isEqualTo(
             mapOf("valid" to Audience(id = "valid", rules = """{"==":[1,1]}""")),
         )
     }
 
     @Test
-    fun `backend predicate results are read from the topic item`() = runTest {
-        returnDefaultBlob("{}")
-        returnTopicItems(
-            "backend_predicate_results" to """
-            {
-              "349OzehoTyCAdiZblj9w0J0yD-Uow8X3": false,
-              "PROg2cJoAVWa3sWx-6djaRxQQbDPpWwW": true
-            }
-            """.trimIndent(),
-        )
-
-        assertThat(provider.getSnapshot()?.backendPredicateResults).isEqualTo(
-            mapOf(
-                "349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to RulesDimensionValue.BoolValue(false),
-                "PROg2cJoAVWa3sWx-6djaRxQQbDPpWwW" to RulesDimensionValue.BoolValue(true),
-            ),
-        )
-    }
-
-    @Test
-    fun `every backend predicate result shape a rule can read is kept`() = runTest {
-        returnDefaultBlob("{}")
-        returnTopicItems(
-            "backend_predicate_results" to """
-            {
-              "string": "variant_b",
-              "int": 3,
-              "double": 1.5,
-              "object": { "value": true, "count": 2 },
-              "records": [{ "id": "one" }, { "id": "two" }]
-            }
-            """.trimIndent(),
-        )
-
-        assertThat(provider.getSnapshot()?.backendPredicateResults).isEqualTo(
-            mapOf(
-                "string" to RulesDimensionValue.StringValue("variant_b"),
-                "int" to RulesDimensionValue.IntValue(3),
-                "double" to RulesDimensionValue.DoubleValue(1.5),
-                "object" to RulesDimensionValue.ObjectValue(
-                    mapOf(
-                        "value" to RulesDimensionValue.BoolValue(true),
-                        "count" to RulesDimensionValue.IntValue(2),
-                    ),
-                ),
-                "records" to RulesDimensionValue.ObjectListValue(
-                    listOf(
-                        mapOf("id" to RulesDimensionValue.StringValue("one")),
-                        mapOf("id" to RulesDimensionValue.StringValue("two")),
-                    ),
-                ),
-            ),
-        )
-    }
-
-    @Test
-    fun `a backend predicate result no rule could read is dropped without dropping the others`() = runTest {
-        returnDefaultBlob("{}")
-        returnTopicItems(
-            "backend_predicate_results" to """
-            {
-              "null-result": null,
-              "scalar-array": [1, 2, 3],
-              "null-in-object": { "value": null, "kept": true },
-              "kept": true
-            }
-            """.trimIndent(),
-        )
-
-        assertThat(provider.getSnapshot()?.backendPredicateResults).isEqualTo(
-            mapOf(
-                "null-result" to RulesDimensionValue.NullValue,
-                "null-in-object" to RulesDimensionValue.ObjectValue(
-                    mapOf(
-                        "value" to RulesDimensionValue.NullValue,
-                        "kept" to RulesDimensionValue.BoolValue(true),
-                    ),
-                ),
-                "kept" to RulesDimensionValue.BoolValue(true),
-            ),
-        )
-    }
-
-    @Test
-    fun `no backend predicate results item leaves the results empty rather than unavailable`() = runTest {
-        returnDefaultBlob("""{"aud_123":{"id":"aud_123","rules":{"==":[1,1]}}}""")
-        returnTopicItems("unrelated_item" to """{"some":"metadata"}""")
-
-        val snapshot = provider.getSnapshot()
-
-        assertThat(snapshot?.audiences).containsOnlyKeys("aud_123")
-        assertThat(snapshot?.backendPredicateResults).isEmpty()
-    }
-
-    @Test
-    fun `a topic that disappears mid-read leaves the results empty rather than unavailable`() = runTest {
-        returnDefaultBlob("{}")
-        coEvery { manager.topic(RemoteConfigTopic.Audiences) } returns null
-
-        assertThat(provider.getSnapshot()?.backendPredicateResults).isEmpty()
-    }
-
-    @Test
-    fun `getSnapshot reads again when the config generation changes during the read`() = runTest {
+    fun `getAudiences reads again when the config generation changes during the read`() = runTest {
         every { manager.configGeneration } returnsMany listOf(0, 1)
         returnDefaultBlob("""{"aud_123":{"id":"aud_123","rules":{"==":[1,1]}}}""")
 
-        assertThat(provider.getSnapshot()?.audiences).isEqualTo(
+        assertThat(provider.getAudiences()).isEqualTo(
             mapOf("aud_123" to Audience(id = "aud_123", rules = """{"==":[1,1]}""")),
         )
         coVerify(exactly = 2) {
@@ -230,11 +120,11 @@ internal class AudiencesConfigProviderTest {
     }
 
     @Test
-    fun `getSnapshot returns null when the config changes during both reads`() = runTest {
+    fun `getAudiences returns null when the config changes during both reads`() = runTest {
         every { manager.configGeneration } returnsMany listOf(0, 1, 1, 2)
         returnDefaultBlob("""{"aud_123":{"id":"aud_123","rules":{"==":[1,1]}}}""")
 
-        assertThat(provider.getSnapshot()).isNull()
+        assertThat(provider.getAudiences()).isNull()
         coVerify(exactly = 2) {
             manager.blobData(RemoteConfigTopic.Audiences, "default", any<(ByteArray) -> Map<String, Audience>?>())
         }
@@ -252,15 +142,5 @@ internal class AudiencesConfigProviderTest {
         coEvery {
             manager.blobData(RemoteConfigTopic.Audiences, "default", any<(ByteArray) -> Map<String, Audience>?>())
         } returns null
-    }
-
-    private fun returnTopicItems(vararg items: Pair<String, String>) {
-        coEvery { manager.topic(RemoteConfigTopic.Audiences) } returns ConfigTopic(
-            items.associate { (key, json) ->
-                key to RemoteConfiguration.ConfigItem(
-                    metadata = JsonTools.json.parseToJsonElement(json).jsonObject,
-                )
-            },
-        )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -176,44 +176,6 @@ class LocalRulesEvaluatorTest {
     }
 
     @Test
-    fun `a predicate reading a backend value matches`() = runTest {
-        val rules = listOf(TestRule("only", """{"var": ["backend.hash", false]}"""))
-
-        assertThat(
-            evaluator().match(rules, backendValues = mapOf("hash" to RulesDimensionValue.BoolValue(true)))
-                .getOrThrow()?.name,
-        ).isEqualTo("only")
-        assertThat(
-            evaluator().match(rules, backendValues = mapOf("hash" to RulesDimensionValue.BoolValue(false)))
-                .getOrThrow(),
-        ).isNull()
-        // A backend value this SDK never received reads as the default the rule was authored with.
-        assertThat(evaluator().match(rules).getOrThrow()).isNull()
-    }
-
-    @Test
-    fun `backend values, custom variables, and ambient dimensions are visible in the same call`() = runTest {
-        val rules = listOf(
-            TestRule(
-                "only",
-                """{"and": [
-                    {"==": [{"var": "platform"}, "android"]},
-                    {"==": [{"var": "custom.source"}, "settings"]},
-                    {"var": ["backend.hash", false]}
-                ]}""",
-            ),
-        )
-
-        val matched = evaluator().match(
-            rules,
-            customVariables = mapOf("source" to RulesDimensionValue.StringValue("settings")),
-            backendValues = mapOf("hash" to RulesDimensionValue.BoolValue(true)),
-        )
-
-        assertThat(matched.getOrThrow()?.name).isEqualTo("only")
-    }
-
-    @Test
     fun `dimensions are collected once per call regardless of rule count`() = runTest {
         evaluator().match(listOf("first", "second", "third")) { rule ->
             Result.success(if (rule == "third") matchingPredicate else nonMatchingPredicate)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -341,47 +341,6 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `backend values are nested under the backend root`() = runTest {
-        val resolver = resolver(provider("platform" to string("android")))
-
-        val values = resolver
-            .snapshot(backendValues = mapOf("349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to RulesDimensionValue.BoolValue(true)))
-            .getOrThrow()
-            .values
-
-        val matches = RulesEngine.evaluate(
-            """{"var": ["backend.349OzehoTyCAdiZblj9w0J0yD-Uow8X3", false]}""",
-            values,
-        )
-        assertThat(matches.getOrThrow()).isTrue()
-    }
-
-    @Test
-    fun `no backend values leaves the root absent rather than empty`() = runTest {
-        val resolver = resolver(provider("platform" to string("android")))
-
-        val values = resolver.snapshot().getOrThrow().values
-
-        assertThat(values).containsOnlyKeys("evaluated_at", "platform")
-        // An absent hash reads as the rule's default, which is what keeps unknown hashes forward-compatible.
-        assertThat(
-            RulesEngine.evaluate("""{"var": ["backend.unknown_hash", false]}""", values).getOrThrow(),
-        ).isFalse()
-    }
-
-    @Test
-    fun `a provider claiming the backend root fails the snapshot`() = runTest {
-        val resolver = resolver(
-            provider("backend" to RulesDimensionValue.ObjectValue(mapOf("source" to string("x")))),
-        )
-
-        // Reserved whether or not this evaluation supplies backend values, so the collision is deterministic.
-        val error = resolver.snapshot().exceptionOrNull()
-
-        assertThat(error).isEqualTo(RulesDimensionResolutionException.ConflictingDimension("backend"))
-    }
-
-    @Test
     fun `a provider claiming the custom root fails the snapshot`() = runTest {
         val resolver = resolver(
             provider("custom" to RulesDimensionValue.ObjectValue(mapOf("source" to string("x")))),
@@ -424,10 +383,10 @@ class RulesDimensionResolverTest {
 
     @Test
     fun `a nested name no predicate could read is dropped rather than exposed`() = runTest {
-        // Object values carry names too — one `var` path segment each — and the backend's pre-evaluated results
-        // are the source that can nest arbitrarily, so the same reachability rule applies at every depth.
-        val values = resolver().snapshot(
-            backendValues = mapOf(
+        // Object values carry names too — one `var` path segment each — and a provider can nest them
+        // arbitrarily, so the same reachability rule applies at every depth.
+        val resolver = resolver(
+            provider(
                 "profile" to RulesDimensionValue.ObjectValue(
                     mapOf(
                         "user.tier" to string("gold"),
@@ -440,29 +399,27 @@ class RulesDimensionResolverTest {
                     ),
                 ),
             ),
-        ).getOrThrow().values
+        )
 
-        assertThat(values["backend"]).isEqualTo(
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values["profile"]).isEqualTo(
             Value.ObjectValue(
                 mapOf(
-                    "profile" to Value.ObjectValue(
-                        mapOf(
-                            "tier" to Value.StringValue("gold"),
-                            "nested" to Value.ObjectValue(mapOf("kept" to Value.StringValue("yes"))),
-                        ),
-                    ),
+                    "tier" to Value.StringValue("gold"),
+                    "nested" to Value.ObjectValue(mapOf("kept" to Value.StringValue("yes"))),
                 ),
             ),
         )
         assertThat(
-            RulesEngine.evaluate("""{"==": [{"var": "backend.profile.tier"}, "gold"]}""", values).getOrThrow(),
+            RulesEngine.evaluate("""{"==": [{"var": "profile.tier"}, "gold"]}""", values).getOrThrow(),
         ).isTrue()
     }
 
     @Test
     fun `a name inside an object list record no predicate could read is dropped rather than exposed`() = runTest {
-        val values = resolver().snapshot(
-            backendValues = mapOf(
+        val resolver = resolver(
+            provider(
                 "results" to RulesDimensionValue.ObjectListValue(
                     listOf(
                         mapOf("user.tier" to string("gold"), "id" to string("a")),
@@ -470,17 +427,15 @@ class RulesDimensionResolverTest {
                     ),
                 ),
             ),
-        ).getOrThrow().values
+        )
 
-        assertThat(values["backend"]).isEqualTo(
-            Value.ObjectValue(
-                mapOf(
-                    "results" to Value.ArrayValue(
-                        listOf(
-                            Value.ObjectValue(mapOf("id" to Value.StringValue("a"))),
-                            Value.ObjectValue(mapOf("id" to Value.StringValue("b"))),
-                        ),
-                    ),
+        val values = resolver.snapshot().getOrThrow().values
+
+        assertThat(values["results"]).isEqualTo(
+            Value.ArrayValue(
+                listOf(
+                    Value.ObjectValue(mapOf("id" to Value.StringValue("a"))),
+                    Value.ObjectValue(mapOf("id" to Value.StringValue("b"))),
                 ),
             ),
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -53,7 +53,7 @@ class RulesDimensionScopeTest {
 
     @Test
     fun `the whole evaluation scope`() = runTest {
-        val scope = resolver().snapshot(CUSTOM_VARIABLES, BACKEND_VALUES).getOrThrow().values
+        val scope = resolver().snapshot(CUSTOM_VARIABLES).getOrThrow().values
 
         assertThat(scope.render()).isEqualTo(
             """
@@ -61,9 +61,6 @@ class RulesDimensionScopeTest {
               "acquisition_channel": "paid_search",
               "app_user_id": "current_user",
               "app_version": "1.2.3",
-              "backend": {
-                "349OzehoTyCAdiZblj9w0J0yD-Uow8X3": true
-              },
               "custom": {
                 "plan": "gold",
                 "seats": 3,
@@ -180,13 +177,12 @@ class RulesDimensionScopeTest {
 
     @Test
     fun `every root of the scope is readable by a predicate`() = runTest {
-        val scope = resolver().snapshot(CUSTOM_VARIABLES, BACKEND_VALUES).getOrThrow().values
+        val scope = resolver().snapshot(CUSTOM_VARIABLES).getOrThrow().values
 
         val predicates = listOf(
             """{"==": [{"var": "platform"}, "android"]}""",
             """{"==": [{"var": "storefront"}, "USA"]}""",
             """{"==": [{"var": "custom.plan"}, "gold"]}""",
-            """{"var": ["backend.349OzehoTyCAdiZblj9w0J0yD-Uow8X3", false]}""",
             """{"==": [{"var": "app_user_id"}, "current_user"]}""",
             """{"==": [{"var": "acquisition_channel"}, "paid_search"]}""",
             """{"some": [{"var": "purchases"}, {"==": [{"var": "period_type"}, "trial"]}]}""",
@@ -290,10 +286,6 @@ class RulesDimensionScopeTest {
             "plan" to RulesDimensionValue.StringValue("gold"),
             "seats" to RulesDimensionValue.IntValue(3),
             "trialEligible" to RulesDimensionValue.BoolValue(true),
-        )
-
-        val BACKEND_VALUES = mapOf(
-            "349OzehoTyCAdiZblj9w0J0yD-Uow8X3" to RulesDimensionValue.BoolValue(true),
         )
 
         /** The dimensions the backend last sent alongside the subscriber, root-level under their own names. */


### PR DESCRIPTION
### Motivation
The backend is dropping the `backend_predicate_results` item from the `audiences` remote-config topic, so the SDK no longer needs to read it or expose it to rule evaluation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how checkpoint and audience rules resolve when predicates still reference `backend.*` (those reads are no longer supplied), which can shift match outcomes until dashboard rules are updated.
> 
> **Overview**
> Aligns the SDK with the backend removing the `backend_predicate_results` item from the audiences remote-config topic.
> 
> **Audiences config** no longer bundles pre-evaluated backend predicates with the audience blob: `AudiencesSnapshot` and `getSnapshot()` are gone in favor of `getAudiences()`, which only loads the `default` audiences blob under a consistent config generation.
> 
> **Local rules evaluation** drops the reserved `backend.*` dimension scope—`LocalRulesEvaluator` and `RulesDimensionResolver` no longer accept `backendValues`, and checkpoint audience matching passes only custom variables plus audience predicates. Subscriber dimensions from the customer response remain as root-level names (unchanged).
> 
> Tests that covered backend predicate matching and metadata parsing were removed or updated to match the slimmer API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f7e62455413775c48fa951abc4a7ec9499fdbf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->