### PR TITLE
other: echo step experiment params on workflow events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -323,8 +323,6 @@ internal sealed class BackendEvent : Event {
             val experimentId: String? = null,
             @SerialName("experiment_variant")
             val experimentVariant: String? = null,
-            @SerialName("is_last_variant_step")
-            val isLastVariantStep: Boolean? = null,
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -576,6 +576,8 @@ internal fun WorkflowEvent.toBackendStoredEvent(
             entryReason = entryReason,
             isFirstStep = isFirstStep,
             isLastStep = isLastStep,
+            experimentId = experimentId,
+            experimentVariant = experimentVariant,
         )
         is WorkflowEvent.StepCompleted -> BackendEvent.Workflows.Properties(
             workflowId = workflowId,
@@ -584,6 +586,8 @@ internal fun WorkflowEvent.toBackendStoredEvent(
             toStepId = toStepId,
             isFirstStep = isFirstStep,
             isLastStep = isLastStep,
+            experimentId = experimentId,
+            experimentVariant = experimentVariant,
         )
         is WorkflowEvent.Close -> BackendEvent.Workflows.Properties(
             workflowId = workflowId,
@@ -591,6 +595,8 @@ internal fun WorkflowEvent.toBackendStoredEvent(
             traceId = traceId,
             isFirstStep = isFirstStep,
             isLastStep = isLastStep,
+            experimentId = experimentId,
+            experimentVariant = experimentVariant,
         )
     }
     return BackendStoredEvent.Workflows(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -118,12 +118,12 @@ public data class WorkflowStep(
             }
         }
 
-    /** The experiment running on this step, or null if there is none. */
+    /** The step's `experiment_id` param, or null if it has none. */
     @InternalRevenueCatAPI
     public val experimentId: String?
         get() = stringParam(EXPERIMENT_ID_PARAM)
 
-    /** The variant of [experimentId] this step belongs to. */
+    /** The step's `experiment_variant` param, or null if it has none. */
     @InternalRevenueCatAPI
     public val experimentVariant: String?
         get() = stringParam(EXPERIMENT_VARIANT_PARAM)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -117,7 +117,26 @@ public data class WorkflowStep(
                 (element as? JsonPrimitive)?.takeIf { it.isString }?.content
             }
         }
+
+    /**
+     * The experiment this step belongs to, baked into `param_values` by the backend for the steps of the
+     * enrolled variant only. Echoed verbatim on step events; null for steps outside an experiment.
+     */
+    @InternalRevenueCatAPI
+    public val experimentId: String?
+        get() = stringParam(EXPERIMENT_ID_PARAM)
+
+    /** The enrolled variant key, alongside [experimentId]. */
+    @InternalRevenueCatAPI
+    public val experimentVariant: String?
+        get() = stringParam(EXPERIMENT_VARIANT_PARAM)
+
+    private fun stringParam(key: String): String? =
+        (paramValues[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
 }
+
+private const val EXPERIMENT_ID_PARAM = "experiment_id"
+private const val EXPERIMENT_VARIANT_PARAM = "experiment_variant"
 
 @InternalRevenueCatAPI
 @Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -119,8 +119,8 @@ public data class WorkflowStep(
         }
 
     /**
-     * The experiment this step belongs to, baked into `param_values` by the backend for the steps of the
-     * enrolled variant only. Echoed verbatim on step events; null for steps outside an experiment.
+     * Set by the backend only on the steps of the enrolled variant, and echoed verbatim on step events so
+     * khepri can enroll on exposure. Null for steps outside an experiment.
      */
     @InternalRevenueCatAPI
     public val experimentId: String?

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -118,15 +118,12 @@ public data class WorkflowStep(
             }
         }
 
-    /**
-     * The experiment active on this step's path, set by the backend and echoed verbatim on step events.
-     * Null when no experiment applies to the step.
-     */
+    /** The experiment running on this step, or null if there is none. */
     @InternalRevenueCatAPI
     public val experimentId: String?
         get() = stringParam(EXPERIMENT_ID_PARAM)
 
-    /** The variant active on this step's path, alongside [experimentId]. */
+    /** The variant of [experimentId] this step belongs to. */
     @InternalRevenueCatAPI
     public val experimentVariant: String?
         get() = stringParam(EXPERIMENT_VARIANT_PARAM)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -119,14 +119,14 @@ public data class WorkflowStep(
         }
 
     /**
-     * Set by the backend only on the steps of the enrolled variant, and echoed verbatim on step events so
-     * khepri can enroll on exposure. Null for steps outside an experiment.
+     * The experiment active on this step's path, set by the backend and echoed verbatim on step events.
+     * Null when no experiment applies to the step.
      */
     @InternalRevenueCatAPI
     public val experimentId: String?
         get() = stringParam(EXPERIMENT_ID_PARAM)
 
-    /** The enrolled variant key, alongside [experimentId]. */
+    /** The variant active on this step's path, alongside [experimentId]. */
     @InternalRevenueCatAPI
     public val experimentVariant: String?
         get() = stringParam(EXPERIMENT_VARIANT_PARAM)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -119,12 +119,10 @@ public data class WorkflowStep(
         }
 
     /** The step's `experiment_id` param, or null if it has none. */
-    @InternalRevenueCatAPI
     public val experimentId: String?
         get() = stringParam(EXPERIMENT_ID_PARAM)
 
     /** The step's `experiment_variant` param, or null if it has none. */
-    @InternalRevenueCatAPI
     public val experimentVariant: String?
         get() = stringParam(EXPERIMENT_VARIANT_PARAM)
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/events/WorkflowEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/events/WorkflowEvent.kt
@@ -40,6 +40,8 @@ public sealed class WorkflowEvent : FeatureEvent {
         public val entryReason: String? = null,
         public val isFirstStep: Boolean? = null,
         public val isLastStep: Boolean? = null,
+        public val experimentId: String? = null,
+        public val experimentVariant: String? = null,
     ) : WorkflowEvent()
 
     @Serializable
@@ -52,6 +54,8 @@ public sealed class WorkflowEvent : FeatureEvent {
         public val toStepId: String? = null,
         public val isFirstStep: Boolean? = null,
         public val isLastStep: Boolean? = null,
+        public val experimentId: String? = null,
+        public val experimentVariant: String? = null,
     ) : WorkflowEvent()
 
     /**
@@ -68,5 +72,7 @@ public sealed class WorkflowEvent : FeatureEvent {
         override val traceId: String,
         public val isFirstStep: Boolean? = null,
         public val isLastStep: Boolean? = null,
+        public val experimentId: String? = null,
+        public val experimentVariant: String? = null,
     ) : WorkflowEvent()
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/WorkflowEventsRequestSerializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/WorkflowEventsRequestSerializationTest.kt
@@ -78,6 +78,35 @@ class WorkflowEventsRequestSerializationTest {
     }
 
     @Test
+    fun `experiment params use their khepri wire names`() {
+        val withExperiment = EventsRequest(
+            listOf(
+                (request.events.first() as BackendEvent.Workflows).let { event ->
+                    event.copy(
+                        properties = event.properties.copy(
+                            experimentId = "exp_abc",
+                            experimentVariant = "b",
+                        ),
+                    )
+                },
+            ),
+        )
+
+        val requestString = JsonProvider.defaultJson.encodeToString(withExperiment)
+
+        assertThat(requestString).contains("\"experiment_id\":\"exp_abc\"")
+        assertThat(requestString).contains("\"experiment_variant\":\"b\"")
+    }
+
+    @Test
+    fun `experiment params are omitted from JSON when the step has none`() {
+        val requestString = JsonProvider.defaultJson.encodeToString(request)
+
+        assertThat(requestString).doesNotContain("experiment_id")
+        assertThat(requestString).doesNotContain("experiment_variant")
+    }
+
+    @Test
     fun `workflow_type absent from JSON output`() {
         val requestString = JsonProvider.defaultJson.encodeToString(request)
         assertThat(requestString).doesNotContain("workflow_type")

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -65,7 +65,6 @@ internal class WorkflowModelsDeserializationTest {
 
     @Test
     fun `WorkflowStep experiment params are null when absent`() {
-        // Steps outside an enrolled variant (default combo, shared steps) carry no experiment params.
         val json = """
             {"id": "step_1", "type": "screen", "param_values": {"offering_identifier": "premium"}}
         """.trimIndent()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -53,6 +53,38 @@ internal class WorkflowModelsDeserializationTest {
     }
 
     @Test
+    fun `WorkflowStep experiment params read experiment_id and experiment_variant from param_values`() {
+        val json = """
+            {"id": "step_1", "type": "screen",
+             "param_values": {"experiment_id": "exp_abc", "experiment_variant": "b", "other": 1}}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.experimentId).isEqualTo("exp_abc")
+        assertThat(step.experimentVariant).isEqualTo("b")
+    }
+
+    @Test
+    fun `WorkflowStep experiment params are null when absent`() {
+        // Steps outside an enrolled variant (default combo, shared steps) carry no experiment params.
+        val json = """
+            {"id": "step_1", "type": "screen", "param_values": {"offering_identifier": "premium"}}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.experimentId).isNull()
+        assertThat(step.experimentVariant).isNull()
+    }
+
+    @Test
+    fun `WorkflowStep experiment params are null when not strings`() {
+        val json = """
+            {"id": "step_1", "type": "screen", "param_values": {"experiment_id": 12, "experiment_variant": null}}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.experimentId).isNull()
+        assertThat(step.experimentVariant).isNull()
+    }
+
+    @Test
     fun `WorkflowStep stepScreenType is null when metadata is absent`() {
         val json = """
             {"id": "step_1", "type": "screen"}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -74,6 +74,16 @@ internal class WorkflowModelsDeserializationTest {
     }
 
     @Test
+    fun `WorkflowStep experiment params are read independently`() {
+        val json = """
+            {"id": "step_1", "type": "screen", "param_values": {"experiment_id": "exp_abc"}}
+        """.trimIndent()
+        val step = JsonTools.json.decodeFromString(WorkflowStep.serializer(), json)
+        assertThat(step.experimentId).isEqualTo("exp_abc")
+        assertThat(step.experimentVariant).isNull()
+    }
+
+    @Test
     fun `WorkflowStep experiment params are null when not strings`() {
         val json = """
             {"id": "step_1", "type": "screen", "param_values": {"experiment_id": 12, "experiment_variant": null}}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/events/WorkflowEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/events/WorkflowEventTest.kt
@@ -142,7 +142,6 @@ class WorkflowEventTest {
             val properties = (event.toBackendStoredEvent("user_42") as BackendStoredEvent.Workflows).event.properties
             assertThat(properties.experimentId).`as`(event::class.simpleName).isEqualTo("exp_abc")
             assertThat(properties.experimentVariant).`as`(event::class.simpleName).isEqualTo("b")
-            assertThat(properties.isLastVariantStep).isNull()
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/events/WorkflowEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/events/WorkflowEventTest.kt
@@ -147,7 +147,7 @@ class WorkflowEventTest {
     }
 
     @Test
-    fun `experiment params default to null so steps outside an experiment send nothing`() {
+    fun `experiment params are null when the step has none`() {
         val event = WorkflowEvent.StepStarted(
             creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
             workflowId = "wfl_abc",

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/events/WorkflowEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/events/WorkflowEventTest.kt
@@ -109,6 +109,58 @@ class WorkflowEventTest {
     }
 
     @Test
+    fun `experiment params are echoed into backend properties for every workflow event`() {
+        val creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date())
+        val events = listOf(
+            WorkflowEvent.StepStarted(
+                creationData = creationData,
+                workflowId = "wfl_abc",
+                stepId = "step-1",
+                traceId = "trace",
+                experimentId = "exp_abc",
+                experimentVariant = "b",
+            ),
+            WorkflowEvent.StepCompleted(
+                creationData = creationData,
+                workflowId = "wfl_abc",
+                stepId = "step-1",
+                traceId = "trace",
+                experimentId = "exp_abc",
+                experimentVariant = "b",
+            ),
+            WorkflowEvent.Close(
+                creationData = creationData,
+                workflowId = "wfl_abc",
+                stepId = "step-1",
+                traceId = "trace",
+                experimentId = "exp_abc",
+                experimentVariant = "b",
+            ),
+        )
+
+        for (event in events) {
+            val properties = (event.toBackendStoredEvent("user_42") as BackendStoredEvent.Workflows).event.properties
+            assertThat(properties.experimentId).`as`(event::class.simpleName).isEqualTo("exp_abc")
+            assertThat(properties.experimentVariant).`as`(event::class.simpleName).isEqualTo("b")
+            assertThat(properties.isLastVariantStep).isNull()
+        }
+    }
+
+    @Test
+    fun `experiment params default to null so steps outside an experiment send nothing`() {
+        val event = WorkflowEvent.StepStarted(
+            creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
+            workflowId = "wfl_abc",
+            stepId = "step-1",
+            traceId = "trace",
+        )
+
+        val properties = (event.toBackendStoredEvent("user_42") as BackendStoredEvent.Workflows).event.properties
+        assertThat(properties.experimentId).isNull()
+        assertThat(properties.experimentVariant).isNull()
+    }
+
+    @Test
     fun `Close carries workflow, step, and step-position metadata`() {
         val event = WorkflowEvent.Close(
             creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -1420,6 +1420,8 @@ internal class PaywallViewModelImpl(
                 entryReason = entryReason.value,
                 isFirstStep = step.id == workflow.initialStepId,
                 isLastStep = isTerminalStep(workflow, step.id),
+                experimentId = step.experimentId,
+                experimentVariant = step.experimentVariant,
             ),
         )
     }
@@ -1435,6 +1437,8 @@ internal class PaywallViewModelImpl(
                 toStepId = toStepId,
                 isFirstStep = step.id == workflow.initialStepId,
                 isLastStep = isTerminalStep(workflow, step.id),
+                experimentId = step.experimentId,
+                experimentVariant = step.experimentVariant,
             ),
         )
     }
@@ -1481,6 +1485,8 @@ internal class PaywallViewModelImpl(
                 traceId = workflowTraceId,
                 isFirstStep = step.id == workflow.initialStepId,
                 isLastStep = isTerminalStep(workflow, step.id),
+                experimentId = step.experimentId,
+                experimentVariant = step.experimentVariant,
             ),
         )
     }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -1338,7 +1338,7 @@ class PaywallViewModelWorkflowTest {
 
     @Test
     fun `step events echo the experiment params baked into the step`() {
-        // step-2 has no experiment on its path, so it has nothing to echo.
+        // step-2 has no experiment params.
         val experimentStep1 = step1.copy(
             paramValues = mapOf(
                 "experiment_id" to JsonPrimitive("exp_abc"),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -1338,7 +1338,7 @@ class PaywallViewModelWorkflowTest {
 
     @Test
     fun `step events echo the experiment params baked into the step`() {
-        // step-2 is outside the variant, so it has nothing to echo.
+        // step-2 has no experiment on its path, so it has nothing to echo.
         val experimentStep1 = step1.copy(
             paramValues = mapOf(
                 "experiment_id" to JsonPrimitive("exp_abc"),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -1338,7 +1338,6 @@ class PaywallViewModelWorkflowTest {
 
     @Test
     fun `step events echo the experiment params baked into the step`() {
-        // step-2 has no experiment params.
         val experimentStep1 = step1.copy(
             paramValues = mapOf(
                 "experiment_id" to JsonPrimitive("exp_abc"),
@@ -1364,8 +1363,9 @@ class PaywallViewModelWorkflowTest {
         assertThat(step1Started).hasSize(2)
         assertThat(step1Started.map { it.experimentId }).containsOnly("exp_abc")
         assertThat(step1Started.map { it.experimentVariant }).containsOnly("b")
+        // step-1 completes twice: once on forward navigation, once from closePaywall.
         val step1Completed = completed.filter { it.stepId == "step-1" }
-        assertThat(step1Completed).isNotEmpty
+        assertThat(step1Completed).hasSize(2)
         assertThat(step1Completed.map { it.experimentId }).containsOnly("exp_abc")
         assertThat(step1Completed.map { it.experimentVariant }).containsOnly("b")
         assertThat(close.stepId).isEqualTo("step-1")
@@ -1375,6 +1375,9 @@ class PaywallViewModelWorkflowTest {
         val step2Started = started.single { it.stepId == "step-2" }
         assertThat(step2Started.experimentId).isNull()
         assertThat(step2Started.experimentVariant).isNull()
+        val step2Completed = completed.single { it.stepId == "step-2" }
+        assertThat(step2Completed.experimentId).isNull()
+        assertThat(step2Completed.experimentVariant).isNull()
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -1337,6 +1337,48 @@ class PaywallViewModelWorkflowTest {
     }
 
     @Test
+    fun `step events echo the experiment params baked into the step`() {
+        // The backend bakes experiment_id / experiment_variant into the steps of the enrolled variant.
+        // Every step event echoes them verbatim so khepri can enroll on exposure. step-2 has none.
+        val experimentStep1 = step1.copy(
+            paramValues = mapOf(
+                "experiment_id" to JsonPrimitive("exp_abc"),
+                "experiment_variant" to JsonPrimitive("b"),
+            ),
+        )
+        val experimentWorkflow = workflow.copy(steps = mapOf("step-1" to experimentStep1, "step-2" to step2))
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        vm.startWorkflowPresentationFromResult(experimentWorkflow, testOfferings, null, uiConfig)
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        vm.onTransitionComplete(vm.workflowState.value!!.pendingTransition!!.id)
+        vm.handleBackNavigation()
+        vm.closePaywall(result = null)
+
+        val started = captured.filterIsInstance<WorkflowEvent.StepStarted>()
+        val completed = captured.filterIsInstance<WorkflowEvent.StepCompleted>()
+        val close = captured.filterIsInstance<WorkflowEvent.Close>().single()
+
+        val step1Started = started.filter { it.stepId == "step-1" }
+        assertThat(step1Started).hasSize(2)
+        assertThat(step1Started.map { it.experimentId }).containsOnly("exp_abc")
+        assertThat(step1Started.map { it.experimentVariant }).containsOnly("b")
+        val step1Completed = completed.filter { it.stepId == "step-1" }
+        assertThat(step1Completed).isNotEmpty
+        assertThat(step1Completed.map { it.experimentId }).containsOnly("exp_abc")
+        assertThat(step1Completed.map { it.experimentVariant }).containsOnly("b")
+        assertThat(close.stepId).isEqualTo("step-1")
+        assertThat(close.experimentId).isEqualTo("exp_abc")
+        assertThat(close.experimentVariant).isEqualTo("b")
+
+        val step2Started = started.single { it.stepId == "step-2" }
+        assertThat(step2Started.experimentId).isNull()
+        assertThat(step2Started.experimentVariant).isNull()
+    }
+
+    @Test
     fun `closePaywall without a purchase fires workflows Close for the current step`() {
         val captured = mutableListOf<FeatureEvent>()
         every { purchases.track(any()) } answers { captured.add(firstArg()) }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -1338,8 +1338,7 @@ class PaywallViewModelWorkflowTest {
 
     @Test
     fun `step events echo the experiment params baked into the step`() {
-        // The backend bakes experiment_id / experiment_variant into the steps of the enrolled variant.
-        // Every step event echoes them verbatim so khepri can enroll on exposure. step-2 has none.
+        // step-2 is outside the variant, so it has nothing to echo.
         val experimentStep1 = step1.copy(
             paramValues = mapOf(
                 "experiment_id" to JsonPrimitive("exp_abc"),


### PR DESCRIPTION
### Motivation

backend send experiment_id and experiment_variant into the param_values of every step in the enrolled variant. We need to echo them back on step impression.

We also report the content identity of the workflow payload they came from, so the backend can validate the claim instead of trusting it. The three travel together as one value on the event, named `workflowBlobRef` at the SDK level, and none of them are sent for a step with no experiment. Wire keys stay `experiment_id`, `experiment_variant` and `blob_ref`.

Ref: [WFL-520](https://linear.app/revenuecat/issue/WFL-520/add-experiment-properties-to-sdk-workflow-step-events)

iOS counterpart: RevenueCat/purchases-ios#7659. Backend field: RevenueCat/khepri#25025.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this one
- Branch: `facu/workflow-experiment-echo`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Claude Opus 5)
- Session source: current conversation
- Generated: 2026-09-08
- Context document version: 1

## Goal

Let khepri enroll a subscriber in a multipage paywall experiment on exposure: the SDK echoes the experiment id and variant the backend baked into the rendered step.

## Initial Prompt

Port the iOS change (purchases-ios #7659) to Android, after investigating in khepri how workflow experiments reach the SDK and how they are reported back.

## Important Follow-up Prompts

- Design confirmed from khepri #24946 (EXP-526) and the Slack thread with Álvaro: one experiment per screen, params baked into step `param_values`, SDK echoes them, nothing derived from the config fetch.
- User: no khepri contract change and no SDK min-version gate needed; old SDKs send nothing and absence means no enrollment.

## Agent Contribution

- Code: `WorkflowStep.experimentId` / `experimentVariant`; two new fields on each `WorkflowEvent` subclass; passed through `toBackendStoredEvent`; set at the three `purchases.track` call sites in `PaywallViewModel`.
- Tests: 3 deserialization cases, 2 event-conversion cases, 1 view-model case covering forward nav, back nav and close.

## Human Decisions

- Echo only; the SDK never interprets the params.
- `is_last_variant_step` left null, to be baked by khepri if wanted.

## Key Implementation Decisions

- Decision: accessors on `WorkflowStep` following the existing `stepScreenType` pattern, non-string values decode to null.
- Decision: echo on `StepStarted`, `StepCompleted` and `Close`, not just `StepStarted`.
  - Rationale: all three build properties from the same step; khepri ignores them where it does not need them.

## Files / Symbols Touched

- `purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt`: `WorkflowStep.experimentId`, `experimentVariant`, `stringParam`.
- `purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/events/WorkflowEvent.kt`: new fields on `StepStarted`, `StepCompleted`, `Close`.
- `purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt`: `toBackendStoredEvent`.
- `ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt`: the three tracking functions.

## Dependencies / Config / Migrations

- None. All new members are `@InternalRevenueCatAPI`, so no `api*.txt` change; `./scripts/api-check.sh` passes. Requires khepri #24946 to be deployed for the params to be present.

## Validation

- RED: `PaywallViewModelWorkflowTest` with the model and event changes in place but the view model unwired: 82 tests, 1 failed (the new echo test).
- GREEN: `PaywallViewModelWorkflowTest` 82/82; `WorkflowModelsDeserializationTest` 22/22; `WorkflowEventTest` 9/9.
- `./gradlew detektAll` BUILD SUCCESSFUL. `./scripts/api-check.sh` BUILD SUCCESSFUL.
- Manual verification: Not run. CI: Not captured at time of writing.

## Validation Gaps

- Not verified against a real blob from khepri #24946; fixtures mirror its test payload.
- `is_last_variant_step` not produced.

## Review Focus

- Is echoing on `Close` acceptable, or should it be step transitions only?
- Should `is_last_variant_step` be derived client side or baked by khepri?

## Risks / Reviewer Notes

- Risk: an app on this SDK version with #24946 not yet deployed sends nothing. Evidence: params absent means null, khepri treats absence as no enrollment. Mitigation: none needed.

## Non-goals / Out of Scope

- Deriving enrollment from the config fetch (explicitly not an enrollment per EXP-526).
- Offering experiments.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional analytics fields on internal workflow events; absent params stay null and older backends/SDKs are unaffected.
> 
> **Overview**
> Workflow analytics now **echo** `experiment_id` and `experiment_variant` from each step’s `param_values` onto workflow lifecycle events sent to the backend, matching the iOS/khepri contract for multipage paywall experiments.
> 
> `WorkflowStep` exposes the two string params (non-strings decode as null). **StepStarted**, **StepCompleted**, and **Close** carry them through `toBackendStoredEvent` as `experiment_id` / `experiment_variant` on the wire (omitted when absent). `PaywallViewModel` fills these from the current step at all three tracking sites. **`is_last_variant_step`** was removed from the backend properties model; it is not set client-side.
> 
> Tests cover deserialization, JSON wire names, event conversion, and paywall navigation/close behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be0fa5a0b96fcdad6d72d7f142335f934900e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
