### PR TITLE
refactor(admob): share next-gen AdMob test fixtures

### DIFF
--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AdResponseInfoFixtures.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/AdResponseInfoFixtures.kt
@@ -1,0 +1,10 @@
+package com.revenuecat.purchases.admob.nextgen
+
+import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
+import io.mockk.every
+import io.mockk.mockk
+
+internal fun responseInfo(adapterClassName: String, responseId: String): ResponseInfo = mockk {
+    every { this@mockk.adapterClassName } returns adapterClassName
+    every { this@mockk.responseId } returns responseId
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/BannerAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/BannerAdFlowTest.kt
@@ -11,11 +11,9 @@ import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdEventCallback
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdRefreshCallback
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
-import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdLoadedData
@@ -23,34 +21,20 @@ import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.slot
-import io.mockk.unmockkObject
 import io.mockk.verify
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 class BannerAdFlowTest {
 
-    private val adTracker = mockk<AdTracker>(relaxed = true)
-    private val purchases = mockk<Purchases>(relaxed = true)
+    @get:Rule
+    val configuredPurchases = ConfiguredPurchasesRule()
 
-    @Before
-    fun setUp() {
-        every { purchases.adTracker } returns adTracker
-        mockkObject(Purchases)
-        every { Purchases.isConfigured } returns true
-        every { Purchases.sharedInstance } returns purchases
-    }
-
-    @After
-    fun tearDown() {
-        unmockkObject(Purchases)
-    }
+    private val adTracker get() = configuredPurchases.adTracker
 
     @Test
     fun `success installs tracking callbacks before forwarding loaded banner`() {
@@ -58,10 +42,7 @@ class BannerAdFlowTest {
         val adRequest = mockk<BannerAdRequest> {
             every { adUnitId } returns "banner-unit"
         }
-        val responseInfo = mockk<ResponseInfo>(relaxed = true) {
-            every { adapterClassName } returns "test-network"
-            every { responseId } returns "response-id"
-        }
+        val responseInfo = responseInfo("test-network", "response-id")
         val bannerAd = mockk<BannerAd>(relaxed = true) {
             every { getResponseInfo() } returns responseInfo
         }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/BannerAdResponseFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/BannerAdResponseFlowTest.kt
@@ -9,13 +9,10 @@ import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallbac
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdEventCallback
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdRefreshCallback
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
-import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdLoadedData
@@ -24,41 +21,27 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.slot
-import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 class BannerAdResponseFlowTest {
 
-    private val adTracker = mockk<AdTracker>(relaxed = true)
-    private val purchases = mockk<Purchases>(relaxed = true)
+    @get:Rule
+    val configuredPurchases = ConfiguredPurchasesRule()
 
-    @Before
-    fun setUp() {
-        every { purchases.adTracker } returns adTracker
-        mockkObject(Purchases)
-        every { Purchases.isConfigured } returns true
-        every { Purchases.sharedInstance } returns purchases
-    }
-
-    @After
-    fun tearDown() {
-        unmockkObject(Purchases)
-    }
+    private val adTracker get() = configuredPurchases.adTracker
 
     @Test
     fun `callback response success tracks and installs callbacks before forwarding`() {
         val order = mutableListOf<String>()
         val adView = mockk<AdView>()
-        val responseInfo = responseInfo()
+        val responseInfo = responseInfo("test-network", "response-id")
         val bannerAd = mockk<BannerAd>(relaxed = true) {
             every { getResponseInfo() } returns responseInfo
         }
@@ -143,7 +126,7 @@ class BannerAdResponseFlowTest {
         runBlocking {
             val adView = mockk<AdView>()
             val bannerAd = mockk<BannerAd>(relaxed = true) {
-                every { getResponseInfo() } returns responseInfo()
+                every { getResponseInfo() } returns responseInfo("test-network", "response-id")
             }
             val eventCallback = RecordingBannerEventCallback()
             val refreshCallback = RecordingBannerRefreshCallback()
@@ -196,11 +179,6 @@ class BannerAdResponseFlowTest {
             adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
         }
         assertFailedData(failedData.captured)
-    }
-
-    private fun responseInfo(): ResponseInfo = mockk(relaxed = true) {
-        every { adapterClassName } returns "test-network"
-        every { responseId } returns "response-id"
     }
 
     private fun assertLoadedData(data: AdLoadedData) {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/ConfiguredPurchasesRule.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/ConfiguredPurchasesRule.kt
@@ -1,0 +1,34 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.admob.nextgen
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.ads.events.AdTracker
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class ConfiguredPurchasesRule : TestRule {
+    val adTracker = mockk<AdTracker>(relaxed = true)
+    val purchases = mockk<Purchases>(relaxed = true) {
+        every { adTracker } returns this@ConfiguredPurchasesRule.adTracker
+    }
+
+    override fun apply(base: Statement, description: Description): Statement = object : Statement() {
+        override fun evaluate() {
+            mockkObject(Purchases)
+            try {
+                every { Purchases.isConfigured } returns true
+                every { Purchases.sharedInstance } returns purchases
+                base.evaluate()
+            } finally {
+                unmockkObject(Purchases)
+            }
+        }
+    }
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdBatchFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdBatchFlowTest.kt
@@ -2,23 +2,14 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
-import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
-import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
-import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd
-import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
-import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
-import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdEventCallback
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingNativeAdEventCallback
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
-import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdLoadedData
@@ -39,33 +30,31 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 class NativeAdBatchFlowTest {
-    private val adTracker = mockk<AdTracker>(relaxed = true)
-    private val purchases = mockk<Purchases>(relaxed = true)
+    @get:Rule
+    val configuredPurchases = ConfiguredPurchasesRule()
+
+    private val adTracker get() = configuredPurchases.adTracker
 
     @Before
     fun setUp() {
-        every { purchases.adTracker } returns adTracker
         mockkObject(NativeAdLoader.Companion)
-        mockkObject(Purchases)
-        every { Purchases.isConfigured } returns true
-        every { Purchases.sharedInstance } returns purchases
     }
 
     @After
     fun tearDown() {
-        unmockkObject(Purchases)
         unmockkObject(NativeAdLoader.Companion)
     }
 
     @Test
     fun `callback batch tracks configures and forwards every result and completion`() {
-        val adRequest = adRequest("native-unit")
+        val adRequest = nativeAdRequest("native-unit")
         val nativeAd = nativeAd("native-network", "native-response")
         val customNativeAd = customNativeAd("custom-network", "custom-response")
-        val bannerAd = bannerAd("banner-network", "banner-response")
+        val bannerAd = nativeBannerAd("banner-network", "banner-response")
         val error = mockk<LoadAdError> {
             every { code } returns LoadAdError.ErrorCode.NO_FILL
         }
@@ -84,7 +73,7 @@ class NativeAdBatchFlowTest {
         assertEquals(listOf(nativeAd), delegate.nativeAds)
         assertEquals(listOf(customNativeAd), delegate.customNativeAds)
         assertEquals(listOf(bannerAd), delegate.bannerAds)
-        assertEquals(listOf(error), delegate.errors)
+        assertEquals(listOf(error), delegate.loadErrors)
         assertEquals(1, delegate.completionCount)
         assertTrue(nativeAd.adEventCallback is TrackingNativeAdEventCallback)
         assertTrue(customNativeAd.adEventCallback is TrackingNativeAdEventCallback)
@@ -95,10 +84,10 @@ class NativeAdBatchFlowTest {
 
     @Test
     fun `flow batch tracks and configures each result when collected`() = runBlocking {
-        val adRequest = adRequest("native-unit")
+        val adRequest = nativeAdRequest("native-unit")
         val nativeAd = nativeAd("native-network", "native-response")
         val customNativeAd = customNativeAd("custom-network", "custom-response")
-        val bannerAd = bannerAd("banner-network", "banner-response")
+        val bannerAd = nativeBannerAd("banner-network", "banner-response")
         val error = mockk<LoadAdError> {
             every { code } returns LoadAdError.ErrorCode.NO_FILL
         }
@@ -130,67 +119,4 @@ class NativeAdBatchFlowTest {
         assertEquals("native-unit", failedData.captured.adUnitId)
     }
 
-    private fun adRequest(adUnitId: String): NativeAdRequest = mockk {
-        every { this@mockk.adUnitId } returns adUnitId
-    }
-
-    private fun nativeAd(network: String, responseId: String): NativeAd {
-        var callback: NativeAdEventCallback? = null
-        return mockk(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo(network, responseId)
-            every { adEventCallback } answers { callback }
-            every { adEventCallback = any() } answers { callback = firstArg() }
-        }
-    }
-
-    private fun customNativeAd(network: String, responseId: String): CustomNativeAd {
-        var callback: NativeAdEventCallback? = null
-        return mockk(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo(network, responseId)
-            every { adEventCallback } answers { callback }
-            every { adEventCallback = any() } answers { callback = firstArg() }
-        }
-    }
-
-    private fun bannerAd(network: String, responseId: String): BannerAd {
-        var callback: BannerAdEventCallback? = null
-        return mockk(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo(network, responseId)
-            every { adEventCallback } answers { callback }
-            every { adEventCallback = any() } answers { callback = firstArg() }
-        }
-    }
-
-    private fun responseInfo(network: String, responseId: String): ResponseInfo = mockk {
-        every { adapterClassName } returns network
-        every { this@mockk.responseId } returns responseId
-    }
-
-    private class RecordingNativeAdLoaderCallback : NativeAdLoaderCallback {
-        val nativeAds = mutableListOf<NativeAd>()
-        val customNativeAds = mutableListOf<CustomNativeAd>()
-        val bannerAds = mutableListOf<BannerAd>()
-        val errors = mutableListOf<LoadAdError>()
-        var completionCount = 0
-
-        override fun onNativeAdLoaded(nativeAd: NativeAd) {
-            nativeAds += nativeAd
-        }
-
-        override fun onCustomNativeAdLoaded(customNativeAd: CustomNativeAd) {
-            customNativeAds += customNativeAd
-        }
-
-        override fun onBannerAdLoaded(bannerAd: BannerAd) {
-            bannerAds += bannerAd
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            errors += adError
-        }
-
-        override fun onAdLoadingCompleted() {
-            completionCount++
-        }
-    }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdFixtures.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdFixtures.kt
@@ -1,0 +1,76 @@
+package com.revenuecat.purchases.admob.nextgen
+
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
+import io.mockk.every
+import io.mockk.mockk
+
+internal fun nativeAdRequest(adUnitId: String): NativeAdRequest = mockk {
+    every { this@mockk.adUnitId } returns adUnitId
+}
+
+internal fun nativeAd(network: String, responseId: String): NativeAd {
+    var callback: NativeAdEventCallback? = null
+    return mockk(relaxed = true) {
+        every { getResponseInfo() } returns responseInfo(network, responseId)
+        every { adEventCallback } answers { callback }
+        every { adEventCallback = any() } answers { callback = firstArg() }
+    }
+}
+
+internal fun customNativeAd(network: String, responseId: String): CustomNativeAd {
+    var callback: NativeAdEventCallback? = null
+    return mockk(relaxed = true) {
+        every { getResponseInfo() } returns responseInfo(network, responseId)
+        every { adEventCallback } answers { callback }
+        every { adEventCallback = any() } answers { callback = firstArg() }
+    }
+}
+
+internal fun nativeBannerAd(network: String, responseId: String): BannerAd {
+    var callback: BannerAdEventCallback? = null
+    var refreshCallback: BannerAdRefreshCallback? = null
+    return mockk(relaxed = true) {
+        every { getResponseInfo() } returns responseInfo(network, responseId)
+        every { adEventCallback } answers { callback }
+        every { adEventCallback = any() } answers { callback = firstArg() }
+        every { bannerAdRefreshCallback } answers { refreshCallback }
+        every { bannerAdRefreshCallback = any() } answers { refreshCallback = firstArg() }
+    }
+}
+
+internal class RecordingNativeAdLoaderCallback : NativeAdLoaderCallback {
+    val nativeAds = mutableListOf<NativeAd>()
+    val customNativeAds = mutableListOf<CustomNativeAd>()
+    val bannerAds = mutableListOf<BannerAd>()
+    val loadErrors = mutableListOf<LoadAdError>()
+    var completionCount = 0
+        private set
+
+    override fun onNativeAdLoaded(nativeAd: NativeAd) {
+        nativeAds += nativeAd
+    }
+
+    override fun onCustomNativeAdLoaded(customNativeAd: CustomNativeAd) {
+        customNativeAds += customNativeAd
+    }
+
+    override fun onBannerAdLoaded(bannerAd: BannerAd) {
+        bannerAds += bannerAd
+    }
+
+    override fun onAdFailedToLoad(adError: LoadAdError) {
+        loadErrors += adError
+    }
+
+    override fun onAdLoadingCompleted() {
+        completionCount++
+    }
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdFlowTest.kt
@@ -2,25 +2,17 @@
 
 package com.revenuecat.purchases.admob.nextgen
 
-import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
-import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
-import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd
-import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
-import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdEventCallback
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdRefreshCallback
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingNativeAdEventCallback
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
-import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdLoadedData
@@ -40,32 +32,30 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 class NativeAdFlowTest {
-    private val adTracker = mockk<AdTracker>(relaxed = true)
-    private val purchases = mockk<Purchases>(relaxed = true)
+    @get:Rule
+    val configuredPurchases = ConfiguredPurchasesRule()
+
+    private val adTracker get() = configuredPurchases.adTracker
 
     @Before
     fun setUp() {
-        every { purchases.adTracker } returns adTracker
         mockkObject(NativeAdLoader.Companion)
-        mockkObject(Purchases)
-        every { Purchases.isConfigured } returns true
-        every { Purchases.sharedInstance } returns purchases
     }
 
     @After
     fun tearDown() {
-        unmockkObject(Purchases)
         unmockkObject(NativeAdLoader.Companion)
     }
 
     @Test
     fun `callback load tracks and configures every possible success before forwarding`() {
-        val adRequest = adRequest("native-unit")
+        val adRequest = nativeAdRequest("native-unit")
         val nativeAd = nativeAd("native-network", "native-response")
         val customNativeAd = customNativeAd("custom-network", "custom-response")
-        val bannerAd = bannerAd("banner-network", "banner-response")
+        val bannerAd = nativeBannerAd("banner-network", "banner-response")
         val nativeEventCallback = mockk<NativeAdEventCallback>(relaxed = true)
         val bannerEventCallback = mockk<BannerAdEventCallback>(relaxed = true)
         val trackingLoadCallback = slot<NativeAdLoaderCallback>()
@@ -107,7 +97,7 @@ class NativeAdFlowTest {
 
     @Test
     fun `callback load tracks failure before forwarding`() {
-        val adRequest = adRequest("native-unit")
+        val adRequest = nativeAdRequest("native-unit")
         val error = mockk<LoadAdError> {
             every { code } returns LoadAdError.ErrorCode.NO_FILL
         }
@@ -131,7 +121,7 @@ class NativeAdFlowTest {
 
     @Test
     fun `suspending load returns and configures native result unchanged`() = runBlocking {
-        val adRequest = adRequest("native-unit")
+        val adRequest = nativeAdRequest("native-unit")
         val nativeAd = nativeAd("native-network", "native-response")
         val sdkResult = NativeAdLoadResult.NativeAdSuccess(nativeAd)
 
@@ -146,9 +136,9 @@ class NativeAdFlowTest {
 
     @Test
     fun `suspending load maps custom native banner and failure results`() = runBlocking {
-        val adRequest = adRequest("native-unit")
+        val adRequest = nativeAdRequest("native-unit")
         val customNativeAd = customNativeAd("custom-network", "custom-response")
-        val bannerAd = bannerAd("banner-network", "banner-response")
+        val bannerAd = nativeBannerAd("banner-network", "banner-response")
         val error = mockk<LoadAdError> {
             every { code } returns LoadAdError.ErrorCode.NETWORK_ERROR
         }
@@ -177,7 +167,7 @@ class NativeAdFlowTest {
     fun `tracking-safe setters preserve native custom native and banner wrappers`() {
         val nativeAd = nativeAd("native-network", "native-response")
         val customNativeAd = customNativeAd("custom-network", "custom-response")
-        val bannerAd = bannerAd("banner-network", "banner-response")
+        val bannerAd = nativeBannerAd("banner-network", "banner-response")
         nativeAd.installTrackingEventCallback(null, "feed", "native-unit")
         customNativeAd.installTrackingEventCallback(null, "feed", "native-unit")
         bannerAd.installTrackingCallbacks(null, null, "feed", "native-unit")
@@ -198,7 +188,7 @@ class NativeAdFlowTest {
     fun `tracking-safe setters directly assign callbacks when tracking is not installed`() {
         val nativeAd = nativeAd("native-network", "native-response")
         val customNativeAd = customNativeAd("custom-network", "custom-response")
-        val bannerAd = bannerAd("banner-network", "banner-response")
+        val bannerAd = nativeBannerAd("banner-network", "banner-response")
         nativeAd.adEventCallback = mockk(relaxed = true)
         customNativeAd.adEventCallback = mockk(relaxed = true)
         bannerAd.adEventCallback = mockk(relaxed = true)
@@ -215,65 +205,4 @@ class NativeAdFlowTest {
         assertSame(bannerCallback, bannerAd.adEventCallback)
     }
 
-    private fun adRequest(adUnitId: String): NativeAdRequest = mockk {
-        every { this@mockk.adUnitId } returns adUnitId
-    }
-
-    private fun nativeAd(network: String, responseId: String): NativeAd {
-        var callback: NativeAdEventCallback? = null
-        return mockk(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo(network, responseId)
-            every { adEventCallback } answers { callback }
-            every { adEventCallback = any() } answers { callback = firstArg() }
-        }
-    }
-
-    private fun customNativeAd(network: String, responseId: String): CustomNativeAd {
-        var callback: NativeAdEventCallback? = null
-        return mockk(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo(network, responseId)
-            every { adEventCallback } answers { callback }
-            every { adEventCallback = any() } answers { callback = firstArg() }
-        }
-    }
-
-    private fun bannerAd(network: String, responseId: String): BannerAd {
-        var callback: BannerAdEventCallback? = null
-        var refreshCallback: BannerAdRefreshCallback? = null
-        return mockk(relaxed = true) {
-            every { getResponseInfo() } returns responseInfo(network, responseId)
-            every { adEventCallback } answers { callback }
-            every { adEventCallback = any() } answers { callback = firstArg() }
-            every { bannerAdRefreshCallback } answers { refreshCallback }
-            every { bannerAdRefreshCallback = any() } answers { refreshCallback = firstArg() }
-        }
-    }
-
-    private fun responseInfo(network: String, responseId: String): ResponseInfo = mockk {
-        every { adapterClassName } returns network
-        every { this@mockk.responseId } returns responseId
-    }
-
-    private class RecordingNativeAdLoaderCallback : NativeAdLoaderCallback {
-        val nativeAds = mutableListOf<NativeAd>()
-        val customNativeAds = mutableListOf<CustomNativeAd>()
-        val bannerAds = mutableListOf<BannerAd>()
-        val loadErrors = mutableListOf<LoadAdError>()
-
-        override fun onNativeAdLoaded(nativeAd: NativeAd) {
-            nativeAds += nativeAd
-        }
-
-        override fun onCustomNativeAdLoaded(customNativeAd: CustomNativeAd) {
-            customNativeAds += customNativeAd
-        }
-
-        override fun onBannerAdLoaded(bannerAd: BannerAd) {
-            bannerAds += bannerAd
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            loadErrors += adError
-        }
-    }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdResponseFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdResponseFlowTest.kt
@@ -12,12 +12,10 @@ import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdEventCallbac
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdEventCallback
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingBannerAdRefreshCallback
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingNativeAdEventCallback
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
-import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdLoadedData
@@ -35,23 +33,21 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 class NativeAdResponseFlowTest {
-    private val adTracker = mockk<AdTracker>(relaxed = true)
-    private val purchases = mockk<Purchases>(relaxed = true)
+    @get:Rule
+    val configuredPurchases = ConfiguredPurchasesRule()
+
+    private val adTracker get() = configuredPurchases.adTracker
 
     @Before
     fun setUp() {
-        every { purchases.adTracker } returns adTracker
         mockkObject(NativeAdLoader.Companion)
-        mockkObject(Purchases)
-        every { Purchases.isConfigured } returns true
-        every { Purchases.sharedInstance } returns purchases
     }
 
     @After
     fun tearDown() {
-        unmockkObject(Purchases)
         unmockkObject(NativeAdLoader.Companion)
     }
 
@@ -60,10 +56,7 @@ class NativeAdResponseFlowTest {
         val order = mutableListOf<String>()
         var installedCallback: NativeAdEventCallback? = null
         val loadedAd = mockk<NativeAd>(relaxed = true) {
-            every { getResponseInfo() } returns mockk<ResponseInfo> {
-                every { adapterClassName } returns "native-network"
-                every { responseId } returns "native-response"
-            }
+            every { getResponseInfo() } returns responseInfo("native-network", "native-response")
             every { adEventCallback } answers { installedCallback }
         }
         val trackingLoadCallback = slot<NativeAdLoaderCallback>()

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/PreloaderTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/PreloaderTest.kt
@@ -8,42 +8,26 @@ import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
 import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
 import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
-import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdLoadedData
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.slot
-import io.mockk.unmockkObject
 import io.mockk.verify
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 
 internal abstract class PreloaderTest {
 
-    protected val adTracker = mockk<AdTracker>(relaxed = true)
-    private val purchases = mockk<Purchases>(relaxed = true)
+    @get:Rule
+    val configuredPurchases = ConfiguredPurchasesRule()
 
-    @Before
-    fun setUpPurchases() {
-        every { purchases.adTracker } returns adTracker
-        mockkObject(Purchases)
-        every { Purchases.isConfigured } returns true
-        every { Purchases.sharedInstance } returns purchases
-    }
-
-    @After
-    fun tearDownPurchases() {
-        unmockkObject(Purchases)
-    }
+    protected val adTracker get() = configuredPurchases.adTracker
 
     protected fun assertStartInstallsPreloadTracking(
         expectedAdFormat: AdFormat,
@@ -76,11 +60,6 @@ internal abstract class PreloaderTest {
 
         assertNull(pollAndTrackAd(PRELOAD_ID))
         verify(exactly = 0) { adTracker.trackAdLoaded(any(), any()) }
-    }
-
-    protected fun responseInfo(networkName: String, responseId: String): ResponseInfo = mockk(relaxed = true) {
-        every { adapterClassName } returns networkName
-        every { this@mockk.responseId } returns responseId
     }
 
     protected fun loadError(errorCode: LoadAdError.ErrorCode): LoadAdError = mockk {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/AdLoadResultTrackingTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/AdLoadResultTrackingTest.kt
@@ -5,9 +5,9 @@ package com.revenuecat.purchases.admob.nextgen.tracking
 import com.google.android.libraries.ads.mobile.sdk.common.Ad
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.responseInfo
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
@@ -162,10 +162,4 @@ class AdLoadResultTrackingTest {
 
         assertSame(ad, configuredAd)
     }
-
-    private fun responseInfo(adapterClassName: String, responseId: String): ResponseInfo =
-        mockk<ResponseInfo>().also {
-            every { it.adapterClassName } returns adapterClassName
-            every { it.responseId } returns responseId
-        }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingAdEventCallbackTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingAdEventCallbackTest.kt
@@ -5,10 +5,10 @@ package com.revenuecat.purchases.admob.nextgen.tracking
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.common.AdValue
 import com.google.android.libraries.ads.mobile.sdk.common.PrecisionType
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.responseInfo
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdDisplayedData
@@ -31,13 +31,11 @@ import org.junit.Test
 class TrackingAdEventCallbackTest {
     private val adTracker = mockk<AdTracker>(relaxed = true)
     private val purchases = mockk<Purchases>(relaxed = true)
-    private val responseInfo = mockk<ResponseInfo>()
+    private val responseInfo = responseInfo("test-network", "response-id")
 
     @Before
     fun setUp() {
         every { purchases.adTracker } returns adTracker
-        every { responseInfo.adapterClassName } returns "test-network"
-        every { responseInfo.responseId } returns "response-id"
         mockkObject(Purchases)
         every { Purchases.isConfigured } returns true
         every { Purchases.sharedInstance } returns purchases
@@ -190,9 +188,7 @@ class TrackingAdEventCallbackTest {
 
     @Test
     fun `refreshed banner reads current response info at event time`() {
-        val refreshedResponseInfo = mockk<ResponseInfo>()
-        every { refreshedResponseInfo.adapterClassName } returns "refreshed-network"
-        every { refreshedResponseInfo.responseId } returns "refreshed-response"
+        val refreshedResponseInfo = responseInfo("refreshed-network", "refreshed-response")
         var currentResponseInfo = responseInfo
         val callback = TrackingBannerAdEventCallback(null, "home", "ad-unit") { currentResponseInfo }
         currentResponseInfo = refreshedResponseInfo

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingAdLoadCallbackTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingAdLoadCallbackTest.kt
@@ -5,9 +5,9 @@ package com.revenuecat.purchases.admob.nextgen.tracking
 import com.google.android.libraries.ads.mobile.sdk.common.Ad
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.responseInfo
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
@@ -189,10 +189,4 @@ class TrackingAdLoadCallbackTest {
 
         assertEquals(listOf("configure", "delegate"), order)
     }
-
-    private fun responseInfo(adapterClassName: String, responseId: String): ResponseInfo =
-        mockk<ResponseInfo>().also {
-            every { it.adapterClassName } returns adapterClassName
-            every { it.responseId } returns responseId
-        }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingBannerAdRefreshCallbackTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingBannerAdRefreshCallbackTest.kt
@@ -4,9 +4,9 @@ package com.revenuecat.purchases.admob.nextgen.tracking
 
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.responseInfo
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
@@ -136,10 +136,4 @@ class TrackingBannerAdRefreshCallbackTest {
         verify(exactly = 0) { adTracker.trackAdLoaded(any(), any()) }
         assertTrue(delegated)
     }
-
-    private fun responseInfo(adapterClassName: String, responseId: String): ResponseInfo =
-        mockk<ResponseInfo>().also {
-            every { it.adapterClassName } returns adapterClassName
-            every { it.responseId } returns responseId
-        }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingEventCallbackContractTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingEventCallbackContractTest.kt
@@ -6,7 +6,7 @@ import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.common.AdValue
 import com.google.android.libraries.ads.mobile.sdk.common.PrecisionType
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.ConfiguredPurchasesRule
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdDisplayedData
@@ -14,33 +14,20 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkClass
-import io.mockk.mockkObject
 import io.mockk.slot
-import io.mockk.unmockkObject
 import io.mockk.verify
-import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.lang.reflect.Proxy
 
 class TrackingEventCallbackContractTest {
-    private val purchases = mockk<Purchases>(relaxed = true)
+    @get:Rule
+    val configuredPurchases = ConfiguredPurchasesRule()
 
-    @Before
-    fun setUp() {
-        every { purchases.adTracker } returns mockk<AdTracker>(relaxed = true)
-        mockkObject(Purchases)
-        every { Purchases.isConfigured } returns true
-        every { Purchases.sharedInstance } returns purchases
-    }
-
-    @After
-    fun tearDown() {
-        unmockkObject(Purchases)
-    }
+    private val purchases get() = configuredPurchases.purchases
 
     @Test
     fun `format callbacks override every SDK callback`() {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingNativeAdLoaderCallbackTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingNativeAdLoaderCallbackTest.kt
@@ -4,48 +4,33 @@ package com.revenuecat.purchases.admob.nextgen.tracking
 
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.google.android.libraries.ads.mobile.sdk.common.ResponseInfo
 import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.admob.nextgen.ConfiguredPurchasesRule
+import com.revenuecat.purchases.admob.nextgen.responseInfo
 import com.revenuecat.purchases.ads.events.AdCaptureMethod
-import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdLoadedData
 import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.slot
-import io.mockk.unmockkObject
 import io.mockk.verify
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 class TrackingNativeAdLoaderCallbackTest {
-    private val adTracker = mockk<AdTracker>(relaxed = true)
-    private val purchases = mockk<Purchases>(relaxed = true)
+    @get:Rule
+    val configuredPurchases = ConfiguredPurchasesRule()
 
-    @Before
-    fun setUp() {
-        every { purchases.adTracker } returns adTracker
-        mockkObject(Purchases)
-        every { Purchases.isConfigured } returns true
-        every { Purchases.sharedInstance } returns purchases
-    }
-
-    @After
-    fun tearDown() {
-        unmockkObject(Purchases)
-    }
+    private val adTracker get() = configuredPurchases.adTracker
 
     @Test
     fun `tracks native load then configures it before delegating`() {
@@ -218,10 +203,4 @@ class TrackingNativeAdLoaderCallbackTest {
         assertTrue(loadingCompleted)
         assertFalse(configured)
     }
-
-    private fun responseInfo(adapterClassName: String, responseId: String): ResponseInfo =
-        mockk<ResponseInfo>().also {
-            every { it.adapterClassName } returns adapterClassName
-            every { it.responseId } returns responseId
-        }
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingPreloadCallbackTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingPreloadCallbackTest.kt
@@ -6,6 +6,7 @@ import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.google.android.libraries.ads.mobile.sdk.common.PreloadCallback
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.admob.nextgen.PreloaderTest
+import com.revenuecat.purchases.admob.nextgen.responseInfo
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import io.mockk.confirmVerified
 import io.mockk.every


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids
### Motivation
Reduce repeated next-gen AdMob test setup while keeping lifecycle behavior explicit and isolated.

<details>
<summary>More context</summary>

- Extracts `ConfiguredPurchasesRule` with reliable `Purchases` teardown and a shared `responseInfo` fixture.
- Shares native request/ad fixtures and `RecordingNativeAdLoaderCallback` across `NativeAdFlowTest` and `NativeAdBatchFlowTest`.
- Adopts the fixtures in tracking, Banner, Native, and Preloader tests without changing production behavior or test scenarios.
- Intentionally leaves `AppOpenAdFlowTest`, `InterstitialAdFlowTest`, `RewardedAdFlowTest`, `RewardedInterstitialAdFlowTest`, and their four matching `*AdResponseFlowTest` classes untouched; tests that manipulate Purchases configuration or service lifecycle retain explicit local setup.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test code and shared mocks; production ad tracking behavior and test scenarios are unchanged.
> 
> **Overview**
> This PR **refactors admob-next-gen unit tests only**—no production changes. It introduces shared test infrastructure and removes duplicated mock setup across flow, native, preloader, and tracking tests.
> 
> **`ConfiguredPurchasesRule`** is a JUnit `TestRule` that mocks `Purchases.isConfigured`, `Purchases.sharedInstance`, and a relaxed `AdTracker`, with **`unmockkObject(Purchases)` in a `finally` block** so teardown is consistent. Banner, native, preloader base, and several tracking tests now use `@get:Rule` instead of per-class `@Before`/`@After` Purchases mocking.
> 
> **Shared fixtures:** `responseInfo()` in `AdResponseInfoFixtures.kt`; native helpers (`nativeAdRequest`, `nativeAd`, `customNativeAd`, `nativeBannerAd`) plus **`RecordingNativeAdLoaderCallback`** (failed loads collected in **`loadErrors`**) in `NativeAdFixtures.kt`. Duplicated private helpers were deleted from individual test classes.
> 
> Tracking tests mostly **import the shared `responseInfo`**; a subset also adopt the rule. **Interstitial, rewarded, app-open flow/response tests** still use explicit local Purchases setup, as noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be3fd8641f6578db6f330bdbad0409549f871c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->