### PR TITLE
Chore(Paywalls): Begin to support min/max size attributes - #4161

### DIFF
--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -51,6 +51,12 @@ android {
             value = (localProperties["ENABLE_EXTRA_REQUEST_LOGGING"] as? String ?: "false"),
         )
 
+        buildConfigField(
+            type = "boolean",
+            name = "ENABLE_PAYWALL_MIN_MAX_SIZING",
+            value = (localProperties["ENABLE_PAYWALL_MIN_MAX_SIZING"] as? String ?: "false"),
+        )
+
         packagingOptions.resources.excludes.addAll(
             listOf("META-INF/LICENSE.md", "META-INF/LICENSE-notice.md"),
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Size.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Size.kt
@@ -3,10 +3,15 @@ package com.revenuecat.purchases.paywalls.components.properties
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.utils.serializers.SealedDeserializerWithDefault
 import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @InternalRevenueCatAPI
 @Poko
@@ -56,12 +61,25 @@ public sealed interface SizeConstraint {
 }
 
 @OptIn(InternalRevenueCatAPI::class)
-internal object SizeConstraintDeserializer : SealedDeserializerWithDefault<SizeConstraint>(
-    serialName = "SizeConstraint",
-    serializerByType = mapOf(
-        "fit" to { SizeConstraint.Fit.serializer() },
-        "fill" to { SizeConstraint.Fill.serializer() },
-        "fixed" to { SizeConstraint.Fixed.serializer() },
-    ),
-    defaultValue = { SizeConstraint.Fit() },
-)
+internal object SizeConstraintDeserializer : KSerializer<SizeConstraint> {
+    private val delegate = object : SealedDeserializerWithDefault<SizeConstraint>(
+        serialName = "SizeConstraint",
+        serializerByType = mapOf(
+            "fit" to { SizeConstraint.Fit.serializer() },
+            "fill" to { SizeConstraint.Fill.serializer() },
+            "fixed" to { SizeConstraint.Fixed.serializer() },
+        ),
+        defaultValue = { SizeConstraint.Fit() },
+    ) {}
+    override val descriptor: SerialDescriptor = delegate.descriptor
+    override fun deserialize(decoder: Decoder): SizeConstraint {
+        val constraint = delegate.deserialize(decoder)
+        if (BuildConfig.ENABLE_PAYWALL_MIN_MAX_SIZING) return constraint
+        return when (constraint) {
+            is SizeConstraint.Fit -> SizeConstraint.Fit(default = constraint.default)
+            is SizeConstraint.Fill -> SizeConstraint.Fill()
+            is SizeConstraint.Fixed -> constraint
+        }
+    }
+    override fun serialize(encoder: Encoder, value: SizeConstraint) = delegate.serialize(encoder, value)
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/SizeTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/SizeTests.kt
@@ -1,7 +1,9 @@
 package com.revenuecat.purchases.paywalls.components.properties
 
 import com.revenuecat.purchases.JsonTools
+import com.revenuecat.purchases.api.BuildConfig
 import org.intellij.lang.annotations.Language
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
@@ -17,6 +19,7 @@ internal class SizeTests {
             @Language("json")
             val json: String,
             val expected: SizeConstraint,
+            val requiresMinMaxSizing: Boolean = false,
         )
 
         companion object {
@@ -82,7 +85,8 @@ internal class SizeTests {
                               "max": 100
                             }
                         """.trimIndent(),
-                        expected = SizeConstraint.Fit(min = 20u, max = 100u)
+                        expected = SizeConstraint.Fit(min = 20u, max = 100u),
+                        requiresMinMaxSizing = true,
                     )
                 ),
                 arrayOf(
@@ -95,7 +99,8 @@ internal class SizeTests {
                               "max": 20
                             }
                         """.trimIndent(),
-                        expected = SizeConstraint.Fit(min = 40u, max = 20u)
+                        expected = SizeConstraint.Fit(min = 40u, max = 20u),
+                        requiresMinMaxSizing = true,
                     )
                 ),
                 arrayOf(
@@ -130,7 +135,8 @@ internal class SizeTests {
                               "min": 20
                             }
                         """.trimIndent(),
-                        expected = SizeConstraint.Fill(min = 20u)
+                        expected = SizeConstraint.Fill(min = 20u),
+                        requiresMinMaxSizing = true,
                     )
                 ),
                 arrayOf(
@@ -142,7 +148,8 @@ internal class SizeTests {
                               "max": 100
                             }
                         """.trimIndent(),
-                        expected = SizeConstraint.Fill(max = 100u)
+                        expected = SizeConstraint.Fill(max = 100u),
+                        requiresMinMaxSizing = true,
                     )
                 ),
                 arrayOf(
@@ -155,7 +162,8 @@ internal class SizeTests {
                               "max": 100
                             }
                         """.trimIndent(),
-                        expected = SizeConstraint.Fill(min = 20u, max = 100u)
+                        expected = SizeConstraint.Fill(min = 20u, max = 100u),
+                        requiresMinMaxSizing = true,
                     )
                 ),
                 arrayOf(
@@ -217,6 +225,11 @@ internal class SizeTests {
 
         @Test
         fun `Should properly deserialize SizeConstraint`() {
+            assumeTrue(
+                "Requires ENABLE_PAYWALL_MIN_MAX_SIZING=true",
+                !args.requiresMinMaxSizing || BuildConfig.ENABLE_PAYWALL_MIN_MAX_SIZING,
+            )
+
             // Arrange, Act
             val actual = JsonTools.json.decodeFromString<SizeConstraint>(args.json)
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -41,6 +41,7 @@ import com.revenuecat.purchases.paywalls.events.PaywallComponentInteractionData
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.TransitionView
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.resolveComponentSizeParentData
 import com.revenuecat.purchases.ui.revenuecatui.components.previewEmptyState
 import com.revenuecat.purchases.ui.revenuecatui.components.previewStackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.previewTextComponentStyle
@@ -205,7 +206,7 @@ internal fun ButtonComponentView(
                     color = progressColorFor(style.stackComponentStyle.background),
                 )
             },
-            modifier = modifier,
+            modifier = modifier.resolveComponentSizeParentData(stackState.size),
             measurePolicy = { measurables, constraints ->
                 val stack = measurables[0].measure(constraints)
                 // Ensure that the progress indicator is not bigger than the stack.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentView.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.border
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.resolveComponentSizeParentData
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.shadow
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.previewEmptyState
@@ -67,6 +68,7 @@ internal fun IconComponentView(
 
     Box(
         modifier = modifier
+            .resolveComponentSizeParentData(iconState.sizePlusMargin)
             .size(iconState.sizePlusMargin)
             .padding(iconState.margin),
     ) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentState.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.revenuecat.purchases.paywalls.components.properties.ImageUrls
 import com.revenuecat.purchases.paywalls.components.properties.Size
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
@@ -38,6 +37,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toLocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toPaddingValues
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toShape
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.AspectRatio
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.adjustForMedia
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDelegate
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ImageComponentStyle
@@ -279,46 +279,9 @@ internal class ImageComponentState(
      * Adjusts this size to take into account the size of the image.
      */
     private fun Size.adjustForImage(imageUrls: ImageUrls, density: Density): Size =
-        Size(
-            width = width.adjustDimension(
-                other = height,
-                thisImageDimensionPx = imageUrls.width,
-                otherImageDimensionPx = imageUrls.height,
-                density = density,
-            ),
-            height = height.adjustDimension(
-                other = width,
-                thisImageDimensionPx = imageUrls.height,
-                otherImageDimensionPx = imageUrls.width,
-                density = density,
-            ),
+        adjustForMedia(
+            widthPx = imageUrls.width,
+            heightPx = imageUrls.height,
+            density = density,
         )
-
-    /**
-     * Adjusts this size constraint to take into account the size of the image.
-     */
-    private fun SizeConstraint.adjustDimension(
-        other: SizeConstraint,
-        thisImageDimensionPx: UInt,
-        otherImageDimensionPx: UInt,
-        density: Density,
-    ): SizeConstraint = when (this) {
-        is Fit -> {
-            when (other) {
-                is Fit -> Fixed(with(density) { thisImageDimensionPx.toInt().toDp().value.toUInt() })
-                is Fill -> this
-
-                is Fixed -> {
-                    // If the other dimension is Fixed, we'll have to scale this one by the same factor.
-                    val otherImageDimensionDp = with(density) { otherImageDimensionPx.toInt().toDp() }
-                    val scaleFactor = other.value.toFloat() / otherImageDimensionDp.value
-                    Fixed(with(density) { (scaleFactor * thisImageDimensionPx.toInt()).toDp().value.toUInt() })
-                }
-            }
-        }
-
-        is Fill,
-        is Fixed,
-        -> this
-    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -58,6 +58,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.urlsForCurrentThe
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.aspectRatio
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.border
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.overlay
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.resolveComponentSizeParentData
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.shadow
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.previewEmptyState
@@ -101,6 +102,7 @@ internal fun ImageComponentView(
         // in order to have the border applied on top of the overlay, which uses onDrawWithContent
         Box(
             modifier = modifier
+                .resolveComponentSizeParentData(imageState.sizePlusMargin)
                 .size(imageState.sizePlusMargin)
                 .applyIfNotNull(imageState.marginAdjustedAspectRatio) { aspectRatio(it) }
                 .padding(imageState.margin)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Size.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Size.kt
@@ -23,7 +23,13 @@ private fun SizeConstraint.addMargin(
     margin: UInt,
 ): SizeConstraint = when (this) {
     is Fixed -> Fixed(value + margin)
-    is Fill,
-    is Fit,
-    -> this
+    is Fill -> Fill(
+        min = min?.plus(margin),
+        max = max?.plus(margin),
+    )
+    is Fit -> Fit(
+        default = default,
+        min = min?.plus(margin),
+        max = max?.plus(margin),
+    )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/ComponentSizeParentDataModifier.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/ComponentSizeParentDataModifier.kt
@@ -1,0 +1,36 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.modifier
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ParentDataModifier
+import androidx.compose.ui.unit.Density
+import com.revenuecat.purchases.paywalls.components.properties.Size
+
+/**
+ * Replaces the [ComponentSizeParentDataModifier] a parent stack attached to this chain with one carrying the
+ * component's fully resolved [size] (overrides and margin applied).
+ *
+ * Compose folds parent data from the innermost modifier outwards, so the outermost [ParentDataModifier] wins. The
+ * resolved modifier is therefore prepended (`then(this)`) rather than appended. Does nothing when no parent asked for
+ * size parent data.
+ */
+internal fun Modifier.resolveComponentSizeParentData(size: Size): Modifier =
+    if (any { it is ComponentSizeParentDataModifier }) {
+        ComponentSizeParentDataModifier(size).then(this)
+    } else {
+        this
+    }
+
+/**
+ * Parent data read by `ConstrainedFillLayout` to allocate main-axis space to a child.
+ *
+ * [modifyParentData] intentionally ignores the incoming value: this must stay the outermost [ParentDataModifier] on
+ * a component, and any other parent data (e.g. `Modifier.layoutId`) applied outside of it would hide it from the
+ * stack, which would then treat the child as non-Fill.
+ */
+internal data class ComponentSizeParentDataModifier(
+    val size: Size,
+) : ParentDataModifier {
+    override fun Density.modifyParentData(parentData: Any?): Any = this@ComponentSizeParentDataModifier
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/MediaSize.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/MediaSize.kt
@@ -1,0 +1,115 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.modifier
+
+import androidx.compose.ui.unit.Density
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+
+/**
+ * Resolves intrinsic media dimensions while preserving the media's aspect ratio when both axes are [Fit].
+ */
+internal fun Size.adjustForMedia(
+    widthPx: UInt,
+    heightPx: UInt,
+    density: Density,
+): Size {
+    val fitWidth = width as? Fit
+    val fitHeight = height as? Fit
+    if (fitWidth != null && fitHeight != null) {
+        return adjustFitDimensions(
+            width = fitWidth,
+            height = fitHeight,
+            widthPx = widthPx,
+            heightPx = heightPx,
+            density = density,
+        )
+    }
+
+    return Size(
+        width = width.adjustDimension(
+            other = height,
+            thisDimensionPx = widthPx,
+            otherDimensionPx = heightPx,
+            density = density,
+        ),
+        height = height.adjustDimension(
+            other = width,
+            thisDimensionPx = heightPx,
+            otherDimensionPx = widthPx,
+            density = density,
+        ),
+    )
+}
+
+private fun adjustFitDimensions(
+    width: Fit,
+    height: Fit,
+    widthPx: UInt,
+    heightPx: UInt,
+    density: Density,
+): Size {
+    val intrinsicWidth = with(density) { widthPx.toInt().toDp().value }
+    val intrinsicHeight = with(density) { heightPx.toInt().toDp().value }
+    if (intrinsicWidth <= 0f || intrinsicHeight <= 0f) {
+        return Size(
+            width = Fixed(width.clamp(0u)),
+            height = Fixed(height.clamp(0u)),
+        )
+    }
+
+    val minimumScale = maxOf(
+        width.minimum.scaleFor(intrinsicWidth, fallback = 0f),
+        height.minimum.scaleFor(intrinsicHeight, fallback = 0f),
+    )
+    val maximumScale = minOf(
+        width.effectiveMaximum.scaleFor(intrinsicWidth, fallback = Float.POSITIVE_INFINITY),
+        height.effectiveMaximum.scaleFor(intrinsicHeight, fallback = Float.POSITIVE_INFINITY),
+    )
+    val scale = if (minimumScale <= maximumScale) {
+        1f.coerceIn(minimumScale, maximumScale)
+    } else {
+        // The two axes cannot both satisfy their limits without distortion. Match the existing size behavior by
+        // prioritizing minimums over maximums.
+        minimumScale
+    }
+
+    return Size(
+        width = Fixed((intrinsicWidth * scale).toUInt()),
+        height = Fixed((intrinsicHeight * scale).toUInt()),
+    )
+}
+
+private fun UInt?.scaleFor(intrinsicDimension: Float, fallback: Float): Float =
+    this?.toFloat()?.div(intrinsicDimension) ?: fallback
+
+private fun SizeConstraint.adjustDimension(
+    other: SizeConstraint,
+    thisDimensionPx: UInt,
+    otherDimensionPx: UInt,
+    density: Density,
+): SizeConstraint = when (this) {
+    is Fit -> {
+        when (other) {
+            is Fit -> error("Fit dimensions must be adjusted together.")
+            is Fill -> this
+
+            is Fixed -> {
+                // If the other dimension is Fixed, we'll have to scale this one by the same factor.
+                val otherDimensionDp = with(density) { otherDimensionPx.toInt().toDp() }
+                val scaleFactor = other.value.toFloat() / otherDimensionDp.value
+                val scaledSize = with(density) {
+                    (scaleFactor * thisDimensionPx.toInt()).toDp().value.toUInt()
+                }
+                Fixed(clamp(scaledSize))
+            }
+        }
+    }
+
+    is Fill,
+    is Fixed,
+    -> this
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Size.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Size.kt
@@ -59,15 +59,20 @@ internal fun Modifier.size(
         ),
     )
 
-    val layoutWidth = placeable.width.coerceIn(incomingConstraints.minWidth, incomingConstraints.maxWidth)
-    val layoutHeight = placeable.height.coerceIn(incomingConstraints.minHeight, incomingConstraints.maxHeight)
+    // A real placeable already satisfies the constraints it was measured with; this only matters during intrinsic
+    // measurement, where Compose reports the content's intrinsic size and ignores minimums (e.g. an empty Fixed box
+    // would report 0). Without this, a parent bounding itself to its intrinsic size would collapse.
+    val contentWidth = placeable.width.coerceIn(widthConstraints.min, widthConstraints.max)
+    val contentHeight = placeable.height.coerceIn(heightConstraints.min, heightConstraints.max)
+    val layoutWidth = contentWidth.coerceIn(incomingConstraints.minWidth, incomingConstraints.maxWidth)
+    val layoutHeight = contentHeight.coerceIn(incomingConstraints.minHeight, incomingConstraints.maxHeight)
     val x = (horizontalAlignment ?: Alignment.CenterHorizontally).align(
-        size = placeable.width,
+        size = contentWidth,
         space = layoutWidth,
         layoutDirection = layoutDirection,
     )
     val y = (verticalAlignment ?: Alignment.CenterVertically).align(
-        size = placeable.height,
+        size = contentHeight,
         space = layoutHeight,
     )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Size.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Size.kt
@@ -4,29 +4,28 @@ package com.revenuecat.purchases.ui.revenuecatui.components.modifier
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import kotlin.math.roundToInt
 
 /**
  * @param horizontalAlignment Alignment to apply when the provided [size]'s width is [Fit], and the component is
@@ -40,21 +39,89 @@ internal fun Modifier.size(
     size: Size,
     horizontalAlignment: Alignment.Horizontal? = null,
     verticalAlignment: Alignment.Vertical? = null,
-): Modifier {
-    val widthModifier = when (val width = size.width) {
-        is Fit -> Modifier.wrapContentWidth(align = horizontalAlignment ?: Alignment.CenterHorizontally)
-        is Fill -> Modifier.fillMaxWidth()
-        is Fixed -> Modifier.width(width.value.toInt().dp)
-    }
+): Modifier = this.layout { measurable, incomingConstraints ->
+    val widthConstraints = size.width.measurementConstraints(
+        incomingMin = incomingConstraints.minWidth,
+        incomingMax = incomingConstraints.maxWidth,
+        density = this,
+    )
+    val heightConstraints = size.height.measurementConstraints(
+        incomingMin = incomingConstraints.minHeight,
+        incomingMax = incomingConstraints.maxHeight,
+        density = this,
+    )
+    val placeable = measurable.measure(
+        Constraints(
+            minWidth = widthConstraints.min,
+            maxWidth = widthConstraints.max,
+            minHeight = heightConstraints.min,
+            maxHeight = heightConstraints.max,
+        ),
+    )
 
-    val heightModifier = when (val height = size.height) {
-        is Fit -> Modifier.wrapContentHeight(align = verticalAlignment ?: Alignment.CenterVertically)
-        is Fill -> Modifier.fillMaxHeight()
-        is Fixed -> Modifier.height(height.value.toInt().dp)
-    }
+    val layoutWidth = placeable.width.coerceIn(incomingConstraints.minWidth, incomingConstraints.maxWidth)
+    val layoutHeight = placeable.height.coerceIn(incomingConstraints.minHeight, incomingConstraints.maxHeight)
+    val x = (horizontalAlignment ?: Alignment.CenterHorizontally).align(
+        size = placeable.width,
+        space = layoutWidth,
+        layoutDirection = layoutDirection,
+    )
+    val y = (verticalAlignment ?: Alignment.CenterVertically).align(
+        size = placeable.height,
+        space = layoutHeight,
+    )
 
-    return this then widthModifier then heightModifier
+    layout(layoutWidth, layoutHeight) {
+        placeable.place(x, y)
+    }
 }
+
+private data class AxisConstraints(
+    val min: Int,
+    val max: Int,
+)
+
+private fun SizeConstraint.measurementConstraints(
+    incomingMin: Int,
+    incomingMax: Int,
+    density: Density,
+): AxisConstraints = when (this) {
+    is Fit -> {
+        val limits = limitsInPx(density)
+        val maximum = maxOf(limits.min, minOf(incomingMax, limits.max))
+        AxisConstraints(min = limits.min, max = maximum)
+    }
+    is Fill -> {
+        val limits = limitsInPx(density)
+        if (incomingMax != Constraints.Infinity) {
+            val resolved = limits.clamp(incomingMax)
+            AxisConstraints(min = resolved, max = resolved)
+        } else {
+            val minimum = limits.clamp(incomingMin)
+            AxisConstraints(min = minimum, max = maxOf(minimum, limits.max))
+        }
+    }
+    is Fixed -> {
+        val resolved = this.value.toPx(density).coerceIn(incomingMin, incomingMax)
+        AxisConstraints(min = resolved, max = resolved)
+    }
+}
+
+private data class Limits(
+    val min: Int,
+    val max: Int,
+) {
+    fun clamp(value: Int): Int = value.coerceIn(min, max)
+}
+
+private fun SizeConstraint.limitsInPx(density: Density): Limits {
+    val minimumPx = minimum?.toPx(density) ?: 0
+    val maximumPx = effectiveMaximum?.toPx(density) ?: Constraints.Infinity
+    return Limits(min = minimumPx, max = maximumPx)
+}
+
+private fun UInt.toPx(density: Density): Int =
+    (toDouble() * density.density).roundToInt().coerceAtLeast(0)
 
 @Composable
 private fun Size_Preview(size: Size) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/ConstrainedFillAllocation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/ConstrainedFillAllocation.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import kotlin.math.roundToInt
+import kotlin.math.sign
 
 /**
  * Divides [availableSpace] equally between Fill children while honoring their minimums and maximums.
@@ -38,10 +39,14 @@ internal fun allocateConstrainedFillSpace(
         }
 
         if (constrainedIndices.isEmpty()) {
-            val baseShare = remainingSpace / remainingIndices.size
-            val remainder = remainingSpace % remainingIndices.size
-            remainingIndices.forEachIndexed { remainderIndex, index ->
-                result[index] = baseShare.toInt() + if (remainderIndex < remainder) 1 else 0
+            // Match Row/Column's weight rounding: round each equal share, then correct the rounding error one
+            // pixel at a time starting from the first child.
+            val roundedShare = equalShare.roundToInt()
+            var remainder = remainingSpace.toInt() - roundedShare * remainingIndices.size
+            remainingIndices.forEach { index ->
+                val correction = remainder.sign
+                result[index] = roundedShare + correction
+                remainder -= correction
             }
             break
         }
@@ -68,5 +73,5 @@ private fun Fill.minimumPx(density: Density): Int = min?.toPx(density) ?: 0
 private fun Fill.maximumPx(density: Density): Int =
     maxOf(max?.toPx(density) ?: Constraints.Infinity, minimumPx(density))
 
-private fun UInt.toPx(density: Density): Int =
+internal fun UInt.toPx(density: Density): Int =
     (toDouble() * density.density).roundToInt().coerceAtLeast(0)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/ConstrainedFillArrangement.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/ConstrainedFillArrangement.kt
@@ -14,26 +14,69 @@ internal fun MeasureScope.arrangeConstrainedFillItems(
     sizes: IntArray,
     spacing: Int,
 ): IntArray {
-    if (config.distribution.usesAllAvailableSpace) {
-        return flexibleSpacePositions(
+    return if (config.distribution.usesAllAvailableSpace) {
+        flexibleSpacePositions(
             totalSize = totalSize,
             sizes = sizes,
             spacing = spacing,
             distribution = config.distribution,
             reverseInput = config.orientation == Orientation.Horizontal && layoutDirection == LayoutDirection.Rtl,
         )
-    }
-
-    return IntArray(sizes.size).also { positions ->
-        when (config) {
-            is ConstrainedFillLayout.Config.Horizontal -> with(config.arrangement) {
-                arrange(totalSize, sizes, layoutDirection, positions)
-            }
-            is ConstrainedFillLayout.Config.Vertical -> with(config.arrangement) {
-                arrange(totalSize, sizes, positions)
+    } else {
+        val occupiedSize = sizes.sum() + spacing * (sizes.size - 1).coerceAtLeast(0)
+        if (occupiedSize > totalSize) {
+            overflowingFixedSpacingPositions(
+                config = config,
+                totalSize = totalSize,
+                sizes = sizes,
+                spacing = spacing,
+                occupiedSize = occupiedSize,
+            )
+        } else {
+            IntArray(sizes.size).also { positions ->
+                when (config) {
+                    is ConstrainedFillLayout.Config.Horizontal -> with(config.arrangement) {
+                        arrange(totalSize, sizes, layoutDirection, positions)
+                    }
+                    is ConstrainedFillLayout.Config.Vertical -> with(config.arrangement) {
+                        arrange(totalSize, sizes, positions)
+                    }
+                }
             }
         }
     }
+}
+
+private fun MeasureScope.overflowingFixedSpacingPositions(
+    config: ConstrainedFillLayout.Config,
+    totalSize: Int,
+    sizes: IntArray,
+    spacing: Int,
+    occupiedSize: Int,
+): IntArray {
+    val isRtl = config.orientation == Orientation.Horizontal && layoutDirection == LayoutDirection.Rtl
+    val groupStart = when (config.distribution) {
+        FlexDistribution.START -> if (isRtl) totalSize - occupiedSize else 0
+        FlexDistribution.END -> if (isRtl) 0 else totalSize - occupiedSize
+        FlexDistribution.CENTER -> (totalSize - occupiedSize) / 2
+        else -> error("Expected a fixed-spacing distribution, but was ${config.distribution}.")
+    }
+    val positions = IntArray(sizes.size)
+    if (isRtl) {
+        var currentPosition = groupStart + occupiedSize
+        sizes.forEachIndexed { index, size ->
+            currentPosition -= size
+            positions[index] = currentPosition
+            currentPosition -= spacing
+        }
+    } else {
+        var currentPosition = groupStart
+        sizes.forEachIndexed { index, size ->
+            positions[index] = currentPosition
+            currentPosition += size + spacing
+        }
+    }
+    return positions
 }
 
 private fun flexibleSpacePositions(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/ConstrainedFillLayout.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/ConstrainedFillLayout.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.Placeable
@@ -15,16 +16,24 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.ComponentSizeParentDataModifier
 
+/**
+ * A Row/Column replacement that is only used when a stack has min/max size constraints on its main axis (see
+ * [needsConstrainedFillLayout]). It divides the main axis between Fill children while honoring their minimums and
+ * maximums, and lets a Fit stack with a positive minimum hug its content.
+ */
 internal object ConstrainedFillLayout {
     internal sealed interface Config {
         val orientation: Orientation
         val distribution: FlexDistribution
+        val fitMainAxis: Boolean
 
         data class Horizontal(
             override val distribution: FlexDistribution,
             val arrangement: Arrangement.Horizontal,
             val alignment: Alignment.Vertical,
+            override val fitMainAxis: Boolean = false,
         ) : Config {
             override val orientation: Orientation = Orientation.Horizontal
         }
@@ -33,61 +42,120 @@ internal object ConstrainedFillLayout {
             override val distribution: FlexDistribution,
             val arrangement: Arrangement.Vertical,
             val alignment: Alignment.Horizontal,
+            override val fitMainAxis: Boolean = false,
         ) : Config {
             override val orientation: Orientation = Orientation.Vertical
         }
     }
 
+    /**
+     * Every child is expected to carry a [ComponentSizeParentDataModifier] describing its resolved size. Children are
+     * matched to their constraints through that parent data rather than by index, so children that are not composed
+     * (e.g. `visible = false`) do not shift the constraints of their siblings.
+     */
     @Composable
     operator fun invoke(
         config: Config,
-        fillConstraints: List<Fill?>,
         spacing: Dp,
         modifier: Modifier = Modifier,
         content: @Composable () -> Unit,
     ) {
         Layout(modifier = modifier, content = content) { measurables, constraints ->
-            val spacingPx = spacing.roundToPx()
-            val totalSpacing = spacingPx * (measurables.size - 1).coerceAtLeast(0)
+            measure(measurables, constraints, config, spacingPx = spacing.roundToPx())
+        }
+    }
 
-            if (constraints.isFullyUnbounded(config.orientation)) {
-                val measured = measurables.map { it.measure(constraints.withZeroMinimums()) }
-                return@Layout layoutAndPlace(
-                    placeables = measured,
-                    mainAxisSize = measured.sumOf { it.mainAxisSize(config.orientation) } + totalSpacing,
-                    constraints = constraints,
-                    config = config,
-                    spacing = spacingPx,
-                )
-            }
+    private fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+        config: Config,
+        spacingPx: Int,
+    ): MeasureResult {
+        val orientation = config.orientation
+        val fillConstraints = measurables.map {
+            (it.parentData as? ComponentSizeParentDataModifier)?.size?.mainAxis(orientation) as? Fill
+        }
+        val totalSpacing = spacingPx * (measurables.size - 1).coerceAtLeast(0)
 
-            val targetMainAxisSize = constraints.targetMainAxisSize(config.orientation)
-            val placeables = arrayOfNulls<Placeable>(measurables.size)
-            var nonFillSize = 0
-            measurables.forEachIndexed { index, measurable ->
-                if (fillConstraints[index] == null) {
-                    placeables[index] = measurable.measure(constraints.withZeroMinimums())
-                    nonFillSize += placeables[index]!!.mainAxisSize(config.orientation)
-                }
-            }
-
-            val availableForFill = (targetMainAxisSize - nonFillSize - totalSpacing).coerceAtLeast(0)
-            val fillSizes = allocateConstrainedFillSpace(availableForFill, fillConstraints, this)
+        val placeables: List<Placeable>
+        val mainAxisSize: Int
+        if (constraints.isFullyUnbounded(orientation)) {
+            // Nothing to distribute: every child, Fill or not, wraps its own content.
+            placeables = measurables.map { it.measure(constraints.forNonFillChild(consumed = 0, orientation)) }
+            mainAxisSize = placeables.sumOf { it.mainAxisSize(orientation) } + totalSpacing
+        } else {
+            val measured = arrayOfNulls<Placeable>(measurables.size)
+            measureNonFillChildren(measurables, fillConstraints, measured, constraints, config, spacingPx)
+            val nonFillSize = measured.filterNotNull().sumOf { it.mainAxisSize(orientation) }
+            mainAxisSize = targetMainAxisSize(config, constraints, fillConstraints, nonFillSize + totalSpacing)
+            val availableForFill = (mainAxisSize - nonFillSize - totalSpacing).coerceAtLeast(0)
+            val fillSizes = allocateConstrainedFillSpace(availableForFill, fillConstraints, density = this)
             measurables.forEachIndexed { index, measurable ->
                 if (fillConstraints[index] != null) {
-                    placeables[index] = measurable.measure(
-                        constraints.withExactMainAxisSize(fillSizes[index], config.orientation),
+                    measured[index] = measurable.measure(
+                        constraints.withExactMainAxisSize(fillSizes[index], orientation),
                     )
                 }
             }
+            placeables = measured.requireNoNulls().asList()
+        }
 
-            layoutAndPlace(
-                placeables = placeables.requireNoNulls().asList(),
-                mainAxisSize = targetMainAxisSize,
-                constraints = constraints,
-                config = config,
-                spacing = spacingPx,
-            )
+        return layoutAndPlace(
+            placeables = placeables,
+            mainAxisSize = mainAxisSize,
+            constraints = constraints,
+            config = config,
+            spacing = spacingPx,
+        )
+    }
+
+    /**
+     * A Fit stack with a positive minimum only grows to hug its content (with Fill children at their minimums); any
+     * other stack takes all the space it is offered.
+     */
+    private fun MeasureScope.targetMainAxisSize(
+        config: Config,
+        constraints: Constraints,
+        fillConstraints: List<Fill?>,
+        contentSize: Int,
+    ): Int {
+        val orientation = config.orientation
+        if (!config.fitMainAxis) {
+            return constraints.mainAxisMax(orientation)
+                .takeUnless { it == Constraints.Infinity }
+                ?: constraints.mainAxisMin(orientation)
+        }
+        val minimumFillSize = allocateConstrainedFillSpace(availableSpace = 0, fillConstraints, density = this).sum()
+        return (contentSize + minimumFillSize).coerceIn(
+            constraints.mainAxisMin(orientation),
+            constraints.mainAxisMax(orientation),
+        )
+    }
+
+    /**
+     * Measures every non-Fill child into [placeables], mirroring Row/Column: spacedBy distributions reserve spacing
+     * after each measured non-Fill child, while SPACE_* distributions use explicit spacers, which reserve spacing
+     * after *every* preceding child.
+     */
+    @Suppress("LongParameterList")
+    private fun measureNonFillChildren(
+        measurables: List<Measurable>,
+        fillConstraints: List<Fill?>,
+        placeables: Array<Placeable?>,
+        constraints: Constraints,
+        config: Config,
+        spacingPx: Int,
+    ) {
+        var nonFillSize = 0
+        var nonFillCount = 0
+        measurables.forEachIndexed { index, measurable ->
+            if (fillConstraints[index] != null) return@forEachIndexed
+            val gaps = if (config.distribution.usesAllAvailableSpace) index else nonFillCount
+            val consumed = nonFillSize + spacingPx * gaps
+            val placeable = measurable.measure(constraints.forNonFillChild(consumed, config.orientation))
+            placeables[index] = placeable
+            nonFillSize += placeable.mainAxisSize(config.orientation)
+            nonFillCount++
         }
     }
 }
@@ -95,16 +163,32 @@ internal object ConstrainedFillLayout {
 private fun Constraints.isFullyUnbounded(orientation: Orientation): Boolean =
     mainAxisMax(orientation) == Constraints.Infinity && mainAxisMin(orientation) == 0
 
-private fun Constraints.targetMainAxisSize(orientation: Orientation): Int =
-    mainAxisMax(orientation).takeUnless { it == Constraints.Infinity } ?: mainAxisMin(orientation)
-
 private fun Constraints.mainAxisMin(orientation: Orientation): Int =
     if (orientation == Orientation.Horizontal) minWidth else minHeight
 
 private fun Constraints.mainAxisMax(orientation: Orientation): Int =
     if (orientation == Orientation.Horizontal) maxWidth else maxHeight
 
-private fun Constraints.withZeroMinimums(): Constraints = copy(minWidth = 0, minHeight = 0)
+private fun Constraints.crossAxisMin(orientation: Orientation): Int =
+    if (orientation == Orientation.Horizontal) minHeight else minWidth
+
+private fun Constraints.crossAxisMax(orientation: Orientation): Int =
+    if (orientation == Orientation.Horizontal) maxHeight else maxWidth
+
+/**
+ * Like Row/Column, non-Fill children are measured without minimums and are only offered the main-axis space that
+ * previous siblings left over.
+ */
+private fun Constraints.forNonFillChild(consumed: Int, orientation: Orientation): Constraints {
+    val mainAxisMax = mainAxisMax(orientation)
+    if (mainAxisMax == Constraints.Infinity) return copy(minWidth = 0, minHeight = 0)
+    val remaining = (mainAxisMax - consumed).coerceAtLeast(0)
+    return if (orientation == Orientation.Horizontal) {
+        copy(minWidth = 0, minHeight = 0, maxWidth = remaining)
+    } else {
+        copy(minWidth = 0, minHeight = 0, maxHeight = remaining)
+    }
+}
 
 private fun Constraints.withExactMainAxisSize(size: Int, orientation: Orientation): Constraints =
     if (orientation == Orientation.Horizontal) {
@@ -115,6 +199,9 @@ private fun Constraints.withExactMainAxisSize(size: Int, orientation: Orientatio
 
 private fun Placeable.mainAxisSize(orientation: Orientation): Int =
     if (orientation == Orientation.Horizontal) width else height
+
+private fun Placeable.crossAxisSize(orientation: Orientation): Int =
+    if (orientation == Orientation.Horizontal) height else width
 
 private fun MeasureScope.layoutAndPlace(
     placeables: List<Placeable>,
@@ -128,9 +215,7 @@ private fun MeasureScope.layoutAndPlace(
         constraints.mainAxisMin(orientation),
         constraints.mainAxisMax(orientation),
     )
-    val resolvedCrossAxisSize = placeables.maxOfOrNull {
-        if (orientation == Orientation.Horizontal) it.height else it.width
-    }
+    val resolvedCrossAxisSize = placeables.maxOfOrNull { it.crossAxisSize(orientation) }
         ?.coerceIn(constraints.crossAxisMin(orientation), constraints.crossAxisMax(orientation))
         ?: constraints.crossAxisMin(orientation)
     val sizes = placeables.map { it.mainAxisSize(orientation) }.toIntArray()
@@ -157,9 +242,3 @@ private fun MeasureScope.layoutAndPlace(
         }
     }
 }
-
-private fun Constraints.crossAxisMin(orientation: Orientation): Int =
-    if (orientation == Orientation.Horizontal) minHeight else minWidth
-
-private fun Constraints.crossAxisMax(orientation: Orientation): Int =
-    if (orientation == Orientation.Horizontal) maxHeight else maxWidth

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/ConstrainedFillLayout.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/ConstrainedFillLayout.kt
@@ -12,11 +12,13 @@ import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.ComponentSizeParentDataModifier
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 
 /**
  * A Row/Column replacement that is only used when a stack has min/max size constraints on its main axis (see
@@ -52,18 +54,48 @@ internal object ConstrainedFillLayout {
      * Every child is expected to carry a [ComponentSizeParentDataModifier] describing its resolved size. Children are
      * matched to their constraints through that parent data rather than by index, so children that are not composed
      * (e.g. `visible = false`) do not shift the constraints of their siblings.
+     *
+     * @param hasCrossAxisFillChild Whether any child is Fill on the cross axis. Under an unbounded cross axis (e.g. a
+     * Fit row inside the root vertical scroll) such a child has nothing to fill and would collapse to its minimum.
+     * Flexbox stretches it to the tallest sibling instead, so the layout is then bounded to its own intrinsic
+     * cross-axis size, which Fill children can fill.
      */
     @Composable
     operator fun invoke(
         config: Config,
         spacing: Dp,
+        hasCrossAxisFillChild: Boolean,
         modifier: Modifier = Modifier,
         content: @Composable () -> Unit,
     ) {
-        Layout(modifier = modifier, content = content) { measurables, constraints ->
+        Layout(
+            modifier = modifier.conditional(hasCrossAxisFillChild) {
+                boundUnboundedCrossAxisToIntrinsicSize(config.orientation)
+            },
+            content = content,
+        ) { measurables, constraints ->
             measure(measurables, constraints, config, spacingPx = spacing.roundToPx())
         }
     }
+
+    private fun Modifier.boundUnboundedCrossAxisToIntrinsicSize(orientation: Orientation): Modifier =
+        layout { measurable, constraints ->
+            val bounded = when {
+                orientation == Orientation.Horizontal && constraints.maxHeight == Constraints.Infinity ->
+                    constraints.copy(
+                        maxHeight = measurable.maxIntrinsicHeight(constraints.maxWidth)
+                            .coerceAtLeast(constraints.minHeight),
+                    )
+                orientation == Orientation.Vertical && constraints.maxWidth == Constraints.Infinity ->
+                    constraints.copy(
+                        maxWidth = measurable.maxIntrinsicWidth(constraints.maxHeight)
+                            .coerceAtLeast(constraints.minWidth),
+                    )
+                else -> constraints
+            }
+            val placeable = measurable.measure(bounded)
+            layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+        }
 
     private fun MeasureScope.measure(
         measurables: List<Measurable>,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
@@ -47,6 +47,7 @@ internal fun HorizontalStack(
                 fitMainAxis = size.width.shouldFitMainAxis(hasAnyItemsWithFillWidth),
             ),
             spacing = spacing,
+            hasCrossAxisFillChild = items.any { it.size.height is Fill },
             modifier = modifier,
         ) {
             items.forEachIndexed { index, item ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
@@ -2,37 +2,60 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
+import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
 import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
 import com.revenuecat.purchases.paywalls.components.properties.Size
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toAlignment
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toHorizontalArrangement
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.ComponentSizeParentDataModifier
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
 
 /**
  * A horizontal stack of components which properly handles the arrangement of items.
+ *
+ * @param mainAxisUnbounded Whether this stack is being measured with an unbounded width (e.g. inside a horizontal
+ * scroll). Fill children are not given `weight` in that case, as they would collapse to zero.
+ * @param itemContent Emits a child. The provided modifier must be applied to the child's outermost layout node.
  */
+@Suppress("LongParameterList")
 @Composable
 internal fun HorizontalStack(
     size: Size,
     dimension: Dimension.Horizontal,
     spacing: Dp,
+    items: List<ComponentStyle>,
+    mainAxisUnbounded: Boolean,
     modifier: Modifier = Modifier,
-    content: HorizontalStackScope.() -> Unit,
+    itemContent: @Composable (index: Int, item: ComponentStyle, modifier: Modifier) -> Unit,
 ) {
+    val hasAnyItemsWithFillWidth = items.any { it.size.width is Fill }
+    if (needsConstrainedFillLayout(size, dimension.distribution, items, Orientation.Horizontal)) {
+        ConstrainedFillLayout(
+            config = ConstrainedFillLayout.Config.Horizontal(
+                distribution = dimension.distribution,
+                arrangement = dimension.distribution.toHorizontalArrangement(spacing),
+                alignment = dimension.alignment.toAlignment(),
+                fitMainAxis = size.width.shouldFitMainAxis(hasAnyItemsWithFillWidth),
+            ),
+            spacing = spacing,
+            modifier = modifier,
+        ) {
+            items.forEachIndexed { index, item ->
+                itemContent(index, item, ComponentSizeParentDataModifier(item.size))
+            }
+        }
+        return
+    }
+
     Row(
         modifier = modifier,
         verticalAlignment = dimension.alignment.toAlignment(),
@@ -40,21 +63,13 @@ internal fun HorizontalStack(
             spacing = spacing,
         ),
     ) {
+        val shouldApplyFillSpacers = size.width !is Fit && !hasAnyItemsWithFillWidth
         val fillSpaceSpacer: @Composable (Float) -> Unit = @Composable { weight ->
             Spacer(modifier = Modifier.weight(weight))
         }
-        val latestContent by rememberUpdatedState(content)
-        val scope = remember(dimension.distribution, spacing, latestContent) {
-            HorizontalStackScopeImpl(
-                distribution = dimension.distribution,
-                spacing = spacing,
-                fillSpaceSpacer = fillSpaceSpacer,
-                width = size.width,
-            ).apply(latestContent)
-        }
 
         val edgeSpacerIfNeeded = @Composable {
-            if (scope.shouldApplyFillSpacers &&
+            if (shouldApplyFillSpacers &&
                 (
                     dimension.distribution == FlexDistribution.SPACE_AROUND ||
                         dimension.distribution == FlexDistribution.SPACE_EVENLY
@@ -65,46 +80,21 @@ internal fun HorizontalStack(
         }
 
         edgeSpacerIfNeeded()
-        scope.rowContent(this)
-        edgeSpacerIfNeeded()
-    }
-}
+        items.forEachIndexed { index, item ->
+            val childModifier = if (item.size.width is Fill && !mainAxisUnbounded) {
+                Modifier.weight(1f)
+            } else {
+                Modifier
+            }
+            itemContent(index, item, childModifier)
 
-internal interface HorizontalStackScope {
-    fun items(
-        items: List<ComponentStyle>,
-        itemContent: @Composable RowScope.(index: Int, item: ComponentStyle) -> Unit,
-    )
-}
-
-private class HorizontalStackScopeImpl(
-    private val distribution: FlexDistribution,
-    private val spacing: Dp,
-    private val fillSpaceSpacer: @Composable (Float) -> Unit,
-    private val width: SizeConstraint,
-) : HorizontalStackScope {
-    private var hasAnyItemsWithFillWidth = false
-    val shouldApplyFillSpacers: Boolean
-        get() = width !is Fit && !hasAnyItemsWithFillWidth
-    var rowContent: @Composable RowScope.() -> Unit = {}
-
-    override fun items(
-        items: List<ComponentStyle>,
-        itemContent: @Composable RowScope.(index: Int, item: ComponentStyle) -> Unit,
-    ) {
-        hasAnyItemsWithFillWidth = items.any { it.size.width is Fill }
-        rowContent = {
-            items.forEachIndexed { index, item ->
-                val isLast = index == items.size - 1
-                itemContent(index, item)
-
-                if (distribution.usesAllAvailableSpace && !isLast) {
-                    Spacer(modifier = Modifier.widthIn(min = spacing))
-                    if (shouldApplyFillSpacers) {
-                        fillSpaceSpacer(if (distribution == FlexDistribution.SPACE_AROUND) 2f else 1f)
-                    }
+            if (dimension.distribution.usesAllAvailableSpace && index != items.lastIndex) {
+                Spacer(modifier = Modifier.widthIn(min = spacing))
+                if (shouldApplyFillSpacers) {
+                    fillSpaceSpacer(if (dimension.distribution == FlexDistribution.SPACE_AROUND) 2f else 1f)
                 }
             }
         }
+        edgeSpacerIfNeeded()
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -2,9 +2,6 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -18,13 +15,12 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowWidthSizeClass
-import com.revenuecat.purchases.paywalls.components.properties.Size
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
 import com.revenuecat.purchases.ui.revenuecatui.components.ConditionContext
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
 import com.revenuecat.purchases.ui.revenuecatui.components.buildPresentedPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.addMargin
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toPaddingValues
 import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDelegate
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
@@ -163,7 +159,7 @@ internal class StackComponentState(
 
     @get:JvmSynthetic
     val size by derivedStateOf {
-        (presentedPartial?.partial?.size ?: style.size).adjustForMargin(margin, layoutDirection)
+        (presentedPartial?.partial?.size ?: style.size).addMargin(margin, layoutDirection)
     }
 
     @get:JvmSynthetic
@@ -194,35 +190,5 @@ internal class StackComponentState(
         if (windowSize != null) this.windowSize = windowSize
         if (windowDpSize != null) this.windowDpSize = windowDpSize
         if (layoutDirection != null) this.layoutDirection = layoutDirection
-    }
-
-    /**
-     * Since margin is not a thing in Compose, and we apply it as extra padding outside the border and background, we
-     * need to make sure the Composable's size is large enough to contain the margin.
-     */
-    private fun Size.adjustForMargin(margin: PaddingValues, layoutDirection: LayoutDirection): Size {
-        val adjustedWidth = when (val baseWidth = width) {
-            is SizeConstraint.Fixed -> SizeConstraint.Fixed(
-                baseWidth.value +
-                    margin.calculateStartPadding(layoutDirection).value.toUInt() +
-                    margin.calculateEndPadding(layoutDirection).value.toUInt(),
-            )
-            is SizeConstraint.Fill,
-            is SizeConstraint.Fit,
-            -> baseWidth
-        }
-
-        val adjustedHeight = when (val baseHeight = height) {
-            is SizeConstraint.Fixed -> SizeConstraint.Fixed(
-                baseHeight.value +
-                    margin.calculateTopPadding().value.toUInt() +
-                    margin.calculateBottomPadding().value.toUInt(),
-            )
-            is SizeConstraint.Fill,
-            is SizeConstraint.Fit,
-            -> baseHeight
-        }
-
-        return Size(width = adjustedWidth, height = adjustedHeight)
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -75,6 +75,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toShape
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toVerticalAlignmentOrNull
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.border
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.resolveComponentSizeParentData
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.scrollable
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.shadow
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
@@ -149,6 +150,7 @@ internal fun StackComponentView(
         return
     }
 
+    val resolvedModifier = modifier.resolveComponentSizeParentData(stackState.size)
     val badge = stackState.badge
     if (badge != null) {
         when (badge.style) {
@@ -161,7 +163,7 @@ internal fun StackComponentView(
                     clickHandler,
                     componentInteractionTracker,
                     contentAlpha,
-                    modifier,
+                    resolvedModifier,
                     onStackClick = onStackClick,
                     enabled = enabled,
                     interactionSource = interactionSource,
@@ -180,7 +182,7 @@ internal fun StackComponentView(
                         clickHandler,
                         componentInteractionTracker,
                         contentAlpha,
-                        modifier,
+                        resolvedModifier,
                         onStackClick = onStackClick,
                         enabled = enabled,
                         interactionSource = interactionSource,
@@ -195,7 +197,7 @@ internal fun StackComponentView(
                         clickHandler,
                         componentInteractionTracker,
                         contentAlpha,
-                        modifier,
+                        resolvedModifier,
                         onStackClick = onStackClick,
                         enabled = enabled,
                         interactionSource = interactionSource,
@@ -210,7 +212,7 @@ internal fun StackComponentView(
                     clickHandler = clickHandler,
                     componentInteractionTracker = componentInteractionTracker,
                     contentAlpha = contentAlpha,
-                    modifier = modifier,
+                    modifier = resolvedModifier,
                     onStackClick = onStackClick,
                     enabled = enabled,
                     interactionSource = interactionSource,
@@ -224,7 +226,7 @@ internal fun StackComponentView(
             clickHandler = clickHandler,
             componentInteractionTracker = componentInteractionTracker,
             contentAlpha = contentAlpha,
-            modifier = modifier,
+            modifier = resolvedModifier,
             onStackClick = onStackClick,
             enabled = enabled,
             interactionSource = interactionSource,
@@ -627,6 +629,8 @@ private fun MainStackComponent(
                         size = stackState.size,
                         dimension = dimension,
                         spacing = stackState.spacing,
+                        items = stackState.children,
+                        mainAxisUnbounded = mainAxisUnbounded.value,
                         modifier = outerModifier
                             .size(stackState.size, verticalAlignment = dimension.alignment.toAlignment())
                             .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
@@ -636,25 +640,20 @@ private fun MainStackComponent(
                             .conditional(hasFillWidthChild) {
                                 trackMainAxisUnbounded(isHorizontal = true, unboundedState = mainAxisUnbounded)
                             },
-                    ) {
-                        items(stackState.children) { _, child ->
-                            ComponentView(
-                                style = child,
-                                state = state,
-                                onClick = clickHandler,
-                                componentInteractionTracker = componentInteractionTracker,
-                                modifier = Modifier
-                                    .conditional(child.size.width is Fill && !mainAxisUnbounded.value) {
-                                        Modifier.weight(1f)
-                                    }
-                                    .conditional(
-                                        stackState.applyTopWindowInsets && !child.shouldIgnoreTopWindowInsets,
-                                    ) {
-                                        windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
-                                    }
-                                    .contentAlpha(contentAlpha),
-                            )
-                        }
+                    ) { _, child, childModifier ->
+                        ComponentView(
+                            style = child,
+                            state = state,
+                            onClick = clickHandler,
+                            componentInteractionTracker = componentInteractionTracker,
+                            modifier = childModifier
+                                .conditional(
+                                    stackState.applyTopWindowInsets && !child.shouldIgnoreTopWindowInsets,
+                                ) {
+                                    windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
+                                }
+                                .contentAlpha(contentAlpha),
+                        )
                     }
                 }
 
@@ -666,6 +665,8 @@ private fun MainStackComponent(
                         size = stackState.size,
                         dimension = dimension,
                         spacing = stackState.spacing,
+                        items = stackState.children,
+                        mainAxisUnbounded = mainAxisUnbounded.value,
                         modifier = outerModifier
                             .size(stackState.size, horizontalAlignment = dimension.alignment.toAlignment())
                             .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
@@ -675,29 +676,24 @@ private fun MainStackComponent(
                             .conditional(hasFillHeightChild) {
                                 trackMainAxisUnbounded(isHorizontal = false, unboundedState = mainAxisUnbounded)
                             },
-                    ) {
-                        items(stackState.children) { index, child ->
-                            ComponentView(
-                                style = child,
-                                state = state,
-                                onClick = clickHandler,
-                                componentInteractionTracker = componentInteractionTracker,
-                                modifier = Modifier
-                                    .conditional(child.size.height is Fill && !mainAxisUnbounded.value) {
-                                        Modifier.weight(1f)
-                                    }
-                                    .conditional(
-                                        // In a Vertical container, we only want to apply topSystemBarsPadding to the
-                                        // first child, except when that child has `ignoreTopWindowInsets` set to true.
-                                        stackState.applyTopWindowInsets &&
-                                            index == 0 &&
-                                            !child.shouldIgnoreTopWindowInsets,
-                                    ) {
-                                        windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
-                                    }
-                                    .contentAlpha(contentAlpha),
-                            )
-                        }
+                    ) { index, child, childModifier ->
+                        ComponentView(
+                            style = child,
+                            state = state,
+                            onClick = clickHandler,
+                            componentInteractionTracker = componentInteractionTracker,
+                            modifier = childModifier
+                                .conditional(
+                                    // In a Vertical container, we only want to apply topSystemBarsPadding to the
+                                    // first child, except when that child has `ignoreTopWindowInsets` set to true.
+                                    stackState.applyTopWindowInsets &&
+                                        index == 0 &&
+                                        !child.shouldIgnoreTopWindowInsets,
+                                ) {
+                                    windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
+                                }
+                                .contentAlpha(contentAlpha),
+                        )
                     }
                 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackSizeConstraint.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackSizeConstraint.kt
@@ -2,8 +2,133 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
+import androidx.compose.foundation.gestures.Orientation
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.ui.revenuecatui.components.LocalizedTextPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedCarouselPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedIconPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedImagePartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverride
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedPackagePartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedStackPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedTabsPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedTimelineItemPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedTimelinePartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedVideoPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedWebViewPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.CarouselComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.CountdownComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.HeaderComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.IconComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ImageComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.PackageComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StickyFooterComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabControlButtonComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabControlStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabControlToggleComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabsComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TimelineComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
+
+internal val SizeConstraint.hasPositiveFitMinimum: Boolean
+    get() = this is Fit && (min ?: 0u) > 0u
 
 internal val SizeConstraint.allowsFlexDistribution: Boolean
-    get() = this !is Fit || (min ?: 0u) > 0u
+    get() = this !is Fit || hasPositiveFitMinimum
+
+/**
+ * A Fit stack with a positive minimum hugs its content (Fill children sit at their minimums). Without a minimum, a
+ * Fit stack with Fill children takes all the space it is offered, matching Row/Column's `weight` behavior.
+ */
+internal fun SizeConstraint.shouldFitMainAxis(hasFillChildren: Boolean): Boolean =
+    this is Fit && (!hasFillChildren || hasPositiveFitMinimum)
+
+internal fun Size.mainAxis(orientation: Orientation): SizeConstraint =
+    if (orientation == Orientation.Horizontal) width else height
+
+/**
+ * Whether this stack needs [ConstrainedFillLayout] instead of a plain Row/Column. This is the only entry point into
+ * the min/max layout code: stacks without any min/max on the main axis (i.e. every pre-existing paywall) keep using
+ * Row/Column unchanged.
+ *
+ * Row/Column can't do two things:
+ * - Redistribute leftover space when a `weight`ed child is capped by a maximum or floored by a minimum.
+ * - Hug a Fit stack that has a positive minimum: any `weight` (Fill child or SPACE_* spacer) expands it to the
+ *   parent's maximum instead.
+ */
+internal fun needsConstrainedFillLayout(
+    stackSize: Size,
+    distribution: FlexDistribution,
+    children: List<ComponentStyle>,
+    orientation: Orientation,
+): Boolean {
+    val mainAxis = stackSize.mainAxis(orientation)
+    val hasFillChild = children.any { it.size.mainAxis(orientation) is Fill }
+    val hasLimitedFillChild = children.any { child ->
+        child.candidateSizes.any { it.mainAxis(orientation).isLimitedFill }
+    }
+    return hasLimitedFillChild ||
+        (mainAxis.hasPositiveFitMinimum && (hasFillChild || distribution.usesAllAvailableSpace))
+}
+
+private val SizeConstraint.isLimitedFill: Boolean
+    get() = this is Fill && (min != null || max != null)
+
+/**
+ * Every size this component may resolve to: its base size plus the size of every override, since overrides are only
+ * resolved by the component itself at composition time.
+ */
+private val ComponentStyle.candidateSizes: Sequence<Size>
+    get() = sequenceOf(size) + overrideSizes()
+
+// A flat, exhaustive mapping over the sealed ComponentStyle hierarchy.
+@Suppress("CyclomaticComplexMethod")
+private fun ComponentStyle.overrideSizes(): Sequence<Size> = when (this) {
+    is StackComponentStyle -> overrides.sizes()
+    is TextComponentStyle -> overrides.sizes()
+    is ImageComponentStyle -> overrides.sizes()
+    is IconComponentStyle -> overrides.sizes()
+    is VideoComponentStyle -> overrides.sizes()
+    is CarouselComponentStyle -> overrides.sizes()
+    is TabsComponentStyle -> overrides.sizes()
+    is TimelineComponentStyle -> overrides.sizes()
+    is WebViewComponentStyle -> overrides.sizes()
+    is ButtonComponentStyle -> stackComponentStyle.overrideSizes()
+    is PackageComponentStyle -> stackComponentStyle.overrideSizes()
+    is StickyFooterComponentStyle -> stackComponentStyle.overrideSizes()
+    is HeaderComponentStyle -> stackComponentStyle.overrideSizes()
+    is CountdownComponentStyle -> countdownStackComponentStyle.overrideSizes()
+    is TabControlButtonComponentStyle -> stack.overrideSizes()
+    is TabControlStyle.Buttons -> stack.overrideSizes()
+    is TabControlStyle.Toggle -> stack.overrideSizes()
+    is TabControlToggleComponentStyle -> emptySequence()
+}
+
+private fun List<PresentedOverride<*>>.sizes(): Sequence<Size> =
+    asSequence().mapNotNull { it.properties.size }
+
+private val PresentedPartial<*>.size: Size?
+    get() = when (this) {
+        is PresentedStackPartial -> partial.size
+        is LocalizedTextPartial -> partial.size
+        is PresentedImagePartial -> partial.size
+        is PresentedIconPartial -> partial.size
+        is PresentedVideoPartial -> partial.size
+        is PresentedCarouselPartial -> partial.size
+        is PresentedTabsPartial -> partial.size
+        is PresentedTimelinePartial -> partial.size
+        is PresentedWebViewPartial,
+        is PresentedTimelineItemPartial,
+        is PresentedPackagePartial,
+        -> null
+    }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/VerticalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/VerticalStack.kt
@@ -2,37 +2,60 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
+import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
 import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
 import com.revenuecat.purchases.paywalls.components.properties.Size
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toAlignment
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toVerticalArrangement
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.ComponentSizeParentDataModifier
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
 
 /**
  * A vertical stack of components which properly handles the arrangement of items.
+ *
+ * @param mainAxisUnbounded Whether this stack is being measured with an unbounded height (e.g. inside a vertical
+ * scroll). Fill children are not given `weight` in that case, as they would collapse to zero.
+ * @param itemContent Emits a child. The provided modifier must be applied to the child's outermost layout node.
  */
+@Suppress("LongParameterList")
 @Composable
 internal fun VerticalStack(
     size: Size,
     dimension: Dimension.Vertical,
     spacing: Dp,
+    items: List<ComponentStyle>,
+    mainAxisUnbounded: Boolean,
     modifier: Modifier = Modifier,
-    content: VerticalStackScope.() -> Unit,
+    itemContent: @Composable (index: Int, item: ComponentStyle, modifier: Modifier) -> Unit,
 ) {
+    val hasAnyItemsWithFillHeight = items.any { it.size.height is Fill }
+    if (needsConstrainedFillLayout(size, dimension.distribution, items, Orientation.Vertical)) {
+        ConstrainedFillLayout(
+            config = ConstrainedFillLayout.Config.Vertical(
+                distribution = dimension.distribution,
+                arrangement = dimension.distribution.toVerticalArrangement(spacing),
+                alignment = dimension.alignment.toAlignment(),
+                fitMainAxis = size.height.shouldFitMainAxis(hasAnyItemsWithFillHeight),
+            ),
+            spacing = spacing,
+            modifier = modifier,
+        ) {
+            items.forEachIndexed { index, item ->
+                itemContent(index, item, ComponentSizeParentDataModifier(item.size))
+            }
+        }
+        return
+    }
+
     Column(
         modifier = modifier,
         verticalArrangement = dimension.distribution.toVerticalArrangement(
@@ -40,21 +63,13 @@ internal fun VerticalStack(
         ),
         horizontalAlignment = dimension.alignment.toAlignment(),
     ) {
+        val shouldApplyFillSpacers = size.height !is Fit && !hasAnyItemsWithFillHeight
         val fillSpaceSpacer: @Composable (Float) -> Unit = @Composable { weight ->
             Spacer(modifier = Modifier.weight(weight))
         }
-        val latestContent by rememberUpdatedState(content)
-        val scope = remember(dimension.distribution, spacing, latestContent) {
-            VerticalStackScopeImpl(
-                distribution = dimension.distribution,
-                spacing = spacing,
-                fillSpaceSpacer = fillSpaceSpacer,
-                height = size.height,
-            ).apply(latestContent)
-        }
 
         val edgeSpacerIfNeeded = @Composable {
-            if (scope.shouldApplyFillSpacers &&
+            if (shouldApplyFillSpacers &&
                 (
                     dimension.distribution == FlexDistribution.SPACE_AROUND ||
                         dimension.distribution == FlexDistribution.SPACE_EVENLY
@@ -65,46 +80,21 @@ internal fun VerticalStack(
         }
 
         edgeSpacerIfNeeded()
-        scope.columnContent(this)
-        edgeSpacerIfNeeded()
-    }
-}
+        items.forEachIndexed { index, item ->
+            val childModifier = if (item.size.height is Fill && !mainAxisUnbounded) {
+                Modifier.weight(1f)
+            } else {
+                Modifier
+            }
+            itemContent(index, item, childModifier)
 
-internal interface VerticalStackScope {
-    fun items(
-        items: List<ComponentStyle>,
-        itemContent: @Composable ColumnScope.(index: Int, item: ComponentStyle) -> Unit,
-    )
-}
-
-private class VerticalStackScopeImpl(
-    private val distribution: FlexDistribution,
-    private val spacing: Dp,
-    private val fillSpaceSpacer: @Composable (Float) -> Unit,
-    private val height: SizeConstraint,
-) : VerticalStackScope {
-    private var hasAnyItemsWithFillHeight = false
-    val shouldApplyFillSpacers: Boolean
-        get() = height !is Fit && !hasAnyItemsWithFillHeight
-    var columnContent: @Composable ColumnScope.() -> Unit = {}
-
-    override fun items(
-        items: List<ComponentStyle>,
-        itemContent: @Composable ColumnScope.(index: Int, item: ComponentStyle) -> Unit,
-    ) {
-        hasAnyItemsWithFillHeight = items.any { it.size.height is Fill }
-        columnContent = {
-            items.forEachIndexed { index, item ->
-                val isLast = index == items.size - 1
-                itemContent(index, item)
-
-                if (distribution.usesAllAvailableSpace && !isLast) {
-                    Spacer(modifier = Modifier.heightIn(min = spacing))
-                    if (shouldApplyFillSpacers) {
-                        fillSpaceSpacer(if (distribution == FlexDistribution.SPACE_AROUND) 2f else 1f)
-                    }
+            if (dimension.distribution.usesAllAvailableSpace && index != items.lastIndex) {
+                Spacer(modifier = Modifier.heightIn(min = spacing))
+                if (shouldApplyFillSpacers) {
+                    fillSpaceSpacer(if (dimension.distribution == FlexDistribution.SPACE_AROUND) 2f else 1f)
                 }
             }
         }
+        edgeSpacerIfNeeded()
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/VerticalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/VerticalStack.kt
@@ -47,6 +47,7 @@ internal fun VerticalStack(
                 fitMainAxis = size.height.shouldFitMainAxis(hasAnyItemsWithFillHeight),
             ),
             spacing = spacing,
+            hasCrossAxisFillChild = items.any { it.size.width is Fill },
             modifier = modifier,
         ) {
             items.forEachIndexed { index, item ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoComponentState.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.revenuecat.purchases.paywalls.components.properties.ImageUrls
 import com.revenuecat.purchases.paywalls.components.properties.Size
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
@@ -38,6 +37,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toLocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toPaddingValues
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toShape
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.AspectRatio
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.adjustForMedia
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDelegate
 import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentStyle
@@ -258,48 +258,11 @@ internal class VideoComponentState(
      * Adjusts this size to take into account the size of the video.
      */
     private fun Size.adjustForVideo(videoUrls: VideoUrls, density: Density): Size =
-        Size(
-            width = width.adjustDimension(
-                other = height,
-                thisDimensionPx = videoUrls.width,
-                otherDimensionPx = videoUrls.height,
-                density = density,
-            ),
-            height = height.adjustDimension(
-                other = width,
-                thisDimensionPx = videoUrls.height,
-                otherDimensionPx = videoUrls.width,
-                density = density,
-            ),
+        adjustForMedia(
+            widthPx = videoUrls.width,
+            heightPx = videoUrls.height,
+            density = density,
         )
-
-    /**
-     * Adjusts this size constraint to take into account the size of the video.
-     */
-    private fun SizeConstraint.adjustDimension(
-        other: SizeConstraint,
-        thisDimensionPx: UInt,
-        otherDimensionPx: UInt,
-        density: Density,
-    ): SizeConstraint = when (this) {
-        is Fit -> {
-            when (other) {
-                is Fit -> Fixed(with(density) { thisDimensionPx.toInt().toDp().value.toUInt() })
-                is Fill -> this
-
-                is Fixed -> {
-                    // If the other dimension is Fixed, we'll have to scale this one by the same factor.
-                    val otherDimensionDp = with(density) { otherDimensionPx.toInt().toDp() }
-                    val scaleFactor = other.value.toFloat() / otherDimensionDp.value
-                    Fixed(with(density) { (scaleFactor * thisDimensionPx.toInt()).toDp().value.toUInt() })
-                }
-            }
-        }
-
-        is Fill,
-        is Fixed,
-        -> this
-    }
 }
 
 @Stable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoComponentView.kt
@@ -27,6 +27,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.image.ImageComponentV
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.aspectRatio
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.border
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.overlay
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.resolveComponentSizeParentData
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.shadow
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.forCurrentTheme
@@ -93,6 +94,7 @@ internal fun VideoComponentView(
 
         Box(
             modifier = modifier
+                .resolveComponentSizeParentData(videoState.sizePlusMargin)
                 .size(videoState.sizePlusMargin)
                 .applyIfNotNull(videoState.marginAdjustedAspectRatio) { aspectRatio(it) }
                 .padding(videoState.margin)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewComponentView.kt
@@ -39,6 +39,7 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fi
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.ui.revenuecatui.BuildConfig
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.clamp
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.style.WebViewComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
@@ -240,9 +241,13 @@ internal fun resolveAxis(
     unbounded: Boolean,
 ): SizeConstraint =
     when (constraint) {
-        is Fit -> Fixed(if (contentCssPx > 0) contentCssPx.toUInt() else constraint.default ?: placeholder)
+        is Fit -> {
+            val baseSize = if (contentCssPx > 0) contentCssPx.toUInt() else constraint.default ?: placeholder
+            Fixed(constraint.clamp(baseSize))
+        }
         is Fill -> if (unbounded) {
-            Fixed(if (contentCssPx > 0) contentCssPx.toUInt() else placeholder)
+            val baseSize = if (contentCssPx > 0) contentCssPx.toUInt() else placeholder
+            Fixed(constraint.clamp(baseSize))
         } else {
             constraint
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
@@ -2,7 +2,14 @@ package com.revenuecat.purchases.ui.revenuecatui.extensions
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.unit.Constraints
 
 /**
  * Tracks in [unboundedState] whether this modifier's main-axis constraint leaves `weight` no space to
@@ -18,16 +25,52 @@ import androidx.compose.ui.layout.layout
 internal fun Modifier.trackMainAxisUnbounded(
     isHorizontal: Boolean,
     unboundedState: MutableState<Boolean>,
-): Modifier = this.layout { measurable, constraints ->
-    unboundedState.value = if (isHorizontal) {
-        !constraints.hasBoundedWidth && constraints.minWidth == 0
-    } else {
-        !constraints.hasBoundedHeight && constraints.minHeight == 0
+): Modifier = this then TrackMainAxisUnboundedElement(isHorizontal, unboundedState)
+
+private data class TrackMainAxisUnboundedElement(
+    val isHorizontal: Boolean,
+    val unboundedState: MutableState<Boolean>,
+) : ModifierNodeElement<TrackMainAxisUnboundedNode>() {
+    override fun create() = TrackMainAxisUnboundedNode(isHorizontal, unboundedState)
+
+    override fun update(node: TrackMainAxisUnboundedNode) {
+        node.isHorizontal = isHorizontal
+        node.unboundedState = unboundedState
     }
-    val placeable = measurable.measure(constraints)
-    layout(placeable.width, placeable.height) {
-        placeable.place(0, 0)
+}
+
+/**
+ * Implemented as a node rather than `Modifier.layout {}` so that intrinsic measurements pass straight through: the
+ * default intrinsics run the measure block with unbounded constraints, which would write a value that the real
+ * measure immediately contradicts, recomposing forever.
+ */
+private class TrackMainAxisUnboundedNode(
+    var isHorizontal: Boolean,
+    var unboundedState: MutableState<Boolean>,
+) : Modifier.Node(), LayoutModifierNode {
+    override fun MeasureScope.measure(measurable: Measurable, constraints: Constraints): MeasureResult {
+        unboundedState.value = if (isHorizontal) {
+            !constraints.hasBoundedWidth && constraints.minWidth == 0
+        } else {
+            !constraints.hasBoundedHeight && constraints.minHeight == 0
+        }
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {
+            placeable.place(0, 0)
+        }
     }
+
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(measurable: IntrinsicMeasurable, height: Int): Int =
+        measurable.minIntrinsicWidth(height)
+
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(measurable: IntrinsicMeasurable, height: Int): Int =
+        measurable.maxIntrinsicWidth(height)
+
+    override fun IntrinsicMeasureScope.minIntrinsicHeight(measurable: IntrinsicMeasurable, width: Int): Int =
+        measurable.minIntrinsicHeight(width)
+
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(measurable: IntrinsicMeasurable, width: Int): Int =
+        measurable.maxIntrinsicHeight(width)
 }
 
 internal fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> Modifier): Modifier {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -36,6 +36,9 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationKey
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.getBestMatch
@@ -226,8 +229,15 @@ internal fun Offering.validatePaywallComponentsDataOrNull(
         // This is a temporary hack to make the root component fill the screen. This will be removed once we have a
         // definite solution for positioning the root component.
         val rootComponent = (backendRootComponent as? StackComponentStyle)
-            ?.takeIf { it.size.height is SizeConstraint.Fit }
-            ?.copy(size = Size(width = SizeConstraint.Fill(), height = SizeConstraint.Fill()))
+            ?.takeIf { it.size.height is Fit }
+            ?.let { rootStack ->
+                rootStack.copy(
+                    size = Size(
+                        width = rootStack.size.width.asFill(),
+                        height = rootStack.size.height.asFill(),
+                    ),
+                )
+            }
             ?: backendRootComponent
 
         PaywallValidationResult.Components(
@@ -249,6 +259,12 @@ internal fun Offering.validatePaywallComponentsDataOrNull(
             stateDeclarations = componentsData.stateDeclarations.orEmpty(),
         )
     }
+}
+
+private fun SizeConstraint.asFill(): Fill = when (this) {
+    is Fit -> Fill(min = min, max = max)
+    is Fill -> this
+    is Fixed -> Fill()
 }
 
 @Suppress("ReturnCount")

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallComponentDataValidationTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallComponentDataValidationTests.kt
@@ -89,7 +89,10 @@ class PaywallComponentDataValidationTests {
                             ),
                             TestData.Components.monthlyPackageComponent,
                         ),
-                        size = Size(width = SizeConstraint.Fill(), height = SizeConstraint.Fit()),
+                        size = Size(
+                            width = SizeConstraint.Fill(min = 10u, max = 1000u),
+                            height = SizeConstraint.Fit(min = 20u, max = 40u),
+                        ),
                     ),
                     background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
                 ),
@@ -791,7 +794,9 @@ class PaywallComponentDataValidationTests {
     @Test
     fun `Should use Fill size in root component even if given Fit`() {
         val validated = offering.validatePaywallComponentsDataOrNull()?.getOrThrow()!!
-        assert((validated.stack as StackComponentStyle).size.height == SizeConstraint.Fill())
+        val size = (validated.stack as StackComponentStyle).size
+        assertEquals(SizeConstraint.Fill(min = 10u, max = 1000u), size.width)
+        assertEquals(SizeConstraint.Fill(min = 20u, max = 40u), size.height)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/SizeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/SizeTest.kt
@@ -1,0 +1,54 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.ktx
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SizeTest {
+
+    private val margin = PaddingValues(
+        start = 4.dp,
+        top = 3.dp,
+        end = 6.dp,
+        bottom = 7.dp,
+    )
+
+    @Test
+    fun `adds margins to fixed dimensions`() {
+        val result = Size(
+            width = Fixed(20u),
+            height = Fixed(30u),
+        ).addMargin(margin, LayoutDirection.Ltr)
+
+        assertThat(result.width).isEqualTo(Fixed(30u))
+        assertThat(result.height).isEqualTo(Fixed(40u))
+    }
+
+    @Test
+    fun `adds margins to fill limits`() {
+        val result = Size(
+            width = Fill(min = 20u, max = 30u),
+            height = Fill(min = 40u, max = 50u),
+        ).addMargin(margin, LayoutDirection.Ltr)
+
+        assertThat(result.width).isEqualTo(Fill(min = 30u, max = 40u))
+        assertThat(result.height).isEqualTo(Fill(min = 50u, max = 60u))
+    }
+
+    @Test
+    fun `adds margins to fit limits without changing default`() {
+        val result = Size(
+            width = Fit(default = 15u, min = 20u, max = 30u),
+            height = Fit(default = 25u),
+        ).addMargin(margin, LayoutDirection.Ltr)
+
+        assertThat(result.width).isEqualTo(Fit(default = 15u, min = 30u, max = 40u))
+        assertThat(result.height).isEqualTo(Fit(default = 25u))
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/MediaSizeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/MediaSizeTest.kt
@@ -1,0 +1,43 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.modifier
+
+import androidx.compose.ui.unit.Density
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class MediaSizeTest {
+
+    @Test
+    fun `fit dimensions use intrinsic size when it is within limits`() {
+        val size = Size(width = Fit(max = 300u), height = Fit(min = 40u))
+
+        assertThat(size.adjustForMedia(widthPx = 200u, heightPx = 100u, density = Density(1f)))
+            .isEqualTo(Size(width = Fixed(200u), height = Fixed(100u)))
+    }
+
+    @Test
+    fun `width maximum scales both fit dimensions down`() {
+        val size = Size(width = Fit(max = 100u), height = Fit())
+
+        assertThat(size.adjustForMedia(widthPx = 200u, heightPx = 100u, density = Density(1f)))
+            .isEqualTo(Size(width = Fixed(100u), height = Fixed(50u)))
+    }
+
+    @Test
+    fun `height minimum scales both fit dimensions up`() {
+        val size = Size(width = Fit(), height = Fit(min = 150u))
+
+        assertThat(size.adjustForMedia(widthPx = 200u, heightPx = 100u, density = Density(1f)))
+            .isEqualTo(Size(width = Fixed(300u), height = Fixed(150u)))
+    }
+
+    @Test
+    fun `most restrictive maximum scales both fit dimensions`() {
+        val size = Size(width = Fit(max = 150u), height = Fit(max = 40u))
+
+        assertThat(size.adjustForMedia(widthPx = 200u, heightPx = 100u, density = Density(1f)))
+            .isEqualTo(Size(width = Fixed(80u), height = Fixed(40u)))
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/SizeModifierTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/SizeModifierTest.kt
@@ -1,0 +1,166 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.modifier
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@Config(sdk = [26])
+@RunWith(AndroidJUnit4::class)
+class SizeModifierTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `fit respects minimum width and height`() {
+        val measured = measure(
+            size = Size(
+                width = Fit(min = 20u),
+                height = Fit(min = 30u),
+            ),
+            contentWidth = 10,
+            contentHeight = 10,
+        )
+
+        assertThat(measured).isEqualTo(IntSize(width = 20, height = 30))
+    }
+
+    @Test
+    fun `fit respects maximum width and height`() {
+        val measured = measure(
+            size = Size(
+                width = Fit(max = 20u),
+                height = Fit(max = 30u),
+            ),
+            contentWidth = 80,
+            contentHeight = 90,
+        )
+
+        assertThat(measured).isEqualTo(IntSize(width = 20, height = 30))
+    }
+
+    @Test
+    fun `fill respects maximum width`() {
+        val measured = measure(
+            size = Size(
+                width = Fill(max = 20u),
+                height = Fixed(10u),
+            ),
+        )
+
+        assertThat(measured.width).isEqualTo(20)
+    }
+
+    @Test
+    fun `fill minimum can exceed parent width`() {
+        val measured = measure(
+            size = Size(
+                width = Fill(min = 120u),
+                height = Fixed(10u),
+            ),
+        )
+
+        assertThat(measured.width).isEqualTo(120)
+    }
+
+    @Test
+    fun `minimum takes precedence over maximum`() {
+        val measured = measure(
+            size = Size(
+                width = Fill(min = 40u, max = 20u),
+                height = Fixed(10u),
+            ),
+        )
+
+        assertThat(measured.width).isEqualTo(40)
+    }
+
+    @Test
+    fun `start alignment places content at the right in RTL`() {
+        assertHorizontalAlignmentInRtl(
+            alignment = Alignment.Start,
+            expectedLeft = 80,
+        )
+    }
+
+    @Test
+    fun `end alignment places content at the left in RTL`() {
+        assertHorizontalAlignmentInRtl(
+            alignment = Alignment.End,
+            expectedLeft = 0,
+        )
+    }
+
+    private fun assertHorizontalAlignmentInRtl(
+        alignment: Alignment.Horizontal,
+        expectedLeft: Int,
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                Box(Modifier.requiredSize(100.dp)) {
+                    Box(
+                        modifier = Modifier
+                            .requiredSize(100.dp)
+                            .size(
+                                size = Size(width = Fit(), height = Fit()),
+                                horizontalAlignment = alignment,
+                            )
+                            .testTag(SUBJECT_TAG)
+                            .requiredSize(width = 20.dp, height = 20.dp),
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        val actualLeft = composeTestRule.onNodeWithTag(SUBJECT_TAG).fetchSemanticsNode().boundsInRoot.left
+        val expectedLeftPx = with(composeTestRule.density) { expectedLeft.dp.toPx() }
+        assertThat(actualLeft).isEqualTo(expectedLeftPx)
+    }
+
+    private fun measure(
+        size: Size,
+        contentWidth: Int = 10,
+        contentHeight: Int = 10,
+    ): IntSize {
+        composeTestRule.setContent {
+            Box(Modifier.requiredSize(100.dp)) {
+                Box(
+                    modifier = Modifier
+                        .size(size)
+                        .testTag(SUBJECT_TAG)
+                        .width(contentWidth.dp)
+                        .height(contentHeight.dp),
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        return composeTestRule.onNodeWithTag(SUBJECT_TAG).fetchSemanticsNode().size
+    }
+
+    private companion object {
+        const val SUBJECT_TAG = "subject"
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackConstrainedFillDistributionTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackConstrainedFillDistributionTest.kt
@@ -422,6 +422,49 @@ class StackConstrainedFillDistributionTest {
             .assertPixelColorEquals(Color.Red, x, y, width = 1, height = 1)
     }
 
+    /**
+     * Regression: the cross-axis stretch measures the row's intrinsic height, which runs every child's layout
+     * modifiers with unbounded constraints. A nested Fit column with Fill-height children tracks whether its main axis
+     * is unbounded in a state; if that tracking ran during the intrinsic pass it would flip the state on every frame
+     * and never settle.
+     */
+    @Test
+    fun `nested stack tracking its unbounded main axis inside a stretching row settles`() {
+        val nestedColumn = StackComponent(
+            components = listOf(
+                coloredBlock(size = Size(width = Fill(), height = Fill()), color = Color.Green),
+                coloredBlock(size = Size(width = Fill(min = 120u, max = 240u), height = Fill(min = 48u, max = 64u)), color = Color.Gray),
+            ),
+            dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+            size = Size(width = Fill(min = 120u, max = 240u), height = Fit(min = 120u, max = 160u)),
+        )
+        val row = StackComponent(
+            components = listOf(
+                coloredBlock(size = Size(width = Fit(min = 64u, max = 96u), height = Fit(min = 120u, max = 140u)), color = Color.Black),
+                nestedColumn,
+                coloredBlock(size = Size(width = Fill(max = 40u), height = Fill(max = 120u)), color = Color.Red),
+            ),
+            dimension = Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START),
+            size = Size(width = Fill(), height = Fit()),
+        )
+        val style = styleFactory.create(row).getOrThrow().componentStyle as StackComponentStyle
+
+        composeTestRule.setContent {
+            Box(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                StackComponentView(
+                    style = style,
+                    state = FakePaywallState(components = emptyList()),
+                    clickHandler = {},
+                    modifier = Modifier.testTag("stack"),
+                )
+            }
+        }
+
+        // waitForIdle throws if composition never settles.
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("stack").assertExists()
+    }
+
     private fun coloredBlock(
         size: Size,
         color: Color,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackConstrainedFillDistributionTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackConstrainedFillDistributionTest.kt
@@ -1,0 +1,421 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.stack
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.PartialStackComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.common.ComponentOverride
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.Dimension
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment
+import com.revenuecat.purchases.paywalls.components.properties.Padding
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import com.revenuecat.purchases.paywalls.components.properties.VerticalAlignment
+import com.revenuecat.purchases.ui.revenuecatui.assertions.assertPixelColorEquals
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.helpers.FakePaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.StyleFactory
+import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowPixelCopy
+
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(shadows = [ShadowPixelCopy::class], sdk = [26])
+@RunWith(AndroidJUnit4::class)
+class StackConstrainedFillDistributionTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val styleFactory = StyleFactory()
+
+    @Test
+    fun `horizontal capped Fill children preserve space between distribution`() {
+        assertCappedFillDistribution(
+            horizontal = true,
+            distribution = FlexDistribution.SPACE_BETWEEN,
+            firstColorPosition = 10,
+            secondColorPosition = 90,
+        )
+    }
+
+    @Test
+    fun `horizontal capped Fill children preserve space around distribution`() {
+        assertCappedFillDistribution(
+            horizontal = true,
+            distribution = FlexDistribution.SPACE_AROUND,
+            firstColorPosition = 25,
+            secondColorPosition = 75,
+        )
+    }
+
+    @Test
+    fun `horizontal capped Fill children preserve space evenly distribution`() {
+        assertCappedFillDistribution(
+            horizontal = true,
+            distribution = FlexDistribution.SPACE_EVENLY,
+            firstColorPosition = 30,
+            secondColorPosition = 70,
+        )
+    }
+
+    @Test
+    fun `vertical capped Fill children preserve space between distribution`() {
+        assertCappedFillDistribution(
+            horizontal = false,
+            distribution = FlexDistribution.SPACE_BETWEEN,
+            firstColorPosition = 10,
+            secondColorPosition = 90,
+        )
+    }
+
+    @Test
+    fun `vertical capped Fill children preserve space around distribution`() {
+        assertCappedFillDistribution(
+            horizontal = false,
+            distribution = FlexDistribution.SPACE_AROUND,
+            firstColorPosition = 25,
+            secondColorPosition = 75,
+        )
+    }
+
+    @Test
+    fun `vertical capped Fill children preserve space evenly distribution`() {
+        assertCappedFillDistribution(
+            horizontal = false,
+            distribution = FlexDistribution.SPACE_EVENLY,
+            firstColorPosition = 30,
+            secondColorPosition = 70,
+        )
+    }
+
+    @Test
+    fun `horizontal constrained Fill allocation includes resolved margins`() {
+        assertConstrainedFillAllocationIncludesMargins(horizontal = true)
+    }
+
+    @Test
+    fun `vertical constrained Fill allocation includes resolved margins`() {
+        assertConstrainedFillAllocationIncludesMargins(horizontal = false)
+    }
+
+    private fun assertConstrainedFillAllocationIncludesMargins(horizontal: Boolean) {
+        val firstChild = StackComponent(
+            components = emptyList(),
+            size = if (horizontal) {
+                Size(width = Fill(min = 50u), height = Fill())
+            } else {
+                Size(width = Fill(), height = Fill(min = 50u))
+            },
+            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+            overrides = listOf(
+                ComponentOverride(
+                    conditions = emptyList(),
+                    properties = PartialStackComponent(
+                        margin = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                    ),
+                ),
+            ),
+        )
+        val secondChild = coloredBlock(
+            size = Size(width = Fill(), height = Fill()),
+            color = Color.Blue,
+        )
+        val stack = StackComponent(
+            components = listOf(firstChild, secondChild),
+            dimension = if (horizontal) {
+                Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START)
+            } else {
+                Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START)
+            },
+            size = if (horizontal) {
+                Size(width = Fixed(100u), height = Fixed(20u))
+            } else {
+                Size(width = Fixed(20u), height = Fixed(100u))
+            },
+            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Green.toArgb())),
+        )
+        val style = styleFactory.create(stack).getOrThrow().componentStyle as StackComponentStyle
+
+        composeTestRule.setContent {
+            StackComponentView(
+                style = style,
+                state = FakePaywallState(components = emptyList()),
+                clickHandler = {},
+                modifier = Modifier.testTag("stack"),
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        val marginPosition = with(composeTestRule.density) { 65.dp.roundToPx() }
+        val secondChildPosition = with(composeTestRule.density) { 75.dp.roundToPx() }
+        val crossAxisPosition = with(composeTestRule.density) { 10.dp.roundToPx() }
+        val (marginX, marginY) = if (horizontal) {
+            marginPosition to crossAxisPosition
+        } else {
+            crossAxisPosition to marginPosition
+        }
+        val (secondChildX, secondChildY) = if (horizontal) {
+            secondChildPosition to crossAxisPosition
+        } else {
+            crossAxisPosition to secondChildPosition
+        }
+        composeTestRule.onNodeWithTag("stack")
+            .assertPixelColorEquals(Color.Green, marginX, marginY, width = 1, height = 1)
+            .assertPixelColorEquals(Color.Blue, secondChildX, secondChildY, width = 1, height = 1)
+    }
+
+    @Test
+    fun `horizontal Fill child capped by an override does not take a full Fill share`() {
+        assertOverriddenFirstChildOccupies20dp(
+            horizontal = true,
+            overrideSize = Size(width = Fill(max = 20u), height = Fill()),
+        )
+    }
+
+    @Test
+    fun `vertical Fill child capped by an override does not take a full Fill share`() {
+        assertOverriddenFirstChildOccupies20dp(
+            horizontal = false,
+            overrideSize = Size(width = Fill(), height = Fill(max = 20u)),
+        )
+    }
+
+    /**
+     * The children's *style* sizes are plain [Fill] here; only the override carries the constraint. This verifies both
+     * that the stack detects the override when choosing its layout, and that it picks up the resolved size from
+     * parent data at measure time.
+     */
+    private fun assertOverriddenFirstChildOccupies20dp(horizontal: Boolean, overrideSize: Size) {
+        val fillSize = Size(width = Fill(), height = Fill())
+        val firstChild = StackComponent(
+            components = emptyList(),
+            size = fillSize,
+            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+            overrides = listOf(
+                ComponentOverride(
+                    conditions = emptyList(),
+                    properties = PartialStackComponent(size = overrideSize),
+                ),
+            ),
+        )
+        val secondChild = coloredBlock(size = fillSize, color = Color.Blue)
+        val stack = StackComponent(
+            components = listOf(firstChild, secondChild),
+            dimension = if (horizontal) {
+                Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START)
+            } else {
+                Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START)
+            },
+            size = if (horizontal) {
+                Size(width = Fixed(100u), height = Fixed(20u))
+            } else {
+                Size(width = Fixed(20u), height = Fixed(100u))
+            },
+        )
+        val style = styleFactory.create(stack).getOrThrow().componentStyle as StackComponentStyle
+
+        composeTestRule.setContent {
+            StackComponentView(
+                style = style,
+                state = FakePaywallState(components = emptyList()),
+                clickHandler = {},
+                modifier = Modifier.testTag("stack"),
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        // First child should occupy 0..20dp; with an equal Fill split it would occupy 0..50dp instead.
+        val insideFirstChild = with(composeTestRule.density) { 10.dp.roundToPx() }
+        val insideSecondChild = with(composeTestRule.density) { 30.dp.roundToPx() }
+        val crossAxisPosition = with(composeTestRule.density) { 10.dp.roundToPx() }
+        val (firstX, firstY) = if (horizontal) {
+            insideFirstChild to crossAxisPosition
+        } else {
+            crossAxisPosition to insideFirstChild
+        }
+        val (secondX, secondY) = if (horizontal) {
+            insideSecondChild to crossAxisPosition
+        } else {
+            crossAxisPosition to insideSecondChild
+        }
+        composeTestRule.onNodeWithTag("stack")
+            .assertPixelColorEquals(Color.Red, firstX, firstY, width = 1, height = 1)
+            .assertPixelColorEquals(Color.Blue, secondX, secondY, width = 1, height = 1)
+    }
+
+    @Test
+    fun `nested horizontal Fit minimum does not consume space reserved for sibling`() {
+        assertNestedFitMinimum(horizontal = true)
+    }
+
+    @Test
+    fun `nested vertical Fit minimum does not consume space reserved for sibling`() {
+        assertNestedFitMinimum(horizontal = false)
+    }
+
+    private fun assertNestedFitMinimum(horizontal: Boolean) {
+        val stack = nestedFitMinimumStack(horizontal)
+        val style = styleFactory.create(stack).getOrThrow().componentStyle as StackComponentStyle
+
+        composeTestRule.setContent {
+            StackComponentView(
+                style = style,
+                state = FakePaywallState(components = emptyList()),
+                clickHandler = {},
+                modifier = Modifier.testTag("stack"),
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        val innerEndMainAxisPosition = with(composeTestRule.density) {
+            (if (horizontal) 120 else 104).dp.roundToPx()
+        }
+        val outerEndMainAxisPosition = with(composeTestRule.density) {
+            (if (horizontal) 300 else 264).dp.roundToPx()
+        }
+        val crossAxisPosition = with(composeTestRule.density) {
+            (if (horizontal) 36 else 120).dp.roundToPx()
+        }
+        val (innerEndX, innerEndY) = if (horizontal) {
+            innerEndMainAxisPosition to crossAxisPosition
+        } else {
+            crossAxisPosition to innerEndMainAxisPosition
+        }
+        val (outerEndX, outerEndY) = if (horizontal) {
+            outerEndMainAxisPosition to crossAxisPosition
+        } else {
+            crossAxisPosition to outerEndMainAxisPosition
+        }
+        composeTestRule.onNodeWithTag("stack")
+            .assertPixelColorEquals(Color.Green, innerEndX, innerEndY, width = 1, height = 1)
+            .assertPixelColorEquals(Color.Blue, outerEndX, outerEndY, width = 1, height = 1)
+    }
+
+    private fun nestedFitMinimumStack(horizontal: Boolean): StackComponent {
+        val innerChildSize = if (horizontal) {
+            Size(width = Fixed(40u), height = Fill())
+        } else {
+            Size(width = Fill(), height = Fixed(32u))
+        }
+        val innerStack = StackComponent(
+            components = listOf(
+                coloredBlock(innerChildSize, Color.Red),
+                coloredBlock(innerChildSize, Color.Green),
+            ),
+            dimension = if (horizontal) {
+                Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.SPACE_BETWEEN)
+            } else {
+                Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.SPACE_BETWEEN)
+            },
+            size = if (horizontal) {
+                Size(width = Fit(min = 140u), height = Fill())
+            } else {
+                Size(width = Fill(), height = Fit(min = 120u))
+            },
+            spacing = 0f,
+        )
+        return StackComponent(
+            components = listOf(innerStack, coloredBlock(innerChildSize, Color.Blue)),
+            dimension = if (horizontal) {
+                Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.SPACE_BETWEEN)
+            } else {
+                Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.SPACE_BETWEEN)
+            },
+            size = if (horizontal) {
+                Size(width = Fit(min = 320u), height = Fixed(72u))
+            } else {
+                Size(width = Fixed(240u), height = Fit(min = 280u))
+            },
+            spacing = 0f,
+        )
+    }
+
+    private fun coloredBlock(
+        size: Size,
+        color: Color,
+    ) = StackComponent(
+        components = emptyList(),
+        size = size,
+        backgroundColor = ColorScheme(light = ColorInfo.Hex(color.toArgb())),
+    )
+
+    private fun assertCappedFillDistribution(
+        horizontal: Boolean,
+        distribution: FlexDistribution,
+        firstColorPosition: Int,
+        secondColorPosition: Int,
+    ) {
+        val childSize = if (horizontal) {
+            Size(width = Fill(max = 20u), height = Fill())
+        } else {
+            Size(width = Fill(), height = Fill(max = 20u))
+        }
+        val firstChild = StackComponent(
+            components = emptyList(),
+            size = childSize,
+            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+        )
+        val secondChild = StackComponent(
+            components = emptyList(),
+            size = childSize,
+            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+        )
+        val stack = StackComponent(
+            components = listOf(firstChild, secondChild),
+            dimension = if (horizontal) {
+                Dimension.Horizontal(VerticalAlignment.CENTER, distribution)
+            } else {
+                Dimension.Vertical(HorizontalAlignment.CENTER, distribution)
+            },
+            size = if (horizontal) {
+                Size(width = Fixed(100u), height = Fixed(20u))
+            } else {
+                Size(width = Fixed(20u), height = Fixed(100u))
+            },
+        )
+        val style = styleFactory.create(stack).getOrThrow().componentStyle as StackComponentStyle
+
+        composeTestRule.setContent {
+            StackComponentView(
+                style = style,
+                state = FakePaywallState(components = emptyList()),
+                clickHandler = {},
+                modifier = Modifier.testTag("stack"),
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        val firstPositionPx = with(composeTestRule.density) { firstColorPosition.dp.roundToPx() }
+        val secondPositionPx = with(composeTestRule.density) { secondColorPosition.dp.roundToPx() }
+        val crossPositionPx = with(composeTestRule.density) { 10.dp.roundToPx() }
+        val (firstX, firstY) = if (horizontal) {
+            firstPositionPx to crossPositionPx
+        } else {
+            crossPositionPx to firstPositionPx
+        }
+        val (secondX, secondY) = if (horizontal) {
+            secondPositionPx to crossPositionPx
+        } else {
+            crossPositionPx to secondPositionPx
+        }
+        composeTestRule.onNodeWithTag("stack")
+            .assertPixelColorEquals(Color.Red, firstX, firstY, width = 1, height = 1)
+            .assertPixelColorEquals(Color.Blue, secondX, secondY, width = 1, height = 1)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackConstrainedFillDistributionTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackConstrainedFillDistributionTest.kt
@@ -1,5 +1,9 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -344,6 +348,78 @@ class StackConstrainedFillDistributionTest {
             },
             spacing = 0f,
         )
+    }
+
+    @Test
+    fun `horizontal cross-axis Fill child stretches to its siblings under an unbounded height`() {
+        assertCrossAxisFillChildStretches(horizontal = true)
+    }
+
+    @Test
+    fun `vertical cross-axis Fill child stretches to its siblings under an unbounded width`() {
+        assertCrossAxisFillChildStretches(horizontal = false)
+    }
+
+    /**
+     * A Fit stack inside a scroll has an unbounded cross axis, so a cross-axis Fill child has nothing to fill. It must
+     * stretch to the tallest (widest) sibling like flexbox does, instead of collapsing to its (empty) content.
+     */
+    private fun assertCrossAxisFillChildStretches(horizontal: Boolean) {
+        val fixedSibling = coloredBlock(
+            size = if (horizontal) {
+                Size(width = Fill(max = 40u), height = Fixed(60u))
+            } else {
+                Size(width = Fixed(60u), height = Fill(max = 40u))
+            },
+            color = Color.Blue,
+        )
+        val crossAxisFillChild = coloredBlock(
+            size = if (horizontal) {
+                Size(width = Fill(max = 40u), height = Fill())
+            } else {
+                Size(width = Fill(), height = Fill(max = 40u))
+            },
+            color = Color.Red,
+        )
+        val stack = StackComponent(
+            components = listOf(fixedSibling, crossAxisFillChild),
+            dimension = if (horizontal) {
+                Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START)
+            } else {
+                Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START)
+            },
+            size = if (horizontal) {
+                Size(width = Fixed(100u), height = Fit())
+            } else {
+                Size(width = Fit(), height = Fixed(100u))
+            },
+        )
+        val style = styleFactory.create(stack).getOrThrow().componentStyle as StackComponentStyle
+
+        composeTestRule.setContent {
+            Box(
+                modifier = if (horizontal) {
+                    Modifier.verticalScroll(rememberScrollState())
+                } else {
+                    Modifier.horizontalScroll(rememberScrollState())
+                },
+            ) {
+                StackComponentView(
+                    style = style,
+                    state = FakePaywallState(components = emptyList()),
+                    clickHandler = {},
+                    modifier = Modifier.testTag("stack"),
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        // The Fill child occupies 40..80dp on the main axis and must span the sibling's 60dp on the cross axis.
+        val insideFillChild = with(composeTestRule.density) { 60.dp.roundToPx() }
+        val nearCrossAxisEdge = with(composeTestRule.density) { 55.dp.roundToPx() }
+        val (x, y) = if (horizontal) insideFillChild to nearCrossAxisEdge else nearCrossAxisEdge to insideFillChild
+        composeTestRule.onNodeWithTag("stack")
+            .assertPixelColorEquals(Color.Red, x, y, width = 1, height = 1)
     }
 
     private fun coloredBlock(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackSizeConstraintTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackSizeConstraintTest.kt
@@ -1,9 +1,22 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.paywalls.components.CountdownComponent
+import com.revenuecat.purchases.paywalls.components.PartialStackComponent
+import com.revenuecat.purchases.paywalls.components.properties.Dimension
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment
+import com.revenuecat.purchases.paywalls.components.properties.Shape
+import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverride
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedStackPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -26,6 +39,112 @@ class StackSizeConstraintTest {
         assertThat(Fill().allowsFlexDistribution).isTrue()
         assertThat(Fixed(100u).allowsFlexDistribution).isTrue()
     }
+
+    @Test
+    fun `stacks without any min or max keep using Row and Column`() {
+        // Every combination pre-existing paywalls can express must stay on the Row/Column path.
+        val children = listOf(
+            stackStyle(Size(width = Fill(), height = Fill())),
+            stackStyle(Size(width = Fit(), height = Fit())),
+            stackStyle(Size(width = Fixed(10u), height = Fixed(10u))),
+        )
+        val stackSizes = listOf(
+            Size(width = Fill(), height = Fill()),
+            Size(width = Fit(), height = Fit()),
+            Size(width = Fixed(100u), height = Fixed(100u)),
+            Size(width = Fit(max = 100u), height = Fit(max = 100u)),
+        )
+
+        for (stackSize in stackSizes) {
+            for (distribution in FlexDistribution.values()) {
+                for (orientation in Orientation.values()) {
+                    assertThat(needsConstrainedFillLayout(stackSize, distribution, children, orientation))
+                        .describedAs("size=$stackSize distribution=$distribution orientation=$orientation")
+                        .isFalse()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a child with a limited Fill on the main axis needs the constrained layout`() {
+        val children = listOf(stackStyle(Size(width = Fill(max = 100u), height = Fill())))
+        val stackSize = Size(width = Fill(), height = Fill())
+
+        assertThat(needsConstrainedFillLayout(stackSize, FlexDistribution.START, children, Orientation.Horizontal))
+            .isTrue()
+        assertThat(needsConstrainedFillLayout(stackSize, FlexDistribution.START, children, Orientation.Vertical))
+            .isFalse()
+    }
+
+    @Test
+    fun `a child whose override introduces a limited Fill needs the constrained layout`() {
+        val child = stackStyle(
+            size = Size(width = Fill(), height = Fill()),
+            overrides = listOf(
+                PresentedOverride(
+                    conditions = emptyList(),
+                    properties = PresentedStackPartial(
+                        backgroundStyles = null,
+                        borderStyles = null,
+                        shadowStyles = null,
+                        badgeStyle = null,
+                        partial = PartialStackComponent(size = Size(width = Fill(), height = Fill(min = 20u))),
+                    ),
+                ),
+            ),
+        )
+        val stackSize = Size(width = Fill(), height = Fill())
+
+        assertThat(needsConstrainedFillLayout(stackSize, FlexDistribution.START, listOf(child), Orientation.Vertical))
+            .isTrue()
+        assertThat(needsConstrainedFillLayout(stackSize, FlexDistribution.START, listOf(child), Orientation.Horizontal))
+            .isFalse()
+    }
+
+    @Test
+    fun `a Fit stack with a positive minimum needs the constrained layout only when Row or Column would expand it`() {
+        val stackSize = Size(width = Fit(min = 100u), height = Fit())
+        val fillChild = listOf(stackStyle(Size(width = Fill(), height = Fill())))
+        val fixedChild = listOf(stackStyle(Size(width = Fixed(10u), height = Fixed(10u))))
+
+        // Fill children and SPACE_* spacers use `weight`, which would expand the Fit stack to the parent's maximum.
+        assertThat(needsConstrainedFillLayout(stackSize, FlexDistribution.START, fillChild, Orientation.Horizontal))
+            .isTrue()
+        assertThat(
+            needsConstrainedFillLayout(stackSize, FlexDistribution.SPACE_BETWEEN, fixedChild, Orientation.Horizontal),
+        ).isTrue()
+        // Nothing weighted: Modifier.size alone handles the minimum.
+        assertThat(needsConstrainedFillLayout(stackSize, FlexDistribution.START, fixedChild, Orientation.Horizontal))
+            .isFalse()
+        // The minimum is on the width, so a vertical stack is unaffected.
+        assertThat(needsConstrainedFillLayout(stackSize, FlexDistribution.SPACE_BETWEEN, fillChild, Orientation.Vertical))
+            .isFalse()
+    }
+
+    private fun stackStyle(
+        size: Size,
+        overrides: List<PresentedOverride<PresentedStackPartial>> = emptyList(),
+    ): StackComponentStyle = StackComponentStyle(
+        children = emptyList(),
+        dimension = Dimension.Vertical(alignment = HorizontalAlignment.CENTER, distribution = FlexDistribution.START),
+        visible = true,
+        size = size,
+        spacing = 0.dp,
+        background = null,
+        padding = PaddingValues(0.dp),
+        margin = PaddingValues(0.dp),
+        shape = Shape.Rectangle(),
+        border = null,
+        shadow = null,
+        badge = null,
+        scrollOrientation = null,
+        rcPackage = null,
+        tabIndex = null,
+        countdownDate = null,
+        countFrom = CountdownComponent.CountFrom.DAYS,
+        overrides = overrides,
+    )
 
     @Test
     fun `fill minimum is reserved before distributing remaining space`() {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/webview/WebViewEffectiveSizeTest.kt
@@ -46,6 +46,21 @@ internal class WebViewEffectiveSizeTest {
     }
 
     @Test
+    fun `fit axes clamp the resolved content default and placeholder sizes`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(
+                width = Fit(default = 240u, min = 300u),
+                height = Fit(max = 80u),
+            ),
+            contentWidthCssPx = 0,
+            contentHeightCssPx = 200,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(300u))
+        assertThat(size.height).isEqualTo(Fixed(80u))
+    }
+
+    @Test
     fun `non-fit axes ignore reported content sizes`() {
         val size = webViewEffectiveSize(
             declaredSize = Size(width = Fill(), height = Fixed(200u)),
@@ -102,6 +117,39 @@ internal class WebViewEffectiveSizeTest {
 
         assertThat(size.width).isEqualTo(Fixed(320u))
         assertThat(size.height).isEqualTo(Fixed(480u))
+    }
+
+    @Test
+    fun `unbounded fill axes clamp after resolving their base size`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(
+                width = Fill(max = 200u),
+                height = Fill(min = 500u),
+            ),
+            contentWidthCssPx = 320,
+            contentHeightCssPx = 480,
+            widthAxisUnbounded = true,
+            heightAxisUnbounded = true,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(200u))
+        assertThat(size.height).isEqualTo(Fixed(500u))
+    }
+
+    @Test
+    fun `minimum takes precedence over maximum for web view sizing`() {
+        val size = webViewEffectiveSize(
+            declaredSize = Size(
+                width = Fit(min = 400u, max = 200u),
+                height = Fill(min = 400u, max = 200u),
+            ),
+            contentWidthCssPx = 320,
+            contentHeightCssPx = 320,
+            heightAxisUnbounded = true,
+        )
+
+        assertThat(size.width).isEqualTo(Fixed(400u))
+        assertThat(size.height).isEqualTo(Fixed(400u))
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for [`purchases-ios`](https://github.com/RevenueCat/purchases-ios/pull/7574) and hybrids


> [!NOTE]
> previews were moved to a new branch 

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

We want to have more responsive paywalls, to best support that, we should be able to set minimum and maximum sizes.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

Wires the new min/max size attributes through the codebase. Puts the bits behind a flag that could cause the SDK to render the changes in production. This way it's a specific opt in until we officially release this. All changes are backward compatible until the flag is on or removed. There are things that need to be iterated on. The flag is there so we can merge this PR and fix those in isolated smaller PRs.
supersedes #4161

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core paywall layout and measurement across stacks and media; behavior is gated at parse time but UI layout changes are substantial and could affect rendering even for paywalls without min/max until the flag is on.
> 
> **Overview**
> Adds **opt-in paywall min/max sizing** via `ENABLE_PAYWALL_MIN_MAX_SIZING` in `local.properties` / BuildConfig. When the flag is off, JSON deserialization still accepts `min`/`max` on `Fit` and `Fill` but **strips them** so existing paywalls behave unchanged.
> 
> When enabled (and in UI either way for layout code paths that read constraints), **RevenueCat UI** honors limits end-to-end: the custom `Modifier.size` applies min/max during measure; margins adjust limits on `Fit`/`Fill`; image/video sizing uses shared `adjustForMedia` with aspect-ratio-aware scaling; WebView content sizing clamps resolved dimensions.
> 
> Stacks that need more than Row/Column `weight` switch to **`ConstrainedFillLayout`** (detected by `needsConstrainedFillLayout`—limited Fill children, overrides, or Fit stacks with positive minimums plus Fill/SPACE_* children). That layout allocates main-axis space with min/max, hugs content for Fit-with-minimum, passes **resolved sizes** through `ComponentSizeParentDataModifier`, and handles scroll/unbounded cross-axis Fill stretching. Horizontal/vertical stacks were simplified to pass child modifiers explicitly; `trackMainAxisUnbounded` is now a layout **node** to avoid intrinsic-measure recomposition loops.
> 
> The root Fit→Fill screen hack now **preserves** min/max when promoting axes to Fill. Broad unit/UI tests cover deserialization gating, modifiers, margins, media sizing, and constrained-fill distributions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d3d9ad22715a6a3fac82fe21c57461a2919e90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->