### PR TITLE
refactor(admob): deduplicate native ad load result handling

### DIFF
--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/AdTrackerAdMobExtensions.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/AdTrackerAdMobExtensions.kt
@@ -23,10 +23,9 @@ import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAdEventCallback
+import com.revenuecat.purchases.admob.nextgen.tracking.NativeAdLoadResultHandler
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingAdLoadCallback
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingNativeAdLoaderCallback
-import com.revenuecat.purchases.admob.nextgen.tracking.trackAdFailedToLoad
-import com.revenuecat.purchases.admob.nextgen.tracking.trackAdLoaded
 import com.revenuecat.purchases.admob.nextgen.tracking.trackAndConfigureAdLoadResult
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFormat
@@ -614,13 +613,12 @@ public suspend fun AdTracker.loadAndTrackNativeAd(
     bannerAdEventCallback: BannerAdEventCallback? = null,
 ): NativeAdLoadResult {
     val result = NativeAdLoader.load(adRequest)
-    trackAndConfigureNativeAdLoadResult(
-        result = result,
+    nativeAdLoadResultHandler(
         placement = placement,
         adUnitId = adRequest.adUnitId,
         nativeAdEventCallback = nativeAdEventCallback,
         bannerAdEventCallback = bannerAdEventCallback,
-    )
+    ).handle(result)
     return result
 }
 
@@ -705,15 +703,14 @@ public suspend fun AdTracker.loadAndTrackNativeAds(
     nativeAdEventCallback: NativeAdEventCallback? = null,
     bannerAdEventCallback: BannerAdEventCallback? = null,
 ): Flow<NativeAdLoadResult> {
-    val adUnitId = adRequest.adUnitId
+    val resultHandler = nativeAdLoadResultHandler(
+        placement = placement,
+        adUnitId = adRequest.adUnitId,
+        nativeAdEventCallback = nativeAdEventCallback,
+        bannerAdEventCallback = bannerAdEventCallback,
+    )
     return NativeAdLoader.load(adRequest, maxNumberOfAds).onEach { result ->
-        trackAndConfigureNativeAdLoadResult(
-            result = result,
-            placement = placement,
-            adUnitId = adUnitId,
-            nativeAdEventCallback = nativeAdEventCallback,
-            bannerAdEventCallback = bannerAdEventCallback,
-        )
+        resultHandler.handle(result)
     }
 }
 
@@ -725,6 +722,20 @@ private fun trackingNativeAdLoaderCallback(
     bannerAdEventCallback: BannerAdEventCallback?,
 ): TrackingNativeAdLoaderCallback = TrackingNativeAdLoaderCallback(
     delegate = delegate,
+    resultHandler = nativeAdLoadResultHandler(
+        placement = placement,
+        adUnitId = adUnitId,
+        nativeAdEventCallback = nativeAdEventCallback,
+        bannerAdEventCallback = bannerAdEventCallback,
+    ),
+)
+
+private fun nativeAdLoadResultHandler(
+    placement: String?,
+    adUnitId: String,
+    nativeAdEventCallback: NativeAdEventCallback?,
+    bannerAdEventCallback: BannerAdEventCallback?,
+): NativeAdLoadResultHandler = NativeAdLoadResultHandler(
     placement = placement,
     adUnitId = adUnitId,
     configureAd = { ad -> ad.installTrackingEventCallback(nativeAdEventCallback, placement, adUnitId) },
@@ -733,29 +744,3 @@ private fun trackingNativeAdLoaderCallback(
     },
     configureBannerAd = { ad -> ad.installTrackingCallbacks(bannerAdEventCallback, null, placement, adUnitId) },
 )
-
-private fun trackAndConfigureNativeAdLoadResult(
-    result: NativeAdLoadResult,
-    placement: String?,
-    adUnitId: String,
-    nativeAdEventCallback: NativeAdEventCallback?,
-    bannerAdEventCallback: BannerAdEventCallback?,
-) {
-    when (result) {
-        is NativeAdLoadResult.NativeAdSuccess -> {
-            trackAdLoaded({ result.ad.getResponseInfo() }, AdFormat.NATIVE, placement, adUnitId)
-            result.ad.installTrackingEventCallback(nativeAdEventCallback, placement, adUnitId)
-        }
-        is NativeAdLoadResult.CustomNativeAdSuccess -> {
-            trackAdLoaded({ result.ad.getResponseInfo() }, AdFormat.NATIVE, placement, adUnitId)
-            result.ad.installTrackingEventCallback(nativeAdEventCallback, placement, adUnitId)
-        }
-        is NativeAdLoadResult.BannerAdSuccess -> {
-            trackAdLoaded({ result.ad.getResponseInfo() }, AdFormat.BANNER, placement, adUnitId)
-            result.ad.installTrackingCallbacks(bannerAdEventCallback, null, placement, adUnitId)
-        }
-        is NativeAdLoadResult.Failure -> {
-            trackAdFailedToLoad(result.error, AdFormat.NATIVE, placement, adUnitId)
-        }
-    }
-}

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/NativeAdLoadResultHandler.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/NativeAdLoadResultHandler.kt
@@ -1,0 +1,35 @@
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoadResult
+import com.revenuecat.purchases.ads.events.types.AdFormat
+
+internal class NativeAdLoadResultHandler(
+    private val placement: String?,
+    private val adUnitId: String,
+    private val configureAd: (NativeAd) -> Unit,
+    private val configureCustomNativeAd: (CustomNativeAd) -> Unit = {},
+    private val configureBannerAd: (BannerAd) -> Unit = {},
+) {
+    fun handle(result: NativeAdLoadResult) {
+        when (result) {
+            is NativeAdLoadResult.NativeAdSuccess -> {
+                trackAdLoaded({ result.ad.getResponseInfo() }, AdFormat.NATIVE, placement, adUnitId)
+                configureAd(result.ad)
+            }
+            is NativeAdLoadResult.CustomNativeAdSuccess -> {
+                trackAdLoaded({ result.ad.getResponseInfo() }, AdFormat.NATIVE, placement, adUnitId)
+                configureCustomNativeAd(result.ad)
+            }
+            is NativeAdLoadResult.BannerAdSuccess -> {
+                trackAdLoaded({ result.ad.getResponseInfo() }, AdFormat.BANNER, placement, adUnitId)
+                configureBannerAd(result.ad)
+            }
+            is NativeAdLoadResult.Failure -> {
+                trackAdFailedToLoad(result.error, AdFormat.NATIVE, placement, adUnitId)
+            }
+        }
+    }
+}

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingNativeAdLoaderCallback.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingNativeAdLoaderCallback.kt
@@ -5,45 +5,37 @@ import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
-import com.revenuecat.purchases.ads.events.types.AdFormat
 
 /**
  * A [NativeAdLoaderCallback] wrapper that tracks standard native load results and delegates every callback.
  *
- * Each configure callback runs after its ad is tracked and before it is forwarded to [delegate], allowing callers to
- * install post-load tracking without coupling this load wrapper to the event-tracking implementation. Custom native
- * results are tracked as native ads, while banner results are tracked as banner ads.
+ * [resultHandler] tracks and configures each result before it is forwarded to [delegate]. Custom native results are
+ * tracked as native ads, while banner results are tracked as banner ads.
  */
 internal class TrackingNativeAdLoaderCallback(
     private val delegate: NativeAdLoaderCallback?,
-    private val placement: String?,
-    private val adUnitId: String,
-    private val configureAd: (NativeAd) -> Unit,
-    private val configureCustomNativeAd: (CustomNativeAd) -> Unit = {},
-    private val configureBannerAd: (BannerAd) -> Unit = {},
+    private val resultHandler: NativeAdLoadResultHandler,
 ) : NativeAdLoaderCallback {
 
     override fun onNativeAdLoaded(nativeAd: NativeAd) {
-        trackAdLoaded({ nativeAd.getResponseInfo() }, AdFormat.NATIVE, placement, adUnitId)
-        configureAd(nativeAd)
+        resultHandler.handle(NativeAdLoadResult.NativeAdSuccess(nativeAd))
         delegate?.onNativeAdLoaded(nativeAd)
     }
 
     override fun onCustomNativeAdLoaded(customNativeAd: CustomNativeAd) {
-        trackAdLoaded({ customNativeAd.getResponseInfo() }, AdFormat.NATIVE, placement, adUnitId)
-        configureCustomNativeAd(customNativeAd)
+        resultHandler.handle(NativeAdLoadResult.CustomNativeAdSuccess(customNativeAd))
         delegate?.onCustomNativeAdLoaded(customNativeAd)
     }
 
     override fun onBannerAdLoaded(bannerAd: BannerAd) {
-        trackAdLoaded({ bannerAd.getResponseInfo() }, AdFormat.BANNER, placement, adUnitId)
-        configureBannerAd(bannerAd)
+        resultHandler.handle(NativeAdLoadResult.BannerAdSuccess(bannerAd))
         delegate?.onBannerAdLoaded(bannerAd)
     }
 
     override fun onAdFailedToLoad(adError: LoadAdError) {
-        trackAdFailedToLoad(adError, AdFormat.NATIVE, placement, adUnitId)
+        resultHandler.handle(NativeAdLoadResult.Failure(adError))
         delegate?.onAdFailedToLoad(adError)
     }
 

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingNativeAdLoaderCallbackTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/TrackingNativeAdLoaderCallbackTest.kt
@@ -59,9 +59,7 @@ class TrackingNativeAdLoaderCallbackTest {
                     order += "delegate"
                 }
             },
-            placement = "home",
-            adUnitId = "ad-unit",
-            configureAd = { order += "configure" },
+            resultHandler = resultHandler(configureAd = { order += "configure" }),
         )
 
         callback.onNativeAdLoaded(nativeAd)
@@ -96,9 +94,7 @@ class TrackingNativeAdLoaderCallbackTest {
                     delegatedError = adError
                 }
             },
-            placement = null,
-            adUnitId = "ad-unit",
-            configureAd = { configured = true },
+            resultHandler = resultHandler(placement = null, configureAd = { configured = true }),
         )
 
         callback.onAdFailedToLoad(error)
@@ -133,9 +129,7 @@ class TrackingNativeAdLoaderCallbackTest {
                     delegatedCustomNativeAd = customNativeAd
                 }
             },
-            placement = "home",
-            adUnitId = "ad-unit",
-            configureAd = { configured = true },
+            resultHandler = resultHandler(configureAd = { configured = true }),
         )
 
         callback.onCustomNativeAdLoaded(customNativeAd)
@@ -171,9 +165,7 @@ class TrackingNativeAdLoaderCallbackTest {
                     delegatedBannerAd = bannerAd
                 }
             },
-            placement = "home",
-            adUnitId = "ad-unit",
-            configureAd = { configured = true },
+            resultHandler = resultHandler(configureAd = { configured = true }),
         )
 
         callback.onBannerAdLoaded(bannerAd)
@@ -207,9 +199,7 @@ class TrackingNativeAdLoaderCallbackTest {
                     loadingCompleted = true
                 }
             },
-            placement = "home",
-            adUnitId = "ad-unit",
-            configureAd = { configured = true },
+            resultHandler = resultHandler(configureAd = { configured = true }),
         )
 
         callback.onAdLoadingCompleted()
@@ -218,6 +208,15 @@ class TrackingNativeAdLoaderCallbackTest {
         assertTrue(loadingCompleted)
         assertFalse(configured)
     }
+
+    private fun resultHandler(
+        placement: String? = "home",
+        configureAd: (NativeAd) -> Unit,
+    ): NativeAdLoadResultHandler = NativeAdLoadResultHandler(
+        placement = placement,
+        adUnitId = "ad-unit",
+        configureAd = configureAd,
+    )
 
     private fun responseInfo(adapterClassName: String, responseId: String): ResponseInfo =
         mockk<ResponseInfo>().also {


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Small refactor. Native callback loads and suspend/Flow loads independently dispatched the same native ad result variants, making their tracking behavior vulnerable to drift.

### Description
Adds one internal `NativeAdLoadResultHandler` shared by callback, suspend, and Flow paths while preserving track-before-configuration-before-delegate ordering and leaving preloader polling separate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in ad event tracking with no API surface changes; main risk is subtle ordering or format mismatches if handler logic drifts from prior inline code.
> 
> **Overview**
> Consolidates **native ad load tracking and post-load configuration** into a single internal `NativeAdLoadResultHandler`, so callback, suspend, and `Flow` load paths no longer duplicate the same `when` over `NativeAdLoadResult` variants.
> 
> `AdTrackerAdMobExtensions` now builds a handler via `nativeAdLoadResultHandler(...)` and calls `.handle(result)` for suspend/Flow loads; the old `trackAndConfigureNativeAdLoadResult` helper is removed. **`TrackingNativeAdLoaderCallback`** takes a `resultHandler` instead of placement/ad unit/configure lambdas, and maps each callback to the matching `NativeAdLoadResult` before delegating—preserving **track → configure → delegate** ordering. Unit tests construct the callback through a shared `resultHandler` test helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf2355bc52b28fd865e86fef9faf44b21ee1369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->