### PR TITLE
fix(paywalls): custom components context packages: send only current paywall packages

### DIFF
--- a/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewTestSupport.kt
+++ b/ui/revenuecatui/src/androidTest/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewTestSupport.kt
@@ -17,6 +17,7 @@ internal fun deviceContextSnapshot(
     WebViewContextInput(
         customVariables = customVariables,
         offering = null,
+        packages = emptyList(),
         componentPackage = null,
         selectedPackage = null,
         store = Store.PLAY_STORE,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextInput.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextInput.kt
@@ -10,6 +10,8 @@ import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowScreenContext
 internal data class WebViewContextInput(
     val customVariables: Map<String, CustomVariableValue>,
     val offering: Offering?,
+    /** The packages the paywall shows. */
+    val packages: List<Package>,
     /** Its own when the component sits inside a package, else the selection. */
     val componentPackage: Package?,
     val selectedPackage: Package?,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
@@ -34,6 +34,7 @@ internal fun webViewContextSnapshot(
         WebViewContextInput(
             customVariables = state.mergedCustomVariables,
             offering = state.offering,
+            packages = state.paywallPackages,
             // Inside a package component the values describe that package; elsewhere they follow
             // the selection, matching what a text component resolves.
             componentPackage = style.rcPackage ?: selectedPackage,
@@ -61,10 +62,10 @@ internal fun webViewContextSnapshot(input: WebViewContextInput): JsonObject = bu
     }
     put(Keys.OFFERING, input.offering?.asJson() ?: JsonNull)
     putJsonArray(Keys.PACKAGES) {
-        input.offering?.availablePackages?.forEach { add(it.asJson(input)) }
+        input.packages.forEach { add(it.asJson(input)) }
     }
-    put(Keys.PACKAGE, input.componentPackage?.asJson(input) ?: JsonNull)
-    put(Keys.SELECTED_PACKAGE, input.selectedPackage?.asJson(input) ?: JsonNull)
+    put(Keys.PACKAGE, input.onPaywall(input.componentPackage)?.asJson(input) ?: JsonNull)
+    put(Keys.SELECTED_PACKAGE, input.onPaywall(input.selectedPackage)?.asJson(input) ?: JsonNull)
     putJsonObject(Keys.INPUTS) {}
     input.workflowScreen?.let { putWorkflow(it) }
     putJsonObject(Keys.DEVICE_META) {
@@ -74,6 +75,10 @@ internal fun webViewContextSnapshot(input: WebViewContextInput): JsonObject = bu
         put(Keys.UPDATED_AT, System.currentTimeMillis())
     }
 }
+
+/** iOS and web resolve both references against `packages`, so one outside the list is `null` everywhere. */
+private fun WebViewContextInput.onPaywall(pkg: Package?): Package? =
+    pkg?.takeIf { candidate -> packages.any { it.identifier == candidate.identifier } }
 
 private fun JsonObjectBuilder.putWorkflow(workflowScreen: WorkflowScreenContext) {
     putJsonObject(Keys.WORKFLOW) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshot.kt
@@ -76,7 +76,6 @@ internal fun webViewContextSnapshot(input: WebViewContextInput): JsonObject = bu
     }
 }
 
-/** iOS and web resolve both references against `packages`, so one outside the list is `null` everywhere. */
 private fun WebViewContextInput.onPaywall(pkg: Package?): Package? =
     pkg?.takeIf { candidate -> packages.any { it.identifier == candidate.identifier } }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -155,6 +155,12 @@ internal sealed interface PaywallState {
 
             val store: Store get() = purchases.store
 
+            /** A subset of the offering: packages the paywall never shows are not in it. */
+            val paywallPackages: List<Package> = (
+                packages.packagesOutsideTabs +
+                    packages.packagesByTab.toSortedMap().values.flatten()
+                ).map { it.pkg }.distinctBy { it.identifier }
+
             data class AvailablePackages(
                 val packagesOutsideTabs: List<Info>,
                 val packagesByTab: Map<Int, List<Info>>,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -156,10 +156,11 @@ internal sealed interface PaywallState {
             val store: Store get() = purchases.store
 
             /** A subset of the offering: packages the paywall never shows are not in it. */
-            val paywallPackages: List<Package> = (
-                packages.packagesOutsideTabs +
-                    packages.packagesByTab.toSortedMap().values.flatten()
-                ).map { it.pkg }.distinctBy { it.identifier }
+            val paywallPackages: List<Package> by lazy {
+                (packages.packagesOutsideTabs + packages.packagesByTab.toSortedMap().values.flatten())
+                    .map { it.pkg }
+                    .distinctBy { it.identifier }
+            }
 
             data class AvailablePackages(
                 val packagesOutsideTabs: List<Info>,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewContextSnapshotTest.kt
@@ -176,13 +176,30 @@ internal class WebViewContextSnapshotTest {
     }
 
     @Test
-    fun `packages carries every available package in order`() {
+    fun `packages carries the packages the paywall shows, not the whole offering`() {
         val offering = TestData.template7CustomPackageOffering
+        val shown = offering.availablePackages.drop(1).reversed()
 
-        val packages = testContextSnapshot(offering = offering).getValue("packages").jsonArray
+        val packages = testContextSnapshot(offering = offering, packages = shown).getValue("packages").jsonArray
 
         assertThat(packages.map { it.jsonObject.getValue("identifier").jsonPrimitive.content })
-            .isEqualTo(offering.availablePackages.map { it.identifier })
+            .isEqualTo(shown.map { it.identifier })
+    }
+
+    @Test
+    fun `package and selected_package are null when they are not on the paywall`() {
+        val offering = TestData.template7CustomPackageOffering
+        val hidden = offering.availablePackages.first()
+
+        val snapshot = testContextSnapshot(
+            offering = offering,
+            packages = offering.availablePackages - hidden,
+            componentPackage = hidden,
+            selectedPackage = hidden,
+        )
+
+        assertThat(snapshot.getValue("package")).isEqualTo(JsonNull)
+        assertThat(snapshot.getValue("selected_package")).isEqualTo(JsonNull)
     }
 
     @Test
@@ -282,8 +299,10 @@ internal class WebViewContextSnapshotTest {
 
     @Test
     fun `is_auto_renewing is false for a prepaid base plan`() {
+        val prepaid = prepaidPackage()
         val product = testContextSnapshot(
-            componentPackage = prepaidPackage(),
+            packages = listOf(prepaid),
+            componentPackage = prepaid,
         ).productOfPackage()
 
         assertThat(product.getValue("is_auto_renewing").jsonPrimitive.boolean).isFalse()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewSnapshotFixture.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewSnapshotFixture.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.json.jsonObject
 internal fun testContextSnapshot(
     customVariables: Map<String, CustomVariableValue> = emptyMap(),
     offering: Offering? = null,
+    packages: List<Package> = offering?.availablePackages.orEmpty(),
     componentPackage: Package? = null,
     selectedPackage: Package? = null,
     store: Store = Store.PLAY_STORE,
@@ -37,6 +38,7 @@ internal fun testContextSnapshot(
     WebViewContextInput(
         customVariables = customVariables,
         offering = offering,
+        packages = packages,
         componentPackage = componentPackage,
         selectedPackage = selectedPackage,
         store = store,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsPackageSelectionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsPackageSelectionTests.kt
@@ -373,6 +373,27 @@ internal class PaywallStateLoadedComponentsPackageSelectionTests {
     }
 
     @Test
+    fun `paywallPackages lists packages outside tabs first, then by tab, without duplicates`() {
+        val state = paywallState(
+            packagesOutsideTabs = listOf(packageInfo(TestData.Packages.annual, isSelectedByDefault = true)),
+            packagesByTab = mapOf(
+                1 to listOf(packageInfo(TestData.Packages.weekly, isSelectedByDefault = false)),
+                0 to listOf(
+                    packageInfo(TestData.Packages.monthly, isSelectedByDefault = false),
+                    packageInfo(TestData.Packages.annual, isSelectedByDefault = false),
+                ),
+            ),
+            initialSelectedTabIndex = 0,
+        )
+
+        assertThat(state.paywallPackages).containsExactly(
+            TestData.Packages.annual,
+            TestData.Packages.monthly,
+            TestData.Packages.weekly,
+        )
+    }
+
+    @Test
     fun `Should not select a hidden package when switching to a tab with nothing visible`() {
         val state = paywallState(
             packagesOutsideTabs = emptyList(),


### PR DESCRIPTION
- `packages` in the custom component context now lists only the packages the paywall declares, in tree order and deduplicated. It used to be the whole offering, which is out of spec
- `package` and `selected_package` are `null` when they are not in that list, matching iOS and JS.
- The tree list comes from the existing `AvailablePackages` on the loaded state, exposed as `paywallPackages`.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

The contract in RevenueCat/docs#1874 defines `packages` as "the Packages on the paywall". iOS sends `paywallState.packages` (the tree-declared list) and web filters the offering by the package ids in the tree. Android serialized `offering.availablePackages`, so a component saw packages the paywall never shows.

Once `packages` is a subset, `package` and `selected_package` can point outside it. iOS and web resolve both against the emitted list and send `null` on a miss; Android sent the state's package regardless.

### Description

- `PaywallState.Loaded.Components.paywallPackages`: `packagesOutsideTabs` first, then `packagesByTab` in tab index order, deduplicated by identifier. A package that sits in several tabs appears once.
- `WebViewContextInput.packages` replaces the offering as the source of the `packages` array.
- `package` and `selected_package` are emitted only when their identifier is in `packages`.
- Tests: subset and order in `WebViewContextSnapshotTest`, null-on-miss regression test there, `paywallPackages` order and dedup in `PaywallStateLoadedComponentsPackageSelectionTests`.

Regression gate: `package and selected_package are null when they are not on the paywall`.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the WebView context payload for custom paywall components; integrators that assumed `packages` matched the full offering may see different data, but behavior now matches the documented contract.
> 
> **Overview**
> Aligns Android **custom component WebView context** with the contract (and iOS/JS): `packages` is no longer the full offering—it is only what the paywall tree declares.
> 
> **`paywallPackages`** on loaded component paywall state collects packages outside tabs first, then tab contents in tab index order, **deduplicated** by identifier. That list is passed through **`WebViewContextInput.packages`** and serialized as the context `packages` array.
> 
> **`package`** and **`selected_package`** are emitted only when their identifier appears in that list; otherwise they are **`null`** (via `onPaywall`), fixing cases where selection or component scope pointed at a package not shown on the paywall.
> 
> Tests cover subset ordering, null-on-miss, and `paywallPackages` ordering/dedup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ba55c9a8e202c3271c65f9c57ac3925d010341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->