### PR TITLE
Render the offering's own paywall when its topic workflow is an offering step

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/checkpoints/CheckpointWorkflowResolverImpl.kt
@@ -158,13 +158,13 @@ internal class CheckpointWorkflowResolverImpl(
         }
         val initialStep = workflow.steps[workflow.initialStepId]
             ?: return unservableRule(rule, "its initial step was not found")
-        return if (initialStep.type == OFFERING_STEP_TYPE) {
+        return if (initialStep.isOfferingStep) {
             if (workflow.steps.size != 1) {
                 unservableRule(rule, "an offering step cannot be mixed with other steps")
             } else {
                 resolveOfferingRule(checkpointIdentifier, rule, initialStep)
             }
-        } else if (workflow.steps.values.any { it.type == OFFERING_STEP_TYPE }) {
+        } else if (workflow.steps.values.any { it.isOfferingStep }) {
             unservableRule(rule, "a UI workflow cannot contain offering steps")
         } else {
             resolveUiRule(checkpointIdentifier, workflowManager, rule, workflow, uiConfig)
@@ -259,7 +259,6 @@ internal class CheckpointWorkflowResolverImpl(
 
     private companion object {
         const val SIMULATED_ERROR_CHECKPOINT_ID = "error_checkpoint"
-        const val OFFERING_STEP_TYPE = "offering"
         const val OFFERING_IDENTIFIER_PARAM = "offering_identifier"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -124,12 +124,18 @@ public data class WorkflowStep(
     public val experimentVariant: String?
         get() = stringParam(EXPERIMENT_VARIANT_PARAM)
 
+    /** A terminal step that resolves to an offering instead of rendering a screen. */
+    @InternalRevenueCatAPI
+    public val isOfferingStep: Boolean
+        get() = type == OFFERING_STEP_TYPE
+
     private fun stringParam(key: String): String? =
         (paramValues[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
 }
 
 private const val EXPERIMENT_ID_PARAM = "experiment_id"
 private const val EXPERIMENT_VARIANT_PARAM = "experiment_variant"
+private const val OFFERING_STEP_TYPE = "offering"
 
 @InternalRevenueCatAPI
 @Serializable

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -23,6 +23,20 @@ internal class WorkflowModelsDeserializationTest {
     }
 
     @Test
+    fun `WorkflowStep isOfferingStep is true only for offering steps`() {
+        val offeringStep = JsonTools.json.decodeFromString(
+            WorkflowStep.serializer(),
+            """{"id": "step_1", "type": "offering"}""",
+        )
+        val screenStep = JsonTools.json.decodeFromString(
+            WorkflowStep.serializer(),
+            """{"id": "step_2", "type": "screen", "screen_id": "screen_1"}""",
+        )
+        assertThat(offeringStep.isOfferingStep).isTrue
+        assertThat(screenStep.isOfferingStep).isFalse
+    }
+
+    @Test
     fun `WorkflowStep stepScreenType is empty when tagged with empty array`() {
         // A step the backend tagged with no known type. Empty (not null) means "explicitly not a
         // paywall", which suppresses paywall events.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -920,8 +920,9 @@ internal class PaywallViewModelImpl(
 
     /**
      * Resolves [workflowOffering] to its workflow and either presents it or decides how to fall back: a
-     * workflowless offering renders its own paywall, and an unreadable workflows topic renders the default
-     * paywall.
+     * workflowless offering renders its own paywall, an unreadable workflows topic renders the default
+     * paywall, and a workflow that is only an offering step (a checkpoint's terminal offering) has no UI of its
+     * own, so the offering renders its own paywall as well.
      */
     @Suppress("ReturnCount")
     private suspend fun presentWorkflowOrResolveFallback(
@@ -931,8 +932,7 @@ internal class PaywallViewModelImpl(
         when (val resolution = purchases.resolveWorkflow(workflowOffering.identifier)) {
             is WorkflowResolution.Found -> {
                 try {
-                    presentWorkflow(resolution.workflowId, workflowOffering, preloadedOfferings)
-                    return WorkflowOutcome.Presented
+                    return presentWorkflow(resolution.workflowId, workflowOffering, preloadedOfferings)
                 } catch (e: PurchasesException) {
                     // The workflow id resolved but its body or ui config could not be served. Reloading offerings
                     // would only yield the offering's skipped-away components, so surface the error instead of
@@ -965,20 +965,35 @@ internal class PaywallViewModelImpl(
         }
     }
 
-    private suspend fun presentWorkflow(workflowId: String, offering: Offering, preloadedOfferings: Offerings?) {
-        coroutineScope {
-            val workflowDeferred = async { purchases.awaitGetWorkflow(workflowId) }
-            val uiConfigDeferred = async { purchases.awaitGetUiConfig() }
-            val offeringsDeferred = async { preloadedOfferings ?: purchases.awaitOfferings() }
-            val workflowBlobRefDeferred = async { purchases.awaitWorkflowBlobRef(workflowId) }
-            startWorkflowPresentation(
-                workflowDeferred.await(),
-                uiConfigDeferred.await(),
-                offeringsDeferred.await(),
-                offering.presentedOfferingContext,
-                workflowBlobRefDeferred.await(),
+    private suspend fun presentWorkflow(
+        workflowId: String,
+        offering: Offering,
+        preloadedOfferings: Offerings?,
+    ): WorkflowOutcome = coroutineScope {
+        val workflowDeferred = async { purchases.awaitGetWorkflow(workflowId) }
+        val uiConfigDeferred = async { purchases.awaitGetUiConfig() }
+        val offeringsDeferred = async { preloadedOfferings ?: purchases.awaitOfferings() }
+        val workflowBlobRefDeferred = async { purchases.awaitWorkflowBlobRef(workflowId) }
+        val workflow = workflowDeferred.await()
+        if (workflow.steps[workflow.initialStepId]?.isOfferingStep == true) {
+            Logger.d(
+                "Paywalls: Workflow '$workflowId' for offering '${offering.identifier}' is an offering workflow. " +
+                    "Presenting the offering's own paywall.",
             )
+            uiConfigDeferred.cancel()
+            offeringsDeferred.cancel()
+            workflowBlobRefDeferred.cancel()
+            clearWorkflowState()
+            return@coroutineScope WorkflowOutcome.Fallback(offering, preloadedOfferings)
         }
+        startWorkflowPresentation(
+            workflow,
+            uiConfigDeferred.await(),
+            offeringsDeferred.await(),
+            offering.presentedOfferingContext,
+            workflowBlobRefDeferred.await(),
+        )
+        WorkflowOutcome.Presented
     }
 
     private suspend fun resolveOfferingSelection(offeringSelection: OfferingSelection): ResolvedOfferingSelection =

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -983,6 +983,34 @@ class PaywallViewModelWorkflowTest {
     }
 
     @Test
+    fun `an offering whose topic workflow is an offering step renders its own paywall`() = runTest {
+        // A checkpoint's terminal offering workflow is mapped to its offering in the workflows topic, but it has
+        // no screen to render: presenting the offering must not try to render it as a UI workflow.
+        val offeringStep = WorkflowStep(id = "offering-step", type = "offering")
+        val offeringWorkflow = PublishedWorkflow(
+            id = "wfl-offering",
+            displayName = "Offering",
+            initialStepId = offeringStep.id,
+            steps = mapOf(offeringStep.id to offeringStep),
+            screens = emptyMap(),
+            metadata = emptyMap(),
+            singleStepFallbackId = null,
+        )
+        coEvery { purchases.resolveWorkflow(offeringId) } returns WorkflowResolution.Found(offeringWorkflow.id)
+        coEvery { purchases.awaitGetWorkflow(offeringWorkflow.id) } returns offeringWorkflow
+        // Fetched alongside the workflow body; the fallback decision cancels them.
+        coEvery { purchases.awaitGetUiConfig() } returns uiConfig
+        coEvery { purchases.awaitOfferings() } returns testOfferings
+
+        val vm = createVm()
+        advanceUntilIdle()
+
+        assertThat(vm.state.value).isInstanceOf(PaywallState.Loaded.Legacy::class.java)
+        assertThat(vm.state.value).isNotInstanceOf(PaywallState.Error::class.java)
+        assertThat(vm.workflowState.value).isNull()
+    }
+
+    @Test
     fun `warm cache renders the workflow on the first composition with no Loading state`() {
         // Model Dispatchers.Main.immediate with an unconfined main dispatcher so viewModelScope.launch runs
         // eagerly, as in production. On a warm cache every suspend read resolves without suspending (mockk


### PR DESCRIPTION
### Description

When presenting workflow with an offering step, and no paywall presenter configured, the default paywall failed to show with an error:  "Step '...' has no screen_id in workflow '...'".

This solves that by short-circuiting to the default paywall when we encounter that the initial step is an offering step. We probably will need to do this for every step in follow-ups though

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core paywall/workflow presentation routing for offerings mapped to terminal offering workflows; behavior is narrowed with tests but affects revenue-critical UI paths.
> 
> **Overview**
> Fixes paywall presentation when an offering’s workflows-topic entry is a **single “offering” step** (e.g. checkpoint terminal workflows with no screen). Previously the UI tried to render that workflow and failed with a missing `screen_id` error.
> 
> **`WorkflowStep`** now exposes **`isOfferingStep`** (centralizing the `"offering"` type check). Checkpoint resolution uses it instead of a local constant.
> 
> **`PaywallViewModel`** detects an offering-only workflow after loading the workflow body: it cancels unnecessary fetches, clears workflow UI state, and **falls back to the offering’s own paywall** (same path as no-workflow / unavailable workflows). **`presentWorkflow`** now returns **`WorkflowOutcome`** so this path is explicit.
> 
> Tests cover deserialization of `isOfferingStep` and the ViewModel fallback for offering-step workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed32ab7c136cfff52cc144c879652ad28406868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->