### PR TITLE
Hoist shadow path and paint out of the draw phase

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Shadow.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Shadow.kt
@@ -19,9 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.translate
 import androidx.compose.ui.graphics.ClipOp
 import androidx.compose.ui.graphics.Color
@@ -34,8 +33,6 @@ import androidx.compose.ui.graphics.addOutline
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
@@ -47,10 +44,14 @@ import com.revenuecat.purchases.ui.revenuecatui.components.properties.toColorSty
 internal fun Modifier.shadow(
     shadow: ShadowStyle,
     shape: Shape,
-) = this.drawBehind {
+) = this.drawWithCache {
+    // One outline serves both paths, and neither depends on anything the draw phase provides.
+    val outline = shape.createOutline(size, layoutDirection, this)
     // Where to draw
     val offset = Offset(x = shadow.x.toPx(), y = shadow.y.toPx())
-    val path = shape.toPath(size, layoutDirection, this, offset)
+    val shadowPath = Path().apply { addOutline(outline, offset) }
+    // Make sure we don't draw inside our original shape. This would be visible if the composable is transparent.
+    val clipPath = Path().apply { addOutline(outline) }
     // What to draw
     val paint = Paint().apply {
         when (shadow.color) {
@@ -64,22 +65,13 @@ internal fun Modifier.shadow(
     }
 
     // Actually drawing
-    drawIntoCanvas { canvas ->
-        canvas.save()
-        // Make sure we don't draw inside our original shape. This would be visible if the composable is transparent.
-        canvas.clipPath(shape.toPath(size, layoutDirection, this), ClipOp.Difference)
-        canvas.drawPath(path, paint)
-        canvas.restore()
-    }
-}
-
-private fun Shape.toPath(size: Size, layoutDirection: LayoutDirection, density: Density, offset: Offset? = null): Path {
-    val outline = createOutline(size, layoutDirection, density)
-
-    return if (offset == null) {
-        Path().apply { addOutline(outline) }
-    } else {
-        Path().apply { addOutline(outline, offset) }
+    onDrawBehind {
+        drawIntoCanvas { canvas ->
+            canvas.save()
+            canvas.clipPath(clipPath, ClipOp.Difference)
+            canvas.drawPath(shadowPath, paint)
+            canvas.restore()
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

`Modifier.shadow` used `drawBehind`, so every draw frame of every shadowed stack allocated an `Offset`, two `Outline`s, two `Path`s, a `Paint`, and a native `BlurMaskFilter`. None of that depends on anything the draw phase provides.

It also computed the shape outline twice per frame, once offset for the shadow and once unoffset for the difference clip.

### Description

Switched to `drawWithCache`:

- The outline is computed once and shared by both paths.
- The paths and the paint are built in the cache block, so they are rebuilt only when the size, layout direction, or shadow parameters change, instead of on every frame.
- The draw block now only clips and draws.

### Verification

Snapshots are not committed for this module, so I recorded all 279 Paparazzi snapshots on `main` and on this branch and compared them. They are byte for byte identical.

`:ui:revenuecatui:testDefaultsDebugUnitTest` (2046 tests) and `detektAll` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rendering-only performance refactor in a UI modifier; behavior is unchanged per snapshot and unit test verification.
> 
> **Overview**
> **`Modifier.shadow`** no longer rebuilds geometry and paint on every draw frame. It now uses **`drawWithCache`** instead of **`drawBehind`**, so outline, clip/shadow paths, and **`Paint`** (including blur) are created only when size, layout direction, or shadow inputs change.
> 
> The shape outline is computed **once** and reused for both the offset shadow path and the difference clip path, replacing the removed **`Shape.toPath`** helper. The draw step only saves canvas state, clips, and draws the cached paths—intended to cut per-frame allocations with **visually identical** output (per Paparazzi comparison in the PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2035d47e02742a9cd991e006d2d2b6f799d894e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->