### PR TITLE
Report checkpoint evaluations to the CheckpointListener

### DIFF
--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointEvaluationAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointEvaluationAPI.kt
@@ -13,10 +13,10 @@ private class CheckpointEvaluationAPI {
 
     fun checkEvaluation(evaluation: CheckpointEvaluation) {
         when (evaluation) {
-            is CheckpointEvaluation.OfferingReturned -> {
+            is CheckpointEvaluation.MatchedOffering -> {
                 val offering: Offering = evaluation.offering
             }
-            is CheckpointEvaluation.FlowPresented -> {}
+            is CheckpointEvaluation.MatchedUIFlow -> {}
             is CheckpointEvaluation.NoAction -> {
                 val reason: CheckpointResult.NoAction.Reason = evaluation.reason
             }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointEvaluationAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointEvaluationAPI.kt
@@ -4,7 +4,6 @@ package com.revenuecat.apitester.kotlin.revenuecatui
 
 import com.revenuecat.apitester.kotlin.exhaustive
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointEvaluation
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointResult
 
@@ -13,10 +12,7 @@ private class CheckpointEvaluationAPI {
 
     fun checkEvaluation(evaluation: CheckpointEvaluation) {
         when (evaluation) {
-            is CheckpointEvaluation.MatchedOffering -> {
-                val offering: Offering = evaluation.offering
-            }
-            is CheckpointEvaluation.MatchedUIFlow -> {}
+            is CheckpointEvaluation.MatchedFlow -> {}
             is CheckpointEvaluation.NoAction -> {
                 val reason: CheckpointResult.NoAction.Reason = evaluation.reason
             }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointEvaluationAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointEvaluationAPI.kt
@@ -1,0 +1,27 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.apitester.kotlin.revenuecatui
+
+import com.revenuecat.apitester.kotlin.exhaustive
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointEvaluation
+import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointResult
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class CheckpointEvaluationAPI {
+
+    fun checkEvaluation(evaluation: CheckpointEvaluation) {
+        when (evaluation) {
+            is CheckpointEvaluation.OfferingReturned -> {
+                val offering: Offering = evaluation.offering
+            }
+            is CheckpointEvaluation.FlowPresented -> {}
+            is CheckpointEvaluation.NoAction -> {
+                val reason: CheckpointResult.NoAction.Reason = evaluation.reason
+            }
+            // The hierarchy is closed but not sealed, so consumers must handle cases added later.
+            else -> {}
+        }.exhaustive
+    }
+}

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointListenerAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/CheckpointListenerAPI.kt
@@ -6,6 +6,8 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointCompletedContext
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointContext
+import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointEvaluatedContext
+import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointEvaluation
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointHitContext
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointListener
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointResult
@@ -16,6 +18,8 @@ private class CheckpointListenerAPI {
     fun check() {
         val listener = object : CheckpointListener {
             override fun onCheckpointHit(context: CheckpointHitContext) {}
+
+            override fun onCheckpointEvaluated(context: CheckpointEvaluatedContext) {}
 
             override fun onCheckpointCompleted(context: CheckpointCompletedContext) {}
         }
@@ -31,6 +35,11 @@ private class CheckpointListenerAPI {
 
     fun checkCheckpointHitContext(context: CheckpointHitContext) {
         val supertype: CheckpointContext = context
+    }
+
+    fun checkCheckpointEvaluatedContext(context: CheckpointEvaluatedContext) {
+        val supertype: CheckpointContext = context
+        val evaluation: CheckpointEvaluation = context.evaluation
     }
 
     fun checkCheckpointCompletedContext(context: CheckpointCompletedContext) {

--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/checkpoints/CheckpointEventLog.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/checkpoints/CheckpointEventLog.kt
@@ -49,8 +49,8 @@ object CheckpointEventLog : CheckpointListener {
     }
 
     private fun describe(evaluation: CheckpointEvaluation): String = when (evaluation) {
-        is CheckpointEvaluation.OfferingReturned -> "Offering returned (${evaluation.offering.identifier})"
-        CheckpointEvaluation.FlowPresented -> "Flow presented"
+        is CheckpointEvaluation.MatchedOffering -> "Matched offering (${evaluation.offering.identifier})"
+        CheckpointEvaluation.MatchedUIFlow -> "Matched UI flow"
         is CheckpointEvaluation.NoAction -> "No action (${evaluation.reason})"
         else -> "Unknown evaluation"
     }

--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/checkpoints/CheckpointEventLog.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/checkpoints/CheckpointEventLog.kt
@@ -49,8 +49,7 @@ object CheckpointEventLog : CheckpointListener {
     }
 
     private fun describe(evaluation: CheckpointEvaluation): String = when (evaluation) {
-        is CheckpointEvaluation.MatchedOffering -> "Matched offering (${evaluation.offering.identifier})"
-        CheckpointEvaluation.MatchedUIFlow -> "Matched UI flow"
+        CheckpointEvaluation.MatchedFlow -> "Matched flow"
         is CheckpointEvaluation.NoAction -> "No action (${evaluation.reason})"
         else -> "Unknown evaluation"
     }

--- a/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/checkpoints/CheckpointEventLog.kt
+++ b/examples/checkpointtester/src/main/java/com/revenuecat/checkpointtester/checkpoints/CheckpointEventLog.kt
@@ -3,6 +3,8 @@ package com.revenuecat.checkpointtester.checkpoints
 import android.util.Log
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointCompletedContext
+import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointEvaluatedContext
+import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointEvaluation
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointHitContext
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointListener
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointPaywallOutcome
@@ -34,12 +36,23 @@ object CheckpointEventLog : CheckpointListener {
         track("Hit · ${context.identifier} · customVariables=${context.customVariables}")
     }
 
+    override fun onCheckpointEvaluated(context: CheckpointEvaluatedContext) {
+        track("Evaluated · ${context.identifier} · ${describe(context.evaluation)}")
+    }
+
     override fun onCheckpointCompleted(context: CheckpointCompletedContext) {
         track("Completed · ${context.identifier} · ${describe(context.result)}")
     }
 
     fun clear() {
         _events.update { emptyList() }
+    }
+
+    private fun describe(evaluation: CheckpointEvaluation): String = when (evaluation) {
+        is CheckpointEvaluation.OfferingReturned -> "Offering returned (${evaluation.offering.identifier})"
+        CheckpointEvaluation.FlowPresented -> "Flow presented"
+        is CheckpointEvaluation.NoAction -> "No action (${evaluation.reason})"
+        else -> "Unknown evaluation"
     }
 
     private fun describe(result: CheckpointResult): String = when (result) {

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointCompletedContext
+import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointEvaluatedContext
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointHitContext
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.CheckpointListener
 import com.revenuecat.purchases.ui.revenuecatui.checkpoints.checkpointListener
@@ -41,6 +42,10 @@ class MainApplication : Application() {
                     "Checkpoint hit: ${context.identifier}",
                     Toast.LENGTH_SHORT,
                 ).show()
+            }
+
+            override fun onCheckpointEvaluated(context: CheckpointEvaluatedContext) {
+                Log.d(TAG, "CheckpointListener: onCheckpointEvaluated: ${context.evaluation}")
             }
 
             override fun onCheckpointCompleted(context: CheckpointCompletedContext) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointEvaluation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointEvaluation.kt
@@ -13,13 +13,13 @@ public abstract class CheckpointEvaluation internal constructor() {
 
     /** A rule matched and the checkpoint resolved to [offering], which is handed to the app to present. */
     @Poko
-    public class OfferingReturned internal constructor(
+    public class MatchedOffering internal constructor(
         public val offering: Offering,
     ) : CheckpointEvaluation()
 
-    /** A rule matched and a RevenueCat flow is being presented. */
-    public object FlowPresented : CheckpointEvaluation() {
-        override fun toString(): String = "FlowPresented"
+    /** A rule matched and a RevenueCat flow is about to be presented. */
+    public object MatchedUIFlow : CheckpointEvaluation() {
+        override fun toString(): String = "MatchedUIFlow"
     }
 
     /** Nothing is served for this checkpoint; [reason] says why. */

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointEvaluation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointEvaluation.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.checkpoints
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.Offering
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -11,15 +10,9 @@ import dev.drewhamilton.poko.Poko
 @InternalRevenueCatAPI
 public abstract class CheckpointEvaluation internal constructor() {
 
-    /** A rule matched and the checkpoint resolved to [offering], which is handed to the app to present. */
-    @Poko
-    public class MatchedOffering internal constructor(
-        public val offering: Offering,
-    ) : CheckpointEvaluation()
-
-    /** A rule matched and a RevenueCat flow is about to be presented. */
-    public object MatchedUIFlow : CheckpointEvaluation() {
-        override fun toString(): String = "MatchedUIFlow"
+    /** A rule matched and a flow is about to be presented. */
+    public object MatchedFlow : CheckpointEvaluation() {
+        override fun toString(): String = "MatchedFlow"
     }
 
     /** Nothing is served for this checkpoint; [reason] says why. */

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointEvaluation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointEvaluation.kt
@@ -1,0 +1,30 @@
+package com.revenuecat.purchases.ui.revenuecatui.checkpoints
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import dev.drewhamilton.poko.Poko
+
+/**
+ * What a checkpoint evaluated to, delivered to [CheckpointListener.onCheckpointEvaluated] before anything is
+ * presented.
+ */
+@InternalRevenueCatAPI
+public abstract class CheckpointEvaluation internal constructor() {
+
+    /** A rule matched and the checkpoint resolved to [offering], which is handed to the app to present. */
+    @Poko
+    public class OfferingReturned internal constructor(
+        public val offering: Offering,
+    ) : CheckpointEvaluation()
+
+    /** A rule matched and a RevenueCat flow is being presented. */
+    public object FlowPresented : CheckpointEvaluation() {
+        override fun toString(): String = "FlowPresented"
+    }
+
+    /** Nothing is served for this checkpoint; [reason] says why. */
+    @Poko
+    public class NoAction internal constructor(
+        public val reason: CheckpointResult.NoAction.Reason,
+    ) : CheckpointEvaluation()
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointListener.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointListener.kt
@@ -28,6 +28,18 @@ public class CheckpointHitContext internal constructor(
 ) : CheckpointContext()
 
 /**
+ * Context delivered to [CheckpointListener.onCheckpointEvaluated].
+ */
+@InternalRevenueCatAPI
+@Poko
+public class CheckpointEvaluatedContext internal constructor(
+    override val identifier: String,
+    override val customVariables: Map<String, CustomVariableValue>,
+    /** What the checkpoint evaluated to. */
+    public val evaluation: CheckpointEvaluation,
+) : CheckpointContext()
+
+/**
  * Context delivered to [CheckpointListener.onCheckpointCompleted].
  */
 @InternalRevenueCatAPI
@@ -49,6 +61,11 @@ public interface CheckpointListener {
 
     /** A checkpoint was hit, before evaluation. */
     public fun onCheckpointHit(context: CheckpointHitContext) {
+        // Default empty implementation
+    }
+
+    /** The checkpoint's rules were evaluated; fired before anything is presented. */
+    public fun onCheckpointEvaluated(context: CheckpointEvaluatedContext) {
         // Default empty implementation
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
@@ -41,7 +41,10 @@ internal class CheckpointRun(
             )
             // The hierarchy is closed but not sealed; an evaluation this code doesn't know is treated as nothing
             // served rather than as a presented flow.
-            else -> CheckpointResult.NoAction(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+            else -> {
+                Logger.e("Unknown checkpoint evaluation '$evaluation'; treating it as nothing served.")
+                CheckpointResult.NoAction(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
+            }
         }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.checkpoints
 
+import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -25,20 +26,22 @@ internal class CheckpointPresentation(
 /**
  * What a checkpoint run produced: its [evaluation], the terminal [flowOutcome] of whatever it presented (null when
  * nothing was), and [backedOut], true when the presented flow went away because the user navigated back (system
- * back, or a navigate-back action on a workflow's first step) without purchasing or restoring.
+ * back, or a navigate-back action on a workflow's first step) without purchasing or restoring. [offering] is the
+ * offering handed to the app when the checkpoint resolved to one instead of presenting a flow.
  */
 internal class CheckpointRun(
     val evaluation: CheckpointEvaluation,
     val flowOutcome: CheckpointPaywallOutcome?,
     val backedOut: Boolean,
+    val offering: Offering? = null,
 ) {
     val result: CheckpointResult
         get() = when (evaluation) {
-            is CheckpointEvaluation.MatchedOffering -> CheckpointResult.ReceivedOffering(evaluation.offering)
             is CheckpointEvaluation.NoAction -> CheckpointResult.NoAction(evaluation.reason)
-            is CheckpointEvaluation.MatchedUIFlow -> CheckpointResult.PaywallPresented(
-                requireNotNull(flowOutcome) { "A presented flow always ends with an outcome." },
-            )
+            is CheckpointEvaluation.MatchedFlow -> offering?.let { CheckpointResult.ReceivedOffering(it) }
+                ?: CheckpointResult.PaywallPresented(
+                    requireNotNull(flowOutcome) { "A presented flow always ends with an outcome." },
+                )
             // The hierarchy is closed but not sealed; an evaluation this code doesn't know is treated as nothing
             // served rather than as a presented flow.
             else -> {
@@ -120,14 +123,16 @@ internal class CheckpointsManager(
                 customVariables.mapValues { (_, value) -> value.asRulesDimensionValue },
             )
             val evaluation = when (resolution) {
-                is CheckpointResolution.MatchedOffering -> CheckpointEvaluation.MatchedOffering(resolution.offering)
-                is CheckpointResolution.MatchedWorkflow -> CheckpointEvaluation.MatchedUIFlow
+                is CheckpointResolution.MatchedOffering, is CheckpointResolution.MatchedWorkflow ->
+                    CheckpointEvaluation.MatchedFlow
                 is CheckpointResolution.NoAction -> CheckpointEvaluation.NoAction(resolution.reason.toResultReason())
             }
             notifyEvaluated(identifier, customVariables, evaluation)
             when (resolution) {
                 is CheckpointResolution.MatchedWorkflow -> present(purchases, evaluation, resolution, customVariables)
-                else -> CheckpointRun(evaluation, flowOutcome = null, backedOut = false)
+                is CheckpointResolution.MatchedOffering ->
+                    CheckpointRun(evaluation, flowOutcome = null, backedOut = false, offering = resolution.offering)
+                is CheckpointResolution.NoAction -> CheckpointRun(evaluation, flowOutcome = null, backedOut = false)
             }
         }
         checkpointListener?.onCheckpointCompleted(CheckpointCompletedContext(identifier, customVariables, run.result))

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
@@ -23,10 +23,24 @@ internal class CheckpointPresentation(
 )
 
 /**
- * [backedOut] is true when a presented paywall went away because the user navigated back (system back,
- * or a navigate-back action on a workflow's first step) without purchasing or restoring.
+ * What a checkpoint run produced: its [evaluation], the terminal [flowOutcome] of whatever it presented (null when
+ * nothing was), and [backedOut], true when the presented flow went away because the user navigated back (system
+ * back, or a navigate-back action on a workflow's first step) without purchasing or restoring.
  */
-internal class CheckpointRun(val result: CheckpointResult, val backedOut: Boolean)
+internal class CheckpointRun(
+    val evaluation: CheckpointEvaluation,
+    val flowOutcome: CheckpointPaywallOutcome?,
+    val backedOut: Boolean,
+) {
+    val result: CheckpointResult
+        get() = when (evaluation) {
+            is CheckpointEvaluation.OfferingReturned -> CheckpointResult.ReceivedOffering(evaluation.offering)
+            is CheckpointEvaluation.NoAction -> CheckpointResult.NoAction(evaluation.reason)
+            else -> CheckpointResult.PaywallPresented(
+                requireNotNull(flowOutcome) { "A presented flow always ends with an outcome." },
+            )
+        }
+}
 
 /**
  * Runs a checkpoint hit end to end: fires listener events, asks the core module what the checkpoint resolves
@@ -48,9 +62,10 @@ internal class CheckpointsManager(
 
     private class PendingCall(
         val callId: String,
+        val evaluation: CheckpointEvaluation,
         val resolution: CheckpointResolution.MatchedWorkflow,
         val customVariables: Map<String, CustomVariableValue>,
-        val paywallFinished: CompletableDeferred<PresentationEnd>,
+        val flowFinished: CompletableDeferred<CheckpointRun>,
     ) {
         // Null until the paywall reports something; kept on the call rather than the presented window so
         // losing the window (configuration change) doesn't reset it.
@@ -59,8 +74,6 @@ internal class CheckpointsManager(
         // Only used to take an orphaned workflow window down when its call is abandoned.
         var presenter: CheckpointWorkflowPresenter? = null
     }
-
-    private class PresentationEnd(val outcome: CheckpointPaywallOutcome, val backedOut: Boolean)
 
     @get:Synchronized
     @set:Synchronized
@@ -89,29 +102,38 @@ internal class CheckpointsManager(
     ): CheckpointRun = withContext(Dispatchers.Main) {
         val customVariables = (params ?: CheckpointParams {}).customVariables
         checkpointListener?.onCheckpointHit(CheckpointHitContext(identifier, customVariables))
-        if (!CheckpointIdentifierValidator.isValid(identifier)) {
+        val run = if (!CheckpointIdentifierValidator.isValid(identifier)) {
             Logger.e(CheckpointIdentifierValidator.invalidIdentifierLogMessage(identifier))
-            val result = CheckpointResult.NoAction(CheckpointResult.NoAction.Reason.INVALID_CHECKPOINT_IDENTIFIER)
-            checkpointListener?.onCheckpointCompleted(CheckpointCompletedContext(identifier, customVariables, result))
-            return@withContext CheckpointRun(result, backedOut = false)
-        }
-
-        val resolution = purchases.resolveCheckpoint(
-            identifier,
-            customVariables.mapValues { (_, value) -> value.asRulesDimensionValue },
-        )
-        val run = when (resolution) {
-            is CheckpointResolution.MatchedOffering ->
-                CheckpointRun(CheckpointResult.ReceivedOffering(resolution.offering), backedOut = false)
-            is CheckpointResolution.MatchedWorkflow -> {
-                val end = present(purchases, resolution, customVariables)
-                CheckpointRun(CheckpointResult.PaywallPresented(end.outcome), end.backedOut)
+            val evaluation =
+                CheckpointEvaluation.NoAction(CheckpointResult.NoAction.Reason.INVALID_CHECKPOINT_IDENTIFIER)
+            notifyEvaluated(identifier, customVariables, evaluation)
+            CheckpointRun(evaluation, flowOutcome = null, backedOut = false)
+        } else {
+            val resolution = purchases.resolveCheckpoint(
+                identifier,
+                customVariables.mapValues { (_, value) -> value.asRulesDimensionValue },
+            )
+            val evaluation = when (resolution) {
+                is CheckpointResolution.MatchedOffering -> CheckpointEvaluation.OfferingReturned(resolution.offering)
+                is CheckpointResolution.MatchedWorkflow -> CheckpointEvaluation.FlowPresented
+                is CheckpointResolution.NoAction -> CheckpointEvaluation.NoAction(resolution.reason.toResultReason())
             }
-            is CheckpointResolution.NoAction ->
-                CheckpointRun(CheckpointResult.NoAction(resolution.reason.toResultReason()), backedOut = false)
+            notifyEvaluated(identifier, customVariables, evaluation)
+            when (resolution) {
+                is CheckpointResolution.MatchedWorkflow -> present(purchases, evaluation, resolution, customVariables)
+                else -> CheckpointRun(evaluation, flowOutcome = null, backedOut = false)
+            }
         }
         checkpointListener?.onCheckpointCompleted(CheckpointCompletedContext(identifier, customVariables, run.result))
         run
+    }
+
+    private fun notifyEvaluated(
+        identifier: String,
+        customVariables: Map<String, CustomVariableValue>,
+        evaluation: CheckpointEvaluation,
+    ) {
+        checkpointListener?.onCheckpointEvaluated(CheckpointEvaluatedContext(identifier, customVariables, evaluation))
     }
 
     fun presentation(callId: String): CheckpointPresentation? =
@@ -128,8 +150,12 @@ internal class CheckpointsManager(
         val finished = take(callId) ?: return
         val recorded = finished.outcome
         val obtained = recorded is CheckpointPaywallOutcome.Purchased || recorded is CheckpointPaywallOutcome.Restored
-        finished.paywallFinished.complete(
-            PresentationEnd(recorded ?: CheckpointPaywallOutcome.Dismissed, backedOut = navigatedBack && !obtained),
+        finished.flowFinished.complete(
+            CheckpointRun(
+                finished.evaluation,
+                recorded ?: CheckpointPaywallOutcome.Dismissed,
+                backedOut = navigatedBack && !obtained,
+            ),
         )
     }
 
@@ -138,21 +164,32 @@ internal class CheckpointsManager(
     // reporting anything surfaces as an error rather than a phantom dismissal.
     fun onPresentationFailed(callId: String, error: PurchasesError) {
         val failed = take(callId) ?: return
-        failed.paywallFinished.complete(
-            PresentationEnd(failed.outcome ?: CheckpointPaywallOutcome.Error(error), backedOut = false),
+        failed.flowFinished.complete(
+            CheckpointRun(
+                failed.evaluation,
+                failed.outcome ?: CheckpointPaywallOutcome.Error(error),
+                backedOut = false,
+            ),
         )
     }
 
     private suspend fun present(
         purchases: Purchases,
+        evaluation: CheckpointEvaluation,
         resolution: CheckpointResolution.MatchedWorkflow,
         customVariables: Map<String, CustomVariableValue>,
-    ): PresentationEnd {
+    ): CheckpointRun {
         val activity = purchases.currentActivity ?: presentationError(
             PurchasesErrorCode.ConfigurationError,
             "Cannot present checkpoint workflow: no started Activity found.",
         )
-        val call = PendingCall(UUID.randomUUID().toString(), resolution, customVariables, CompletableDeferred())
+        val call = PendingCall(
+            UUID.randomUUID().toString(),
+            evaluation,
+            resolution,
+            customVariables,
+            CompletableDeferred(),
+        )
         val claimed = synchronized(this) { (pendingCall == null).also { if (it) pendingCall = call } }
         if (!claimed) {
             presentationError(
@@ -164,7 +201,7 @@ internal class CheckpointsManager(
             val presenter = presenterFactory(call.callId, this)
             withPendingCall(call.callId) { it.presenter = presenter }
             presenter.show(activity)
-            return call.paywallFinished.await()
+            return call.flowFinished.await()
         } catch (e: CancellationException) {
             abandon(call.callId)
             throw e

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
@@ -34,7 +34,7 @@ internal class CheckpointRun(
 ) {
     val result: CheckpointResult
         get() = when (evaluation) {
-            is CheckpointEvaluation.OfferingReturned -> CheckpointResult.ReceivedOffering(evaluation.offering)
+            is CheckpointEvaluation.MatchedOffering -> CheckpointResult.ReceivedOffering(evaluation.offering)
             is CheckpointEvaluation.NoAction -> CheckpointResult.NoAction(evaluation.reason)
             else -> CheckpointResult.PaywallPresented(
                 requireNotNull(flowOutcome) { "A presented flow always ends with an outcome." },
@@ -114,8 +114,8 @@ internal class CheckpointsManager(
                 customVariables.mapValues { (_, value) -> value.asRulesDimensionValue },
             )
             val evaluation = when (resolution) {
-                is CheckpointResolution.MatchedOffering -> CheckpointEvaluation.OfferingReturned(resolution.offering)
-                is CheckpointResolution.MatchedWorkflow -> CheckpointEvaluation.FlowPresented
+                is CheckpointResolution.MatchedOffering -> CheckpointEvaluation.MatchedOffering(resolution.offering)
+                is CheckpointResolution.MatchedWorkflow -> CheckpointEvaluation.MatchedUIFlow
                 is CheckpointResolution.NoAction -> CheckpointEvaluation.NoAction(resolution.reason.toResultReason())
             }
             notifyEvaluated(identifier, customVariables, evaluation)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManager.kt
@@ -36,9 +36,12 @@ internal class CheckpointRun(
         get() = when (evaluation) {
             is CheckpointEvaluation.MatchedOffering -> CheckpointResult.ReceivedOffering(evaluation.offering)
             is CheckpointEvaluation.NoAction -> CheckpointResult.NoAction(evaluation.reason)
-            else -> CheckpointResult.PaywallPresented(
+            is CheckpointEvaluation.MatchedUIFlow -> CheckpointResult.PaywallPresented(
                 requireNotNull(flowOutcome) { "A presented flow always ends with an outcome." },
             )
+            // The hierarchy is closed but not sealed; an evaluation this code doesn't know is treated as nothing
+            // served rather than as a presented flow.
+            else -> CheckpointResult.NoAction(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE)
         }
 }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
@@ -538,6 +538,14 @@ class CheckpointsManagerTest {
     }
 
     @Test
+    fun `an unknown evaluation resolves to a configuration-unavailable no action`() {
+        val run = CheckpointRun(object : CheckpointEvaluation() {}, flowOutcome = null, backedOut = false)
+
+        assertThat(run.result)
+            .isEqualTo(CheckpointResult.NoAction(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE))
+    }
+
+    @Test
     fun `checkpoint works without a listener`() = runTest(dispatcher) {
         manager.checkpointListener = null
         resolvesTo(CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.NO_MATCH))

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
@@ -128,7 +128,7 @@ class CheckpointsManagerTest {
 
         verify(exactly = 1) {
             mockListener.onCheckpointEvaluated(
-                CheckpointEvaluatedContext(checkpointId, emptyMap(), CheckpointEvaluation.FlowPresented),
+                CheckpointEvaluatedContext(checkpointId, emptyMap(), CheckpointEvaluation.MatchedUIFlow),
             )
         }
         verify(exactly = 0) { mockListener.onCheckpointCompleted(any()) }
@@ -148,7 +148,7 @@ class CheckpointsManagerTest {
         verifyOrder {
             mockListener.onCheckpointHit(CheckpointHitContext(checkpointId, emptyMap()))
             mockListener.onCheckpointEvaluated(
-                CheckpointEvaluatedContext(checkpointId, emptyMap(), CheckpointEvaluation.OfferingReturned(offering)),
+                CheckpointEvaluatedContext(checkpointId, emptyMap(), CheckpointEvaluation.MatchedOffering(offering)),
             )
             mockListener.onCheckpointCompleted(any())
         }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
@@ -141,7 +141,7 @@ class CheckpointsManagerTest {
     @Test
     fun `a matched offering is reported as evaluated as a matched flow`() = runTest(dispatcher) {
         val offering = mockk<Offering>()
-        resolvesTo(CheckpointResolution.MatchedOffering(offering))
+        resolvesTo(CheckpointResolution.MatchedOffering(offering, checkpointRuleId = null))
 
         checkpoint()
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
@@ -538,11 +538,12 @@ class CheckpointsManagerTest {
     }
 
     @Test
-    fun `an unknown evaluation resolves to a configuration-unavailable no action`() {
+    fun `an unknown evaluation resolves to a configuration-unavailable no action and logs an error`() {
         val run = CheckpointRun(object : CheckpointEvaluation() {}, flowOutcome = null, backedOut = false)
 
         assertThat(run.result)
             .isEqualTo(CheckpointResult.NoAction(CheckpointResult.NoAction.Reason.CONFIGURATION_UNAVAILABLE))
+        verify(exactly = 1) { Logger.e(match { it.startsWith("Unknown checkpoint evaluation") }) }
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
@@ -122,6 +122,65 @@ class CheckpointsManagerTest {
     }
 
     @Test
+    fun `a matched workflow is reported as evaluated before its paywall finishes`() = runTest(dispatcher) {
+        resolvesToWorkflow()
+        val call = launch { checkpoint() }
+
+        verify(exactly = 1) {
+            mockListener.onCheckpointEvaluated(
+                CheckpointEvaluatedContext(checkpointId, emptyMap(), CheckpointEvaluation.FlowPresented),
+            )
+        }
+        verify(exactly = 0) { mockListener.onCheckpointCompleted(any()) }
+
+        finishPaywall(CheckpointPaywallOutcome.Dismissed)
+        call.join()
+        verify(exactly = 1) { mockListener.onCheckpointCompleted(any()) }
+    }
+
+    @Test
+    fun `a matched offering is reported as evaluated with the offering`() = runTest(dispatcher) {
+        val offering = mockk<Offering>()
+        resolvesTo(CheckpointResolution.MatchedOffering(offering))
+
+        checkpoint()
+
+        verifyOrder {
+            mockListener.onCheckpointHit(CheckpointHitContext(checkpointId, emptyMap()))
+            mockListener.onCheckpointEvaluated(
+                CheckpointEvaluatedContext(checkpointId, emptyMap(), CheckpointEvaluation.OfferingReturned(offering)),
+            )
+            mockListener.onCheckpointCompleted(any())
+        }
+    }
+
+    @Test
+    fun `no action and an invalid identifier are reported as evaluated with their reason`() = runTest(dispatcher) {
+        resolvesTo(CheckpointResolution.NoAction(CheckpointResolution.NoAction.Reason.UNKNOWN_CHECKPOINT))
+        checkpoint()
+        manager.checkpoint(mockPurchases, " bad", null)
+
+        verify(exactly = 1) {
+            mockListener.onCheckpointEvaluated(
+                CheckpointEvaluatedContext(
+                    checkpointId,
+                    emptyMap(),
+                    CheckpointEvaluation.NoAction(CheckpointResult.NoAction.Reason.UNKNOWN_CHECKPOINT),
+                ),
+            )
+        }
+        verify(exactly = 1) {
+            mockListener.onCheckpointEvaluated(
+                CheckpointEvaluatedContext(
+                    " bad",
+                    emptyMap(),
+                    CheckpointEvaluation.NoAction(CheckpointResult.NoAction.Reason.INVALID_CHECKPOINT_IDENTIFIER),
+                ),
+            )
+        }
+    }
+
+    @Test
     fun `offering checkpoint returns without an activity or presentation`() = runTest(dispatcher) {
         val offering = mockk<Offering>()
         every { mockPurchases.currentActivity } returns null

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointsManagerTest.kt
@@ -128,7 +128,7 @@ class CheckpointsManagerTest {
 
         verify(exactly = 1) {
             mockListener.onCheckpointEvaluated(
-                CheckpointEvaluatedContext(checkpointId, emptyMap(), CheckpointEvaluation.MatchedUIFlow),
+                CheckpointEvaluatedContext(checkpointId, emptyMap(), CheckpointEvaluation.MatchedFlow),
             )
         }
         verify(exactly = 0) { mockListener.onCheckpointCompleted(any()) }
@@ -139,7 +139,7 @@ class CheckpointsManagerTest {
     }
 
     @Test
-    fun `a matched offering is reported as evaluated with the offering`() = runTest(dispatcher) {
+    fun `a matched offering is reported as evaluated as a matched flow`() = runTest(dispatcher) {
         val offering = mockk<Offering>()
         resolvesTo(CheckpointResolution.MatchedOffering(offering))
 
@@ -148,7 +148,7 @@ class CheckpointsManagerTest {
         verifyOrder {
             mockListener.onCheckpointHit(CheckpointHitContext(checkpointId, emptyMap()))
             mockListener.onCheckpointEvaluated(
-                CheckpointEvaluatedContext(checkpointId, emptyMap(), CheckpointEvaluation.MatchedOffering(offering)),
+                CheckpointEvaluatedContext(checkpointId, emptyMap(), CheckpointEvaluation.MatchedFlow),
             )
             mockListener.onCheckpointCompleted(any())
         }


### PR DESCRIPTION
### Description

`CheckpointListener` has a new `CheckpointListener.onCheckpointEvaluated(CheckpointEvaluatedContext)`, fired right after the rules are evaluated and before anything is presented, with a `CheckpointEvaluation`:
  - `MatchedFlow`: a rule matched and a flow is about to be presented (whether the offering is handed to the app or a RevenueCat flow is shown);
  - `NoAction(reason)`: nothing is served, and why (same `Reason` constants the result uses).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint lifecycle ordering and internal result assembly in `CheckpointsManager`, but the public listener API is additive with default no-op methods under `@InternalRevenueCatAPI`.
> 
> **Overview**
> Adds a **pre-presentation** checkpoint callback so apps can observe rule evaluation separately from the final result.
> 
> `CheckpointListener` gains **`onCheckpointEvaluated`** with **`CheckpointEvaluatedContext`**, carrying a new **`CheckpointEvaluation`** (`MatchedFlow` when a rule matched and something is about to be served, or `NoAction(reason)` when nothing will be). **`CheckpointsManager`** now maps core resolution (including invalid identifiers) to that evaluation, fires **hit → evaluated → completed** in order, and refactors internal **`CheckpointRun`** to store evaluation plus optional offering/flow outcome and derive **`CheckpointResult`** from them (unknown evaluation types fall back to configuration-unavailable no-action with a log).
> 
> API tester coverage, sample apps, and manager tests are updated for the new callback and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f68a8dd3c316a0fd8ab65755c6933889e7606798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->