### PR TITLE
IAM P2.6: Add public Identity façade

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/Identity.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/Identity.kt
@@ -1,0 +1,86 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.identity
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+
+/**
+ * An external identity credential to exchange for a RevenueCat session via IAM login (see
+ * `Authentication.logIn`). Construct one with the factory matching the identity provider the app
+ * already authenticated the user with -- [signInWithApple], [oidc], [google], [firebase], or
+ * [facebook] -- there is no public constructor.
+ *
+ * This is a thin façade: the actual credential payload lives in [IdentityAuthToken], which stays
+ * internal because its cases carry raw token bytes and aren't meaningful to app code beyond
+ * "which provider, and here's the opaque token."
+ */
+@InternalRevenueCatAPI
+public class Identity internal constructor(internal val authToken: IdentityAuthToken) {
+
+    /** Which external identity provider this credential came from. */
+    public val identitySource: IdentitySource
+        get() = authToken.authenticationMethod
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Identity) return false
+        return authToken == other.authToken
+    }
+
+    override fun hashCode(): Int = authToken.hashCode()
+
+    override fun toString(): String = "Identity($authToken)"
+
+    public companion object {
+
+        /**
+         * An identity credential from a Sign in with Apple identity token.
+         *
+         * @param identityToken the raw identity token produced by Apple's sign-in SDK.
+         */
+        public fun signInWithApple(identityToken: ByteArray): Identity =
+            Identity(IdentityAuthToken.SignInWithApple(identityToken))
+
+        /**
+         * An identity credential from a generic OIDC identity token.
+         *
+         * @param identityToken the raw ID token produced by the OIDC provider.
+         */
+        public fun oidc(identityToken: ByteArray): Identity =
+            Identity(IdentityAuthToken.Oidc(identityToken))
+
+        /**
+         * An identity credential from a Google Sign-In identity token.
+         *
+         * @param identityToken the raw ID token produced by Google's sign-in SDK.
+         */
+        public fun google(identityToken: ByteArray): Identity =
+            Identity(IdentityAuthToken.Google(identityToken))
+
+        /**
+         * An identity credential from a Firebase Authentication identity token.
+         *
+         * @param identityToken the raw ID token produced by Firebase Auth.
+         */
+        public fun firebase(identityToken: ByteArray): Identity =
+            Identity(IdentityAuthToken.Firebase(identityToken))
+
+        /**
+         * An identity credential from a Facebook Login identity token.
+         *
+         * @param identityToken the raw identity token produced by the Facebook Login SDK.
+         * @param email the user's email, if the app requested and was granted the `email`
+         *   permission during Facebook Login. Optional -- Facebook Login doesn't guarantee it.
+         */
+        public fun facebook(identityToken: ByteArray, email: String?): Identity =
+            Identity(IdentityAuthToken.Facebook(identityToken, email))
+
+        /**
+         * The SDK's own identity before any external sign-in has happened, used internally to
+         * drive the silent bootstrap login (see `IdentityManager.needsIAMLogin`). Not exposed to
+         * app code -- there's no scenario where an app should construct an anonymous [Identity]
+         * itself.
+         */
+        internal val anonymous: Identity = Identity(IdentityAuthToken.Anonymous)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityTests.kt
@@ -1,0 +1,90 @@
+package com.revenuecat.purchases.identity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class IdentityTests {
+
+    // region identitySource per factory
+
+    @Test
+    fun `signInWithApple has identitySource SIGN_IN_WITH_APPLE`() {
+        val identity = Identity.signInWithApple("token".toByteArray())
+        assertThat(identity.identitySource).isEqualTo(IdentitySource.SIGN_IN_WITH_APPLE)
+    }
+
+    @Test
+    fun `oidc has identitySource OIDC`() {
+        val identity = Identity.oidc("token".toByteArray())
+        assertThat(identity.identitySource).isEqualTo(IdentitySource.OIDC)
+    }
+
+    @Test
+    fun `google has identitySource GOOGLE`() {
+        val identity = Identity.google("token".toByteArray())
+        assertThat(identity.identitySource).isEqualTo(IdentitySource.GOOGLE)
+    }
+
+    @Test
+    fun `firebase has identitySource FIREBASE`() {
+        val identity = Identity.firebase("token".toByteArray())
+        assertThat(identity.identitySource).isEqualTo(IdentitySource.FIREBASE)
+    }
+
+    @Test
+    fun `facebook has identitySource FACEBOOK`() {
+        val identity = Identity.facebook("token".toByteArray(), email = "a@b.com")
+        assertThat(identity.identitySource).isEqualTo(IdentitySource.FACEBOOK)
+    }
+
+    @Test
+    fun `anonymous has identitySource ANONYMOUS`() {
+        assertThat(Identity.anonymous.identitySource).isEqualTo(IdentitySource.ANONYMOUS)
+    }
+
+    // endregion
+
+    // region equality
+
+    @Test
+    fun `identities from the same factory and payload are equal`() {
+        val first = Identity.oidc("same-token".toByteArray())
+        val second = Identity.oidc("same-token".toByteArray())
+        assertThat(first).isEqualTo(second)
+        assertThat(first.hashCode()).isEqualTo(second.hashCode())
+    }
+
+    @Test
+    fun `identities from different payloads are not equal`() {
+        val first = Identity.oidc("token-1".toByteArray())
+        val second = Identity.oidc("token-2".toByteArray())
+        assertThat(first).isNotEqualTo(second)
+    }
+
+    @Test
+    fun `identities from different providers with identical payload bytes are not equal`() {
+        val oidc = Identity.oidc("identical-bytes".toByteArray())
+        val google = Identity.google("identical-bytes".toByteArray())
+        assertThat(oidc).isNotEqualTo(google)
+    }
+
+    @Test
+    fun `facebook identities with the same token but different emails are not equal`() {
+        val withEmail = Identity.facebook("token".toByteArray(), email = "a@b.com")
+        val withoutEmail = Identity.facebook("token".toByteArray(), email = null)
+        assertThat(withEmail).isNotEqualTo(withoutEmail)
+    }
+
+    @Test
+    fun `anonymous is a stable singleton-equal identity`() {
+        assertThat(Identity.anonymous).isEqualTo(Identity.anonymous)
+    }
+
+    @Test
+    fun `an identity is not equal to an unrelated type`() {
+        val identity = Identity.oidc("token".toByteArray())
+        assertThat(identity).isNotEqualTo("token")
+    }
+
+    // endregion
+}


### PR DESCRIPTION
This adds the public API for defining how a developer provides an external auth token to the SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new API surface and tests only; no changes to existing login or networking behavior in this diff.
> 
> **Overview**
> Introduces **`Identity`**, a public (opt-in `@InternalRevenueCatAPI`) façade for passing external auth tokens into IAM login. Apps build credentials via companion factories—**Sign in with Apple**, **OIDC**, **Google**, **Firebase**, and **Facebook** (optional email)—instead of touching internal `IdentityAuthToken` types.
> 
> `identitySource` surfaces the provider; equality/hashCode delegate to the wrapped token. An **internal `anonymous`** singleton supports silent bootstrap login. Unit tests cover provider mapping and equality semantics (including Facebook email and cross-provider byte collisions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2d58ce1774a12147579a5a41413070a77381570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->