### PR TITLE
Treat a rule on an unsupplied dimension as a non-match

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -409,6 +409,7 @@ internal class PurchasesFactory(
                         cache.getCachedSubscriberDimensionsJson(identityManager.currentAppUserID)
                     },
                 ),
+                currentAppUserId = { identityManager.currentAppUserID },
             )
 
             val customerInfoUpdateHandler = CustomerInfoUpdateHandler(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -187,7 +187,10 @@ internal class PurchasesOrchestrator(
     internal val audiencesConfigProvider: AudiencesConfigProvider,
     val adTracker: AdTracker = AdTracker(adEventsManager),
     private val currentActivityTracker: CurrentActivityTracker = CurrentActivityTracker(),
-    private val localRulesEvaluator: LocalRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+    private val localRulesEvaluator: LocalRulesEvaluator = LocalRulesEvaluator(
+        providers = emptyList(),
+        currentAppUserId = { identityManager.currentAppUserID },
+    ),
     @OptIn(InternalRevenueCatAPI::class)
     private val checkpointWorkflowResolver: CheckpointWorkflowResolver = CheckpointWorkflowResolverImpl(
         workflowManager = workflowManager,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -93,8 +93,9 @@ internal class CheckpointWorkflowResolverImpl(
         // (audiences read from a later commit than the rules) is stale rather than authoritative, and deserves
         // the retry as much as a stale success does.
         if (!checkpointsConfigProvider.isCurrent(rulesResolution)) return null
-        // An audience the SDK failed to evaluate is not the same answer as an audience the customer is outside of,
-        // so it can't report NO_MATCH.
+        // An audience the SDK failed to evaluate (unreadable audiences, a predicate the engine cannot run) is not
+        // the same answer as an audience the customer is outside of, so it can't report NO_MATCH. A predicate on a
+        // dimension this SDK does not supply is the latter: the evaluator already counts it as a non-match.
         val rule = matchResult.getOrElse { error ->
             return configurationUnavailable(
                 "The audiences for checkpoint '$identifier' could not be evaluated: ${error.message}",

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProvider.kt
@@ -26,8 +26,10 @@ internal class CustomerInfoDimensionProvider(
      * The app user ID is reported without waiting for the customer info, so a rule targeting only the ID does not
      * depend on the network: it is known as soon as the SDK is configured.
      *
-     * Read once per evaluation, so the ID reported and the customer info fetched cannot describe two different
-     * customers within this provider's values.
+     * Read once per evaluation. Reading it here does not by itself guarantee the fetched customer info describes
+     * the same customer: an identity change can land while the fetch is in flight, and on a cold cache the
+     * pending-purchase sync reads the current user for itself. [RulesDimensionResolver] closes that gap by
+     * re-reading the current ID after every provider has run and failing the snapshot on a change.
      */
     override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
         // Nobody to ask about: the SDK has no cached user, so there is no request to make on their behalf.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -37,10 +37,13 @@ internal class LocalRulesEvaluator(
     /**
      * The first rule that matches, or `null` when none does.
      *
-     * A predicate the engine cannot evaluate (malformed JSON, an operator this SDK version does not implement, a
-     * dimension this SDK version does not supply) is not enough to fail the call on its own: a later rule may
-     * still match definitively, and it wins. Only when nothing matched does the first such failure surface,
-     * because then "no match" cannot be told apart from "we failed to ask".
+     * A predicate that reads a dimension this SDK version does not supply is a non-match for that rule: the
+     * customer is outside an audience the SDK cannot place them in, and the remaining rules are still walked.
+     *
+     * A predicate the engine cannot evaluate for any other reason (malformed JSON, an operator this SDK version
+     * does not implement) is not enough to fail the call on its own: a later rule may still match definitively,
+     * and it wins. Only when nothing matched does the first such failure surface, because then "no match" cannot
+     * be told apart from "we failed to ask".
      *
      * When a predicate must be resolved before it can be evaluated, a resolution failure fails the call immediately.
      * [customVariables] are the caller's own values for this evaluation, readable under `custom.*`.
@@ -70,7 +73,7 @@ internal class LocalRulesEvaluator(
             val predicate = predicateFor(rule).getOrElse { error -> return Result.failure(error) }
             val result = RulesEngine.evaluate(predicate, snapshot.values)
             val matches = result.getOrElse { error ->
-                if (firstFailure == null) {
+                if (error !is RulesEngine.EvaluationException.UnresolvedVariable && firstFailure == null) {
                     firstFailure = LocalRulesEvaluationException.PredicateEvaluation(index, error)
                 }
                 false

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -28,10 +28,11 @@ internal sealed class LocalRulesEvaluationException(message: String) : Exception
  */
 internal class LocalRulesEvaluator(
     providers: List<RulesDimensionProvider>,
+    currentAppUserId: () -> String,
     dateProvider: DateProvider = DefaultDateProvider(),
 ) {
 
-    private val dimensionResolver = RulesDimensionResolver(providers, dateProvider)
+    private val dimensionResolver = RulesDimensionResolver(providers, currentAppUserId, dateProvider)
 
     /**
      * The first rule that matches, or `null` when none does.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -29,8 +29,8 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
         val path: String,
     ) : RulesDimensionResolutionException("two dimension sources supplied '$path'")
 
-    internal class CustomerChanged :
-        RulesDimensionResolutionException("the customer changed while dimensions were being collected")
+    internal class AppUserChanged :
+        RulesDimensionResolutionException("the app user changed while dimensions were being collected")
 }
 
 /**
@@ -92,7 +92,7 @@ internal class RulesDimensionResolver(
 
         // Checked once, at the end: a change at any point during collection is still a change here.
         if (currentAppUserId() != appUserId) {
-            return Result.failure(RulesDimensionResolutionException.CustomerChanged())
+            return Result.failure(RulesDimensionResolutionException.AppUserChanged())
         }
 
         return Result.success(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/RulesDimensionResolver.kt
@@ -28,6 +28,9 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
     internal data class ConflictingDimension(
         val path: String,
     ) : RulesDimensionResolutionException("two dimension sources supplied '$path'")
+
+    internal class CustomerChanged :
+        RulesDimensionResolutionException("the customer changed while dimensions were being collected")
 }
 
 /**
@@ -36,13 +39,18 @@ internal sealed class RulesDimensionResolutionException(message: String) : Excep
  *
  * All providers see the same reference instant, so every dimension in one snapshot is consistent with the others.
  *
- * Both failure modes are configuration bugs rather than runtime conditions — a provider that cannot produce its
- * values, and two sources claiming the same root name — so they fail the whole snapshot instead of silently
+ * Two of the failure modes are configuration bugs rather than runtime conditions — a provider that cannot produce
+ * its values, and two sources claiming the same root name — so they fail the whole snapshot instead of silently
  * degrading a rule to a non-match, which would be indistinguishable from a customer who genuinely does not match.
- * Cancellation is neither, and propagates.
+ * The third is a runtime condition: providers suspend, so an identity change can land mid-collection and leave a
+ * snapshot describing two customers at once, or one whose values were emptied under it. That snapshot must not be
+ * evaluated either, so [currentAppUserId] is read before the first provider and verified after the last. An
+ * identity change also advances the remote config generation, so a caller guarding on it retries against the new
+ * customer rather than reporting this failure. Cancellation is none of these, and propagates.
  */
 internal class RulesDimensionResolver(
     private val providers: List<RulesDimensionProvider>,
+    private val currentAppUserId: () -> String,
     private val dateProvider: DateProvider = DefaultDateProvider(),
 ) {
 
@@ -55,6 +63,7 @@ internal class RulesDimensionResolver(
     suspend fun snapshot(
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
     ): Result<RulesDimensionSnapshot> {
+        val appUserId = currentAppUserId()
         val date = dateProvider.now
         // Seeded before any provider runs, so a provider claiming this root is an ordinary collision.
         val values = mutableMapOf<String, Value>(KEY_EVALUATED_AT to Value.IntValue(date.time))
@@ -79,6 +88,11 @@ internal class RulesDimensionResolver(
 
         values.addNestedDimensions(KEY_CUSTOM, customVariables)?.let { conflict ->
             return Result.failure(conflict)
+        }
+
+        // Checked once, at the end: a change at any point during collection is still a change here.
+        if (currentAppUserId() != appUserId) {
+            return Result.failure(RulesDimensionResolutionException.CustomerChanged())
         }
 
         return Result.success(

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -98,7 +98,7 @@ class CheckpointWorkflowResolverImplTest {
             uiConfigProvider = mockUiConfigProvider,
             checkpointsConfigProvider = mockCheckpointsConfigProvider,
             audiencesConfigProvider = mockAudiencesConfigProvider,
-            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList(), currentAppUserId = { "user" }),
             getOfferings = {
                 offeringsFetched++
                 offeringsFetchError?.let { throw PurchasesException(it) }
@@ -386,7 +386,7 @@ class CheckpointWorkflowResolverImplTest {
                 uiConfigProvider = mockUiConfigProvider,
                 checkpointsConfigProvider = mockCheckpointsConfigProvider,
                 audiencesConfigProvider = mockAudiencesConfigProvider,
-                localRulesEvaluator = LocalRulesEvaluator(providers = listOf(FailingDimensionProvider)),
+                localRulesEvaluator = LocalRulesEvaluator(providers = listOf(FailingDimensionProvider), currentAppUserId = { "user" }),
                 getOfferings = { mockOfferings },
             )
 
@@ -596,7 +596,7 @@ class CheckpointWorkflowResolverImplTest {
             uiConfigProvider = mockUiConfigProvider,
             checkpointsConfigProvider = mockCheckpointsConfigProvider,
             audiencesConfigProvider = mockAudiencesConfigProvider,
-            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+            localRulesEvaluator = LocalRulesEvaluator(providers = emptyList(), currentAppUserId = { "user" }),
             getOfferings = { throw CancellationException("cancelled") },
         )
 
@@ -680,7 +680,7 @@ class CheckpointWorkflowResolverImplTest {
         uiConfigProvider = mockUiConfigProvider,
         checkpointsConfigProvider = CheckpointsConfigProvider(manager),
         audiencesConfigProvider = AudiencesConfigProvider(manager),
-        localRulesEvaluator = LocalRulesEvaluator(providers = emptyList()),
+        localRulesEvaluator = LocalRulesEvaluator(providers = emptyList(), currentAppUserId = { "user" }),
         getOfferings = { mockOfferings },
     )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -53,6 +53,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class CheckpointWorkflowResolverImplTest {
 
     private val checkpointId = "test_checkpoint"
+    private val unsuppliedDimensionPredicate = """{"in": [{"var": "last_seen.country"}, ["ES"]]}"""
 
     private lateinit var mockWorkflowManager: WorkflowManager
     private lateinit var mockUiConfigProvider: UiConfigProvider
@@ -330,6 +331,28 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
+    fun `an audience on an unsupplied dimension resolves to no match`() = runTest {
+        configureAudiences(Audience("aud_wf1234", unsuppliedDimensionPredicate))
+
+        assertThat(noActionReason(resolve())).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
+        coVerify(exactly = 0) { mockWorkflowManager.getWorkflowBody(any()) }
+    }
+
+    @Test
+    fun `an audience on an unsupplied dimension does not block a later matching workflow`() = runTest {
+        configureRules(rule("wf5678"), rule("wf1234"))
+        configureAudiences(
+            Audience("aud_wf5678", unsuppliedDimensionPredicate),
+            Audience("aud_wf1234", "true"),
+        )
+
+        val resolution = resolve() as CheckpointResolution.MatchedWorkflow
+
+        assertThat(resolution.workflow).isEqualTo(mockWorkflow)
+        coVerify(exactly = 0) { mockWorkflowManager.getWorkflowBody("wf5678") }
+    }
+
+    @Test
     fun `a malformed audience before a match does not prevent a later matching workflow`() = runTest {
         configureRules(rule("wf5678"), rule("wf1234"))
         configureAudiences(
@@ -430,13 +453,11 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
-    fun `a custom variable the audience requires but the app omitted is not a NO_MATCH`() = runTest {
-        // The audience asks about a variable the call never supplied, so the SDK cannot place this
-        // customer inside or outside it. Saying NO_MATCH would claim an answer it does not have.
+    fun `a custom variable the audience requires but the app omitted resolves NoAction with NO_MATCH`() = runTest {
         configureAudiences(Audience("aud_wf1234", """{"==": [{"var": "custom.source"}, "settings"]}"""))
 
         assertThat(noActionReason(resolver.resolve(checkpointId, emptyMap())))
-            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+            .isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
     }
 
     @Test
@@ -448,8 +469,7 @@ class CheckpointWorkflowResolverImplTest {
         val resolution = resolver.resolve(checkpointId, emptyMap())
 
         assertThat(resolution).isNotInstanceOf(CheckpointResolution.MatchedWorkflow::class.java)
-        assertThat(noActionReason(resolution))
-            .isEqualTo(CheckpointResolution.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+        assertThat(noActionReason(resolution)).isEqualTo(CheckpointResolution.NoAction.Reason.NO_MATCH)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -271,6 +271,41 @@ class CustomerInfoDimensionProviderTest {
     }
 
     @Test
+    fun `a customer change while the customer info is being fetched fails the snapshot`() = runTest {
+        var currentUser = APP_USER_ID
+        val provider = CustomerInfoDimensionProvider(
+            currentAppUserId = { currentUser },
+            customerInfo = {
+                // A logIn completing while the fetch is in flight: the answer describes the previous customer.
+                currentUser = "another_user"
+                customerInfo(SUBSCRIBED_RESPONSE)
+            },
+        )
+
+        val error = resolver(provider, currentAppUserId = { currentUser }).snapshot().exceptionOrNull()
+
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+    }
+
+    @Test
+    fun `a customer info read broken by a customer change fails the snapshot instead of degrading it`() = runTest {
+        var currentUser = APP_USER_ID
+        val provider = CustomerInfoDimensionProvider(
+            currentAppUserId = { currentUser },
+            customerInfo = {
+                // A logOut wiping the caches mid-fetch: the read fails *because* the customer changed, so the
+                // snapshot must not quietly carry on with only the identity dimensions.
+                currentUser = "another_user"
+                throw PurchasesException(PurchasesError(PurchasesErrorCode.NetworkError, "Caches were cleared."))
+            },
+        )
+
+        val error = resolver(provider, currentAppUserId = { currentUser }).snapshot().exceptionOrNull()
+
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+    }
+
+    @Test
     fun `a customer the SDK has no ID for is not asked about`() = runTest {
         var asked = false
         val provider = CustomerInfoDimensionProvider(
@@ -355,8 +390,12 @@ class CustomerInfoDimensionProviderTest {
         customerInfo = customerInfo,
     )
 
-    private fun resolver(customerInfoProvider: RulesDimensionProvider) = RulesDimensionResolver(
+    private fun resolver(
+        customerInfoProvider: RulesDimensionProvider,
+        currentAppUserId: () -> String = { APP_USER_ID },
+    ) = RulesDimensionResolver(
         providers = listOf(deviceProvider(), customerInfoProvider),
+        currentAppUserId = currentAppUserId,
     )
 
     private fun deviceProvider() = object : RulesDimensionProvider {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/CustomerInfoDimensionProviderTest.kt
@@ -271,7 +271,7 @@ class CustomerInfoDimensionProviderTest {
     }
 
     @Test
-    fun `a customer change while the customer info is being fetched fails the snapshot`() = runTest {
+    fun `an app user change while the customer info is being fetched fails the snapshot`() = runTest {
         var currentUser = APP_USER_ID
         val provider = CustomerInfoDimensionProvider(
             currentAppUserId = { currentUser },
@@ -284,16 +284,16 @@ class CustomerInfoDimensionProviderTest {
 
         val error = resolver(provider, currentAppUserId = { currentUser }).snapshot().exceptionOrNull()
 
-        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.AppUserChanged::class.java)
     }
 
     @Test
-    fun `a customer info read broken by a customer change fails the snapshot instead of degrading it`() = runTest {
+    fun `a customer info read broken by an app user change fails the snapshot instead of degrading it`() = runTest {
         var currentUser = APP_USER_ID
         val provider = CustomerInfoDimensionProvider(
             currentAppUserId = { currentUser },
             customerInfo = {
-                // A logOut wiping the caches mid-fetch: the read fails *because* the customer changed, so the
+                // A logOut wiping the caches mid-fetch: the read fails *because* the app user changed, so the
                 // snapshot must not quietly carry on with only the identity dimensions.
                 currentUser = "another_user"
                 throw PurchasesException(PurchasesError(PurchasesErrorCode.NetworkError, "Caches were cleared."))
@@ -302,7 +302,7 @@ class CustomerInfoDimensionProviderTest {
 
         val error = resolver(provider, currentAppUserId = { currentUser }).snapshot().exceptionOrNull()
 
-        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.AppUserChanged::class.java)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -15,6 +15,7 @@ class LocalRulesEvaluatorTest {
     private val matchingPredicate = """{"==": [{"var": "platform"}, "android"]}"""
     private val nonMatchingPredicate = """{"==": [{"var": "platform"}, "amazon"]}"""
     private val malformedPredicate = "{not json"
+    private val unsuppliedDimensionPredicate = """{"==": [{"var": "unknown_dimension"}, true]}"""
 
     private var snapshotsTaken = 0
     private val deviceProvider = object : RulesDimensionProvider {
@@ -54,18 +55,45 @@ class LocalRulesEvaluatorTest {
     }
 
     @Test
-    fun `a predicate reading an unsupplied dimension surfaces as an error`() = runTest {
-        // A dimension this SDK version cannot resolve makes the rule
-        // unanswerable. Reporting that is what lets the caller tell it apart
-        // from a rule that was evaluated and did not match.
+    fun `a predicate reading an unsupplied dimension is a non-match`() = runTest {
+        val result = evaluator().match(listOf(TestRule("only", unsuppliedDimensionPredicate)))
+
+        assertThat(result.getOrThrow()).isNull()
+    }
+
+    @Test
+    fun `a negated predicate reading an unsupplied dimension is a non-match`() = runTest {
         val result = evaluator().match(
-            listOf(TestRule("only", """{"==": [{"var": "unknown_dimension"}, true]}""")),
+            listOf(TestRule("only", """{"!": [{"==": [{"var": "unknown_dimension"}, "NL"]}]}""")),
+        )
+
+        assertThat(result.getOrThrow()).isNull()
+    }
+
+    @Test
+    fun `an unsupplied dimension does not block a later match`() = runTest {
+        val result = evaluator().match(
+            listOf(
+                TestRule("unsupplied", unsuppliedDimensionPredicate),
+                TestRule("match", matchingPredicate),
+            ),
+        )
+
+        assertThat(result.getOrThrow()?.name).isEqualTo("match")
+    }
+
+    @Test
+    fun `an unsupplied dimension is not remembered as the first failure`() = runTest {
+        val result = evaluator().match(
+            listOf(
+                TestRule("unsupplied", unsuppliedDimensionPredicate),
+                TestRule("broken", malformedPredicate),
+            ),
         )
 
         val error = result.exceptionOrNull() as LocalRulesEvaluationException.PredicateEvaluation
-        assertThat(error.ruleIndex).isZero()
-        assertThat(error.error)
-            .isEqualTo(RulesEngine.EvaluationException.UnresolvedVariable("unknown_dimension"))
+        assertThat(error.ruleIndex).isEqualTo(1)
+        assertThat(error.error).isInstanceOf(RulesEngine.EvaluationException.Parse::class.java)
     }
 
     @Test
@@ -169,10 +197,8 @@ class LocalRulesEvaluatorTest {
             evaluator().match(rules, mapOf("source" to RulesDimensionValue.StringValue("other")))
                 .getOrThrow(),
         ).isNull()
-        // Supplying no custom variables at all leaves `custom.source` unresolved,
-        // which is unanswerable rather than a non-match.
-        assertThat(evaluator().match(rules).exceptionOrNull())
-            .isInstanceOf(LocalRulesEvaluationException.PredicateEvaluation::class.java)
+        // Supplying no custom variables at all leaves `custom.source` unresolved, which is a non-match.
+        assertThat(evaluator().match(rules).getOrThrow()).isNull()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -103,12 +103,30 @@ class LocalRulesEvaluatorTest {
                 throw IllegalStateException("nope")
         }
 
-        val result = LocalRulesEvaluator(providers = listOf(failing))
+        val result = LocalRulesEvaluator(providers = listOf(failing), currentAppUserId = { "user" })
             .match(listOf(TestRule("only", matchingPredicate)))
 
         val error = result.exceptionOrNull() as LocalRulesEvaluationException.DimensionResolution
         assertThat(error.reason)
             .isEqualTo(RulesDimensionResolutionException.ProviderFailed("device", "nope"))
+    }
+
+    @Test
+    fun `a customer change during the snapshot fails the evaluation`() = runTest {
+        var currentUser = "userA"
+        val flipping = object : RulesDimensionProvider {
+            override val name = "identity_flipper"
+            override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+                currentUser = "userB"
+                return emptyMap()
+            }
+        }
+
+        val result = LocalRulesEvaluator(providers = listOf(flipping), currentAppUserId = { currentUser })
+            .match(listOf(TestRule("only", matchingPredicate)))
+
+        val error = result.exceptionOrNull() as LocalRulesEvaluationException.DimensionResolution
+        assertThat(error.reason).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
     }
 
     @Test
@@ -184,7 +202,7 @@ class LocalRulesEvaluatorTest {
         assertThat(snapshotsTaken).isEqualTo(1)
     }
 
-    private fun evaluator() = LocalRulesEvaluator(providers = listOf(deviceProvider))
+    private fun evaluator() = LocalRulesEvaluator(providers = listOf(deviceProvider), currentAppUserId = { "user" })
 
     private data class TestRule(
         val name: String,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -112,7 +112,7 @@ class LocalRulesEvaluatorTest {
     }
 
     @Test
-    fun `a customer change during the snapshot fails the evaluation`() = runTest {
+    fun `an app user change during the snapshot fails the evaluation`() = runTest {
         var currentUser = "userA"
         val flipping = object : RulesDimensionProvider {
             override val name = "identity_flipper"
@@ -126,7 +126,7 @@ class LocalRulesEvaluatorTest {
             .match(listOf(TestRule("only", matchingPredicate)))
 
         val error = result.exceptionOrNull() as LocalRulesEvaluationException.DimensionResolution
-        assertThat(error.reason).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+        assertThat(error.reason).isInstanceOf(RulesDimensionResolutionException.AppUserChanged::class.java)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -95,6 +95,51 @@ class RulesDimensionResolverTest {
     }
 
     @Test
+    fun `a customer change while dimensions are collected fails the snapshot`() = runTest {
+        var currentUser = "userA"
+        val resolver = resolver(
+            provider("platform" to string("android")),
+            object : RulesDimensionProvider {
+                override val name = "identity_flipper"
+                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+                    currentUser = "userB"
+                    return emptyMap()
+                }
+            },
+            currentAppUserId = { currentUser },
+        )
+
+        val error = resolver.snapshot().exceptionOrNull()
+
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
+        assertThat(error).hasMessage("the customer changed while dimensions were being collected")
+    }
+
+    @Test
+    fun `a customer that changed back by the end of collection does not fail the snapshot`() = runTest {
+        var currentUser = "userA"
+        val resolver = resolver(
+            object : RulesDimensionProvider {
+                override val name = "identity_flipper"
+                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+                    currentUser = "userB"
+                    return emptyMap()
+                }
+            },
+            object : RulesDimensionProvider {
+                override val name = "identity_flipper_back"
+                override suspend fun dimensions(date: Date): Map<String, RulesDimensionValue> {
+                    currentUser = "userA"
+                    return emptyMap()
+                }
+            },
+            currentAppUserId = { currentUser },
+        )
+
+        assertThat(resolver.snapshot().isSuccess).isTrue()
+    }
+
+    @Test
     fun `cancellation propagates instead of failing the snapshot`() = runTest {
         val resolver = resolver(
             object : RulesDimensionProvider {
@@ -495,8 +540,12 @@ class RulesDimensionResolverTest {
         assertThat(resolver().snapshot().getOrThrow().values).isEqualTo(mapOf(evaluatedAt))
     }
 
-    private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
+    private fun resolver(
+        vararg providers: RulesDimensionProvider,
+        currentAppUserId: () -> String = { "user" },
+    ) = RulesDimensionResolver(
         providers = providers.toList(),
+        currentAppUserId = currentAppUserId,
         dateProvider = object : DateProvider {
             override val now: Date = evaluationDate
         },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionResolverTest.kt
@@ -95,7 +95,7 @@ class RulesDimensionResolverTest {
     }
 
     @Test
-    fun `a customer change while dimensions are collected fails the snapshot`() = runTest {
+    fun `an app user change while dimensions are collected fails the snapshot`() = runTest {
         var currentUser = "userA"
         val resolver = resolver(
             provider("platform" to string("android")),
@@ -111,12 +111,12 @@ class RulesDimensionResolverTest {
 
         val error = resolver.snapshot().exceptionOrNull()
 
-        assertThat(error).isInstanceOf(RulesDimensionResolutionException.CustomerChanged::class.java)
-        assertThat(error).hasMessage("the customer changed while dimensions were being collected")
+        assertThat(error).isInstanceOf(RulesDimensionResolutionException.AppUserChanged::class.java)
+        assertThat(error).hasMessage("the app user changed while dimensions were being collected")
     }
 
     @Test
-    fun `a customer that changed back by the end of collection does not fail the snapshot`() = runTest {
+    fun `an app user that changed back by the end of collection does not fail the snapshot`() = runTest {
         var currentUser = "userA"
         val resolver = resolver(
             object : RulesDimensionProvider {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/RulesDimensionScopeTest.kt
@@ -227,6 +227,7 @@ class RulesDimensionScopeTest {
                 SubscriberAttributesDimensionProvider { SUBSCRIBER_ATTRIBUTES },
                 SubscriberDimensionsProvider { SUBSCRIBER_DIMENSIONS },
             ),
+            currentAppUserId = { APP_USER_ID },
             dateProvider = object : DateProvider {
                 override val now: Date get() = evaluationDate
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/StoreDimensionProviderTest.kt
@@ -58,6 +58,7 @@ class StoreDimensionProviderTest {
                     deviceProvider("platform" to "android"),
                     StoreDimensionProvider { throw failure },
                 ),
+                currentAppUserId = { "user" },
             ).snapshot()
 
             assertThat(snapshot.isSuccess).describedAs("%s", failure).isTrue()
@@ -95,7 +96,8 @@ class StoreDimensionProviderTest {
 
     @Test
     fun `the storefront is reachable by name from a predicate`() = runTest {
-        val values = RulesDimensionResolver(providers = listOf(provider("US"))).snapshot().getOrThrow().values
+        val values = RulesDimensionResolver(providers = listOf(provider("US")), currentAppUserId = { "user" })
+            .snapshot().getOrThrow().values
 
         val matches = RulesEngine.evaluate("""{"==": [{"var": "storefront"}, "USA"]}""", values)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionIntegrationTest.kt
@@ -72,6 +72,7 @@ class SubscriberAttributesDimensionIntegrationTest {
                     attributesCache.getAllStoredSubscriberAttributes(cache.getCachedAppUserID() ?: "")
                 },
             ),
+            currentAppUserId = { cache.getCachedAppUserID() ?: "" },
             dateProvider = object : DateProvider {
                 override val now: Date get() = evaluationDate
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberAttributesDimensionProviderTest.kt
@@ -209,6 +209,7 @@ class SubscriberAttributesDimensionProviderTest {
 
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
         providers = providers.toList(),
+        currentAppUserId = { "user" },
         dateProvider = object : DateProvider {
             override val now: Date = evaluationDate
         },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/SubscriberDimensionsProviderTest.kt
@@ -169,6 +169,7 @@ class SubscriberDimensionsProviderTest {
 
     private fun resolver(vararg providers: RulesDimensionProvider) = RulesDimensionResolver(
         providers = providers.toList(),
+        currentAppUserId = { "user" },
         dateProvider = object : DateProvider {
             override val now: Date = evaluationDate
         },


### PR DESCRIPTION
## Description

Ports the missing-dimension change from RevenueCat/purchases-ios#7602 to Android.

When there is a variable that can't be found in the rule evaluator, right now we return an error to the consumer with a "CONFIGURATION_UNAVAILABLE". This PR changes it so we instead return a "NO_MATCH" in that scenario

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint and audience outcomes for rules that reference missing dimensions or omitted custom variables, which can alter which workflow runs versus returning a configuration error.
> 
> **Overview**
> **Audience and local rule matching** now treats predicates that reference variables the SDK cannot resolve (unknown dimensions or omitted `custom.*` values) as a **rule non-match** instead of surfacing **`CONFIGURATION_UNAVAILABLE`**.
> 
> In **`LocalRulesEvaluator`**, `RulesEngine.EvaluationException.UnresolvedVariable` is skipped when recording the “first failure”: those rules evaluate as false and evaluation continues so a later rule can still win. Malformed JSON, unsupported operators, and dimension snapshot failures behave as before.
> 
> **Checkpoint resolution** inherits this via `matchRule`, so audiences on unsupplied dimensions (e.g. `last_seen.country` with no provider) return **`NO_MATCH`**, including negated predicates that previously could have looked like a match. Tests cover fall-through to a later matching workflow and updated expectations for omitted custom variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8098bc36acbc9760cdd4d1aaff67addf8e47a824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->