### PR TITLE
IAM P2.5: IdentityAuthToken

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityAuthToken.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityAuthToken.kt
@@ -1,5 +1,8 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
 package com.revenuecat.purchases.identity
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.models.toHexString
 import java.security.MessageDigest
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityAuthToken.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityAuthToken.kt
@@ -1,0 +1,154 @@
+package com.revenuecat.purchases.identity
+
+import com.revenuecat.purchases.models.toHexString
+import java.security.MessageDigest
+
+/**
+ * An external identity credential supplied to IAM login, wrapping the raw payload bytes handed to
+ * the SDK by the identity provider's own SDK (e.g. a raw OIDC/Google/Firebase ID token, or a Sign
+ * in with Apple identity token). This is never validated locally -- it's still an "unvalidated,
+ * quick-and-dirty" credential-to-be-exchanged (mirroring [com.revenuecat.purchases.common.JWT]'s
+ * own no-signature-verification stance); the backend is what actually verifies it during
+ * `/auth/login`.
+ *
+ * [Anonymous] is a real case, not the absence of one -- it's what the SDK uses for its silent
+ * bootstrap login before any external identity provider is ever involved.
+ */
+internal sealed class IdentityAuthToken {
+
+    /** Which external identity provider (or none, for [Anonymous]) this token came from. */
+    abstract val authenticationMethod: IdentitySource
+
+    /** The bytes that make this specific identity unique, for [cacheIdentifier] to hash. */
+    protected abstract val payloadForCacheIdentifier: ByteArray
+
+    /**
+     * `true` unless this case wraps an empty payload. [Anonymous] has no payload to validate and
+     * is always valid.
+     */
+    abstract fun validate(): Boolean
+
+    /**
+     * A stable, hash-based identifier for this specific identity credential: the same
+     * `(authenticationMethod, payload)` pair always produces the same identifier, and different
+     * payloads -- including across different [authenticationMethod]s, since the method is mixed
+     * into the hash -- produce different ones. This lets callers key a cache or de-duplicate
+     * concurrent identical requests (e.g. `TokenAPI.logIn`'s in-flight-call de-duplication) off an
+     * opaque string rather than the raw token bytes themselves.
+     *
+     * Local-only value: never sent to the backend, and under no obligation to match whatever
+     * equivalent value `purchases-ios` computes for the same credential.
+     */
+    val cacheIdentifier: String
+        get() {
+            val digest = MessageDigest.getInstance("SHA-256")
+            digest.update(authenticationMethod.rawValue.toByteArray())
+            digest.update(payloadForCacheIdentifier)
+            return digest.digest().toHexString()
+        }
+
+    /** The SDK's default identity before any external sign-in has happened. */
+    object Anonymous : IdentityAuthToken() {
+        override val authenticationMethod: IdentitySource = IdentitySource.ANONYMOUS
+        override val payloadForCacheIdentifier: ByteArray = ByteArray(0)
+        override fun validate(): Boolean = true
+        override fun toString(): String = "IdentityAuthToken.Anonymous"
+    }
+
+    data class Oidc(val identityToken: ByteArray) : IdentityAuthToken() {
+        override val authenticationMethod: IdentitySource = IdentitySource.OIDC
+        override val payloadForCacheIdentifier: ByteArray get() = identityToken
+        override fun validate(): Boolean = identityToken.isNotEmpty()
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            other as Oidc
+            return identityToken.contentEquals(other.identityToken)
+        }
+
+        override fun hashCode(): Int = identityToken.contentHashCode()
+
+        override fun toString(): String =
+            "IdentityAuthToken.Oidc(identityToken=<${identityToken.size} bytes>)"
+    }
+
+    data class Google(val identityToken: ByteArray) : IdentityAuthToken() {
+        override val authenticationMethod: IdentitySource = IdentitySource.GOOGLE
+        override val payloadForCacheIdentifier: ByteArray get() = identityToken
+        override fun validate(): Boolean = identityToken.isNotEmpty()
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            other as Google
+            return identityToken.contentEquals(other.identityToken)
+        }
+
+        override fun hashCode(): Int = identityToken.contentHashCode()
+
+        override fun toString(): String =
+            "IdentityAuthToken.Google(identityToken=<${identityToken.size} bytes>)"
+    }
+
+    data class SignInWithApple(val identityToken: ByteArray) : IdentityAuthToken() {
+        override val authenticationMethod: IdentitySource = IdentitySource.SIGN_IN_WITH_APPLE
+        override val payloadForCacheIdentifier: ByteArray get() = identityToken
+        override fun validate(): Boolean = identityToken.isNotEmpty()
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            other as SignInWithApple
+            return identityToken.contentEquals(other.identityToken)
+        }
+
+        override fun hashCode(): Int = identityToken.contentHashCode()
+
+        override fun toString(): String =
+            "IdentityAuthToken.SignInWithApple(identityToken=<${identityToken.size} bytes>)"
+    }
+
+    data class Facebook(
+        val identityToken: ByteArray,
+        val email: String?,
+    ) : IdentityAuthToken() {
+        override val authenticationMethod: IdentitySource = IdentitySource.FACEBOOK
+        override val payloadForCacheIdentifier: ByteArray
+            get() = identityToken + (email?.toByteArray() ?: ByteArray(0))
+        override fun validate(): Boolean = identityToken.isNotEmpty()
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            other as Facebook
+            if (!identityToken.contentEquals(other.identityToken)) return false
+            return email == other.email
+        }
+
+        override fun hashCode(): Int = 31 * identityToken.contentHashCode() + (email?.hashCode() ?: 0)
+
+        override fun toString(): String {
+            val redactedEmail = if (email != null) "<redacted>" else "null"
+            return "IdentityAuthToken.Facebook(identityToken=<${identityToken.size} bytes>, email=$redactedEmail)"
+        }
+    }
+
+    data class Firebase(val identityToken: ByteArray) : IdentityAuthToken() {
+        override val authenticationMethod: IdentitySource = IdentitySource.FIREBASE
+        override val payloadForCacheIdentifier: ByteArray get() = identityToken
+        override fun validate(): Boolean = identityToken.isNotEmpty()
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            other as Firebase
+            return identityToken.contentEquals(other.identityToken)
+        }
+
+        override fun hashCode(): Int = identityToken.contentHashCode()
+
+        override fun toString(): String =
+            "IdentityAuthToken.Firebase(identityToken=<${identityToken.size} bytes>)"
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityAuthTokenTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityAuthTokenTests.kt
@@ -1,0 +1,144 @@
+package com.revenuecat.purchases.identity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class IdentityAuthTokenTests {
+
+    // region authenticationMethod
+
+    @Test
+    fun `Anonymous authenticationMethod is ANONYMOUS`() {
+        assertThat(IdentityAuthToken.Anonymous.authenticationMethod).isEqualTo(IdentitySource.ANONYMOUS)
+    }
+
+    @Test
+    fun `Oidc authenticationMethod is OIDC`() {
+        val token = IdentityAuthToken.Oidc("token".toByteArray())
+        assertThat(token.authenticationMethod).isEqualTo(IdentitySource.OIDC)
+    }
+
+    @Test
+    fun `Google authenticationMethod is GOOGLE`() {
+        val token = IdentityAuthToken.Google("token".toByteArray())
+        assertThat(token.authenticationMethod).isEqualTo(IdentitySource.GOOGLE)
+    }
+
+    @Test
+    fun `SignInWithApple authenticationMethod is SIGN_IN_WITH_APPLE`() {
+        val token = IdentityAuthToken.SignInWithApple("token".toByteArray())
+        assertThat(token.authenticationMethod).isEqualTo(IdentitySource.SIGN_IN_WITH_APPLE)
+    }
+
+    @Test
+    fun `Facebook authenticationMethod is FACEBOOK`() {
+        val token = IdentityAuthToken.Facebook("token".toByteArray(), email = "a@b.com")
+        assertThat(token.authenticationMethod).isEqualTo(IdentitySource.FACEBOOK)
+    }
+
+    @Test
+    fun `Firebase authenticationMethod is FIREBASE`() {
+        val token = IdentityAuthToken.Firebase("token".toByteArray())
+        assertThat(token.authenticationMethod).isEqualTo(IdentitySource.FIREBASE)
+    }
+
+    // endregion
+
+    // region validate()
+
+    @Test
+    fun `Anonymous always validates`() {
+        assertThat(IdentityAuthToken.Anonymous.validate()).isTrue()
+    }
+
+    @Test
+    fun `Oidc validates only with a non-empty payload`() {
+        assertThat(IdentityAuthToken.Oidc(ByteArray(0)).validate()).isFalse()
+        assertThat(IdentityAuthToken.Oidc("token".toByteArray()).validate()).isTrue()
+    }
+
+    @Test
+    fun `Google validates only with a non-empty payload`() {
+        assertThat(IdentityAuthToken.Google(ByteArray(0)).validate()).isFalse()
+        assertThat(IdentityAuthToken.Google("token".toByteArray()).validate()).isTrue()
+    }
+
+    @Test
+    fun `SignInWithApple validates only with a non-empty payload`() {
+        assertThat(IdentityAuthToken.SignInWithApple(ByteArray(0)).validate()).isFalse()
+        assertThat(IdentityAuthToken.SignInWithApple("token".toByteArray()).validate()).isTrue()
+    }
+
+    @Test
+    fun `Facebook validates only with a non-empty payload, regardless of email`() {
+        assertThat(IdentityAuthToken.Facebook(ByteArray(0), email = null).validate()).isFalse()
+        assertThat(IdentityAuthToken.Facebook(ByteArray(0), email = "a@b.com").validate()).isFalse()
+        assertThat(IdentityAuthToken.Facebook("token".toByteArray(), email = null).validate()).isTrue()
+        assertThat(IdentityAuthToken.Facebook("token".toByteArray(), email = "a@b.com").validate()).isTrue()
+    }
+
+    @Test
+    fun `Firebase validates only with a non-empty payload`() {
+        assertThat(IdentityAuthToken.Firebase(ByteArray(0)).validate()).isFalse()
+        assertThat(IdentityAuthToken.Firebase("token".toByteArray()).validate()).isTrue()
+    }
+
+    // endregion
+
+    // region cacheIdentifier
+
+    @Test
+    fun `cacheIdentifier is stable for the same payload`() {
+        val first = IdentityAuthToken.Oidc("same-token".toByteArray())
+        val second = IdentityAuthToken.Oidc("same-token".toByteArray())
+        assertThat(first.cacheIdentifier).isEqualTo(second.cacheIdentifier)
+    }
+
+    @Test
+    fun `cacheIdentifier is stable for Anonymous`() {
+        assertThat(IdentityAuthToken.Anonymous.cacheIdentifier).isEqualTo(IdentityAuthToken.Anonymous.cacheIdentifier)
+    }
+
+    @Test
+    fun `cacheIdentifier differs for different payloads within the same case`() {
+        val first = IdentityAuthToken.Google("token-1".toByteArray())
+        val second = IdentityAuthToken.Google("token-2".toByteArray())
+        assertThat(first.cacheIdentifier).isNotEqualTo(second.cacheIdentifier)
+    }
+
+    @Test
+    fun `cacheIdentifier differs across authentication methods for identical payload bytes`() {
+        val oidc = IdentityAuthToken.Oidc("identical-bytes".toByteArray())
+        val google = IdentityAuthToken.Google("identical-bytes".toByteArray())
+        val apple = IdentityAuthToken.SignInWithApple("identical-bytes".toByteArray())
+        val firebase = IdentityAuthToken.Firebase("identical-bytes".toByteArray())
+
+        val identifiers = listOf(oidc, google, apple, firebase).map { it.cacheIdentifier }
+        assertThat(identifiers).doesNotHaveDuplicates()
+    }
+
+    @Test
+    fun `Facebook cacheIdentifier differs by email even with the same identity token`() {
+        val withoutEmail = IdentityAuthToken.Facebook("token".toByteArray(), email = null)
+        val withEmail = IdentityAuthToken.Facebook("token".toByteArray(), email = "a@b.com")
+        val withDifferentEmail = IdentityAuthToken.Facebook("token".toByteArray(), email = "c@d.com")
+
+        val identifiers = listOf(withoutEmail, withEmail, withDifferentEmail).map { it.cacheIdentifier }
+        assertThat(identifiers).doesNotHaveDuplicates()
+    }
+
+    @Test
+    fun `Anonymous cacheIdentifier differs from every other case, even with an empty payload`() {
+        val identifiers = listOf(
+            IdentityAuthToken.Anonymous.cacheIdentifier,
+            IdentityAuthToken.Oidc(ByteArray(0)).cacheIdentifier,
+            IdentityAuthToken.Google(ByteArray(0)).cacheIdentifier,
+            IdentityAuthToken.SignInWithApple(ByteArray(0)).cacheIdentifier,
+            IdentityAuthToken.Firebase(ByteArray(0)).cacheIdentifier,
+            IdentityAuthToken.Facebook(ByteArray(0), email = null).cacheIdentifier,
+        )
+        assertThat(identifiers).doesNotHaveDuplicates()
+    }
+
+    // endregion
+}


### PR DESCRIPTION
Adds the internal storage for developer-provided identity tokens. These are the tokens that will be sent to the server to initiate the user session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds internal credential wrappers and tests only; no signature verification or login API wiring in this diff.
> 
> **Overview**
> Introduces an internal **`IdentityAuthToken`** sealed type to represent IAM login credentials before they are exchanged on `/auth/login`: provider-specific variants (OIDC, Google, Sign in with Apple, Facebook with optional email, Firebase) plus **`Anonymous`** for silent bootstrap login.
> 
> Each variant maps to **`IdentitySource`**, applies a lightweight **`validate()`** (non-empty token bytes; anonymous always passes), and exposes a local-only **`cacheIdentifier`** (SHA-256 over method + payload) for in-flight request de-duplication without sending raw tokens. **`toString()`** redacts token contents and Facebook email.
> 
> Unit tests cover provider mapping, validation rules, and cache identifier stability/uniqueness across methods, payloads, and Facebook email.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e7db4ebf5cea5fbdd7f8e6fb35304ae4f2b4653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->