### PR TITLE
Memoize Markdown parsing and paragraph text building

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -114,7 +115,7 @@ internal fun Markdown(
     textFillMaxWidth: Boolean = false,
     applyFontSizeToParagraph: Boolean = true,
 ) {
-    val root = parser.parse(text) as Document
+    val root = remember(text) { parser.parse(text) as Document }
 
     val density = LocalDensity.current
     val paragraphPadding = with(density) {
@@ -261,10 +262,12 @@ private fun MDParagraph(
                 textAlign = textAlign ?: TextAlign.Unspecified,
             ),
         )
-        val styledText = buildAnnotatedString {
-            pushStyle(resolvedTextStyle.toSpanStyle())
-            appendMarkdownChildren(paragraph as Node, color, allowLinks, baseFontWeight = fontWeight)
-            pop()
+        val styledText = remember(paragraph, resolvedTextStyle, color, allowLinks, fontWeight) {
+            buildAnnotatedString {
+                pushStyle(resolvedTextStyle.toSpanStyle())
+                appendMarkdownChildren(paragraph as Node, color, allowLinks, baseFontWeight = fontWeight)
+                pop()
+            }
         }
         MarkdownText(
             text = styledText,


### PR DESCRIPTION
### Motivation

`Markdown` is the leaf renderer for every text component, so every recomposition of a text component re-runs a full CommonMark parse and rebuilds the paragraph `AnnotatedString`.

That is not a rare path. Countdown texts update once per second, and selecting a package invalidates every text component at once, so the parse runs on frames where the user is waiting.

Also, `Document` and `Node` come from commonmark and are unannotated mutable types, and `parser.parse()` returns a new instance every time. So `MDDocument` -> `MDBlockChildren` -> `MDParagraph` could never skip, and every markdown subtree re-executed in full.

### Description

- `parser.parse(text)` is now wrapped in `remember(text)`, so the AST is built once per text value instead of once per composition.
- The paragraph `buildAnnotatedString` is now wrapped in `remember`, keyed on the paragraph node and the values it reads.

### Verification

Snapshots are not committed for this module, so I recorded all 279 Paparazzi snapshots on `main` and on this branch and compared them. They are byte for byte identical.

`:ui:revenuecatui:testDefaultsDebugUnitTest` (2046 tests, including `MarkdownTests`, `TextComponentViewTests` and `TextComponentViewWindowTests`) and `detektAll` pass.