### PR TITLE
Wire up AppUpdateWarningView

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/AppVersionComparison.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/AppVersionComparison.kt
@@ -1,0 +1,53 @@
+package com.revenuecat.purchases.ui.revenuecatui.customercenter
+
+private const val VERSION_SEPARATOR = "."
+private const val PRERELEASE_SEPARATOR = "-"
+private const val BUILD_SEPARATOR = "+"
+
+/**
+ * Whether [currentVersion] is older than [latestVersion].
+ *
+ * The core SDK's `rc.semverCompare` lives in the purchases module and is internal, so this is a
+ * deliberately small local comparison: numeric core components only, a missing component counts
+ * as 0 ("2.1" is "2.1.0"), and prerelease/build suffixes are dropped rather than ordered.
+ *
+ * Returns false whenever either side is missing or doesn't parse, so an unrecognised version
+ * string never nags the customer.
+ */
+internal fun isAppVersionOutdated(currentVersion: String?, latestVersion: String?): Boolean =
+    compareVersionCores(currentVersion, latestVersion)?.let { it < 0 } ?: false
+
+private fun compareVersionCores(left: String?, right: String?): Int? {
+    val leftCore = parseVersionCore(left)
+    val rightCore = parseVersionCore(right)
+    return if (leftCore == null || rightCore == null) {
+        null
+    } else {
+        val componentCount = maxOf(leftCore.size, rightCore.size)
+        (0 until componentCount)
+            .map { leftCore.getOrElse(it) { 0L }.compareTo(rightCore.getOrElse(it) { 0L }) }
+            .firstOrNull { it != 0 } ?: 0
+    }
+}
+
+private fun parseVersionCore(version: String?): List<Long>? {
+    val core = version
+        ?.trim()
+        ?.substringBefore(BUILD_SEPARATOR)
+        ?.substringBefore(PRERELEASE_SEPARATOR)
+
+    return if (core.isNullOrEmpty()) {
+        null
+    } else {
+        val components = core.split(VERSION_SEPARATOR).map { it.toLongOrNull() }
+        if (components.any { it == null }) null else components.filterNotNull()
+    }
+}
+
+/**
+ * The host app's version name. `AppConfig.versionName` in the core SDK is internal to that module,
+ * so this reads it directly. Null when the package manager can't tell us.
+ */
+internal fun android.content.Context.currentAppVersion(): String? = runCatching {
+    packageManager.getPackageInfo(packageName, 0).versionName
+}.getOrNull()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -63,6 +63,7 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.navigation.Custom
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.viewmodel.CustomerCenterViewModel
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.viewmodel.CustomerCenterViewModelFactory
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.viewmodel.CustomerCenterViewModelImpl
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.AppUpdateWarningView
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.CreateSupportTicketView
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.CustomerCenterErrorView
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.views.CustomerCenterLoadingView
@@ -164,6 +165,14 @@ internal fun InternalCustomerCenter(
                     viewModel.pathButtonPressed(context, action.path, action.purchaseInformation)
                 }
 
+                is CustomerCenterAction.UpdateApp -> {
+                    viewModel.updateApp(context)
+                }
+
+                is CustomerCenterAction.ContinueDespiteAppUpdate -> {
+                    viewModel.continueDespiteAppUpdate()
+                }
+
                 is CustomerCenterAction.PerformRestore -> {
                     coroutineScope.launch {
                         viewModel.restorePurchases()
@@ -244,10 +253,18 @@ private fun InternalCustomerCenter(
                 }
 
                 is CustomerCenterState.Success -> {
-                    CustomerCenterLoaded(
-                        state = state,
-                        onAction = onAction,
-                    )
+                    if (state.showAppUpdateWarning) {
+                        AppUpdateWarningView(
+                            localization = state.customerCenterConfigData.localization,
+                            onUpdateAppClick = { onAction(CustomerCenterAction.UpdateApp) },
+                            onContinueAnywayClick = { onAction(CustomerCenterAction.ContinueDespiteAppUpdate) },
+                        )
+                    } else {
+                        CustomerCenterLoaded(
+                            state = state,
+                            onAction = onAction,
+                        )
+                    }
                 }
             }
         }
@@ -638,6 +655,7 @@ private fun getCustomerCenterViewModel(
             MaterialTheme.colorScheme,
             isDarkMode = isDarkMode,
             listener = listener,
+            appVersion = LocalContext.current.currentAppVersion(),
         ),
     ),
 ): CustomerCenterViewModel {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/actions/CustomerCenterAction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/actions/CustomerCenterAction.kt
@@ -24,5 +24,7 @@ internal sealed class CustomerCenterAction {
     object ShowSupportTicketCreation : CustomerCenterAction()
     object DismissSupportTicketSuccessSnackbar : CustomerCenterAction()
     object ShowPurchaseHistory : CustomerCenterAction()
+    object UpdateApp : CustomerCenterAction()
+    object ContinueDespiteAppUpdate : CustomerCenterAction()
     data class ShowPurchaseHistoryDetail(val purchase: PurchaseInformation) : CustomerCenterAction()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterState.kt
@@ -42,6 +42,7 @@ internal sealed class CustomerCenterState(
         @get:JvmSynthetic val showSupportTicketSuccessSnackbar: Boolean = false,
         @get:JvmSynthetic val isRefreshing: Boolean = false,
         @get:JvmSynthetic val shouldShowPurchaseHistory: Boolean = false,
+        @get:JvmSynthetic val showAppUpdateWarning: Boolean = false,
     ) : CustomerCenterState(navigationButtonType) {
         val currentDestination: CustomerCenterDestination
             get() = navigationState.currentDestination

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -60,6 +60,7 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PurchaseInfo
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.shouldShowSeeAllPurchases
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.dialogs.RestorePurchasesState
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.extensions.getLocalizedDescription
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.isAppVersionOutdated
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.navigation.CustomerCenterDestination
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.resolveOfferingSuspend
 import com.revenuecat.purchases.ui.revenuecatui.data.PurchasesType
@@ -167,6 +168,10 @@ internal interface CustomerCenterViewModel {
      * Called when the activity resumes. Used to refresh after returning from external subscription management.
      */
     fun onActivityResumed()
+
+    fun updateApp(context: Context)
+
+    fun continueDespiteAppUpdate()
 }
 
 @Stable
@@ -218,7 +223,7 @@ internal sealed class TransactionDetails(
     ) : TransactionDetails(productIdentifier, store, price, isSandbox, purchaseHistoryEntryId, displayName)
 }
 
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
 internal class CustomerCenterViewModelImpl(
     private val purchases: PurchasesType,
     private val dateFormatter: DateFormatter = DefaultDateFormatter(),
@@ -226,14 +231,17 @@ internal class CustomerCenterViewModelImpl(
     private val colorScheme: ColorScheme,
     private var isDarkMode: Boolean,
     private val listener: CustomerCenterListener? = null,
+    private val appVersion: String? = null,
 ) : ViewModel(), CustomerCenterViewModel {
     companion object {
         private const val STOP_FLOW_TIMEOUT = 5_000L
+        private const val PLAY_STORE_DETAILS_URL = "https://play.google.com/store/apps/details?id="
     }
 
     private var impressionCreationData: CustomerCenterImpressionEvent.CreationData? = null
     private var wasBackgrounded = false
     private var shouldRefreshOnResume = false
+    private var ignoreAppUpdateWarning = false
     private val _lastLocaleList = MutableStateFlow(getCurrentLocaleList())
     private val _colorScheme = MutableStateFlow(colorScheme)
     private val _state = MutableStateFlow<CustomerCenterState>(CustomerCenterState.NotLoaded)
@@ -1217,6 +1225,7 @@ internal class CustomerCenterViewModelImpl(
                 isRefreshing = false,
                 shouldShowPurchaseHistory = customerCenterConfigData.support.displayPurchaseHistoryLink == true &&
                     customerInfo.shouldShowSeeAllPurchases(),
+                showAppUpdateWarning = shouldShowAppUpdateWarning(customerCenterConfigData),
             )
             val mainScreenPaths = computeMainScreenPaths(successState)
 
@@ -1262,6 +1271,30 @@ internal class CustomerCenterViewModelImpl(
             wasBackgrounded = false
             if (!shouldRefreshOnResume) {
                 launchRefreshIfPossible()
+            }
+        }
+    }
+
+    // Warn unless the dashboard opted out, and only when we can tell the app is behind.
+    private fun shouldShowAppUpdateWarning(configData: CustomerCenterConfigData): Boolean =
+        !ignoreAppUpdateWarning &&
+            configData.support.shouldWarnCustomerToUpdate != false &&
+            isAppVersionOutdated(appVersion, configData.lastPublishedAppVersion)
+
+    override fun updateApp(context: Context) {
+        openURL(
+            context,
+            PLAY_STORE_DETAILS_URL + context.packageName,
+            HelpPath.OpenMethod.EXTERNAL,
+        )
+    }
+
+    override fun continueDespiteAppUpdate() {
+        ignoreAppUpdateWarning = true
+        _state.update { currentState ->
+            when (currentState) {
+                is CustomerCenterState.Success -> currentState.copy(showAppUpdateWarning = false)
+                else -> currentState
             }
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModelFactory.kt
@@ -11,6 +11,7 @@ internal class CustomerCenterViewModelFactory(
     private val colorScheme: ColorScheme,
     private val isDarkMode: Boolean,
     private val listener: CustomerCenterListener? = null,
+    private val appVersion: String? = null,
 ) : ViewModelProvider.NewInstanceFactory() {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -19,6 +20,7 @@ internal class CustomerCenterViewModelFactory(
             colorScheme = colorScheme,
             isDarkMode = isDarkMode,
             listener = listener,
+            appVersion = appVersion,
         ) as T
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/AppVersionComparisonTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/AppVersionComparisonTest.kt
@@ -1,0 +1,50 @@
+package com.revenuecat.purchases.ui.revenuecatui.customercenter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AppVersionComparisonTest {
+
+    @Test
+    fun `older patch is outdated`() {
+        assertThat(isAppVersionOutdated("1.2.3", "1.2.4")).isTrue()
+    }
+
+    @Test
+    fun `same version is not outdated`() {
+        assertThat(isAppVersionOutdated("1.2.3", "1.2.3")).isFalse()
+    }
+
+    @Test
+    fun `newer version is not outdated`() {
+        assertThat(isAppVersionOutdated("1.3.0", "1.2.9")).isFalse()
+    }
+
+    @Test
+    fun `compares numerically, not lexicographically`() {
+        assertThat(isAppVersionOutdated("1.9.0", "1.10.0")).isTrue()
+        assertThat(isAppVersionOutdated("1.10.0", "1.9.0")).isFalse()
+    }
+
+    @Test
+    fun `missing components count as zero`() {
+        assertThat(isAppVersionOutdated("2.1", "2.1.0")).isFalse()
+        assertThat(isAppVersionOutdated("2.1", "2.1.1")).isTrue()
+        assertThat(isAppVersionOutdated("2", "2.0.0")).isFalse()
+    }
+
+    @Test
+    fun `prerelease and build suffixes are dropped`() {
+        assertThat(isAppVersionOutdated("1.2.3-beta.1", "1.2.3")).isFalse()
+        assertThat(isAppVersionOutdated("1.2.3+build42", "1.2.4")).isTrue()
+    }
+
+    @Test
+    fun `unparseable versions never warn`() {
+        assertThat(isAppVersionOutdated(null, "1.2.3")).isFalse()
+        assertThat(isAppVersionOutdated("1.2.3", null)).isFalse()
+        assertThat(isAppVersionOutdated("", "1.2.3")).isFalse()
+        assertThat(isAppVersionOutdated("not-a-version", "1.2.3")).isFalse()
+        assertThat(isAppVersionOutdated("1.2.3", "latest")).isFalse()
+    }
+}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

Stacked on #4202, which added the composable but left it unused. This hooks it up, so `shouldWarnCustomerToUpdate` finally does something on Android. Part of PW-1361.

### Description

When the app is behind `lastPublishedAppVersion` and the dashboard hasn't opted out, Customer Center shows the warning instead of the management list. Update opens the Play Store listing, Continue dismisses it for the rest of the session.

Two things I couldn't reuse from the core SDK, both because of module visibility:

- **Version comparison.** `SemverOperator` is `internal` to `purchases` and its `SemanticVersion` is `private`, and revenuecatui has no friend access (everything it imports from `purchases.common` is public). So `AppVersionComparison.kt` has a small local one: numeric core components, missing components count as 0, prerelease/build suffixes dropped rather than ordered, and anything unparseable never warns. The alternative is making the core SDK's semver public, which felt like a big change to `purchases` for a UI concern. Happy to switch if you'd rather.
- **App version.** `AppConfig.versionName` and `Context.versionName` are both internal too, so this reads `packageManager.getPackageInfo` directly.

Also added `LongParameterList` to the existing `@Suppress` on `CustomerCenterViewModelImpl`, the constructor is now 8 params against a threshold of 7.

Still to do, separate PR: the failed-restore dialog half, an Update button and a line of copy on `PurchasesNotFoundDialog`. iOS gates both surfaces on the same flag, so until that lands the toggle does a bit less here than on iOS.
