### PR TITLE
Log checkpoint rule evaluation

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -133,13 +133,10 @@ internal class CheckpointWorkflowResolverImpl(
         if (rules.isEmpty()) return Result.success(null)
         val audiences = audiencesConfigProvider.getAudiences()
             ?: return Result.failure(AudiencesUnavailableException())
-        verboseLog {
-            val described = rules.joinToString { "id ${it.id}, audience ${it.audienceId}, workflow ${it.workflowId}" }
-            "Evaluating ${rules.size} rules for checkpoint '$identifier': $described."
-        }
         return localRulesEvaluator.match(
             rules = rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
+            context = "checkpoint '$identifier'",
         ) { rule ->
             audiences[rule.audienceId]
                 ?.let { audience -> Result.success(audience.rules) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -88,7 +88,12 @@ internal class CheckpointWorkflowResolverImpl(
             CheckpointRulesResolution.Unavailable ->
                 return configurationUnavailable("The rules for checkpoint '$identifier' could not be read.")
         }
-        val matchResult = matchRule(audiencesConfigProvider, rulesResolution.checkpoint.rules, customVariables)
+        val matchResult = matchRule(
+            audiencesConfigProvider,
+            identifier,
+            rulesResolution.checkpoint.rules,
+            customVariables,
+        )
         // Checked before the result is unwrapped: a match that failed against a generation that moved mid-read
         // (audiences read from a later commit than the rules) is stale rather than authoritative, and deserves
         // the retry as much as a stale success does.
@@ -121,15 +126,20 @@ internal class CheckpointWorkflowResolverImpl(
     @Suppress("ReturnCount")
     private suspend fun matchRule(
         audiencesConfigProvider: AudiencesConfigProvider,
+        identifier: String,
         rules: List<CheckpointRule>,
         customVariables: Map<String, RulesDimensionValue>,
     ): Result<CheckpointRule?> {
         if (rules.isEmpty()) return Result.success(null)
         val audiences = audiencesConfigProvider.getAudiences()
             ?: return Result.failure(AudiencesUnavailableException())
+        debugLog { "Evaluating ${rules.size} rules for checkpoint '$identifier'." }
         return localRulesEvaluator.match(
             rules = rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
+            label = { index, rule ->
+                "Rule ${index + 1} (id ${rule.id}, audience ${rule.audienceId}, workflow ${rule.workflowId})"
+            },
         ) { rule ->
             audiences[rule.audienceId]
                 ?.let { audience -> Result.success(audience.rules) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -133,13 +133,13 @@ internal class CheckpointWorkflowResolverImpl(
         if (rules.isEmpty()) return Result.success(null)
         val audiences = audiencesConfigProvider.getAudiences()
             ?: return Result.failure(AudiencesUnavailableException())
-        debugLog { "Evaluating ${rules.size} rules for checkpoint '$identifier'." }
+        verboseLog {
+            val described = rules.joinToString { "id ${it.id}, audience ${it.audienceId}, workflow ${it.workflowId}" }
+            "Evaluating ${rules.size} rules for checkpoint '$identifier': $described."
+        }
         return localRulesEvaluator.match(
             rules = rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
-            label = { index, rule ->
-                "Rule ${index + 1} (id ${rule.id}, audience ${rule.audienceId}, workflow ${rule.workflowId})"
-            },
         ) { rule ->
             audiences[rule.audienceId]
                 ?.let { audience -> Result.success(audience.rules) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -136,7 +136,7 @@ internal class CheckpointWorkflowResolverImpl(
         return localRulesEvaluator.match(
             rules = rules,
             customVariables = CustomVariableKeyValidator.validateAndFilter(customVariables),
-            context = "checkpoint '$identifier'",
+            logPrefix = "[Checkpoint '$identifier'] ",
         ) { rule ->
             audiences[rule.audienceId]
                 ?.let { audience -> Result.success(audience.rules) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -5,6 +5,8 @@ package com.revenuecat.purchases.common.localrules
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.rules.RulesEngine
 
 internal sealed class LocalRulesEvaluationException(message: String) : Exception(message) {
@@ -47,6 +49,9 @@ internal class LocalRulesEvaluator(
      *
      * When a predicate must be resolved before it can be evaluated, a resolution failure fails the call immediately.
      * [customVariables] are the caller's own values for this evaluation, readable under `custom.*`.
+     *
+     * Every rule's outcome is logged under the name [label] gives it. Logs never include dimension values or
+     * predicates, only dimension names and how each rule fared.
      */
     suspend fun <Rule : LocalRule> match(
         rules: List<Rule>,
@@ -57,6 +62,7 @@ internal class LocalRulesEvaluator(
     suspend fun <Rule> match(
         rules: List<Rule>,
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
+        label: (index: Int, rule: Rule) -> String = { index, _ -> "Rule ${index + 1}" },
         predicateFor: suspend (Rule) -> Result<String>,
     ): Result<Rule?> {
         if (rules.isEmpty()) return Result.success(null)
@@ -67,18 +73,30 @@ internal class LocalRulesEvaluator(
                 return Result.failure(LocalRulesEvaluationException.DimensionResolution(error))
             },
         )
+        verboseLog { "Evaluating ${rules.size} rules against dimensions ${snapshot.values.keys.sorted()}." }
 
         var firstFailure: LocalRulesEvaluationException.PredicateEvaluation? = null
         for ((index, rule) in rules.withIndex()) {
             val predicate = predicateFor(rule).getOrElse { error -> return Result.failure(error) }
             val result = RulesEngine.evaluate(predicate, snapshot.values)
             val matches = result.getOrElse { error ->
-                if (error !is RulesEngine.EvaluationException.UnresolvedVariable && firstFailure == null) {
-                    firstFailure = LocalRulesEvaluationException.PredicateEvaluation(index, error)
+                if (error is RulesEngine.EvaluationException.UnresolvedVariable) {
+                    verboseLog {
+                        "${label(index, rule)} did not match: it reads '${error.path}', which this SDK does not supply."
+                    }
+                } else {
+                    debugLog { "${label(index, rule)} could not be evaluated (${error.javaClass.simpleName})." }
+                    if (firstFailure == null) {
+                        firstFailure = LocalRulesEvaluationException.PredicateEvaluation(index, error)
+                    }
                 }
                 false
             }
-            if (matches) return Result.success(rule)
+            if (matches) {
+                debugLog { "${label(index, rule)} matched." }
+                return Result.success(rule)
+            }
+            if (result.isSuccess) verboseLog { "${label(index, rule)} did not match." }
         }
 
         return firstFailure?.let { failure -> Result.failure(failure) } ?: Result.success(null)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -50,7 +50,7 @@ internal class LocalRulesEvaluator(
      * When a predicate must be resolved before it can be evaluated, a resolution failure fails the call immediately.
      * [customVariables] are the caller's own values for this evaluation, readable under `custom.*`.
      *
-     * Every rule's outcome is logged under the name [label] gives it. Logs never include dimension values or
+     * Every rule's outcome is logged by its position in [rules]. Logs never include dimension values or
      * predicates, only dimension names and how each rule fared.
      */
     suspend fun <Rule : LocalRule> match(
@@ -62,7 +62,6 @@ internal class LocalRulesEvaluator(
     suspend fun <Rule> match(
         rules: List<Rule>,
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
-        label: (index: Int, rule: Rule) -> String = { index, _ -> "Rule ${index + 1}" },
         predicateFor: suspend (Rule) -> Result<String>,
     ): Result<Rule?> {
         if (rules.isEmpty()) return Result.success(null)
@@ -82,10 +81,10 @@ internal class LocalRulesEvaluator(
             val matches = result.getOrElse { error ->
                 if (error is RulesEngine.EvaluationException.UnresolvedVariable) {
                     verboseLog {
-                        "${label(index, rule)} did not match: it reads '${error.path}', which this SDK does not supply."
+                        "${label(index)} did not match: it reads '${error.path}', which this SDK does not supply."
                     }
                 } else {
-                    debugLog { "${label(index, rule)} could not be evaluated (${error.javaClass.simpleName})." }
+                    debugLog { "${label(index)} could not be evaluated (${error.javaClass.simpleName})." }
                     if (firstFailure == null) {
                         firstFailure = LocalRulesEvaluationException.PredicateEvaluation(index, error)
                     }
@@ -93,12 +92,14 @@ internal class LocalRulesEvaluator(
                 false
             }
             if (matches) {
-                debugLog { "${label(index, rule)} matched." }
+                verboseLog { "${label(index)} matched." }
                 return Result.success(rule)
             }
-            if (result.isSuccess) verboseLog { "${label(index, rule)} did not match." }
+            if (result.isSuccess) verboseLog { "${label(index)} did not match." }
         }
 
         return firstFailure?.let { failure -> Result.failure(failure) } ?: Result.success(null)
     }
+
+    private fun label(index: Int): String = "Rule ${index + 1}"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -50,8 +50,9 @@ internal class LocalRulesEvaluator(
      * When a predicate must be resolved before it can be evaluated, a resolution failure fails the call immediately.
      * [customVariables] are the caller's own values for this evaluation, readable under `custom.*`.
      *
-     * Every rule's outcome is logged by its position in [rules]. Logs never include dimension values or
-     * predicates, only dimension names and how each rule fared.
+     * Every rule's outcome is logged by its position in [rules], for the [context] the rules belong to (e.g.
+     * `checkpoint 'onboarding'`). Logs never include dimension values or predicates, only dimension names and how
+     * each rule fared.
      */
     suspend fun <Rule : LocalRule> match(
         rules: List<Rule>,
@@ -62,8 +63,10 @@ internal class LocalRulesEvaluator(
     suspend fun <Rule> match(
         rules: List<Rule>,
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
+        context: String? = null,
         predicateFor: suspend (Rule) -> Result<String>,
     ): Result<Rule?> {
+        val forContext = context?.let { " for $it" } ?: ""
         if (rules.isEmpty()) return Result.success(null)
 
         val snapshot = dimensionResolver.snapshot(customVariables).fold(
@@ -72,7 +75,7 @@ internal class LocalRulesEvaluator(
                 return Result.failure(LocalRulesEvaluationException.DimensionResolution(error))
             },
         )
-        verboseLog { "Evaluating ${rules.size} rules against dimensions ${snapshot.values.keys.sorted()}." }
+        verboseLog { "Evaluating ${rules.size} rules$forContext against dimensions ${snapshot.values.keys.sorted()}." }
 
         var firstFailure: LocalRulesEvaluationException.PredicateEvaluation? = null
         for ((index, rule) in rules.withIndex()) {
@@ -81,10 +84,11 @@ internal class LocalRulesEvaluator(
             val matches = result.getOrElse { error ->
                 if (error is RulesEngine.EvaluationException.UnresolvedVariable) {
                     verboseLog {
-                        "${label(index)} did not match: it reads '${error.path}', which this SDK does not supply."
+                        "Rule ${index + 1}$forContext did not match: it reads '${error.path}', which this SDK " +
+                            "does not supply."
                     }
                 } else {
-                    debugLog { "${label(index)} could not be evaluated (${error.javaClass.simpleName})." }
+                    debugLog { "Rule ${index + 1}$forContext could not be evaluated (${error.javaClass.simpleName})." }
                     if (firstFailure == null) {
                         firstFailure = LocalRulesEvaluationException.PredicateEvaluation(index, error)
                     }
@@ -92,14 +96,12 @@ internal class LocalRulesEvaluator(
                 false
             }
             if (matches) {
-                verboseLog { "${label(index)} matched." }
+                verboseLog { "Rule ${index + 1}$forContext matched." }
                 return Result.success(rule)
             }
-            if (result.isSuccess) verboseLog { "${label(index)} did not match." }
+            if (result.isSuccess) verboseLog { "Rule ${index + 1}$forContext did not match." }
         }
 
         return firstFailure?.let { failure -> Result.failure(failure) } ?: Result.success(null)
     }
-
-    private fun label(index: Int): String = "Rule ${index + 1}"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/localrules/LocalRulesEvaluator.kt
@@ -50,9 +50,9 @@ internal class LocalRulesEvaluator(
      * When a predicate must be resolved before it can be evaluated, a resolution failure fails the call immediately.
      * [customVariables] are the caller's own values for this evaluation, readable under `custom.*`.
      *
-     * Every rule's outcome is logged by its position in [rules], for the [context] the rules belong to (e.g.
-     * `checkpoint 'onboarding'`). Logs never include dimension values or predicates, only dimension names and how
-     * each rule fared.
+     * Every rule's outcome is logged by its position in [rules], with [logPrefix] prepended verbatim to each line
+     * (e.g. `[Checkpoint 'onboarding'] `). Logs never include dimension values or predicates, only dimension names
+     * and how each rule fared.
      */
     suspend fun <Rule : LocalRule> match(
         rules: List<Rule>,
@@ -63,10 +63,9 @@ internal class LocalRulesEvaluator(
     suspend fun <Rule> match(
         rules: List<Rule>,
         customVariables: Map<String, RulesDimensionValue> = emptyMap(),
-        context: String? = null,
+        logPrefix: String = "",
         predicateFor: suspend (Rule) -> Result<String>,
     ): Result<Rule?> {
-        val forContext = context?.let { " for $it" } ?: ""
         if (rules.isEmpty()) return Result.success(null)
 
         val snapshot = dimensionResolver.snapshot(customVariables).fold(
@@ -75,7 +74,7 @@ internal class LocalRulesEvaluator(
                 return Result.failure(LocalRulesEvaluationException.DimensionResolution(error))
             },
         )
-        verboseLog { "Evaluating ${rules.size} rules$forContext against dimensions ${snapshot.values.keys.sorted()}." }
+        verboseLog { "${logPrefix}Evaluating ${rules.size} rules against dimensions ${snapshot.values.keys.sorted()}." }
 
         var firstFailure: LocalRulesEvaluationException.PredicateEvaluation? = null
         for ((index, rule) in rules.withIndex()) {
@@ -84,11 +83,11 @@ internal class LocalRulesEvaluator(
             val matches = result.getOrElse { error ->
                 if (error is RulesEngine.EvaluationException.UnresolvedVariable) {
                     verboseLog {
-                        "Rule ${index + 1}$forContext did not match: it reads '${error.path}', which this SDK " +
+                        "${logPrefix}Rule ${index + 1} did not match: it reads '${error.path}', which this SDK " +
                             "does not supply."
                     }
                 } else {
-                    debugLog { "Rule ${index + 1}$forContext could not be evaluated (${error.javaClass.simpleName})." }
+                    debugLog { "${logPrefix}Rule ${index + 1} could not be evaluated (${error.javaClass.simpleName})." }
                     if (firstFailure == null) {
                         firstFailure = LocalRulesEvaluationException.PredicateEvaluation(index, error)
                     }
@@ -96,10 +95,10 @@ internal class LocalRulesEvaluator(
                 false
             }
             if (matches) {
-                verboseLog { "Rule ${index + 1}$forContext matched." }
+                verboseLog { "${logPrefix}Rule ${index + 1} matched." }
                 return Result.success(rule)
             }
-            if (result.isSuccess) verboseLog { "Rule ${index + 1}$forContext did not match." }
+            if (result.isSuccess) verboseLog { "${logPrefix}Rule ${index + 1} did not match." }
         }
 
         return firstFailure?.let { failure -> Result.failure(failure) } ?: Result.success(null)

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -4,6 +4,9 @@ package com.revenuecat.purchases.checkpoints
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.LogLevel
+import com.revenuecat.purchases.LogMessage
+import com.revenuecat.purchases.assertLogs
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.PurchasesError
@@ -182,6 +185,28 @@ class CheckpointWorkflowResolverImplTest {
         assertThat(resolution.uiConfig).isEqualTo(mockUiConfig)
         assertThat(resolution.offering).isEqualTo(mockOffering)
         verify(exactly = 1) { mockWorkflowManager.prewarmWorkflowAssets(mockWorkflow, mockUiConfig) }
+    }
+
+    @Test
+    fun `each rule evaluation is logged with its ids only`() {
+        configureRules(rule("wf5678"), rule("wf1234"))
+        configureAudiences(
+            Audience("aud_wf5678", "false"),
+            Audience("aud_wf1234", "true"),
+        )
+
+        assertLogs(
+            listOf(
+                LogMessage(LogLevel.DEBUG, "Evaluating 2 rules for checkpoint '$checkpointId'."),
+                LogMessage(
+                    LogLevel.VERBOSE,
+                    "Rule 1 (id rule_wf5678, audience aud_wf5678, workflow wf5678) did not match.",
+                ),
+                LogMessage(LogLevel.DEBUG, "Rule 2 (id rule_wf1234, audience aud_wf1234, workflow wf1234) matched."),
+            ),
+        ) {
+            runTest { resolve() }
+        }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -188,7 +188,7 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
-    fun `each rule evaluation is logged with the checkpoint identifier and its position`() {
+    fun `each rule evaluation is logged under the checkpoint's prefix with its position`() {
         configureRules(rule("wf5678"), rule("wf1234"))
         configureAudiences(
             Audience("aud_wf5678", "false"),
@@ -197,8 +197,8 @@ class CheckpointWorkflowResolverImplTest {
 
         assertLogs(
             listOf(
-                LogMessage(LogLevel.VERBOSE, "Rule 1 for checkpoint '$checkpointId' did not match."),
-                LogMessage(LogLevel.VERBOSE, "Rule 2 for checkpoint '$checkpointId' matched."),
+                LogMessage(LogLevel.VERBOSE, "[Checkpoint '$checkpointId'] Rule 1 did not match."),
+                LogMessage(LogLevel.VERBOSE, "[Checkpoint '$checkpointId'] Rule 2 matched."),
             ),
         ) {
             runTest { resolve() }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -188,7 +188,7 @@ class CheckpointWorkflowResolverImplTest {
     }
 
     @Test
-    fun `each rule evaluation is logged with its ids only`() {
+    fun `each rule evaluation is logged with the checkpoint identifier and its position`() {
         configureRules(rule("wf5678"), rule("wf1234"))
         configureAudiences(
             Audience("aud_wf5678", "false"),
@@ -197,13 +197,8 @@ class CheckpointWorkflowResolverImplTest {
 
         assertLogs(
             listOf(
-                LogMessage(
-                    LogLevel.VERBOSE,
-                    "Evaluating 2 rules for checkpoint '$checkpointId': id rule_wf5678, audience aud_wf5678, " +
-                        "workflow wf5678, id rule_wf1234, audience aud_wf1234, workflow wf1234.",
-                ),
-                LogMessage(LogLevel.VERBOSE, "Rule 1 did not match."),
-                LogMessage(LogLevel.VERBOSE, "Rule 2 matched."),
+                LogMessage(LogLevel.VERBOSE, "Rule 1 for checkpoint '$checkpointId' did not match."),
+                LogMessage(LogLevel.VERBOSE, "Rule 2 for checkpoint '$checkpointId' matched."),
             ),
         ) {
             runTest { resolve() }

--- a/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImplTest.kt
@@ -197,12 +197,13 @@ class CheckpointWorkflowResolverImplTest {
 
         assertLogs(
             listOf(
-                LogMessage(LogLevel.DEBUG, "Evaluating 2 rules for checkpoint '$checkpointId'."),
                 LogMessage(
                     LogLevel.VERBOSE,
-                    "Rule 1 (id rule_wf5678, audience aud_wf5678, workflow wf5678) did not match.",
+                    "Evaluating 2 rules for checkpoint '$checkpointId': id rule_wf5678, audience aud_wf5678, " +
+                        "workflow wf5678, id rule_wf1234, audience aud_wf1234, workflow wf1234.",
                 ),
-                LogMessage(LogLevel.DEBUG, "Rule 2 (id rule_wf1234, audience aud_wf1234, workflow wf1234) matched."),
+                LogMessage(LogLevel.VERBOSE, "Rule 1 did not match."),
+                LogMessage(LogLevel.VERBOSE, "Rule 2 matched."),
             ),
         ) {
             runTest { resolve() }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -3,10 +3,18 @@
 package com.revenuecat.purchases.common.localrules
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.LogLevel
+import com.revenuecat.purchases.LogMessage
+import com.revenuecat.purchases.NoOpLogHandler
+import com.revenuecat.purchases.assertDebugLog
+import com.revenuecat.purchases.assertLogs
+import com.revenuecat.purchases.assertVerboseLog
+import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.rules.RulesEngine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import java.util.Date
 
@@ -24,6 +32,11 @@ class LocalRulesEvaluatorTest {
             snapshotsTaken++
             return mapOf("platform" to RulesDimensionValue.StringValue("android"))
         }
+    }
+
+    @Before
+    fun setup() {
+        currentLogHandler = NoOpLogHandler
     }
 
     @Test
@@ -226,6 +239,49 @@ class LocalRulesEvaluatorTest {
         }
 
         assertThat(snapshotsTaken).isEqualTo(1)
+    }
+
+    @Test
+    fun `every rule's outcome is logged without predicates or values`() {
+        assertLogs(
+            listOf(
+                LogMessage(LogLevel.VERBOSE, "Evaluating 2 rules against dimensions [evaluated_at, platform]."),
+                LogMessage(LogLevel.VERBOSE, "Rule 1 did not match."),
+                LogMessage(LogLevel.DEBUG, "Rule 2 matched."),
+            ),
+        ) {
+            runTest {
+                evaluator().match(
+                    listOf(TestRule("first", nonMatchingPredicate), TestRule("second", matchingPredicate)),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `an unsupplied dimension is logged by name`() {
+        assertVerboseLog("Rule 1 did not match: it reads 'unknown_dimension', which this SDK does not supply.") {
+            runTest { evaluator().match(listOf(TestRule("only", unsuppliedDimensionPredicate))) }
+        }
+    }
+
+    @Test
+    fun `an unevaluable predicate is logged by failure kind`() {
+        assertDebugLog("Rule 1 could not be evaluated (Parse).") {
+            runTest { evaluator().match(listOf(TestRule("only", malformedPredicate))) }
+        }
+    }
+
+    @Test
+    fun `a caller-supplied label names the rules in the logs`() {
+        assertDebugLog("rule named second matched.") {
+            runTest {
+                evaluator().match(
+                    rules = listOf(TestRule("first", nonMatchingPredicate), TestRule("second", matchingPredicate)),
+                    label = { _, rule -> "rule named ${rule.name}" },
+                ) { rule -> Result.success(rule.predicate) }
+            }
+        }
     }
 
     private fun evaluator() = LocalRulesEvaluator(providers = listOf(deviceProvider), currentAppUserId = { "user" })

--- a/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/localrules/LocalRulesEvaluatorTest.kt
@@ -247,7 +247,7 @@ class LocalRulesEvaluatorTest {
             listOf(
                 LogMessage(LogLevel.VERBOSE, "Evaluating 2 rules against dimensions [evaluated_at, platform]."),
                 LogMessage(LogLevel.VERBOSE, "Rule 1 did not match."),
-                LogMessage(LogLevel.DEBUG, "Rule 2 matched."),
+                LogMessage(LogLevel.VERBOSE, "Rule 2 matched."),
             ),
         ) {
             runTest {
@@ -269,18 +269,6 @@ class LocalRulesEvaluatorTest {
     fun `an unevaluable predicate is logged by failure kind`() {
         assertDebugLog("Rule 1 could not be evaluated (Parse).") {
             runTest { evaluator().match(listOf(TestRule("only", malformedPredicate))) }
-        }
-    }
-
-    @Test
-    fun `a caller-supplied label names the rules in the logs`() {
-        assertDebugLog("rule named second matched.") {
-            runTest {
-                evaluator().match(
-                    rules = listOf(TestRule("first", nonMatchingPredicate), TestRule("second", matchingPredicate)),
-                    label = { _, rule -> "rule named ${rule.name}" },
-                ) { rule -> Result.success(rule.predicate) }
-            }
         }
     }
 


### PR DESCRIPTION
### Description

Adds some logs for rule evaluation. Tried to make sure we keep PII out, so only logging checkpoint Id + rule index

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes with a default-empty API parameter; no changes to matching or resolution outcomes.
> 
> **Overview**
> Adds **verbose/debug logging** while walking checkpoint and local rules so integrators can see why a rule matched or was skipped, without logging predicates or dimension values.
> 
> **`LocalRulesEvaluator`** now accepts an optional **`logPrefix`** and emits a verbose line at the start (rule count + sorted dimension **names** only), then per-rule outcomes: match, non-match, unsupplied dimension (by name), or unevaluable predicate (debug, error type only). Evaluation semantics are unchanged; unevaluable rules still defer failure the same way.
> 
> **`CheckpointWorkflowResolverImpl`** passes **`[Checkpoint '<id>'] `** into rule matching so checkpoint resolution logs are easy to filter.
> 
> Tests assert the expected log lines for both the evaluator and checkpoint resolver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edcfe9952fc24638deb39b526783ded1b0748f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->