### PR TITLE
fix: send X-Is-Sandbox header when using a Test Store API key

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.ForceServerErrorStrategy
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
@@ -679,6 +680,7 @@ internal class HTTPClient(
             HTTPRequest.POST_PARAMS_HASH to postFieldsToSignHeader,
             "X-Custom-Entitlements-Computation" to if (appConfig.customEntitlementComputation) "true" else null,
             "X-UI-Preview-Mode" to if (appConfig.uiPreviewMode) "true" else null,
+            "X-Is-Sandbox" to if (appConfig.store == Store.TEST_STORE) "true" else null,
             "X-Storefront" to storefrontProvider.getStorefront(),
             "X-Is-Debug-Build" to appConfig.isDebugBuild.toString(),
             "X-Kotlin-Version" to KotlinVersion.CURRENT.toString(),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -8,6 +8,7 @@ package com.revenuecat.purchases.common
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.ForceServerErrorStrategy
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.verification.SignatureVerificationException
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
@@ -959,6 +960,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         assertThat(request.getHeader("X-Kotlin-Version")).isEqualTo(KotlinVersion.CURRENT.toString())
         assertThat(request.getHeader("X-Is-Backgrounded")).isEqualTo("true")
         assertThat(request.getHeader("X-Billing-Client-Sdk-Version")).isEqualTo(BuildConfig.BILLING_CLIENT_VERSION)
+        assertThat(request.headers.names()).doesNotContain("X-Is-Sandbox")
     }
 
     @Test
@@ -992,6 +994,23 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         val request = server.takeRequest()
 
         assertThat(request.headers.names()).doesNotContain("X-Storefront")
+    }
+
+    @Test
+    fun `adds sandbox header if store is test store`() {
+        client = createClient(appConfig = createAppConfig(store = Store.TEST_STORE))
+        val expectedResult = HTTPResult.createResult()
+        val endpoint = Endpoint.LogIn
+        enqueue(
+            endpoint.getPath(),
+            expectedResult
+        )
+
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
+
+        val request = server.takeRequest()
+
+        assertThat(request.getHeader("X-Is-Sandbox")).isEqualTo("true")
     }
 
     @Test


### PR DESCRIPTION
Sends `X-Is-Sandbox: true` on every request when the SDK is configured with a Test Store API key, so backend integrations route those events to the sandbox project.

Part of SDK-4449

- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive HTTP header change gated on store type; covered by unit tests with no auth or purchase-logic changes.
> 
> **Overview**
> When the SDK is configured with a **Test Store** (`Store.TEST_STORE`), every RevenueCat API request now includes **`X-Is-Sandbox: true`**, so the backend can treat traffic as sandbox (e.g. route events to the sandbox project). For other store configurations the header is omitted, matching other optional flags like UI preview mode.
> 
> Unit tests assert the header is absent by default and is **`true`** when the app config uses the test store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 847412df3ea5a736353a40c88cabcaaffe24d576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->