### PR TITLE
Honor explicit `default` stack overflow to disable scrolling

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/StackComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/StackComponent.kt
@@ -113,5 +113,11 @@ public class PartialStackComponent(
 @OptIn(InternalRevenueCatAPI::class)
 internal object StackOverflowDeserializer : EnumDeserializerWithDefault<StackComponent.Overflow>(
     serialName = "com.revenuecat.purchases.paywalls.components.StackComponent.Overflow",
+    valuesByType = mapOf(
+        "none" to StackComponent.Overflow.NONE,
+        // The schema's explicit "not scrollable" value.
+        "default" to StackComponent.Overflow.NONE,
+        "scroll" to StackComponent.Overflow.SCROLL,
+    ),
     defaultValue = StackComponent.Overflow.NONE,
 )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/StackComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/StackComponentTests.kt
@@ -447,6 +447,7 @@ internal class StackComponentTests {
                 }
                 arrayOf(serialized, expected)
             } + listOf(
+                arrayOf("\"default\"", StackComponent.Overflow.NONE),
                 arrayOf("\"some_unknown_overflow\"", StackComponent.Overflow.NONE),
             )
         }

--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/StackOverflowScrollInstrumentedTests.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/StackOverflowScrollInstrumentedTests.kt
@@ -1,0 +1,185 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.paywalls.components.PartialStackComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.LocalizationData
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
+import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationKey
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.Dimension
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.LocalizationDictionary
+import com.revenuecat.purchases.ui.revenuecatui.data.MockPurchasesType
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallResourceProvider
+import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
+import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.validatePaywallComponentsDataOrNull
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URL
+import java.util.Date
+
+/**
+ * On-device verification of the explicit-"default" overflow behavior: the schema's "default"
+ * deserializes to an explicit [StackComponent.Overflow.NONE] (covered by unit tests), and an
+ * explicit NONE must actually stop the paywall from scrolling — both on the root stack (which is
+ * otherwise wrapped in an outer verticalScroll) and when a window size rule's partial sets it.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class StackOverflowScrollInstrumentedTests {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val verticallyScrollable =
+        SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange)
+
+    @Test
+    fun rootStackWithAbsentOverflowGetsTheOuterScrollWrap() {
+        setPaywallContent(rootStack(overflow = null))
+
+        assertThat(verticallyScrollableNodeCount()).isGreaterThan(0)
+    }
+
+    @Test
+    fun rootStackWithExplicitDefaultOverflowDoesNotScroll() {
+        // Explicit "default" in the schema deserializes to Overflow.NONE.
+        setPaywallContent(rootStack(overflow = StackComponent.Overflow.NONE))
+
+        assertThat(verticallyScrollableNodeCount()).isZero()
+    }
+
+    @Test
+    fun rootStackWithScrollOverflowScrollsItself() {
+        setPaywallContent(rootStack(overflow = StackComponent.Overflow.SCROLL))
+
+        assertThat(verticallyScrollableNodeCount()).isGreaterThan(0)
+    }
+
+    @Test
+    fun windowSizeRulePartialWithNoneDisablesTheBaseScroll() {
+        // Base scrolls; a window width rule that matches any realistic device disables it.
+        setPaywallContent(
+            rootStack(
+                overflow = StackComponent.Overflow.SCROLL,
+                overrides = listOf(
+                    ComponentOverride(
+                        conditions = listOf(
+                            ComponentOverride.Condition.WindowWidthRule(
+                                operator = ComponentOverride.ComparisonOperator.GREATER_THAN_OR_EQUAL,
+                                value = 100.0,
+                            ),
+                        ),
+                        properties = PartialStackComponent(overflow = StackComponent.Overflow.NONE),
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(verticallyScrollableNodeCount()).isZero()
+    }
+
+    private fun verticallyScrollableNodeCount(): Int {
+        composeTestRule.waitForIdle()
+        return composeTestRule.onAllNodes(verticallyScrollable).fetchSemanticsNodes().size
+    }
+
+    private fun setPaywallContent(rootStack: StackComponent) {
+        val state = paywallState(rootStack)
+        composeTestRule.setContent {
+            LoadedPaywallComponents(
+                state = state,
+                clickHandler = { },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+
+    private fun rootStack(
+        overflow: StackComponent.Overflow?,
+        overrides: List<ComponentOverride<PartialStackComponent>> = emptyList(),
+    ): StackComponent = StackComponent(
+        components = listOf(
+            // Taller than any device, so the root always has something to scroll to.
+            StackComponent(
+                components = emptyList(),
+                size = Size(width = SizeConstraint.Fill(), height = SizeConstraint.Fixed(4000u)),
+            ),
+        ),
+        dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+        size = Size(width = SizeConstraint.Fill(), height = SizeConstraint.Fill()),
+        overflow = overflow,
+        overrides = overrides,
+    )
+
+    private fun paywallState(rootStack: StackComponent): PaywallState.Loaded.Components {
+        val locale = LocaleId("en_US")
+        val componentsData = PaywallComponentsData(
+            id = "overflow_test_paywall",
+            templateName = "overflow_test_template",
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = rootStack,
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(0xFFFFFFFF.toInt()))),
+                ),
+            ),
+            componentsLocalizations = nonEmptyMapOf(
+                locale to nonEmptyMapOf(
+                    LocalizationKey("overflow_test_key") to LocalizationData.Text("overflow_test"),
+                ) as LocalizationDictionary,
+            ),
+            defaultLocaleIdentifier = locale,
+        )
+        val offering = Offering(
+            identifier = "overflow_test_offering",
+            serverDescription = "",
+            metadata = emptyMap(),
+            availablePackages = emptyList(),
+            paywallComponents = Offering.PaywallComponents(
+                UiConfig(
+                    app = UiConfig.AppConfig(colors = emptyMap(), fonts = emptyMap()),
+                    localizations = mapOf(locale to mapOf(VariableLocalizationKey.DAY to "day")),
+                    variableConfig = UiConfig.VariableConfig(
+                        variableCompatibilityMap = emptyMap(),
+                        functionCompatibilityMap = emptyMap(),
+                    ),
+                ),
+                componentsData,
+            ),
+        )
+        val validation = offering
+            .validatePaywallComponentsDataOrNull(PaywallResourceProvider(composeTestRule.activity))
+            ?.getOrThrow()
+            ?: error("Expected Components paywall validation to succeed")
+        return offering.toComponentsPaywallState(
+            validationResult = validation,
+            storefrontCountryCode = null,
+            dateProvider = { Date() },
+            purchases = MockPurchasesType(),
+        )
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -296,10 +296,13 @@ internal fun Modifier.footerBottomPadding(state: PaywallState.Loaded.Components)
 /**
  * Returns whether the caller should wrap [rootStack] in an outer `verticalScroll` modifier.
  * Returns `false` when the root stack already scrolls vertically (overflow = SCROLL on a vertical
- * dimension), because two vertical scroll modifiers on the same axis crash at runtime.
+ * dimension), because two vertical scroll modifiers on the same axis crash at runtime, and when
+ * the root stack explicitly opts out of scrolling (overflow = "default").
  */
-internal fun shouldWrapMainContentInVerticalScroll(rootStack: ComponentStyle): Boolean =
-    (rootStack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
+internal fun shouldWrapMainContentInVerticalScroll(rootStack: ComponentStyle): Boolean {
+    val stack = rootStack as? StackComponentStyle ?: return true
+    return stack.scrollOrientation != Orientation.Vertical && !stack.scrollExplicitlyDisabled
+}
 
 internal suspend fun handleClick(
     action: PaywallAction,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -297,7 +297,8 @@ internal fun Modifier.footerBottomPadding(state: PaywallState.Loaded.Components)
  * Returns whether the caller should wrap [rootStack] in an outer `verticalScroll` modifier.
  * Returns `false` when the root stack already scrolls vertically (overflow = SCROLL on a vertical
  * dimension), because two vertical scroll modifiers on the same axis crash at runtime, and when
- * the root stack explicitly opts out of scrolling (overflow = "default").
+ * the root stack explicitly opts out of scrolling (an overflow that deserialized to NONE:
+ * "default", "none", or an unrecognized value).
  */
 internal fun shouldWrapMainContentInVerticalScroll(rootStack: ComponentStyle): Boolean {
     val stack = rootStack as? StackComponentStyle ?: return true

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PreviewHelpers.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PreviewHelpers.kt
@@ -284,6 +284,7 @@ internal fun previewStackComponentStyle(
     shadow: ShadowStyles? = null,
     badge: BadgeStyle? = null,
     scrollOrientation: Orientation? = null,
+    scrollExplicitlyDisabled: Boolean = false,
     countdownDate: Date? = null,
     countFrom: CountdownComponent.CountFrom = CountdownComponent.CountFrom.DAYS,
 ): StackComponentStyle {
@@ -301,6 +302,7 @@ internal fun previewStackComponentStyle(
         shadow = shadow,
         badge = badge,
         scrollOrientation = scrollOrientation,
+        scrollExplicitlyDisabled = scrollExplicitlyDisabled,
         rcPackage = null,
         tabIndex = null,
         countdownDate = countdownDate,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -182,7 +182,12 @@ internal class StackComponentState(
 
     @get:JvmSynthetic
     val scrollOrientation by derivedStateOf {
-        presentedPartial?.partial?.overflow?.toOrientation(dimension) ?: style.scrollOrientation
+        // An explicit Overflow.NONE in a partial must disable scrolling, not fall
+        // back to the base style — only an absent overflow inherits it.
+        when (val overflow = presentedPartial?.partial?.overflow) {
+            null -> style.scrollOrientation
+            else -> overflow.toOrientation(dimension)
+        }
     }
 
     @JvmSynthetic

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
@@ -49,6 +49,12 @@ internal data class StackComponentStyle(
     @get:JvmSynthetic
     val scrollOrientation: Orientation?,
     /**
+     * True when the component declares `overflow: "default"`, i.e. scrolling is explicitly turned
+     * off — used by the root stack to opt out of the outer vertical scroll it gets by default.
+     */
+    @get:JvmSynthetic
+    val scrollExplicitlyDisabled: Boolean = false,
+    /**
      * If this is non-null and equal to the currently selected package, the `selected` [overrides] will be used if
      * available.
      */

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
@@ -49,8 +49,9 @@ internal data class StackComponentStyle(
     @get:JvmSynthetic
     val scrollOrientation: Orientation?,
     /**
-     * True when the component declares `overflow: "default"`, i.e. scrolling is explicitly turned
-     * off — used by the root stack to opt out of the outer vertical scroll it gets by default.
+     * True when the component's overflow deserialized to `Overflow.NONE` (`"default"`, `"none"`, or
+     * an unrecognized value) — used by the root stack to opt out of the outer vertical scroll it
+     * gets by default.
      */
     @get:JvmSynthetic
     val scrollExplicitlyDisabled: Boolean = false,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -941,6 +941,7 @@ internal class StyleFactory(
             shadow = shadowStyles,
             badge = badge,
             scrollOrientation = component.overflow?.toOrientation(component.dimension),
+            scrollExplicitlyDisabled = component.overflow == StackComponent.Overflow.NONE,
             rcPackage = rcPackage,
             resolvedOffer = resolvedOffer,
             tabIndex = tabControlIndex,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ShouldWrapMainContentInVerticalScrollTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ShouldWrapMainContentInVerticalScrollTest.kt
@@ -37,6 +37,17 @@ internal class ShouldWrapMainContentInVerticalScrollTest {
     }
 
     @Test
+    fun `root stack with scrolling explicitly disabled is not wrapped`() {
+        val stack = previewStackComponentStyle(
+            children = emptyList(),
+            scrollOrientation = null,
+            scrollExplicitlyDisabled = true,
+        )
+
+        assertThat(shouldWrapMainContentInVerticalScroll(stack)).isFalse()
+    }
+
+    @Test
     fun `non-stack root component is wrapped`() {
         val text = previewTextComponentStyle(text = "non-stack root")
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/StackOverflowScrollTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/StackOverflowScrollTests.kt
@@ -1,11 +1,10 @@
 package com.revenuecat.purchases.ui.revenuecatui.components
 
-import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.UiConfig
@@ -30,11 +29,10 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.LocalizationDictionary
 import com.revenuecat.purchases.ui.revenuecatui.data.MockPurchasesType
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
-import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallResourceProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
+import com.revenuecat.purchases.ui.revenuecatui.extensions.validatePaywallComponentsDataOrNull
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
-import com.revenuecat.purchases.ui.revenuecatui.helpers.validatePaywallComponentsDataOrNull
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -43,57 +41,37 @@ import java.net.URL
 import java.util.Date
 
 /**
- * On-device verification of the explicit-"default" overflow behavior: the schema's "default"
- * deserializes to an explicit [StackComponent.Overflow.NONE] (covered by unit tests), and an
- * explicit NONE must actually stop the paywall from scrolling — both on the root stack (which is
- * otherwise wrapped in an outer verticalScroll) and when a window size rule's partial sets it.
+ * Unit-tier twin of `StackOverflowScrollInstrumentedTests` for the partial-override path, so the
+ * behavior gates per-PR unit runs and not only the emulator job.
  */
 @RunWith(AndroidJUnit4::class)
-internal class StackOverflowScrollInstrumentedTests {
+internal class StackOverflowScrollTests {
 
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+    val composeTestRule = createComposeRule()
 
     private val verticallyScrollable =
         SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange)
 
     @Test
-    fun rootStackWithAbsentOverflowGetsTheOuterScrollWrap() {
-        setPaywallContent(rootStack(overflow = null))
+    fun `base scroll overflow keeps the stack scrollable when a partial leaves overflow absent`() {
+        setPaywallContent(
+            rootStack(
+                overflow = StackComponent.Overflow.SCROLL,
+                overrides = listOf(matchingWindowOverride(PartialStackComponent())),
+            ),
+        )
 
         assertThat(verticallyScrollableNodeCount()).isGreaterThan(0)
     }
 
     @Test
-    fun rootStackWithExplicitDefaultOverflowDoesNotScroll() {
-        setPaywallContent(rootStack(overflow = StackComponent.Overflow.NONE))
-
-        assertThat(verticallyScrollableNodeCount()).isZero()
-    }
-
-    @Test
-    fun rootStackWithScrollOverflowScrollsItself() {
-        setPaywallContent(rootStack(overflow = StackComponent.Overflow.SCROLL))
-
-        assertThat(verticallyScrollableNodeCount()).isGreaterThan(0)
-    }
-
-    @Test
-    fun windowSizeRulePartialWithNoneDisablesTheBaseScroll() {
-        // Base scrolls; a window width rule that matches any realistic device disables it.
+    fun `window size rule partial with NONE disables the base scroll`() {
         setPaywallContent(
             rootStack(
                 overflow = StackComponent.Overflow.SCROLL,
                 overrides = listOf(
-                    ComponentOverride(
-                        conditions = listOf(
-                            ComponentOverride.Condition.WindowWidthRule(
-                                operator = ComponentOverride.ComparisonOperator.GREATER_THAN_OR_EQUAL,
-                                value = 100.0,
-                            ),
-                        ),
-                        properties = PartialStackComponent(overflow = StackComponent.Overflow.NONE),
-                    ),
+                    matchingWindowOverride(PartialStackComponent(overflow = StackComponent.Overflow.NONE)),
                 ),
             ),
         )
@@ -101,16 +79,27 @@ internal class StackOverflowScrollInstrumentedTests {
         assertThat(verticallyScrollableNodeCount()).isZero()
     }
 
+    private fun matchingWindowOverride(
+        properties: PartialStackComponent,
+    ): ComponentOverride<PartialStackComponent> = ComponentOverride(
+        conditions = listOf(
+            ComponentOverride.Condition.WindowWidthRule(
+                operator = ComponentOverride.ComparisonOperator.GREATER_THAN_OR_EQUAL,
+                value = 100.0,
+            ),
+        ),
+        properties = properties,
+    )
+
     private fun verticallyScrollableNodeCount(): Int {
         composeTestRule.waitForIdle()
         return composeTestRule.onAllNodes(verticallyScrollable).fetchSemanticsNodes().size
     }
 
     private fun setPaywallContent(rootStack: StackComponent) {
-        val state = paywallState(rootStack)
         composeTestRule.setContent {
             LoadedPaywallComponents(
-                state = state,
+                state = paywallState(rootStack),
                 clickHandler = { },
                 modifier = Modifier.fillMaxSize(),
             )
@@ -122,7 +111,7 @@ internal class StackOverflowScrollInstrumentedTests {
         overrides: List<ComponentOverride<PartialStackComponent>> = emptyList(),
     ): StackComponent = StackComponent(
         components = listOf(
-            // Taller than any device, so the root always has something to scroll to.
+            // Taller than the test window, so there is always something to scroll to.
             StackComponent(
                 components = emptyList(),
                 size = Size(width = SizeConstraint.Fill(), height = SizeConstraint.Fixed(4000u)),
@@ -137,8 +126,8 @@ internal class StackOverflowScrollInstrumentedTests {
     private fun paywallState(rootStack: StackComponent): PaywallState.Loaded.Components {
         val locale = LocaleId("en_US")
         val componentsData = PaywallComponentsData(
-            id = "overflow_test_paywall",
-            templateName = "overflow_test_template",
+            id = "overflow_partial_test_paywall",
+            templateName = "overflow_partial_test_template",
             assetBaseURL = URL("https://assets.pawwalls.com"),
             componentsConfig = ComponentsConfig(
                 base = PaywallComponentsConfig(
@@ -148,13 +137,13 @@ internal class StackOverflowScrollInstrumentedTests {
             ),
             componentsLocalizations = nonEmptyMapOf(
                 locale to nonEmptyMapOf(
-                    LocalizationKey("overflow_test_key") to LocalizationData.Text("overflow_test"),
+                    LocalizationKey("overflow_partial_test_key") to LocalizationData.Text("overflow_partial_test"),
                 ) as LocalizationDictionary,
             ),
             defaultLocaleIdentifier = locale,
         )
         val offering = Offering(
-            identifier = "overflow_test_offering",
+            identifier = "overflow_partial_test_offering",
             serverDescription = "",
             metadata = emptyMap(),
             availablePackages = emptyList(),
@@ -170,9 +159,7 @@ internal class StackOverflowScrollInstrumentedTests {
                 componentsData,
             ),
         )
-        val validation = offering
-            .validatePaywallComponentsDataOrNull(PaywallResourceProvider(composeTestRule.activity))
-            ?.getOrThrow()
+        val validation = offering.validatePaywallComponentsDataOrNull()?.getOrThrow()
             ?: error("Expected Components paywall validation to succeed")
         return offering.toComponentsPaywallState(
             validationResult = validation,


### PR DESCRIPTION
### Motivation

The paywall schema now accepts `overflow: "default"` on stacks — *explicitly not scrollable* (absent still means platform default). Android conflated explicit `NONE` with absent, so authors couldn't actually turn scrolling off: the root stack always kept its built-in outer scroll, and a rule setting overflow to none/default silently fell back to the base scroll.

### Description

- `"default"` deserializes to an explicit `Overflow.NONE` (same as `"none"`)
- A root stack with explicit `NONE` opts out of the built-in outer `verticalScroll`; absent overflow keeps it
- Partial overrides: `NONE` now disables scrolling instead of inheriting the base orientation — only an absent overflow inherits
- Unknown future overflow values behave like `"default"`, matching iOS

### Testing

- Robolectric + on-device emulator tests assert scroll semantics for absent / `NONE` / `SCROLL` on the root and for window-rule partials
- Video below: the same tall paywall with overflow absent (scrolls) vs `"default"` (doesn't budge)

### Context for AI agents

- khepri now accepts `overflow: "default"` on stacks (RevenueCat/khepri#25061) meaning *explicitly not scrollable*; absent/null keeps platform defaults.
- The deserializer maps `"default"` → `Overflow.NONE` explicitly (was already the unknown-value fallback).
- `StackComponentStyle` gains `scrollExplicitlyDisabled`; `shouldWrapMainContentInVerticalScroll` returns false for a root stack that opts out, so `overflow: "default"` on the root disables the built-in outer scroll.
- Bug fix: a partial override with `Overflow.NONE` used to fall back to the base scroll orientation (`?.toOrientation() ?: base` conflated NONE with absent) — it now disables scrolling.
- iOS needs no change (`Overflow.default` already maps to `scrollable = false`, overriding `isScrollableByDefault`).
- Not covered: the root wrap decision is made once from the base style, so a window-size override toggling the root's overflow doesn't re-evaluate the outer wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when components paywalls scroll (root outer wrap and override-driven stack scroll), which can clip or lock content if misconfigured but matches intended schema behavior.
> 
> **Overview**
> Aligns Android paywall stack **overflow** with the schema: JSON `"default"` now deserializes explicitly to `Overflow.NONE` (same as `"none"`), with unit coverage.
> 
> **Root paywall scrolling:** `StackComponentStyle` gains `scrollExplicitlyDisabled` when overflow is `NONE`. `shouldWrapMainContentInVerticalScroll` skips the built-in outer `verticalScroll` in that case, so an explicit `"default"` / `"none"` on the **root** stack actually prevents scrolling; absent `overflow` still gets the outer wrap.
> 
> **Partial overrides:** `StackComponentState` no longer treats `Overflow.NONE` in a window-size (or other) partial as “inherit base scroll”—only a missing `overflow` in the partial keeps the base orientation. That fixes stacks that should stop scrolling when a rule sets overflow to none/default.
> 
> Compose unit and instrumented tests assert scroll semantics for null vs `NONE` vs `SCROLL` on the root and for partial overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca7169b26062d7090f52c6370cceba9b2919d37b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

https://github.com/user-attachments/assets/d2b899d0-7020-427d-8f90-d049232ba2ee
