### PR TITLE
fix(paywalls): Show the video for the current appearance after the screen is recreated

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoComponentView.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -135,11 +134,11 @@ internal fun Rect.isVisibleInViewport(viewportWidth: Int, viewportHeight: Int): 
 }
 
 @Composable
-private fun rememberVideoContentState(
+internal fun rememberVideoContentState(
     videoUrls: VideoUrls,
     repository: FileRepository,
 ): URI {
-    val videoUrl = rememberSaveable(videoUrls.url) {
+    val videoUrl = remember(videoUrls) {
         resolveVideoUrl(videoUrls, repository)
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/FakeFileRepository.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/FakeFileRepository.kt
@@ -1,0 +1,31 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.video
+
+import com.revenuecat.purchases.models.Checksum
+import com.revenuecat.purchases.storage.FileRepository
+import java.net.URI
+import java.net.URL
+
+internal class FakeFileRepository(
+    private val cachedFiles: Map<URL, URI> = emptyMap(),
+    private val failingUrls: Set<URL> = emptySet(),
+) : FileRepository {
+
+    val getFileRequests: MutableList<URL> = mutableListOf()
+    val generateRequests: MutableList<URL> = mutableListOf()
+
+    override fun prefetch(urls: List<Pair<URL, Checksum?>>) = Unit
+
+    override fun getFile(url: URL, checksum: Checksum?): URI? {
+        getFileRequests += url
+        return cachedFiles[url]
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun generateOrGetCachedFileURL(url: URL, checksum: Checksum?): URI {
+        generateRequests += url
+        if (url in failingUrls) {
+            throw RuntimeException("Simulated failure for $url")
+        }
+        return cachedFiles[url] ?: throw RuntimeException("Missing fake URI for $url")
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/RememberVideoContentStateTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/RememberVideoContentStateTest.kt
@@ -1,0 +1,47 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.video
+
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.properties.VideoUrls
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URI
+import java.net.URL
+
+@RunWith(AndroidJUnit4::class)
+class RememberVideoContentStateTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val lightUrl = URL("https://example.com/light.mp4")
+    private val darkUrl = URL("https://example.com/dark.mp4")
+    private val lightUri = URI("file:///cache/light.mp4")
+    private val darkUri = URI("file:///cache/dark.mp4")
+
+    private val repository = FakeFileRepository(cachedFiles = mapOf(lightUrl to lightUri, darkUrl to darkUri))
+
+    @Test
+    fun `resolves the new video after state restoration with a different theme`() {
+        val restorationTester = StateRestorationTester(composeTestRule)
+        // Not a snapshot state on purpose: the restored composition must start with the dark URLs, the way a
+        // recreated Activity does, instead of recomposing the live one.
+        var videoUrls = videoUrls(lightUrl)
+        var resolvedUri: URI? = null
+
+        restorationTester.setContent {
+            resolvedUri = rememberVideoContentState(videoUrls, repository)
+        }
+        composeTestRule.runOnIdle { assertThat(resolvedUri).isEqualTo(lightUri) }
+
+        videoUrls = videoUrls(darkUrl)
+        restorationTester.emulateSavedInstanceStateRestore()
+
+        composeTestRule.runOnIdle { assertThat(resolvedUri).isEqualTo(darkUri) }
+    }
+
+    private fun videoUrls(url: URL) = VideoUrls(width = 100u, height = 100u, url = url)
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoUrlResolverTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoUrlResolverTest.kt
@@ -112,29 +112,4 @@ class VideoUrlResolverTest {
         urlLowRes = lowUrl,
         checksumLowRes = lowUrl?.let { Checksum(Checksum.Algorithm.SHA256, "low") },
     )
-
-    private class FakeFileRepository(
-        private val cachedFiles: Map<URL, URI> = emptyMap(),
-        private val failingUrls: Set<URL> = emptySet(),
-    ) : FileRepository {
-
-        val getFileRequests: MutableList<URL> = mutableListOf()
-        val generateRequests: MutableList<URL> = mutableListOf()
-
-        override fun prefetch(urls: List<Pair<URL, Checksum?>>) = Unit
-
-        override fun getFile(url: URL, checksum: Checksum?): URI? {
-            getFileRequests += url
-            return cachedFiles[url]
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        override suspend fun generateOrGetCachedFileURL(url: URL, checksum: Checksum?): URI {
-            generateRequests += url
-            if (url in failingUrls) {
-                throw RuntimeException("Simulated failure for $url")
-            }
-            return cachedFiles[url] ?: throw RuntimeException("Missing fake URI for $url")
-        }
-    }
 }


### PR DESCRIPTION
- Plays the video for the current appearance after the hosting Activity is recreated by a light/dark switch. Before, the previous theme's video kept playing while every other component updated.
- Root cause: `rememberVideoContentState` kept the resolved URI in `rememberSaveable(videoUrls.url)`, and `rememberSaveable` restores the saved value before it compares inputs, so the old URI won on every recreation.
- Swaps it for `remember(videoUrls)`. The lookup is a synchronous cache check, so nothing is lost by not persisting it.
- #4159 only covered the case where the composition survives the theme change. `PaywallActivity` declares no `configChanges`, so the recreation path is the common one.
- The brief "correct" frame in the reported recording is the dark fallback image, shown until the light video renders its first frame.
- Adds a Robolectric regression test with `StateRestorationTester`; `FakeFileRepository` moves out of `VideoUrlResolverTest` to be shared.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<details><summary>Agent description</summary>

### Motivation

A report on `10.21.0`, which already ships #4159: switching light/dark mode while a paywall with a video is on screen shows the right video for a moment and then goes back to the previous theme's video. iOS was fixed by #7569.

`rememberVideoContentState` did `rememberSaveable(videoUrls.url) { resolveVideoUrl(...) }`. In Compose's `rememberSaveable` the restored value is consumed inside the `remember {}` block and the holder is created with the *current* inputs, so `getValueIfInputsDidntChange` sees no change and returns the restored light URI even though the input is now the dark URL. Inputs only reset the value within a composition, never across a restore. `VideoView` then receives a consistent light URI on both sides of the restore and the `appliedUri` guard from #4159 never fires.

The "correct for a second" flash is the dark fallback `ImageComponentView`: after recreation `videoReady` starts false, images pick their theme URL with a plain `remember`, and the light video covers the fallback once its first frame renders.

### Description

- `VideoComponentView.kt`: `rememberSaveable(videoUrls.url)` becomes `remember(videoUrls)`. Keyed on the whole `VideoUrls` because `resolveVideoUrl` also reads the low-res URL and the checksums. `rememberVideoContentState` becomes `internal` for the test.
- `RememberVideoContentStateTest`: composes `rememberVideoContentState` with a fake repository under `StateRestorationTester`, swaps the `VideoUrls` between save and restore and asserts the restored composition resolves the new URL. Fails on `main` with `expected: file:///cache/dark.mp4 but was: file:///cache/light.mp4`.
- `FakeFileRepository` extracted from `VideoUrlResolverTest` into its own file, unchanged.

Not visible in the diff: reproduced on an API 34 emulator with an instrumented `VideoComponentView` test and two distinct public videos. After a save/dispose/recompose in dark mode `main` kept playing the light video; with this change the dark video plays. That test is not in the PR: any idle-based wait (Compose test rule, `StateRestorationTester`, `ActivityScenario.onActivity`) hangs while a `TextureView` plays, so it needed hand-rolled main-thread hops and polling for something the Robolectric test covers in 15 lines.

**Rejected:**
- Keeping `rememberSaveable` and adding the theme to the `key`: persists a value that is recomputed in microseconds and would still be wrong whenever the cache state changed between save and restore.
- Fixing in `VideoComponentState`: it already emits the correct dark `VideoUrls` through `derivedStateOf`; only the memo in the view layer broke the chain.

Other `rememberSaveable` uses in `revenuecatui` pass no inputs, so "restore wins" is the intent there and they are unaffected.
</details>

