### PR TITLE
Fade the checkpoint flow window in and out

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowPresenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowPresenter.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.helpers.EDGE_TO_EDGE_WINDOW_THEME
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.applyEdgeToEdge
@@ -86,6 +87,11 @@ internal class CheckpointWorkflowPresenter(
             .build()
         val dialog = ComponentDialog(activity, EDGE_TO_EDGE_WINDOW_THEME)
         dialog.window?.applyEdgeToEdge()
+        // A re-present after a configuration change replaces a window that was already there, so only a first
+        // present fades in.
+        if (pendingSavedState == null) {
+            dialog.window?.setWindowAnimations(R.style.RcCheckpointWindowAnimation)
+        }
         // Back must never fall through to the dispatcher's cancel fallback; the paywall's own BackHandler
         // decides what back does.
         dialog.setCancelable(false)
@@ -120,6 +126,7 @@ internal class CheckpointWorkflowPresenter(
             val isConfigurationChange = activity.isChangingConfigurations
             if (isConfigurationChange) {
                 pendingSavedState = dialog?.onSaveInstanceState()
+                dialog?.window?.setWindowAnimations(0)
             }
             // Always before the host's own window teardown, or the framework reports the dialog as leaked.
             dismissWindowOnly()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowPresenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowPresenter.kt
@@ -87,11 +87,13 @@ internal class CheckpointWorkflowPresenter(
             .build()
         val dialog = ComponentDialog(activity, EDGE_TO_EDGE_WINDOW_THEME)
         dialog.window?.applyEdgeToEdge()
-        // A re-present after a configuration change replaces a window that was already there, so only a first
-        // present fades in.
-        if (pendingSavedState == null) {
-            dialog.window?.setWindowAnimations(R.style.RcCheckpointWindowAnimation)
+        // A re-present after a configuration change replaces a window that was already there, so it only fades out.
+        val animations = if (pendingSavedState == null) {
+            R.style.RcCheckpointWindowAnimation
+        } else {
+            R.style.RcCheckpointWindowAnimation_Represent
         }
+        dialog.window?.setWindowAnimations(animations)
         // Back must never fall through to the dispatcher's cancel fallback; the paywall's own BackHandler
         // decides what back does.
         dialog.setCancelable(false)

--- a/ui/revenuecatui/src/main/res/anim/rc_checkpoint_window_enter.xml
+++ b/ui/revenuecatui/src/main/res/anim/rc_checkpoint_window_enter.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 220 ms is the framework's config_activityDefaultDur, which is not a public resource. -->
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromAlpha="0.0"
+    android:toAlpha="1.0"
+    android:interpolator="@android:interpolator/decelerate_cubic"
+    android:duration="220" />

--- a/ui/revenuecatui/src/main/res/anim/rc_checkpoint_window_exit.xml
+++ b/ui/revenuecatui/src/main/res/anim/rc_checkpoint_window_exit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromAlpha="1.0"
+    android:toAlpha="0.0"
+    android:interpolator="@android:interpolator/accelerate_cubic"
+    android:duration="400" />

--- a/ui/revenuecatui/src/main/res/values/themes.xml
+++ b/ui/revenuecatui/src/main/res/values/themes.xml
@@ -6,4 +6,8 @@
         <item name="android:windowExitAnimation">@anim/rc_checkpoint_window_exit</item>
     </style>
 
+    <style name="RcCheckpointWindowAnimation.Represent">
+        <item name="android:windowEnterAnimation">@null</item>
+    </style>
+
 </resources>

--- a/ui/revenuecatui/src/main/res/values/themes.xml
+++ b/ui/revenuecatui/src/main/res/values/themes.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <style name="RcCheckpointWindowAnimation">
+        <item name="android:windowEnterAnimation">@anim/rc_checkpoint_window_enter</item>
+        <item name="android:windowExitAnimation">@anim/rc_checkpoint_window_exit</item>
+    </style>
+
 </resources>

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowPresenterTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowPresenterTest.kt
@@ -14,6 +14,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.checkpoints.CheckpointResolution
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+import com.revenuecat.purchases.ui.revenuecatui.R
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -256,6 +257,24 @@ class CheckpointWorkflowPresenterTest {
         val window = ShadowDialog.getLatestDialog().window!!
         assertThat(window.attributes.flags and WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED)
             .isNotEqualTo(0)
+    }
+
+    @Test
+    fun `a first present fades the workflow window in and out`() {
+        launchCheckpoint()
+
+        val window = ShadowDialog.getLatestDialog().window!!
+        assertThat(window.attributes.windowAnimations).isEqualTo(R.style.RcCheckpointWindowAnimation)
+    }
+
+    @Test
+    fun `a re-present after a configuration change does not animate`() {
+        launchCheckpoint()
+
+        controller.recreate()
+
+        val window = ShadowDialog.getLatestDialog().window!!
+        assertThat(window.attributes.windowAnimations).isNotEqualTo(R.style.RcCheckpointWindowAnimation)
     }
 
     private fun launchCheckpoint(): Job = CoroutineScope(dispatcher).launch {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowPresenterTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/checkpoints/CheckpointWorkflowPresenterTest.kt
@@ -268,13 +268,13 @@ class CheckpointWorkflowPresenterTest {
     }
 
     @Test
-    fun `a re-present after a configuration change does not animate`() {
+    fun `a re-present after a configuration change only fades out`() {
         launchCheckpoint()
 
         controller.recreate()
 
         val window = ShadowDialog.getLatestDialog().window!!
-        assertThat(window.attributes.windowAnimations).isNotEqualTo(R.style.RcCheckpointWindowAnimation)
+        assertThat(window.attributes.windowAnimations).isEqualTo(R.style.RcCheckpointWindowAnimation_Represent)
     }
 
     private fun launchCheckpoint(): Job = CoroutineScope(dispatcher).launch {


### PR DESCRIPTION
### Motivation

A checkpoint flow currently pops in and out with no animation. This adds a simple fade animation to the window, so it looks a bit nicer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only window animation with a config-change special case; no purchase, auth, or data-path changes.
> 
> **Overview**
> Adds **fade in/out window animations** for the checkpoint workflow dialog so the paywall overlay no longer appears and disappears instantly.
> 
> `CheckpointWorkflowPresenter` applies `RcCheckpointWindowAnimation` (220ms enter, 400ms exit alpha) on the first show. After a **configuration change**, re-present uses `RcCheckpointWindowAnimation_Represent` (exit fade only, no enter) so rotation does not flash a second fade-in. On config teardown it clears window animations before dismiss to avoid fighting the activity transition.
> 
> New resources: `rc_checkpoint_window_enter.xml`, `rc_checkpoint_window_exit.xml`, and the two styles in `themes.xml`. Unit tests assert the animation style on first present vs after `recreate()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dabed41d58ba8c298b8fe91492960a439624029c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->