### PR TITLE
docs(admob): consolidate next-gen adapter guide

### DIFF
--- a/examples/admob-next-gen-sample/README.md
+++ b/examples/admob-next-gen-sample/README.md
@@ -1,7 +1,7 @@
 # AdMob Next-Gen sample
 
 This app demonstrates RevenueCat ad-event tracking with the Google Mobile Ads Next-Gen SDK. See the
-[adapter README](../../feature/admob-next-gen/README.md) for installation instructions and complete API examples.
+[adapter README](../../feature/admob-next-gen/README.md) for installation instructions and the complete API guide.
 
 ## Run locally
 

--- a/feature/admob-next-gen/README.md
+++ b/feature/admob-next-gen/README.md
@@ -20,9 +20,9 @@ direct loading, preloading, placement overrides, native batch loading, and rewar
 - [Installation](#installation)
 - [Initialize Google Mobile Ads Next-Gen](#initialize-google-mobile-ads-next-gen)
 - [Events tracked](#events-tracked)
+- [Usage](#usage)
 - [Placement](#placement)
 - [Callback handling](#callback-handling)
-- [Usage](#usage)
 - [Further guides](#further-guides)
 
 ## Requirements
@@ -133,49 +133,6 @@ no creative was served.
 
 Network and impression ID are read when each callback fires. This ensures that an auto-refreshing banner attributes
 events to the creative currently on screen rather than the first one loaded.
-
-## Placement
-
-Every tracking helper accepts an optional `placement` that identifies the logical location of an ad in your app, such
-as `"home_banner"`, `"app_start"`, or `"level_complete_reward"`. Use stable names so events from the same slot can
-be grouped together in RevenueCat.
-
-Placement ownership depends on the loading stage:
-
-| Stage | Placement applies to |
-| --- | --- |
-| Direct load | Load success or failure and, by default, the ad's later lifecycle events |
-| `startAndTrack` | Preload success or failure only |
-| `pollAndTrackAd` | The polled ad's display, click, revenue, and banner-refresh events |
-| Tracked `show(activity, placement, ...)` | Overrides the polled or load-time placement for full-screen lifecycle events |
-
-The placements passed to `startAndTrack` and `pollAndTrackAd` are independent. Polling does not emit another loaded
-event. Calling Google's regular `show` retains the load-time or poll-time placement; passing a placement to the
-adapter's tracked `show` overload replaces it. Passing `null` explicitly clears it.
-
-Banner and native ads do not have a placement-aware `show` call. They keep the placement supplied when loaded or
-polled for their complete lifecycle, including banner refreshes.
-
-## Callback handling
-
-The adapter installs tracking wrappers before returning a loaded or polled ad. Pass your event callbacks to the
-RevenueCat load or poll helper instead of assigning the ad's callback property afterward. Direct assignment replaces
-the tracking wrapper.
-
-Every supported ad type exposes the same tracking-safe event callback setter:
-
-```kotlin
-ad.setTrackingAdEventCallback(adEventCallback)
-```
-
-Banners also expose `setTrackingBannerAdRefreshCallback` for their refresh callback.
-
-All Google callbacks are forwarded after RevenueCat performs its own tracking. Forwarding still occurs if RevenueCat
-is not configured or tracking fails.
-
-Google Mobile Ads Next-Gen can invoke load and event callbacks on a background thread. Dispatch to the main thread
-before updating views or other UI-confined state. RevenueCat's `rewardVerificationStarted` and
-`rewardVerificationCompleted` callbacks are delivered on the main thread.
 
 ## Usage
 
@@ -558,6 +515,49 @@ Purchases.sharedInstance.adTracker.loadAndTrackNativeAd(
 A `NativeAdRequest` can combine standard native, custom-native, and banner inventory. RevenueCat tracks each result
 using its actual format and installs the corresponding event wrapper before forwarding it. Use
 `nativeAdEventCallback` for native and custom-native results and `bannerAdEventCallback` for banner results.
+
+## Placement
+
+Every tracking helper accepts an optional `placement` that identifies the logical location of an ad in your app, such
+as `"home_banner"`, `"app_start"`, or `"level_complete_reward"`. Use stable names so events from the same slot can
+be grouped together in RevenueCat.
+
+Placement ownership depends on the loading stage:
+
+| Stage | Placement applies to |
+| --- | --- |
+| Direct load | Load success or failure and, by default, the ad's later lifecycle events |
+| `startAndTrack` | Preload success or failure only |
+| `pollAndTrackAd` | The polled ad's display, click, revenue, and banner-refresh events |
+| Tracked `show(activity, placement, ...)` | Overrides the polled or load-time placement for full-screen lifecycle events |
+
+The placements passed to `startAndTrack` and `pollAndTrackAd` are independent. Polling does not emit another loaded
+event. Calling Google's regular `show` retains the load-time or poll-time placement; passing a placement to the
+adapter's tracked `show` overload replaces it. Passing `null` explicitly clears it.
+
+Banner and native ads do not have a placement-aware `show` call. They keep the placement supplied when loaded or
+polled for their complete lifecycle, including banner refreshes.
+
+## Callback handling
+
+The adapter installs tracking wrappers before returning a loaded or polled ad. Pass your event callbacks to the
+RevenueCat load or poll helper instead of assigning the ad's callback property afterward. Direct assignment replaces
+the tracking wrapper.
+
+Every supported ad type exposes the same tracking-safe event callback setter:
+
+```kotlin
+ad.setTrackingAdEventCallback(adEventCallback)
+```
+
+Banners also expose `setTrackingBannerAdRefreshCallback` for their refresh callback.
+
+All Google callbacks are forwarded after RevenueCat performs its own tracking. Forwarding still occurs if RevenueCat
+is not configured or tracking fails.
+
+Google Mobile Ads Next-Gen can invoke load and event callbacks on a background thread. Dispatch to the main thread
+before updating views or other UI-confined state. RevenueCat's `rewardVerificationStarted` and
+`rewardVerificationCompleted` callbacks are delivered on the main thread.
 
 ## Further guides
 

--- a/feature/admob-next-gen/README.md
+++ b/feature/admob-next-gen/README.md
@@ -3,13 +3,27 @@
 The `purchases-admob-next-gen` module integrates RevenueCat with the
 [Google Mobile Ads Next-Gen SDK](https://developers.google.com/admob/android/next-gen/quick-start).
 
-See the [AdMob Next-Gen sample](../../examples/admob-next-gen-sample/README.md) for a runnable Compose app that
-demonstrates direct loading and preloading for every supported format, plus placement overrides and reward
-verification.
+**Kotlin only.** The load-and-track helpers are not available from Java. Java apps can still use the core
+[`AdTracker`](https://revenuecat.github.io/purchases-android/docs/core/com.revenuecat.purchases.ads.events/-ad-tracker/index.html)
+APIs directly.
+
+See the [AdMob Next-Gen sample](../../examples/admob-next-gen-sample/README.md) for a runnable Compose app covering
+direct loading, preloading, placement overrides, native batch loading, and reward verification.
 
 > [!IMPORTANT]
-> `purchases-admob-next-gen` and the legacy `purchases-admob` adapter are mutually exclusive.
-> Remove the legacy adapter and `com.google.android.gms:play-services-ads` before adding this module.
+> `purchases-admob-next-gen` and the legacy `purchases-admob` adapter are mutually exclusive. Remove the legacy
+> adapter and `com.google.android.gms:play-services-ads` before adding this module.
+
+## Contents
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Initialize Google Mobile Ads Next-Gen](#initialize-google-mobile-ads-next-gen)
+- [Events tracked](#events-tracked)
+- [Placement](#placement)
+- [Callback handling](#callback-handling)
+- [Usage](#usage)
+- [Further guides](#further-guides)
 
 ## Requirements
 
@@ -69,83 +83,10 @@ See Google's
 [migration guide](https://developers.google.com/admob/android/next-gen/migration)
 for additional mediation-specific requirements.
 
-## Migrate from the legacy adapter
-
-`purchases-admob-next-gen` is not a drop-in binary replacement for `purchases-admob`. Migrate the underlying Google
-Mobile Ads SDK and the RevenueCat adapter together. Before starting, confirm that your app meets the requirements
-above and review Google's migration guide, especially if you use mediation.
-
-### Replace the dependencies
-
-Remove both legacy artifacts and add their Next-Gen replacements. Do not keep both SDK generations in the same app:
-
-```kotlin
-dependencies {
-    // Remove these legacy dependencies:
-    // implementation("com.revenuecat.purchases:purchases-admob:$revenueCatVersion")
-    // implementation("com.google.android.gms:play-services-ads:<version>")
-
-    implementation("com.revenuecat.purchases:purchases-admob-next-gen:$revenueCatVersion")
-    implementation("com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.3.0")
-}
-```
-
-If mediation adapters pull either legacy Google artifact back into the dependency graph, add the global exclusions
-shown in [Installation](#installation).
-
-### Update imports and initialization
-
-Update RevenueCat adapter imports from `com.revenuecat.purchases.admob` to
-`com.revenuecat.purchases.admob.nextgen`. Google Mobile Ads types move from `com.google.android.gms.ads` to
-`com.google.android.libraries.ads.mobile.sdk`; most requests, ads, and callbacks also use new Next-Gen types rather
-than direct equivalents of the legacy classes.
-
-Initialization is required before loading ads or calling other `MobileAds` APIs. Pass the AdMob app ID through
-`InitializationConfig`, initialize on a background thread, and wait for the callback before loading ads when your
-mediation setup requires every adapter to be ready. See [Initialize Google Mobile Ads Next-Gen](#initialize-google-mobile-ads-next-gen).
-
-### Update RevenueCat tracking calls
-
-Most RevenueCat helper names remain the same, but their Google SDK parameters change:
-
-| Format | Legacy adapter | Next-Gen adapter |
-| ------ | -------------- | ---------------- |
-| Banner | `AdView.loadAndTrackAd(AdRequest, ...)` | `AdView.loadAndTrackAd(BannerAdRequest, ...)` |
-| App open | `AdTracker.loadAndTrackAppOpenAd(...)` | `AdTracker.loadAndTrackAppOpenAd(...)` |
-| Interstitial | `AdTracker.loadAndTrackInterstitialAd(...)` | `AdTracker.loadAndTrackInterstitialAd(...)` |
-| Rewarded | `AdTracker.loadAndTrackRewardedAd(...)` | `AdTracker.loadAndTrackRewardedAd(...)` |
-| Rewarded interstitial | `AdTracker.loadAndTrackRewardedInterstitialAd(...)` | `AdTracker.loadAndTrackRewardedInterstitialAd(...)` |
-| Native | `AdLoader.Builder.forNativeAdWithTracking(...)` | `AdTracker.loadAndTrackNativeAd(...)` or `loadAndTrackNativeAds(...)` |
-
-`BannerAdRequest` is a Next-Gen subclass of `AdRequest` that includes banner-specific configuration. Its builder
-requires the ad unit ID and an `AdSize` (or list of sizes). In the legacy SDK those values were configured directly
-on `AdView`, which then loaded a generic `AdRequest`; Next-Gen `AdView.loadAd` receives the complete
-`BannerAdRequest` instead.
-
-For full-screen formats, build the ad unit ID into the Next-Gen `AdRequest` instead of passing `context` and
-`adUnitId` separately. Replace format-specific legacy load callbacks with `AdLoadCallback<AdType>`, and replace
-`FullScreenContentCallback` plus `OnPaidEventListener` with the corresponding format event callback, such as
-`InterstitialAdEventCallback` or `RewardedAdEventCallback`. Banner and native formats have their own event callback
-types, described in the examples below.
-
-The `enableRewardVerification` and verification-aware `show` helper names are unchanged; update their imports and ad
-types to the Next-Gen packages. Keep existing RevenueCat `placement` values when they represent the same ad slots so
-reporting remains consistent across the migration.
-
-### Review callback handling
-
-Google Mobile Ads Next-Gen invokes load and event callbacks on a background thread. Dispatch to the main thread
-before updating views or other UI-confined state.
-
-Pass event callbacks to the RevenueCat load helper. Assigning a loaded ad's callback property directly replaces the
-tracking wrapper. If a callback must change after loading, use the format's `setTrackingAdEventCallback` helper (and
-`setTrackingBannerAdRefreshCallback` for banners). Test every migrated format—including load failure, display,
-click, revenue, and reward delivery—before removing the legacy implementation.
-
 ## Initialize Google Mobile Ads Next-Gen
 
-Google Mobile Ads Next-Gen must be initialized before loading ads or calling other `MobileAds` APIs. Initialize it
-once, ideally at app launch, on a background thread:
+Initialize Google Mobile Ads once before loading ads or calling other `MobileAds` APIs. Initialization should run on
+a background thread:
 
 ```kotlin
 import android.app.Application
@@ -175,716 +116,71 @@ If you use mediation, wait for the initialization callback before loading ads so
 Configure consent and any request-specific privacy flags before initialization because the SDK or a mediation partner
 may preload ads during initialization.
 
-## Preloading placement
-
-Preloading has two separate tracking stages. The optional placement passed to `startAndTrack` applies to preload
-success and failure events. The optional placement passed to `pollAndTrackAd` is independent and applies to the
-ad's later display, click, revenue, and banner-refresh events.
-
-## Preloading
-
-The adapter supports Google's app-open, banner, interstitial, native, rewarded, and rewarded-interstitial
-preloaders. Swipeable interstitial ads are not yet supported by this integration.
-
-### App-open ads
-
-```kotlin
-val appOpenPreloadConfiguration = PreloadConfiguration(
-    request = AppOpenAdRequest.Builder("AD_UNIT_ID").build(),
-    bufferSize = 2,
-)
-
-AppOpenAdPreloader.startAndTrack(
-    preloadId = "app-open-buffer",
-    preloadConfiguration = appOpenPreloadConfiguration,
-    placement = "app_open_preload",
-)
-
-// Later, adopt a buffered app-open ad. This does not emit another loaded event.
-appOpenAd = AppOpenAdPreloader.pollAndTrackAd(
-    preloadId = "app-open-buffer",
-    placement = "app_open",
-    adEventCallback = appOpenAdEventCallback,
-)
-
-appOpenAd?.show(this)
-```
-
-### Banner ads
-
-```kotlin
-val bannerPreloadConfiguration = PreloadConfiguration(
-    request = BannerAdRequest.Builder(
-        "AD_UNIT_ID",
-        AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(this, 360),
-    ).build(),
-    bufferSize = 2,
-)
-
-BannerAdPreloader.startAndTrack(
-    preloadId = "home-banner-buffer",
-    preloadConfiguration = bannerPreloadConfiguration,
-    placement = "home_banner_preload",
-    preloadCallback = object : PreloadCallback {
-        override fun onAdsExhausted(preloadId: String) {
-            // The buffer is empty. This callback is forwarded but is not a RevenueCat ad event.
-        }
-    },
-)
-
-// Later, adopt a buffered banner. This does not emit another loaded event.
-val bannerAd = BannerAdPreloader.pollAndTrackAd(
-    preloadId = "home-banner-buffer",
-    placement = "home_banner",
-    adEventCallback = bannerAdEventCallback,
-    bannerAdRefreshCallback = bannerAdRefreshCallback,
-)
-
-if (bannerAd != null) {
-    adView.registerBannerAd(bannerAd, this)
-}
-```
-
-Continue to register the returned banner with Google's normal `AdView.registerBannerAd`; the adapter intentionally
-does not combine polling and registration.
-
-### Interstitial ads
-
-```kotlin
-val interstitialPreloadConfiguration = PreloadConfiguration(
-    request = AdRequest.Builder("AD_UNIT_ID").build(),
-    bufferSize = 2,
-)
-
-InterstitialAdPreloader.startAndTrack(
-    preloadId = "game-interstitial-buffer",
-    preloadConfiguration = interstitialPreloadConfiguration,
-    placement = "game_interstitial_preload",
-    preloadCallback = object : PreloadCallback {},
-)
-
-// Later, adopt a buffered interstitial. This does not emit another loaded event.
-interstitialAd = InterstitialAdPreloader.pollAndTrackAd(
-    preloadId = "game-interstitial-buffer",
-    placement = "game_interstitial",
-    adEventCallback = interstitialAdEventCallback,
-)
-
-interstitialAd?.show(this)
-```
-
-### Native ads
-
-```kotlin
-val nativePreloadConfiguration = PreloadConfiguration(
-    request = NativeAdRequest.Builder(
-        "AD_UNIT_ID",
-        listOf(NativeAd.NativeAdType.NATIVE),
-    ).build(),
-    bufferSize = 2,
-)
-
-NativeAdPreloader.startAndTrack(
-    preloadId = "native-buffer",
-    preloadConfiguration = nativePreloadConfiguration,
-    placement = "native_preload",
-)
-
-// Later, adopt a buffered result. This does not emit another loaded event.
-val nativeResult = NativeAdPreloader.pollAndTrackAd(
-    preloadId = "native-buffer",
-    placement = "native",
-    nativeAdEventCallback = nativeAdEventCallback,
-    bannerAdEventCallback = bannerAdEventCallback,
-    bannerAdRefreshCallback = bannerAdRefreshCallback,
-)
-
-when (nativeResult) {
-    is NativeAdLoadResult.NativeAdSuccess -> showNativeAd(nativeResult.ad)
-    is NativeAdLoadResult.CustomNativeAdSuccess -> showCustomNativeAd(nativeResult.ad)
-    is NativeAdLoadResult.BannerAdSuccess -> adView.registerBannerAd(nativeResult.ad, this)
-    null -> Unit
-}
-```
-
-Google's native preloader can return native, custom-native, or banner results depending on the requested ad types.
-`pollAndTrackAd` installs the matching lifecycle callbacks before returning any of these result variants.
-
-### Rewarded ads
-
-```kotlin
-val rewardedPreloadConfiguration = PreloadConfiguration(
-    request = AdRequest.Builder("AD_UNIT_ID").build(),
-    bufferSize = 2,
-)
-
-RewardedAdPreloader.startAndTrack(
-    preloadId = "rewarded-buffer",
-    preloadConfiguration = rewardedPreloadConfiguration,
-    placement = "rewarded_preload",
-)
-
-// Later, adopt a buffered rewarded ad. This does not emit another loaded event.
-rewardedAd = RewardedAdPreloader.pollAndTrackAd(
-    preloadId = "rewarded-buffer",
-    placement = "rewarded",
-    adEventCallback = rewardedAdEventCallback,
-)
-
-rewardedAd?.show(this) { rewardItem ->
-    grantReward(rewardItem)
-}
-```
-
-### Rewarded-interstitial ads
-
-```kotlin
-val rewardedInterstitialPreloadConfiguration = PreloadConfiguration(
-    request = AdRequest.Builder("AD_UNIT_ID").build(),
-    bufferSize = 2,
-)
-
-RewardedInterstitialAdPreloader.startAndTrack(
-    preloadId = "rewarded-interstitial-buffer",
-    preloadConfiguration = rewardedInterstitialPreloadConfiguration,
-    placement = "rewarded_interstitial_preload",
-)
-
-// Later, adopt a buffered rewarded-interstitial ad. This does not emit another loaded event.
-rewardedInterstitialAd = RewardedInterstitialAdPreloader.pollAndTrackAd(
-    preloadId = "rewarded-interstitial-buffer",
-    placement = "rewarded_interstitial",
-    adEventCallback = rewardedInterstitialAdEventCallback,
-)
-
-rewardedInterstitialAd?.show(this) { rewardItem ->
-    grantReward(rewardItem)
-}
-```
-
-If preloading was started through Google's plain `start` API, `pollAndTrackAd` still installs tracking for later
-lifecycle events. RevenueCat cannot retroactively observe the original preload completion, so it does not synthesize
-a loaded event when the ad is polled.
-## Placement
-
-Use the optional `placement` to identify the logical location of an ad in your app, such as `"app_start"` or
-`"level_complete_interstitial"`. Choose stable names and apply them consistently so events from the same slot can be
-grouped together. The load-time placement is attached to load success and failure events and is the default for later
-events. If the final location is only known when the ad is shown, use the format's tracked
-`show(activity, placement)` overload to override the placement for display, click, and revenue events. Calling the
-Next-Gen SDK's regular `show(activity)` keeps the load-time placement.
-
-## Usage
-
-### Interstitial ads
-
-**Google Mobile Ads Next-Gen only**
-
-```kotlin
-val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
-
-InterstitialAd.load(
-    adRequest,
-    object : AdLoadCallback<InterstitialAd> {
-        override fun onAdLoaded(ad: InterstitialAd) {
-            interstitialAd = ad
-            ad.adEventCallback = object : InterstitialAdEventCallback {
-                override fun onAdDismissedFullScreenContent() {
-                    interstitialAd = null
-                }
-            }
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            interstitialAd = null
-        }
-    },
-)
-
-// Later, to show:
-interstitialAd?.show(this)
-```
-
-**With RevenueCat tracking**
-
-```kotlin
-val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
-
-Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
-    adRequest = adRequest,
-    placement = "game_interstitial",
-    loadCallback = object : AdLoadCallback<InterstitialAd> {
-        override fun onAdLoaded(ad: InterstitialAd) {
-            interstitialAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            interstitialAd = null
-        }
-    },
-    adEventCallback = object : InterstitialAdEventCallback {
-        override fun onAdDismissedFullScreenContent() {
-            interstitialAd = null
-        }
-
-        override fun onAdFailedToShowFullScreenContent(
-            fullScreenContentError: FullScreenContentError,
-        ) {
-            interstitialAd = null
-        }
-    },
-)
-
-// Later, override the load-time placement for events emitted while showing:
-interstitialAd?.show(this, placement = "level_complete_interstitial")
-```
-
-The coroutine overload returns Google's original load result:
-
-```kotlin
-lifecycleScope.launch {
-    when (
-        val result = Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
-            adRequest = adRequest,
-            placement = "game_interstitial",
-        )
-    ) {
-        is AdLoadResult.Success -> interstitialAd = result.ad
-        is AdLoadResult.Failure -> interstitialAd = null
-    }
-}
-```
-
-> [!IMPORTANT]
-> Do not assign `interstitialAd.adEventCallback` directly after a tracked load. Direct assignment replaces
-> RevenueCat's tracking wrapper and prevents `show(activity, placement)` from applying its placement override. Pass
-> the callback to `loadAndTrackInterstitialAd`, or replace only the forwarded callback safely:
-
-```kotlin
-interstitialAd?.setTrackingAdEventCallback(newAdEventCallback)
-```
-
-Server-to-server interstitial responses use the callback API exposed by the pinned Google Mobile Ads SDK. Provide
-the ad unit ID explicitly so both successful and failed loads have the required attribution:
-
-```kotlin
-Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAdFromResponse(
-    adResponse = serverAdResponse,
-    adUnitId = "AD_UNIT_ID",
-    placement = "game_interstitial",
-    loadCallback = object : AdLoadCallback<InterstitialAd> {
-        override fun onAdLoaded(ad: InterstitialAd) {
-            interstitialAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            interstitialAd = null
-        }
-    },
-    adEventCallback = interstitialAdEventCallback,
-)
-```
-
-The pinned SDK does not expose a suspending interstitial response-loading API, so the adapter intentionally does not
-add one.
-
-### App open ads
-
-**Google Mobile Ads Next-Gen only**
-
-```kotlin
-val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
-
-AppOpenAd.load(
-    adRequest,
-    object : AdLoadCallback<AppOpenAd> {
-        override fun onAdLoaded(ad: AppOpenAd) {
-            appOpenAd = ad
-            ad.adEventCallback = object : AppOpenAdEventCallback {
-                override fun onAdDismissedFullScreenContent() {
-                    appOpenAd = null
-                }
-            }
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            appOpenAd = null
-        }
-    },
-)
-
-// Later, to show:
-appOpenAd?.show(this)
-```
-
-**With RevenueCat tracking**
-
-```kotlin
-val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
-
-Purchases.sharedInstance.adTracker.loadAndTrackAppOpenAd(
-    adRequest = adRequest,
-    placement = "app_start",
-    loadCallback = object : AdLoadCallback<AppOpenAd> {
-        override fun onAdLoaded(ad: AppOpenAd) {
-            appOpenAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            appOpenAd = null
-        }
-    },
-    adEventCallback = object : AppOpenAdEventCallback {
-        override fun onAdDismissedFullScreenContent() {
-            appOpenAd = null
-        }
-
-        override fun onAdFailedToShowFullScreenContent(
-            fullScreenContentError: FullScreenContentError,
-        ) {
-            appOpenAd = null
-        }
-    },
-)
-
-// Later, override the load-time placement for events emitted while showing:
-appOpenAd?.show(this, placement = "app_start")
-```
-
-The coroutine overload returns Google's original load result:
-
-```kotlin
-lifecycleScope.launch {
-    when (
-        val result = Purchases.sharedInstance.adTracker.loadAndTrackAppOpenAd(
-            adRequest = adRequest,
-            placement = "app_start",
-        )
-    ) {
-        is AdLoadResult.Success -> appOpenAd = result.ad
-        is AdLoadResult.Failure -> appOpenAd = null
-    }
-}
-```
-
-> [!IMPORTANT]
-> Do not assign `appOpenAd.adEventCallback` directly after a tracked load. Direct assignment replaces
-> RevenueCat's tracking wrapper and prevents `show(activity, placement)` from applying its placement override. Pass
-> the callback to `loadAndTrackAppOpenAd`, or replace only the forwarded callback safely:
-
-```kotlin
-appOpenAd?.setTrackingAdEventCallback(newAdEventCallback)
-```
-
-Server-to-server app open responses use the callback API exposed by the pinned Google Mobile Ads SDK. Provide
-the ad unit ID explicitly so both successful and failed loads have the required attribution:
-
-```kotlin
-Purchases.sharedInstance.adTracker.loadAndTrackAppOpenAdFromResponse(
-    adResponse = serverAdResponse,
-    adUnitId = "AD_UNIT_ID",
-    placement = "app_start",
-    loadCallback = object : AdLoadCallback<AppOpenAd> {
-        override fun onAdLoaded(ad: AppOpenAd) {
-            appOpenAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            appOpenAd = null
-        }
-    },
-    adEventCallback = appOpenAdEventCallback,
-)
-```
-
-The pinned SDK does not expose a suspending app open response-loading API, so the adapter intentionally does not
-add one.
-
-Google Mobile Ads Next-Gen invokes load and event callbacks on a background thread. Dispatch explicitly to the main
-thread before updating views or other UI-confined state from a callback.
-
-### Rewarded interstitial ads
-
-**Google Mobile Ads Next-Gen only**
-
-```kotlin
-val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
-
-RewardedInterstitialAd.load(
-    adRequest,
-    object : AdLoadCallback<RewardedInterstitialAd> {
-        override fun onAdLoaded(ad: RewardedInterstitialAd) {
-            rewardedInterstitialAd = ad
-            ad.adEventCallback = object : RewardedInterstitialAdEventCallback {
-                override fun onAdDismissedFullScreenContent() {
-                    rewardedInterstitialAd = null
-                }
-            }
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            rewardedInterstitialAd = null
-        }
-    },
-)
-
-// Later, to show and grant the reward reported by Google:
-rewardedInterstitialAd?.show(this) { rewardItem ->
-    grantReward(rewardItem)
-}
-```
-
-**With RevenueCat tracking**
-
-```kotlin
-val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
-
-Purchases.sharedInstance.adTracker.loadAndTrackRewardedInterstitialAd(
-    adRequest = adRequest,
-    placement = "level_complete_reward",
-    loadCallback = object : AdLoadCallback<RewardedInterstitialAd> {
-        override fun onAdLoaded(ad: RewardedInterstitialAd) {
-            rewardedInterstitialAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            rewardedInterstitialAd = null
-        }
-    },
-    adEventCallback = object : RewardedInterstitialAdEventCallback {
-        override fun onAdDismissedFullScreenContent() {
-            rewardedInterstitialAd = null
-        }
-
-        override fun onAdFailedToShowFullScreenContent(
-            fullScreenContentError: FullScreenContentError,
-        ) {
-            rewardedInterstitialAd = null
-        }
-    },
-)
-
-// Later, override the load-time placement while preserving Google's reward callback:
-rewardedInterstitialAd?.show(this, placement = "bonus_chest") { rewardItem ->
-    grantReward(rewardItem)
-}
-```
-
-The coroutine overload returns Google's original load result:
-
-```kotlin
-lifecycleScope.launch {
-    when (
-        val result = Purchases.sharedInstance.adTracker.loadAndTrackRewardedInterstitialAd(
-            adRequest = adRequest,
-            placement = "level_complete_reward",
-        )
-    ) {
-        is AdLoadResult.Success -> rewardedInterstitialAd = result.ad
-        is AdLoadResult.Failure -> rewardedInterstitialAd = null
-    }
-}
-```
-
-> [!IMPORTANT]
-> Do not assign `rewardedInterstitialAd.adEventCallback` directly after a tracked load. Direct assignment replaces
-> RevenueCat's tracking wrapper and prevents the placement-aware `show` extension from applying its override. Pass
-> the callback to `loadAndTrackRewardedInterstitialAd`, or replace only the forwarded callback safely:
-
-```kotlin
-rewardedInterstitialAd?.setTrackingAdEventCallback(newAdEventCallback)
-```
-
-Server-to-server rewarded interstitial responses use the callback API exposed by the pinned Google Mobile Ads SDK.
-Provide the ad unit ID explicitly so both successful and failed loads have the required attribution:
-
-```kotlin
-Purchases.sharedInstance.adTracker.loadAndTrackRewardedInterstitialAdFromResponse(
-    adResponse = serverAdResponse,
-    adUnitId = "AD_UNIT_ID",
-    placement = "level_complete_reward",
-    loadCallback = object : AdLoadCallback<RewardedInterstitialAd> {
-        override fun onAdLoaded(ad: RewardedInterstitialAd) {
-            rewardedInterstitialAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            rewardedInterstitialAd = null
-        }
-    },
-    adEventCallback = rewardedInterstitialAdEventCallback,
-)
-```
-
-The pinned SDK does not expose a suspending rewarded interstitial response-loading API, so the adapter intentionally
-does not add one.
-
-Google Mobile Ads Next-Gen invokes load and event callbacks on a background thread. Dispatch explicitly to the main
-thread before updating views or other UI-confined state from a callback.
-
-## Supported formats
-
-| Format                | RevenueCat tracking entry point |
-| --------------------- | ------------------------------- |
-| App open              | `AdTracker.loadAndTrackAppOpenAd()` or `AdTracker.loadAndTrackAppOpenAdFromResponse()` |
-| Interstitial          | `AdTracker.loadAndTrackInterstitialAd()` or `AdTracker.loadAndTrackInterstitialAdFromResponse()` |
-| Rewarded interstitial | `AdTracker.loadAndTrackRewardedInterstitialAd()` or `AdTracker.loadAndTrackRewardedInterstitialAdFromResponse()` |
+## Events tracked
+
+All formats automatically report these RevenueCat ad events:
+
+- **Ad Loaded** — the ad loaded successfully. Banner auto-refresh reports each refreshed creative as a new load.
+- **Ad Failed to Load** — the load failed, tagged with the SDK's numeric error code. Banner refresh failures report
+  here too.
+- **Ad Displayed** — the ad was shown.
+- **Ad Opened** — the user clicked the ad.
+- **Ad Revenue** — the ad generated revenue, with the amount, currency, and precision reported by Google.
+
+Every event carries the ad format, ad unit, and optional placement. Ad Loaded, Ad Displayed, Ad Opened, and Ad
+Revenue also carry the mediation network and impression ID. Ad Failed to Load carries the error code instead because
+no creative was served.
+
+Network and impression ID are read when each callback fires. This ensures that an auto-refreshing banner attributes
+events to the creative currently on screen rather than the first one loaded.
 
 ## Placement
 
-Use the optional `placement` to identify the logical location of an ad in your app, such as
-`"level_complete_reward"`. Choose stable names and apply them consistently so events from the same slot can be
-grouped together. The load-time placement is attached to load success and failure events and is the default for later
-events. If the final location is only known when the ad is shown, use
-`RewardedAd.show(activity, placement, onUserEarnedRewardListener)` to override the placement for display, click, and
-revenue events. Calling the Next-Gen SDK's regular `show(activity, onUserEarnedRewardListener)` keeps the load-time
-placement.
+Every tracking helper accepts an optional `placement` that identifies the logical location of an ad in your app, such
+as `"home_banner"`, `"app_start"`, or `"level_complete_reward"`. Use stable names so events from the same slot can
+be grouped together in RevenueCat.
+
+Placement ownership depends on the loading stage:
+
+| Stage | Placement applies to |
+| --- | --- |
+| Direct load | Load success or failure and, by default, the ad's later lifecycle events |
+| `startAndTrack` | Preload success or failure only |
+| `pollAndTrackAd` | The polled ad's display, click, revenue, and banner-refresh events |
+| Tracked `show(activity, placement, ...)` | Overrides the polled or load-time placement for full-screen lifecycle events |
+
+The placements passed to `startAndTrack` and `pollAndTrackAd` are independent. Polling does not emit another loaded
+event. Calling Google's regular `show` retains the load-time or poll-time placement; passing a placement to the
+adapter's tracked `show` overload replaces it. Passing `null` explicitly clears it.
+
+Banner and native ads do not have a placement-aware `show` call. They keep the placement supplied when loaded or
+polled for their complete lifecycle, including banner refreshes.
+
+## Callback handling
+
+The adapter installs tracking wrappers before returning a loaded or polled ad. Pass your event callbacks to the
+RevenueCat load or poll helper instead of assigning the ad's callback property afterward. Direct assignment replaces
+the tracking wrapper.
+
+Every supported ad type exposes the same tracking-safe event callback setter:
+
+```kotlin
+ad.setTrackingAdEventCallback(adEventCallback)
+```
+
+Banners also expose `setTrackingBannerAdRefreshCallback` for their refresh callback.
+
+All Google callbacks are forwarded after RevenueCat performs its own tracking. Forwarding still occurs if RevenueCat
+is not configured or tracking fails.
+
+Google Mobile Ads Next-Gen can invoke load and event callbacks on a background thread. Dispatch to the main thread
+before updating views or other UI-confined state. RevenueCat's `rewardVerificationStarted` and
+`rewardVerificationCompleted` callbacks are delivered on the main thread.
 
 ## Usage
 
-### Rewarded ads
-
-**Google Mobile Ads Next-Gen only**
-
-```kotlin
-val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
-
-RewardedAd.load(
-    adRequest,
-    object : AdLoadCallback<RewardedAd> {
-        override fun onAdLoaded(ad: RewardedAd) {
-            rewardedAd = ad
-            ad.adEventCallback = object : RewardedAdEventCallback {
-                override fun onAdDismissedFullScreenContent() {
-                    rewardedAd = null
-                }
-            }
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            rewardedAd = null
-        }
-    },
-)
-
-// Later, to show and grant the reward:
-rewardedAd?.show(this, OnUserEarnedRewardListener { reward ->
-    grantReward(reward)
-})
-```
-
-**With RevenueCat tracking**
-
-```kotlin
-val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
-
-Purchases.sharedInstance.adTracker.loadAndTrackRewardedAd(
-    adRequest = adRequest,
-    placement = "game_reward",
-    loadCallback = object : AdLoadCallback<RewardedAd> {
-        override fun onAdLoaded(ad: RewardedAd) {
-            rewardedAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            rewardedAd = null
-        }
-    },
-    adEventCallback = object : RewardedAdEventCallback {
-        override fun onAdDismissedFullScreenContent() {
-            rewardedAd = null
-        }
-
-        override fun onAdFailedToShowFullScreenContent(
-            fullScreenContentError: FullScreenContentError,
-        ) {
-            rewardedAd = null
-        }
-    },
-)
-
-// Later, override the load-time placement while preserving Google's reward callback:
-rewardedAd?.show(
-    activity = this,
-    placement = "level_complete_reward",
-    onUserEarnedRewardListener = OnUserEarnedRewardListener { reward ->
-        grantReward(reward)
-    },
-)
-```
-
-The coroutine overload returns Google's original load result:
-
-```kotlin
-lifecycleScope.launch {
-    when (
-        val result = Purchases.sharedInstance.adTracker.loadAndTrackRewardedAd(
-            adRequest = adRequest,
-            placement = "game_reward",
-        )
-    ) {
-        is AdLoadResult.Success -> rewardedAd = result.ad
-        is AdLoadResult.Failure -> rewardedAd = null
-    }
-}
-```
-
-> [!IMPORTANT]
-> Do not assign `rewardedAd.adEventCallback` directly after a tracked load. Direct assignment replaces RevenueCat's
-> tracking wrapper and prevents `show(activity, placement, onUserEarnedRewardListener)` from applying its placement
-> override. Pass the callback to `loadAndTrackRewardedAd`, or replace only the forwarded callback safely:
-
-```kotlin
-rewardedAd?.setTrackingAdEventCallback(newAdEventCallback)
-```
-
-Server-to-server rewarded responses use the callback API exposed by the pinned Google Mobile Ads SDK. Provide the ad
-unit ID explicitly so both successful and failed loads have the required attribution:
-
-```kotlin
-Purchases.sharedInstance.adTracker.loadAndTrackRewardedAdFromResponse(
-    adResponse = serverAdResponse,
-    adUnitId = "AD_UNIT_ID",
-    placement = "game_reward",
-    loadCallback = object : AdLoadCallback<RewardedAd> {
-        override fun onAdLoaded(ad: RewardedAd) {
-            rewardedAd = ad
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            rewardedAd = null
-        }
-    },
-    adEventCallback = rewardedAdEventCallback,
-)
-```
-
-The pinned SDK does not expose a suspending rewarded response-loading API, so the adapter intentionally does not add
-one.
-
-Reward delivery is separate from `RewardedAdEventCallback`. Pass Google's required `OnUserEarnedRewardListener` when
-showing the ad; the placement-aware extension forwards that listener unchanged.
-
-Google Mobile Ads Next-Gen invokes load and event callbacks on a background thread. Dispatch explicitly to the main
-thread before updating views or other UI-confined state from a callback.
-
-## Supported formats
-
-| Format   | RevenueCat tracking entry point                                                       |
-| -------- | ------------------------------------------------------------------------------------- |
-| Rewarded | `AdTracker.loadAndTrackRewardedAd()` or `AdTracker.loadAndTrackRewardedAdFromResponse()` |
-
-## Placement
-
-Use the optional `placement` to identify the logical location of a banner in your app, such as `"home_banner"`.
-Choose stable names and apply them consistently so events from the same slot can be grouped together. A banner keeps
-the placement supplied when it is loaded for its complete lifecycle, including automatic refreshes.
-
-For native ads, use a stable name such as `"home_feed"`. Native ads do not have a `show()` call: the app renders them
-directly, and Google reports the display through `onAdImpression()`. The load-time placement is therefore used for
-every event from that ad.
-
-## Usage
+Each format below shows the Google Mobile Ads Next-Gen call followed by its RevenueCat-tracked equivalent. These
+side-by-side examples make the migration explicit while preserving Google's request, result, and callback types.
 
 ### Banner ads
 
@@ -903,8 +199,8 @@ adView.loadAd(
     adRequest,
     object : AdLoadCallback<BannerAd> {
         override fun onAdLoaded(ad: BannerAd) {
-            ad.adEventCallback = object : BannerAdEventCallback {}
-            ad.bannerAdRefreshCallback = object : BannerAdRefreshCallback {}
+            ad.adEventCallback = bannerAdEventCallback
+            ad.bannerAdRefreshCallback = bannerAdRefreshCallback
         }
 
         override fun onAdFailedToLoad(adError: LoadAdError) {
@@ -937,12 +233,12 @@ adView.loadAndTrackAd(
             // Handle the error.
         }
     },
-    adEventCallback = object : BannerAdEventCallback {},
-    bannerAdRefreshCallback = object : BannerAdRefreshCallback {},
+    adEventCallback = bannerAdEventCallback,
+    bannerAdRefreshCallback = bannerAdRefreshCallback,
 )
 ```
 
-Or use the `AdTracker` extension with the same view, request, and callbacks:
+The equivalent `AdTracker` extension accepts the same view, request, and callbacks:
 
 ```kotlin
 Purchases.sharedInstance.adTracker.loadAndTrackBannerAd(
@@ -950,64 +246,269 @@ Purchases.sharedInstance.adTracker.loadAndTrackBannerAd(
     adRequest = adRequest,
     placement = "home_banner",
     loadCallback = loadCallback,
-    adEventCallback = adEventCallback,
-    bannerAdRefreshCallback = bannerAdRefreshCallback,
-)
-```
-
-Unlike full-screen ads, a banner's `AdView` owns and displays the loaded ad, so the load callback is optional. The
-Next-Gen SDK does not offer a suspending `AdView.loadAd` API. Although `BannerAd.load` has a suspending overload, Google
-deprecates that API in favor of `AdView.loadAd` or preloading, so the adapter intentionally does not wrap it.
-
-> [!IMPORTANT]
-> Do not assign `bannerAd.adEventCallback` or `bannerAd.bannerAdRefreshCallback` directly after a tracked load.
-> Direct assignment replaces RevenueCat's tracking wrappers. Pass callbacks to a load helper, or replace only the
-> forwarded callbacks with the tracking-safe setters:
-
-```kotlin
-bannerAd?.setTrackingAdEventCallback(newAdEventCallback)
-bannerAd?.setTrackingBannerAdRefreshCallback(newBannerAdRefreshCallback)
-```
-
-### Server-to-server banner responses
-
-Provide the ad unit ID explicitly so both successful and failed loads have the required attribution:
-
-```kotlin
-adView.loadAndTrackAdFromResponse(
-    adResponse = serverAdResponse,
-    adUnitId = "AD_UNIT_ID",
-    placement = "home_banner",
-    loadCallback = object : AdLoadCallback<BannerAd> {
-        override fun onAdLoaded(ad: BannerAd) {
-            // The AdView already displays this ad.
-        }
-
-        override fun onAdFailedToLoad(adError: LoadAdError) {
-            // Handle the error.
-        }
-    },
     adEventCallback = bannerAdEventCallback,
     bannerAdRefreshCallback = bannerAdRefreshCallback,
 )
 ```
 
-`AdView.loadFromAdResponse` also offers a suspending API, so both the direct `AdView` helper and its `AdTracker`
-counterpart do too. They return Google's original result unchanged:
+An `AdView` owns and displays its loaded banner, so the load callback is optional. Google does not offer a suspending
+`AdView.loadAd` API. Although `BannerAd.load` has a suspending overload, Google deprecates it in favor of
+`AdView.loadAd` or preloading, so the adapter does not wrap it.
+
+### Interstitial ads
+
+**Google Mobile Ads Next-Gen only**
 
 ```kotlin
-lifecycleScope.launch {
-    when (
-        adView.loadAndTrackAdFromResponse(
-            adResponse = serverAdResponse,
-            adUnitId = "AD_UNIT_ID",
-            placement = "home_banner",
-        )
-    ) {
-        is AdLoadResult.Success -> Unit // The AdView already displays this ad.
-        is AdLoadResult.Failure -> Unit // Handle the error.
+val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
+
+InterstitialAd.load(
+    adRequest,
+    object : AdLoadCallback<InterstitialAd> {
+        override fun onAdLoaded(ad: InterstitialAd) {
+            interstitialAd = ad
+            ad.adEventCallback = interstitialAdEventCallback
+        }
+
+        override fun onAdFailedToLoad(adError: LoadAdError) {
+            interstitialAd = null
+        }
+    },
+)
+
+// Later, to show:
+interstitialAd?.show(this)
+```
+
+**With RevenueCat tracking**
+
+```kotlin
+val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
+
+Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
+    adRequest = adRequest,
+    placement = "game_interstitial",
+    loadCallback = object : AdLoadCallback<InterstitialAd> {
+        override fun onAdLoaded(ad: InterstitialAd) {
+            interstitialAd = ad
+        }
+
+        override fun onAdFailedToLoad(adError: LoadAdError) {
+            interstitialAd = null
+        }
+    },
+    adEventCallback = interstitialAdEventCallback,
+)
+
+// Later, optionally override the load-time placement:
+interstitialAd?.show(this, placement = "level_complete_interstitial")
+```
+
+### Rewarded ads
+
+**Google Mobile Ads Next-Gen only**
+
+```kotlin
+val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
+
+RewardedAd.load(
+    adRequest,
+    object : AdLoadCallback<RewardedAd> {
+        override fun onAdLoaded(ad: RewardedAd) {
+            rewardedAd = ad
+            ad.adEventCallback = rewardedAdEventCallback
+        }
+
+        override fun onAdFailedToLoad(adError: LoadAdError) {
+            rewardedAd = null
+        }
+    },
+)
+
+// Later, to show and grant the reward reported by Google:
+rewardedAd?.show(this) { rewardItem ->
+    grantReward(rewardItem)
+}
+```
+
+**With RevenueCat tracking**
+
+```kotlin
+val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
+
+Purchases.sharedInstance.adTracker.loadAndTrackRewardedAd(
+    adRequest = adRequest,
+    placement = "game_reward",
+    loadCallback = object : AdLoadCallback<RewardedAd> {
+        override fun onAdLoaded(ad: RewardedAd) {
+            rewardedAd = ad
+        }
+
+        override fun onAdFailedToLoad(adError: LoadAdError) {
+            rewardedAd = null
+        }
+    },
+    adEventCallback = rewardedAdEventCallback,
+)
+
+// Later, optionally override the load-time placement while preserving Google's reward callback:
+rewardedAd?.show(
+    activity = this,
+    placement = "level_complete_reward",
+    onUserEarnedRewardListener = OnUserEarnedRewardListener { reward ->
+        grantReward(reward)
+    },
+)
+```
+
+Reward delivery is separate from `RewardedAdEventCallback`. Always pass Google's required
+`OnUserEarnedRewardListener` when showing an ordinary rewarded ad.
+
+#### Reward verification
+
+To use RevenueCat reward verification, enable it on the loaded or polled ad before showing it. Then use the
+verification-aware `show` overload instead of Google's ordinary reward listener:
+
+```kotlin
+override fun onAdLoaded(ad: RewardedAd) {
+    rewardedAd = ad.apply {
+        enableRewardVerification()
     }
 }
+
+// Later, to show:
+rewardedAd?.show(
+    activity = this,
+    placement = "level_complete_reward",
+    rewardVerificationStarted = {
+        // Verification polling has started.
+    },
+    rewardVerificationCompleted = { result ->
+        rewardedAd = null
+        if (result.verifiedReward != null) {
+            // Handle the verified reward.
+        } else if (result.failed) {
+            // Verification failed.
+        }
+    },
+)
+```
+
+The verification choice belongs to the loaded ad. Call `enableRewardVerification` after a direct load or poll and
+before showing that ad.
+
+### Rewarded interstitial ads
+
+**Google Mobile Ads Next-Gen only**
+
+```kotlin
+val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
+
+RewardedInterstitialAd.load(
+    adRequest,
+    object : AdLoadCallback<RewardedInterstitialAd> {
+        override fun onAdLoaded(ad: RewardedInterstitialAd) {
+            rewardedInterstitialAd = ad
+            ad.adEventCallback = rewardedInterstitialAdEventCallback
+        }
+
+        override fun onAdFailedToLoad(adError: LoadAdError) {
+            rewardedInterstitialAd = null
+        }
+    },
+)
+
+// Later, to show and grant the reward reported by Google:
+rewardedInterstitialAd?.show(this) { rewardItem ->
+    grantReward(rewardItem)
+}
+```
+
+**With RevenueCat tracking**
+
+```kotlin
+val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
+
+Purchases.sharedInstance.adTracker.loadAndTrackRewardedInterstitialAd(
+    adRequest = adRequest,
+    placement = "level_complete_reward",
+    loadCallback = object : AdLoadCallback<RewardedInterstitialAd> {
+        override fun onAdLoaded(ad: RewardedInterstitialAd) {
+            rewardedInterstitialAd = ad
+        }
+
+        override fun onAdFailedToLoad(adError: LoadAdError) {
+            rewardedInterstitialAd = null
+        }
+    },
+    adEventCallback = rewardedInterstitialAdEventCallback,
+)
+
+// Later, optionally override the load-time placement while preserving Google's reward callback:
+rewardedInterstitialAd?.show(this, placement = "bonus_chest") { rewardItem ->
+    grantReward(rewardItem)
+}
+```
+
+Reward verification works the same way as for rewarded ads: call `enableRewardVerification()` on the loaded or
+polled `RewardedInterstitialAd`, then use its verification-aware `show` overload:
+
+```kotlin
+rewardedInterstitialAd?.show(
+    activity = this,
+    placement = "bonus_chest",
+    rewardVerificationStarted = { /* Verification polling has started. */ },
+    rewardVerificationCompleted = { result -> /* Handle the verification result. */ },
+)
+```
+
+### App open ads
+
+**Google Mobile Ads Next-Gen only**
+
+```kotlin
+val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
+
+AppOpenAd.load(
+    adRequest,
+    object : AdLoadCallback<AppOpenAd> {
+        override fun onAdLoaded(ad: AppOpenAd) {
+            appOpenAd = ad
+            ad.adEventCallback = appOpenAdEventCallback
+        }
+
+        override fun onAdFailedToLoad(adError: LoadAdError) {
+            appOpenAd = null
+        }
+    },
+)
+
+// Later, to show:
+appOpenAd?.show(this)
+```
+
+**With RevenueCat tracking**
+
+```kotlin
+val adRequest = AdRequest.Builder("AD_UNIT_ID").build()
+
+Purchases.sharedInstance.adTracker.loadAndTrackAppOpenAd(
+    adRequest = adRequest,
+    placement = "app_start",
+    loadCallback = object : AdLoadCallback<AppOpenAd> {
+        override fun onAdLoaded(ad: AppOpenAd) {
+            appOpenAd = ad
+        }
+
+        override fun onAdFailedToLoad(adError: LoadAdError) {
+            appOpenAd = null
+        }
+    },
+    adEventCallback = appOpenAdEventCallback,
+)
+
+// Later, optionally override the load-time placement:
+appOpenAd?.show(this, placement = "resume_from_background")
 ```
 
 ### Native ads
@@ -1025,6 +526,7 @@ NativeAdLoader.load(
     object : NativeAdLoaderCallback {
         override fun onNativeAdLoaded(nativeAd: NativeAd) {
             loadedNativeAd = nativeAd
+            nativeAd.adEventCallback = nativeAdEventCallback
         }
 
         override fun onAdFailedToLoad(adError: LoadAdError) {
@@ -1049,109 +551,16 @@ Purchases.sharedInstance.adTracker.loadAndTrackNativeAd(
             loadedNativeAd = null
         }
     },
-    nativeAdEventCallback = object : NativeAdEventCallback {
-        override fun onCustomMuteThisAdReported() {
-            // The user muted this ad.
-        }
-    },
-)
-```
-
-The coroutine overload returns Google's original result unchanged:
-
-```kotlin
-when (
-    val result = Purchases.sharedInstance.adTracker.loadAndTrackNativeAd(
-        adRequest = adRequest,
-        placement = "home_feed",
-    )
-) {
-    is NativeAdLoadResult.NativeAdSuccess -> loadedNativeAd = result.ad
-    is NativeAdLoadResult.CustomNativeAdSuccess -> handleCustomNativeAd(result.ad)
-    is NativeAdLoadResult.BannerAdSuccess -> handleBannerAd(result.ad)
-    is NativeAdLoadResult.Failure -> loadedNativeAd = null
-}
-```
-
-A `NativeAdRequest` can intentionally combine standard native, custom-native, and banner inventory. RevenueCat
-tracks each result using its actual format and installs the matching event wrapper before forwarding it. Pass
-`nativeAdEventCallback` for standard and custom-native results, and `bannerAdEventCallback` for banner results.
-
-> [!IMPORTANT]
-> Do not assign `adEventCallback` directly after a tracked load. Direct assignment replaces RevenueCat's tracking
-> wrapper. Pass the callback while loading, or replace only the forwarded callback safely:
-
-```kotlin
-loadedNativeAd?.setTrackingAdEventCallback(newNativeAdEventCallback)
-loadedCustomNativeAd?.setTrackingAdEventCallback(newNativeAdEventCallback)
-loadedBannerAd?.setTrackingAdEventCallback(newBannerAdEventCallback)
-```
-
-### Server-to-server native responses
-
-Provide the ad unit ID explicitly so successful and failed loads have the required attribution:
-
-```kotlin
-Purchases.sharedInstance.adTracker.loadAndTrackNativeAdFromResponse(
-    adResponse = serverAdResponse,
-    adUnitId = "AD_UNIT_ID",
-    placement = "home_feed",
-    loadCallback = nativeAdLoaderCallback,
     nativeAdEventCallback = nativeAdEventCallback,
 )
 ```
 
-The pinned SDK does not expose a suspending native response-loading API, so the adapter intentionally does not add
-one.
+A `NativeAdRequest` can combine standard native, custom-native, and banner inventory. RevenueCat tracks each result
+using its actual format and installs the corresponding event wrapper before forwarding it. Use
+`nativeAdEventCallback` for native and custom-native results and `bannerAdEventCallback` for banner results.
 
-Google Mobile Ads Next-Gen invokes load and event callbacks on a background thread. Dispatch explicitly to the main
-thread before updating views or other UI-confined state from a callback.
+## Further guides
 
-## Supported formats
-
-| Format | RevenueCat tracking entry point |
-| ------ | ------------------------------- |
-| Banner | `AdView.loadAndTrackAd()`, `AdTracker.loadAndTrackBannerAd()`, or their `FromResponse` variants |
-| Native | `AdTracker.loadAndTrackNativeAd()` or `AdTracker.loadAndTrackNativeAdFromResponse()` |
-
-## Events tracked
-
-All formats — banner, interstitial, rewarded, rewarded interstitial, app open, and native — report these
-RevenueCat ad events:
-
-- **Ad Loaded** — the ad loaded successfully. Banner auto-refresh reports each refreshed creative as a new load.
-- **Ad Failed to Load** — the load failed, tagged with the SDK's numeric error code. Banner refresh failures
-  report here too.
-- **Ad Displayed** — the ad was shown. Which callback triggers this depends on the format, see below.
-- **Ad Opened** — the user clicked the ad.
-- **Ad Revenue** — the ad generated revenue, with the amount, currency, and precision reported by the SDK.
-
-Every event carries the ad format, the ad unit, and the optional `placement`. Ad Loaded, Ad Displayed, Ad Opened
-and Ad Revenue also carry the mediation network and the impression id; Ad Failed to Load carries the error code
-instead, since no creative was served.
-
-Network and impression id are read when the callback fires rather than when the ad loads, so an auto-refreshing
-banner attributes events to the creative currently on screen instead of the first one loaded.
-
-### Display triggers
-
-| Format                                                  | Trigger                          |
-| ------------------------------------------------------- | -------------------------------- |
-| Banner, native                                          | `onAdImpression()`               |
-| Interstitial, rewarded, rewarded interstitial, app open | `onAdShowedFullScreenContent()`  |
-
-Full-screen formats emit both callbacks, so tracking the display from only one of them is what keeps a single
-display from being counted twice. Banner and native emit `onAdShowedFullScreenContent()` too — the SDK reports any
-screen-covering overlay there, such as an expanding banner or the AdChoices overlay — and the adapter forwards it
-without tracking a display. The adapter keeps no deduplication state.
-
-### Callback forwarding
-
-The adapter wraps your callbacks instead of replacing them. Every callback the SDK exposes is forwarded to your own
-callback after the RevenueCat event is tracked — including the event callbacks the adapter does not track:
-`onAdDismissedFullScreenContent`, `onAdFailedToShowFullScreenContent`, `onAppEvent` (banner, interstitial),
-`onAdMetadataChanged` (rewarded, rewarded interstitial), and `onAdSwipeGestureClicked` /
-`onCustomMuteThisAdReported` (native).
-
-Forwarding is unconditional. If RevenueCat is not configured the adapter logs a warning and skips tracking, and if
-tracking itself fails the adapter logs the error and swallows it. Either way your callback still runs.
+- [Advanced loading](docs/advanced-loading.md): suspending loads, server-to-server responses, native batch loading,
+  and preloading.
+- [Migrate from the legacy adapter](docs/migration.md): dependency, initialization, request, and callback changes.

--- a/feature/admob-next-gen/docs/advanced-loading.md
+++ b/feature/admob-next-gen/docs/advanced-loading.md
@@ -1,0 +1,147 @@
+# Advanced loading
+
+This guide covers alternative loading workflows for the
+[RevenueCat Google Mobile Ads Next-Gen Adapter](../README.md). The adapter preserves Google's original callback and
+result types while installing RevenueCat tracking.
+
+## Contents
+
+- [Suspending loads](#suspending-loads)
+- [Server-to-server responses](#server-to-server-responses)
+- [Native batch loading](#native-batch-loading)
+- [Preloading](#preloading)
+
+## Suspending loads
+
+Interstitial, rewarded, rewarded-interstitial, app-open, and native helpers have suspending overloads. They return
+Google's original result unchanged, with event tracking already installed on successful ads:
+
+```kotlin
+lifecycleScope.launch {
+    when (
+        val result = Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAd(
+            adRequest = AdRequest.Builder("AD_UNIT_ID").build(),
+            placement = "game_interstitial",
+        )
+    ) {
+        is AdLoadResult.Success -> interstitialAd = result.ad
+        is AdLoadResult.Failure -> interstitialAd = null
+    }
+}
+```
+
+Direct banner loading remains callback-based because Google does not provide a supported suspending `AdView.loadAd`
+API.
+
+## Server-to-server responses
+
+Every format can track an opaque server-to-server ad response. Provide the ad unit ID explicitly because neither a
+failed load nor the opaque response reliably supplies it:
+
+```kotlin
+Purchases.sharedInstance.adTracker.loadAndTrackInterstitialAdFromResponse(
+    adResponse = serverAdResponse,
+    adUnitId = "AD_UNIT_ID",
+    placement = "game_interstitial",
+    loadCallback = object : AdLoadCallback<InterstitialAd> {
+        override fun onAdLoaded(ad: InterstitialAd) {
+            interstitialAd = ad
+        }
+
+        override fun onAdFailedToLoad(adError: LoadAdError) {
+            interstitialAd = null
+        }
+    },
+    adEventCallback = interstitialAdEventCallback,
+)
+```
+
+Use the corresponding `loadAndTrack*FromResponse` helper for other formats. Banner responses can be loaded directly
+through `AdView.loadAndTrackAdFromResponse` or through `AdTracker.loadAndTrackBannerAdFromResponse`. Google exposes a
+suspending response-loading API only for banners, so the other response helpers are callback-based.
+
+## Native batch loading
+
+Use `loadAndTrackNativeAds` to load several native results. Its suspending overload returns Google's original `Flow`;
+results are tracked and configured as they are collected:
+
+```kotlin
+lifecycleScope.launch {
+    Purchases.sharedInstance.adTracker.loadAndTrackNativeAds(
+        adRequest = adRequest,
+        maxNumberOfAds = 3,
+        placement = "home_feed",
+    ).collect { result ->
+        when (result) {
+            is NativeAdLoadResult.NativeAdSuccess -> showNativeAd(result.ad)
+            is NativeAdLoadResult.CustomNativeAdSuccess -> showCustomNativeAd(result.ad)
+            is NativeAdLoadResult.BannerAdSuccess -> showBannerAd(result.ad)
+            is NativeAdLoadResult.Failure -> handleError(result.error)
+        }
+    }
+}
+```
+
+A callback overload is also available and forwards `onAdLoadingCompleted` after Google finishes the batch.
+
+## Preloading
+
+All six formats support Google's preloaders through the same two-stage pattern:
+
+```kotlin
+val preloadConfiguration = PreloadConfiguration(
+    request = AdRequest.Builder("AD_UNIT_ID").build(),
+    bufferSize = 2,
+)
+
+InterstitialAdPreloader.startAndTrack(
+    preloadId = "game-interstitial-buffer",
+    preloadConfiguration = preloadConfiguration,
+    placement = "game_interstitial_preload",
+    preloadCallback = object : PreloadCallback {},
+)
+
+// Later, adopt a buffered ad. Polling does not emit another loaded event.
+interstitialAd = InterstitialAdPreloader.pollAndTrackAd(
+    preloadId = "game-interstitial-buffer",
+    placement = "game_interstitial",
+    adEventCallback = interstitialAdEventCallback,
+)
+
+interstitialAd?.show(this)
+```
+
+The placements passed to `startAndTrack` and `pollAndTrackAd` are independent. See the main guide's
+[placement explanation](../README.md#placement) for the complete lifecycle.
+
+Use the corresponding `AppOpenAdPreloader`, `BannerAdPreloader`, `NativeAdPreloader`, `RewardedAdPreloader`, or
+`RewardedInterstitialAdPreloader` extensions for other formats. Their differences are limited to the Google request,
+result, and callback types:
+
+| Format | Request or result-specific behavior after polling |
+| --- | --- |
+| App open | Build an `AppOpenAdRequest`; the returned `AppOpenAd` can be shown normally |
+| Banner | Register the returned `BannerAd` with `AdView.registerBannerAd` |
+| Interstitial | Show the returned `InterstitialAd` normally or with a placement override |
+| Native | Handle the returned native, custom-native, or banner success result |
+| Rewarded | Supply Google's reward listener or enable RevenueCat reward verification before showing |
+| Rewarded interstitial | Supply Google's reward listener or enable RevenueCat reward verification before showing |
+
+For example, polling a banner does not register it automatically:
+
+```kotlin
+val bannerAd = BannerAdPreloader.pollAndTrackAd(
+    preloadId = "home-banner-buffer",
+    placement = "home_banner",
+    adEventCallback = bannerAdEventCallback,
+    bannerAdRefreshCallback = bannerAdRefreshCallback,
+)
+
+if (bannerAd != null) {
+    adView.registerBannerAd(bannerAd, this)
+}
+```
+
+If preloading was started through Google's plain `start` API, `pollAndTrackAd` still installs tracking for later
+lifecycle events. RevenueCat cannot observe the earlier preload completion, so it does not synthesize a loaded event.
+Swipeable interstitial ads are not currently supported by this integration.

--- a/feature/admob-next-gen/docs/migration.md
+++ b/feature/admob-next-gen/docs/migration.md
@@ -1,0 +1,62 @@
+# Migrate from the legacy AdMob adapter
+
+`purchases-admob-next-gen` is not a drop-in binary replacement for `purchases-admob`. Migrate the Google Mobile Ads
+SDK and RevenueCat adapter together, and review Google's
+[Next-Gen migration guide](https://developers.google.com/admob/android/next-gen/migration) if you use mediation.
+
+## Contents
+
+- [Replace the dependencies](#replace-the-dependencies)
+- [Update imports and initialization](#update-imports-and-initialization)
+- [Update RevenueCat tracking calls](#update-revenuecat-tracking-calls)
+- [Review callback handling](#review-callback-handling)
+
+## Replace the dependencies
+
+Remove both legacy artifacts and add their Next-Gen replacements. Do not keep both SDK generations in the same app:
+
+```kotlin
+dependencies {
+    // Remove:
+    // implementation("com.revenuecat.purchases:purchases-admob:$revenueCatVersion")
+    // implementation("com.google.android.gms:play-services-ads:<version>")
+
+    implementation("com.revenuecat.purchases:purchases-admob-next-gen:$revenueCatVersion")
+    implementation("com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.3.0")
+}
+```
+
+If mediation adapters pull either legacy Google artifact back into the dependency graph, add the global exclusions
+shown in the main guide's [installation section](../README.md#installation).
+
+## Update imports and initialization
+
+Update RevenueCat imports from `com.revenuecat.purchases.admob` to `com.revenuecat.purchases.admob.nextgen`. Google
+Mobile Ads types move from `com.google.android.gms.ads` to `com.google.android.libraries.ads.mobile.sdk`. Initialize
+the Next-Gen SDK using `InitializationConfig` before loading ads.
+
+## Update RevenueCat tracking calls
+
+Most RevenueCat helper names remain the same, but their Google SDK parameters change:
+
+| Format | Legacy adapter | Next-Gen adapter |
+| --- | --- | --- |
+| Banner | `AdView.loadAndTrackAd(AdRequest, ...)` | `AdView.loadAndTrackAd(BannerAdRequest, ...)` |
+| Interstitial | `AdTracker.loadAndTrackInterstitialAd(...)` | `AdTracker.loadAndTrackInterstitialAd(...)` |
+| Rewarded | `AdTracker.loadAndTrackRewardedAd(...)` | `AdTracker.loadAndTrackRewardedAd(...)` |
+| Rewarded interstitial | `AdTracker.loadAndTrackRewardedInterstitialAd(...)` | `AdTracker.loadAndTrackRewardedInterstitialAd(...)` |
+| App open | `AdTracker.loadAndTrackAppOpenAd(...)` | `AdTracker.loadAndTrackAppOpenAd(...)` |
+| Native | `AdLoader.Builder.forNativeAdWithTracking(...)` | `AdTracker.loadAndTrackNativeAd(...)` or `loadAndTrackNativeAds(...)` |
+
+`BannerAdRequest` now owns the ad unit ID and size that the legacy SDK stored on `AdView`. Full-screen requests also
+own their ad unit ID instead of receiving `context` and `adUnitId` as separate load parameters. Format-specific load
+callbacks become `AdLoadCallback<AdType>`, while lifecycle and paid events move to each format's event callback.
+
+The reward-verification helper names are unchanged. Keep existing placement values when they represent the same ad
+slots so reporting remains consistent across the migration.
+
+## Review callback handling
+
+Next-Gen callbacks may arrive on a background thread, and assigning an event callback directly after a tracked load
+replaces RevenueCat's wrapper. See the main guide's [callback handling](../README.md#callback-handling) section for
+the tracking-safe setters and threading contract.


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
The Next-Gen AdMob adapter README grew as format-specific work landed independently, leaving repeated top-level sections and shared guidance duplicated across ad types. This makes the integrated documentation difficult to navigate and obscures the common adapter API.

### Description
- Reorganizes the main README around setup, tracked events, format-by-format usage, and shared lifecycle guidance.
- Uses the same ad-format order as the legacy AdMob adapter and adds concise top-level navigation.
- Preserves Google-versus-RevenueCat examples for every supported format.
- Consolidates shared event, placement, and callback behavior, with placement and callback details after the core usage examples.
- Documents reward verification and Kotlin-only availability.
- Moves preloading, suspending loads, server-to-server responses, native batch loading, and legacy migration into focused guides.
- Updates the sample README cross-reference.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation only; no runtime, API, or build changes.
> 
> **Overview**
> **Documentation-only** restructure of the AdMob Next-Gen adapter docs so the main README is easier to scan and shared concepts are not repeated per format.
> 
> The **main `feature/admob-next-gen/README.md`** is reorganized with a table of contents, a **Kotlin-only** note (Java can use core `AdTracker`), a single **Events tracked** section, and **Usage** ordered by format with paired Google vs RevenueCat examples. **Placement** and **callback handling** are unified (including preload vs poll vs `show` placement and tracking-safe setters). Long or advanced topics are **removed from the README** and linked under **Further guides**.
> 
> **New focused guides:** `docs/advanced-loading.md` (suspending loads, server-to-server `FromResponse`, native batch `loadAndTrackNativeAds`, preloading) and `docs/migration.md` (legacy dependency/import/API migration, shortened from the old in-README migration chapter).
> 
> The **sample README** cross-link wording is updated to point at the consolidated “complete API guide.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 630e78abad05916e5035d2d5ae6f36e4c9723c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->