### PR TITLE
fix(admob): prevent using both adapters

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigurePublishedCapabilities.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/convention/ConfigurePublishedCapabilities.kt
@@ -1,0 +1,45 @@
+package com.revenuecat.purchases.android.buildlogic.convention
+
+import org.gradle.api.Project
+
+private const val ADDITIONAL_CAPABILITIES_PROPERTY = "POM_ADDITIONAL_CAPABILITIES"
+
+/**
+ * Adds any capabilities declared through [ADDITIONAL_CAPABILITIES_PROPERTY] to the variants exposed by a public
+ * library. Declaring an explicit capability replaces Gradle's implicit capability, so the publication's own
+ * coordinates are added explicitly as well.
+ */
+internal fun Project.configurePublishedCapabilities() {
+    val additionalCapabilityNames = findProperty(ADDITIONAL_CAPABILITIES_PROPERTY)
+        ?.toString()
+        ?.split(',')
+        ?.map(String::trim)
+        ?.filter(String::isNotEmpty)
+        .orEmpty()
+
+    if (additionalCapabilityNames.isEmpty()) return
+
+    val publishedGroup = property("GROUP")
+    val publishedArtifact = property("POM_ARTIFACT_ID")
+    val publishedVersion = property("VERSION_NAME")
+
+    configurations.configureEach {
+        if (!isCanBeConsumed) return@configureEach
+
+        // AGP uses Elements configurations for project dependencies and separate Publication configurations for
+        // Gradle Module Metadata. Since explicit capabilities replace the implicit one, retain the identity that
+        // consumers request in each context.
+        val ownCapability = when {
+            name.endsWith("ApiElements") || name.endsWith("RuntimeElements") ->
+                "${project.group}:${project.name}:${project.version}"
+            name.endsWith("ApiPublication") || name.endsWith("RuntimePublication") ->
+                "$publishedGroup:$publishedArtifact:$publishedVersion"
+            else -> return@configureEach
+        }
+
+        outgoing.capability(ownCapability)
+        additionalCapabilityNames.forEach { capabilityName ->
+            outgoing.capability("$publishedGroup:$capabilityName:$publishedVersion")
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/PublicLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/android/buildlogic/plugin/PublicLibraryConventionPlugin.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.android.buildlogic.convention.configureApisFlavo
 import com.revenuecat.purchases.android.buildlogic.convention.configureConditionalPublishing
 import com.revenuecat.purchases.android.buildlogic.convention.configureDokka
 import com.revenuecat.purchases.android.buildlogic.convention.configureMetalava
+import com.revenuecat.purchases.android.buildlogic.convention.configurePublishedCapabilities
 import com.revenuecat.purchases.android.buildlogic.ktx.libs
 import com.revenuecat.purchases.android.buildlogic.ktx.plugins
 import org.gradle.api.Plugin
@@ -26,6 +27,7 @@ class PublicLibraryConventionPlugin : Plugin<Project> {
 
         configureAndroidLibrary()
         configureApisFlavors()
+        configurePublishedCapabilities()
         configureConditionalPublishing()
         configureMetalava()
         configureDokka()

--- a/feature/admob-next-gen/gradle.properties
+++ b/feature/admob-next-gen/gradle.properties
@@ -1,4 +1,5 @@
 POM_NAME=purchases-admob-next-gen
 POM_ARTIFACT_ID=purchases-admob-next-gen
 POM_PACKAGING=aar
+POM_ADDITIONAL_CAPABILITIES=purchases-admob-adapter
 minSdkVersion=24

--- a/feature/admob/gradle.properties
+++ b/feature/admob/gradle.properties
@@ -1,3 +1,4 @@
 POM_NAME=purchases-admob
 POM_ARTIFACT_ID=purchases-admob
 POM_PACKAGING=aar
+POM_ADDITIONAL_CAPABILITIES=purchases-admob-adapter


### PR DESCRIPTION
### Checklist

- [x] If applicable, unit tests (validated through Gradle dependency resolution)
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids (not applicable)

### Motivation

The legacy and next-generation AdMob adapters are alternative implementations and should not be present in the same dependency graph. Gradle currently allows consumers to depend on both simultaneously.

### Description

- Add a generic, opt-in `POM_ADDITIONAL_CAPABILITIES` publishing convention for public library modules.
- Have both AdMob adapter modules provide the shared `purchases-admob-adapter` capability.
- Retain each module's own explicit capability for both project dependencies and published Gradle Module Metadata.

Gradle consumers now receive a dependency-resolution error if both adapters are included. Capabilities cannot be represented in Maven POM metadata, so this enforcement applies to consumers using Gradle Module Metadata.

Validated with:

- `./gradlew detektAll`
- `./gradlew :examples:admob-sample:compileDebugKotlin :examples:admob-next-gen-sample:compileDebugKotlin`
- Generated and inspected the Maven publication metadata for both adapters.
- Confirmed that resolving both project dependencies fails with the expected shared-capability conflict.
- Confirmed the same conflict from an isolated consumer using locally published artifacts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how published public libraries expose Gradle capabilities and can alter dependency resolution for any module that opts in via `POM_ADDITIONAL_CAPABILITIES`.
> 
> **Overview**
> Introduces an opt-in **`POM_ADDITIONAL_CAPABILITIES`** Gradle convention so public library modules can publish extra Gradle capabilities alongside their normal coordinates. **`configurePublishedCapabilities()`** is hooked into **`PublicLibraryConventionPlugin`**; modules without the property are unchanged.
> 
> Legacy **`purchases-admob`** and **`purchases-admob-next-gen`** both declare the shared capability **`purchases-admob-adapter`**, so Gradle fails resolution when both adapters appear in the same graph. Each artifact still exposes its own capability for project deps and published module metadata (explicit capabilities replace Gradle’s implicit ones).
> 
> **Note:** This only applies to consumers using Gradle Module Metadata, not plain Maven POM resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b278e3aa6485e88192426e3a226dd27da4d4ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->