### PR TITLE
IAM P2.4: IdentitySource

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/JWT.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/JWT.kt
@@ -1,0 +1,80 @@
+package com.revenuecat.purchases.common
+
+import android.util.Base64
+import com.revenuecat.purchases.utils.optNullableString
+import com.revenuecat.purchases.utils.toList
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * A quick-and-dirty, **unvalidated** parse of a JWT's payload claims.
+ *
+ * This deliberately does not verify the token's signature (or even look at its header contents)
+ * — it exists only to read a handful of well-known claims off of a token the SDK already trusts
+ * because it just received it directly from RevenueCat's backend or from an identity provider's
+ * SDK. Treat [issuer], [appUserId], and [amr] as informational only.
+ *
+ * @param payload the decoded JSON payload (the JWT's second `.`-delimited segment)
+ */
+internal class JWT private constructor(private val payload: JSONObject) {
+
+    /** The `iss` claim, if present. */
+    val issuer: String?
+        get() = payload.optNullableString(ISSUER_CLAIM)
+
+    /** The `rc.app_user_id` claim, if present. */
+    val appUserId: String?
+        get() = payload.optNullableString(APP_USER_ID_CLAIM)
+
+    /** The `amr` (Authentication Methods References) claim, if present. */
+    val amr: List<String>?
+        get() = payload.optJSONArray(AMR_CLAIM)?.toList()
+
+    companion object {
+        private const val EXPECTED_SEGMENT_COUNT = 3
+        private const val PAYLOAD_SEGMENT_INDEX = 1
+
+        private const val ISSUER_CLAIM = "iss"
+        private const val APP_USER_ID_CLAIM = "rc.app_user_id"
+        private const val AMR_CLAIM = "amr"
+
+        /**
+         * Parses [token] as a `header.payload.signature` JWT and returns its decoded payload
+         * claims, or `null` if [token] isn't well-formed enough to read.
+         *
+         * A token with `alg: "none"` has an empty (but present) signature segment — that still
+         * counts as 3 segments, and an empty segment decodes to an empty (but valid) byte array,
+         * so it's handled the same as any other token. Note that [CharSequence.split] (the
+         * `String`-vararg overload used here), unlike Java's regex-based `String.split`, does not
+         * drop trailing empty strings, so an empty signature segment doesn't collapse the segment
+         * count.
+         *
+         * All three segments must decode as valid base64url, even though only the payload's
+         * claims are actually read — a token that isn't even structurally valid base64url isn't
+         * a JWT worth trusting any part of.
+         */
+        fun decode(token: String): JWT? {
+            val segments = token.split(".")
+            if (segments.size != EXPECTED_SEGMENT_COUNT) return null
+
+            val decodedSegments = segments.map { decodeBase64UrlSegment(it) ?: return null }
+
+            val payload = try {
+                JSONObject(decodedSegments[PAYLOAD_SEGMENT_INDEX])
+            } catch (@Suppress("SwallowedException") e: JSONException) {
+                return null
+            }
+
+            return JWT(payload)
+        }
+
+        private fun decodeBase64UrlSegment(segment: String): String? {
+            return try {
+                val bytes = Base64.decode(segment, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+                String(bytes, Charsets.UTF_8)
+            } catch (@Suppress("SwallowedException") e: IllegalArgumentException) {
+                null
+            }
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/JWT.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/JWT.kt
@@ -32,7 +32,9 @@ internal class JWT private constructor(private val payload: JSONObject) {
 
     companion object {
         private const val EXPECTED_SEGMENT_COUNT = 3
+        private const val HEADER_SEGMENT_INDEX = 0
         private const val PAYLOAD_SEGMENT_INDEX = 1
+        private const val SIGNATURE_SEGMENT_INDEX = 2
 
         private const val ISSUER_CLAIM = "iss"
         private const val APP_USER_ID_CLAIM = "rc.app_user_id"
@@ -57,24 +59,30 @@ internal class JWT private constructor(private val payload: JSONObject) {
             val segments = token.split(".")
             if (segments.size != EXPECTED_SEGMENT_COUNT) return null
 
-            val decodedSegments = segments.map { decodeBase64UrlSegment(it) ?: return null }
+            val header = decodeBase64UrlSegment(segments[HEADER_SEGMENT_INDEX])
+            val payloadText = decodeBase64UrlSegment(segments[PAYLOAD_SEGMENT_INDEX])
+            val signature = decodeBase64UrlSegment(segments[SIGNATURE_SEGMENT_INDEX])
 
-            val payload = try {
-                JSONObject(decodedSegments[PAYLOAD_SEGMENT_INDEX])
-            } catch (@Suppress("SwallowedException") e: JSONException) {
-                return null
+            return if (header != null && payloadText != null && signature != null) {
+                parsePayload(payloadText)?.let { JWT(it) }
+            } else {
+                null
             }
-
-            return JWT(payload)
         }
 
-        private fun decodeBase64UrlSegment(segment: String): String? {
-            return try {
+        private fun parsePayload(payloadText: String): JSONObject? =
+            try {
+                JSONObject(payloadText)
+            } catch (@Suppress("SwallowedException") e: JSONException) {
+                null
+            }
+
+        private fun decodeBase64UrlSegment(segment: String): String? =
+            try {
                 val bytes = Base64.decode(segment, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
                 String(bytes, Charsets.UTF_8)
             } catch (@Suppress("SwallowedException") e: IllegalArgumentException) {
                 null
             }
-        }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentitySource.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentitySource.kt
@@ -31,6 +31,6 @@ public enum class IdentitySource(public val rawValue: String) {
          *   source (e.g. a newer wire value this SDK version doesn't recognize yet).
          */
         public fun fromRawValue(value: String): IdentitySource? =
-            entries.firstOrNull { it.rawValue == value }
+            values().firstOrNull { it.rawValue == value }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentitySource.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentitySource.kt
@@ -1,0 +1,36 @@
+package com.revenuecat.purchases.identity
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+
+/**
+ * The kind of external identity provider a user authenticated with when signing in via IAM
+ * login. Each case carries the raw string value the RevenueCat backend uses on the wire (e.g. as
+ * the `amr` claim in an IAM-issued ID token, or the `method` field of a `/auth/login` request
+ * body) — see [fromRawValue] for the inverse mapping.
+ *
+ * [ANONYMOUS] represents a user who hasn't authenticated with any external identity provider yet
+ * (the default state before the SDK's first silent bootstrap login); it is still a real
+ * [IdentitySource] value rather than the absence of one; a token's `amr` claim can list it
+ * alongside other sources.
+ */
+@InternalRevenueCatAPI
+public enum class IdentitySource(public val rawValue: String) {
+    ANONYMOUS("anonymous"),
+    OIDC("oidc"),
+    GOOGLE("google"),
+    SIGN_IN_WITH_APPLE("apple"),
+    FACEBOOK("facebook"),
+    FIREBASE("firebase"),
+    ;
+
+    public companion object {
+        /**
+         * Looks up the [IdentitySource] whose [rawValue] matches [value].
+         *
+         * @return the matching [IdentitySource], or `null` if [value] doesn't match any known
+         *   source (e.g. a newer wire value this SDK version doesn't recognize yet).
+         */
+        public fun fromRawValue(value: String): IdentitySource? =
+            entries.firstOrNull { it.rawValue == value }
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/JWTTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/JWTTest.kt
@@ -123,10 +123,15 @@ class JWTTest {
     // that need the header/payload decode path to succeed regardless of the signature.
     private val validSignature = base64UrlEncode("signature")
 
-    // A single character can never be valid base64 -- decoding requires at least 2 input
-    // characters to produce 1 output byte -- so this is guaranteed to fail to decode
-    // regardless of alphabet leniency toward any individual character.
-    private val invalidBase64Segment = "!"
+    // `android.util.Base64.decode()` is lenient about *characters*: anything outside the
+    // base64url alphabet (e.g. "!" or "#") is silently skipped rather than rejected, so a
+    // segment built out of "invalid" characters can still decode successfully once the
+    // non-alphabet noise is dropped. What it does *not* tolerate is a dangling, incomplete
+    // trailing group: with `NO_PADDING`, a lone leftover base64 alphabet character (a length
+    // of 1 mod 4) can't be completed into a full output byte, and decode() explicitly treats
+    // that as illegal and throws `IllegalArgumentException`. A single alphabet character is
+    // therefore a reliably-invalid segment, whereas non-alphabet characters are not.
+    private val invalidBase64Segment = "A"
 
     private fun buildToken(
         payload: JSONObject,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/JWTTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/JWTTest.kt
@@ -75,7 +75,7 @@ class JWTTest {
     @Test
     fun `returns null when the header segment is invalid base64url`() {
         val encodedPayload = base64UrlEncode(JSONObject().toString())
-        val token = "###invalid-base64###.$encodedPayload.$validSignature"
+        val token = "$invalidBase64Segment.$encodedPayload.$validSignature"
 
         assertThat(JWT.decode(token)).isNull()
     }
@@ -83,7 +83,7 @@ class JWTTest {
     @Test
     fun `returns null when the payload segment is invalid base64url`() {
         val header = base64UrlEncode("""{"alg":"none"}""")
-        val token = "$header.###invalid-base64###.$validSignature"
+        val token = "$header.$invalidBase64Segment.$validSignature"
 
         assertThat(JWT.decode(token)).isNull()
     }
@@ -94,7 +94,7 @@ class JWTTest {
         // structurally valid if one of its segments isn't valid base64url.
         val header = base64UrlEncode("""{"alg":"none"}""")
         val encodedPayload = base64UrlEncode(JSONObject().toString())
-        val token = "$header.$encodedPayload.###invalid-base64###"
+        val token = "$header.$encodedPayload.$invalidBase64Segment"
 
         assertThat(JWT.decode(token)).isNull()
     }
@@ -122,6 +122,11 @@ class JWTTest {
     // A fake but structurally valid (i.e. base64url-decodable) signature segment, for tests
     // that need the header/payload decode path to succeed regardless of the signature.
     private val validSignature = base64UrlEncode("signature")
+
+    // A single character can never be valid base64 -- decoding requires at least 2 input
+    // characters to produce 1 output byte -- so this is guaranteed to fail to decode
+    // regardless of alphabet leniency toward any individual character.
+    private val invalidBase64Segment = "!"
 
     private fun buildToken(
         payload: JSONObject,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/JWTTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/JWTTest.kt
@@ -1,0 +1,137 @@
+package com.revenuecat.purchases.common
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class JWTTest {
+
+    // region valid tokens
+
+    @Test
+    fun `decodes issuer, appUserId, and amr from a valid JWT`() {
+        val token = buildToken(
+            payload = JSONObject().apply {
+                put("iss", "https://api.revenuecat.com")
+                put("rc.app_user_id", "user-1234")
+                put("amr", JSONArray(listOf("pwd", "otp")))
+            },
+        )
+
+        val jwt = JWT.decode(token)
+
+        assertThat(jwt).isNotNull
+        assertThat(jwt!!.issuer).isEqualTo("https://api.revenuecat.com")
+        assertThat(jwt.appUserId).isEqualTo("user-1234")
+        assertThat(jwt.amr).isEqualTo(listOf("pwd", "otp"))
+    }
+
+    @Test
+    fun `decodes a token with alg none and an empty signature segment`() {
+        val payload = JSONObject().apply {
+            put("iss", "https://api.revenuecat.com")
+        }
+        val header = base64UrlEncode("""{"alg":"none"}""")
+        val encodedPayload = base64UrlEncode(payload.toString())
+        val token = "$header.$encodedPayload."
+
+        val jwt = JWT.decode(token)
+
+        assertThat(jwt).isNotNull
+        assertThat(jwt!!.issuer).isEqualTo("https://api.revenuecat.com")
+    }
+
+    @Test
+    fun `missing claims are read as null`() {
+        val token = buildToken(payload = JSONObject())
+
+        val jwt = JWT.decode(token)
+
+        assertThat(jwt).isNotNull
+        assertThat(jwt!!.issuer).isNull()
+        assertThat(jwt.appUserId).isNull()
+        assertThat(jwt.amr).isNull()
+    }
+
+    // endregion
+
+    // region malformed tokens
+
+    @Test
+    fun `returns null when the token does not have exactly 3 segments`() {
+        assertThat(JWT.decode("only-one-segment")).isNull()
+        assertThat(JWT.decode("two.segments")).isNull()
+        assertThat(JWT.decode("way.too.many.segments")).isNull()
+        assertThat(JWT.decode("")).isNull()
+    }
+
+    @Test
+    fun `returns null when the header segment is invalid base64url`() {
+        val encodedPayload = base64UrlEncode(JSONObject().toString())
+        val token = "###invalid-base64###.$encodedPayload.$validSignature"
+
+        assertThat(JWT.decode(token)).isNull()
+    }
+
+    @Test
+    fun `returns null when the payload segment is invalid base64url`() {
+        val header = base64UrlEncode("""{"alg":"none"}""")
+        val token = "$header.###invalid-base64###.$validSignature"
+
+        assertThat(JWT.decode(token)).isNull()
+    }
+
+    @Test
+    fun `returns null when the signature segment is invalid base64url`() {
+        // The signature's contents are never read, but the token as a whole still isn't
+        // structurally valid if one of its segments isn't valid base64url.
+        val header = base64UrlEncode("""{"alg":"none"}""")
+        val encodedPayload = base64UrlEncode(JSONObject().toString())
+        val token = "$header.$encodedPayload.###invalid-base64###"
+
+        assertThat(JWT.decode(token)).isNull()
+    }
+
+    @Test
+    fun `returns null when the payload is not a JSON object`() {
+        val header = base64UrlEncode("""{"alg":"none"}""")
+        val encodedPayload = base64UrlEncode("[1,2,3]")
+        val token = "$header.$encodedPayload.$validSignature"
+
+        assertThat(JWT.decode(token)).isNull()
+    }
+
+    @Test
+    fun `returns null when the payload is not valid JSON at all`() {
+        val header = base64UrlEncode("""{"alg":"none"}""")
+        val encodedPayload = base64UrlEncode("not json")
+        val token = "$header.$encodedPayload.$validSignature"
+
+        assertThat(JWT.decode(token)).isNull()
+    }
+
+    // endregion
+
+    // A fake but structurally valid (i.e. base64url-decodable) signature segment, for tests
+    // that need the header/payload decode path to succeed regardless of the signature.
+    private val validSignature = base64UrlEncode("signature")
+
+    private fun buildToken(
+        payload: JSONObject,
+        header: JSONObject = JSONObject().apply { put("alg", "HS256") },
+    ): String {
+        val encodedHeader = base64UrlEncode(header.toString())
+        val encodedPayload = base64UrlEncode(payload.toString())
+        return "$encodedHeader.$encodedPayload.$validSignature"
+    }
+
+    private fun base64UrlEncode(value: String): String =
+        Base64.encodeToString(value.toByteArray(Charsets.UTF_8), Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentitySourceTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentitySourceTests.kt
@@ -39,7 +39,7 @@ class IdentitySourceTests {
 
     @Test
     fun `every case round trips through its own rawValue`() {
-        IdentitySource.entries.forEach { source ->
+        IdentitySource.values().forEach { source ->
             assertThat(IdentitySource.fromRawValue(source.rawValue)).isEqualTo(source)
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentitySourceTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentitySourceTests.kt
@@ -1,0 +1,68 @@
+package com.revenuecat.purchases.identity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class IdentitySourceTests {
+
+    // region rawValue round trip
+
+    @Test
+    fun `fromRawValue returns ANONYMOUS for anonymous`() {
+        assertThat(IdentitySource.fromRawValue("anonymous")).isEqualTo(IdentitySource.ANONYMOUS)
+    }
+
+    @Test
+    fun `fromRawValue returns OIDC for oidc`() {
+        assertThat(IdentitySource.fromRawValue("oidc")).isEqualTo(IdentitySource.OIDC)
+    }
+
+    @Test
+    fun `fromRawValue returns GOOGLE for google`() {
+        assertThat(IdentitySource.fromRawValue("google")).isEqualTo(IdentitySource.GOOGLE)
+    }
+
+    @Test
+    fun `fromRawValue returns SIGN_IN_WITH_APPLE for apple`() {
+        assertThat(IdentitySource.fromRawValue("apple")).isEqualTo(IdentitySource.SIGN_IN_WITH_APPLE)
+    }
+
+    @Test
+    fun `fromRawValue returns FACEBOOK for facebook`() {
+        assertThat(IdentitySource.fromRawValue("facebook")).isEqualTo(IdentitySource.FACEBOOK)
+    }
+
+    @Test
+    fun `fromRawValue returns FIREBASE for firebase`() {
+        assertThat(IdentitySource.fromRawValue("firebase")).isEqualTo(IdentitySource.FIREBASE)
+    }
+
+    @Test
+    fun `every case round trips through its own rawValue`() {
+        IdentitySource.entries.forEach { source ->
+            assertThat(IdentitySource.fromRawValue(source.rawValue)).isEqualTo(source)
+        }
+    }
+
+    // endregion
+
+    // region unknown values
+
+    @Test
+    fun `fromRawValue returns null for an unrecognized raw value`() {
+        assertThat(IdentitySource.fromRawValue("myspace")).isNull()
+    }
+
+    @Test
+    fun `fromRawValue returns null for an empty string`() {
+        assertThat(IdentitySource.fromRawValue("")).isNull()
+    }
+
+    @Test
+    fun `fromRawValue is case-sensitive`() {
+        assertThat(IdentitySource.fromRawValue("Google")).isNull()
+        assertThat(IdentitySource.fromRawValue("GOOGLE")).isNull()
+    }
+
+    // endregion
+}


### PR DESCRIPTION
Adds an enum that defines the supported identity sources for IAM.

Even though Android doesn't natively support Sign In With Apple, the information we get from the server can still identify SIWA as a linked identity to the current identity, so we need to allow for it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0e3f5ed32d9e1a692f882d6dd4cbe3e0dc14b90e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->