### PR TITLE
Reconcile package selection when a window size rule hides the selected package

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ScreenCondition.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ScreenCondition.kt
@@ -1,14 +1,13 @@
 package com.revenuecat.purchases.ui.revenuecatui.components
 
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.currentWindowSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
@@ -50,12 +49,16 @@ internal fun MeasurePaywallBounds(
                 height = if (constraints.hasBoundedHeight) maxHeight else windowDpSize.height,
             )
         }
+        // Size-class overrides resolve against the app window, not the paywall bounds — the two
+        // can fall in different size classes in a sheet or pane, so reconcile needs both.
+        val screenCondition = ScreenCondition.from(currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass)
         for (state in states) {
             state.paywallBoundsDp = bounds
+            state.windowScreenCondition = screenCondition
         }
         // Keyed on states too: workflow prewarming can add states while bounds stay constant,
         // and those join with a selection that was resolved before the bounds were known.
-        LaunchedEffect(bounds, states) {
+        LaunchedEffect(bounds, screenCondition, states) {
             for (state in states) {
                 state.reconcileSelectionForWindowSize(bounds)
             }
@@ -79,10 +82,6 @@ internal enum class ScreenCondition {
     ;
 
     companion object {
-        // WindowWidthSizeClass breakpoints (WindowSizeClass.kt).
-        private val MIN_WIDTH_MEDIUM = 600.dp
-        private val MIN_WIDTH_EXPANDED = 840.dp
-
         @JvmSynthetic
         fun from(sizeClass: WindowWidthSizeClass) =
             when (sizeClass) {
@@ -93,15 +92,6 @@ internal enum class ScreenCondition {
                     Logger.d("Unexpected WindowWidthSizeClass: '$sizeClass'. Falling back to COMPACT.")
                     COMPACT
                 }
-            }
-
-        /** The condition the renderer would use at [width], for evaluation at a known size. */
-        @JvmSynthetic
-        fun forWindowWidth(width: Dp): ScreenCondition =
-            when {
-                width < MIN_WIDTH_MEDIUM -> COMPACT
-                width < MIN_WIDTH_EXPANDED -> MEDIUM
-                else -> EXPANDED
             }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ScreenCondition.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ScreenCondition.kt
@@ -6,7 +6,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
@@ -51,7 +53,9 @@ internal fun MeasurePaywallBounds(
         for (state in states) {
             state.paywallBoundsDp = bounds
         }
-        LaunchedEffect(bounds) {
+        // Keyed on states too: workflow prewarming can add states while bounds stay constant,
+        // and those join with a selection that was resolved before the bounds were known.
+        LaunchedEffect(bounds, states) {
             for (state in states) {
                 state.reconcileSelectionForWindowSize(bounds)
             }
@@ -75,6 +79,10 @@ internal enum class ScreenCondition {
     ;
 
     companion object {
+        // WindowWidthSizeClass breakpoints (WindowSizeClass.kt).
+        private val MIN_WIDTH_MEDIUM = 600.dp
+        private val MIN_WIDTH_EXPANDED = 840.dp
+
         @JvmSynthetic
         fun from(sizeClass: WindowWidthSizeClass) =
             when (sizeClass) {
@@ -85,6 +93,15 @@ internal enum class ScreenCondition {
                     Logger.d("Unexpected WindowWidthSizeClass: '$sizeClass'. Falling back to COMPACT.")
                     COMPACT
                 }
+            }
+
+        /** The condition the renderer would use at [width], for evaluation at a known size. */
+        @JvmSynthetic
+        fun forWindowWidth(width: Dp): ScreenCondition =
+            when {
+                width < MIN_WIDTH_MEDIUM -> COMPACT
+                width < MIN_WIDTH_EXPANDED -> MEDIUM
+                else -> EXPANDED
             }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ScreenCondition.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ScreenCondition.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.material3.adaptive.currentWindowSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.DpSize
@@ -26,7 +27,9 @@ internal fun currentWindowDpSize(): DpSize = with(LocalDensity.current) {
  * for every state in [states], which window size rules evaluate against — a paywall in a sheet or
  * pane matches its own bounds, not the app window's, same as iOS. An unbounded axis (e.g. the
  * height of a fit-content sheet) falls back to the app window's dimension. Available synchronously
- * to [content], so rules resolve correctly on the first frame.
+ * to [content], so rules resolve correctly on the first frame. Also reconciles the package
+ * selection on bounds changes: a window size rule can hide the selected package (initial selection
+ * happens before the bounds are known, and the bounds can change later).
  */
 @JvmSynthetic
 @Composable
@@ -47,6 +50,11 @@ internal fun MeasurePaywallBounds(
         }
         for (state in states) {
             state.paywallBoundsDp = bounds
+        }
+        LaunchedEffect(bounds) {
+            for (state in states) {
+                state.reconcileSelectionForWindowSize(bounds)
+            }
         }
         content()
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -374,10 +374,11 @@ internal sealed interface PaywallState {
                 if (selectedTabIndex != null) {
                     this.selectedTabIndex = selectedTabIndex
                     // If our currently selected package exists outside of tabs, we don't have to change the selected
-                    // package when the tab changes.
+                    // package when the tab changes — but the new tab's context can still change what's visible.
                     if (selectedPackageUniqueId != null &&
                         packagesOutsideTabsUniqueIds.contains(selectedPackageUniqueId)
                     ) {
+                        reconcileSelectionForWindowSize(paywallBoundsDp)
                         return
                     }
 
@@ -397,8 +398,6 @@ internal sealed interface PaywallState {
                         // Nothing in the tab renders, so fall back outside it rather than clearing.
                         ?: visibleFallbackForHiddenDefaultOutsideTabs
 
-                    // The remembered or default selection for this tab was resolved without the
-                    // measured bounds, so it can be hidden here by a window size rule.
                     reconcileSelectionForWindowSize(paywallBoundsDp)
                 }
 
@@ -419,42 +418,96 @@ internal sealed interface PaywallState {
             }
 
             /**
-             * Moves the selection off a package that a window size rule hides at the measured
-             * window size, so a hidden package can't stay selected and purchasable. Initial
-             * selection is resolved before the window size is known, and the window can change
-             * later. If nothing resolves visible the selection stays put (iOS parity). Acts only
-             * on this state's own selection; the workflow-level [defaultPackageInfo] fallback is
-             * not owned by this state and is left as-is.
+             * Moves the selection off a package that is hidden at the measured window size, so a
+             * hidden package can't stay selected and purchasable. Initial selection is resolved
+             * before the window size is known, and the window can change later. If nothing
+             * resolves visible the selection stays put (iOS parity). Acts only on this state's
+             * own selection; the workflow-level [defaultPackageInfo] fallback is not owned by
+             * this state and is left as-is.
+             *
+             * The keep-check mirrors what the renderer shows: it evaluates the current package as
+             * selected, in the active tab's context, under the screen condition the measured
+             * width implies. Replacement candidates are still evaluated unselected so the choice
+             * can't depend on its own outcome.
              */
             fun reconcileSelectionForWindowSize(windowDpSize: DpSize?) {
                 if (windowDpSize == null) return
-                val current = selectedPackageUniqueId?.let(::findPackageInfoByUniqueId)
-                if (current != null && !current.resolvesVisible(mergedCustomVariables, windowDpSize)) {
-                    val candidates = packages.packagesOutsideTabs +
-                        packages.packagesByTab[selectedTabIndex].orEmpty()
-                    val replacement = candidates.defaultSelection(mergedCustomVariables, windowDpSize)
-                    if (replacement != null && replacement.uniqueId != current.uniqueId) {
-                        update(selectedPackageUniqueId = replacement.uniqueId)
+                val screenCondition = ScreenCondition.forWindowWidth(windowDpSize.width)
+                // Tab-scoped: the same uniqueId can exist in several tabs with different rules,
+                // and only the active tab's copy (or an outside-tabs copy) is on screen.
+                val activeContext = packages.packagesOutsideTabs +
+                    packages.packagesByTab[selectedTabIndex].orEmpty()
+                val current = selectedPackageUniqueId?.let { uid -> activeContext.find { it.uniqueId == uid } }
+                    ?: return
+                val currentRendersVisible = current.resolvesVisible(
+                    customVariables = mergedCustomVariables,
+                    windowDpSize = windowDpSize,
+                    screenCondition = screenCondition,
+                    selectedPackageId = current.pkg.identifier,
+                    viewState = ComponentViewState.SELECTED,
+                )
+                if (!currentRendersVisible) {
+                    val replacement = defaultUniqueIdForCurrentContext(windowDpSize, screenCondition)
+                    if (replacement != null) {
+                        update(selectedPackageUniqueId = replacement)
                     }
                 }
             }
 
+            /**
+             * The visible default for the current tab / root context, with the same priority as
+             * [peekDefaultPackageUniqueIdAfterSheetDismiss]: the tab's authored default first,
+             * then outside the tabs, then the first package that renders.
+             */
+            private fun defaultUniqueIdForCurrentContext(
+                windowDpSize: DpSize?,
+                screenCondition: ScreenCondition,
+            ): String? {
+                val tabPackages = packages.packagesByTab[selectedTabIndex]
+                val outside = packages.packagesOutsideTabs
+                return tabPackages?.authoredDefaultIfVisible(mergedCustomVariables, windowDpSize, screenCondition)
+                    ?.uniqueId
+                    ?: outside.authoredDefaultIfVisible(mergedCustomVariables, windowDpSize, screenCondition)?.uniqueId
+                    ?: tabPackages?.firstVisible(mergedCustomVariables, windowDpSize, screenCondition)?.uniqueId
+                    ?: outside.firstVisible(mergedCustomVariables, windowDpSize, screenCondition)?.uniqueId
+            }
+
             fun resetToDefaultPackage() {
                 selectedPackageUniqueId = peekDefaultPackageUniqueIdAfterSheetDismiss()
-                // The restored default was resolved without the measured bounds.
+                // Remembered ids in the peek chain aren't visibility-checked, so reconcile still runs.
                 reconcileSelectionForWindowSize(paywallBoundsDp)
             }
 
-            /** The package the current tab should fall back to, which is also what a reset restores. */
-            fun peekDefaultPackageUniqueIdAfterSheetDismiss(): String? {
+            /**
+             * The package the current tab should fall back to, which is also what a reset restores.
+             * Evaluates visibility at the measured bounds so callers (analytics, sheet dismiss)
+             * see the same package [resetToDefaultPackage] lands on.
+             */
+            fun peekDefaultPackageUniqueIdAfterSheetDismiss(windowDpSize: DpSize? = paywallBoundsDp): String? {
                 val tabPackages = packages.packagesByTab[selectedTabIndex]
+                val screenCondition = windowDpSize?.let { ScreenCondition.forWindowWidth(it.width) }
+                    ?: ScreenCondition.COMPACT
                 // A default authored outside the tabs outranks a tab package that was never authored as
                 // one, so the tab's own default is consulted first and its first visible package last.
-                return tabPackages?.authoredDefaultIfVisible(mergedCustomVariables)?.uniqueId
-                    ?: initialSelectedPackageOutsideTabs
-                    ?: selectedPackageByTab[selectedTabIndex]
-                    ?: tabPackages?.firstVisible(mergedCustomVariables)?.uniqueId
+                // Remembered ids are skipped when hidden at the measured bounds, so this peek and the
+                // reconcile after [resetToDefaultPackage] land on the same package.
+                return tabPackages?.authoredDefaultIfVisible(mergedCustomVariables, windowDpSize, screenCondition)
+                    ?.uniqueId
+                    ?: uniqueIdIfVisibleAtBounds(initialSelectedPackageOutsideTabs, windowDpSize, screenCondition)
+                    ?: uniqueIdIfVisibleAtBounds(selectedPackageByTab[selectedTabIndex], windowDpSize, screenCondition)
+                    ?: tabPackages?.firstVisible(mergedCustomVariables, windowDpSize, screenCondition)?.uniqueId
                     ?: visibleFallbackForHiddenDefaultOutsideTabs
+            }
+
+            /** [uniqueId] when it renders at the measured bounds; null when hidden. Unknown ids pass through. */
+            private fun uniqueIdIfVisibleAtBounds(
+                uniqueId: String?,
+                windowDpSize: DpSize?,
+                screenCondition: ScreenCondition,
+            ): String? = uniqueId?.takeIf { uid ->
+                val info = (packages.packagesOutsideTabs + packages.packagesByTab[selectedTabIndex].orEmpty())
+                    .find { it.uniqueId == uid }
+                info == null || info.resolvesVisible(mergedCustomVariables, windowDpSize, screenCondition)
             }
 
             fun peekSelectedPackageInfoAfterSheetDismiss(): SelectedPackageInfo? {
@@ -559,25 +612,31 @@ internal val PaywallState.Loaded.Legacy.isInFullScreenMode: Boolean
 /**
  * Whether this package renders, evaluating the same overrides the renderer does.
  *
- * Resolved as unselected with no selected package, because selection is what's being decided: pinning
- * those keeps resolution independent of its own result, so a paywall with `selected` or
- * `selected_package` visibility rules can't oscillate.
+ * By default resolved as unselected with no selected package, because selection is usually what's
+ * being decided: pinning those keeps resolution independent of its own result, so a paywall with
+ * `selected` or `selected_package` visibility rules can't oscillate. The reconcile keep-check passes
+ * the real [selectedPackageId] and [viewState] instead — evaluating an already-selected package as
+ * selected mirrors the renderer and is a stable fixpoint.
  *
  * Note this only covers the package component's own rules. A package hidden solely by an enclosing
- * stack's rule still resolves visible here. The screen condition is pinned to COMPACT, so size-class
- * rules do not influence selection. The window size defaults to unknown (initial selection happens
- * before it can be known); the reconcile-on-resize path passes the measured [windowDpSize].
+ * stack's rule still resolves visible here. The screen condition defaults to COMPACT for initial
+ * selection (which happens before any size is known); paths that know the measured bounds pass the
+ * [screenCondition] the renderer would use, plus the measured [windowDpSize].
  */
+@Suppress("LongParameterList")
 private fun PaywallState.Loaded.Components.AvailablePackages.Info.resolvesVisible(
     customVariables: Map<String, CustomVariableValue>,
     windowDpSize: DpSize? = null,
+    screenCondition: ScreenCondition = ScreenCondition.COMPACT,
+    selectedPackageId: String? = null,
+    viewState: ComponentViewState = ComponentViewState.DEFAULT,
 ): Boolean =
     visibilityOverrides.buildPresentedPartial(
-        windowSize = ScreenCondition.COMPACT,
+        windowSize = screenCondition,
         offerEligibility = offerEligibility ?: OfferEligibility.Ineligible,
-        state = ComponentViewState.DEFAULT,
+        state = viewState,
         conditionContext = ConditionContext(
-            selectedPackageId = null,
+            selectedPackageId = selectedPackageId,
             customVariables = customVariables,
             windowDpSize = windowDpSize,
         ),
@@ -590,18 +649,24 @@ private fun PaywallState.Loaded.Components.AvailablePackages.Info.resolvesVisibl
 private fun List<PaywallState.Loaded.Components.AvailablePackages.Info>.defaultSelection(
     customVariables: Map<String, CustomVariableValue>,
     windowDpSize: DpSize? = null,
+    screenCondition: ScreenCondition = ScreenCondition.COMPACT,
 ): PaywallState.Loaded.Components.AvailablePackages.Info? =
-    authoredDefaultIfVisible(customVariables, windowDpSize) ?: firstVisible(customVariables, windowDpSize)
+    authoredDefaultIfVisible(customVariables, windowDpSize, screenCondition)
+        ?: firstVisible(customVariables, windowDpSize, screenCondition)
 
 /** The package authored as the default, only when it renders. */
 private fun List<PaywallState.Loaded.Components.AvailablePackages.Info>.authoredDefaultIfVisible(
     customVariables: Map<String, CustomVariableValue>,
     windowDpSize: DpSize? = null,
+    screenCondition: ScreenCondition = ScreenCondition.COMPACT,
 ): PaywallState.Loaded.Components.AvailablePackages.Info? =
-    firstOrNull { it.isSelectedByDefault && it.resolvesVisible(customVariables, windowDpSize) }
+    firstOrNull {
+        it.isSelectedByDefault && it.resolvesVisible(customVariables, windowDpSize, screenCondition)
+    }
 
 private fun List<PaywallState.Loaded.Components.AvailablePackages.Info>.firstVisible(
     customVariables: Map<String, CustomVariableValue>,
     windowDpSize: DpSize? = null,
+    screenCondition: ScreenCondition = ScreenCondition.COMPACT,
 ): PaywallState.Loaded.Components.AvailablePackages.Info? =
-    firstOrNull { it.resolvesVisible(customVariables, windowDpSize) }
+    firstOrNull { it.resolvesVisible(customVariables, windowDpSize, screenCondition) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -94,7 +94,7 @@ internal sealed interface PaywallState {
             }
         }
 
-        @Suppress("LongParameterList")
+        @Suppress("LongParameterList", "TooManyFunctions")
         @Stable
         class Components(
             val stack: ComponentStyle,
@@ -414,6 +414,25 @@ internal sealed interface PaywallState {
                 if (currentTabContainsThisPackage) selectedPackageByTab[currentTabIndex] = selectedPackageUniqueId
             }
 
+            /**
+             * Moves the selection off a package that a window size rule hides at the measured
+             * window size, so a hidden package can't stay selected and purchasable. Initial
+             * selection is resolved before the window size is known, and the window can change
+             * later. If nothing resolves visible the selection stays put.
+             */
+            fun reconcileSelectionForWindowSize(windowDpSize: DpSize?) {
+                if (windowDpSize == null) return
+                val current = selectedPackageUniqueId?.let(::findPackageInfoByUniqueId)
+                if (current != null && !current.resolvesVisible(mergedCustomVariables, windowDpSize)) {
+                    val candidates = packages.packagesOutsideTabs +
+                        packages.packagesByTab[selectedTabIndex].orEmpty()
+                    val replacement = candidates.defaultSelection(mergedCustomVariables, windowDpSize)
+                    if (replacement != null && replacement.uniqueId != current.uniqueId) {
+                        update(selectedPackageUniqueId = replacement.uniqueId)
+                    }
+                }
+            }
+
             fun resetToDefaultPackage() {
                 selectedPackageUniqueId = peekDefaultPackageUniqueIdAfterSheetDismiss()
             }
@@ -537,17 +556,23 @@ internal val PaywallState.Loaded.Legacy.isInFullScreenMode: Boolean
  * `selected_package` visibility rules can't oscillate.
  *
  * Note this only covers the package component's own rules. A package hidden solely by an enclosing
- * stack's rule still resolves visible here. The screen condition is pinned to COMPACT and the window
- * size to unknown, so size-class and window-size visibility rules do not influence selection either.
+ * stack's rule still resolves visible here. The screen condition is pinned to COMPACT, so size-class
+ * rules do not influence selection. The window size defaults to unknown (initial selection happens
+ * before it can be known); the reconcile-on-resize path passes the measured [windowDpSize].
  */
 private fun PaywallState.Loaded.Components.AvailablePackages.Info.resolvesVisible(
     customVariables: Map<String, CustomVariableValue>,
+    windowDpSize: DpSize? = null,
 ): Boolean =
     visibilityOverrides.buildPresentedPartial(
         windowSize = ScreenCondition.COMPACT,
         offerEligibility = offerEligibility ?: OfferEligibility.Ineligible,
         state = ComponentViewState.DEFAULT,
-        conditionContext = ConditionContext(selectedPackageId = null, customVariables = customVariables),
+        conditionContext = ConditionContext(
+            selectedPackageId = null,
+            customVariables = customVariables,
+            windowDpSize = windowDpSize,
+        ),
     )?.partial?.visible ?: visible
 
 /**
@@ -556,16 +581,19 @@ private fun PaywallState.Loaded.Components.AvailablePackages.Info.resolvesVisibl
  */
 private fun List<PaywallState.Loaded.Components.AvailablePackages.Info>.defaultSelection(
     customVariables: Map<String, CustomVariableValue>,
+    windowDpSize: DpSize? = null,
 ): PaywallState.Loaded.Components.AvailablePackages.Info? =
-    authoredDefaultIfVisible(customVariables) ?: firstVisible(customVariables)
+    authoredDefaultIfVisible(customVariables, windowDpSize) ?: firstVisible(customVariables, windowDpSize)
 
 /** The package authored as the default, only when it renders. */
 private fun List<PaywallState.Loaded.Components.AvailablePackages.Info>.authoredDefaultIfVisible(
     customVariables: Map<String, CustomVariableValue>,
+    windowDpSize: DpSize? = null,
 ): PaywallState.Loaded.Components.AvailablePackages.Info? =
-    firstOrNull { it.isSelectedByDefault && it.resolvesVisible(customVariables) }
+    firstOrNull { it.isSelectedByDefault && it.resolvesVisible(customVariables, windowDpSize) }
 
 private fun List<PaywallState.Loaded.Components.AvailablePackages.Info>.firstVisible(
     customVariables: Map<String, CustomVariableValue>,
+    windowDpSize: DpSize? = null,
 ): PaywallState.Loaded.Components.AvailablePackages.Info? =
-    firstOrNull { it.resolvesVisible(customVariables) }
+    firstOrNull { it.resolvesVisible(customVariables, windowDpSize) }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -396,6 +396,10 @@ internal sealed interface PaywallState {
                             ?.uniqueId
                         // Nothing in the tab renders, so fall back outside it rather than clearing.
                         ?: visibleFallbackForHiddenDefaultOutsideTabs
+
+                    // The remembered or default selection for this tab was resolved without the
+                    // measured bounds, so it can be hidden here by a window size rule.
+                    reconcileSelectionForWindowSize(paywallBoundsDp)
                 }
 
                 if (clickScopedActionInProgress != null) {
@@ -418,7 +422,9 @@ internal sealed interface PaywallState {
              * Moves the selection off a package that a window size rule hides at the measured
              * window size, so a hidden package can't stay selected and purchasable. Initial
              * selection is resolved before the window size is known, and the window can change
-             * later. If nothing resolves visible the selection stays put.
+             * later. If nothing resolves visible the selection stays put (iOS parity). Acts only
+             * on this state's own selection; the workflow-level [defaultPackageInfo] fallback is
+             * not owned by this state and is left as-is.
              */
             fun reconcileSelectionForWindowSize(windowDpSize: DpSize?) {
                 if (windowDpSize == null) return
@@ -435,6 +441,8 @@ internal sealed interface PaywallState {
 
             fun resetToDefaultPackage() {
                 selectedPackageUniqueId = peekDefaultPackageUniqueIdAfterSheetDismiss()
+                // The restored default was resolved without the measured bounds.
+                reconcileSelectionForWindowSize(paywallBoundsDp)
             }
 
             /** The package the current tab should fall back to, which is also what a reset restores. */

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -153,6 +153,14 @@ internal sealed interface PaywallState {
             var paywallBoundsDp: DpSize? by mutableStateOf(null)
                 @JvmSynthetic internal set
 
+            /**
+             * The screen condition the renderer resolves size-class overrides with — derived from
+             * the app window, not the paywall bounds, which can fall in different size classes in
+             * a sheet or pane. Set alongside [paywallBoundsDp] by the paywall root's measurement.
+             */
+            var windowScreenCondition: ScreenCondition by mutableStateOf(ScreenCondition.COMPACT)
+                @JvmSynthetic internal set
+
             val store: Store get() = purchases.store
 
             /** A subset of the offering: packages the paywall never shows are not in it. */
@@ -432,20 +440,23 @@ internal sealed interface PaywallState {
              */
             fun reconcileSelectionForWindowSize(windowDpSize: DpSize?) {
                 if (windowDpSize == null) return
-                val screenCondition = ScreenCondition.forWindowWidth(windowDpSize.width)
+                val screenCondition = windowScreenCondition
                 // Tab-scoped: the same uniqueId can exist in several tabs with different rules,
-                // and only the active tab's copy (or an outside-tabs copy) is on screen.
+                // and only the active tab's copy (or an outside-tabs copy) is on screen. The
+                // selection stays as long as ANY on-screen copy renders visible.
                 val activeContext = packages.packagesOutsideTabs +
                     packages.packagesByTab[selectedTabIndex].orEmpty()
-                val current = selectedPackageUniqueId?.let { uid -> activeContext.find { it.uniqueId == uid } }
-                    ?: return
-                val currentRendersVisible = current.resolvesVisible(
-                    customVariables = mergedCustomVariables,
-                    windowDpSize = windowDpSize,
-                    screenCondition = screenCondition,
-                    selectedPackageId = current.pkg.identifier,
-                    viewState = ComponentViewState.SELECTED,
-                )
+                val uid = selectedPackageUniqueId ?: return
+                val copies = activeContext.filter { it.uniqueId == uid }
+                val currentRendersVisible = copies.isEmpty() || copies.any { copy ->
+                    copy.resolvesVisible(
+                        customVariables = mergedCustomVariables,
+                        windowDpSize = windowDpSize,
+                        screenCondition = screenCondition,
+                        selectedPackageId = copy.pkg.identifier,
+                        viewState = ComponentViewState.SELECTED,
+                    )
+                }
                 if (!currentRendersVisible) {
                     val replacement = defaultUniqueIdForCurrentContext(windowDpSize, screenCondition)
                     if (replacement != null) {
@@ -485,29 +496,34 @@ internal sealed interface PaywallState {
              */
             fun peekDefaultPackageUniqueIdAfterSheetDismiss(windowDpSize: DpSize? = paywallBoundsDp): String? {
                 val tabPackages = packages.packagesByTab[selectedTabIndex]
-                val screenCondition = windowDpSize?.let { ScreenCondition.forWindowWidth(it.width) }
-                    ?: ScreenCondition.COMPACT
+                val screenCondition = windowScreenCondition
                 // A default authored outside the tabs outranks a tab package that was never authored as
                 // one, so the tab's own default is consulted first and its first visible package last.
                 // Remembered ids are skipped when hidden at the measured bounds, so this peek and the
-                // reconcile after [resetToDefaultPackage] land on the same package.
+                // reconcile after [resetToDefaultPackage] land on the same package. The init-time
+                // fallback is the true last resort, kept even when hidden (matching reconcile's
+                // stay-put behavior when nothing is visible).
                 return tabPackages?.authoredDefaultIfVisible(mergedCustomVariables, windowDpSize, screenCondition)
                     ?.uniqueId
                     ?: uniqueIdIfVisibleAtBounds(initialSelectedPackageOutsideTabs, windowDpSize, screenCondition)
                     ?: uniqueIdIfVisibleAtBounds(selectedPackageByTab[selectedTabIndex], windowDpSize, screenCondition)
                     ?: tabPackages?.firstVisible(mergedCustomVariables, windowDpSize, screenCondition)?.uniqueId
+                    ?: packages.packagesOutsideTabs.firstVisible(mergedCustomVariables, windowDpSize, screenCondition)
+                        ?.uniqueId
                     ?: visibleFallbackForHiddenDefaultOutsideTabs
             }
 
-            /** [uniqueId] when it renders at the measured bounds; null when hidden. Unknown ids pass through. */
+            /** [uniqueId] when any of its copies renders at the measured bounds; null when all are hidden. */
             private fun uniqueIdIfVisibleAtBounds(
                 uniqueId: String?,
                 windowDpSize: DpSize?,
                 screenCondition: ScreenCondition,
             ): String? = uniqueId?.takeIf { uid ->
-                val info = (packages.packagesOutsideTabs + packages.packagesByTab[selectedTabIndex].orEmpty())
-                    .find { it.uniqueId == uid }
-                info == null || info.resolvesVisible(mergedCustomVariables, windowDpSize, screenCondition)
+                val copies = (packages.packagesOutsideTabs + packages.packagesByTab[selectedTabIndex].orEmpty())
+                    .filter { it.uniqueId == uid }
+                copies.isEmpty() || copies.any {
+                    it.resolvesVisible(mergedCustomVariables, windowDpSize, screenCondition)
+                }
             }
 
             fun peekSelectedPackageInfoAfterSheetDismiss(): SelectedPackageInfo? {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WindowSizeSelectionReconcileWindowTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WindowSizeSelectionReconcileWindowTests.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
@@ -75,6 +76,61 @@ internal class WindowSizeSelectionReconcileWindowTests {
                 controller.setWindowSizeInexact(width = 900.dp, height = 600.dp)
                 waitForIdle()
                 assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+            },
+        )
+    }
+
+    @Test
+    fun `a state added after bounds settle is reconciled too`(): Unit = with(composeTestRule) {
+        fun hiddenOnWideState() = FakePaywallState(
+            components = listOf(
+                PackageComponent(
+                    packageId = TestData.Packages.monthly.identifier,
+                    isSelectedByDefault = true,
+                    stack = StackComponent(components = emptyList()),
+                    overrides = listOf(
+                        ComponentOverride(
+                            conditions = listOf(
+                                ComponentOverride.Condition.WindowWidthRule(
+                                    operator = ComponentOverride.ComparisonOperator.GREATER_THAN_OR_EQUAL,
+                                    value = 700.0,
+                                ),
+                            ),
+                            properties = PartialPackageComponent(visible = false),
+                        ),
+                    ),
+                ),
+                PackageComponent(
+                    packageId = TestData.Packages.annual.identifier,
+                    isSelectedByDefault = false,
+                    stack = StackComponent(components = emptyList()),
+                ),
+            ),
+            packages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
+        )
+
+        val firstState = hiddenOnWideState()
+        val lateState = hiddenOnWideState()
+        val states = mutableStateOf(listOf(firstState))
+
+        windowChangingTest(
+            arrange = { states },
+            act = { statesState ->
+                MeasurePaywallBounds(statesState.value) {
+                    Box(Modifier.fillMaxSize())
+                }
+            },
+            assert = { controller ->
+                controller.setWindowSizeInexact(width = 900.dp, height = 600.dp)
+                waitForIdle()
+                assertThat(firstState.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+                // Selection was resolved before any bounds were known.
+                assertThat(lateState.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+
+                // A prewarmed state joining while the bounds stay constant must be reconciled too.
+                states.value = listOf(firstState, lateState)
+                waitForIdle()
+                assertThat(lateState.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
             },
         )
     }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WindowSizeSelectionReconcileWindowTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WindowSizeSelectionReconcileWindowTests.kt
@@ -1,0 +1,81 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.PackageComponent
+import com.revenuecat.purchases.paywalls.components.PartialPackageComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.windowChangingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * End-to-end wiring for reconcile-on-resize: [MeasurePaywallBounds] measures the content area
+ * and moves the selection off a package that a window size rule hides at the new size.
+ */
+@OptIn(InternalRevenueCatAPI::class)
+@RunWith(AndroidJUnit4::class)
+internal class WindowSizeSelectionReconcileWindowTests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `growing the window past a hide rule moves the selection`(): Unit = with(composeTestRule) {
+        val state = FakePaywallState(
+            components = listOf(
+                PackageComponent(
+                    packageId = TestData.Packages.monthly.identifier,
+                    isSelectedByDefault = true,
+                    stack = StackComponent(components = emptyList()),
+                    overrides = listOf(
+                        ComponentOverride(
+                            conditions = listOf(
+                                ComponentOverride.Condition.WindowWidthRule(
+                                    operator = ComponentOverride.ComparisonOperator.GREATER_THAN_OR_EQUAL,
+                                    value = 700.0,
+                                ),
+                            ),
+                            properties = PartialPackageComponent(visible = false),
+                        ),
+                    ),
+                ),
+                PackageComponent(
+                    packageId = TestData.Packages.annual.identifier,
+                    isSelectedByDefault = false,
+                    stack = StackComponent(components = emptyList()),
+                ),
+            ),
+            packages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
+        )
+
+        windowChangingTest(
+            arrange = { state },
+            act = { paywallState ->
+                MeasurePaywallBounds(paywallState) {
+                    Box(Modifier.fillMaxSize())
+                }
+            },
+            assert = { controller ->
+                controller.setWindowSizeInexact(width = 400.dp, height = 800.dp)
+                waitForIdle()
+                assertThat(state.paywallBoundsDp).isNotNull()
+                assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+
+                controller.setWindowSizeInexact(width = 900.dp, height = 600.dp)
+                waitForIdle()
+                assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+            },
+        )
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsPackageSelectionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsPackageSelectionTests.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverride
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedPackagePartial
+import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
 import com.revenuecat.purchases.ui.revenuecatui.components.previewStackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
@@ -525,8 +526,9 @@ internal class PaywallStateLoadedComponentsPackageSelectionTests {
             initialSelectedTabIndex = null,
         )
         state.update(selectedPackageUniqueId = mediumOnly.uniqueId)
+        state.windowScreenCondition = ScreenCondition.MEDIUM
 
-        // 700dp wide is the medium size class: the renderer shows this package, so reconcile keeps it.
+        // The renderer shows this package on a medium window, so reconcile keeps it.
         state.reconcileSelectionForWindowSize(DpSize(700.dp, 600.dp))
 
         assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
@@ -572,8 +574,9 @@ internal class PaywallStateLoadedComponentsPackageSelectionTests {
             initialSelectedTabIndex = null,
         )
         state.update(selectedPackageUniqueId = hiddenCurrent.uniqueId)
+        state.windowScreenCondition = ScreenCondition.MEDIUM
 
-        // 700dp wide is the medium size class: the authored default is hidden there too.
+        // The authored default is hidden on a medium window too, so it can't be the replacement.
         state.reconcileSelectionForWindowSize(DpSize(700.dp, 600.dp))
 
         assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
@@ -620,6 +623,28 @@ internal class PaywallStateLoadedComponentsPackageSelectionTests {
         state.reconcileSelectionForWindowSize(DpSize(800.dp, 600.dp))
 
         assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
+    fun `Reconcile keeps the selection while any on-screen copy is visible`() {
+        val hiddenOutsideCopy = packageInfo(
+            TestData.Packages.monthly,
+            isSelectedByDefault = false,
+            visibilityOverrides = listOf(hiddenWhenWiderThanOverride(width = 700.0)),
+        )
+        val visibleTabCopy = packageInfo(TestData.Packages.monthly, isSelectedByDefault = false)
+        val tabDefault = packageInfo(TestData.Packages.annual, isSelectedByDefault = true)
+        val state = paywallState(
+            packagesOutsideTabs = listOf(hiddenOutsideCopy),
+            packagesByTab = mapOf(0 to listOf(visibleTabCopy, tabDefault)),
+            initialSelectedTabIndex = 0,
+        )
+        state.update(selectedPackageUniqueId = visibleTabCopy.uniqueId)
+
+        // The hidden outside-tabs copy must not mask the visible copy on the active tab.
+        state.reconcileSelectionForWindowSize(DpSize(800.dp, 600.dp))
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsPackageSelectionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsPackageSelectionTests.kt
@@ -487,6 +487,159 @@ internal class PaywallStateLoadedComponentsPackageSelectionTests {
         assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
     }
 
+    @Test
+    fun `Reconcile keeps the selection when nothing is visible at the measured window size`() {
+        val hiddenDefault = packageInfo(
+            TestData.Packages.monthly,
+            isSelectedByDefault = true,
+            visibilityOverrides = listOf(hiddenWhenWiderThanOverride(width = 700.0)),
+        )
+        val hiddenOther = packageInfo(
+            TestData.Packages.annual,
+            isSelectedByDefault = false,
+            visibilityOverrides = listOf(hiddenWhenWiderThanOverride(width = 700.0)),
+        )
+        val state = paywallState(
+            packagesOutsideTabs = listOf(hiddenDefault, hiddenOther),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+
+        state.reconcileSelectionForWindowSize(DpSize(800.dp, 600.dp))
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+    }
+
+    @Test
+    fun `Reconcile keeps a selected package that is visible only under the medium size class`() {
+        val mediumOnly = packageInfo(
+            TestData.Packages.monthly,
+            isSelectedByDefault = false,
+            visible = false,
+            visibilityOverrides = listOf(visibleWhenOverride(ComponentOverride.Condition.Medium)),
+        )
+        val other = packageInfo(TestData.Packages.annual, isSelectedByDefault = true)
+        val state = paywallState(
+            packagesOutsideTabs = listOf(mediumOnly, other),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+        state.update(selectedPackageUniqueId = mediumOnly.uniqueId)
+
+        // 700dp wide is the medium size class: the renderer shows this package, so reconcile keeps it.
+        state.reconcileSelectionForWindowSize(DpSize(700.dp, 600.dp))
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+    }
+
+    @Test
+    fun `Reconcile keeps a selected package that is visible only while selected`() {
+        val selectedOnly = packageInfo(
+            TestData.Packages.monthly,
+            isSelectedByDefault = false,
+            visible = false,
+            visibilityOverrides = listOf(visibleWhenOverride(ComponentOverride.Condition.Selected)),
+        )
+        val other = packageInfo(TestData.Packages.annual, isSelectedByDefault = true)
+        val state = paywallState(
+            packagesOutsideTabs = listOf(selectedOnly, other),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+        state.update(selectedPackageUniqueId = selectedOnly.uniqueId)
+
+        state.reconcileSelectionForWindowSize(DpSize(400.dp, 800.dp))
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+    }
+
+    @Test
+    fun `Reconcile does not move the selection onto a package hidden at the current size class`() {
+        val hiddenCurrent = packageInfo(
+            TestData.Packages.weekly,
+            isSelectedByDefault = false,
+            visibilityOverrides = listOf(hiddenWhenWiderThanOverride(width = 650.0)),
+        )
+        val mediumHiddenDefault = packageInfo(
+            TestData.Packages.monthly,
+            isSelectedByDefault = true,
+            visibilityOverrides = listOf(hiddenWhenOverride(ComponentOverride.Condition.Medium)),
+        )
+        val visibleOther = packageInfo(TestData.Packages.annual, isSelectedByDefault = false)
+        val state = paywallState(
+            packagesOutsideTabs = listOf(hiddenCurrent, mediumHiddenDefault, visibleOther),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+        state.update(selectedPackageUniqueId = hiddenCurrent.uniqueId)
+
+        // 700dp wide is the medium size class: the authored default is hidden there too.
+        state.reconcileSelectionForWindowSize(DpSize(700.dp, 600.dp))
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
+    fun `Reconcile evaluates the active tab's copy of the selected package`() {
+        val visibleCopy = packageInfo(TestData.Packages.monthly, isSelectedByDefault = false)
+        val hiddenCopy = packageInfo(
+            TestData.Packages.monthly,
+            isSelectedByDefault = false,
+            visibilityOverrides = listOf(hiddenWhenWiderThanOverride(width = 700.0)),
+        )
+        val tabDefault = packageInfo(TestData.Packages.annual, isSelectedByDefault = true)
+        val state = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = mapOf(0 to listOf(visibleCopy), 1 to listOf(hiddenCopy, tabDefault)),
+            initialSelectedTabIndex = 1,
+        )
+        state.update(selectedPackageUniqueId = hiddenCopy.uniqueId)
+
+        // The visible tab-0 copy must not mask the hidden copy on the active tab.
+        state.reconcileSelectionForWindowSize(DpSize(800.dp, 600.dp))
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
+    fun `Reconcile prefers the tab's authored default over one outside the tabs, matching sheet dismiss`() {
+        val hiddenSelected = packageInfo(
+            TestData.Packages.weekly,
+            isSelectedByDefault = false,
+            visibilityOverrides = listOf(hiddenWhenWiderThanOverride(width = 700.0)),
+        )
+        val outsideDefault = packageInfo(TestData.Packages.monthly, isSelectedByDefault = true)
+        val tabDefault = packageInfo(TestData.Packages.annual, isSelectedByDefault = true)
+        val state = paywallState(
+            packagesOutsideTabs = listOf(hiddenSelected, outsideDefault),
+            packagesByTab = mapOf(0 to listOf(tabDefault)),
+            initialSelectedTabIndex = 0,
+        )
+        state.update(selectedPackageUniqueId = hiddenSelected.uniqueId)
+
+        state.reconcileSelectionForWindowSize(DpSize(800.dp, 600.dp))
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
+    fun `Peek after sheet dismiss skips a default hidden at the measured bounds`() {
+        val hiddenDefault = packageInfo(
+            TestData.Packages.monthly,
+            isSelectedByDefault = true,
+            visibilityOverrides = listOf(hiddenWhenWiderThanOverride(width = 700.0)),
+        )
+        val visibleOther = packageInfo(TestData.Packages.annual, isSelectedByDefault = false)
+        val state = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = mapOf(0 to listOf(hiddenDefault, visibleOther)),
+            initialSelectedTabIndex = 0,
+        )
+        state.paywallBoundsDp = DpSize(800.dp, 600.dp)
+
+        assertThat(state.peekDefaultPackageUniqueIdAfterSheetDismiss()).isEqualTo(visibleOther.uniqueId)
+    }
+
     private fun hiddenWhenWiderThanOverride(width: Double) = PresentedOverride(
         conditions = listOf(
             ComponentOverride.Condition.WindowWidthRule(
@@ -494,6 +647,16 @@ internal class PaywallStateLoadedComponentsPackageSelectionTests {
                 value = width,
             ),
         ),
+        properties = PresentedPackagePartial(partial = PartialPackageComponent(visible = false)),
+    )
+
+    private fun visibleWhenOverride(condition: ComponentOverride.Condition) = PresentedOverride(
+        conditions = listOf(condition),
+        properties = PresentedPackagePartial(partial = PartialPackageComponent(visible = true)),
+    )
+
+    private fun hiddenWhenOverride(condition: ComponentOverride.Condition) = PresentedOverride(
+        conditions = listOf(condition),
         properties = PresentedPackagePartial(partial = PartialPackageComponent(visible = false)),
     )
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsPackageSelectionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsPackageSelectionTests.kt
@@ -2,6 +2,8 @@ package com.revenuecat.purchases.ui.revenuecatui.data
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.intl.LocaleList
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
@@ -415,6 +417,85 @@ internal class PaywallStateLoadedComponentsPackageSelectionTests {
 
         assertThat(state.selectedPackageInfo).isNull()
     }
+
+    // endregion
+
+    // region window size rules
+
+    @Test
+    fun `Switching tabs reconciles a remembered selection hidden by a window size rule`() {
+        val state = paywallState(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = mapOf(
+                0 to listOf(packageInfo(TestData.Packages.weekly, isSelectedByDefault = true)),
+                1 to listOf(
+                    packageInfo(
+                        TestData.Packages.monthly,
+                        isSelectedByDefault = true,
+                        visibilityOverrides = listOf(hiddenWhenWiderThanOverride(width = 700.0)),
+                    ),
+                    packageInfo(TestData.Packages.annual, isSelectedByDefault = false),
+                ),
+            ),
+            initialSelectedTabIndex = 0,
+        )
+        state.paywallBoundsDp = DpSize(800.dp, 600.dp)
+
+        state.update(selectedTabIndex = 1)
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
+    fun `Resetting to the default package reconciles a default hidden by a window size rule`() {
+        val hiddenDefault = packageInfo(
+            TestData.Packages.monthly,
+            isSelectedByDefault = true,
+            visibilityOverrides = listOf(hiddenWhenWiderThanOverride(width = 700.0)),
+        )
+        val visiblePackage = packageInfo(TestData.Packages.annual, isSelectedByDefault = false)
+        val state = paywallState(
+            packagesOutsideTabs = listOf(hiddenDefault, visiblePackage),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+        state.paywallBoundsDp = DpSize(800.dp, 600.dp)
+        state.update(selectedPackageUniqueId = visiblePackage.uniqueId)
+
+        state.resetToDefaultPackage()
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
+    fun `Reconciles a user-selected package hidden by a window size rule`() {
+        val hideable = packageInfo(
+            TestData.Packages.monthly,
+            isSelectedByDefault = false,
+            visibilityOverrides = listOf(hiddenWhenWiderThanOverride(width = 700.0)),
+        )
+        val visibleDefault = packageInfo(TestData.Packages.annual, isSelectedByDefault = true)
+        val state = paywallState(
+            packagesOutsideTabs = listOf(hideable, visibleDefault),
+            packagesByTab = emptyMap(),
+            initialSelectedTabIndex = null,
+        )
+        state.update(selectedPackageUniqueId = hideable.uniqueId)
+
+        state.reconcileSelectionForWindowSize(DpSize(800.dp, 600.dp))
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    private fun hiddenWhenWiderThanOverride(width: Double) = PresentedOverride(
+        conditions = listOf(
+            ComponentOverride.Condition.WindowWidthRule(
+                operator = ComponentOverride.ComparisonOperator.GREATER_THAN_OR_EQUAL,
+                value = width,
+            ),
+        ),
+        properties = PresentedPackagePartial(partial = PartialPackageComponent(visible = false)),
+    )
 
     // endregion
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WindowSizeSelectionReconcileTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WindowSizeSelectionReconcileTests.kt
@@ -1,0 +1,127 @@
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.PackageComponent
+import com.revenuecat.purchases.paywalls.components.PartialPackageComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@OptIn(InternalRevenueCatAPI::class)
+class WindowSizeSelectionReconcileTests {
+
+    private val wideWindow = DpSize(800.dp, 600.dp)
+    private val narrowWindow = DpSize(400.dp, 800.dp)
+
+    private fun packageComponent(
+        packageId: String,
+        isSelectedByDefault: Boolean = false,
+        overrides: List<ComponentOverride<PartialPackageComponent>> = emptyList(),
+    ) = PackageComponent(
+        packageId = packageId,
+        isSelectedByDefault = isSelectedByDefault,
+        stack = StackComponent(components = emptyList()),
+        overrides = overrides,
+    )
+
+    private fun hiddenWhenWiderThan(width: Double) = ComponentOverride(
+        conditions = listOf(
+            ComponentOverride.Condition.WindowWidthRule(
+                operator = ComponentOverride.ComparisonOperator.GREATER_THAN_OR_EQUAL,
+                value = width,
+            ),
+        ),
+        properties = PartialPackageComponent(visible = false),
+    )
+
+    private fun stateWithDefaultHiddenOnWideWindows(): PaywallState.Loaded.Components =
+        FakePaywallState(
+            components = listOf(
+                packageComponent(
+                    packageId = TestData.Packages.monthly.identifier,
+                    isSelectedByDefault = true,
+                    overrides = listOf(hiddenWhenWiderThan(width = 700.0)),
+                ),
+                packageComponent(packageId = TestData.Packages.annual.identifier),
+            ),
+            packages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
+        )
+
+    @Test
+    fun `moves selection off a package hidden at the measured window size`() {
+        val state = stateWithDefaultHiddenOnWideWindows()
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+
+        state.reconcileSelectionForWindowSize(wideWindow)
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
+    fun `keeps a selection that is visible at the measured window size`() {
+        val state = stateWithDefaultHiddenOnWideWindows()
+
+        state.reconcileSelectionForWindowSize(narrowWindow)
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+    }
+
+    @Test
+    fun `does nothing while the window size is unknown`() {
+        val state = stateWithDefaultHiddenOnWideWindows()
+
+        state.reconcileSelectionForWindowSize(null)
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+    }
+
+    @Test
+    fun `keeps the selection when nothing is visible at the measured window size`() {
+        val state = FakePaywallState(
+            components = listOf(
+                packageComponent(
+                    packageId = TestData.Packages.monthly.identifier,
+                    isSelectedByDefault = true,
+                    overrides = listOf(hiddenWhenWiderThan(width = 700.0)),
+                ),
+                packageComponent(
+                    packageId = TestData.Packages.annual.identifier,
+                    overrides = listOf(hiddenWhenWiderThan(width = 700.0)),
+                ),
+            ),
+            packages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
+        )
+
+        state.reconcileSelectionForWindowSize(wideWindow)
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
+    }
+
+    @Test
+    fun `prefers a visible authored default over the first visible package`() {
+        val state = FakePaywallState(
+            components = listOf(
+                packageComponent(
+                    packageId = TestData.Packages.monthly.identifier,
+                    isSelectedByDefault = true,
+                    overrides = listOf(hiddenWhenWiderThan(width = 700.0)),
+                ),
+                packageComponent(packageId = TestData.Packages.weekly.identifier),
+                packageComponent(
+                    packageId = TestData.Packages.annual.identifier,
+                    isSelectedByDefault = true,
+                ),
+            ),
+            packages = listOf(TestData.Packages.monthly, TestData.Packages.weekly, TestData.Packages.annual),
+        )
+
+        state.reconcileSelectionForWindowSize(wideWindow)
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WindowSizeSelectionReconcileTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WindowSizeSelectionReconcileTests.kt
@@ -103,6 +103,46 @@ class WindowSizeSelectionReconcileTests {
     }
 
     @Test
+    fun `keeps the replacement when resizing back makes the original visible again`() {
+        val state = stateWithDefaultHiddenOnWideWindows()
+        state.reconcileSelectionForWindowSize(wideWindow)
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+
+        state.reconcileSelectionForWindowSize(narrowWindow)
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
+    fun `evaluates height rules against the frame height`() {
+        val state = FakePaywallState(
+            components = listOf(
+                packageComponent(
+                    packageId = TestData.Packages.monthly.identifier,
+                    isSelectedByDefault = true,
+                    overrides = listOf(
+                        ComponentOverride(
+                            conditions = listOf(
+                                ComponentOverride.Condition.WindowHeightRule(
+                                    operator = ComponentOverride.ComparisonOperator.LESS_THAN,
+                                    value = 500.0,
+                                ),
+                            ),
+                            properties = PartialPackageComponent(visible = false),
+                        ),
+                    ),
+                ),
+                packageComponent(packageId = TestData.Packages.annual.identifier),
+            ),
+            packages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
+        )
+
+        state.reconcileSelectionForWindowSize(DpSize(800.dp, 400.dp))
+
+        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.annual)
+    }
+
+    @Test
     fun `prefers a visible authored default over the first visible package`() {
         val state = FakePaywallState(
             components = listOf(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WindowSizeSelectionReconcileTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WindowSizeSelectionReconcileTests.kt
@@ -13,7 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 @OptIn(InternalRevenueCatAPI::class)
-class WindowSizeSelectionReconcileTests {
+internal class WindowSizeSelectionReconcileTests {
 
     private val wideWindow = DpSize(800.dp, 600.dp)
     private val narrowWindow = DpSize(400.dp, 800.dp)
@@ -80,27 +80,9 @@ class WindowSizeSelectionReconcileTests {
         assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
     }
 
-    @Test
-    fun `keeps the selection when nothing is visible at the measured window size`() {
-        val state = FakePaywallState(
-            components = listOf(
-                packageComponent(
-                    packageId = TestData.Packages.monthly.identifier,
-                    isSelectedByDefault = true,
-                    overrides = listOf(hiddenWhenWiderThan(width = 700.0)),
-                ),
-                packageComponent(
-                    packageId = TestData.Packages.annual.identifier,
-                    overrides = listOf(hiddenWhenWiderThan(width = 700.0)),
-                ),
-            ),
-            packages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
-        )
-
-        state.reconcileSelectionForWindowSize(wideWindow)
-
-        assertThat(state.selectedPackageInfo?.rcPackage).isEqualTo(TestData.Packages.monthly)
-    }
+    // The nothing-visible case lives in PaywallStateLoadedComponentsPackageSelectionTests: this
+    // file's FakePaywallState synthesizes an always-visible component per package, which would
+    // make that test pass vacuously.
 
     @Test
     fun `keeps the replacement when resizing back makes the original visible again`() {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/FakePaywallState.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/FakePaywallState.kt
@@ -69,13 +69,18 @@ internal fun FakePaywallState(
     offeringWebCheckoutURL: URL? = null,
     viewModelActionInProgress: State<Boolean> = mutableStateOf(false),
 ): PaywallState.Loaded.Components {
-    val packageComponents = packages.map { pkg ->
-        PackageComponent(
-            packageId = pkg.identifier,
-            isSelectedByDefault = false,
-            stack = StackComponent(components = emptyList())
-        )
-    }
+    // Only synthesize a PackageComponent for packages the caller's components don't already
+    // reference: a synthesized always-visible duplicate would defeat visibility-rule tests.
+    val explicitPackageIds = components.filterIsInstance<PackageComponent>().map { it.packageId }.toSet()
+    val packageComponents = packages
+        .filter { it.identifier !in explicitPackageIds }
+        .map { pkg ->
+            PackageComponent(
+                packageId = pkg.identifier,
+                isSelectedByDefault = false,
+                stack = StackComponent(components = emptyList())
+            )
+        }
     val data = PaywallComponentsData(
         id = "paywall_id",
         templateName = "template",


### PR DESCRIPTION
Stacked on #4193. Closes the selection gap flagged in review: a package hidden by a window size rule could stay selected and purchasable.

### What
- `reconcileSelectionForWindowSize` on `PaywallState.Loaded.Components`: when the measured paywall bounds change and the selected package no longer resolves visible, selection moves to the authored default if it renders, else the first visible package. A visible selection is never moved; if nothing is visible, selection stays put.
- Runs from `MeasurePaywallBounds`, keyed on the measured bounds — also covers the initial selection, which is resolved before the bounds are known.
- Tab switches and sheet-dismiss resets restore selections that were resolved without the bounds, so those paths reconcile too.
- `resolvesVisible` and the default-selection helpers take an optional measured size; the initial-selection path is unchanged (window unknown).

### Design note
When *nothing* resolves visible at the current size, the hidden selection is kept — matching iOS. Rules that hide every package at some size are an authoring error; the plan is to guard against that in the dashboard (validation when window rules can leave zero visible packages) rather than guess at runtime.

### Scope note for reviewers
Size-class (screen condition) rules have the same gap and keep their existing pinned-to-COMPACT behavior — reconciling those changes behavior of already-shipped paywalls, so it's left as a deliberate follow-up decision. Mirrors iOS `reconcileSelection` (window-size scope).

### Tests
- `WindowSizeSelectionReconcileTests`: moves off a hidden package, keeps a visible one, no-op on unknown size, keeps selection when nothing is visible, prefers a visible authored default, no flapping on resize-back, height rules.
- `PaywallStateLoadedComponentsPackageSelectionTests`: tab switch onto a hidden remembered default, sheet-dismiss reset restoring a hidden default, user-selected package hidden by a rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which package is selected for purchase across resize, tabs, and sheet dismiss, but behavior is guarded by extensive tests and explicit iOS parity rules.
> 
> **Overview**
> Fixes a gap where a package hidden by **window width/height** or **size-class** visibility rules could remain selected and purchasable after bounds change, tab switch, or sheet reset—initial selection still runs before measure.
> 
> **`reconcileSelectionForWindowSize`** on `PaywallState.Loaded.Components` re-checks whether the current selection would render visible (using measured **paywall bounds** for dimension rules and **`windowScreenCondition`** from the app window for compact/medium/expanded). If not, selection moves to the tab’s authored default, then other visible fallbacks; if nothing is visible, selection stays put (iOS parity). Replacement candidates are evaluated unselected; the keep-check uses selected view state so `selected`-condition rules don’t oscillate.
> 
> **`MeasurePaywallBounds`** now writes `windowScreenCondition` and runs reconciliation in a **`LaunchedEffect`** keyed on bounds, screen condition, and state list (including prewarmed workflow states). Tab **`update`**, **`resetToDefaultPackage`**, and **`peekDefaultPackageUniqueIdAfterSheetDismiss`** use the same visibility-aware helpers so analytics and dismiss match reset behavior.
> 
> **`resolvesVisible`** / default-selection helpers accept optional measured size and screen condition; **`FakePaywallState`** stops synthesizing extra always-visible package components that broke visibility tests. New unit and Compose window-resize tests cover resize, tabs, medium/selected rules, and late-added states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1763d7ba593f64b2353bf8dfc55a693cd4041492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->