### PR TITLE
fix(admob): attribute banner-only native load failures

### DIFF
--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/AdTrackerAdMobExtensions.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/AdTrackerAdMobExtensions.kt
@@ -26,6 +26,7 @@ import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.Rewarded
 import com.revenuecat.purchases.admob.nextgen.tracking.NativeAdLoadResultHandler
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingAdLoadCallback
 import com.revenuecat.purchases.admob.nextgen.tracking.TrackingNativeAdLoaderCallback
+import com.revenuecat.purchases.admob.nextgen.tracking.failureAdFormat
 import com.revenuecat.purchases.admob.nextgen.tracking.trackAndConfigureAdLoadResult
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFormat
@@ -587,7 +588,7 @@ public fun AdTracker.loadAndTrackNativeAd(
         trackingNativeAdLoaderCallback(
             delegate = loadCallback,
             placement = placement,
-            adUnitId = adRequest.adUnitId,
+            adRequest = adRequest,
             nativeAdEventCallback = nativeAdEventCallback,
             bannerAdEventCallback = bannerAdEventCallback,
         ),
@@ -616,6 +617,7 @@ public suspend fun AdTracker.loadAndTrackNativeAd(
     nativeAdLoadResultHandler(
         placement = placement,
         adUnitId = adRequest.adUnitId,
+        failureAdFormat = adRequest.failureAdFormat(),
         nativeAdEventCallback = nativeAdEventCallback,
         bannerAdEventCallback = bannerAdEventCallback,
     ).handle(result)
@@ -682,7 +684,7 @@ public fun AdTracker.loadAndTrackNativeAds(
         trackingNativeAdLoaderCallback(
             delegate = loadCallback,
             placement = placement,
-            adUnitId = adRequest.adUnitId,
+            adRequest = adRequest,
             nativeAdEventCallback = nativeAdEventCallback,
             bannerAdEventCallback = bannerAdEventCallback,
         ),
@@ -706,6 +708,7 @@ public suspend fun AdTracker.loadAndTrackNativeAds(
     val resultHandler = nativeAdLoadResultHandler(
         placement = placement,
         adUnitId = adRequest.adUnitId,
+        failureAdFormat = adRequest.failureAdFormat(),
         nativeAdEventCallback = nativeAdEventCallback,
         bannerAdEventCallback = bannerAdEventCallback,
     )
@@ -713,6 +716,23 @@ public suspend fun AdTracker.loadAndTrackNativeAds(
         resultHandler.handle(result)
     }
 }
+
+private fun trackingNativeAdLoaderCallback(
+    delegate: NativeAdLoaderCallback,
+    placement: String?,
+    adRequest: NativeAdRequest,
+    nativeAdEventCallback: NativeAdEventCallback?,
+    bannerAdEventCallback: BannerAdEventCallback?,
+): TrackingNativeAdLoaderCallback = TrackingNativeAdLoaderCallback(
+    delegate = delegate,
+    resultHandler = nativeAdLoadResultHandler(
+        placement = placement,
+        adUnitId = adRequest.adUnitId,
+        failureAdFormat = adRequest.failureAdFormat(),
+        nativeAdEventCallback = nativeAdEventCallback,
+        bannerAdEventCallback = bannerAdEventCallback,
+    ),
+)
 
 private fun trackingNativeAdLoaderCallback(
     delegate: NativeAdLoaderCallback,
@@ -725,6 +745,7 @@ private fun trackingNativeAdLoaderCallback(
     resultHandler = nativeAdLoadResultHandler(
         placement = placement,
         adUnitId = adUnitId,
+        failureAdFormat = AdFormat.NATIVE,
         nativeAdEventCallback = nativeAdEventCallback,
         bannerAdEventCallback = bannerAdEventCallback,
     ),
@@ -735,9 +756,11 @@ private fun nativeAdLoadResultHandler(
     adUnitId: String,
     nativeAdEventCallback: NativeAdEventCallback?,
     bannerAdEventCallback: BannerAdEventCallback?,
+    failureAdFormat: AdFormat = AdFormat.NATIVE,
 ): NativeAdLoadResultHandler = NativeAdLoadResultHandler(
     placement = placement,
     adUnitId = adUnitId,
+    failureAdFormat = failureAdFormat,
     configureAd = { ad -> ad.installTrackingEventCallback(nativeAdEventCallback, placement, adUnitId) },
     configureCustomNativeAd = { ad ->
         ad.installTrackingEventCallback(nativeAdEventCallback, placement, adUnitId)

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/NativeAdLoadResultHandler.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/NativeAdLoadResultHandler.kt
@@ -12,6 +12,7 @@ internal class NativeAdLoadResultHandler(
     private val configureAd: (NativeAd) -> Unit,
     private val configureCustomNativeAd: (CustomNativeAd) -> Unit = {},
     private val configureBannerAd: (BannerAd) -> Unit = {},
+    private val failureAdFormat: AdFormat = AdFormat.NATIVE,
 ) {
     fun handle(result: NativeAdLoadResult) {
         when (result) {
@@ -28,7 +29,7 @@ internal class NativeAdLoadResultHandler(
                 configureBannerAd(result.ad)
             }
             is NativeAdLoadResult.Failure -> {
-                trackAdFailedToLoad(result.error, AdFormat.NATIVE, placement, adUnitId)
+                trackAdFailedToLoad(result.error, failureAdFormat, placement, adUnitId)
             }
         }
     }

--- a/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/NativeAdRequestExtensions.kt
+++ b/feature/admob-next-gen/src/main/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/NativeAdRequestExtensions.kt
@@ -1,0 +1,20 @@
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
+import com.revenuecat.purchases.ads.events.types.AdFormat
+
+/**
+ * Infers the format of a failed native-loader request when the request makes that unambiguous.
+ *
+ * Google does not include the requested ad type in a failed load result. A request that only accepts banners can
+ * safely be attributed to [AdFormat.BANNER]. Mixed, empty, and native-only requests remain [AdFormat.NATIVE].
+ */
+internal fun NativeAdRequest.failureAdFormat(): AdFormat {
+    val requestedAdTypes = nativeAdTypes
+    return if (requestedAdTypes.isNotEmpty() && requestedAdTypes.all { it == NativeAd.NativeAdType.BANNER }) {
+        AdFormat.BANNER
+    } else {
+        AdFormat.NATIVE
+    }
+}

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdBatchFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdBatchFlowTest.kt
@@ -3,6 +3,7 @@
 package com.revenuecat.purchases.admob.nextgen
 
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
@@ -117,6 +118,45 @@ class NativeAdBatchFlowTest {
         assertEquals(AdFormat.NATIVE, failedData.captured.adFormat)
         assertEquals("feed", failedData.captured.placement)
         assertEquals("native-unit", failedData.captured.adUnitId)
+    }
+
+    @Test
+    fun `callback batch tracks failure as banner for banner-only request`() {
+        val adRequest = nativeAdRequest("banner-unit", listOf(NativeAd.NativeAdType.BANNER))
+        val error = mockk<LoadAdError> {
+            every { code } returns LoadAdError.ErrorCode.NO_FILL
+        }
+        val trackingCallback = slot<NativeAdLoaderCallback>()
+
+        every { NativeAdLoader.load(adRequest, 1, capture(trackingCallback)) } just runs
+
+        adTracker.loadAndTrackNativeAds(adRequest, 1, "feed", RecordingNativeAdLoaderCallback())
+        trackingCallback.captured.onAdFailedToLoad(error)
+
+        val failedData = slot<AdFailedToLoadData>()
+        verify(exactly = 1) {
+            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
+        }
+        assertEquals(AdFormat.BANNER, failedData.captured.adFormat)
+    }
+
+    @Test
+    fun `flow batch tracks failure as banner for banner-only request`() = runBlocking {
+        val adRequest = nativeAdRequest("banner-unit", listOf(NativeAd.NativeAdType.BANNER))
+        val error = mockk<LoadAdError> {
+            every { code } returns LoadAdError.ErrorCode.NO_FILL
+        }
+        val sdkResult = NativeAdLoadResult.Failure(error)
+        coEvery { NativeAdLoader.load(adRequest, 1) } returns flowOf(sdkResult)
+
+        val results = adTracker.loadAndTrackNativeAds(adRequest, 1, placement = "feed").toList()
+
+        assertSame(sdkResult, results.single())
+        val failedData = slot<AdFailedToLoadData>()
+        verify(exactly = 1) {
+            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
+        }
+        assertEquals(AdFormat.BANNER, failedData.captured.adFormat)
     }
 
 }

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdFixtures.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdFixtures.kt
@@ -12,8 +12,12 @@ import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
 import io.mockk.every
 import io.mockk.mockk
 
-internal fun nativeAdRequest(adUnitId: String): NativeAdRequest = mockk {
+internal fun nativeAdRequest(
+    adUnitId: String,
+    nativeAdTypes: List<NativeAd.NativeAdType> = listOf(NativeAd.NativeAdType.NATIVE),
+): NativeAdRequest = mockk {
     every { this@mockk.adUnitId } returns adUnitId
+    every { this@mockk.nativeAdTypes } returns nativeAdTypes
 }
 
 internal fun nativeAd(network: String, responseId: String): NativeAd {

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdFlowTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/NativeAdFlowTest.kt
@@ -4,6 +4,7 @@ package com.revenuecat.purchases.admob.nextgen
 
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdEventCallback
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
@@ -120,6 +121,28 @@ class NativeAdFlowTest {
     }
 
     @Test
+    fun `callback load tracks failure as banner for banner-only request`() {
+        val adRequest = nativeAdRequest("banner-unit", listOf(NativeAd.NativeAdType.BANNER))
+        val error = mockk<LoadAdError> {
+            every { code } returns LoadAdError.ErrorCode.NO_FILL
+        }
+        val trackingLoadCallback = slot<NativeAdLoaderCallback>()
+
+        every { NativeAdLoader.load(adRequest, capture(trackingLoadCallback)) } just runs
+
+        adTracker.loadAndTrackNativeAd(adRequest, "feed", RecordingNativeAdLoaderCallback())
+        trackingLoadCallback.captured.onAdFailedToLoad(error)
+
+        val failedData = slot<AdFailedToLoadData>()
+        verify(exactly = 1) {
+            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
+        }
+        assertEquals(AdFormat.BANNER, failedData.captured.adFormat)
+        assertEquals("feed", failedData.captured.placement)
+        assertEquals("banner-unit", failedData.captured.adUnitId)
+    }
+
+    @Test
     fun `suspending load returns and configures native result unchanged`() = runBlocking {
         val adRequest = nativeAdRequest("native-unit")
         val nativeAd = nativeAd("native-network", "native-response")
@@ -161,6 +184,26 @@ class NativeAdFlowTest {
         verify(exactly = 2) { adTracker.trackAdLoaded(capture(trackedLoads), AdCaptureMethod.ADAPTER) }
         assertEquals(listOf(AdFormat.NATIVE, AdFormat.BANNER), trackedLoads.map { it.adFormat })
         verify(exactly = 1) { adTracker.trackAdFailedToLoad(any(), AdCaptureMethod.ADAPTER) }
+    }
+
+    @Test
+    fun `suspending load tracks failure as banner for banner-only request`() = runBlocking {
+        val adRequest = nativeAdRequest("banner-unit", listOf(NativeAd.NativeAdType.BANNER))
+        val error = mockk<LoadAdError> {
+            every { code } returns LoadAdError.ErrorCode.NO_FILL
+        }
+        val sdkResult = NativeAdLoadResult.Failure(error)
+
+        coEvery { NativeAdLoader.load(adRequest) } returns sdkResult
+
+        val result = adTracker.loadAndTrackNativeAd(adRequest, placement = "feed")
+
+        assertSame(sdkResult, result)
+        val failedData = slot<AdFailedToLoadData>()
+        verify(exactly = 1) {
+            adTracker.trackAdFailedToLoad(capture(failedData), AdCaptureMethod.ADAPTER)
+        }
+        assertEquals(AdFormat.BANNER, failedData.captured.adFormat)
     }
 
     @Test

--- a/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/NativeAdRequestExtensionsTest.kt
+++ b/feature/admob-next-gen/src/test/kotlin/com/revenuecat/purchases/admob/nextgen/tracking/NativeAdRequestExtensionsTest.kt
@@ -1,0 +1,27 @@
+package com.revenuecat.purchases.admob.nextgen.tracking
+
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
+import com.revenuecat.purchases.ads.events.types.AdFormat
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NativeAdRequestExtensionsTest {
+
+    @Test
+    fun `failure format is banner only when request only accepts banners`() {
+        assertEquals(AdFormat.BANNER, requestWith(NativeAd.NativeAdType.BANNER).failureAdFormat())
+        assertEquals(AdFormat.NATIVE, requestWith(NativeAd.NativeAdType.NATIVE).failureAdFormat())
+        assertEquals(
+            AdFormat.NATIVE,
+            requestWith(NativeAd.NativeAdType.NATIVE, NativeAd.NativeAdType.BANNER).failureAdFormat(),
+        )
+        assertEquals(AdFormat.NATIVE, requestWith().failureAdFormat())
+    }
+
+    private fun requestWith(vararg nativeAdTypes: NativeAd.NativeAdType): NativeAdRequest = mockk {
+        every { this@mockk.nativeAdTypes } returns nativeAdTypes.toList()
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] Unit tests
- [ ] Follow-up issues for purchases-ios and hybrids are not applicable to this Android-only adapter fix

### Motivation
Banner-only NativeAdLoader failures were incorrectly attributed to the native format and distorted format-level fill rates. Edge case but still a bug. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only correction in the AdMob next-gen adapter; no load or show behavior changes.
> 
> **Overview**
> Fixes **incorrect ad-format attribution** when `NativeAdLoader` fails: failures were always reported as `AdFormat.NATIVE`, which skewed format-level fill metrics for requests that only accept banners (Google does not expose the requested type on failure).
> 
> Adds `NativeAdRequest.failureAdFormat()` to infer **BANNER** when `nativeAdTypes` is exclusively banner, and **NATIVE** for native-only, mixed, or empty requests. That value flows through `NativeAdLoadResultHandler` and all `loadAndTrackNativeAd(s)` paths (callback, suspending, and batch flow). Server-to-server loads without a typed request still default failures to native.
> 
> Unit tests cover the extension and callback/flow failure tracking for banner-only requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a60825cd440e801a56fa81e6f8084468f712f4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->