### PR TITLE
Animate button content alpha in the draw phase

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -106,8 +106,15 @@ internal fun ButtonComponentView(
             derivedStateOf { if (myActionInProgress) 0f else if (anyActionInProgress) ALPHA_DISABLED else 1f }
         }
         val progressAlpha by remember { derivedStateOf { if (myActionInProgress) 1f else 0f } }
-        val animatedContentAlpha by animateFloatAsState(targetValue = contentAlpha)
+        val animatedContentAlpha = animateFloatAsState(targetValue = contentAlpha)
         val animatedProgressAlpha by animateFloatAsState(targetValue = progressAlpha)
+        // Handed down as a provider so the stack reads it while drawing instead of recomposing on every
+        // animation frame. Null while undimmed, so no graphics layer is added in the common case.
+        val contentAlphaProvider: (() -> Float)? = if (animatedContentAlpha.value == 1f) {
+            null
+        } else {
+            remember(animatedContentAlpha) { { animatedContentAlpha.value } }
+        }
 
         val layoutDirection = LocalLayoutDirection.current
         val marginTop = remember(style.stackComponentStyle.margin) {
@@ -135,7 +142,7 @@ internal fun ButtonComponentView(
                     // We're the button, so we're handling the click already.
                     clickHandler = { },
                     componentInteractionTracker = componentInteractionTracker,
-                    contentAlpha = animatedContentAlpha,
+                    contentAlpha = contentAlphaProvider,
                     enabled = !anyActionInProgress,
                     onStackClick = onStackClick@{
                         val paywallAction = buttonState.action ?: return@onStackClick

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -34,10 +34,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.SubcomposeLayout
@@ -136,7 +136,7 @@ internal fun StackComponentView(
     onStackClick: (() -> Unit)? = null,
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource? = null,
-    contentAlpha: Float = 1f,
+    contentAlpha: (() -> Float)? = null,
     componentInteractionTracker: PaywallComponentInteractionTracker = PaywallComponentInteractionTracker { _ -> },
 ) {
     // Get a StackComponentState that calculates the overridden properties we should use.
@@ -241,7 +241,7 @@ private fun StackWithOverlaidBadge(
     alignment: TwoDimensionalAlignment,
     clickHandler: suspend (PaywallAction) -> Unit,
     componentInteractionTracker: PaywallComponentInteractionTracker,
-    contentAlpha: Float,
+    contentAlpha: (() -> Float)?,
     modifier: Modifier = Modifier,
     onStackClick: (() -> Unit)? = null,
     enabled: Boolean = true,
@@ -284,7 +284,7 @@ private fun StackWithLongEdgeToEdgeBadge(
     topBadge: Boolean,
     clickHandler: suspend (PaywallAction) -> Unit,
     componentInteractionTracker: PaywallComponentInteractionTracker,
-    contentAlpha: Float,
+    contentAlpha: (() -> Float)?,
     modifier: Modifier = Modifier,
     onStackClick: (() -> Unit)? = null,
     enabled: Boolean = true,
@@ -457,7 +457,7 @@ private fun StackWithShortEdgeToEdgeBadge(
     alignment: TwoDimensionalAlignment,
     clickHandler: suspend (PaywallAction) -> Unit,
     componentInteractionTracker: PaywallComponentInteractionTracker,
-    contentAlpha: Float,
+    contentAlpha: (() -> Float)?,
     modifier: Modifier = Modifier,
     onStackClick: (() -> Unit)? = null,
     enabled: Boolean = true,
@@ -589,7 +589,7 @@ private fun MainStackComponent(
     state: PaywallState.Loaded.Components,
     clickHandler: suspend (PaywallAction) -> Unit,
     componentInteractionTracker: PaywallComponentInteractionTracker,
-    contentAlpha: Float,
+    contentAlpha: (() -> Float)?,
     modifier: Modifier = Modifier,
     onStackClick: (() -> Unit)? = null,
     enabled: Boolean = true,
@@ -652,7 +652,7 @@ private fun MainStackComponent(
                                     ) {
                                         windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
                                     }
-                                    .alpha(contentAlpha),
+                                    .contentAlpha(contentAlpha),
                             )
                         }
                     }
@@ -695,7 +695,7 @@ private fun MainStackComponent(
                                     ) {
                                         windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
                                     }
-                                    .alpha(contentAlpha),
+                                    .contentAlpha(contentAlpha),
                             )
                         }
                     }
@@ -741,7 +741,7 @@ private fun MainStackComponent(
                                     .conditional(applyTopInsets && stackState.ignoreHeaderHeight) {
                                         windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
                                     }
-                                    .alpha(contentAlpha),
+                                    .contentAlpha(contentAlpha),
                             )
                         }
                     }
@@ -983,6 +983,19 @@ private val ComponentStyle.shouldIgnoreTopWindowInsets: Boolean
         is VideoComponentStyle -> ignoreTopWindowInsets
         is WebViewComponentStyle -> ignoreTopWindowInsets
         else -> false
+    }
+
+/**
+ * Mirrors [androidx.compose.ui.draw.alpha]: no graphics layer at all when [provider] is null, and clipping
+ * enabled when there is one. Reading [provider] inside the layer block keeps the animation in the draw phase
+ * instead of recomposing the stack on every frame.
+ */
+private fun Modifier.contentAlpha(provider: (() -> Float)?): Modifier =
+    applyIfNotNull(provider) { alpha ->
+        graphicsLayer {
+            this.alpha = alpha()
+            clip = true
+        }
     }
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
@@ -1949,7 +1962,7 @@ private fun StackComponentView_Preview_ContentAlpha() {
         ),
         state = previewEmptyState(),
         clickHandler = {},
-        contentAlpha = 0.6f,
+        contentAlpha = { 0.6f },
     )
 }
 


### PR DESCRIPTION
`ButtonComponentView` passed its animated alpha to `StackComponentView` as a `Float` parameter, so the entire button stack recomposed on every frame of the press animation.

It is now handed down as a provider that the child modifier reads inside `graphicsLayer`, so the animation runs in the draw phase. The provider is null while undimmed, which keeps `Modifier.alpha`'s behavior of adding no layer at all in the common case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compose rendering/performance change only; no purchase, auth, or data logic. Minor visual risk if graphics-layer clipping behaves differently from `Modifier.alpha` during dimming.
> 
> **Overview**
> **Paywall button press/disable dimming** no longer forces the whole button stack to recompose on every animation frame.
> 
> `ButtonComponentView` now passes animated content alpha to `StackComponentView` as an optional `(() -> Float)?` instead of a `Float`. The provider is **null while fully opaque**, so the common undimmed path skips extra graphics layers. When dimmed, alpha is read inside a `graphicsLayer` block during draw.
> 
> `StackComponentView`’s `contentAlpha` API changes from `Float` to that provider type; child modifiers use a new `Modifier.contentAlpha` helper (replacing `Modifier.alpha`) so updates stay in the draw phase while mirroring `alpha`’s clipping behavior when a layer is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaaa16d674f2af039a1df80a424e78bb2f4e2136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->